### PR TITLE
Add -v shortcut for version flag

### DIFF
--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt
@@ -174,7 +174,7 @@ class CliArgs : Args {
     var jvmTarget: JvmTarget = JvmTarget.DEFAULT
 
     @Parameter(
-        names = ["--version"],
+        names = ["--version", "-v"],
         description = "Prints the detekt CLI version."
     )
     var showVersion: Boolean = false


### PR DESCRIPTION
`-v` is a commonly used shortcut for --version in many cli tools.