### PR TITLE
Extend VarCouldBeVal Rule to Include Class/Object Properties

### DIFF
--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/VarCouldBeValSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/VarCouldBeValSpec.kt
@@ -133,7 +133,7 @@ class VarCouldBeValSpec : Spek({
             }
         }
 
-        it("reports variables that are not re-assigned at class level but is shadowed in a function") {
+        it("reports variables that are not re-assigned at class level but are shadowed in a function") {
             val code = """
             class Test {
                private var someVar = 3
@@ -166,7 +166,7 @@ class VarCouldBeValSpec : Spek({
             }
         }
 
-        it("reports variables that are not but only used in inner class") {
+        it("reports variables that are only used in inner class") {
             val code = """
             class Test {
                 private var unused = 2

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/VarCouldBeValSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/VarCouldBeValSpec.kt
@@ -112,6 +112,83 @@ class VarCouldBeValSpec : Spek({
         }
     }
 
+    describe("declarations at class level") {
+
+        it("reports variables that are not re-assigned at class level") {
+            val code = """
+            class Test {
+               private val someVar = 2
+               private var viewModel = BaseViewModel()
+               fun test() {
+                   var a = 1
+                   a += 2
+               }
+            }
+            """
+            assertThat(subject.lint(code)).hasSize(1)
+        }
+
+        it("reports variables that are not re-assigned at class level but same variable name is present in a function") {
+            val code = """
+            class Test {
+               private var viewModel = 3
+               fun test() {
+                   val viewModel = 4
+               }
+            }
+            """
+            assertThat(subject.lint(code)).hasSize(1)
+        }
+
+        it("reports variables that are not re-assigned at object level") {
+            val code = """
+            object Test {
+                private var someVar = 3
+                fun foo() {
+                    print(someVar)
+                }
+            }
+            """
+            assertThat(subject.lint(code)).hasSize(1)
+        }
+
+        it("does not report variables that are re-assigned in some member function") {
+            val code = """
+            class Test {
+               private var viewModel = 3
+               fun test() {
+                   viewModel = 4
+               }
+            }
+            """
+            assertThat(subject.lint(code)).hasSize(0)
+        }
+
+        it("does not report variables that are re-assigned in some member function1") {
+            val code = """
+            class Test {
+               private var viewModel = 3
+               fun test() {
+                   viewModel = 4
+               }
+            }
+            """
+            assertThat(subject.lint(code)).hasSize(0)
+        }
+
+        it("does not report variables that are of type lateinit") {
+            val code = """
+            class Test {
+               private lateinit var viewModel = 3
+               fun test() {
+                   val a = 4
+               }
+            }
+            """
+            assertThat(subject.lint(code)).hasSize(0)
+        }
+    }
+
     describe("this-prefixed properties - #1257") {
 
         it("finds unused field and local") {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/VarCouldBeValSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/VarCouldBeValSpec.kt
@@ -146,7 +146,7 @@ class VarCouldBeValSpec : Spek({
             val result = subject.compileAndLint(code)
             assertThat(result).hasSize(1)
             with(result[0].entity) {
-                assertThat(result[0].entity.ktElement?.text).isEqualTo("private var someVar = 3")
+                assertThat(ktElement?.text).isEqualTo("private var someVar = 3")
             }
         }
 
@@ -184,18 +184,6 @@ class VarCouldBeValSpec : Spek({
         }
 
         it("does not report variables that are re-assigned in some member function") {
-            val code = """
-            class Test {
-               private var viewModel = 3
-               fun test() {
-                   viewModel = 4
-               }
-            }
-            """
-            assertThat(subject.compileAndLint(code)).isEmpty()
-        }
-
-        it("does not report variables that are re-assigned in some member function1") {
             val code = """
             class Test {
                private var viewModel = 3

--- a/docs/pages/documentation/style.md
+++ b/docs/pages/documentation/style.md
@@ -1448,7 +1448,7 @@ object UtilityClass {
 
 ### VarCouldBeVal
 
-Reports var declarations (locally-scoped variables) that could be val, as they are not re-assigned.
+Reports var declarations that could be val, as they are not re-assigned.
 Val declarations are assign-once (read-only), which makes understanding the current state easier.
 
 **Severity**: Maintainability


### PR DESCRIPTION
Fixes [#1330 ](https://github.com/arturbosch/detekt/issues/1330)

- VarCouldBeVal would run for the class/object variables also
- Excluded variables having lateinit modifiers as they could be injected. Lateinit modifers are verified in `LateinitUsage` rule already.
- Removed specific check for `function.isSomehowNested` . The corresponding tests still pass. Please let me know if this is needed for some other reason