### PR TITLE
Fix serialVersionUID false positive in UnderscoresInNumericLiteral

### DIFF
--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiteralsSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiteralsSpec.kt
@@ -231,6 +231,54 @@ class UnderscoresInNumericLiteralsSpec : Spek({
         }
     }
 
+    describe("a property named serialVersionUID in a companion object inside a serializable class") {
+
+        it("does not report a negative serialVersionUID number") {
+            val code = """
+                class Test : Serializable {
+                    companion object {
+                        private const val serialVersionUID = -43857148126114372L
+                    }
+                }"""
+            val findings = UnderscoresInNumericLiterals().lint(code)
+            assertThat(findings).hasSize(0)
+        }
+
+        it("does not report a positive serialVersionUID number") {
+            val code = """
+                class Test : Serializable {
+                    companion object {
+                        private const val serialVersionUID = 43857148126114372L
+                    }
+                }"""
+            val findings = UnderscoresInNumericLiterals().lint(code)
+            assertThat(findings).hasSize(0)
+        }
+    }
+
+    describe("a property named serialVersionUID number in a serializable class") {
+
+        it("does not report a negative serialVersionUID number") {
+            val code = """
+                class Test : Serializable {
+                    private const val serialVersionUID = -43857148126114372L
+                }
+            """
+            val findings = UnderscoresInNumericLiterals().lint(code)
+            assertThat(findings).hasSize(0)
+        }
+
+        it("does not report a positive serialVersionUID number") {
+            val code = """
+                class Test : Serializable {
+                    private const val serialVersionUID = 43857148126114372L
+                }
+            """
+            val findings = UnderscoresInNumericLiterals().lint(code)
+            assertThat(findings).hasSize(0)
+        }
+    }
+
     describe("an Int of 10000") {
         val code = "val myInt = 10000"
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiteralsSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiteralsSpec.kt
@@ -2,6 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
+import io.gitlab.arturbosch.detekt.test.compileAndLint
 import io.gitlab.arturbosch.detekt.test.lint
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
@@ -12,14 +13,14 @@ class UnderscoresInNumericLiteralsSpec : Spek({
         val code = "val myInt = 1000"
 
         it("should not be reported by default") {
-            val findings = UnderscoresInNumericLiterals().lint(code)
+            val findings = UnderscoresInNumericLiterals().compileAndLint(code)
             assertThat(findings).isEmpty()
         }
 
         it("should be reported if acceptableDecimalLength is 4") {
             val findings = UnderscoresInNumericLiterals(
                     TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "4"))
-            ).lint(code)
+            ).compileAndLint(code)
             assertThat(findings).isNotEmpty
         }
     }
@@ -28,23 +29,23 @@ class UnderscoresInNumericLiteralsSpec : Spek({
         val code = "val myInt = 1_000_000"
 
         it("should not be reported") {
-            val findings = UnderscoresInNumericLiterals().lint(code)
+            val findings = UnderscoresInNumericLiterals().compileAndLint(code)
             assertThat(findings).isEmpty()
         }
     }
 
     describe("a const Int of 1000000") {
-        val code = "const val myInt = 1000000"
+        val code = "val myInt = 1000000"
 
         it("should be reported by default") {
-            val findings = UnderscoresInNumericLiterals().lint(code)
+            val findings = UnderscoresInNumericLiterals().compileAndLint(code)
             assertThat(findings).isNotEmpty
         }
 
         it("should not be reported if acceptableDecimalLength is 8") {
             val findings = UnderscoresInNumericLiterals(
                     TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "8"))
-            ).lint(code)
+            ).compileAndLint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -53,14 +54,14 @@ class UnderscoresInNumericLiteralsSpec : Spek({
         val code = "val myFloat = 1000f"
 
         it("should not be reported by default") {
-            val findings = UnderscoresInNumericLiterals().lint(code)
+            val findings = UnderscoresInNumericLiterals().compileAndLint(code)
             assertThat(findings).isEmpty()
         }
 
         it("should be reported if acceptableDecimalLength is 4") {
             val findings = UnderscoresInNumericLiterals(
                     TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "4"))
-            ).lint(code)
+            ).compileAndLint(code)
             assertThat(findings).isNotEmpty
         }
     }
@@ -69,39 +70,39 @@ class UnderscoresInNumericLiteralsSpec : Spek({
         val code = "val myFloat = -1000f"
 
         it("should not be reported by default") {
-            val findings = UnderscoresInNumericLiterals().lint(code)
+            val findings = UnderscoresInNumericLiterals().compileAndLint(code)
             assertThat(findings).isEmpty()
         }
 
         it("should be reported if acceptableDecimalLength is 4") {
             val findings = UnderscoresInNumericLiterals(
                     TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "4"))
-            ).lint(code)
+            ).compileAndLint(code)
             assertThat(findings).isNotEmpty
         }
     }
 
     describe("a Float of -1_000f") {
-        val code = "const val myFloat = -1_000f"
+        val code = "val myFloat = -1_000f"
 
         it("should not be reported") {
-            val findings = UnderscoresInNumericLiterals().lint(code)
+            val findings = UnderscoresInNumericLiterals().compileAndLint(code)
             assertThat(findings).isEmpty()
         }
     }
 
     describe("a Long of 1000000L") {
-        val code = "const val myLong = 1000000L"
+        val code = "val myLong = 1000000L"
 
         it("should be reported by default") {
-            val findings = UnderscoresInNumericLiterals().lint(code)
+            val findings = UnderscoresInNumericLiterals().compileAndLint(code)
             assertThat(findings).isNotEmpty
         }
 
         it("should not be reported if ignored acceptableDecimalLength is 8") {
             val findings = UnderscoresInNumericLiterals(
                     TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "8"))
-            ).lint(code)
+            ).compileAndLint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -110,7 +111,7 @@ class UnderscoresInNumericLiteralsSpec : Spek({
         val code = "val myDouble = 1_000_000.00_000_000"
 
         it("should not be reported") {
-            val findings = UnderscoresInNumericLiterals().lint(code)
+            val findings = UnderscoresInNumericLiterals().compileAndLint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -119,14 +120,14 @@ class UnderscoresInNumericLiteralsSpec : Spek({
         val code = "fun testFunction(testParam: Int = 1000) {}"
 
         it("should not be reported by default") {
-            val findings = UnderscoresInNumericLiterals().lint(code)
+            val findings = UnderscoresInNumericLiterals().compileAndLint(code)
             assertThat(findings).isEmpty()
         }
 
         it("should be reported if acceptableDecimalLength is 4") {
             val findings = UnderscoresInNumericLiterals(
                     TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "4"))
-            ).lint(code)
+            ).compileAndLint(code)
             assertThat(findings).isNotEmpty
         }
     }
@@ -150,57 +151,59 @@ class UnderscoresInNumericLiteralsSpec : Spek({
     }
 
     describe("an Int of 10_00_00") {
-        val code = "const val myInt = 10_00_00"
+        val code = "val myInt = 10_00_00"
 
         it("should be reported by default") {
-            val findings = UnderscoresInNumericLiterals().lint(code)
+            val findings = UnderscoresInNumericLiterals().compileAndLint(code)
             assertThat(findings).isNotEmpty
         }
 
         it("should still be reported even if acceptableDecimalLength is 7") {
             val findings = UnderscoresInNumericLiterals(
                     TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "7"))
-            ).lint(code)
+            ).compileAndLint(code)
             assertThat(findings).isNotEmpty
         }
     }
 
     describe("a binary Int of 0b1011") {
-        val code = "const val myBinInt = 0b1011"
+        val code = "val myBinInt = 0b1011"
 
         it("should not be reported") {
-            val findings = UnderscoresInNumericLiterals().lint(code)
+            val findings = UnderscoresInNumericLiterals().compileAndLint(code)
             assertThat(findings).isEmpty()
         }
     }
 
     describe("a hexadecimal Int of 0x1facdf") {
-        val code = "const val myHexInt = 0x1facdf"
+        val code = "val myHexInt = 0x1facdf"
 
         it("should not be reported") {
-            val findings = UnderscoresInNumericLiterals().lint(code)
+            val findings = UnderscoresInNumericLiterals().compileAndLint(code)
             assertThat(findings).isEmpty()
         }
     }
 
     describe("a hexadecimal Int of 0xFFFFFF") {
-        val code = "const val myHexInt = 0xFFFFFF"
+        val code = "val myHexInt = 0xFFFFFF"
 
         it("should not be reported") {
-            val findings = UnderscoresInNumericLiterals().lint(code)
+            val findings = UnderscoresInNumericLiterals().compileAndLint(code)
             assertThat(findings).isEmpty()
         }
     }
 
     describe("a property named serialVersionUID in an object that implements Serializable") {
         val code = """
+            import java.io.Serializable
+            
             object TestSerializable : Serializable {
                 private val serialVersionUID = 314159L
             }
         """
 
         it("should not be reported") {
-            val findings = UnderscoresInNumericLiterals().lint(code)
+            val findings = UnderscoresInNumericLiterals().compileAndLint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -213,7 +216,7 @@ class UnderscoresInNumericLiteralsSpec : Spek({
         """
 
         it("should be reported by default") {
-            val findings = UnderscoresInNumericLiterals().lint(code)
+            val findings = UnderscoresInNumericLiterals().compileAndLint(code)
             assertThat(findings).isNotEmpty
         }
     }
@@ -226,7 +229,7 @@ class UnderscoresInNumericLiteralsSpec : Spek({
         """
 
         it("should not be reported") {
-            val findings = UnderscoresInNumericLiterals().lint(code)
+            val findings = UnderscoresInNumericLiterals().compileAndLint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -235,23 +238,27 @@ class UnderscoresInNumericLiteralsSpec : Spek({
 
         it("does not report a negative serialVersionUID number") {
             val code = """
+                import java.io.Serializable
+                
                 class Test : Serializable {
                     companion object {
                         private const val serialVersionUID = -43857148126114372L
                     }
                 }"""
-            val findings = UnderscoresInNumericLiterals().lint(code)
+            val findings = UnderscoresInNumericLiterals().compileAndLint(code)
             assertThat(findings).hasSize(0)
         }
 
         it("does not report a positive serialVersionUID number") {
             val code = """
+                import java.io.Serializable
+                
                 class Test : Serializable {
                     companion object {
                         private const val serialVersionUID = 43857148126114372L
                     }
                 }"""
-            val findings = UnderscoresInNumericLiterals().lint(code)
+            val findings = UnderscoresInNumericLiterals().compileAndLint(code)
             assertThat(findings).hasSize(0)
         }
     }
@@ -260,21 +267,25 @@ class UnderscoresInNumericLiteralsSpec : Spek({
 
         it("does not report a negative serialVersionUID number") {
             val code = """
+                import java.io.Serializable
+                
                 class Test : Serializable {
-                    private const val serialVersionUID = -43857148126114372L
+                    private val serialVersionUID = -43857148126114372L
                 }
             """
-            val findings = UnderscoresInNumericLiterals().lint(code)
+            val findings = UnderscoresInNumericLiterals().compileAndLint(code)
             assertThat(findings).hasSize(0)
         }
 
         it("does not report a positive serialVersionUID number") {
             val code = """
+                import java.io.Serializable
+                
                 class Test : Serializable {
-                    private const val serialVersionUID = 43857148126114372L
+                    private val serialVersionUID = 43857148126114372L
                 }
             """
-            val findings = UnderscoresInNumericLiterals().lint(code)
+            val findings = UnderscoresInNumericLiterals().compileAndLint(code)
             assertThat(findings).hasSize(0)
         }
     }
@@ -283,14 +294,14 @@ class UnderscoresInNumericLiteralsSpec : Spek({
         val code = "val myInt = 10000"
 
         it("should be reported by default") {
-            val findings = UnderscoresInNumericLiterals().lint(code)
+            val findings = UnderscoresInNumericLiterals().compileAndLint(code)
             assertThat(findings).isNotEmpty
         }
 
         it("should not be reported if acceptableDecimalLength is 6") {
             val findings = UnderscoresInNumericLiterals(
                     TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "6"))
-            ).lint(code)
+            ).compileAndLint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -299,7 +310,7 @@ class UnderscoresInNumericLiteralsSpec : Spek({
         val code = "val myFloat = 30_000_000.1415926535897932385f"
 
         it("should not be reported") {
-            val findings = UnderscoresInNumericLiterals().lint(code)
+            val findings = UnderscoresInNumericLiterals().compileAndLint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -308,7 +319,7 @@ class UnderscoresInNumericLiteralsSpec : Spek({
         val code = "val myDouble = 3.1415926535897932385"
 
         it("should not be reported") {
-            val findings = UnderscoresInNumericLiterals().lint(code)
+            val findings = UnderscoresInNumericLiterals().compileAndLint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -319,7 +330,7 @@ class UnderscoresInNumericLiteralsSpec : Spek({
         it("should be reported if acceptableDecimalLength is 4") {
             val findings = UnderscoresInNumericLiterals(
                 TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "4"))
-            ).lint(code)
+            ).compileAndLint(code)
             assertThat(findings).isNotEmpty
         }
     }
@@ -328,14 +339,14 @@ class UnderscoresInNumericLiteralsSpec : Spek({
         val code = "val myFloat = 1000000.31415926535f"
 
         it("should be reported by default") {
-            val findings = UnderscoresInNumericLiterals().lint(code)
+            val findings = UnderscoresInNumericLiterals().compileAndLint(code)
             assertThat(findings).isNotEmpty
         }
 
         it("should not be reported if acceptableDecimalLength is 8") {
             val findings = UnderscoresInNumericLiterals(
                 TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "8"))
-            ).lint(code)
+            ).compileAndLint(code)
             assertThat(findings).isEmpty()
         }
     }


### PR DESCRIPTION
This fixes the cases where a serialVersionUID
1. has either a negative number
2. is inside a companion object
3. or both

Closes #2686