### PR TITLE
Remove $ as a valid char in class and method names

### DIFF
--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -327,7 +327,7 @@ naming:
   ClassNaming:
     active: true
     excludes: ['**/test/**', '**/androidTest/**', '**/*.Test.kt', '**/*.Spec.kt', '**/*.Spek.kt']
-    classPattern: '[A-Z$][a-zA-Z0-9$]*'
+    classPattern: '[A-Z][a-zA-Z0-9]*'
   ConstructorParameterNaming:
     active: true
     excludes: ['**/test/**', '**/androidTest/**', '**/*.Test.kt', '**/*.Spec.kt', '**/*.Spek.kt']

--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -354,7 +354,7 @@ naming:
   FunctionNaming:
     active: true
     excludes: ['**/test/**', '**/androidTest/**', '**/*.Test.kt', '**/*.Spec.kt', '**/*.Spek.kt']
-    functionPattern: '^([a-z$][a-zA-Z$0-9]*)|(`.*`)$'
+    functionPattern: '([a-z][a-zA-Z0-9]*)|(`.*`)'
     excludeClassPattern: '$^'
     ignoreOverridden: true
   FunctionParameterNaming:

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ClassNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ClassNaming.kt
@@ -14,7 +14,7 @@ import org.jetbrains.kotlin.psi.KtClassOrObject
 /**
  * Reports when class or object names which do not follow the specified naming convention are used.
  *
- * @configuration classPattern - naming pattern (default: `'[A-Z$][a-zA-Z0-9$]*'`)
+ * @configuration classPattern - naming pattern (default: `'[A-Z][a-zA-Z0-9]*'`)
  * @active since v1.0.0
  */
 class ClassNaming(config: Config = Config.empty) : Rule(config) {
@@ -23,7 +23,7 @@ class ClassNaming(config: Config = Config.empty) : Rule(config) {
             Severity.Style,
             "A class or object's name should fit the naming pattern defined in the projects configuration.",
             debt = Debt.FIVE_MINS)
-    private val classPattern by LazyRegex(CLASS_PATTERN, "^[A-Z$][a-zA-Z0-9$]*")
+    private val classPattern by LazyRegex(CLASS_PATTERN, "[A-Z][a-zA-Z0-9]*")
 
     override fun visitClassOrObject(classOrObject: KtClassOrObject) {
         if (!classOrObject.identifierName().matches(classPattern)) {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNaming.kt
@@ -18,7 +18,7 @@ import org.jetbrains.kotlin.psi.KtNamedFunction
  * One exception are factory functions used to create instances of classes.
  * These factory functions can have the same name as the class being created.
  *
- * @configuration functionPattern - naming pattern (default: `'^([a-z$][a-zA-Z$0-9]*)|(`.*`)$'`)
+ * @configuration functionPattern - naming pattern (default: `'([a-z][a-zA-Z0-9]*)|(`.*`)'`)
  * @configuration excludeClassPattern - ignores functions in classes which match this regex (default: `'$^'`)
  * @configuration ignoreOverridden - ignores functions that have the override modifier (default: `true`)
  *
@@ -33,7 +33,7 @@ class FunctionNaming(config: Config = Config.empty) : Rule(config) {
             "Function names should follow the naming convention set in the configuration.",
             debt = Debt.FIVE_MINS)
 
-    private val functionPattern by LazyRegex(FUNCTION_PATTERN, "^([a-z$][a-zA-Z$0-9]*)|(`.*`)$")
+    private val functionPattern by LazyRegex(FUNCTION_PATTERN, "([a-z][a-zA-Z0-9]*)|(`.*`)")
     private val excludeClassPattern by LazyRegex(EXCLUDE_CLASS_PATTERN, "$^")
     private val ignoreOverridden = valueOrDefault(IGNORE_OVERRIDDEN, true)
 

--- a/docs/pages/documentation/naming.md
+++ b/docs/pages/documentation/naming.md
@@ -120,7 +120,7 @@ These factory functions can have the same name as the class being created.
 
 #### Configuration options:
 
-* ``functionPattern`` (default: ``'^([a-z$][a-zA-Z$0-9]*)|(`.*`)$'``)
+* ``functionPattern`` (default: ``'([a-z][a-zA-Z0-9]*)|(`.*`)'``)
 
    naming pattern
 

--- a/docs/pages/documentation/naming.md
+++ b/docs/pages/documentation/naming.md
@@ -18,7 +18,7 @@ Reports when class or object names which do not follow the specified naming conv
 
 #### Configuration options:
 
-* ``classPattern`` (default: ``'[A-Z$][a-zA-Z0-9$]*'``)
+* ``classPattern`` (default: ``'[A-Z][a-zA-Z0-9]*'``)
 
    naming pattern
 


### PR DESCRIPTION
This issue was spotted in #2656 (but it's not completely related with that issue).

Extracted from the issue:

> I just realised. Why do we allow classes with `$` in the name? It has little sense. The `$` is usually used by the annotation processors to create new classes. And they use that symbol to get a name that is not going to conflict with the user class names. Our tests didn't check the use of `$` neighter. And you can't use te symbol `$` if you don't use the char `. I think that it's safe to remove it.

I can't even write tests for this change because I can't create a name of a class with `$` if I'm not using `. And the use of ` in class names is exactly what is being talked in #2656. Right now we don't allow it.