### PR TITLE
Add default values to SwallowedException rule

### DIFF
--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedException.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedException.kt
@@ -78,10 +78,10 @@ class SwallowedException(config: Config = Config.empty) : Rule(config) {
         Debt.TWENTY_MINS)
 
     private val defaultIgnoredExceptions = listOf(
-            DEFAULT_IGNORED_EXCEPTION_TYPES.INTERRUPTED_EXCEPTION,
-            DEFAULT_IGNORED_EXCEPTION_TYPES.NUMBER_FORMAT_EXCEPTION,
-            DEFAULT_IGNORED_EXCEPTION_TYPES.PARSE_EXCEPTION,
-            DEFAULT_IGNORED_EXCEPTION_TYPES.MALFORMED_URL_EXCEPTION
+            DefaultIgnoredExceptionTypes.INTERRUPTED_EXCEPTION,
+            DefaultIgnoredExceptionTypes.NUMBER_FORMAT_EXCEPTION,
+            DefaultIgnoredExceptionTypes.PARSE_EXCEPTION,
+            DefaultIgnoredExceptionTypes.MALFORMED_URL_EXCEPTION
     ).map { it.toString() }
     private val ignoredExceptionTypes = valueOrDefaultCommaSeparated(IGNORED_EXCEPTION_TYPES, defaultIgnoredExceptions)
             .map { it.removePrefix("*").removeSuffix("*") }
@@ -167,7 +167,7 @@ class SwallowedException(config: Config = Config.empty) : Rule(config) {
         const val ALLOWED_EXCEPTION_NAME_REGEX = "allowedExceptionNameRegex"
     }
 
-    enum class DEFAULT_IGNORED_EXCEPTION_TYPES {
+    enum class DefaultIgnoredExceptionTypes {
         NUMBER_FORMAT_EXCEPTION {
             override fun toString() = "NumberFormatException"
         },

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedException.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedException.kt
@@ -77,7 +77,7 @@ class SwallowedException(config: Config = Config.empty) : Rule(config) {
         "The caught exception is swallowed. The original exception could be lost.",
         Debt.TWENTY_MINS)
 
-    private val ignoredExceptionTypes = valueOrDefaultCommaSeparated(IGNORED_EXCEPTION_TYPES, emptyList())
+    private val ignoredExceptionTypes = valueOrDefaultCommaSeparated(IGNORED_EXCEPTION_TYPES, listOf("NumberFormatException"))
         .map { it.removePrefix("*").removeSuffix("*") }
 
     private val allowedExceptionNameRegex by LazyRegex(ALLOWED_EXCEPTION_NAME_REGEX, ALLOWED_EXCEPTION_NAME)

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedException.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedException.kt
@@ -78,11 +78,11 @@ class SwallowedException(config: Config = Config.empty) : Rule(config) {
         Debt.TWENTY_MINS)
 
     private val defaultIgnoredExceptions = listOf(
-            DefaultIgnoredExceptionTypes.INTERRUPTED_EXCEPTION,
-            DefaultIgnoredExceptionTypes.NUMBER_FORMAT_EXCEPTION,
-            DefaultIgnoredExceptionTypes.PARSE_EXCEPTION,
-            DefaultIgnoredExceptionTypes.MALFORMED_URL_EXCEPTION
-    ).map { it.toString() }
+            "NumberFormatException",
+            "InterruptedException",
+            "ParseException",
+            "MalformedURLException"
+    )
     private val ignoredExceptionTypes = valueOrDefaultCommaSeparated(IGNORED_EXCEPTION_TYPES, defaultIgnoredExceptions)
             .map { it.removePrefix("*").removeSuffix("*") }
 
@@ -165,20 +165,5 @@ class SwallowedException(config: Config = Config.empty) : Rule(config) {
     companion object {
         const val IGNORED_EXCEPTION_TYPES = "ignoredExceptionTypes"
         const val ALLOWED_EXCEPTION_NAME_REGEX = "allowedExceptionNameRegex"
-    }
-
-    enum class DefaultIgnoredExceptionTypes {
-        NUMBER_FORMAT_EXCEPTION {
-            override fun toString() = "NumberFormatException"
-        },
-        INTERRUPTED_EXCEPTION {
-            override fun toString() = "InterruptedException"
-        },
-        PARSE_EXCEPTION {
-            override fun toString() = "ParseException"
-        },
-        MALFORMED_URL_EXCEPTION {
-            override fun toString() = "MalformedURLException"
-        }
     }
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedException.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedException.kt
@@ -77,7 +77,7 @@ class SwallowedException(config: Config = Config.empty) : Rule(config) {
         "The caught exception is swallowed. The original exception could be lost.",
         Debt.TWENTY_MINS)
 
-    private val ignoredExceptions = listOf("NumberFormatException", "InterruptedException")
+    private val ignoredExceptions = listOf("NumberFormatException", "InterruptedException", "ParseException")
     private val ignoredExceptionTypes = valueOrDefaultCommaSeparated(IGNORED_EXCEPTION_TYPES, ignoredExceptions)
         .map { it.removePrefix("*").removeSuffix("*") }
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedException.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedException.kt
@@ -77,7 +77,7 @@ class SwallowedException(config: Config = Config.empty) : Rule(config) {
         "The caught exception is swallowed. The original exception could be lost.",
         Debt.TWENTY_MINS)
 
-    private val ignoredExceptions = listOf("NumberFormatException", "InterruptedException", "ParseException")
+    private val ignoredExceptions = listOf("NumberFormatException", "InterruptedException", "ParseException", "MalformedURLException")
     private val ignoredExceptionTypes = valueOrDefaultCommaSeparated(IGNORED_EXCEPTION_TYPES, ignoredExceptions)
         .map { it.removePrefix("*").removeSuffix("*") }
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedException.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedException.kt
@@ -77,9 +77,14 @@ class SwallowedException(config: Config = Config.empty) : Rule(config) {
         "The caught exception is swallowed. The original exception could be lost.",
         Debt.TWENTY_MINS)
 
-    private val ignoredExceptions = listOf("NumberFormatException", "InterruptedException", "ParseException", "MalformedURLException")
-    private val ignoredExceptionTypes = valueOrDefaultCommaSeparated(IGNORED_EXCEPTION_TYPES, ignoredExceptions)
-        .map { it.removePrefix("*").removeSuffix("*") }
+    private val defaultIgnoredExceptions = listOf(
+            DEFAULT_IGNORED_EXCEPTION_TYPES.INTERRUPTED_EXCEPTION,
+            DEFAULT_IGNORED_EXCEPTION_TYPES.NUMBER_FORMAT_EXCEPTION,
+            DEFAULT_IGNORED_EXCEPTION_TYPES.PARSE_EXCEPTION,
+            DEFAULT_IGNORED_EXCEPTION_TYPES.MALFORMED_URL_EXCEPTION
+    ).map { it.toString() }
+    private val ignoredExceptionTypes = valueOrDefaultCommaSeparated(IGNORED_EXCEPTION_TYPES, defaultIgnoredExceptions)
+            .map { it.removePrefix("*").removeSuffix("*") }
 
     private val allowedExceptionNameRegex by LazyRegex(ALLOWED_EXCEPTION_NAME_REGEX, ALLOWED_EXCEPTION_NAME)
 
@@ -160,5 +165,20 @@ class SwallowedException(config: Config = Config.empty) : Rule(config) {
     companion object {
         const val IGNORED_EXCEPTION_TYPES = "ignoredExceptionTypes"
         const val ALLOWED_EXCEPTION_NAME_REGEX = "allowedExceptionNameRegex"
+    }
+
+    enum class DEFAULT_IGNORED_EXCEPTION_TYPES {
+        NUMBER_FORMAT_EXCEPTION {
+            override fun toString() = "NumberFormatException"
+        },
+        INTERRUPTED_EXCEPTION {
+            override fun toString() = "InterruptedException"
+        },
+        PARSE_EXCEPTION {
+            override fun toString() = "ParseException"
+        },
+        MALFORMED_URL_EXCEPTION {
+            override fun toString() = "MalformedURLException"
+        }
     }
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedException.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedException.kt
@@ -77,7 +77,8 @@ class SwallowedException(config: Config = Config.empty) : Rule(config) {
         "The caught exception is swallowed. The original exception could be lost.",
         Debt.TWENTY_MINS)
 
-    private val ignoredExceptionTypes = valueOrDefaultCommaSeparated(IGNORED_EXCEPTION_TYPES, listOf("NumberFormatException"))
+    private val ignoredExceptions = listOf("NumberFormatException", "InterruptedException")
+    private val ignoredExceptionTypes = valueOrDefaultCommaSeparated(IGNORED_EXCEPTION_TYPES, ignoredExceptions)
         .map { it.removePrefix("*").removeSuffix("*") }
 
     private val allowedExceptionNameRegex by LazyRegex(ALLOWED_EXCEPTION_NAME_REGEX, ALLOWED_EXCEPTION_NAME)

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedExceptionSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedExceptionSpec.kt
@@ -214,6 +214,18 @@ class SwallowedExceptionSpec : Spek({
             """
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
+
+        it("ignores InterruptedException by default") {
+            val code = """
+                fun f() {
+                    try {
+                    } catch (e: InterruptedException) {
+                        throw MyCustomException()
+                    }
+                }
+            """
+            assertThat(subject.compileAndLint(code)).isEmpty()
+        }
     }
 })
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedExceptionSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedExceptionSpec.kt
@@ -238,6 +238,18 @@ class SwallowedExceptionSpec : Spek({
             """
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
+
+        it("ignores MalformedURLException by default") {
+            val code = """
+                fun f() {
+                    try {
+                    } catch (e: MalformedURLException) {
+                        throw MyCustomException()
+                    }
+                }
+            """
+            assertThat(subject.compileAndLint(code)).isEmpty()
+        }
     }
 })
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedExceptionSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedExceptionSpec.kt
@@ -202,5 +202,19 @@ class SwallowedExceptionSpec : Spek({
             """
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
+
+        it("ignores NumberFormatException by default") {
+            val code = """
+                fun f() {
+                    try {
+                    } catch (e: NumberFormatException) {
+                        throw MyCustomException()
+                    }
+                }
+            """
+            assertThat(subject.compileAndLint(code)).isEmpty()
+        }
     }
 })
+
+class MyCustomException() : Exception()

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedExceptionSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedExceptionSpec.kt
@@ -5,6 +5,8 @@ import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
+import java.net.MalformedURLException
+import java.text.ParseException
 
 class SwallowedExceptionSpec : Spek({
     val subject by memoized { SwallowedException() }
@@ -203,52 +205,26 @@ class SwallowedExceptionSpec : Spek({
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
-        it("ignores NumberFormatException by default") {
-            val code = """
-                fun f() {
-                    try {
-                    } catch (e: NumberFormatException) {
-                        throw Exception()
-                    }
-                }
-            """
-            assertThat(subject.compileAndLint(code)).isEmpty()
-        }
+        listOf(
+            InterruptedException::class.java.simpleName,
+            MalformedURLException::class.java.simpleName,
+            NumberFormatException::class.java.simpleName,
+            ParseException::class.java.simpleName
+        ).forEach { exceptionName ->
+            it("ignores $exceptionName by default") {
+                val code = """
+                import java.net.MalformedURLException
+                import java.text.ParseException
 
-        it("ignores InterruptedException by default") {
-            val code = """
                 fun f() {
                     try {
-                    } catch (e: InterruptedException) {
+                    } catch (e: $exceptionName) {
                         throw Exception()
                     }
                 }
             """
-            assertThat(subject.compileAndLint(code)).isEmpty()
-        }
-
-        it("ignores ParseException by default") {
-            val code = """
-                fun f() {
-                    try {
-                    } catch (e: ParseException) {
-                        throw Exception()
-                    }
-                }
-            """
-            assertThat(subject.compileAndLint(code)).isEmpty()
-        }
-
-        it("ignores MalformedURLException by default") {
-            val code = """
-                fun f() {
-                    try {
-                    } catch (e: MalformedURLException) {
-                        throw Exception()
-                    }
-                }
-            """
-            assertThat(subject.compileAndLint(code)).isEmpty()
+                assertThat(subject.compileAndLint(code)).isEmpty()
+            }
         }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedExceptionSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedExceptionSpec.kt
@@ -208,7 +208,7 @@ class SwallowedExceptionSpec : Spek({
                 fun f() {
                     try {
                     } catch (e: NumberFormatException) {
-                        throw MyCustomException()
+                        throw Exception()
                     }
                 }
             """
@@ -220,7 +220,7 @@ class SwallowedExceptionSpec : Spek({
                 fun f() {
                     try {
                     } catch (e: InterruptedException) {
-                        throw MyCustomException()
+                        throw Exception()
                     }
                 }
             """
@@ -232,7 +232,7 @@ class SwallowedExceptionSpec : Spek({
                 fun f() {
                     try {
                     } catch (e: ParseException) {
-                        throw MyCustomException()
+                        throw Exception()
                     }
                 }
             """
@@ -244,7 +244,7 @@ class SwallowedExceptionSpec : Spek({
                 fun f() {
                     try {
                     } catch (e: MalformedURLException) {
-                        throw MyCustomException()
+                        throw Exception()
                     }
                 }
             """
@@ -252,5 +252,3 @@ class SwallowedExceptionSpec : Spek({
         }
     }
 })
-
-class MyCustomException() : Exception()

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedExceptionSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedExceptionSpec.kt
@@ -226,6 +226,18 @@ class SwallowedExceptionSpec : Spek({
             """
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
+
+        it("ignores ParseException by default") {
+            val code = """
+                fun f() {
+                    try {
+                    } catch (e: ParseException) {
+                        throw MyCustomException()
+                    }
+                }
+            """
+            assertThat(subject.compileAndLint(code)).isEmpty()
+        }
     }
 })
 


### PR DESCRIPTION
There are some rules that have default values [in the documentation](https://detekt.github.io/detekt/exceptions.html) but those values are not implemented in the code.
This is a bug mapped here #2597

This PR adds default values to `SwallowedException` rule as mapped in the documentation.

---

⚠️  _This is my very first contribution to OS so sorry if I'm doing anything wrong. If this PR is OK, I'm gonna add more default values to other rules._