### PR TITLE
Update sample Gradle KTS integration link

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Visit [the project website](https://detekt.github.io/detekt/) for installation g
 - [Suppressing issues via baseline file](https://detekt.github.io/detekt/baseline.html)
 - [Configuring detekt](https://detekt.github.io/detekt/configurations.html)
 - Sample Gradle integrations examples:
-    - [multi project (Kotlin DSL)](https://github.com/detekt/detekt/blob/master/build.gradle.kts)
+    - [multi project (Kotlin DSL) with precompiled script plugin](https://github.com/detekt/detekt/blob/master/buildSrc/src/main/kotlin/detekt.gradle.kts)
     - [single project (Groovy DSL)](https://github.com/arturbosch/kutils/blob/master/build.gradle)
     - [single project (Unofficial Maven plugin)](https://github.com/detekt/sonar-kotlin/blob/master/pom.xml)
     - [setup additional detekt task for all modules (Kotlin DSL)](https://github.com/detekt/detekt/blob/3357abba87e1550c65b6610012bb291e0fbb64ce/build.gradle.kts#L280-L295)


### PR DESCRIPTION
The link to the sample Kotlin DSL detekt integration points to the top level gradle file. This is probably not really useful after the project was migrated to use `buildSrc` and the precompiled gradle plugin.

I'm updating that link.