### PR TITLE
Use compileAndLint instead of lint

### DIFF
--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/MandatoryBracesIfStatementsSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/MandatoryBracesIfStatementsSpec.kt
@@ -3,6 +3,7 @@ package io.gitlab.arturbosch.detekt.rules.style.optional
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.Case
 import io.gitlab.arturbosch.detekt.test.assertThat
+import io.gitlab.arturbosch.detekt.test.compileAndLint
 import io.gitlab.arturbosch.detekt.test.lint
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
@@ -13,33 +14,33 @@ class MandatoryBracesIfStatementsSpec : Spek({
     describe("reports multi-line if statements should have braces") {
 
         it("simple if") {
-            val findings = subject.lint("""
+            val findings = subject.compileAndLint("""
             fun f() {
                 if (true)
                     println()
             }
-            """.trimIndent())
+            """)
 
             assertThat(findings).hasSize(1)
             assertThat(findings).hasTextLocations(32 to 41)
         }
 
         it("if-else") {
-            val findings = subject.lint("""
+            val findings = subject.compileAndLint("""
             fun f() {
                 if (true)
                     println()
                 else
                     println()
             }
-            """.trimIndent())
+            """)
 
             assertThat(findings).hasSize(2)
             assertThat(findings).hasTextLocations(32 to 41, 59 to 68)
         }
 
         it("if-else with else-if") {
-            val findings = subject.lint("""
+            val findings = subject.compileAndLint("""
             fun f() {
                 if (true)
                     println()
@@ -48,28 +49,28 @@ class MandatoryBracesIfStatementsSpec : Spek({
                 else
                     println()
             }
-            """.trimIndent())
+            """)
 
             assertThat(findings).hasSize(3)
             assertThat(findings).hasTextLocations(32 to 41, 70 to 79, 97 to 106)
         }
 
         it("if with braces but else without") {
-            val findings = subject.lint("""
+            val findings = subject.compileAndLint("""
             fun f() {
                 if (true) {
                     println()
                 } else
                     println()
             }
-            """.trimIndent())
+            """)
 
             assertThat(findings).hasSize(1)
             assertThat(findings).hasTextLocations(63 to 72)
         }
 
         it("else with braces but if without") {
-            val findings = subject.lint("""
+            val findings = subject.compileAndLint("""
             fun f() {
                 if (true)
                     println()
@@ -77,31 +78,31 @@ class MandatoryBracesIfStatementsSpec : Spek({
                     println()
                 }
             }
-            """.trimIndent())
+            """)
 
             assertThat(findings).hasSize(1)
             assertThat(findings).hasTextLocations(32 to 41)
         }
 
         it("else in new line") {
-            val findings = subject.lint("""
+            val findings = subject.compileAndLint("""
             fun f() {
                 if (true) println()
                 else println()
             }
-            """.trimIndent())
+            """)
 
             assertThat(findings).hasSize(1)
             assertThat(findings).hasTextLocations(24 to 33)
         }
 
         it("only else body in new line") {
-            val findings = subject.lint("""
+            val findings = subject.compileAndLint("""
             fun f() {
                 if (true) println() else
                     println()
             }
-            """.trimIndent())
+            """)
 
             assertThat(findings).hasSize(1)
             assertThat(findings).hasTextLocations(47 to 56)


### PR DESCRIPTION
in MandatoryBracesIfStatementsSpec.
