### PR TITLE
Integrate with detekt-hint

### DIFF
--- a/.github/workflows/detekt-hint.yaml
+++ b/.github/workflows/detekt-hint.yaml
@@ -1,9 +1,6 @@
 name: detekt hint
 
 on:
-  push:
-    branches:
-      - master
   pull_request:
     branches:
       - '*'

--- a/.github/workflows/detekt-hint.yaml
+++ b/.github/workflows/detekt-hint.yaml
@@ -1,0 +1,28 @@
+name: detekt hint
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - '*'
+
+jobs:
+  gradle:
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        jdk: [11]
+    runs-on: ${{ matrix.os }}
+    if: ${{ !contains(github.event.head_commit.message, 'detekt hint skip') }}
+    env:
+      JDK_VERSION:  ${{ matrix.jdk }}
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+
+      - name: Run detekt hint
+        uses: Mkohm/detekt-hint-action@master
+        env:
+          DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/detekt-hint.yaml
+++ b/.github/workflows/detekt-hint.yaml
@@ -22,6 +22,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v2
 
+
       - name: Run detekt hint
         uses: Mkohm/detekt-hint-action@v1.1
         with:

--- a/.github/workflows/detekt-hint.yaml
+++ b/.github/workflows/detekt-hint.yaml
@@ -23,6 +23,6 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Run detekt hint
-        uses: Mkohm/detekt-hint-action@master
-        env:
-          DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: Mkohm/detekt-hint-action@v1.1
+        with:
+          github-api-token: ${{ secrets.GITHUB_TOKEN }}

--- a/config/detekt-hint-config.yml
+++ b/config/detekt-hint-config.yml
@@ -1,0 +1,11 @@
+detekt-hint:
+  UseCompositionInsteadOfInheritance:
+    active: true
+    yourUniquePackageName: "io.gitlab.arturbosch.detekt"
+  LackOfCohesionMethods:
+    active: true
+    threshold: "0.8"
+  InterfaceSegregationPrinciple:
+    active: true
+  OpenClosedPrinciple:
+    active: true


### PR DESCRIPTION
The previous PR got messy, so i created a new one only containing the new implementation.

I have now changed the implementation so that PRs from forks should work. Now, the only required files are the config file and the new github action that will run detekt-hint.