### PR TITLE
GuardCluase also matches if-with-body that contains a return

### DIFF
--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/GuardClauses.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/GuardClauses.kt
@@ -7,6 +7,7 @@ import org.jetbrains.kotlin.psi.KtIfExpression
 import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.KtReturnExpression
 import org.jetbrains.kotlin.psi.psiUtil.findDescendantOfType
+import org.jetbrains.kotlin.psi.psiUtil.lastBlockStatementOrThis
 
 fun KtNamedFunction.yieldStatementsSkippingGuardClauses(): Sequence<KtExpression> = sequence {
     var firstNonGuardFound = false
@@ -24,9 +25,12 @@ fun KtNamedFunction.yieldStatementsSkippingGuardClauses(): Sequence<KtExpression
 
 fun KtExpression.isGuardClause(): Boolean {
 
-    fun KtReturnExpression.isIfConditionGuardClause(ancestorExpression: KtExpression): Boolean {
-        val ifExpr = ancestorExpression as? KtIfExpression
-        return ifExpr != null && ifExpr.`else` == null
+    fun isIfConditionGuardClause(returnExpr: KtReturnExpression): Boolean {
+        val ifExpr = this as? KtIfExpression
+            ?: return false
+
+        return ifExpr.`else` == null &&
+                returnExpr === ifExpr.then?.lastBlockStatementOrThis()
     }
 
     fun KtReturnExpression.isElvisOperatorGuardClause(): Boolean {
@@ -35,5 +39,5 @@ fun KtExpression.isGuardClause(): Boolean {
     }
 
     val returnExpr = this.findDescendantOfType<KtReturnExpression>() ?: return false
-    return returnExpr.isIfConditionGuardClause(this) || returnExpr.isElvisOperatorGuardClause()
+    return isIfConditionGuardClause(returnExpr) || returnExpr.isElvisOperatorGuardClause()
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/GuardClauses.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/GuardClauses.kt
@@ -24,8 +24,8 @@ fun KtNamedFunction.yieldStatementsSkippingGuardClauses(): Sequence<KtExpression
 
 fun KtExpression.isGuardClause(): Boolean {
 
-    fun KtReturnExpression.isIfConditionGuardClause(): Boolean {
-        val ifExpr = this.parent?.parent as? KtIfExpression
+    fun KtReturnExpression.isIfConditionGuardClause(ancestorExpression: KtExpression): Boolean {
+        val ifExpr = ancestorExpression as? KtIfExpression
         return ifExpr != null && ifExpr.`else` == null
     }
 
@@ -35,5 +35,5 @@ fun KtExpression.isGuardClause(): Boolean {
     }
 
     val returnExpr = this.findDescendantOfType<KtReturnExpression>() ?: return false
-    return returnExpr.isIfConditionGuardClause() || returnExpr.isElvisOperatorGuardClause()
+    return returnExpr.isIfConditionGuardClause(this) || returnExpr.isElvisOperatorGuardClause()
 }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCountSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCountSpec.kt
@@ -29,6 +29,28 @@ class ReturnCountSpec : Spek({
             }
         }
 
+        context("a file with an if condition guard clause with body and 2 returns") {
+            val code = """
+            fun test(x: Int): Int {
+                if (x < 4) {
+                    logger.debug("x is less than 4")
+                    return 0
+                }
+                when (x) {
+                    5 -> return 5
+                    4 -> return 4
+                }
+            }
+        """
+
+            it("should not get flagged for if condition guard clauses") {
+                val findings = ReturnCount(TestConfig(mapOf(ReturnCount.EXCLUDE_GUARD_CLAUSES to "true")))
+                    .lint(code)
+                assertThat(findings).isEmpty()
+            }
+        }
+
+
         context("a file with an ELVIS operator guard clause and 2 returns") {
             val code = """
             fun test(x: Int): Int {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCountSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCountSpec.kt
@@ -16,15 +16,16 @@ class ReturnCountSpec : Spek({
             fun test(x: Int): Int {
                 if (x < 4) return 0
                 when (x) {
-                    5 -> return 5
+                    5 -> println("x=5")
                     4 -> return 4
                 }
+                return 6
             }
         """
 
             it("should not get flagged for if condition guard clauses") {
                 val findings = ReturnCount(TestConfig(mapOf(ReturnCount.EXCLUDE_GUARD_CLAUSES to "true")))
-                    .lint(code)
+                    .compileAndLint(code)
                 assertThat(findings).isEmpty()
             }
         }
@@ -37,9 +38,10 @@ class ReturnCountSpec : Spek({
                     return 0
                 }
                 when (x) {
-                    5 -> return 5
+                    5 -> println("x=5")
                     4 -> return 4
                 }
+                return 6
             }
         """
 
@@ -69,9 +71,10 @@ class ReturnCountSpec : Spek({
                     return 0
                 }
                 when (x) {
-                    5 -> return 5
+                    5 -> println("x=5")
                     4 -> return 4
                 }
+                return 6
             }
         """
 
@@ -96,15 +99,16 @@ class ReturnCountSpec : Spek({
             fun test(x: Int): Int {
                 val y = x ?: return 0
                 when (x) {
-                    5 -> return 5
+                    5 -> println("x=5")
                     4 -> return 4
                 }
+                return 6
             }
         """
 
             it("should not get flagged for ELVIS operator guard clauses") {
                 val findings = ReturnCount(TestConfig(mapOf(ReturnCount.EXCLUDE_GUARD_CLAUSES to "true")))
-                    .lint(code)
+                    .compileAndLint(code)
                 assertThat(findings).isEmpty()
             }
         }
@@ -113,16 +117,17 @@ class ReturnCountSpec : Spek({
             val code = """
             fun test(x: Int): Int {
                 when (x) {
-                    5 -> return 5
+                    5 -> println("x=5")
                     4 -> return 4
                 }
                 if (x < 4) return 0
+                return 6
             }
         """
 
             it("should get flagged for an if condition guard clause which is not the first statement") {
                 val findings = ReturnCount(TestConfig(mapOf(ReturnCount.EXCLUDE_GUARD_CLAUSES to "true")))
-                    .lint(code)
+                    .compileAndLint(code)
                 assertThat(findings).hasSize(1)
             }
         }
@@ -131,16 +136,17 @@ class ReturnCountSpec : Spek({
             val code = """
             fun test(x: Int): Int {
                 when (x) {
-                    5 -> return 5
+                    5 -> println("x=5")
                     4 -> return 4
                 }
                 val y = x ?: return 0
+                return 6
             }
         """
 
             it("should get flagged for an ELVIS guard clause which is not the first statement") {
                 val findings = ReturnCount(TestConfig(mapOf(ReturnCount.EXCLUDE_GUARD_CLAUSES to "true")))
-                    .lint(code)
+                    .compileAndLint(code)
                 assertThat(findings).hasSize(1)
             }
         }
@@ -179,25 +185,26 @@ class ReturnCountSpec : Spek({
             val code = """
             fun test(x: Int): Int {
                 when (x) {
-                    5 -> return 5
+                    5 -> println("x=5")
                     4 -> return 4
                     3 -> return 3
                 }
+                return 6
             }
         """
 
             it("should get flagged by default") {
-                val findings = ReturnCount().lint(code)
+                val findings = ReturnCount().compileAndLint(code)
                 assertThat(findings).hasSize(1)
             }
 
             it("should not get flagged when max value is 3") {
-                val findings = ReturnCount(TestConfig(mapOf(ReturnCount.MAX to "3"))).lint(code)
+                val findings = ReturnCount(TestConfig(mapOf(ReturnCount.MAX to "3"))).compileAndLint(code)
                 assertThat(findings).isEmpty()
             }
 
             it("should get flagged when max value is 1") {
-                val findings = ReturnCount(TestConfig(mapOf(ReturnCount.MAX to "1"))).lint(code)
+                val findings = ReturnCount(TestConfig(mapOf(ReturnCount.MAX to "1"))).compileAndLint(code)
                 assertThat(findings).hasSize(1)
             }
         }
@@ -206,24 +213,25 @@ class ReturnCountSpec : Spek({
             val code = """
             fun test(x: Int): Int {
                 when (x) {
-                    5 -> return 5
+                    5 -> println("x=5")
                     4 -> return 4
                 }
+                return 6
             }
         """
 
             it("should not get flagged by default") {
-                val findings = ReturnCount().lint(code)
+                val findings = ReturnCount().compileAndLint(code)
                 assertThat(findings).isEmpty()
             }
 
             it("should not get flagged when max value is 2") {
-                val findings = ReturnCount(TestConfig(mapOf(ReturnCount.MAX to "2"))).lint(code)
+                val findings = ReturnCount(TestConfig(mapOf(ReturnCount.MAX to "2"))).compileAndLint(code)
                 assertThat(findings).isEmpty()
             }
 
             it("should get flagged when max value is 1") {
-                val findings = ReturnCount(TestConfig(mapOf(ReturnCount.MAX to "1"))).lint(code)
+                val findings = ReturnCount(TestConfig(mapOf(ReturnCount.MAX to "1"))).compileAndLint(code)
                 assertThat(findings).hasSize(1)
             }
         }
@@ -232,10 +240,11 @@ class ReturnCountSpec : Spek({
             val code = """
             fun test(x: Int): Int {
                 when (x) {
-                    5 -> return 5
+                    5 -> println("x=5")
                     4 -> return 4
                     3 -> return 3
                 }
+                return 6
             }
         """
 
@@ -243,7 +252,7 @@ class ReturnCountSpec : Spek({
                 val findings = ReturnCount(TestConfig(mapOf(
                     ReturnCount.MAX to "2",
                     ReturnCount.EXCLUDED_FUNCTIONS to "test")
-                )).lint(code)
+                )).compileAndLint(code)
                 assertThat(findings).isEmpty()
             }
         }
@@ -252,26 +261,29 @@ class ReturnCountSpec : Spek({
             val code = """
             fun test1(x: Int): Int {
                 when (x) {
-                    5 -> return 5
+                    5 -> println("x=5")
                     4 -> return 4
                     3 -> return 3
                 }
+                return 6
             }
 
             fun test2(x: Int): Int {
                 when (x) {
-                    5 -> return 5
+                    5 -> println("x=5")
                     4 -> return 4
                     3 -> return 3
                 }
+                return 6
             }
 
             fun test3(x: Int): Int {
                 when (x) {
-                    5 -> return 5
+                    5 -> println("x=5")
                     4 -> return 4
                     3 -> return 3
                 }
+                return 6
             }
         """
 
@@ -279,7 +291,7 @@ class ReturnCountSpec : Spek({
                 val findings = ReturnCount(TestConfig(mapOf(
                     ReturnCount.MAX to "2",
                     ReturnCount.EXCLUDED_FUNCTIONS to "test1,test2")
-                )).lint(code)
+                )).compileAndLint(code)
                 assertThat(findings).hasSize(1)
             }
         }
@@ -290,20 +302,22 @@ class ReturnCountSpec : Spek({
                 val a = object {
                     fun test2(x: Int): Int {
                         when (x) {
-                            5 -> return 5
+                            5 -> println("x=5")
                             else -> return 0
                         }
+                        return 6
                     }
                 }
                 when (x) {
-                    5 -> return 5
+                    5 -> println("x=5")
                     else -> return 0
                 }
+                return 6
             }
         """
 
             it("should not get flag when returns is in inner object") {
-                val findings = ReturnCount(TestConfig(mapOf(ReturnCount.MAX to "2"))).lint(code)
+                val findings = ReturnCount(TestConfig(mapOf(ReturnCount.MAX to "2"))).compileAndLint(code)
                 assertThat(findings).isEmpty()
             }
         }
@@ -316,26 +330,29 @@ class ReturnCountSpec : Spek({
                         val b = object {
                             fun test3(x: Int): Int {
                                 when (x) {
-                                    5 -> return 5
+                                    5 -> println("x=5")
                                     else -> return 0
                                 }
+                                return 6
                             }
                         }
                         when (x) {
-                            5 -> return 5
+                            5 -> println("x=5")
                             else -> return 0
                         }
+                        return 6
                     }
                 }
                 when (x) {
-                    5 -> return 5
+                    5 -> println("x=5")
                     else -> return 0
                 }
+                return 6
             }
         """
 
             it("should not get flag when returns is in inner object") {
-                val findings = ReturnCount(TestConfig(mapOf(ReturnCount.MAX to "2"))).lint(code)
+                val findings = ReturnCount(TestConfig(mapOf(ReturnCount.MAX to "2"))).compileAndLint(code)
                 assertThat(findings).isEmpty()
             }
         }
@@ -348,28 +365,31 @@ class ReturnCountSpec : Spek({
                         val b = object {
                             fun test3(x: Int): Int {
                                 when (x) {
-                                    5 -> return 5
+                                    5 -> println("x=5")
                                     else -> return 0
                                 }
+                                return 6
                             }
                         }
                         when (x) {
-                            5 -> return 5
+                            5 -> println("x=5")
                             else -> return 0
                         }
+                        return 6
                     }
                 }
                 when (x) {
-                    5 -> return 5
+                    5 -> println("x=5")
                     4 -> return 4
                     3 -> return 3
                     else -> return 0
                 }
+                return 6
             }
         """
 
             it("should get flagged when returns is in inner object") {
-                val findings = ReturnCount(TestConfig(mapOf(ReturnCount.MAX to "2"))).lint(code)
+                val findings = ReturnCount(TestConfig(mapOf(ReturnCount.MAX to "2"))).compileAndLint(code)
                 assertThat(findings).hasSize(1)
             }
         }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCountSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCountSpec.kt
@@ -45,7 +45,7 @@ class ReturnCountSpec : Spek({
 
             it("should not get flagged for if condition guard clauses") {
                 val findings = ReturnCount(TestConfig(mapOf(ReturnCount.EXCLUDE_GUARD_CLAUSES to "true")))
-                    .lint(code)
+                    .compileAndLint(code)
                 assertThat(findings).isEmpty()
             }
         }


### PR DESCRIPTION
@arturbosch 
I thought opening a PR was better than opening an Issue.
Although, I didn't properly test it yet - I'm new to gradle and Spek.
If you prefere, I can open an issue instead...

What I want -
to consider an `if` with a body as guard clause as well.
I've added a test-case to demonstrate.

In my company, we almost disabled `ReturnCount` because it catches guard-clauses, and then I saw guard-clauses - and was disappointed it applies only to `if`s without a body.
Our code-style convention don't allow if's without body.