### PR TITLE
New Rule: IgnoredReturnValue

### DIFF
--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -431,6 +431,8 @@ potential-bugs:
     active: true
   HasPlatformType:
     active: false
+  IgnoredReturnValue:
+    active: false
   ImplicitDefaultLocale:
     active: false
   InvalidRange:

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValue.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValue.kt
@@ -7,15 +7,20 @@ import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
-import org.jetbrains.kotlin.psi.KtBinaryExpression
+import org.jetbrains.kotlin.com.intellij.psi.PsiComment
+import org.jetbrains.kotlin.com.intellij.psi.PsiElement
+import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
+import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
+import org.jetbrains.kotlin.lexer.KtSingleValueToken
 import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
 import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.calls.callUtil.getResolvedCall
 import org.jetbrains.kotlin.types.typeUtil.isUnit
 
 /**
  * The Kotlin compiler gives no warning for when a function which returns a value is called but its returned
- * value is ignored.  This rule warns on instances where a function returns a value but that value is not
+ * value is ignored. This rule warns on instances where a function returns a value but that value is not
  * used in any way.
  *
  * fun returnsValue() = 42
@@ -34,7 +39,7 @@ class IgnoredReturnValue(config: Config = Config.empty) : Rule(config) {
     override val issue: Issue = Issue(
         "IgnoredReturnValue",
         Severity.Defect,
-        "This call returns a value which has been ignored",
+        "This call returns a value which is ignored",
         Debt.TWENTY_MINS
     )
 
@@ -45,12 +50,45 @@ class IgnoredReturnValue(config: Config = Config.empty) : Rule(config) {
         if (bindingContext == BindingContext.EMPTY) return
         val resolvedCall = expression.getResolvedCall(bindingContext) ?: return
         val returnType = resolvedCall.resultingDescriptor.returnType ?: return
+
         if (returnType.isUnit()) {
             return
         }
-        // If this is part of a binary expression, then its return value is being checked
-        if (expression.parent is KtBinaryExpression) return
 
-        report(CodeSmell(issue, Entity.from(expression), ""))
+        val elementsToInspect = mutableListOf<PsiElement>(expression)
+        if (expression.parent is KtDotQualifiedExpression) {
+            elementsToInspect += expression.parent
+        }
+
+        if (elementsToInspect.any(PsiElement::isIsolated)) {
+            report(
+                CodeSmell(
+                    issue,
+                    Entity.from(expression),
+                    message = "The call ${expression.text} is returning a value that is ignored."
+                )
+            )
+        }
     }
 }
+
+private val PsiElement.isIsolated: Boolean
+    get() =
+        true == this.prevSibling?.isAnIsolationElement && true == this.nextSibling?.isAnIsolationElement
+
+private val PsiElement?.isAnIsolationElement: Boolean
+    get() {
+        if (this is PsiWhiteSpace) {
+            return true
+        }
+        if (this is PsiComment) {
+            return true
+        }
+        if (this is LeafPsiElement && this.elementType is KtSingleValueToken) {
+            val token = (this.elementType as KtSingleValueToken)
+            if (token.value == ";") {
+                return true
+            }
+        }
+        return false
+    }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValue.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValue.kt
@@ -1,0 +1,56 @@
+package io.gitlab.arturbosch.detekt.rules.bugs
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import org.jetbrains.kotlin.psi.KtBinaryExpression
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.resolve.BindingContext
+import org.jetbrains.kotlin.resolve.calls.callUtil.getResolvedCall
+import org.jetbrains.kotlin.types.typeUtil.isUnit
+
+/**
+ * The Kotlin compiler gives no warning for when a function which returns a value is called but its returned
+ * value is ignored.  This rule warns on instances where a function returns a value but that value is not
+ * used in any way.
+ *
+ * fun returnsValue() = 42
+ * fun returnsNoValue() {}
+ *
+ * <noncompliant>
+ *     returnsValue()
+ * </noncompliant>
+ *
+ * <compliant>
+ *     if (42 == returnsValue()) {}
+ *     val x = returnsValue()
+ * </compliant>
+ */
+class IgnoredReturnValue(config: Config = Config.empty) : Rule(config) {
+    override val issue: Issue = Issue(
+        "IgnoredReturnValue",
+        Severity.Defect,
+        "This call returns a value which has been ignored",
+        Debt.TWENTY_MINS
+    )
+
+    @Suppress("ReturnCount")
+    override fun visitCallExpression(expression: KtCallExpression) {
+        super.visitCallExpression(expression)
+
+        if (bindingContext == BindingContext.EMPTY) return
+        val resolvedCall = expression.getResolvedCall(bindingContext) ?: return
+        val returnType = resolvedCall.resultingDescriptor.returnType ?: return
+        if (returnType.isUnit()) {
+            return
+        }
+        // If this is part of a binary expression, then its return value is being checked
+        if (expression.parent is KtBinaryExpression) return
+
+        report(CodeSmell(issue, Entity.from(expression), ""))
+    }
+}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/PotentialBugProvider.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/PotentialBugProvider.kt
@@ -10,6 +10,7 @@ import io.gitlab.arturbosch.detekt.rules.bugs.EqualsWithHashCodeExist
 import io.gitlab.arturbosch.detekt.rules.bugs.ExplicitGarbageCollectionCall
 import io.gitlab.arturbosch.detekt.rules.bugs.HasPlatformType
 import io.gitlab.arturbosch.detekt.rules.bugs.ImplicitDefaultLocale
+import io.gitlab.arturbosch.detekt.rules.bugs.IgnoredReturnValue
 import io.gitlab.arturbosch.detekt.rules.bugs.InvalidRange
 import io.gitlab.arturbosch.detekt.rules.bugs.IteratorHasNextCallsNextMethod
 import io.gitlab.arturbosch.detekt.rules.bugs.IteratorNotThrowingNoSuchElementException
@@ -58,7 +59,8 @@ class PotentialBugProvider : DefaultRuleSetProvider {
                 UnsafeCallOnNullableType(config),
                 UnsafeCast(config),
                 UselessPostfixExpression(config),
-                WrongEqualsTypeParameter(config)
+                WrongEqualsTypeParameter(config),
+                IgnoredReturnValue(config)
         ))
     }
 }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValueSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValueSpec.kt
@@ -97,14 +97,14 @@ object IgnoredReturnValueSpec : Spek({
 
         it("reports when an extension function which returns a value is called and the return is ignored") {
             val code = """
-                fun Byte.setLastBit(): Byte = this or 0x1
-                fun foo(b: Byte) {
-                    b.setLastBit()
+                fun Int.isTheAnswer(): Boolean = this == 42
+                fun foo(input: Int) {
+                    input.isTheAnswer()
                 }
             """.trimIndent()
             val findings = subject.compileAndLintWithContext(wrapper.env, code)
             assertThat(findings).hasSize(1)
-            assertThat(findings).hasSourceLocation(3, 7)
+            assertThat(findings).hasSourceLocation(3, 11)
         }
     }
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValueSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValueSpec.kt
@@ -1,0 +1,78 @@
+package io.gitlab.arturbosch.detekt.rules.bugs
+
+import io.gitlab.arturbosch.detekt.test.KtTestCompiler
+import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import org.assertj.core.api.Assertions.assertThat
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+object IgnoredReturnValueSpec : Spek({
+
+    val subject by memoized { IgnoredReturnValue() }
+
+    val wrapper by memoized(
+        factory = { KtTestCompiler.createEnvironment() },
+        destructor = { it.dispose() }
+    )
+
+    describe("IgnoredReturnValue rule") {
+        it("reports when a function which returns a value is called and the return is ignored") {
+            val code = """
+                fun foo() {
+                    listOf("hello")
+                }
+            """.trimIndent()
+            assertThat(subject.compileAndLintWithContext(wrapper.env, code)).hasSize(1)
+        }
+
+        it("reports when an extension function which returns a value is called and the return is ignored") {
+            val code = """
+                fun Byte.setLastBit(): Byte = this or 0x1
+                fun foo(b: Byte) {
+                    b.setLastBit()
+                }
+            """.trimIndent()
+            assertThat(subject.compileAndLintWithContext(wrapper.env, code)).hasSize(1)
+        }
+
+        it("does not report when the return value is assigned to a pre-existing variable") {
+            val code = """
+                fun foo() {
+                    var x: List<String>
+                    x = listOf("hello")
+                }
+            """.trimIndent()
+            assertThat(subject.compileAndLintWithContext(wrapper.env, code)).hasSize(0)
+        }
+
+        it("does not report when a function which doesn't return a value is called") {
+            val code = """
+                fun noReturnValue() {}
+
+                fun foo() {
+                    noReturnValue()
+                }
+            """.trimIndent()
+            assertThat(subject.compileAndLintWithContext(wrapper.env, code)).hasSize(0)
+        }
+
+        it("does not report when a function's return value is used in a test statement") {
+            val code = """
+                fun returnsBoolean() = true
+                
+                if (returnsBoolean() {}
+
+            """.trimIndent()
+            assertThat(subject.compileAndLintWithContext(wrapper.env, code)).hasSize(0)
+        }
+
+        it("does not report when a function's return value is used in a comparison") {
+            val code = """
+                fun returnsInt() = 42
+                
+                if (42 == returnsInt()) {}
+            """.trimIndent()
+            assertThat(subject.compileAndLintWithContext(wrapper.env, code)).hasSize(0)
+        }
+    }
+})

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValueSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValueSpec.kt
@@ -15,19 +15,18 @@ object IgnoredReturnValueSpec : Spek({
         destructor = { it.dispose() }
     )
 
-    describe("reports scenarios") {
-        it("reports when a function which returns a value is called and the return is ignored") {
+    describe("non-annotated return values") {
+        it("does not report when a function which returns a value is called and the return is ignored") {
             val code = """
                 fun foo() {
                     listOf("hello")
                 }
             """.trimIndent()
             val findings = subject.compileAndLintWithContext(wrapper.env, code)
-            assertThat(findings).hasSize(1)
-            assertThat(findings).hasSourceLocation(2, 5)
+            assertThat(findings).isEmpty()
         }
 
-        it("reports when a function which returns a value is called before a valid return") {
+        it("does not report when a function which returns a value is called before a valid return") {
             val code = """
                 fun foo() : Int {
                     listOf("hello")
@@ -35,67 +34,50 @@ object IgnoredReturnValueSpec : Spek({
                 }
             """.trimIndent()
             val findings = subject.compileAndLintWithContext(wrapper.env, code)
-            assertThat(findings).hasSize(1)
-            assertThat(findings).hasSourceLocation(2, 5)
+            assertThat(findings).isEmpty()
         }
 
-        it("reports when a function which returns a value is called in chain and the return is ignored") {
+        it("does not report when a function which returns a value is called in chain and the return is ignored") {
             val code = """
                 fun foo() {
                     listOf("hello").isEmpty().not()
                 }
             """.trimIndent()
             val findings = subject.compileAndLintWithContext(wrapper.env, code)
-            assertThat(findings).hasSize(1)
-            assertThat(findings).hasSourceLocation(2, 31)
+            assertThat(findings).isEmpty()
         }
 
-        it("reports when a function which returns a value is called before a semicolon") {
+        it("does not report when a function which returns a value is called before a semicolon") {
             val code = """
                 fun foo() {
                     listOf("hello");println("foo")
                 }
             """.trimIndent()
             val findings = subject.compileAndLintWithContext(wrapper.env, code)
-            assertThat(findings).hasSize(1)
-            assertThat(findings).hasSourceLocation(2, 5)
+            assertThat(findings).isEmpty()
         }
 
-        it("reports when a function which returns a value is called after a semicolon") {
+        it("does not report when a function which returns a value is called after a semicolon") {
             val code = """
                 fun foo() {
                     println("foo");listOf("hello")
                 }
             """.trimIndent()
             val findings = subject.compileAndLintWithContext(wrapper.env, code)
-            assertThat(findings).hasSize(1)
-            assertThat(findings).hasSourceLocation(2, 20)
+            assertThat(findings).isEmpty()
         }
 
-        it("reports when a function which returns a value is called before a comment") {
+        it("does not report when a function which returns a value is called between comments") {
             val code = """
                 fun foo() {
                     listOf("hello")//foo
                 }
             """.trimIndent()
             val findings = subject.compileAndLintWithContext(wrapper.env, code)
-            assertThat(findings).hasSize(1)
-            assertThat(findings).hasSourceLocation(2, 5)
+            assertThat(findings).isEmpty()
         }
 
-        it("reports when a function which returns a value is called after a semicolon") {
-            val code = """
-                fun foo() {
-                    /* foo */listOf("hello")
-                }
-            """.trimIndent()
-            val findings = subject.compileAndLintWithContext(wrapper.env, code)
-            assertThat(findings).hasSize(1)
-            assertThat(findings).hasSourceLocation(2, 14)
-        }
-
-
-        it("reports when an extension function which returns a value is called and the return is ignored") {
+        it("does not report when an extension function which returns a value is called and the return is ignored") {
             val code = """
                 fun Int.isTheAnswer(): Boolean = this == 42
                 fun foo(input: Int) {
@@ -103,17 +85,22 @@ object IgnoredReturnValueSpec : Spek({
                 }
             """.trimIndent()
             val findings = subject.compileAndLintWithContext(wrapper.env, code)
-            assertThat(findings).hasSize(1)
-            assertThat(findings).hasSourceLocation(3, 11)
+            assertThat(findings).isEmpty()
         }
-    }
 
-    describe("empty scenarios") {
         it("does not report when the return value is assigned to a pre-existing variable") {
             val code = """
+                package com.example
+                
+                annotation class CheckReturnValue
+                
+                @CheckReturnValue
+                @Deprecated("Yes")
+                fun listA() = listOf("hello")
+                
                 fun foo() {
                     var x: List<String>
-                    x = listOf("hello")
+                    x = listA()
                 }
             """.trimIndent()
             val findings = subject.compileAndLintWithContext(wrapper.env, code)
@@ -166,7 +153,7 @@ object IgnoredReturnValueSpec : Spek({
             assertThat(findings).isEmpty()
         }
 
-        it("does not report when a function's return value is used with named paramters") {
+        it("does not report when a function's return value is used with named parameters") {
             val code = """
                 fun returnsInt() = 42
                 
@@ -177,4 +164,236 @@ object IgnoredReturnValueSpec : Spek({
         }
     }
 
+    describe("annotated return values") {
+        it("reports when a function which returns a value is called and the return is ignored") {
+            val code = """
+                annotation class CheckReturnValue
+                
+                @CheckReturnValue
+                fun listOfChecked(value: String) = listOf(value)
+                
+                fun foo() : Int {
+                    listOfChecked("hello")
+                    return 42
+                }
+            """.trimIndent()
+            val findings = subject.compileAndLintWithContext(wrapper.env, code)
+            assertThat(findings).hasSize(1)
+            assertThat(findings).hasSourceLocation(7, 5)
+        }
+
+        it("reports when a function which returns a value is called before a valid return") {
+            val code = """
+                annotation class CheckReturnValue
+                
+                @CheckReturnValue
+                fun listOfChecked(value: String) = listOf(value)
+                
+                fun foo() : Int {
+                    listOfChecked("hello")
+                    return 42
+                }
+            """.trimIndent()
+            val findings = subject.compileAndLintWithContext(wrapper.env, code)
+            assertThat(findings).hasSize(1)
+            assertThat(findings).hasSourceLocation(7, 5)
+        }
+
+        it("reports when a function which returns a value is called in chain and the return is ignored") {
+            val code = """
+                annotation class CheckReturnValue
+                
+                @CheckReturnValue
+                fun listOfChecked(value: String) = listOf(value)
+                
+                fun foo() : Int {
+                    listOfChecked("hello").isEmpty().not()
+                    return 42
+                }
+            """.trimIndent()
+            val findings = subject.compileAndLintWithContext(wrapper.env, code)
+            assertThat(findings).hasSize(1)
+            assertThat(findings).hasSourceLocation(7, 5)
+        }
+
+        it("reports when a function which returns a value is called before a semicolon") {
+            val code = """
+                annotation class CheckReturnValue
+                
+                @CheckReturnValue
+                fun listOfChecked(value: String) = listOf(value)
+                
+                fun foo() {
+                    listOfChecked("hello");println("foo")
+                }
+            """.trimIndent()
+            val findings = subject.compileAndLintWithContext(wrapper.env, code)
+            assertThat(findings).hasSize(1)
+            assertThat(findings).hasSourceLocation(7, 5)
+        }
+
+        it("reports when a function which returns a value is called after a semicolon") {
+            val code = """
+                annotation class CheckReturnValue
+                
+                @CheckReturnValue
+                fun listOfChecked(value: String) = listOf(value)
+                
+                fun foo() : Int {
+                    println("foo");listOfChecked("hello")
+                    return 42
+                }
+            """.trimIndent()
+            val findings = subject.compileAndLintWithContext(wrapper.env, code)
+            assertThat(findings).hasSize(1)
+            assertThat(findings).hasSourceLocation(7, 20)
+        }
+
+        it("reports when a function which returns a value is called between comments") {
+            val code = """
+                annotation class CheckReturnValue
+                
+                @CheckReturnValue
+                fun listOfChecked(value: String) = listOf(value)
+                
+                fun foo() : Int {
+                    /* foo */listOfChecked("hello")//foo
+                    return 42
+                }
+            """.trimIndent()
+            val findings = subject.compileAndLintWithContext(wrapper.env, code)
+            assertThat(findings).hasSize(1)
+            assertThat(findings).hasSourceLocation(7, 14)
+        }
+
+        it("reports when an extension function which returns a value is called and the return is ignored") {
+            val code = """
+                annotation class CheckReturnValue
+                
+                @CheckReturnValue
+                fun Int.isTheAnswer(): Boolean = this == 42
+                fun foo(input: Int) : Int {
+                    input.isTheAnswer()
+                    return 42
+                }
+            """.trimIndent()
+            val findings = subject.compileAndLintWithContext(wrapper.env, code)
+            assertThat(findings).hasSize(1)
+            assertThat(findings).hasSourceLocation(6, 11)
+        }
+
+        it("does not report when the return value is assigned to a pre-existing variable") {
+            val code = """
+                annotation class CheckReturnValue
+                
+                @CheckReturnValue
+                fun listOfChecked(value: String) = listOf(value)
+                
+                fun foo() : Int {
+                    var x: List<String>
+                    x = listOfChecked("hello")
+                    return 42
+                }
+            """.trimIndent()
+            val findings = subject.compileAndLintWithContext(wrapper.env, code)
+            assertThat(findings).isEmpty()
+        }
+
+        it("does not report when a function which doesn't return a value is called") {
+            val code = """
+                annotation class CheckReturnValue
+                
+                @CheckReturnValue
+                fun noReturnValue() {}
+
+                fun foo() : Int {
+                    noReturnValue()
+                    return 42
+                }
+            """.trimIndent()
+            val findings = subject.compileAndLintWithContext(wrapper.env, code)
+            assertThat(findings).isEmpty()
+        }
+
+        it("does not report when a function's return value is used in a test statement") {
+            val code = """
+                annotation class CheckReturnValue
+                
+                @CheckReturnValue
+                fun returnsBoolean() = true
+                
+                if (returnsBoolean()) {
+                    // no-op
+                }
+            """.trimIndent()
+            val findings = subject.compileAndLintWithContext(wrapper.env, code)
+            assertThat(findings).isEmpty()
+        }
+
+        it("does not report when a function's return value is used in a comparison") {
+            val code = """
+                annotation class CheckReturnValue
+                
+                @CheckReturnValue
+                fun returnsInt() = 42
+                
+                if (42 == returnsInt()) {
+                    // no-op
+                }
+            """.trimIndent()
+            val findings = subject.compileAndLintWithContext(wrapper.env, code)
+            assertThat(findings).isEmpty()
+        }
+
+        it("does not report when a function's return value is used as parameter for another call") {
+            val code = """
+                annotation class CheckReturnValue
+                
+                @CheckReturnValue
+                fun returnsInt() = 42
+                
+                println(returnsInt())
+            """.trimIndent()
+            val findings = subject.compileAndLintWithContext(wrapper.env, code)
+            assertThat(findings).isEmpty()
+        }
+
+        it("does not report when a function's return value is used with named parameters") {
+            val code = """
+                annotation class CheckReturnValue
+                
+                @CheckReturnValue
+                fun returnsInt() = 42
+                
+                println(message = returnsInt())
+            """.trimIndent()
+            val findings = subject.compileAndLintWithContext(wrapper.env, code)
+            assertThat(findings).isEmpty()
+        }
+
+        it("does not report when a function is the last statement in a block") {
+            val code = """
+                import kotlin.random.Random
+                
+                annotation class CheckReturnValue
+                
+                @CheckReturnValue
+                fun returnsInt() = 42
+                
+                if (Random.nextBoolean()) {
+                    println("hello")
+                } else {
+                    returnsInt()
+                }
+                
+                val result = if (Random.nextBoolean()) {
+                    1
+                } else {
+                    returnsInt()
+                }
+            """.trimIndent()
+            val findings = subject.compileAndLintWithContext(wrapper.env, code)
+            assertThat(findings).isEmpty()
+        }
+    }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValueSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValueSpec.kt
@@ -1,8 +1,8 @@
 package io.gitlab.arturbosch.detekt.rules.bugs
 
 import io.gitlab.arturbosch.detekt.test.KtTestCompiler
+import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
-import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
@@ -15,15 +15,85 @@ object IgnoredReturnValueSpec : Spek({
         destructor = { it.dispose() }
     )
 
-    describe("IgnoredReturnValue rule") {
+    describe("reports scenarios") {
         it("reports when a function which returns a value is called and the return is ignored") {
             val code = """
                 fun foo() {
                     listOf("hello")
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(wrapper.env, code)).hasSize(1)
+            val findings = subject.compileAndLintWithContext(wrapper.env, code)
+            assertThat(findings).hasSize(1)
+            assertThat(findings).hasSourceLocation(2, 5)
         }
+
+        it("reports when a function which returns a value is called before a valid return") {
+            val code = """
+                fun foo() : Int {
+                    listOf("hello")
+                    return 42
+                }
+            """.trimIndent()
+            val findings = subject.compileAndLintWithContext(wrapper.env, code)
+            assertThat(findings).hasSize(1)
+            assertThat(findings).hasSourceLocation(2, 5)
+        }
+
+        it("reports when a function which returns a value is called in chain and the return is ignored") {
+            val code = """
+                fun foo() {
+                    listOf("hello").isEmpty().not()
+                }
+            """.trimIndent()
+            val findings = subject.compileAndLintWithContext(wrapper.env, code)
+            assertThat(findings).hasSize(1)
+            assertThat(findings).hasSourceLocation(2, 31)
+        }
+
+        it("reports when a function which returns a value is called before a semicolon") {
+            val code = """
+                fun foo() {
+                    listOf("hello");println("foo")
+                }
+            """.trimIndent()
+            val findings = subject.compileAndLintWithContext(wrapper.env, code)
+            assertThat(findings).hasSize(1)
+            assertThat(findings).hasSourceLocation(2, 5)
+        }
+
+        it("reports when a function which returns a value is called after a semicolon") {
+            val code = """
+                fun foo() {
+                    println("foo");listOf("hello")
+                }
+            """.trimIndent()
+            val findings = subject.compileAndLintWithContext(wrapper.env, code)
+            assertThat(findings).hasSize(1)
+            assertThat(findings).hasSourceLocation(2, 20)
+        }
+
+        it("reports when a function which returns a value is called before a comment") {
+            val code = """
+                fun foo() {
+                    listOf("hello")//foo
+                }
+            """.trimIndent()
+            val findings = subject.compileAndLintWithContext(wrapper.env, code)
+            assertThat(findings).hasSize(1)
+            assertThat(findings).hasSourceLocation(2, 5)
+        }
+
+        it("reports when a function which returns a value is called after a semicolon") {
+            val code = """
+                fun foo() {
+                    /* foo */listOf("hello")
+                }
+            """.trimIndent()
+            val findings = subject.compileAndLintWithContext(wrapper.env, code)
+            assertThat(findings).hasSize(1)
+            assertThat(findings).hasSourceLocation(2, 14)
+        }
+
 
         it("reports when an extension function which returns a value is called and the return is ignored") {
             val code = """
@@ -32,9 +102,13 @@ object IgnoredReturnValueSpec : Spek({
                     b.setLastBit()
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(wrapper.env, code)).hasSize(1)
+            val findings = subject.compileAndLintWithContext(wrapper.env, code)
+            assertThat(findings).hasSize(1)
+            assertThat(findings).hasSourceLocation(3, 7)
         }
+    }
 
+    describe("empty scenarios") {
         it("does not report when the return value is assigned to a pre-existing variable") {
             val code = """
                 fun foo() {
@@ -42,7 +116,8 @@ object IgnoredReturnValueSpec : Spek({
                     x = listOf("hello")
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(wrapper.env, code)).hasSize(0)
+            val findings = subject.compileAndLintWithContext(wrapper.env, code)
+            assertThat(findings).isEmpty()
         }
 
         it("does not report when a function which doesn't return a value is called") {
@@ -53,26 +128,53 @@ object IgnoredReturnValueSpec : Spek({
                     noReturnValue()
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(wrapper.env, code)).hasSize(0)
+            val findings = subject.compileAndLintWithContext(wrapper.env, code)
+            assertThat(findings).isEmpty()
         }
 
         it("does not report when a function's return value is used in a test statement") {
             val code = """
                 fun returnsBoolean() = true
                 
-                if (returnsBoolean() {}
-
+                if (returnsBoolean()) {
+                    // no-op
+                }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(wrapper.env, code)).hasSize(0)
+            val findings = subject.compileAndLintWithContext(wrapper.env, code)
+            assertThat(findings).isEmpty()
         }
 
         it("does not report when a function's return value is used in a comparison") {
             val code = """
                 fun returnsInt() = 42
                 
-                if (42 == returnsInt()) {}
+                if (42 == returnsInt()) {
+                    // no-op
+                }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(wrapper.env, code)).hasSize(0)
+            val findings = subject.compileAndLintWithContext(wrapper.env, code)
+            assertThat(findings).isEmpty()
+        }
+
+        it("does not report when a function's return value is used as parameter for another call") {
+            val code = """
+                fun returnsInt() = 42
+                
+                println(returnsInt())
+            """.trimIndent()
+            val findings = subject.compileAndLintWithContext(wrapper.env, code)
+            assertThat(findings).isEmpty()
+        }
+
+        it("does not report when a function's return value is used with named paramters") {
+            val code = """
+                fun returnsInt() = 42
+                
+                println(message = returnsInt())
+            """.trimIndent()
+            val findings = subject.compileAndLintWithContext(wrapper.env, code)
+            assertThat(findings).isEmpty()
         }
     }
+
 })

--- a/docs/pages/documentation/potential-bugs.md
+++ b/docs/pages/documentation/potential-bugs.md
@@ -161,9 +161,9 @@ fun apiCall(): String = System.getProperty("propertyName")
 
 ### IgnoredReturnValue
 
-The Kotlin compiler gives no warning for when a function which returns a value is called but its returned
-value is ignored. This rule warns on instances where a function returns a value but that value is not
-used in any way.
+This rule warns on instances where a function, annotated with either `@CheckReturnValue` or `@CheckResult`,
+returns a value but that value is not used in any way. The Kotlin compiler gives no warning for this scenario
+normally so that's the rationale behind this rule.
 
 fun returnsValue() = 42
 fun returnsNoValue() {}

--- a/docs/pages/documentation/potential-bugs.md
+++ b/docs/pages/documentation/potential-bugs.md
@@ -159,6 +159,32 @@ fun apiCall(): String = System.getProperty("propertyName")
 }
 ```
 
+### IgnoredReturnValue
+
+The Kotlin compiler gives no warning for when a function which returns a value is called but its returned
+value is ignored.  This rule warns on instances where a function returns a value but that value is not
+used in any way.
+
+fun returnsValue() = 42
+fun returnsNoValue() {}
+
+**Severity**: Defect
+
+**Debt**: 20min
+
+#### Noncompliant Code:
+
+```kotlin
+    returnsValue()
+```
+
+#### Compliant Code:
+
+```kotlin
+    if (42 == returnsValue()) {}
+    val x = returnsValue()
+```
+
 ### ImplicitDefaultLocale
 
 Prefer passing [java.util.Locale] explicitly than using implicit default value when formatting

--- a/docs/pages/documentation/potential-bugs.md
+++ b/docs/pages/documentation/potential-bugs.md
@@ -162,7 +162,7 @@ fun apiCall(): String = System.getProperty("propertyName")
 ### IgnoredReturnValue
 
 The Kotlin compiler gives no warning for when a function which returns a value is called but its returned
-value is ignored.  This rule warns on instances where a function returns a value but that value is not
+value is ignored. This rule warns on instances where a function returns a value but that value is not
 used in any way.
 
 fun returnsValue() = 42


### PR DESCRIPTION
I've cherry-picked @bbaldino commits and fixed the tests for the new rule `IgnoredReturnValue`.

I've tried this approach that checks if a `PsiElement` is "isolated" and the return value is not `Unit`. I'm not sure it's the correct one but from the tests it seems promising.

I'd be happy to receive further ideas for test cases or improvements.

Closes #209 
Closes #2239
Closes #2242
