### PR TITLE
Simplify patterns

### DIFF
--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -124,7 +124,7 @@ empty-blocks:
   active: true
   EmptyCatchBlock:
     active: true
-    allowedExceptionNameRegex: '^(_|(ignore|expected).*)'
+    allowedExceptionNameRegex: '_|(ignore|expected).*'
   EmptyClassBlock:
     active: true
   EmptyDefaultConstructor:
@@ -179,7 +179,7 @@ exceptions:
      - NumberFormatException
      - ParseException
      - MalformedURLException
-    allowedExceptionNameRegex: '^(_|(ignore|expected).*)'
+    allowedExceptionNameRegex: '_|(ignore|expected).*'
   ThrowingExceptionFromFinally:
     active: false
   ThrowingExceptionInMain:
@@ -204,7 +204,7 @@ exceptions:
      - IndexOutOfBoundsException
      - RuntimeException
      - Throwable
-    allowedExceptionNameRegex: '^(_|(ignore|expected).*)'
+    allowedExceptionNameRegex: '_|(ignore|expected).*'
   TooGenericExceptionThrown:
     active: true
     exceptionNames:
@@ -338,7 +338,7 @@ naming:
   EnumNaming:
     active: true
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**', '**/*.Test.kt', '**/*.Spec.kt', '**/*.Spek.kt']
-    enumEntryPattern: '^[A-Z][_a-zA-Z0-9]*'
+    enumEntryPattern: '[A-Z][_a-zA-Z0-9]*'
   ForbiddenClassName:
     active: false
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**', '**/*.Test.kt', '**/*.Spec.kt', '**/*.Spek.kt']
@@ -381,7 +381,7 @@ naming:
   PackageNaming:
     active: true
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**', '**/*.Test.kt', '**/*.Spec.kt', '**/*.Spek.kt']
-    packagePattern: '^[a-z]+(\.[a-z][A-Za-z0-9]*)*$'
+    packagePattern: '[a-z]+(\.[a-z][A-Za-z0-9]*)*'
   TopLevelPropertyNaming:
     active: true
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**', '**/*.Test.kt', '**/*.Spec.kt', '**/*.Spek.kt']

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/AllowedExceptionNamePattern.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/AllowedExceptionNamePattern.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules
 
 import org.jetbrains.kotlin.psi.KtCatchClause
 
-internal const val ALLOWED_EXCEPTION_NAME = "^(_|(ignore|expected).*)"
+internal const val ALLOWED_EXCEPTION_NAME = "_|(ignore|expected).*"
 
 internal fun KtCatchClause.isAllowedExceptionName(regex: Regex) =
     catchParameter?.identifierName()?.matches(regex) == true

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyCatchBlock.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyCatchBlock.kt
@@ -12,7 +12,7 @@ import org.jetbrains.kotlin.psi.KtCatchClause
  * by using the specified names in the `allowedExceptionNameRegex`.
  *
  * @configuration allowedExceptionNameRegex - ignores exception types which match this regex
- * (default: `'^(_|(ignore|expected).*)'`)
+ * (default: `'_|(ignore|expected).*'`)
  * @active since v1.0.0
  */
 class EmptyCatchBlock(config: Config) : EmptyRule(

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedException.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedException.kt
@@ -69,7 +69,7 @@ import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
  *            - ParseException
  *            - MalformedURLException`)
  * @configuration allowedExceptionNameRegex - ignores too generic exception types which match this regex
- * (default: `'^(_|(ignore|expected).*)'`)
+ * (default: `'_|(ignore|expected).*'`)
  */
 class SwallowedException(config: Config = Config.empty) : Rule(config) {
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionCaught.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionCaught.kt
@@ -44,7 +44,7 @@ import org.jetbrains.kotlin.psi.KtTypeReference
  *            - RuntimeException
  *            - Throwable`)
  * @configuration allowedExceptionNameRegex - ignores too generic exception types which match this regex
- * (default: `'^(_|(ignore|expected).*)'`)
+ * (default: `'_|(ignore|expected).*'`)
  * @active since v1.0.0
  */
 class TooGenericExceptionCaught(config: Config) : Rule(config) {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/EnumNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/EnumNaming.kt
@@ -14,7 +14,7 @@ import org.jetbrains.kotlin.psi.KtEnumEntry
 /**
  * Reports when enum names which do not follow the specified naming convention are used.
  *
- * @configuration enumEntryPattern - naming pattern (default: `'^[A-Z][_a-zA-Z0-9]*'`)
+ * @configuration enumEntryPattern - naming pattern (default: `'[A-Z][_a-zA-Z0-9]*'`)
  * @active since v1.0.0
  */
 class EnumNaming(config: Config = Config.empty) : Rule(config) {
@@ -24,7 +24,7 @@ class EnumNaming(config: Config = Config.empty) : Rule(config) {
             "Enum names should follow the naming convention set in the projects configuration.",
             debt = Debt.FIVE_MINS)
 
-    private val enumEntryPattern by LazyRegex(ENUM_PATTERN, "^[A-Z][_a-zA-Z0-9]*")
+    private val enumEntryPattern by LazyRegex(ENUM_PATTERN, "[A-Z][_a-zA-Z0-9]*")
 
     override fun visitEnumEntry(enumEntry: KtEnumEntry) {
         if (!enumEntry.identifierName().matches(enumEntryPattern)) {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/PackageNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/PackageNaming.kt
@@ -13,7 +13,7 @@ import org.jetbrains.kotlin.psi.KtPackageDirective
 /**
  * Reports when package names which do not follow the specified naming convention are used.
  *
- * @configuration packagePattern - naming pattern (default: `'^[a-z]+(\.[a-z][A-Za-z0-9]*)*$'`)
+ * @configuration packagePattern - naming pattern (default: `'[a-z]+(\.[a-z][A-Za-z0-9]*)*'`)
  * @active since v1.0.0
  */
 class PackageNaming(config: Config = Config.empty) : Rule(config) {
@@ -22,7 +22,7 @@ class PackageNaming(config: Config = Config.empty) : Rule(config) {
             Severity.Style,
             "Package names should match the naming convention set in the configuration.",
             debt = Debt.FIVE_MINS)
-    private val packagePattern by LazyRegex(PACKAGE_PATTERN, "^[a-z]+(\\.[a-z][A-Za-z0-9]*)*$")
+    private val packagePattern by LazyRegex(PACKAGE_PATTERN, "[a-z]+(\\.[a-z][A-Za-z0-9]*)*")
 
     override fun visitPackageDirective(directive: KtPackageDirective) {
         val name = directive.qualifiedName

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiterals.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiterals.kt
@@ -41,7 +41,7 @@ class UnderscoresInNumericLiterals(config: Config = Config.empty) : Rule(config)
                     "should be underscore separated to increase readability. Underscores that do not make groups of " +
                     "3 digits are also reported.", Debt.FIVE_MINS)
 
-    private val underscoreNumberRegex = Regex("^[0-9]{1,3}(_[0-9]{3})*\$")
+    private val underscoreNumberRegex = Regex("[0-9]{1,3}(_[0-9]{3})*")
 
     private val acceptableDecimalLength = valueOrDefault(ACCEPTABLE_DECIMAL_LENGTH, DEFAULT_ACCEPTABLE_DECIMAL_LENGTH)
 

--- a/docs/pages/documentation/empty-blocks.md
+++ b/docs/pages/documentation/empty-blocks.md
@@ -21,7 +21,7 @@ by using the specified names in the `allowedExceptionNameRegex`.
 
 #### Configuration options:
 
-* ``allowedExceptionNameRegex`` (default: ``'^(_|(ignore|expected).*)'``)
+* ``allowedExceptionNameRegex`` (default: ``'_|(ignore|expected).*'``)
 
    ignores exception types which match this regex
 

--- a/docs/pages/documentation/exceptions.md
+++ b/docs/pages/documentation/exceptions.md
@@ -221,7 +221,7 @@ passed into a newly thrown exception.
 
    exception types which should be ignored by this rule
 
-* ``allowedExceptionNameRegex`` (default: ``'^(_|(ignore|expected).*)'``)
+* ``allowedExceptionNameRegex`` (default: ``'_|(ignore|expected).*'``)
 
    ignores too generic exception types which match this regex
 
@@ -400,7 +400,7 @@ exception is too broad it can lead to unintended exceptions being caught.
 
    exceptions which are too generic and should not be caught
 
-* ``allowedExceptionNameRegex`` (default: ``'^(_|(ignore|expected).*)'``)
+* ``allowedExceptionNameRegex`` (default: ``'_|(ignore|expected).*'``)
 
    ignores too generic exception types which match this regex
 

--- a/docs/pages/documentation/naming.md
+++ b/docs/pages/documentation/naming.md
@@ -58,7 +58,7 @@ Reports when enum names which do not follow the specified naming convention are 
 
 #### Configuration options:
 
-* ``enumEntryPattern`` (default: ``'^[A-Z][_a-zA-Z0-9]*'``)
+* ``enumEntryPattern`` (default: ``'[A-Z][_a-zA-Z0-9]*'``)
 
    naming pattern
 
@@ -299,7 +299,7 @@ Reports when package names which do not follow the specified naming convention a
 
 #### Configuration options:
 
-* ``packagePattern`` (default: ``'^[a-z]+(\.[a-z][A-Za-z0-9]*)*$'``)
+* ``packagePattern`` (default: ``'[a-z]+(\.[a-z][A-Za-z0-9]*)*'``)
 
    naming pattern
 


### PR DESCRIPTION
We are using `^` and `$` to match the start or end of a `String` but we don't need it. We are using `.matches` that ensure that we are maching all the `String`.