### PR TITLE
Remove print statement in MandatoryBracesLoops

### DIFF
--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/MandatoryBracesLoops.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/MandatoryBracesLoops.kt
@@ -66,7 +66,6 @@ class MandatoryBracesLoops(config: Config = Config.empty) : Rule(config) {
 
     private fun hasNewLine(element: PsiElement?): Boolean =
             element?.siblings(forward = true, withItself = false)
-                    ?.map { println(it); it }
                     ?.filterIsInstance<PsiWhiteSpace>()
                     ?.firstOrNull { it.textContains('\n') } != null
 


### PR DESCRIPTION
This spams the console and shouldn't be used in productive code.
Thus, I removed the unnecessary statement altogether.
