### PR TITLE
Add rule to warn on ignored return value

### DIFF
--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -406,6 +406,8 @@ potential-bugs:
     active: true
   HasPlatformType:
     active: false
+  IgnoredReturnValue:
+    active: false
   ImplicitDefaultLocale:
     active: false
   InvalidRange:

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValue.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValue.kt
@@ -38,6 +38,7 @@ class IgnoredReturnValue(config: Config = Config.empty) : Rule(config) {
         Debt.TWENTY_MINS
     )
 
+    @Suppress("ReturnCount")
     override fun visitCallExpression(expression: KtCallExpression) {
         super.visitCallExpression(expression)
         println("Call expression: ${expression.text}")

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValue.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValue.kt
@@ -1,6 +1,12 @@
 package io.gitlab.arturbosch.detekt.rules.bugs
 
-import io.gitlab.arturbosch.detekt.api.*
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.psi.KtBinaryExpression
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.resolve.BindingContext

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValue.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValue.kt
@@ -1,0 +1,50 @@
+package io.gitlab.arturbosch.detekt.rules.bugs
+
+import io.gitlab.arturbosch.detekt.api.*
+import org.jetbrains.kotlin.psi.KtBinaryExpression
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.resolve.BindingContext
+import org.jetbrains.kotlin.resolve.calls.callUtil.getResolvedCall
+import org.jetbrains.kotlin.types.typeUtil.isUnit
+
+/**
+ * The Kotlin compiler gives no warning for when a function which returns a value is called but its returned
+ * value is ignored.  This rule warns on instances where a function returns a value but that value is not
+ * used in any way.
+ *
+ * fun returnsValue() = 42
+ * fun returnsNoValue() {}
+ *
+ * <noncompliant>
+ *     returnsValue()
+ * </noncompliant>
+ *
+ * <compliant>
+ *     if (42 == returnsValue()) {}
+ *     val x = returnsValue()
+ * </compliant>
+ */
+class IgnoredReturnValue(config: Config = Config.empty) : Rule(config) {
+    override val issue: Issue = Issue(
+        "IgnoredReturnValue",
+        Severity.Defect,
+        "This call returns a value which has been ignored",
+        Debt.TWENTY_MINS
+    )
+
+    override fun visitCallExpression(expression: KtCallExpression) {
+        super.visitCallExpression(expression)
+        println("Call expression: ${expression.text}")
+
+        if (bindingContext == BindingContext.EMPTY) return
+        val resolvedCall = expression.getResolvedCall(bindingContext) ?: return
+        val returnType = resolvedCall.resultingDescriptor.returnType ?: return
+        if (returnType.isUnit()) {
+            return
+        }
+        // If this is part of a binary expression, then its return value is being checked
+        if (expression.parent is KtBinaryExpression) return
+
+        report(CodeSmell(issue, Entity.from(expression), ""))
+    }
+}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValue.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValue.kt
@@ -41,7 +41,6 @@ class IgnoredReturnValue(config: Config = Config.empty) : Rule(config) {
     @Suppress("ReturnCount")
     override fun visitCallExpression(expression: KtCallExpression) {
         super.visitCallExpression(expression)
-        println("Call expression: ${expression.text}")
 
         if (bindingContext == BindingContext.EMPTY) return
         val resolvedCall = expression.getResolvedCall(bindingContext) ?: return

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/PotentialBugProvider.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/PotentialBugProvider.kt
@@ -9,6 +9,7 @@ import io.gitlab.arturbosch.detekt.rules.bugs.EqualsAlwaysReturnsTrueOrFalse
 import io.gitlab.arturbosch.detekt.rules.bugs.EqualsWithHashCodeExist
 import io.gitlab.arturbosch.detekt.rules.bugs.ExplicitGarbageCollectionCall
 import io.gitlab.arturbosch.detekt.rules.bugs.HasPlatformType
+import io.gitlab.arturbosch.detekt.rules.bugs.IgnoredReturnValue
 import io.gitlab.arturbosch.detekt.rules.bugs.InvalidRange
 import io.gitlab.arturbosch.detekt.rules.bugs.IteratorHasNextCallsNextMethod
 import io.gitlab.arturbosch.detekt.rules.bugs.IteratorNotThrowingNoSuchElementException
@@ -54,7 +55,8 @@ class PotentialBugProvider : RuleSetProvider {
                 UnreachableCode(config),
                 UnsafeCallOnNullableType(config),
                 UnsafeCast(config),
-                ImplicitDefaultLocale(config)
+                ImplicitDefaultLocale(config),
+                IgnoredReturnValue(config)
         ))
     }
 }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValueSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValueSpec.kt
@@ -1,0 +1,78 @@
+package io.gitlab.arturbosch.detekt.rules.bugs
+
+import io.gitlab.arturbosch.detekt.test.KtTestCompiler
+import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import org.assertj.core.api.Assertions.assertThat
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+object IgnoredReturnValueSpec : Spek({
+
+    val subject by memoized { IgnoredReturnValue() }
+
+    val wrapper by memoized(
+        factory = { KtTestCompiler.createEnvironment() },
+        destructor = { it.dispose() }
+    )
+
+    describe("IgnoredReturnValue rule") {
+        it("reports when a function which returns a value is called and the return is ignored") {
+            val code = """
+                fun foo() {
+                    listOf("hello")
+                }
+            """.trimIndent()
+            assertThat(subject.compileAndLintWithContext(wrapper.env, code)).hasSize(1)
+        }
+
+        it("reports when an extension function which returns a value is called and the return is ignored") {
+            val code = """
+                fun Byte.setLastBit(): Byte = this or 0x1
+                fun foo(b: Byte) {
+                    b.setLastBit()
+                }
+            """.trimIndent()
+            assertThat(subject.compileAndLintWithContext(wrapper.env, code)).hasSize(1)
+        }
+
+        it("does not report when the return value is assigned to a pre-existing variable") {
+            val code = """
+                fun foo() {
+                    var x: List<String>
+                    x = listOf("hello")
+                }
+            """.trimIndent()
+            assertThat(subject.compileAndLintWithContext(wrapper.env, code)).hasSize(0)
+        }
+
+        it("does not report when a function which doesn't return a value is called") {
+            val code = """
+                fun noReturnValue() {}
+
+                fun foo() {
+                    noReturnValue()
+                }
+            """.trimIndent()
+            assertThat(subject.compileAndLintWithContext(wrapper.env, code)).hasSize(0)
+        }
+
+        it("does not report when a function's return value is used in a test statement") {
+            val code = """
+                fun returnsBoolean() = true
+                
+                if (returnsBoolean() {}
+
+            """.trimIndent()
+            assertThat(subject.compileAndLintWithContext(wrapper.env, code)).hasSize(0)
+        }
+
+        it("does not report when a function's return value is used in a comparison") {
+            val code = """
+                fun returnsInt() = 42
+                
+                if (42 == returnsInt()) {}
+            """.trimIndent()
+            assertThat(subject.compileAndLintWithContext(wrapper.env, code)).hasSize(0)
+        }
+    }
+})

--- a/docs/pages/documentation/potential-bugs.md
+++ b/docs/pages/documentation/potential-bugs.md
@@ -159,6 +159,32 @@ fun apiCall(): String = System.getProperty("propertyName")
 }
 ```
 
+### IgnoredReturnValue
+
+The Kotlin compiler gives no warning for when a function which returns a value is called but its returned
+value is ignored.  This rule warns on instances where a function returns a value but that value is not
+used in any way.
+
+fun returnsValue() = 42
+fun returnsNoValue() {}
+
+**Severity**: Defect
+
+**Debt**: 20min
+
+#### Noncompliant Code:
+
+```kotlin
+    returnsValue()
+```
+
+#### Compliant Code:
+
+```kotlin
+    if (42 == returnsValue()) {}
+    val x = returnsValue()
+```
+
 ### ImplicitDefaultLocale
 
 Prefer passing [java.util.Locale] explicitly than using implicit default value when formatting


### PR DESCRIPTION
Addresses #2239.

I'd consider this as draft at this point.  It works for the test cases I've provided, but I'm not familiar with all of the psi element types and I worry a bit that there may be some I missed (or perhaps a better way to detect what I am detecting).