### PR TITLE
Fix wrong test cases for CollapsibleIfs rule

### DIFF
--- a/detekt-rules/src/test/resources/cases/CollapsibleIfsNegative.kt
+++ b/detekt-rules/src/test/resources/cases/CollapsibleIfsNegative.kt
@@ -3,52 +3,33 @@ package cases
 @Suppress("unused", "ConstantConditionIf", "SimplifyBooleanWithConstants", "RedundantSemicolon")
 fun collapsibleIfsNegative() {
 
-    if (true) {
-    } else if (1 == 1) {
-        if (true) {
-        }
+    if (true) {}
+    else if (1 == 1) {
+        if (true) {}
     }
 
     if (true) {
-        if (1 == 1) {
-        }
-    } else {
-    }
+        if (1 == 1) {}
+    } else {}
 
     if (true) {
-        if (1 == 1) {
-        }
-    } else if (false) {
-    } else {
-    }
+        if (1 == 1) {}
+    } else if (false) {}
+    else {}
 
 
     if (true) {
-        if (1 == 1);
+        if (1 == 1) ;
         println()
     }
 
     if (true) {
         if (1 == 1) {
-        } else {
-        }
+        } else {}
     }
 
     if (true) {
         if (1 == 1) {
-        } else if (2 == 2) {
-        }
-    }
-
-    if (true) {
-        if (1 == 1) {
-        }
-        println()
-    }
-
-    if (true) {
-        println()
-        if (1 == 1) {
-        }
+        } else if (2 == 2) {}
     }
 }

--- a/detekt-rules/src/test/resources/cases/CollapsibleIfsPositive.kt
+++ b/detekt-rules/src/test/resources/cases/CollapsibleIfsPositive.kt
@@ -4,15 +4,13 @@ package cases
 fun collapsibleIfsPositive() {
 
     if (true) { // reports 1 - if statements could be merged
-        if (1 == 1) {
-        }
+        if (1 == 1) {}
         // a comment
     }
 
     if (true) {
         if (1 == 1) { // reports 1 - if statements could be merged
-            if (2 == 2) {
-            }
+            if (2 == 2) {}
         }
         println()
     }


### PR DESCRIPTION
The test case was wrong due to the code reformatting happening in commit 445ffb0.
