### PR TITLE
Don't report unused private properties in expect class

### DIFF
--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
@@ -30,6 +30,7 @@ import org.jetbrains.kotlin.psi.KtPrimaryConstructor
 import org.jetbrains.kotlin.psi.KtProperty
 import org.jetbrains.kotlin.psi.KtReferenceExpression
 import org.jetbrains.kotlin.psi.KtSecondaryConstructor
+import org.jetbrains.kotlin.psi.psiUtil.containingClassOrObject
 import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
 import org.jetbrains.kotlin.psi.psiUtil.isPrivate
 import org.jetbrains.kotlin.resolve.BindingContext
@@ -235,7 +236,7 @@ private class UnusedPropertyVisitor(allowedNames: Regex) : UnusedMemberVisitor(a
     override fun visitPrimaryConstructor(constructor: KtPrimaryConstructor) {
         super.visitPrimaryConstructor(constructor)
         constructor.valueParameters
-                .filter { it.isPrivate() || !it.hasValOrVar() }
+                .filter { (it.isPrivate() || !it.hasValOrVar()) && it.containingClassOrObject?.isExpect() == false }
                 .forEach { maybeAddUnusedProperty(it) }
     }
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMemberSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMemberSpec.kt
@@ -77,7 +77,8 @@ class UnusedPrivateMemberSpec : Spek({
 
         it("should not report parameters in expect class with constructor") {
             val code = """
-                expect class Foo(private val bar: String) {}
+                expect class Foo1(private val bar: String) {}
+                expect class Foo2(bar: String) {}
             """
             assertThat(subject.lint(code)).isEmpty()
         }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMemberSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMemberSpec.kt
@@ -59,7 +59,7 @@ class UnusedPrivateMemberSpec : Spek({
 
         it("should not report parameters in expect class functions") {
             val code = """
-                expect class Foo  {
+                expect class Foo {
                     fun bar(i: Int)
                     fun baz(i: Int, s: String)
                 }
@@ -74,11 +74,18 @@ class UnusedPrivateMemberSpec : Spek({
             """
             assertThat(subject.lint(code)).isEmpty()
         }
+
+        it("should not report parameters in expect class with constructor") {
+            val code = """
+                expect class Foo(private val bar: String) {}
+            """
+            assertThat(subject.lint(code)).isEmpty()
+        }
     }
 
     describe("actual functions") {
 
-        it("should not report parameters in actual functions") {
+        it("reports unused parameters in actual functions") {
             val code = """
                 actual class Foo {
                     actual fun bar(i: Int) {}
@@ -86,6 +93,13 @@ class UnusedPrivateMemberSpec : Spek({
                 }
             """
             assertThat(subject.lint(code)).hasSize(3)
+        }
+
+        it("reports unused parameters in constructors") {
+            val code = """
+                actual class Foo actual constructor(private val bar: String) {}
+            """
+            assertThat(subject.lint(code)).hasSize(1)
         }
     }
 


### PR DESCRIPTION
This is a subsequent commit of #2643.
Further tests are added that check unused elements in expect and actual classes.
