### PR TITLE
Use task configuration avoidance for detekt plugin

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
@@ -155,17 +155,17 @@ class DetektPlugin : Plugin<Project> {
     }
 
     private fun setTaskDefaults(project: Project) {
-        project.tasks.withType(Detekt::class.java) {
+        project.tasks.withType(Detekt::class.java).configureEach {
             it.detektClasspath.setFrom(project.configurations.getAt(CONFIGURATION_DETEKT))
             it.pluginClasspath.setFrom(project.configurations.getAt(CONFIGURATION_DETEKT_PLUGINS))
         }
 
-        project.tasks.withType(DetektCreateBaselineTask::class.java) {
+        project.tasks.withType(DetektCreateBaselineTask::class.java).configureEach {
             it.detektClasspath.setFrom(project.configurations.getAt(CONFIGURATION_DETEKT))
             it.pluginClasspath.setFrom(project.configurations.getAt(CONFIGURATION_DETEKT_PLUGINS))
         }
 
-        project.tasks.withType(DetektGenerateConfigTask::class.java) {
+        project.tasks.withType(DetektGenerateConfigTask::class.java).configureEach {
             it.detektClasspath.setFrom(project.configurations.getAt(CONFIGURATION_DETEKT))
         }
     }


### PR DESCRIPTION
The [withType](https://docs.gradle.org/current/userguide/task_configuration_avoidance.html#sec:how_do_i_defer_configuration) method configures tasks eagerly. Adding a configureEach at the end will ensure that the tasks are configured lazily.

Here's the build scan showing the tasks being configured eagerly:
<img width="1008" alt="Screen Shot 2020-05-05 at 5 54 08 PM" src="https://user-images.githubusercontent.com/332597/81086980-776f3880-8ef9-11ea-9165-0dc43bee8b5f.png">
