### PR TITLE
Reformat code with fixed Indentation rule

### DIFF
--- a/buildSrc/src/main/kotlin/packaging.gradle.kts
+++ b/buildSrc/src/main/kotlin/packaging.gradle.kts
@@ -33,29 +33,37 @@ subprojects {
 
         setPublications(detektPublication)
 
-        pkg(delegateClosureOf<BintrayExtension.PackageConfig> {
-            repo = "code-analysis"
-            name = "detekt"
-            userOrg = "arturbosch"
-            setLicenses("Apache-2.0")
-            vcsUrl = "https://github.com/detekt/detekt"
+        pkg(
+            delegateClosureOf<BintrayExtension.PackageConfig> {
+                repo = "code-analysis"
+                name = "detekt"
+                userOrg = "arturbosch"
+                setLicenses("Apache-2.0")
+                vcsUrl = "https://github.com/detekt/detekt"
 
-            version(delegateClosureOf<BintrayExtension.VersionConfig> {
-                name = project.version as? String
-                released = Date().toString()
+                version(
+                    delegateClosureOf<BintrayExtension.VersionConfig> {
+                        name = project.version as? String
+                        released = Date().toString()
 
-                gpg(delegateClosureOf<BintrayExtension.GpgConfig> {
-                    sign = true
-                })
+                        gpg(
+                            delegateClosureOf<BintrayExtension.GpgConfig> {
+                                sign = true
+                            }
+                        )
 
-                mavenCentralSync(delegateClosureOf<BintrayExtension.MavenCentralSyncConfig> {
-                    sync = true
-                    user = mavenCentralUser
-                    password = mavenCentralPassword
-                    close = "1"
-                })
-            })
-        })
+                        mavenCentralSync(
+                            delegateClosureOf<BintrayExtension.MavenCentralSyncConfig> {
+                                sync = true
+                                user = mavenCentralUser
+                                password = mavenCentralPassword
+                                close = "1"
+                            }
+                        )
+                    }
+                )
+            }
+        )
     }
 
     val sourcesJar by tasks.creating(Jar::class) {
@@ -112,18 +120,24 @@ subprojects {
 
     configure<ArtifactoryPluginConvention> {
         setContextUrl("https://oss.jfrog.org/artifactory")
-        publish(delegateClosureOf<PublisherConfig> {
-            repository(delegateClosureOf<GroovyObject> {
-                setProperty("repoKey", "oss-snapshot-local")
-                setProperty("username", bintrayUser)
-                setProperty("password", bintrayKey)
-                setProperty("maven", true)
-            })
-            defaults(delegateClosureOf<GroovyObject> {
-                invokeMethod("publications", detektPublication)
-                setProperty("publishArtifacts", true)
-                setProperty("publishPom", true)
-            })
-        })
+        publish(
+            delegateClosureOf<PublisherConfig> {
+                repository(
+                    delegateClosureOf<GroovyObject> {
+                        setProperty("repoKey", "oss-snapshot-local")
+                        setProperty("username", bintrayUser)
+                        setProperty("password", bintrayKey)
+                        setProperty("maven", true)
+                    }
+                )
+                defaults(
+                    delegateClosureOf<GroovyObject> {
+                        invokeMethod("publications", detektPublication)
+                        setProperty("publishArtifacts", true)
+                        setProperty("publishPom", true)
+                    }
+                )
+            }
+        )
     }
 }

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -60,6 +60,8 @@ formatting:
   autoCorrect: true
   MaximumLineLength:
     active: false
+  Indentation:
+    active: true
 
 naming:
   MemberNameEqualsClassName:

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -1,10 +1,6 @@
 build:
   maxIssues: 1
 
-# can be removed after 1.7.0 is published
-config:
-  excludes: 'complexity>ComplexInterface>includePrivateDeclarations'
-
 comments:
   CommentOverPrivateProperty:
     active: true
@@ -61,6 +57,10 @@ formatting:
   MaximumLineLength:
     active: false
   Indentation:
+    active: true
+  NoEmptyFirstLineInMethodBlock:
+    active: true
+  AnnotationOnSeparateLine:
     active: true
 
 naming:

--- a/config/detekt/format.yml
+++ b/config/detekt/format.yml
@@ -6,4 +6,7 @@ formatting:
     active: false
   Indentation:
     active: true
-    autoCorrect: true
+  NoEmptyFirstLineInMethodBlock:
+    active: true
+  AnnotationOnSeparateLine:
+    active: true

--- a/config/detekt/format.yml
+++ b/config/detekt/format.yml
@@ -4,3 +4,6 @@ formatting:
   autoCorrect: true
   MaximumLineLength:
     active: false
+  Indentation:
+    active: true
+    autoCorrect: true

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/AnnotationExcluder.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/AnnotationExcluder.kt
@@ -16,12 +16,12 @@ class AnnotationExcluder(
     constructor(root: KtFile, excludes: SplitPattern) : this(root, excludes.mapAll { it })
 
     private val resolvedAnnotations = root.importList
-            ?.imports
-            ?.asSequence()
-            ?.filterNot { it.isAllUnder }
-            ?.mapNotNull { it.importedFqName?.asString() }
-            ?.map { it.substringAfterLast('.') to it }
-            ?.toMap() ?: emptyMap()
+        ?.imports
+        ?.asSequence()
+        ?.filterNot { it.isAllUnder }
+        ?.mapNotNull { it.importedFqName?.asString() }
+        ?.map { it.substringAfterLast('.') to it }
+        ?.toMap() ?: emptyMap()
 
     /**
      * Is true if any given annotation name is declared in the SplitPattern

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/BaseRule.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/BaseRule.kt
@@ -17,9 +17,11 @@ typealias RuleId = String
  * This base rule class abstracts over single and multi rules and allows the
  * detekt core engine to only care about a single type.
  */
-@Deprecated("""
+@Deprecated(
+    """
 Do not use this class directly. Use Rule or MultiRule instead.
 This class was introduced to support a common handling of the mentioned rule types.
 This class will be made sealed in a different release and you won't be able to derive from it. 
-""")
+"""
+)
 typealias BaseRule = io.gitlab.arturbosch.detekt.api.internal.BaseRule

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Config.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Config.kt
@@ -76,12 +76,14 @@ interface Config {
  * A configuration which keeps track of the config it got sub-config'ed from by the [subConfig] function.
  * It's main usage is to recreate the property-path which was taken when using the [subConfig] function repeatedly.
  */
-@Deprecated("""
+@Deprecated(
+    """
 A Config is a long lived object and is derived via subConfig a lot.
 Keeping track of the parent it was derived, creates long-lived object chains which takes the GC longer to release them.
 It can even lead to OOM if detekt get's embedded in an other application which reuses the top most Config object. 
 The property 'parentPath' of the Config interface can be used as a replacement for parent.key calls.
-""")
+"""
+)
 interface HierarchicalConfig : Config {
     /**
      * Returns the parent config which encloses this config part.

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Location.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Location.kt
@@ -46,8 +46,10 @@ data class Location(
         fun startLineAndColumn(element: PsiElement, offset: Int = 0): PsiDiagnosticUtils.LineAndColumn {
             return try {
                 val range = element.textRange
-                DiagnosticUtils.getLineAndColumnInPsiFile(element.containingFile,
-                    TextRange(range.startOffset + offset, range.endOffset + offset))
+                DiagnosticUtils.getLineAndColumnInPsiFile(
+                    element.containingFile,
+                    TextRange(range.startOffset + offset, range.endOffset + offset)
+                )
             } catch (e: IndexOutOfBoundsException) {
                 // #18 - somehow the TextRange is out of bound on '}' leaf nodes, returning fail safe -1
                 PsiDiagnosticUtils.LineAndColumn(-1, -1, null)

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/BaseConfig.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/BaseConfig.kt
@@ -24,11 +24,15 @@ abstract class BaseConfig : HierarchicalConfig {
                 default
             }
         } catch (_: ClassCastException) {
-            error("Value \"$result\" set for config parameter \"${keySequence(key)}\" is not of" +
-                " required type ${default::class.simpleName}.")
+            error(
+                "Value \"$result\" set for config parameter \"${keySequence(key)}\" is not of" +
+                    " required type ${default::class.simpleName}."
+            )
         } catch (_: NumberFormatException) {
-            error("Value \"$result\" set for config parameter \"${keySequence(key)}\" is not of" +
-                " required type ${default::class.simpleName}.")
+            error(
+                "Value \"$result\" set for config parameter \"${keySequence(key)}\" is not of" +
+                    " required type ${default::class.simpleName}."
+            )
         }
     }
 

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/KotlinEnvironmentUtils.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/KotlinEnvironmentUtils.kt
@@ -68,7 +68,6 @@ fun createCompilerConfiguration(
     languageVersion: LanguageVersion?,
     jvmTarget: JvmTarget
 ): CompilerConfiguration {
-
     val javaFiles = pathsToAnalyze.flatMap { path ->
         path.toFile().walk()
             .filter { it.isFile && it.extension.equals("java", true) }

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/PathFilters.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/PathFilters.kt
@@ -29,7 +29,6 @@ class PathFilters internal constructor(
     }
 
     fun isIgnored(path: Path): Boolean {
-
         fun isIncluded() = includes?.any { it.matches(path) }
         fun isExcluded() = excludes?.any { it.matches(path) }
 

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/PathMatchers.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/PathMatchers.kt
@@ -12,7 +12,6 @@ import java.nio.file.PathMatcher
  * Internally a globbing pattern is transformed to a regex respecting the Windows file system.
  */
 fun pathMatcher(pattern: String): PathMatcher {
-
     val result = when (pattern.substringBefore(":")) {
         "glob" -> pattern
         "regex" -> throw IllegalArgumentException(USE_GLOB_MSG)

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/Signatures.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/Signatures.kt
@@ -30,15 +30,15 @@ internal fun PsiElement.searchClass(): String {
 internal fun PsiElement.buildFullSignature(): String {
     val signature = this.searchSignature()
     val fullClassSignature = this.parents.filter { it is KtClassOrObject }
-            .map { it.extractClassName() }
-            .fold("") { sig, sig2 -> "$sig2${dotOrNot(sig, sig2)}$sig" }
+        .map { it.extractClassName() }
+        .fold("") { sig, sig2 -> "$sig2${dotOrNot(sig, sig2)}$sig" }
     val filename = this.containingFile.name
     return (if (!fullClassSignature.startsWith(filename)) filename + "\$" else "") +
-            if (fullClassSignature.isNotEmpty()) "$fullClassSignature\$$signature" else signature
+        if (fullClassSignature.isNotEmpty()) "$fullClassSignature\$$signature" else signature
 }
 
 private fun PsiElement.extractClassName() =
-        this.getNonStrictParentOfType<KtClassOrObject>()?.nameAsSafeName?.asString() ?: ""
+    this.getNonStrictParentOfType<KtClassOrObject>()?.nameAsSafeName?.asString() ?: ""
 
 private fun PsiElement.searchSignature(): String {
     return when (this) {
@@ -85,8 +85,9 @@ private fun buildFunctionSignature(element: KtNamedFunction): String {
         "Error building function signature with range $methodStart - $methodEnd for element: ${element.text}"
     }
     return getTextSafe(
-            { element.nameAsSafeName.identifier },
-            { element.text.substring(methodStart, methodEnd) })
+        { element.nameAsSafeName.identifier },
+        { element.text.substring(methodStart, methodEnd) }
+    )
 }
 
 /*

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/ValidatableConfiguration.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/ValidatableConfiguration.kt
@@ -51,7 +51,6 @@ fun validateConfig(
 
     fun testKeys(current: Map<String, Any>, base: Map<String, Any>, parentPath: String?) {
         for (prop in current.keys) {
-
             val propertyPath = "${if (parentPath == null) "" else "$parentPath>"}$prop"
 
             val matchedDeprecation = DEPRECATED_PROPERTIES

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/Validation.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/Validation.kt
@@ -6,7 +6,6 @@ private val identifierRegex = Regex("[aA-zZ]+([-][aA-zZ]+)*")
  * Checks if given string matches the criteria of an id - [aA-zZ]+([-][aA-zZ]+)* .
  */
 internal fun validateIdentifier(id: String) {
-
     require(id.matches(identifierRegex)) {
         "id '$id' must match ${identifierRegex.pattern}"
     }

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/YamlConfig.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/YamlConfig.kt
@@ -53,11 +53,13 @@ class YamlConfig internal constructor(
          * and point to a readable file.
          */
         fun load(path: Path): Config =
-            load(path.toFile().apply {
-                require(exists()) { "Configuration does not exist: $path" }
-                require(isFile) { "Configuration must be a file: $path" }
-                require(canRead()) { "Configuration must be readable: $path" }
-            }.bufferedReader())
+            load(
+                path.toFile().apply {
+                    require(exists()) { "Configuration does not exist: $path" }
+                    require(isFile) { "Configuration must be a file: $path" }
+                    require(canRead()) { "Configuration must be readable: $path" }
+                }.bufferedReader()
+            )
 
         /**
          * Factory method to load a yaml configuration from a URL.

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/AnnotationExcluderSpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/AnnotationExcluderSpec.kt
@@ -15,11 +15,13 @@ class AnnotationExcluderSpec : Spek({
         val fullyQualifiedJvmFieldAnnotation = psiFactory.createAnnotationEntry("@kotlin.jvm.JvmField")
         val sinceKotlinAnnotation = psiFactory.createAnnotationEntry("@SinceKotlin")
 
-        val file = compileContentForTest("""
+        val file = compileContentForTest(
+            """
             package foo
 
             import kotlin.jvm.JvmField
-        """.trimIndent())
+            """.trimIndent()
+        )
 
         it("should exclude when the annotation was found") {
             val excluder = AnnotationExcluder(file, listOf("JvmField"))

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/SuppressionSpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/SuppressionSpec.kt
@@ -22,7 +22,8 @@ internal class SuppressionSpec : Spek({
     describe("detekt findings can be suppressed with @Suppress or @SuppressWarnings") {
 
         fun checkSuppression(annotation: String, argument: String): Boolean {
-            val annotated = """
+            val annotated =
+                """
             @$annotation("$argument")
             class Test {}
              """
@@ -132,7 +133,8 @@ internal class SuppressionSpec : Spek({
         }
 
         it("rule should be suppressed by detekt prefix in uppercase with dot separator") {
-            val ktFile = compileContentForTest("""
+            val ktFile = compileContentForTest(
+                """
             @file:Suppress("Detekt.ALL")
             object SuppressedWithDetektPrefix {
 
@@ -140,14 +142,16 @@ internal class SuppressionSpec : Spek({
                     println("FAILED TEST")
                 }
             }
-            """)
+            """
+            )
             val rule = TestRule()
             rule.visitFile(ktFile)
             assertThat(rule.expected).isNotNull()
         }
 
         it("rule should be suppressed by detekt prefix in lowercase with colon separator") {
-            val ktFile = compileContentForTest("""
+            val ktFile = compileContentForTest(
+                """
             @file:Suppress("detekt:ALL")
             object SuppressedWithDetektPrefix {
 
@@ -155,14 +159,16 @@ internal class SuppressionSpec : Spek({
                     println("FAILED TEST")
                 }
             }
-            """)
+            """
+            )
             val rule = TestRule()
             rule.visitFile(ktFile)
             assertThat(rule.expected).isNotNull()
         }
 
         it("rule should be suppressed by detekt prefix in all caps with colon separator") {
-            val ktFile = compileContentForTest("""
+            val ktFile = compileContentForTest(
+                """
             @file:Suppress("DETEKT:ALL")
             object SuppressedWithDetektPrefix {
 
@@ -170,7 +176,8 @@ internal class SuppressionSpec : Spek({
                     println("FAILED TEST")
                 }
             }
-            """)
+            """
+            )
             val rule = TestRule()
             rule.visitFile(ktFile)
             assertThat(rule.expected).isNotNull()
@@ -180,7 +187,8 @@ internal class SuppressionSpec : Spek({
     describe("suppression based on aliases from config property") {
 
         it("allows to declare") {
-            val ktFile = compileContentForTest("""
+            val ktFile = compileContentForTest(
+                """
             @file:Suppress("detekt:MyTest")
             object SuppressedWithDetektPrefixAndCustomConfigBasedPrefix {
 
@@ -188,7 +196,8 @@ internal class SuppressionSpec : Spek({
                     println("FAILED TEST")
                 }
             }
-            """)
+            """
+            )
             val rule = TestRule(TestConfig(mutableMapOf("aliases" to "[MyTest]")))
             rule.visitFile(ktFile)
             assertThat(rule.expected).isNotNull()
@@ -197,9 +206,10 @@ internal class SuppressionSpec : Spek({
 
     describe("suppression's via rule set id") {
 
-        val code = """
+        val code =
+            """
             fun lpl(a: Int, b: Int, c: Int, d: Int, e: Int, f: Int) = Unit
-        """.trimIndent()
+            """.trimIndent()
         val config = yamlConfig("ruleset-suppression.yml").subConfig("complexity")
 
         it("reports without a suppression") {

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/internal/CompositeConfigTest.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/internal/CompositeConfigTest.kt
@@ -12,10 +12,12 @@ class CompositeConfigTest : Spek({
         val first = yamlConfig("detekt.yml")
         val compositeConfig = CompositeConfig(second, first)
 
-        it("""
+        it(
+            """
             should have style sub config with active false which is overridden
             in `second` config regardless of default value
-        """) {
+        """
+        ) {
             val styleConfig = compositeConfig.subConfig("style").subConfig("WildcardImport")
             assertThat(styleConfig.valueOrDefault("active", true)).isEqualTo(false)
             assertThat(styleConfig.valueOrDefault("active", false)).isEqualTo(false)

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Configurations.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Configurations.kt
@@ -21,7 +21,8 @@ fun CliArgs.createFilters(): PathFilters? = PathFilters.of(
     (excludes ?: "")
         .trim()
         .commaSeparatedPattern(",", ";")
-        .toList())
+        .toList()
+)
 
 fun CliArgs.createPlugins(): List<Path> = plugins.letIfNonEmpty {
     MultipleExistingPathConverter().convert(this)
@@ -48,8 +49,11 @@ fun CliArgs.loadConfiguration(): Config {
 
     if (failFast) {
         val initializedDefaultConfig = defaultConfig ?: loadDefaultConfig()
-        declaredConfig = FailFastConfig(declaredConfig
-            ?: initializedDefaultConfig, initializedDefaultConfig)
+        declaredConfig = FailFastConfig(
+            declaredConfig
+                ?: initializedDefaultConfig,
+            initializedDefaultConfig
+        )
     }
 
     if (!autoCorrect) {

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/FilteredDetectionResult.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/FilteredDetectionResult.kt
@@ -11,8 +11,8 @@ class FilteredDetectionResult(detektion: Detektion, baselineFacade: BaselineFaca
 
     init {
         filteredFindings = detektion.findings
-                .map { (key, value) -> key to baselineFacade.filter(value) }
-                .toMap()
+            .map { (key, value) -> key to baselineFacade.filter(value) }
+            .toMap()
     }
 
     override val findings = filteredFindings

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/JCommander.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/JCommander.kt
@@ -35,11 +35,14 @@ inline fun <reified T : Args> parseArguments(
     }
 
     val violations = mutableListOf<String>()
-    validateCli(cli, object : MessageCollector {
-        override fun plusAssign(msg: String) {
-            violations += msg
+    validateCli(
+        cli,
+        object : MessageCollector {
+            override fun plusAssign(msg: String) {
+                violations += msg
+            }
         }
-    })
+    )
     if (violations.isNotEmpty()) {
         violations.forEach(errorPrinter::println)
         errorPrinter.println()

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/baseline/BaselineFacade.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/baseline/BaselineFacade.kt
@@ -10,19 +10,19 @@ import java.nio.file.Path
 class BaselineFacade(private val baselineFile: Path) {
 
     private val listings: Pair<Whitelist, Blacklist>? =
-            if (baselineExists()) {
-                val format = BaselineFormat().read(baselineFile)
-                format.whitelist to format.blacklist
-            } else null
+        if (baselineExists()) {
+            val format = BaselineFormat().read(baselineFile)
+            format.whitelist to format.blacklist
+        } else null
 
     fun filter(smells: List<Finding>) =
-            if (listings != null) {
-                val whiteFiltered = smells.filterNot { finding -> listings.first.ids.contains(finding.baselineId) }
-                val blackFiltered = whiteFiltered.filterNot { finding ->
-                    listings.second.ids.contains(finding.baselineId)
-                }
-                blackFiltered
-            } else smells
+        if (listings != null) {
+            val whiteFiltered = smells.filterNot { finding -> listings.first.ids.contains(finding.baselineId) }
+            val blackFiltered = whiteFiltered.filterNot { finding ->
+                listings.second.ids.contains(finding.baselineId)
+            }
+            blackFiltered
+        } else smells
 
     fun create(smells: List<Finding>) {
         val blacklist = if (baselineExists()) {

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/baseline/BaselineHandler.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/baseline/BaselineHandler.kt
@@ -11,7 +11,8 @@ internal class BaselineHandler : DefaultHandler() {
     private val blackIds = mutableSetOf<String>()
 
     internal fun createBaseline() = Baseline(
-            Blacklist(blackIds), Whitelist(whiteIds))
+        Blacklist(blackIds), Whitelist(whiteIds)
+    )
 
     override fun startElement(uri: String, localName: String, qName: String, attributes: Attributes) {
         when (qName) {

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/console/Colorizer.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/console/Colorizer.kt
@@ -7,7 +7,8 @@ private val RESET = Color(0)
 private val RED = Color(31)
 private val YELLOW = Color(33)
 
-private val escapeSequenceRegex = """$ESC\[\d+m""".toRegex()
+private val escapeSequenceRegex =
+    """$ESC\[\d+m""".toRegex()
 
 private data class Color(private val value: Byte) {
     val escapeSequence: String

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/out/HtmlUtils.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/out/HtmlUtils.kt
@@ -83,7 +83,8 @@ private fun createReportUrl(ruleName: String, throwable: Throwable): String {
         .lineSequence()
         .take(STACK_TRACE_LINES_TO_SHOW)
         .joinToString("\n")
-    val bodyMessage = """
+    val bodyMessage =
+        """
             |I found an error in the html report:
             |- Rule: $ruleName
             |- Detekt version: ${whichDetekt() ?: "<WRITE HERE THE VERSION OF DETEKT THAT YOU ARE USING>"}

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/out/XmlOutputReport.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/out/XmlOutputReport.kt
@@ -25,11 +25,11 @@ class XmlOutputReport : OutputReport() {
             lines += "<file name=\"${fileName.toXmlString()}\">"
             findings.forEach {
                 lines += arrayOf(
-                        "\t<error line=\"${it.location.source.line.toXmlString()}\"",
-                        "column=\"${it.location.source.column.toXmlString()}\"",
-                        "severity=\"${it.severityLabel.toXmlString()}\"",
-                        "message=\"${it.messageOrDescription().toXmlString()}\"",
-                        "source=\"${"detekt.${it.id.toXmlString()}"}\" />"
+                    "\t<error line=\"${it.location.source.line.toXmlString()}\"",
+                    "column=\"${it.location.source.column.toXmlString()}\"",
+                    "severity=\"${it.severityLabel.toXmlString()}\"",
+                    "message=\"${it.messageOrDescription().toXmlString()}\"",
+                    "source=\"${"detekt.${it.id.toXmlString()}"}\" />"
                 ).joinToString(separator = " ")
             }
             lines += "</file>"

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/SingleRuleRunner.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/SingleRuleRunner.kt
@@ -38,7 +38,8 @@ class SingleRuleRunner(
                 excludeDefaultRuleSets = disableDefaultRuleSets,
                 pluginPaths = createPlugins(),
                 outPrinter = outPrinter,
-                errPrinter = errPrinter)
+                errPrinter = errPrinter
+            )
         }.use { settings ->
             val realProvider = requireNotNull(
                 RuleSetLocator(settings).load().find { it.ruleSetId == ruleSet }

--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -9,7 +9,8 @@ build:
 
 config:
   validation: true
-  # when writing own rules with new properties, exclude the property path e.g.: 'my_rule_set,.*>.*>[my_property]'
+  # when writing own rules with new properties, exclude the property path
+  # e.g.: 'my_rule_set,.*>.*>[my_property]'
   excludes: ''
 
 processors:

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgsSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgsSpec.kt
@@ -26,7 +26,8 @@ internal class CliArgsSpec : Spek({
             val cli = parseArguments<CliArgs>(
                 arrayOf("--input", "$projectPath"),
                 NullPrintStream(),
-                NullPrintStream())
+                NullPrintStream()
+            )
             assertThat(cli.inputPaths).hasSize(1)
             assertThat(cli.inputPaths.first().toAbsolutePath()).isEqualTo(projectPath)
         }
@@ -37,7 +38,8 @@ internal class CliArgsSpec : Spek({
             val cli = parseArguments<CliArgs>(
                 arrayOf("--input", "$mainPath,$testPath"),
                 NullPrintStream(),
-                NullPrintStream())
+                NullPrintStream()
+            )
             assertThat(cli.inputPaths).hasSize(2)
             assertThat(cli.inputPaths.map(Path::toAbsolutePath)).containsExactlyInAnyOrder(mainPath, testPath)
         }

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/FileProcessorLocatorSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/FileProcessorLocatorSpec.kt
@@ -28,8 +28,8 @@ class FileProcessorLocatorSpec : Spek({
 
             assertThat(processorClasses).isNotEmpty
             processorClasses
-                    .filter { clazz -> processors.firstOrNull { clazz == it.javaClass } == null }
-                    .forEach { fail("$it processor is not loaded by the FileProcessorLocator") }
+                .filter { clazz -> processors.firstOrNull { clazz == it.javaClass } == null }
+                .forEach { fail("$it processor is not loaded by the FileProcessorLocator") }
         }
 
         it("has disabled processors") {
@@ -42,6 +42,6 @@ class FileProcessorLocatorSpec : Spek({
 
 private fun getProcessorClasses(): List<Class<out FileProcessListener>> {
     return Reflections("io.gitlab.arturbosch.detekt.core.processors")
-            .getSubTypesOf(FileProcessListener::class.java)
-            .filter { !Modifier.isAbstract(it.modifiers) }
+        .getSubTypesOf(FileProcessListener::class.java)
+        .filter { !Modifier.isAbstract(it.modifiers) }
 }

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/OutputFacadeSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/OutputFacadeSpec.kt
@@ -57,7 +57,8 @@ internal class OutputFacadeSpec : Spek({
             assertThat(printStream.toString()).contains(
                 "Successfully generated ${TxtOutputReport().name} at $plainOutputPath$LN",
                 "Successfully generated ${XmlOutputReport().name} at $xmlOutputPath$LN",
-                "Successfully generated ${HtmlOutputReport().name} at $htmlOutputPath$LN")
+                "Successfully generated ${HtmlOutputReport().name} at $htmlOutputPath$LN"
+            )
         }
     }
 })

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/baseline/BaselineFormatSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/baseline/BaselineFormatSpec.kt
@@ -44,7 +44,8 @@ class BaselineFormatSpec : Spek({
 
             val savedBaseline = Baseline(
                 Blacklist(setOf("4", "2", "2")),
-                Whitelist(setOf("1", "2", "3")))
+                Whitelist(setOf("1", "2", "3"))
+            )
 
             it("has a new line at the end of the written baseline file") {
                 val tempFile = createTempFileForTest("baseline1", ".xml")

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/console/FindingsReportSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/console/FindingsReportSpec.kt
@@ -46,7 +46,8 @@ class FindingsReportSpec : Spek({
         it("reports no findings with rule set containing no smells") {
             val detektion = object : TestDetektion() {
                 override val findings: Map<String, List<Finding>> = mapOf(
-                    Pair("Ruleset", emptyList()))
+                    Pair("Ruleset", emptyList())
+                )
             }
             assertThat(subject.render(detektion)).isNull()
         }

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/console/ProjectStatisticsReportSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/console/ProjectStatisticsReportSpec.kt
@@ -16,7 +16,8 @@ class ProjectStatisticsReportSpec : Spek({
             val expected = "Project Statistics:\n\t- M2: 2\n\t- M1: 1\n"
             val detektion = object : TestDetektion() {
                 override val metrics: Collection<ProjectMetric> = listOf(
-                    ProjectMetric("M1", 1, priority = 1), ProjectMetric("M2", 2, priority = 2))
+                    ProjectMetric("M1", 1, priority = 1), ProjectMetric("M2", 2, priority = 2)
+                )
             }
             assertThat(subject.render(detektion)).isEqualTo(expected)
         }

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/out/HtmlOutputReportSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/out/HtmlOutputReportSpec.kt
@@ -212,7 +212,8 @@ private fun createHtmlDetektion(vararg findingPairs: Pair<String, List<Finding>>
     }
 }
 
-private val generatedRegex = """^generated\swith.*$""".toRegex(RegexOption.MULTILINE)
+private val generatedRegex =
+    """^generated\swith.*$""".toRegex(RegexOption.MULTILINE)
 private const val replacement = "generated with..."
 
 private fun createReportWithFindings(findings: Array<Pair<String, List<Finding>>>): Path {

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/out/HtmlUtilsSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/out/HtmlUtilsSpec.kt
@@ -10,7 +10,8 @@ import org.spekframework.spek2.style.specification.describe
 class HtmlUtilsSpec : Spek({
 
     describe("HTML snippet code") {
-        val code = """
+        val code =
+            """
             package cases
             // reports 1 - line with just one space
 
@@ -27,14 +28,15 @@ class HtmlUtilsSpec : Spek({
                 // reports 1
                 }
             }
-        """.trimIndent().splitToSequence('\n')
+            """.trimIndent().splitToSequence('\n')
 
         it("all line") {
             val snippet = createHTML().div() {
                 snippetCode("ruleName", code.asSequence(), SourceLocation(7, 1), 34)
             }
 
-            assertThat(snippet).isEqualTo("""
+            assertThat(snippet).isEqualTo(
+                """
                 <div>
                   <pre><code><span class="lineno">   4 </span>// reports 1 - a comment with trailing space
                 <span class="lineno">   5 </span>// A comment
@@ -55,7 +57,8 @@ class HtmlUtilsSpec : Spek({
                 snippetCode("ruleName", code.asSequence(), SourceLocation(7, 7), 26)
             }
 
-            assertThat(snippet).isEqualTo("""
+            assertThat(snippet).isEqualTo(
+                """
                 <div>
                   <pre><code><span class="lineno">   4 </span>// reports 1 - a comment with trailing space
                 <span class="lineno">   5 </span>// A comment
@@ -76,7 +79,8 @@ class HtmlUtilsSpec : Spek({
                 snippetCode("ruleName", code.asSequence(), SourceLocation(7, 7), 66)
             }
 
-            assertThat(snippet).isEqualTo("""
+            assertThat(snippet).isEqualTo(
+                """
                 <div>
                   <pre><code><span class="lineno">   4 </span>// reports 1 - a comment with trailing space
                 <span class="lineno">   5 </span>// A comment

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/out/ReportsSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/out/ReportsSpec.kt
@@ -74,13 +74,21 @@ internal class ReportsSpec : Spek({
             }
 
             it("should recognize custom output format") {
-                assertThat(reports).haveExactly(1,
-                    Condition(Predicate { it.kind == reportUnderTest },
-                        "Corresponds exactly to the test output report."))
+                assertThat(reports).haveExactly(
+                    1,
+                    Condition(
+                        Predicate { it.kind == reportUnderTest },
+                        "Corresponds exactly to the test output report."
+                    )
+                )
 
-                assertThat(extensions).haveExactly(1,
-                    Condition(Predicate { it is TestOutputReport && it.ending == "yml" },
-                        "Is exactly the test output report."))
+                assertThat(extensions).haveExactly(
+                    1,
+                    Condition(
+                        Predicate { it is TestOutputReport && it.ending == "yml" },
+                        "Is exactly the test output report."
+                    )
+                )
             }
         }
 

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/out/TxtOutputReportSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/out/TxtOutputReportSpec.kt
@@ -29,13 +29,15 @@ class TxtOutputReportSpec : Spek({
             val detektion = TestDetektion(
                 createFinding(ruleName = "TestSmellA"),
                 createFinding(ruleName = "TestSmellB"),
-                createFinding(ruleName = "TestSmellC"))
-            val renderedText = """
+                createFinding(ruleName = "TestSmellC")
+            )
+            val renderedText =
+                """
                 TestSmellA - [TestEntity] at TestFile.kt:1:1 - Signature=TestEntitySignature
                 TestSmellB - [TestEntity] at TestFile.kt:1:1 - Signature=TestEntitySignature
                 TestSmellC - [TestEntity] at TestFile.kt:1:1 - Signature=TestEntitySignature
 
-            """.trimIndent()
+                """.trimIndent()
             assertThat(report.render(detektion)).isEqualTo(renderedText)
         }
     }

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/out/XmlOutputFormatSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/out/XmlOutputFormatSpec.kt
@@ -15,12 +15,20 @@ import org.spekframework.spek2.style.specification.describe
 
 class XmlOutputFormatSpec : Spek({
 
-    val entity1 = Entity("Sample1", "com.sample.Sample1", "",
-            Location(SourceLocation(11, 1), TextLocation(0, 10),
-                    "abcd", "src/main/com/sample/Sample1.kt"))
-    val entity2 = Entity("Sample2", "com.sample.Sample2", "",
-            Location(SourceLocation(22, 2), TextLocation(0, 20),
-                    "efgh", "src/main/com/sample/Sample2.kt"))
+    val entity1 = Entity(
+        "Sample1", "com.sample.Sample1", "",
+        Location(
+            SourceLocation(11, 1), TextLocation(0, 10),
+            "abcd", "src/main/com/sample/Sample1.kt"
+        )
+    )
+    val entity2 = Entity(
+        "Sample2", "com.sample.Sample2", "",
+        Location(
+            SourceLocation(22, 2), TextLocation(0, 20),
+            "efgh", "src/main/com/sample/Sample2.kt"
+        )
+    )
 
     val outputFormat = XmlOutputReport()
 
@@ -98,7 +106,8 @@ class XmlOutputFormatSpec : Spek({
                         entity = entity1
                     )
 
-                    val expected = """
+                    val expected =
+                        """
                     <?xml version="1.0" encoding="utf-8"?>
                     <checkstyle version="4.3">
                     <file name="${finding.location.file}">

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/ElementPrinterSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/ElementPrinterSpec.kt
@@ -22,22 +22,25 @@ class ElementPrinterSpec : Spek({
     }
 })
 
-private val expected = """0: KtFile
-  1: KtPackageDirective
-    1: KtNameReferenceExpression
-    1: KtImportList
-    3: KtClass
-      3: KtClassBody
-        5: KtProperty
-          5: KtTypeReference
-          5: KtUserType
-          5: KtNameReferenceExpression
-          5: KtStringTemplateExpression
-          5: KtLiteralStringTemplateEntry
-        6: KtNamedFunction
-          6: KtParameterList
-          6: KtStringTemplateExpression
-          6: KtLiteralStringTemplateEntry
-          6: KtSimpleNameStringTemplateEntry
-          6: KtNameReferenceExpression
-""".trimIndent()
+@Suppress("detekt.Indentation")
+private val expected =
+    """
+    0: KtFile
+      1: KtPackageDirective
+        1: KtNameReferenceExpression
+        1: KtImportList
+        3: KtClass
+          3: KtClassBody
+            5: KtProperty
+              5: KtTypeReference
+              5: KtUserType
+              5: KtNameReferenceExpression
+              5: KtStringTemplateExpression
+              5: KtLiteralStringTemplateEntry
+            6: KtNamedFunction
+              6: KtParameterList
+              6: KtStringTemplateExpression
+              6: KtLiteralStringTemplateEntry
+              6: KtSimpleNameStringTemplateEntry
+              6: KtNameReferenceExpression
+    """.trimIndent()

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/RunnerSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/RunnerSpec.kt
@@ -123,7 +123,8 @@ class RunnerSpec : Spek({
             beforeEachTest {
                 val args = createCliArgs(
                     "--input", inputPath.toString(),
-                    "--config-resource", "/configs/max-issues-0.yml")
+                    "--config-resource", "/configs/max-issues-0.yml"
+                )
 
                 try {
                     Runner(args, outPrintStream, errPrintStream).execute()

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/KtCompiler.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/KtCompiler.kt
@@ -20,8 +20,10 @@ open class KtCompiler(
     fun compile(root: Path, subPath: Path): KtFile {
         require(subPath.isFile()) { "Given sub path ($subPath) should be a regular file!" }
         val relativePath =
-            (if (root == subPath) subPath.fileName
-            else root.fileName.resolve(root.relativize(subPath))).normalize()
+            (
+                if (root == subPath) subPath.fileName
+                else root.fileName.resolve(root.relativize(subPath))
+                ).normalize()
         val absolutePath = subPath.toAbsolutePath().normalize()
         val content = subPath.toFile().readText()
         val lineSeparator = content.determineLineSeparator()

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/ProcessingSettings.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/ProcessingSettings.kt
@@ -27,7 +27,9 @@ import java.util.concurrent.ExecutorService
  * If using a custom executor service be aware that detekt won't shut it down after use!
  */
 @OptIn(UnstableApi::class)
-class ProcessingSettings @Suppress("LongParameterList") constructor(
+class ProcessingSettings
+@Suppress("LongParameterList")
+constructor(
     val inputPaths: List<Path>,
     override val config: Config = Config.empty,
     val pathFilters: PathFilters? = null,

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/processors/AbstractProcessor.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/processors/AbstractProcessor.kt
@@ -17,8 +17,8 @@ abstract class AbstractProcessor : FileProcessListener {
 
     override fun onFinish(files: List<KtFile>, result: Detektion) {
         val count = files
-                .mapNotNull { it.getUserData(key) }
-                .sum()
+            .mapNotNull { it.getUserData(key) }
+            .sum()
         result.addData(key, count)
     }
 }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/processors/AbstractProjectMetricProcessor.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/processors/AbstractProjectMetricProcessor.kt
@@ -10,8 +10,8 @@ abstract class AbstractProjectMetricProcessor : AbstractProcessor() {
 
     override fun onFinish(files: List<KtFile>, result: Detektion) {
         val count = files
-                .mapNotNull { it.getUserData(key) }
-                .sum()
+            .mapNotNull { it.getUserData(key) }
+            .sum()
         result.add(ProjectMetric(type, count))
     }
 }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/processors/PackageCountProcessor.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/processors/PackageCountProcessor.kt
@@ -18,9 +18,9 @@ class PackageCountProcessor : FileProcessListener {
 
     override fun onFinish(files: List<KtFile>, result: Detektion) {
         val count = files
-                .mapNotNull { it.getUserData(key) }
-                .distinct()
-                .size
+            .mapNotNull { it.getUserData(key) }
+            .distinct()
+            .size
         result.add(ProjectMetric(key.toString(), count))
     }
 }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/processors/ProjectSLOCProcessor.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/processors/ProjectSLOCProcessor.kt
@@ -24,9 +24,9 @@ class SLOCVisitor : DetektVisitor() {
 
         fun count(lines: List<String>): Int {
             return lines
-                    .map { it.trim() }
-                    .filter { trim -> trim.isNotEmpty() && !comments.any { trim.startsWith(it) } }
-                    .size
+                .map { it.trim() }
+                .filter { trim -> trim.isNotEmpty() && !comments.any { trim.startsWith(it) } }
+                .size
         }
     }
 }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/processors/util/LLOC.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/processors/util/LLOC.kt
@@ -25,7 +25,6 @@ object LLOC {
         @Suppress("LoopWithTooManyJumpStatements")
         internal fun run(): Int {
             for (line in lines) {
-
                 val trimmed = line.trim()
 
                 if (trimmed.isEmpty()) {
@@ -83,7 +82,6 @@ object LLOC {
         }
 
         private fun frequency(source: String, part: String): Int {
-
             if (source.isEmpty() || part.isEmpty()) {
                 return 0
             }

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/KtTreeCompilerSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/KtTreeCompilerSpec.kt
@@ -12,8 +12,12 @@ import java.nio.file.Paths
 class KtTreeCompilerSpec : Spek({
 
     fun fixture(vararg filters: String): KtTreeCompiler =
-        KtTreeCompiler(settings = createProcessingSettings(path,
-            pathFilters = PathFilters.of(emptyList(), filters.toList())))
+        KtTreeCompiler(
+            settings = createProcessingSettings(
+                path,
+                pathFilters = PathFilters.of(emptyList(), filters.toList())
+            )
+        )
 
     describe("tree compiler functionality") {
 

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/processors/ClassCountVisitorTest.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/processors/ClassCountVisitorTest.kt
@@ -12,8 +12,8 @@ class ClassCountVisitorTest : Spek({
 
         it("twoClassesInSeparateFile") {
             val files = arrayOf(
-                    compileForTest(path.resolve("Test.kt")),
-                    compileForTest(path.resolve("Default.kt"))
+                compileForTest(path.resolve("Test.kt")),
+                compileForTest(path.resolve("Default.kt"))
             )
             val count = getClassCount(files)
             assertThat(count).isEqualTo(2)
@@ -27,8 +27,8 @@ class ClassCountVisitorTest : Spek({
 
         it("testEnumAndInterface") {
             val files = arrayOf(
-                    compileForTest(path.resolve("../empty/EmptyEnum.kt")),
-                    compileForTest(path.resolve("../empty/EmptyInterface.kt"))
+                compileForTest(path.resolve("../empty/EmptyEnum.kt")),
+                compileForTest(path.resolve("../empty/EmptyInterface.kt"))
             )
             val count = getClassCount(files)
             assertThat(count).isEqualTo(2)
@@ -38,8 +38,8 @@ class ClassCountVisitorTest : Spek({
 
 private fun getClassCount(files: Array<KtFile>): Int {
     return files
-            .map { getData(it) }
-            .sum()
+        .map { getData(it) }
+        .sum()
 }
 
 private fun getData(file: KtFile): Int {

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/processors/KtFileCountVisitorTest.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/processors/KtFileCountVisitorTest.kt
@@ -12,12 +12,12 @@ class KtFileCountVisitorTest : Spek({
 
         it("twoFiles") {
             val files = arrayOf(
-                    compileForTest(path.resolve("Default.kt")),
-                    compileForTest(path.resolve("Test.kt"))
+                compileForTest(path.resolve("Default.kt")),
+                compileForTest(path.resolve("Test.kt"))
             )
             val count = files
-                    .map { getData(it) }
-                    .sum()
+                .map { getData(it) }
+                .sum()
             assertThat(count).isEqualTo(2)
         }
     }

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/processors/PackageCountVisitorTest.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/processors/PackageCountVisitorTest.kt
@@ -12,13 +12,13 @@ class PackageCountVisitorTest : Spek({
 
         it("twoClassesInSeparatePackage") {
             val files = arrayOf(
-                    compileForTest(path.resolve("Default.kt")),
-                    compileForTest(path.resolve("../empty/EmptyEnum.kt"))
+                compileForTest(path.resolve("Default.kt")),
+                compileForTest(path.resolve("../empty/EmptyEnum.kt"))
             )
             val count = files
-                    .map { getData(it) }
-                    .distinct()
-                    .count()
+                .map { getData(it) }
+                .distinct()
+                .count()
             assertThat(count).isEqualTo(2)
         }
     }

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingProvider.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingProvider.kt
@@ -23,5 +23,5 @@ class FormattingProvider : RuleSetProvider {
     override val ruleSetId: String = "formatting"
 
     override fun instance(config: Config) =
-            RuleSet(ruleSetId, listOf(KtLintMultiRule(config)))
+        RuleSet(ruleSetId, listOf(KtLintMultiRule(config)))
 }

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/Indentation.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/Indentation.kt
@@ -1,7 +1,7 @@
 package io.gitlab.arturbosch.detekt.formatting.wrappers
 
 import com.pinterest.ktlint.core.EditorConfig
-import com.pinterest.ktlint.ruleset.standard.IndentationRule
+import com.pinterest.ktlint.ruleset.experimental.IndentationRule
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.formatting.DEFAULT_CONTINUATION_INDENT
 import io.gitlab.arturbosch.detekt.formatting.DEFAULT_INDENT

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/Indentation.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/Indentation.kt
@@ -25,9 +25,11 @@ class Indentation(config: Config) : FormattingRule(config) {
     private val continuationIndentSize = valueOrDefault(CONTINUATION_INDENT_SIZE, DEFAULT_CONTINUATION_INDENT)
 
     override fun editorConfigUpdater(): ((oldEditorConfig: EditorConfig?) -> EditorConfig)? = {
-        EditorConfig.merge(it,
-                indentSize = indentSize,
-                continuationIndentSize = continuationIndentSize)
+        EditorConfig.merge(
+            it,
+            indentSize = indentSize,
+            continuationIndentSize = continuationIndentSize
+        )
     }
 
     companion object {

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/ParameterListWrapping.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/ParameterListWrapping.kt
@@ -23,8 +23,10 @@ class ParameterListWrapping(config: Config) : FormattingRule(config) {
     private val indentSize = valueOrDefault(INDENT_SIZE, DEFAULT_INDENT)
 
     override fun editorConfigUpdater(): ((oldEditorConfig: EditorConfig?) -> EditorConfig)? = {
-        EditorConfig.merge(it,
-                indentSize = indentSize)
+        EditorConfig.merge(
+            it,
+            indentSize = indentSize
+        )
     }
 
     companion object {

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/FinalNewlineSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/FinalNewlineSpec.kt
@@ -20,20 +20,24 @@ class FinalNewlineSpec : Spek({
         }
 
         it("should not report as new line is present") {
-            val findings = FinalNewline(Config.empty).lint("""
-                    fun main() = Unit
+            val findings = FinalNewline(Config.empty).lint(
+                """
+                fun main() = Unit
 
-            """.trimIndent())
+                """.trimIndent()
+            )
 
             assertThat(findings).isEmpty()
         }
 
         it("should report new line when configured") {
             val findings = FinalNewline(TestConfig(INSERT_FINAL_NEWLINE to "false"))
-                .lint("""
-                fun main() = Unit
+                .lint(
+                    """
+                    fun main() = Unit
 
-            """.trimIndent())
+                    """.trimIndent()
+                )
 
             assertThat(findings).hasSize(1)
         }

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingRuleSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingRuleSpec.kt
@@ -14,21 +14,25 @@ class FormattingRuleSpec : Spek({
     describe("formatting rules can be suppressed") {
 
         it("does support suppression only on file level") {
-            val findings = subject.lint("""
+            val findings = subject.lint(
+                """
                 @file:Suppress("NoLineBreakBeforeAssignment")
                 fun main() 
                 = Unit
-            """.trimIndent())
+                """.trimIndent()
+            )
 
             assertThat(findings).isEmpty()
         }
 
         it("does not support suppression on node level") {
-            val findings = subject.lint("""
+            val findings = subject.lint(
+                """
                 @Suppress("NoLineBreakBeforeAssignment")
                 fun main() 
                 = Unit
-            """.trimIndent())
+                """.trimIndent()
+            )
 
             assertThat(findings).hasSize(1)
         }
@@ -37,20 +41,24 @@ class FormattingRuleSpec : Spek({
     describe("formatting rules have a signature") {
 
         it("has no package name") {
-            val findings = subject.lint("""
+            val findings = subject.lint(
+                """
                 fun main() 
                 = Unit
-            """.trimIndent())
+                """.trimIndent()
+            )
 
             assertThat(findings.first().signature).isEqualTo("Test.kt:2")
         }
 
         it("has a package name") {
-            val findings = subject.lint("""
+            val findings = subject.lint(
+                """
                 package test.test.test
                 fun main() 
                 = Unit
-            """.trimIndent())
+                """.trimIndent()
+            )
 
             assertThat(findings.first().signature).isEqualTo("test.test.test.Test.kt:3")
         }

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/TestFiles.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/TestFiles.kt
@@ -21,76 +21,78 @@ fun loadFile(resourceName: String) = compileForTest(Paths.get(resource(resourceN
 fun loadFileContent(resourceName: String) =
     StringUtilRt.convertLineSeparators(File(resource(resourceName)).readText())
 
-val contentAfterChainWrapping = """
-fun main() {
-    val anchor = owner.firstChild!!
-        .siblings(forward = true)
-        .dropWhile { it is PsiComment || it is PsiWhiteSpace }
-    val s = foo()
-        ?: bar
-    val s = foo()
-        ?.bar
-    val s = 1
-        + 2
-    val s = true &&
-        false
-    val s = b.equals(o.b) &&
-        g == o.g
-    val d = 1 +
-        -1
-    val d = 1
-        + -1
-    when (foo){
-        0 -> {
+val contentAfterChainWrapping =
+    """
+    fun main() {
+        val anchor = owner.firstChild!!
+            .siblings(forward = true)
+            .dropWhile { it is PsiComment || it is PsiWhiteSpace }
+        val s = foo()
+            ?: bar
+        val s = foo()
+            ?.bar
+        val s = 1
+            + 2
+        val s = true &&
+            false
+        val s = b.equals(o.b) &&
+            g == o.g
+        val d = 1 +
+            -1
+        val d = 1
+            + -1
+        when (foo){
+            0 -> {
+            }
+            1 -> {
+            }
+            -2 -> {
+            }
         }
-        1 -> {
+        if (
+          -3 == a()
+        ) {}
+        if (
+          // comment
+          -3 == a()
+        ) {}
+        if (
+          /* comment */
+          -3 == a()
+        ) {}
+        if (c)
+          -7
+        else
+          -8
+        try {
+          fn()
+        } catch(e: Exception) {
+          -9
         }
-        -2 -> {
-        }
+        var x =
+            -2 >
+            (2 + 2)
+        -3
     }
-    if (
-      -3 == a()
-    ) {}
-    if (
-      // comment
-      -3 == a()
-    ) {}
-    if (
-      /* comment */
-      -3 == a()
-    ) {}
-    if (c)
-      -7
-    else
-      -8
-    try {
-      fn()
-    } catch(e: Exception) {
-      -9
-    }
-    var x =
-        -2 >
-        (2 + 2)
-    -3
-}
 
-""".trimIndent()
+    """.trimIndent()
 
-val longLines = """
-/**
- * These are class docs.
- */
-class C {
+val longLines =
+    """
     /**
-     * These are function docs.
+     * These are class docs.
      */
-    fun getLoremIpsum() = "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua."
-
-    companion object {
+    class C {
         /**
-         * This is a constant for "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua."
+         * These are function docs.
          */
-        val LOREM_IPSUM = "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua."
+        fun getLoremIpsum() = "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua."
+
+        companion object {
+            /**
+             * This is a constant for "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua."
+             */
+            val LOREM_IPSUM = "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua."
+        }
     }
-}
-""".trimIndent()
+    """.trimIndent()

--- a/detekt-generator/build.gradle.kts
+++ b/detekt-generator/build.gradle.kts
@@ -22,10 +22,12 @@ val generateDocumentation by tasks.registering {
 
     inputs.files(
         fileTree("${rootProject.rootDir}/detekt-rules/src/main/kotlin"),
-        file("${rootProject.rootDir}/detekt-generator/build/libs/detekt-generator-${Versions.DETEKT}-all.jar"))
+        file("${rootProject.rootDir}/detekt-generator/build/libs/detekt-generator-${Versions.DETEKT}-all.jar")
+    )
     outputs.files(
         fileTree("${rootProject.rootDir}/detekt-generator/documentation"),
-        file("${rootProject.rootDir}/detekt-cli/src/main/resources/default-detekt-config.yml"))
+        file("${rootProject.rootDir}/detekt-cli/src/main/resources/default-detekt-config.yml")
+    )
 
     doLast {
         javaexec {
@@ -38,7 +40,8 @@ val generateDocumentation by tasks.registering {
                 "--documentation",
                 "${rootProject.rootDir}/docs/pages/documentation",
                 "--config",
-                "${rootProject.rootDir}/detekt-cli/src/main/resources")
+                "${rootProject.rootDir}/detekt-cli/src/main/resources"
+            )
         }
     }
 }
@@ -55,14 +58,18 @@ val verifyGeneratorOutput by tasks.registering {
 fun assertDefaultConfigUpToDate() {
     val configDiff = ByteArrayOutputStream()
     exec {
-        commandLine = listOf("git", "diff",
-            "${rootProject.rootDir}/detekt-cli/src/main/resources/default-detekt-config.yml")
+        commandLine = listOf(
+            "git", "diff",
+            "${rootProject.rootDir}/detekt-cli/src/main/resources/default-detekt-config.yml"
+        )
         standardOutput = configDiff
     }
 
     if (configDiff.toString().isNotEmpty()) {
-        throw GradleException("The default-detekt-config.yml is not up-to-date. " +
-            "You can execute the generateDocumentation Gradle task to update it and commit the changed files.")
+        throw GradleException(
+            "The default-detekt-config.yml is not up-to-date. " +
+                "You can execute the generateDocumentation Gradle task to update it and commit the changed files."
+        )
     }
 }
 
@@ -76,8 +83,10 @@ fun assertDocumentationUpToDate() {
     }
 
     if (configDiff.toString().isNotEmpty()) {
-        throw GradleException("The detekt documentation is not up-to-date. " +
-            "Please build detekt locally to update it and commit the changed files.")
+        throw GradleException(
+            "The detekt documentation is not up-to-date. " +
+                "Please build detekt locally to update it and commit the changed files."
+        )
     }
 }
 

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/GeneratorArgs.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/GeneratorArgs.kt
@@ -8,23 +8,31 @@ import java.nio.file.Path
 
 class GeneratorArgs : Args {
 
-    @Parameter(names = ["--input", "-i"],
+    @Parameter(
+        names = ["--input", "-i"],
         required = true,
-        description = "Input paths to analyze.")
+        description = "Input paths to analyze."
+    )
     private var input: String? = null
 
-    @Parameter(names = ["--documentation", "-d"],
+    @Parameter(
+        names = ["--documentation", "-d"],
         required = true,
-        converter = ExistingPathConverter::class, description = "Output path for generated documentation.")
+        converter = ExistingPathConverter::class, description = "Output path for generated documentation."
+    )
     private var documentation: Path? = null
 
-    @Parameter(names = ["--config", "-c"],
+    @Parameter(
+        names = ["--config", "-c"],
         required = true,
-        converter = ExistingPathConverter::class, description = "Output path for generated detekt config.")
+        converter = ExistingPathConverter::class, description = "Output path for generated detekt config."
+    )
     private var config: Path? = null
 
-    @Parameter(names = ["--help", "-h"],
-        help = true, description = "Shows the usage.")
+    @Parameter(
+        names = ["--help", "-h"],
+        help = true, description = "Shows the usage."
+    )
     override var help: Boolean = false
 
     val inputPath: List<Path> by lazy {

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/Runner.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/Runner.kt
@@ -16,10 +16,13 @@ class Runner(
     private val collector = DetektCollector()
     private val printer = DetektPrinter(arguments)
 
-    private fun createCompiler(path: Path) = KtTreeCompiler.instance(ProcessingSettings(
-        listOf(path),
-        outPrinter = outPrinter,
-        errPrinter = errPrinter))
+    private fun createCompiler(path: Path) = KtTreeCompiler.instance(
+        ProcessingSettings(
+            listOf(path),
+            outPrinter = outPrinter,
+            errPrinter = errPrinter
+        )
+    )
 
     fun execute() {
         val time = measureTimeMillis {

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/DetektCollector.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/DetektCollector.kt
@@ -49,11 +49,11 @@ class DetektCollector : Collector<RuleSetPage> {
 
     private fun List<Rule>.resolveParentRule(rules: List<Rule>) {
         this.filter { it.debt.isEmpty() && it.severity.isEmpty() }
-                .forEach {
-                    val parentRule = rules.findRuleByName(it.parent)
-                    it.debt = parentRule.debt
-                    it.severity = parentRule.severity
-                }
+            .forEach {
+                val parentRule = rules.findRuleByName(it.parent)
+                it.debt = parentRule.debt
+                it.severity = parentRule.severity
+            }
     }
 
     override fun visit(file: KtFile) {

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/KDocTags.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/KDocTags.kt
@@ -6,10 +6,10 @@ import org.jetbrains.kotlin.kdoc.psi.impl.KDocTag
 import org.jetbrains.kotlin.psi.KtClassOrObject
 
 fun KtClassOrObject.parseConfigurationTags() =
-        kDocSection()?.findTagsByName(TAG_CONFIGURATION)
-                ?.filter { it.isValidConfigurationTag() }
-                ?.map { it.parseConfigTag() }
-            ?: emptyList()
+    kDocSection()?.findTagsByName(TAG_CONFIGURATION)
+        ?.filter { it.isValidConfigurationTag() }
+        ?.map { it.parseConfigTag() }
+        ?: emptyList()
 
 fun KtClassOrObject.kDocSection(): KDocSection? = docComment?.getDefaultSection()
 
@@ -18,35 +18,37 @@ fun KDocTag.parseConfigTag(): Configuration {
     val delimiterIndex = content.indexOf('-')
     val name = content.substring(0, delimiterIndex - 1)
     val defaultValue = configurationDefaultValueRegex.find(content)
-            ?.groupValues
-            ?.get(1)
-            ?.trim() ?: ""
+        ?.groupValues
+        ?.get(1)
+        ?.trim() ?: ""
     val deprecatedMessage = configurationDeprecatedRegex.find(content)
-            ?.groupValues
-            ?.get(1)
-            ?.trim()
+        ?.groupValues
+        ?.get(1)
+        ?.trim()
     val description = content.substring(delimiterIndex + 1)
-            .replace(configurationDefaultValueRegex, "")
-            .replace(configurationDeprecatedRegex, "")
-            .trim()
+        .replace(configurationDefaultValueRegex, "")
+        .replace(configurationDeprecatedRegex, "")
+        .trim()
     return Configuration(name, description, defaultValue, deprecatedMessage)
 }
 
 private const val EXPECTED_CONFIGURATION_FORMAT =
-        "Expected format: @configuration {paramName} - {paramDescription} (default: `{defaultValue}`)."
+    "Expected format: @configuration {paramName} - {paramDescription} (default: `{defaultValue}`)."
 
 fun KDocTag.isValidConfigurationTag(entity: String = "Rule"): Boolean {
     val content: String = getContent()
     if (!content.contains(" - ")) {
         throw InvalidDocumentationException(
-                "[${containingFile.name}] $entity '$content' doesn't seem to contain a description.\n" +
-                        EXPECTED_CONFIGURATION_FORMAT)
+            "[${containingFile.name}] $entity '$content' doesn't seem to contain a description.\n" +
+                EXPECTED_CONFIGURATION_FORMAT
+        )
     }
     if (content.substringAfter("`", "").substringBeforeLast("`", "").isBlank()) {
         val parameterName = content.substringBefore(" - ")
         throw InvalidDocumentationException(
-                "[${containingFile.name}] $entity '$parameterName' doesn't seem to contain a default value.\n" +
-                        EXPECTED_CONFIGURATION_FORMAT)
+            "[${containingFile.name}] $entity '$parameterName' doesn't seem to contain a default value.\n" +
+                EXPECTED_CONFIGURATION_FORMAT
+        )
     }
     return true
 }

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/MultiRuleCollector.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/MultiRuleCollector.kt
@@ -48,7 +48,7 @@ class MultiRuleVisitor : DetektVisitor() {
         val rules = mutableListOf<String>()
 
         val ruleProperties = rulesVisitor.ruleProperties
-                .mapNotNull { properties[it] }
+            .mapNotNull { properties[it] }
         rules.addAll(ruleProperties)
         rules.addAll(rulesVisitor.ruleNames)
 
@@ -63,8 +63,8 @@ class MultiRuleVisitor : DetektVisitor() {
 
     override fun visitSuperTypeList(list: KtSuperTypeList) {
         val isMultiRule = list.entries
-                ?.mapNotNull { it.typeAsUserType?.referencedName }
-                ?.any { it == multiRule } ?: false
+            ?.mapNotNull { it.typeAsUserType?.referencedName }
+            ?.any { it == multiRule } ?: false
 
         val containingClass = list.containingClass()
         val className = containingClass?.name
@@ -112,13 +112,17 @@ class RuleListVisitor : DetektVisitor() {
         val argumentExpressions = list.arguments.map { it.getArgumentExpression() }
 
         // Call Expression = Constructor of rule
-        ruleNames.addAll(argumentExpressions
+        ruleNames.addAll(
+            argumentExpressions
                 .filterIsInstance<KtCallExpression>()
-                .map { it.calleeExpression?.text ?: "" })
+                .map { it.calleeExpression?.text ?: "" }
+        )
 
         // Reference Expression = variable we need to search for
-        ruleProperties.addAll(argumentExpressions
+        ruleProperties.addAll(
+            argumentExpressions
                 .filterIsInstance<KtReferenceExpression>()
-                .map { it.text ?: "" })
+                .map { it.text ?: "" }
+        )
     }
 }

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleSetProviderCollector.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleSetProviderCollector.kt
@@ -80,8 +80,10 @@ class RuleSetProviderVisitor : DetektVisitor() {
         super.visitProperty(property)
         if (property.isOverride() && property.name != null && property.name == PROPERTY_RULE_SET_ID) {
             name = (property.initializer as? KtStringTemplateExpression)?.entries?.get(0)?.text
-                ?: throw InvalidDocumentationException("RuleSetProvider class " +
-                        "${property.containingClass()?.name ?: ""} doesn't provide list of rules.")
+                ?: throw InvalidDocumentationException(
+                    "RuleSetProvider class " +
+                        "${property.containingClass()?.name ?: ""} doesn't provide list of rules."
+                )
         }
     }
 
@@ -90,14 +92,14 @@ class RuleSetProviderVisitor : DetektVisitor() {
 
         if (expression.calleeExpression?.text == "RuleSet") {
             val ruleListExpression = expression.valueArguments
-                    .map { it.getArgumentExpression() }
-                    .firstOrNull { it?.referenceExpression()?.text == "listOf" }
+                .map { it.getArgumentExpression() }
+                .firstOrNull { it?.referenceExpression()?.text == "listOf" }
                 ?: throw InvalidDocumentationException("RuleSetProvider $name doesn't provide list of rules.")
 
             val ruleArgumentNames = (ruleListExpression as? KtCallExpression)
-                    ?.valueArguments
-                    ?.map { it.getArgumentExpression() }
-                    ?.mapNotNull { it?.referenceExpression()?.text }
+                ?.valueArguments
+                ?.map { it.getArgumentExpression() }
+                ?.mapNotNull { it?.referenceExpression()?.text }
                 ?: emptyList()
 
             ruleNames.addAll(ruleArgumentNames)

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleVisitor.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleVisitor.kt
@@ -40,15 +40,17 @@ internal class RuleVisitor : DetektVisitor() {
             throw InvalidDocumentationException("Rule $name is missing a description in its KDoc.")
         }
 
-        return Rule(name, description, nonCompliant, compliant,
-                active, severity, debt, aliases, parent, configuration, autoCorrect)
+        return Rule(
+            name, description, nonCompliant, compliant,
+            active, severity, debt, aliases, parent, configuration, autoCorrect
+        )
     }
 
     override fun visitSuperTypeList(list: KtSuperTypeList) {
         val isRule = list.entries
-                ?.asSequence()
-                ?.map { it.typeAsUserType?.referencedName }
-                ?.any { ruleClasses.contains(it) } ?: false
+            ?.asSequence()
+            ?.map { it.typeAsUserType?.referencedName }
+            ?.any { ruleClasses.contains(it) } ?: false
 
         val containingClass = list.containingClass()
         val className = containingClass?.name
@@ -92,7 +94,8 @@ internal class RuleVisitor : DetektVisitor() {
                 extractCompliantDocumentation(comment, compliantIndex)
             }
             compliantIndex != -1 -> throw InvalidCodeExampleDocumentationException(
-                    "Rule $name contains a compliant without a noncompliant code definition")
+                "Rule $name contains a compliant without a noncompliant code definition"
+            )
             else -> description = comment
         }
     }
@@ -101,12 +104,13 @@ internal class RuleVisitor : DetektVisitor() {
         val nonCompliantEndIndex = comment.indexOf(ENDTAG_NONCOMPLIANT)
         if (nonCompliantEndIndex == -1) {
             throw InvalidCodeExampleDocumentationException(
-                    "Rule $name contains an incorrect noncompliant code definition")
+                "Rule $name contains an incorrect noncompliant code definition"
+            )
         }
         description = comment.substring(0, nonCompliantIndex).trim()
         nonCompliant = comment.substring(nonCompliantIndex + TAG_NONCOMPLIANT.length, nonCompliantEndIndex)
-                .trimStartingLineBreaks()
-                .trimEnd()
+            .trimStartingLineBreaks()
+            .trimEnd()
     }
 
     private fun extractCompliantDocumentation(comment: String, compliantIndex: Int) {
@@ -114,31 +118,36 @@ internal class RuleVisitor : DetektVisitor() {
         if (compliantIndex != -1) {
             if (compliantEndIndex == -1) {
                 throw InvalidCodeExampleDocumentationException(
-                        "Rule $name contains an incorrect compliant code definition")
+                    "Rule $name contains an incorrect compliant code definition"
+                )
             }
             compliant = comment.substring(compliantIndex + TAG_COMPLIANT.length, compliantEndIndex)
-                    .trimStartingLineBreaks()
-                    .trimEnd()
+                .trimStartingLineBreaks()
+                .trimEnd()
         }
     }
 
     private fun extractAliases(klass: KtClass) {
         val initializer = klass.getProperties()
-                .singleOrNull { it.name == "defaultRuleIdAliases" }
-                ?.initializer
+            .singleOrNull { it.name == "defaultRuleIdAliases" }
+            ?.initializer
         if (initializer != null) {
-            aliases = (initializer as? KtCallExpression
-                ?: throw InvalidAliasesDeclaration())
-                    .valueArguments
-                    .joinToString(", ") { it.text.replace("\"", "") }
+            aliases = (
+                initializer as? KtCallExpression
+                    ?: throw InvalidAliasesDeclaration()
+                )
+                .valueArguments
+                .joinToString(", ") { it.text.replace("\"", "") }
         }
     }
 
     private fun extractIssueSeverityAndDebt(klass: KtClass) {
-        val arguments = (klass.getProperties()
+        val arguments = (
+            klass.getProperties()
                 .singleOrNull { it.name == "issue" }
-                ?.initializer as? KtCallExpression)
-                ?.valueArguments ?: emptyList()
+                ?.initializer as? KtCallExpression
+            )
+            ?.valueArguments ?: emptyList()
 
         if (arguments.size >= ISSUE_ARGUMENT_SIZE) {
             severity = getArgument(arguments[1], "Severity")
@@ -163,10 +172,10 @@ internal class RuleVisitor : DetektVisitor() {
 
     companion object {
         private val ruleClasses = listOf(
-                io.gitlab.arturbosch.detekt.api.Rule::class.simpleName,
-                FormattingRule::class.simpleName,
-                ThresholdRule::class.simpleName,
-                EmptyRule::class.simpleName
+            io.gitlab.arturbosch.detekt.api.Rule::class.simpleName,
+            FormattingRule::class.simpleName,
+            ThresholdRule::class.simpleName,
+            EmptyRule::class.simpleName
         )
 
         private const val TAG_ACTIVE = "active"

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/exception/InvalidAliasesDeclaration.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/exception/InvalidAliasesDeclaration.kt
@@ -1,5 +1,5 @@
 package io.gitlab.arturbosch.detekt.generator.collection.exception
 
 class InvalidAliasesDeclaration : RuntimeException(
-        "Invalid aliases declaration. Example: override val defaultRuleIdAliases = setOf(\"Name1\", \"Name2\")"
+    "Invalid aliases declaration. Example: override val defaultRuleIdAliases = setOf(\"Name1\", \"Name2\")"
 )

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/out/Markdown.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/out/Markdown.kt
@@ -40,7 +40,7 @@ inline fun MarkdownContent.orderedList(sectionList: () -> List<String>) {
 }
 
 inline fun MarkdownContent.referenceToHeading(reference: () -> String) =
-        "[${reference()}](#${reference().replace(' ', '-').toLowerCase()})"
+    "[${reference()}](#${reference().replace(' ', '-').toLowerCase()})"
 
 inline fun MarkdownContent.code(code: () -> String) = "``${code()}``"
 inline fun MarkdownContent.codeBlock(code: () -> String) = "```kotlin\n${code()}\n```"

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/rulesetpage/ConfigPrinter.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/rulesetpage/ConfigPrinter.kt
@@ -38,12 +38,12 @@ object ConfigPrinter : DocumentationPrinter<List<RuleSetPage>> {
             }
             ruleSet.configuration
                 .forEach { configuration ->
-                if (configuration.defaultValue.isYamlList()) {
-                    list(configuration.name, configuration.defaultValue.toList())
-                } else {
-                    keyValue { configuration.name to configuration.defaultValue }
+                    if (configuration.defaultValue.isYamlList()) {
+                        list(configuration.name, configuration.defaultValue.toList())
+                    } else {
+                        keyValue { configuration.name to configuration.defaultValue }
+                    }
                 }
-            }
             rules.forEach { rule ->
                 node(rule.name) {
                     keyValue { "active" to "${rule.active}" }
@@ -55,58 +55,63 @@ object ConfigPrinter : DocumentationPrinter<List<RuleSetPage>> {
                     }
                     rule.configuration
                         .forEach { configuration ->
-                        if (configuration.defaultValue.isYamlList()) {
-                            list(configuration.name, configuration.defaultValue.toList())
-                        } else if (configuration.deprecated == null) {
-                            keyValue { configuration.name to configuration.defaultValue }
+                            if (configuration.defaultValue.isYamlList()) {
+                                list(configuration.name, configuration.defaultValue.toList())
+                            } else if (configuration.deprecated == null) {
+                                keyValue { configuration.name to configuration.defaultValue }
+                            }
                         }
-                    }
                 }
             }
             emptyLine()
         }
     }
 
-    private fun defaultBuildConfiguration(): String = """
-      build:
-        maxIssues: 0
-        excludeCorrectable: false
-        weights:
-          # complexity: 2
-          # LongParameterList: 1
-          # style: 1
-          # comments: 1
-    """.trimIndent()
+    private fun defaultBuildConfiguration(): String =
+        """
+        build:
+          maxIssues: 0
+          excludeCorrectable: false
+          weights:
+            # complexity: 2
+            # LongParameterList: 1
+            # style: 1
+            # comments: 1
+        """.trimIndent()
 
-    private fun defaultConfigConfiguration(): String = """
-      config:
-        validation: true
-        # when writing own rules with new properties, exclude the property path e.g.: 'my_rule_set,.*>.*>[my_property]'
-        excludes: ''
-    """.trimIndent()
+    private fun defaultConfigConfiguration(): String =
+        """
+        config:
+          validation: true
+          # when writing own rules with new properties, exclude the property path
+          # e.g.: 'my_rule_set,.*>.*>[my_property]'
+          excludes: ''
+        """.trimIndent()
 
-    private fun defaultProcessorsConfiguration(): String = """
-      processors:
-        active: true
-        exclude:
-          - 'DetektProgressListener'
-        # - 'FunctionCountProcessor'
-        # - 'PropertyCountProcessor'
-        # - 'ClassCountProcessor'
-        # - 'PackageCountProcessor'
-        # - 'KtFileCountProcessor'
-    """.trimIndent()
+    private fun defaultProcessorsConfiguration(): String =
+        """
+        processors:
+          active: true
+          exclude:
+            - 'DetektProgressListener'
+          # - 'FunctionCountProcessor'
+          # - 'PropertyCountProcessor'
+          # - 'ClassCountProcessor'
+          # - 'PackageCountProcessor'
+          # - 'KtFileCountProcessor'
+        """.trimIndent()
 
-    private fun defaultConsoleReportsConfiguration(): String = """
-      console-reports:
-        active: true
-        exclude:
-           - 'ProjectStatisticsReport'
-           - 'ComplexityReport'
-           - 'NotificationReport'
-        #  - 'FindingsReport'
-           - 'FileBasedFindingsReport'
-    """.trimIndent()
+    private fun defaultConsoleReportsConfiguration(): String =
+        """
+        console-reports:
+          active: true
+          exclude:
+             - 'ProjectStatisticsReport'
+             - 'ComplexityReport'
+             - 'NotificationReport'
+          #  - 'FindingsReport'
+             - 'FileBasedFindingsReport'
+        """.trimIndent()
 
     private fun String.isYamlList() = trim().startsWith("-")
 

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/MultiRuleCollectorSpec.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/MultiRuleCollectorSpec.kt
@@ -31,7 +31,8 @@ class MultiRuleCollectorSpec : Spek({
         }
 
         it("collects all rules in fields and in the rule property") {
-            val code = """
+            val code =
+                """
                 class MyRule : MultiRule {
                     val p1 = Rule3()
                     val p2 = Rule4()

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleCollectorSpec.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleCollectorSpec.kt
@@ -38,7 +38,8 @@ class RuleCollectorSpec : Spek({
 
         it("collects the rule name") {
             val name = "SomeRandomClass"
-            val code = """
+            val code =
+                """
                 /**
                  * description
                  */
@@ -50,7 +51,8 @@ class RuleCollectorSpec : Spek({
 
         it("collects the rule description") {
             val description = "description"
-            val code = """
+            val code =
+                """
                 /**
                  * $description
                  */
@@ -62,7 +64,8 @@ class RuleCollectorSpec : Spek({
 
         it("has a multi paragraph description") {
             val description = "description"
-            val code = """
+            val code =
+                """
                 /**
                  * $description
                  *
@@ -76,7 +79,8 @@ class RuleCollectorSpec : Spek({
         }
 
         it("is not active") {
-            val code = """
+            val code =
+                """
                 /**
                  * description
                  */
@@ -87,7 +91,8 @@ class RuleCollectorSpec : Spek({
         }
 
         it("is active tag present") {
-            val code = """
+            val code =
+                """
                 /**
                  * description
                  * @active
@@ -99,7 +104,8 @@ class RuleCollectorSpec : Spek({
         }
 
         it("is auto-correctable tag is present") {
-            val code = """
+            val code =
+                """
                 /**
                  * description
                  * @autoCorrect
@@ -111,7 +117,8 @@ class RuleCollectorSpec : Spek({
         }
 
         it("is active if the tag is there and has a description") {
-            val code = """
+            val code =
+                """
                 /**
                  * description
                  * @active description about the active tag
@@ -123,7 +130,8 @@ class RuleCollectorSpec : Spek({
         }
 
         it("collects the issue property") {
-            val code = """
+            val code =
+                """
                 /**
                  * description
                  */
@@ -139,7 +147,8 @@ class RuleCollectorSpec : Spek({
         }
 
         it("contains no configuration options by default") {
-            val code = """
+            val code =
+                """
                 /**
                  * description
                  */
@@ -150,7 +159,8 @@ class RuleCollectorSpec : Spek({
         }
 
         it("contains one configuration option with correct formatting") {
-            val code = """
+            val code =
+                """
                 /**
                  * description
                  * @configuration config - description (default: `'[A-Z$]'`)
@@ -165,7 +175,8 @@ class RuleCollectorSpec : Spek({
         }
 
         it("contains multiple configuration options") {
-            val code = """
+            val code =
+                """
                 /**
                  * description
                  * @configuration config - description (default: `''`)
@@ -178,7 +189,8 @@ class RuleCollectorSpec : Spek({
         }
 
         it("config option doesn't have a default value") {
-            val code = """
+            val code =
+                """
                 /**
                  * description
                  * @configuration config - description
@@ -189,7 +201,8 @@ class RuleCollectorSpec : Spek({
         }
 
         it("has a blank default value") {
-            val code = """
+            val code =
+                """
                 /**
                  * description
                  * @configuration config - description (default: ``)
@@ -200,7 +213,8 @@ class RuleCollectorSpec : Spek({
         }
 
         it("has an incorrectly delimited default value") {
-            val code = """
+            val code =
+                """
                 /**
                  * description
                  * @configuration config - description (default: true)
@@ -211,7 +225,8 @@ class RuleCollectorSpec : Spek({
         }
 
         it("contains a misconfigured configuration option") {
-            val code = """
+            val code =
+                """
                 /**
                  * description
                  * @configuration something: description
@@ -222,7 +237,8 @@ class RuleCollectorSpec : Spek({
         }
 
         it("contains compliant and noncompliant code examples") {
-            val code = """
+            val code =
+                """
                 /**
                  * description
                  *
@@ -242,7 +258,8 @@ class RuleCollectorSpec : Spek({
         }
 
         it("has wrong noncompliant code example declaration") {
-            val code = """
+            val code =
+                """
                 /**
                  * description
                  *
@@ -255,7 +272,8 @@ class RuleCollectorSpec : Spek({
         }
 
         it("has wrong compliant code example declaration") {
-            val code = """
+            val code =
+                """
                 /**
                  * description
                  *
@@ -271,7 +289,8 @@ class RuleCollectorSpec : Spek({
         }
 
         it("has wrong compliant without noncompliant code example declaration") {
-            val code = """
+            val code =
+                """
                 /**
                  * description
                  *
@@ -286,7 +305,8 @@ class RuleCollectorSpec : Spek({
         }
 
         it("has wrong issue style property") {
-            val code = """
+            val code =
+                """
                 /**
                  * description
                  */
@@ -303,7 +323,8 @@ class RuleCollectorSpec : Spek({
         }
 
         it("has wrong aliases property structure") {
-            val code = """
+            val code =
+                """
                 /**
                  * description
                  */
@@ -322,7 +343,8 @@ class RuleCollectorSpec : Spek({
 
         it("contains tabs in KDoc") {
             val description = "\tdescription"
-            val code = """
+            val code =
+                """
                 /**
                  * $description
                  */

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleSetProviderCollectorSpec.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleSetProviderCollectorSpec.kt
@@ -13,7 +13,8 @@ class RuleSetProviderCollectorSpec : Spek({
 
     describe("RuleSetProviderCollector rule") {
         context("a non-RuleSetProvider class extending nothing") {
-            val code = """
+            val code =
+                """
             package foo
 
             class SomeRandomClass {
@@ -29,7 +30,8 @@ class RuleSetProviderCollectorSpec : Spek({
         }
 
         context("a non-RuleSetProvider class extending a class that is not related to rules") {
-            val code = """
+            val code =
+                """
             package foo
 
             class SomeRandomClass: SomeOtherClass {
@@ -45,7 +47,8 @@ class RuleSetProviderCollectorSpec : Spek({
         }
 
         context("a RuleSetProvider without documentation") {
-            val code = """
+            val code =
+                """
             package foo
 
             class TestProvider: RuleSetProvider {
@@ -56,12 +59,13 @@ class RuleSetProviderCollectorSpec : Spek({
         """
             it("throws an exception") {
                 assertThatExceptionOfType(InvalidDocumentationException::class.java)
-                        .isThrownBy { subject.run(code) }
+                    .isThrownBy { subject.run(code) }
             }
         }
 
         context("a correct RuleSetProvider class extending RuleSetProvider but missing parameters") {
-            val code = """
+            val code =
+                """
             package foo
 
             class TestProvider: RuleSetProvider {
@@ -73,7 +77,7 @@ class RuleSetProviderCollectorSpec : Spek({
 
             it("throws an exception") {
                 assertThatExceptionOfType(InvalidDocumentationException::class.java)
-                        .isThrownBy { subject.run(code) }
+                    .isThrownBy { subject.run(code) }
             }
         }
 
@@ -81,7 +85,8 @@ class RuleSetProviderCollectorSpec : Spek({
             val description = "This is a description"
             val ruleSetId = "test"
             val ruleName = "TestRule"
-            val code = """
+            val code =
+                """
             package foo
 
             /**
@@ -135,7 +140,8 @@ class RuleSetProviderCollectorSpec : Spek({
             val description = "This is a description"
             val ruleSetId = "test"
             val ruleName = "TestRule"
-            val code = """
+            val code =
+                """
             package foo
 
             /**
@@ -162,7 +168,8 @@ class RuleSetProviderCollectorSpec : Spek({
         context("a RuleSetProvider with missing name") {
             val description = "This is a description"
             val ruleName = "TestRule"
-            val code = """
+            val code =
+                """
             package foo
 
             /**
@@ -179,14 +186,15 @@ class RuleSetProviderCollectorSpec : Spek({
 
             it("throws an exception") {
                 assertThatExceptionOfType(InvalidDocumentationException::class.java)
-                        .isThrownBy { subject.run(code) }
+                    .isThrownBy { subject.run(code) }
             }
         }
 
         context("a RuleSetProvider with missing description") {
             val ruleSetId = "test"
             val ruleName = "TestRule"
-            val code = """
+            val code =
+                """
             package foo
 
             class TestProvider: RuleSetProvider {
@@ -202,13 +210,14 @@ class RuleSetProviderCollectorSpec : Spek({
 
             it("throws an exception") {
                 assertThatExceptionOfType(InvalidDocumentationException::class.java)
-                        .isThrownBy { subject.run(code) }
+                    .isThrownBy { subject.run(code) }
             }
         }
 
         context("a RuleSetProvider with no rules") {
             val ruleSetId = "test"
-            val code = """
+            val code =
+                """
             package foo
 
             class TestProvider: RuleSetProvider {
@@ -222,7 +231,7 @@ class RuleSetProviderCollectorSpec : Spek({
 
             it("throws an exception") {
                 assertThatExceptionOfType(InvalidDocumentationException::class.java)
-                        .isThrownBy { subject.run(code) }
+                    .isThrownBy { subject.run(code) }
             }
         }
 
@@ -231,7 +240,8 @@ class RuleSetProviderCollectorSpec : Spek({
             val ruleSetId = "test"
             val ruleName = "TestRule"
             val secondRuleName = "SecondRule"
-            val code = """
+            val code =
+                """
             package foo
 
             /**

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/util/RuleSetPageCreator.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/util/RuleSetPageCreator.kt
@@ -12,13 +12,21 @@ internal fun createRuleSetPage(): RuleSetPage {
 }
 
 internal fun createRules(): List<Rule> {
-    val rule1 = Rule("WildcardImport", "a wildcard import", "import foo.*", "import foo.bar", true, "Defect",
-            "10min", "alias1, alias2", "", listOf(
-                    Configuration("conf1", "a config option", "foo", null),
-                    Configuration("conf2", "deprecated config", "false", "use conf1 instead")))
-    val rule2 = Rule("EqualsNull", "equals null", "", "", false, "",
-            "", null, "WildcardImport", emptyList())
-    val rule3 = Rule("NoUnitKeyword", "removes :Unit", "fun stuff(): Unit {}",
-            "fun stuff() {}", true, "", "5m", null, "", emptyList(), true)
+    val rule1 = Rule(
+        "WildcardImport", "a wildcard import", "import foo.*", "import foo.bar", true, "Defect",
+        "10min", "alias1, alias2", "",
+        listOf(
+            Configuration("conf1", "a config option", "foo", null),
+            Configuration("conf2", "deprecated config", "false", "use conf1 instead")
+        )
+    )
+    val rule2 = Rule(
+        "EqualsNull", "equals null", "", "", false, "",
+        "", null, "WildcardImport", emptyList()
+    )
+    val rule3 = Rule(
+        "NoUnitKeyword", "removes :Unit", "fun stuff(): Unit {}",
+        "fun stuff() {}", true, "", "5m", null, "", emptyList(), true
+    )
     return listOf(rule1, rule2, rule3)
 }

--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -46,7 +46,8 @@ val generateDefaultDetektVersionFile by tasks.registering {
 
     doFirst {
         defaultDetektVersionFile.parentFile.mkdirs()
-        defaultDetektVersionFile.writeText("""
+        defaultDetektVersionFile.writeText(
+            """
             package io.gitlab.arturbosch.detekt
 
             internal const val DEFAULT_DETEKT_VERSION = "$version"

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -199,18 +199,20 @@ open class Detekt : SourceTask(), VerificationTask {
             AutoCorrectArgument(autoCorrectProp.getOrElse(false)),
             DisableDefaultRuleSetArgument(disableDefaultRuleSetsProp.getOrElse(false))
         )
-        arguments.addAll(customReports.get().map {
-            val reportId = it.reportIdProp.orNull
-            val destination = it.destinationProperty.orNull
+        arguments.addAll(
+            customReports.get().map {
+                val reportId = it.reportIdProp.orNull
+                val destination = it.destinationProperty.orNull
 
-            checkNotNull(reportId) { "If a custom report is specified, the reportId must be present" }
-            check(!DetektReportType.isWellKnownReportId(reportId)) {
-                "The custom report reportId may not be same as one of the default reports"
+                checkNotNull(reportId) { "If a custom report is specified, the reportId must be present" }
+                check(!DetektReportType.isWellKnownReportId(reportId)) {
+                    "The custom report reportId may not be same as one of the default reports"
+                }
+                checkNotNull(destination) { "If a custom report is specified, the destination must be present" }
+
+                CustomReportArgument(reportId, destination)
             }
-            checkNotNull(destination) { "If a custom report is specified, the destination must be present" }
-
-            CustomReportArgument(reportId, destination)
-        })
+        )
 
         DetektInvoker.create(project).invokeCli(
             arguments = arguments.toList(),

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektGenerateConfigTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektGenerateConfigTask.kt
@@ -25,7 +25,6 @@ open class DetektGenerateConfigTask : DefaultTask() {
 
     @TaskAction
     fun generateConfig() {
-
         val configDir = project.mkdir("${project.rootDir}/$CONFIG_DIR_NAME")
         val config = project.files("${configDir.canonicalPath}/$CONFIG_FILE")
 

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/KotlinExtension.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/KotlinExtension.kt
@@ -5,7 +5,9 @@ package io.gitlab.arturbosch.detekt
 import io.gitlab.arturbosch.detekt.extensions.DetektExtension
 import org.gradle.api.Project
 
-@Deprecated("""Either apply detekt plugin to root project or follow this advice:
-https://docs.gradle.org/current/userguide/kotlin_dsl.html#sec:multi_project_builds_applying_plugins""")
+@Deprecated(
+    """Either apply detekt plugin to root project or follow this advice:
+https://docs.gradle.org/current/userguide/kotlin_dsl.html#sec:multi_project_builds_applying_plugins"""
+)
 fun Project.detekt(configure: DetektExtension.() -> Unit) =
     extensions.configure(DetektExtension::class.java, configure)

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/CliArgument.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/CliArgument.kt
@@ -39,7 +39,8 @@ internal data class InputArgument(val fileCollection: FileCollection) : CliArgum
 internal data class ClasspathArgument(val fileCollection: FileCollection) : CliArgument() {
     override fun toArgument() = if (!fileCollection.isEmpty) listOf(
         CLASSPATH_PARAMETER,
-        fileCollection.joinToString(";") { it.absolutePath }) else emptyList()
+        fileCollection.joinToString(";") { it.absolutePath }
+    ) else emptyList()
 }
 
 internal data class LanguageVersionArgument(val languageVersion: String?) : CliArgument() {

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/DetektInvoker.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/DetektInvoker.kt
@@ -44,7 +44,8 @@ private class DefaultCliInvoker : DetektInvoker {
         try {
             val loader = ClassLoaderCache.getOrCreate(classpath)
             val clazz = loader.loadClass("io.gitlab.arturbosch.detekt.cli.Main")
-            val runner = clazz.getMethod("buildRunner",
+            val runner = clazz.getMethod(
+                "buildRunner",
                 Array<String>::class.java,
                 PrintStream::class.java,
                 PrintStream::class.java

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/CreateBaselineTaskDslTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/CreateBaselineTaskDslTest.kt
@@ -10,7 +10,8 @@ internal class CreateBaselineTaskDslTest : Spek({
         listOf(DslTestBuilder.groovy(), DslTestBuilder.kotlin()).forEach { builder ->
             describe("using ${builder.gradleBuildName}") {
                 it("can be executed when baseline file is specified") {
-                    val detektConfig = """
+                    val detektConfig =
+                        """
                         |detekt {
                         |   baseline = file("build/baseline.xml")
                         |}

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskDslTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskDslTest.kt
@@ -47,7 +47,8 @@ internal object DetektTaskDslTest : Spek({
                 describe("without multiple detekt configs") {
 
                     beforeGroup {
-                        val config = """
+                        val config =
+                            """
                         |detekt {
                         |    config.setFrom(files("firstConfig.yml", "secondConfig.yml"))
                         |}
@@ -72,7 +73,8 @@ internal object DetektTaskDslTest : Spek({
 
                     beforeGroup {
 
-                        val config = """
+                        val config =
+                            """
                         |detekt {
                         |   baseline = file("$baselineFilename")
                         |}
@@ -98,7 +100,8 @@ internal object DetektTaskDslTest : Spek({
 
                     beforeGroup {
 
-                        val config = """
+                        val config =
+                            """
                         |detekt {
                         |    input = files("$customSrc1", "$customSrc2", "folder_that_does_not_exist")
                         |}
@@ -128,7 +131,8 @@ internal object DetektTaskDslTest : Spek({
 
                     beforeGroup {
 
-                        val config = """
+                        val config =
+                            """
                         |detekt {
                         |    reportsDir = file("build/detekt-reports")
                         |}
@@ -160,7 +164,8 @@ internal object DetektTaskDslTest : Spek({
 
                     beforeGroup {
 
-                        val config = """
+                        val config =
+                            """
                         |detekt {
                         |    reportsDir = file("build/detekt-reports")
                         |    reports {
@@ -195,7 +200,8 @@ internal object DetektTaskDslTest : Spek({
 
                     beforeGroup {
 
-                        val config = """
+                        val config =
+                            """
                         |detekt {
                         |    reports {
                         |        xml.enabled = false
@@ -224,7 +230,8 @@ internal object DetektTaskDslTest : Spek({
                     describe("configured correctly") {
                         beforeGroup {
 
-                            val config = """
+                            val config =
+                                """
                                 |detekt {
                                 |    reports {
                                 |        custom {
@@ -257,7 +264,8 @@ internal object DetektTaskDslTest : Spek({
                     describe("report id is missing") {
                         beforeGroup {
 
-                            val config = """
+                            val config =
+                                """
                                 |detekt {
                                 |    reports {
                                 |        custom {
@@ -278,7 +286,8 @@ internal object DetektTaskDslTest : Spek({
                     describe("report filename is missing") {
                         beforeGroup {
 
-                            val config = """
+                            val config =
+                                """
                                 |detekt {
                                 |    reports {
                                 |        custom {
@@ -301,7 +310,8 @@ internal object DetektTaskDslTest : Spek({
 
                             val aDirectory = "\${rootDir}/src"
 
-                            val config = """
+                            val config =
+                                """
                                 |detekt {
                                 |    reports {
                                 |        custom {
@@ -325,7 +335,8 @@ internal object DetektTaskDslTest : Spek({
                             context(wellKnownType.name) {
                                 beforeGroup {
 
-                                    val config = """
+                                    val config =
+                                        """
                                         |detekt {
                                         |    reports {
                                         |        custom {
@@ -350,7 +361,8 @@ internal object DetektTaskDslTest : Spek({
 
                     beforeGroup {
 
-                        val config = """
+                        val config =
+                            """
                         |detekt {
                         |    debug = true
                         |    parallel = true
@@ -399,7 +411,8 @@ internal object DetektTaskDslTest : Spek({
 
                 describe("with an additional plugin") {
                     beforeGroup {
-                        val config = """
+                        val config =
+                            """
                             |dependencies {
                             |   detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:$VERSION_UNDER_TEST")
                             |}
@@ -423,7 +436,8 @@ internal object DetektTaskDslTest : Spek({
                 describe("with a custom tool version") {
                     val customVersion = "1.0.0.RC8"
                     beforeGroup {
-                        val config = """
+                        val config =
+                            """
                             |detekt {
                             |    toolVersion = "$customVersion"
                             |}
@@ -450,7 +464,8 @@ internal object DetektTaskDslTest : Spek({
             context("using the groovy dsl") {
                 val builder = groovy().dryRun()
                 beforeGroup {
-                    val config = """
+                    val config =
+                        """
                         |task detektFailFast(type: io.gitlab.arturbosch.detekt.Detekt) {
                         |    description = "Runs a failfast detekt build."
                         |
@@ -526,7 +541,8 @@ internal object DetektTaskDslTest : Spek({
             context("using the kotlin dsl") {
                 val builder = kotlin().dryRun()
                 beforeGroup {
-                    val config = """
+                    val config =
+                        """
                         |task<io.gitlab.arturbosch.detekt.Detekt>("detektFailFast") {
                         |    description = "Runs a failfast detekt build."
                         |

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskIntegrationTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskIntegrationTest.kt
@@ -20,7 +20,8 @@ internal class DetektTaskIntegrationTest : Spek({
 
                     it("build succeeds with more issues than threshold if enabled") {
 
-                        val config = """
+                        val config =
+                            """
                             |detekt {
                             |   ignoreFailures = true
                             |}
@@ -37,7 +38,8 @@ internal class DetektTaskIntegrationTest : Spek({
                     }
                     it("build fails with more issues than threshold successfully if disabled") {
 
-                        val config = """
+                        val config =
+                            """
                             |detekt {
                             |   ignoreFailures = false
                             |}

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskMultiModuleIntegrationTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskMultiModuleIntegrationTest.kt
@@ -15,15 +15,18 @@ internal class DetektTaskMultiModuleIntegrationTest : Spek({
 
             describe("using ${builder.gradleBuildName}") {
 
-                it("""
+                it(
+                    """
                     |is applied with defaults to all subprojects individually
                     |without sources in root project using the subprojects block
-                """.trimMargin()) {
+                """.trimMargin()
+                ) {
                     val projectLayout = ProjectLayout(0)
                         .withSubmodule("child1", 2)
                         .withSubmodule("child2", 4)
 
-                    val mainBuildFileContent: String = """
+                    val mainBuildFileContent: String =
+                        """
                         |${builder.gradlePluginsSection}
                         |
                         |allprojects {
@@ -54,15 +57,18 @@ internal class DetektTaskMultiModuleIntegrationTest : Spek({
                     }
                 }
 
-                it("""
+                it(
+                    """
                     |is applied with defaults to main project
                     |and subprojects individually using the allprojects block
-                """.trimMargin()) {
+                """.trimMargin()
+                ) {
                     val projectLayout = ProjectLayout(1)
                         .withSubmodule("child1", 2)
                         .withSubmodule("child2", 4)
 
-                    val mainBuildFileContent: String = """
+                    val mainBuildFileContent: String =
+                        """
                         |${builder.gradlePluginsSection}
                         |
                         |allprojects {
@@ -96,7 +102,8 @@ internal class DetektTaskMultiModuleIntegrationTest : Spek({
                         .withSubmodule("child1", 2)
                         .withSubmodule("child2", 4)
 
-                    val mainBuildFileContent: String = """
+                    val mainBuildFileContent: String =
+                        """
                         |${builder.gradlePluginsSection}
                         |
                         |allprojects {
@@ -129,7 +136,8 @@ internal class DetektTaskMultiModuleIntegrationTest : Spek({
                 }
 
                 it("allows changing defaults in allprojects block that can be overwritten in subprojects") {
-                    val child2DetektConfig = """
+                    val child2DetektConfig =
+                        """
                         |detekt {
                         |   reportsDir = file("build/custom")
                         |}
@@ -139,7 +147,8 @@ internal class DetektTaskMultiModuleIntegrationTest : Spek({
                         .withSubmodule("child1", 2)
                         .withSubmodule("child2", 4, detektConfig = child2DetektConfig)
 
-                    val mainBuildFileContent: String = """
+                    val mainBuildFileContent: String =
+                        """
                         |${builder.gradlePluginsSection}
                         |
                         |allprojects {
@@ -178,7 +187,8 @@ internal class DetektTaskMultiModuleIntegrationTest : Spek({
                         .withSubmodule("child1", 2)
                         .withSubmodule("child2", 4)
 
-                    val detektConfig: String = """
+                    val detektConfig: String =
+                        """
                         |detekt {
                         |    input = files(
                         |       "${"$"}projectDir/src",

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DslGradleRunner.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DslGradleRunner.kt
@@ -19,19 +19,22 @@ class DslGradleRunner @Suppress("LongParameterList") constructor(
     private val rootDir: File = createTempDirectoryForTest(prefix = "applyPlugin").toFile()
     private val randomString = UUID.randomUUID().toString()
 
-    private val settingsContent = """
+    private val settingsContent =
+        """
         |rootProject.name = "rootDir-project"
         |include(${projectLayout.submodules.map { "\"${it.name}\"" }.joinToString(",")})
         |
         """.trimMargin()
 
-    private val baselineContent = """
+    private val baselineContent =
+        """
         |<some>
         |   <xml/>
         |</some>
         """.trimMargin()
 
-    private val configFileContent = """
+    private val configFileContent =
+        """
         |build:
         |  maxIssues: 5
         |style:
@@ -42,7 +45,8 @@ class DslGradleRunner @Suppress("LongParameterList") constructor(
     /**
      * Each generated file is different so the artifacts are not cached in between test runs
      */
-    private fun ktFileContent(className: String, withCodeSmell: Boolean = false) = """
+    private fun ktFileContent(className: String, withCodeSmell: Boolean = false) =
+        """
     |internal class $className(
     |   val randomDefaultValue: String = "$randomString"
     |) {

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DslGradleRunner.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DslGradleRunner.kt
@@ -6,7 +6,9 @@ import org.gradle.testkit.runner.GradleRunner
 import java.io.File
 import java.util.UUID
 
-class DslGradleRunner @Suppress("LongParameterList") constructor(
+class DslGradleRunner
+@Suppress("LongParameterList")
+constructor(
     val projectLayout: ProjectLayout,
     val buildFileName: String,
     val mainBuildFileContent: String,

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DslTestBuilder.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DslTestBuilder.kt
@@ -46,7 +46,8 @@ abstract class DslTestBuilder {
     }
 
     fun build(): DslGradleRunner {
-        val mainBuildFileContent = """
+        val mainBuildFileContent =
+            """
             |$gradleBuildConfig
             |$detektConfig
             """.trimMargin()
@@ -67,7 +68,8 @@ abstract class DslTestBuilder {
         override val gradleBuildName: String = "build.gradle"
         override val gradlePluginsSection = GROOVY_PLUGINS_SECTION
         override val gradleApplyPlugins = GROOVY_APPLY_PLUGINS
-        override val gradleBuildConfig: String = """
+        override val gradleBuildConfig: String =
+            """
             |$gradlePluginsSection
             |
             |$gradleRepositoriesSection
@@ -82,7 +84,8 @@ abstract class DslTestBuilder {
         override val gradleBuildName: String = "build.gradle.kts"
         override val gradlePluginsSection = KOTLIN_PLUGINS_SECTION
         override val gradleApplyPlugins = KOTLIN_APPLY_PLUGINS
-        override val gradleBuildConfig: String = """
+        override val gradleBuildConfig: String =
+            """
             |$gradlePluginsSection
             |
             |$gradleRepositoriesSection
@@ -97,21 +100,24 @@ abstract class DslTestBuilder {
         fun kotlin(): DslTestBuilder = KotlinBuilder()
         fun groovy(): DslTestBuilder = GroovyBuilder()
 
-        private const val GROOVY_PLUGINS_SECTION = """
+        private const val GROOVY_PLUGINS_SECTION =
+            """
             |plugins {
             |   id "org.jetbrains.kotlin.jvm"
             |   id "io.gitlab.arturbosch.detekt"
             |}
             |"""
 
-        private const val KOTLIN_PLUGINS_SECTION = """
+        private const val KOTLIN_PLUGINS_SECTION =
+            """
             |plugins {
             |   kotlin("jvm")
             |   id("io.gitlab.arturbosch.detekt")
             |}
             |"""
 
-        private const val REPOSITORIES_SECTION = """
+        private const val REPOSITORIES_SECTION =
+            """
             |repositories {
             |   mavenLocal()
             |   mavenCentral()
@@ -119,12 +125,14 @@ abstract class DslTestBuilder {
             |}
             |"""
 
-        private const val GROOVY_APPLY_PLUGINS = """
+        private const val GROOVY_APPLY_PLUGINS =
+            """
             |apply plugin: "kotlin"
             |apply plugin: "io.gitlab.arturbosch.detekt"
             |"""
 
-        private const val KOTLIN_APPLY_PLUGINS = """
+        private const val KOTLIN_APPLY_PLUGINS =
+            """
             |plugins.apply("kotlin")
             |plugins.apply("io.gitlab.arturbosch.detekt")
             |"""

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/PluginTaskBehaviorTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/PluginTaskBehaviorTest.kt
@@ -15,7 +15,8 @@ internal class PluginTaskBehaviorTest : Spek({
     val configFileName = "config.yml"
     val baselineFileName = "baseline.xml"
 
-    val detektConfig = """
+    val detektConfig =
+        """
                     |detekt {
                     |    config = files("$configFileName")
                     |    baseline = file("$baselineFileName")
@@ -63,7 +64,8 @@ internal class PluginTaskBehaviorTest : Spek({
             }
         }
         it("should run again after changing config") {
-            val configFileWithCommentsDisabled = """
+            val configFileWithCommentsDisabled =
+                """
                             |comments:
                             |  active: false
                         """.trimMargin()
@@ -80,7 +82,8 @@ internal class PluginTaskBehaviorTest : Spek({
             }
         }
         it("should run again after changing baseline") {
-            val changedBaselineContent = """
+            val changedBaselineContent =
+                """
                             |<some>
                             |    <more/>
                             |    <xml/>

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/ProjectLayout.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/ProjectLayout.kt
@@ -14,7 +14,6 @@ data class ProjectLayout(
         detektConfig: String? = null,
         srcDirs: List<String> = this.srcDirs
     ): ProjectLayout {
-
         val submodule = Submodule(
             name = name,
             numberOfSourceFilesPerSourceDir = numberOfSourceFilesPerSourceDir,

--- a/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/CognitiveComplexitySpec.kt
+++ b/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/CognitiveComplexitySpec.kt
@@ -10,7 +10,8 @@ class CognitiveComplexitySpec : Spek({
     describe("cognitive complexity") {
 
         it("sums seven for sumOfPrimes example") {
-            val code = compileContentForTest("""
+            val code = compileContentForTest(
+                """
                 fun sumOfPrimes(max: Int): Int {
                     var total = 0
                     next@ for (i in 1..max) {
@@ -24,20 +25,23 @@ class CognitiveComplexitySpec : Spek({
                     }
                     return total
                 }
-            """)
+            """
+            )
 
             assertThat(CognitiveComplexity.calculate(code)).isEqualTo(7)
         }
 
         it("sums one for getWords example for a single when expression") {
-            val code = compileContentForTest("""
+            val code = compileContentForTest(
+                """
                  fun getWords(number: Int): String = when (number) {
                      1 -> "one"
                      2 -> "a couple"
                      3 -> "a few"
                      else -> "lots"
                  }
-             """)
+             """
+            )
 
             assertThat(CognitiveComplexity.calculate(code)).isEqualTo(1)
         }
@@ -45,62 +49,73 @@ class CognitiveComplexitySpec : Spek({
         describe("recursion") {
 
             it("adds one for recursion inside class") {
-                val code = compileContentForTest("""
+                val code = compileContentForTest(
+                    """
                     class A {
                         fun factorial(n: Int): Int =
                             if (n >= 1) n * this.factorial(n - 1) else 1
                     }
-            """)
+            """
+                )
 
                 assertThat(CognitiveComplexity.calculate(code)).isEqualTo(2)
             }
 
             it("adds one for top level recursion") {
-                val code = compileContentForTest("""
+                val code = compileContentForTest(
+                    """
                     fun factorial(n: Int): Int =
                         if (n >= 1) n * factorial(n - 1) else 1
-                """)
+                """
+                )
 
                 assertThat(CognitiveComplexity.calculate(code)).isEqualTo(2)
             }
 
             it("does not add as it is only the same name") {
-                val code = compileContentForTest("""
+                val code = compileContentForTest(
+                    """
                     object O { fun factorial(i: Int): Int = i - 1 }
                     fun factorial(n: Int): Int =
                         if (n >= 1) n * O.factorial(n - 1) else 1
-                """)
+                """
+                )
 
                 assertThat(CognitiveComplexity.calculate(code)).isEqualTo(1)
             }
         }
 
         it("ignores shorthand operators") {
-            val code = compileContentForTest("""
+            val code = compileContentForTest(
+                """
                 fun parse(args: Array<String>): Nothing = TODO()
                 fun main(args: Array<String>) {
                    args.takeIf { it.size > 3 }?.let(::parse) ?: error("not enough arguments")
                 }
-            """)
+            """
+            )
 
             assertThat(CognitiveComplexity.calculate(code)).isEqualTo(0)
         }
 
         it("adds one per catch clause") {
-            val code = compileContentForTest("""
+            val code = compileContentForTest(
+                """
                 fun main() {
                     try {
                     } catch (e: IllegalArgumentException) {
                     } catch (e: IllegalStateException) {
                     } catch (e: Throwable) {}
                 }
-            """)
+            """
+            )
 
             assertThat(CognitiveComplexity.calculate(code)).isEqualTo(3)
         }
 
         it("adds extra complexity for nesting") {
-            val code = compileContentForTest("""
+            val code = compileContentForTest(
+                """
                 fun main() {
                     try {
                         if (true) { // +1
@@ -114,23 +129,28 @@ class CognitiveComplexitySpec : Spek({
                         do {} while(true) // +2
                     }
                 }
-            """)
+            """
+            )
 
             assertThat(CognitiveComplexity.calculate(code)).isEqualTo(9)
         }
 
         it("adds nesting for lambdas but not complexity") {
-            val code = compileContentForTest("""
+            val code = compileContentForTest(
+                """
                 fun main() { run { if (true) {} } }
-            """)
+            """
+            )
 
             assertThat(CognitiveComplexity.calculate(code)).isEqualTo(2)
         }
 
         it("adds nesting for nested functions but not complexity") {
-            val code = compileContentForTest("""
+            val code = compileContentForTest(
+                """
                 fun main() { fun run() { if (true) {} } }
-            """)
+            """
+            )
 
             assertThat(CognitiveComplexity.calculate(code)).isEqualTo(2)
         }
@@ -138,9 +158,11 @@ class CognitiveComplexitySpec : Spek({
         describe("binary expressions") {
 
             it("does not increment on just a condition") {
-                val code = compileContentForTest("""
+                val code = compileContentForTest(
+                    """
                     fun test(cond: Boolean) = !cond
-                """)
+                """
+                )
 
                 assertThat(CognitiveComplexity.calculate(code)).isEqualTo(0)
             }
@@ -148,31 +170,38 @@ class CognitiveComplexitySpec : Spek({
             describe("increments for every non-like operator") {
 
                 it("adds one for just a &&") {
-                    val code = compileContentForTest("""
+                    val code = compileContentForTest(
+                        """
                         fun test(cond: Boolean) = !cond && !cond
-                    """)
+                    """
+                    )
 
                     assertThat(CognitiveComplexity.calculate(code)).isEqualTo(1)
                 }
 
                 it("adds only one for repeated &&") {
-                    val code = compileContentForTest("""
+                    val code = compileContentForTest(
+                        """
                         fun test(cond: Boolean) = !cond && !cond && !cond
-                    """)
+                    """
+                    )
 
                     assertThat(CognitiveComplexity.calculate(code)).isEqualTo(1)
                 }
 
                 it("adds one per logical alternate operator") {
-                    val code = compileContentForTest("""
+                    val code = compileContentForTest(
+                        """
                         fun test(cond: Boolean) = !cond && !cond || cond
-                    """)
+                    """
+                    )
 
                     assertThat(CognitiveComplexity.calculate(code)).isEqualTo(2)
                 }
 
                 it("adds one per logical alternate operator with like operators in between") {
-                    val code = compileContentForTest("""
+                    val code = compileContentForTest(
+                        """
                         fun test(cond: Boolean) {
                             if (                    // +1
                                 !cond 
@@ -181,39 +210,45 @@ class CognitiveComplexitySpec : Spek({
                                 && cond             // +1
                             ) {}
                         }
-                    """)
+                    """
+                    )
 
                     assertThat(CognitiveComplexity.calculate(code)).isEqualTo(4)
                 }
 
                 it("adds one for negated but similar operators") {
-                    val code = compileContentForTest("""
+                    val code = compileContentForTest(
+                        """
                         fun test(cond: Boolean) {
                             if (                    // +1
                                 !cond 
                                 && !(cond && cond)  // +2
                             ) {}
                         }
-                    """)
+                    """
+                    )
 
                     assertThat(CognitiveComplexity.calculate(code)).isEqualTo(3)
                 }
 
                 it("adds only one for a negated chain of similar operators") {
-                    val code = compileContentForTest("""
+                    val code = compileContentForTest(
+                        """
                         fun test(cond: Boolean) {
                             if (                    // +1
                                 !cond 
                                 && !(cond && cond && cond)  // +2
                             ) {}
                         }
-                    """)
+                    """
+                    )
 
                     assertThat(CognitiveComplexity.calculate(code)).isEqualTo(3)
                 }
 
                 it("adds one for every negated similar operator chain") {
-                    val code = compileContentForTest("""
+                    val code = compileContentForTest(
+                        """
                         fun test(cond: Boolean) {
                             if (                            // +1
                                 !cond 
@@ -221,7 +256,8 @@ class CognitiveComplexitySpec : Spek({
                                 || !(cond || cond)          // +2
                             ) {}
                         }
-                    """)
+                    """
+                    )
 
                     assertThat(CognitiveComplexity.calculate(code)).isEqualTo(5)
                 }

--- a/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/CyclomaticComplexitySpec.kt
+++ b/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/CyclomaticComplexitySpec.kt
@@ -13,9 +13,11 @@ class CyclomaticComplexitySpec : Spek({
     describe("basic function expressions are tested") {
 
         it("counts for safe navigation") {
-            val code = compileContentForTest("""
-                    fun test() = null as? String ?: ""
-                """.trimIndent())
+            val code = compileContentForTest(
+                """
+                fun test() = null as? String ?: ""
+                """.trimIndent()
+            )
 
             val actual = CyclomaticComplexity.calculate(code)
 
@@ -23,9 +25,11 @@ class CyclomaticComplexitySpec : Spek({
         }
 
         it("counts if and && and || expressions") {
-            val code = compileContentForTest("""
-                    fun test() = if (true || true && false) 1 else 0
-                """.trimIndent())
+            val code = compileContentForTest(
+                """
+                fun test() = if (true || true && false) 1 else 0
+                """.trimIndent()
+            )
 
             val actual = CyclomaticComplexity.calculate(code)
 
@@ -33,21 +37,23 @@ class CyclomaticComplexitySpec : Spek({
         }
 
         it("counts while, continue and break") {
-            val code = compileContentForTest("""
-                    fun test(i: Int) {
-                        var j = i
-                        while(true) { // 1
-                            if (j == 5) { // 1
-                                continue // 1
-                            } else if (j == 2) { // 1
-                                break // 1
-                            } else {
-                                j += i
-                            }
+            val code = compileContentForTest(
+                """
+                fun test(i: Int) {
+                    var j = i
+                    while(true) { // 1
+                        if (j == 5) { // 1
+                            continue // 1
+                        } else if (j == 2) { // 1
+                            break // 1
+                        } else {
+                            j += i
                         }
-                        println("finished")
                     }
-                """.trimIndent())
+                    println("finished")
+                }
+                """.trimIndent()
+            )
 
             val actual = CyclomaticComplexity.calculate(code)
 
@@ -56,11 +62,12 @@ class CyclomaticComplexitySpec : Spek({
     }
 
     describe("counts function calls used for nesting") {
-        val code = compileContentForTest("""
-                    fun test(i: Int) {
-                        (1..10).forEach { println(it) }
-                    }
-                """.trimIndent()
+        val code = compileContentForTest(
+            """
+            fun test(i: Int) {
+                (1..10).forEach { println(it) }
+            }
+            """.trimIndent()
         )
 
         it("counts them by default") {
@@ -97,7 +104,8 @@ class CyclomaticComplexitySpec : Spek({
     describe("ignoreSimpleWhenEntries is false") {
 
         it("counts simple when branches as 1") {
-            val function = compileContentForTest("""
+            val function = compileContentForTest(
+                """
                 fun test() {
                     when (System.currentTimeMillis()) {
                         0 -> println("Epoch!")
@@ -105,7 +113,8 @@ class CyclomaticComplexitySpec : Spek({
                         else -> println("Meh")
                     }
                 }
-            """).getFunctionByName("test")
+            """
+            ).getFunctionByName("test")
 
             val actual = CyclomaticComplexity.calculate(function) {
                 ignoreSimpleWhenEntries = false
@@ -115,7 +124,8 @@ class CyclomaticComplexitySpec : Spek({
         }
 
         it("counts block when branches as 1") {
-            val function = compileContentForTest("""
+            val function = compileContentForTest(
+                """
                 fun test() {
                     when (System.currentTimeMillis()) {
                         0 -> {
@@ -125,7 +135,8 @@ class CyclomaticComplexitySpec : Spek({
                         else -> println("Meh")
                     }
                 }
-            """).getFunctionByName("test")
+            """
+            ).getFunctionByName("test")
 
             val actual = CyclomaticComplexity.calculate(function) {
                 ignoreSimpleWhenEntries = false
@@ -138,7 +149,8 @@ class CyclomaticComplexitySpec : Spek({
     describe("ignoreSimpleWhenEntries is true") {
 
         it("counts a when with only simple branches as 1") {
-            val function = compileContentForTest("""
+            val function = compileContentForTest(
+                """
                 fun test() {
                     when (System.currentTimeMillis()) {
                         0 -> println("Epoch!")
@@ -146,7 +158,8 @@ class CyclomaticComplexitySpec : Spek({
                         else -> println("Meh")
                     }
                 }
-            """).getFunctionByName("test")
+            """
+            ).getFunctionByName("test")
 
             val actual = CyclomaticComplexity.calculate(function) {
                 ignoreSimpleWhenEntries = true
@@ -156,7 +169,8 @@ class CyclomaticComplexitySpec : Spek({
         }
 
         it("does not count simple when branches") {
-            val function = compileContentForTest("""
+            val function = compileContentForTest(
+                """
                 fun test() {
                     when (System.currentTimeMillis()) {
                         0 -> {
@@ -169,7 +183,8 @@ class CyclomaticComplexitySpec : Spek({
                         else -> println("Meh")
                     }
                 }
-            """).getFunctionByName("test")
+            """
+            ).getFunctionByName("test")
 
             val actual = CyclomaticComplexity.calculate(function) {
                 ignoreSimpleWhenEntries = true
@@ -179,7 +194,8 @@ class CyclomaticComplexitySpec : Spek({
         }
 
         it("counts block when branches as 1") {
-            val function = compileContentForTest("""
+            val function = compileContentForTest(
+                """
                 fun test() {
                     when (System.currentTimeMillis()) {
                         0 -> {
@@ -194,7 +210,8 @@ class CyclomaticComplexitySpec : Spek({
                         else -> println("Meh")
                     }
                 }
-            """).getFunctionByName("test")
+            """
+            ).getFunctionByName("test")
 
             val actual = CyclomaticComplexity.calculate(function) {
                 ignoreSimpleWhenEntries = true

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/GuardClauses.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/GuardClauses.kt
@@ -24,7 +24,6 @@ fun KtNamedFunction.yieldStatementsSkippingGuardClauses(): Sequence<KtExpression
 }
 
 fun KtExpression.isGuardClause(): Boolean {
-
     fun isIfConditionGuardClause(returnExpr: KtReturnExpression): Boolean {
         val ifExpr = this as? KtIfExpression
             ?: return false

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/GuardClauses.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/GuardClauses.kt
@@ -30,7 +30,7 @@ fun KtExpression.isGuardClause(): Boolean {
             ?: return false
 
         return ifExpr.`else` == null &&
-                returnExpr === ifExpr.then?.lastBlockStatementOrThis()
+            returnExpr === ifExpr.then?.lastBlockStatementOrThis()
     }
 
     fun KtReturnExpression.isElvisOperatorGuardClause(): Boolean {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/KtAnnotatedExtensions.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/KtAnnotatedExtensions.kt
@@ -10,9 +10,9 @@ fun KtAnnotated.hasAnnotation(
     val names = annotationNames.toHashSet()
     val predicate: (KtAnnotationEntry) -> Boolean = {
         it.typeReference
-                ?.typeElement
-                ?.safeAs<KtUserType>()
-                ?.referencedName in names
+            ?.typeElement
+            ?.safeAs<KtUserType>()
+            ?.referencedName in names
     }
     return annotationEntries.any(predicate)
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/KtModifierList.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/KtModifierList.kt
@@ -7,7 +7,7 @@ import org.jetbrains.kotlin.psi.KtModifierListOwner
 import org.jetbrains.kotlin.psi.psiUtil.isPublic
 
 fun KtModifierListOwner.isPublicNotOverridden() =
-        isPublic && !isOverride()
+    isPublic && !isOverride()
 
 fun KtModifierListOwner.isAbstract() = hasModifier(KtTokens.ABSTRACT_KEYWORD)
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/MethodSignature.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/MethodSignature.kt
@@ -5,14 +5,14 @@ import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.KtObjectDeclaration
 
 fun KtFunction.isEqualsFunction() =
-        this.name == "equals" && this.isOverride() && hasCorrectEqualsParameter()
+    this.name == "equals" && this.isOverride() && hasCorrectEqualsParameter()
 
 fun KtFunction.isHashCodeFunction() =
-        this.name == "hashCode" && this.isOverride() && this.valueParameters.isEmpty()
+    this.name == "hashCode" && this.isOverride() && this.valueParameters.isEmpty()
 
 private val knownAnys = setOf("Any?", "kotlin.Any?")
 fun KtFunction.hasCorrectEqualsParameter() =
-        this.valueParameters.singleOrNull()?.typeReference?.text in knownAnys
+    this.valueParameters.singleOrNull()?.typeReference?.text in knownAnys
 
 fun KtNamedFunction.isMainFunction() = hasMainSignature() && (this.isTopLevel || isMainInsideObject())
 
@@ -23,7 +23,7 @@ private fun KtNamedFunction.hasMainParameter() =
     valueParameters.isEmpty() || valueParameters.size == 1 && valueParameters[0].typeReference?.text == "Array<String>"
 
 private fun KtNamedFunction.isMainInsideObject() =
-        this.name == "main" &&
-                this.isPublicNotOverridden() &&
-                this.parent?.parent is KtObjectDeclaration &&
-                this.hasAnnotation("JvmStatic", "kotlin.jvm.JvmStatic")
+    this.name == "main" &&
+        this.isPublicNotOverridden() &&
+        this.parent?.parent is KtObjectDeclaration &&
+        this.hasAnnotation("JvmStatic", "kotlin.jvm.JvmStatic")

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DuplicateCaseInWhenExpression.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DuplicateCaseInWhenExpression.kt
@@ -34,10 +34,12 @@ import org.jetbrains.kotlin.psi.KtWhenExpression
  */
 class DuplicateCaseInWhenExpression(config: Config) : Rule(config) {
 
-    override val issue = Issue("DuplicateCaseInWhenExpression",
-            Severity.Warning,
-            "Duplicated case statements in when expression. Both cases should be merged.",
-            Debt.TEN_MINS)
+    override val issue = Issue(
+        "DuplicateCaseInWhenExpression",
+        Severity.Warning,
+        "Duplicated case statements in when expression. Both cases should be merged.",
+        Debt.TEN_MINS
+    )
 
     override fun visitWhenExpression(expression: KtWhenExpression) {
         val distinctEntries = expression.entries.distinctBy { entry -> entry.conditions.joinToString { it.text } }
@@ -46,8 +48,12 @@ class DuplicateCaseInWhenExpression(config: Config) : Rule(config) {
             val duplicateEntries = expression.entries
                 .subtract(distinctEntries)
                 .map { entry -> entry.conditions.joinToString { it.text } }
-            report(CodeSmell(issue, Entity.from(expression),
-                "When expression has multiple case statements for ${duplicateEntries.joinToString("; ")}."))
+            report(
+                CodeSmell(
+                    issue, Entity.from(expression),
+                    "When expression has multiple case statements for ${duplicateEntries.joinToString("; ")}."
+                )
+            )
         }
     }
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsAlwaysReturnsTrueOrFalse.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsAlwaysReturnsTrueOrFalse.kt
@@ -40,13 +40,15 @@ import org.jetbrains.kotlin.psi.psiUtil.collectDescendantsOfType
  */
 class EqualsAlwaysReturnsTrueOrFalse(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue("EqualsAlwaysReturnsTrueOrFalse",
-            Severity.Defect,
-            "Having an equals method which always returns true or false is not a good idea. " +
-                    "It does not follow the contract of this method. " +
-                    "Consider a good default implementation. " +
-                    "For example this == other",
-            Debt.TWENTY_MINS)
+    override val issue = Issue(
+        "EqualsAlwaysReturnsTrueOrFalse",
+        Severity.Defect,
+        "Having an equals method which always returns true or false is not a good idea. " +
+            "It does not follow the contract of this method. " +
+            "Consider a good default implementation. " +
+            "For example this == other",
+        Debt.TWENTY_MINS
+    )
 
     override fun visitNamedFunction(function: KtNamedFunction) {
         if (function.isEqualsFunction() && function.returnsBooleanConstant()) {
@@ -56,7 +58,8 @@ class EqualsAlwaysReturnsTrueOrFalse(config: Config = Config.empty) : Rule(confi
                     Entity.atName(function),
                     "This equals function always returns the same " +
                         "result regardless of the input parameters."
-                ))
+                )
+            )
         }
     }
 
@@ -77,8 +80,10 @@ class EqualsAlwaysReturnsTrueOrFalse(config: Config = Config.empty) : Rule(confi
         val allReturnExpressions = bodyExpression.collectDescendantsOfType<KtReturnExpression>()
         val hasNoNestedReturnExpression = allReturnExpressions.size == returnExpressionsInBlock.size
         return lastValidReturnExpression?.isBooleanConstant() == true &&
-                (hasNoNestedReturnExpression ||
-                        allReturnExpressions.all { it.returnedExpression?.text == lastValidReturnExpression.text })
+            (
+                hasNoNestedReturnExpression ||
+                    allReturnExpressions.all { it.returnedExpression?.text == lastValidReturnExpression.text }
+                )
     }
 
     private fun PsiElement.isBooleanConstant() = node.elementType == KtNodeTypes.BOOLEAN_CONSTANT

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsWithHashCodeExist.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsWithHashCodeExist.kt
@@ -48,13 +48,15 @@ import java.util.ArrayDeque
  */
 class EqualsWithHashCodeExist(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue("EqualsWithHashCodeExist",
-            Severity.Defect,
-            "Always override hashCode when you override equals. " +
-                    "All hash-based collections depend on objects meeting the equals-contract. " +
-                    "Two equal objects must produce the same hashcode. When inheriting equals or hashcode, " +
-                    "override the inherited and call the super method for clarification.",
-            Debt.FIVE_MINS)
+    override val issue = Issue(
+        "EqualsWithHashCodeExist",
+        Severity.Defect,
+        "Always override hashCode when you override equals. " +
+            "All hash-based collections depend on objects meeting the equals-contract. " +
+            "Two equal objects must produce the same hashcode. When inheriting equals or hashcode, " +
+            "override the inherited and call the super method for clarification.",
+        Debt.FIVE_MINS
+    )
 
     private val queue = ArrayDeque<ViolationHolder>(MAXIMUM_EXPECTED_NESTED_CLASSES)
 
@@ -73,8 +75,13 @@ class EqualsWithHashCodeExist(config: Config = Config.empty) : Rule(config) {
         queue.push(ViolationHolder())
         super.visitClassOrObject(classOrObject)
         if (queue.pop().violation()) {
-            report(CodeSmell(issue, Entity.atName(classOrObject), "A class should always override hashCode " +
-                    "when overriding equals and the other way around."))
+            report(
+                CodeSmell(
+                    issue, Entity.atName(classOrObject),
+                    "A class should always override hashCode " +
+                        "when overriding equals and the other way around."
+                )
+            )
         }
     }
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ExplicitGarbageCollectionCall.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ExplicitGarbageCollectionCall.kt
@@ -27,12 +27,14 @@ import org.jetbrains.kotlin.psi.psiUtil.getReceiverExpression
  */
 class ExplicitGarbageCollectionCall(config: Config) : Rule(config) {
 
-    override val issue = Issue("ExplicitGarbageCollectionCall",
-            Severity.Defect,
-            "Don't try to be smarter than the JVM. Your code should work independently if the garbage " +
-                    "collector is disabled or not. If you face memory issues, " +
-                    "try tuning the JVM options instead of relying on code itself.",
-            Debt.TWENTY_MINS)
+    override val issue = Issue(
+        "ExplicitGarbageCollectionCall",
+        Severity.Defect,
+        "Don't try to be smarter than the JVM. Your code should work independently if the garbage " +
+            "collector is disabled or not. If you face memory issues, " +
+            "try tuning the JVM options instead of relying on code itself.",
+        Debt.TWENTY_MINS
+    )
 
     override fun visitCallExpression(expression: KtCallExpression) {
         expression.getCallNameExpression()?.let {
@@ -44,8 +46,13 @@ class ExplicitGarbageCollectionCall(config: Config) : Rule(config) {
         if (it.textMatches("gc") || it.textMatches("runFinalization")) {
             it.getReceiverExpression()?.let {
                 when (it.text) {
-                    "System", "Runtime.getRuntime()" -> report(CodeSmell(issue, Entity.from(expression),
-                            "An explicit call to the Garbage Collector as in ${it.text} should not be made."))
+                    "System", "Runtime.getRuntime()" ->
+                        report(
+                            CodeSmell(
+                                issue, Entity.from(expression),
+                                "An explicit call to the Garbage Collector as in ${it.text} should not be made."
+                            )
+                        )
                 }
             }
         }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/HasPlatformType.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/HasPlatformType.kt
@@ -48,7 +48,8 @@ class HasPlatformType(config: Config) : Rule(config) {
         super.visitKtElement(element)
 
         if (bindingContext != BindingContext.EMPTY && element is KtCallableDeclaration &&
-            element.hasImplicitPlatformType()) {
+            element.hasImplicitPlatformType()
+        ) {
             report(
                 CodeSmell(
                     issue,

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ImplicitDefaultLocale.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ImplicitDefaultLocale.kt
@@ -44,9 +44,9 @@ import org.jetbrains.kotlin.resolve.calls.callUtil.getType
 class ImplicitDefaultLocale(config: Config = Config.empty) : Rule(config) {
 
     override val issue = Issue(
-            "ImplicitDefaultLocale", Severity.CodeSmell,
-            "Implicit default locale used for string processing. Consider using explicit locale.",
-            Debt.FIVE_MINS
+        "ImplicitDefaultLocale", Severity.CodeSmell,
+        "Implicit default locale used for string processing. Consider using explicit locale.",
+        Debt.FIVE_MINS
     )
 
     override fun visitDotQualifiedExpression(expression: KtDotQualifiedExpression) {
@@ -68,8 +68,9 @@ class ImplicitDefaultLocale(config: Config = Config.empty) : Rule(config) {
         ) {
             report(
                 CodeSmell(
-                issue, Entity.from(expression),
-                "${expression.text} uses implicitly default locale for string formatting.")
+                    issue, Entity.from(expression),
+                    "${expression.text} uses implicitly default locale for string formatting."
+                )
             )
         }
     }
@@ -77,11 +78,15 @@ class ImplicitDefaultLocale(config: Config = Config.empty) : Rule(config) {
     fun checkCaseConversion(expression: KtQualifiedExpression) {
         if (isStringOrNullableString(expression.receiverExpression.getType(bindingContext)) &&
             expression.isCalleeCaseConversion() &&
-            expression.isCalleeNoArgs()) {
-            report(CodeSmell(
-                issue,
-                Entity.from(expression),
-                "${expression.text} uses implicitly default locale for case conversion."))
+            expression.isCalleeNoArgs()
+        ) {
+            report(
+                CodeSmell(
+                    issue,
+                    Entity.from(expression),
+                    "${expression.text} uses implicitly default locale for case conversion."
+                )
+            )
         }
     }
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/InvalidRange.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/InvalidRange.kt
@@ -35,18 +35,24 @@ import org.jetbrains.kotlin.psi.KtBinaryExpression
  */
 class InvalidRange(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue(javaClass.simpleName,
-            Severity.Defect,
-            "If a for loops condition is false before the first iteration, the loop will never get executed.",
-            Debt.TEN_MINS)
+    override val issue = Issue(
+        javaClass.simpleName,
+        Severity.Defect,
+        "If a for loops condition is false before the first iteration, the loop will never get executed.",
+        Debt.TEN_MINS
+    )
 
     private val minimumSize = 3
 
     override fun visitBinaryExpression(expression: KtBinaryExpression) {
         val range = expression.children
         if (range.size >= minimumSize && hasInvalidLoopRange(range)) {
-            report(CodeSmell(issue, Entity.from(expression),
-                    "This loop will never be executed due to its expression."))
+            report(
+                CodeSmell(
+                    issue, Entity.from(expression),
+                    "This loop will never be executed due to its expression."
+                )
+            )
         }
         super.visitBinaryExpression(expression)
     }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IteratorHasNextCallsNextMethod.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IteratorHasNextCallsNextMethod.kt
@@ -32,18 +32,25 @@ import org.jetbrains.kotlin.psi.psiUtil.getSuperNames
  */
 class IteratorHasNextCallsNextMethod(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue("IteratorHasNextCallsNextMethod", Severity.Defect,
-            "The hasNext() method of an Iterator implementation should not call the next() method. " +
-                    "The state of the iterator should not be changed inside the hasNext() method. " +
-                    "The hasNext() method is not supposed to have any side effects.",
-            Debt.TEN_MINS)
+    override val issue = Issue(
+        "IteratorHasNextCallsNextMethod", Severity.Defect,
+        "The hasNext() method of an Iterator implementation should not call the next() method. " +
+            "The state of the iterator should not be changed inside the hasNext() method. " +
+            "The hasNext() method is not supposed to have any side effects.",
+        Debt.TEN_MINS
+    )
 
     override fun visitClassOrObject(classOrObject: KtClassOrObject) {
         if (classOrObject.getSuperNames().contains("Iterator")) {
             val hasNextMethod = classOrObject.findFunctionByName("hasNext")
             if (hasNextMethod != null && callsNextMethod(hasNextMethod)) {
-                report(CodeSmell(issue, Entity.atName(classOrObject), "Calling hasNext() on an Iterator should " +
-                        "have no side-effects. Calling next() is a side effect."))
+                report(
+                    CodeSmell(
+                        issue, Entity.atName(classOrObject),
+                        "Calling hasNext() on an Iterator should " +
+                            "have no side-effects. Calling next() is a side effect."
+                    )
+                )
             }
         }
         super.visitClassOrObject(classOrObject)

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IteratorNotThrowingNoSuchElementException.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IteratorNotThrowingNoSuchElementException.kt
@@ -47,18 +47,24 @@ import org.jetbrains.kotlin.psi.psiUtil.getSuperNames
  */
 class IteratorNotThrowingNoSuchElementException(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue("IteratorNotThrowingNoSuchElementException", Severity.Defect,
-            "The next() method of an Iterator implementation should throw a NoSuchElementException " +
-                    "when there are no more elements to return",
-            Debt.TEN_MINS)
+    override val issue = Issue(
+        "IteratorNotThrowingNoSuchElementException", Severity.Defect,
+        "The next() method of an Iterator implementation should throw a NoSuchElementException " +
+            "when there are no more elements to return",
+        Debt.TEN_MINS
+    )
 
     override fun visitClassOrObject(classOrObject: KtClassOrObject) {
         if (classOrObject.getSuperNames().contains("Iterator")) {
             val nextMethod = classOrObject.findFunctionByName("next")
             if (nextMethod != null && !nextMethod.throwsNoSuchElementExceptionThrown()) {
-                report(CodeSmell(issue, Entity.atName(classOrObject),
+                report(
+                    CodeSmell(
+                        issue, Entity.atName(classOrObject),
                         "This implementation of Iterator does not correctly implement the next() method as " +
-                                "it doesn't throw a NoSuchElementException when no elements remain in the Iterator."))
+                            "it doesn't throw a NoSuchElementException when no elements remain in the Iterator."
+                    )
+                )
             }
         }
         super.visitClassOrObject(classOrObject)

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/LateinitUsage.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/LateinitUsage.kt
@@ -34,11 +34,13 @@ import org.jetbrains.kotlin.psi.psiUtil.containingClass
  */
 class LateinitUsage(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue(javaClass.simpleName,
-            Severity.Defect,
-            "Usage of lateinit detected. Using lateinit for property initialization " +
-                    "is error prone, try using constructor injection or delegation.",
-            Debt.TWENTY_MINS)
+    override val issue = Issue(
+        javaClass.simpleName,
+        Severity.Defect,
+        "Usage of lateinit detected. Using lateinit for property initialization " +
+            "is error prone, try using constructor injection or delegation.",
+        Debt.TWENTY_MINS
+    )
 
     private val excludeAnnotatedProperties = valueOrDefaultCommaSeparated(EXCLUDE_ANNOTATED_PROPERTIES, emptyList())
         .map { it.removePrefix("*").removeSuffix("*") }
@@ -61,10 +63,10 @@ class LateinitUsage(config: Config = Config.empty) : Rule(config) {
         val annotationExcluder = AnnotationExcluder(root, excludeAnnotatedProperties)
 
         properties.filterNot { annotationExcluder.shouldExclude(it.annotationEntries) }
-                .filterNot { it.containingClass()?.name?.matches(ignoreOnClassesPattern) == true }
-                .forEach {
-                    report(CodeSmell(issue, Entity.from(it), "Usages of lateinit should be avoided."))
-                }
+            .filterNot { it.containingClass()?.name?.matches(ignoreOnClassesPattern) == true }
+            .forEach {
+                report(CodeSmell(issue, Entity.from(it), "Usages of lateinit should be avoided."))
+            }
     }
 
     companion object {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MapGetWithNotNullAssertionOperator.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MapGetWithNotNullAssertionOperator.kt
@@ -49,7 +49,7 @@ class MapGetWithNotNullAssertionOperator(config: Config) : Rule(config) {
             "MapGetWithNotNullAssertionOperator",
             Severity.CodeSmell,
             "map.get() with not-null assertion operator (!!) can result in a NullPointerException. " +
-                    "Consider usage of map.getValue(), map.getOrDefault() or map.getOrElse() instead.",
+                "Consider usage of map.getValue(), map.getOrDefault() or map.getOrElse() instead.",
             Debt.FIVE_MINS
         )
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingWhenCase.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingWhenCase.kt
@@ -87,7 +87,7 @@ class MissingWhenCase(config: Config = Config.empty) : Rule(config) {
                     CodeSmell(
                         issue, Entity.from(expression),
                         "When expression is missing cases: ${enumMissingCases.joinToString()}. Either add missing " +
-                                "cases or a default `else` case."
+                            "cases or a default `else` case."
                     )
                 )
             }
@@ -101,7 +101,7 @@ class MissingWhenCase(config: Config = Config.empty) : Rule(config) {
                     CodeSmell(
                         issue, Entity.from(expression),
                         "When expression is missing cases: ${sealedClassMissingCases.joinToString()}. Either add " +
-                                "missing cases or a default `else` case."
+                            "missing cases or a default `else` case."
                     )
                 )
             }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnconditionalJumpStatementInLoop.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnconditionalJumpStatementInLoop.kt
@@ -33,15 +33,23 @@ import org.jetbrains.kotlin.psi.KtReturnExpression
  */
 class UnconditionalJumpStatementInLoop(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue(javaClass.simpleName, Severity.Defect,
+    override val issue = Issue(
+        javaClass.simpleName, Severity.Defect,
         "An unconditional jump statement in a loop is useless. " +
-            "The loop itself is only executed once.", Debt.TEN_MINS)
+            "The loop itself is only executed once.",
+        Debt.TEN_MINS
+    )
 
     override fun visitLoopExpression(loopExpression: KtLoopExpression) {
         if (hasJumpStatement(loopExpression.body)) {
-            report(CodeSmell(issue, Entity.from(loopExpression), "This loop contains an unconditional " +
-                "jump expression which " +
-                "essentially renders it useless as it will exit the loop during the first iteration."))
+            report(
+                CodeSmell(
+                    issue, Entity.from(loopExpression),
+                    "This loop contains an unconditional " +
+                        "jump expression which " +
+                        "essentially renders it useless as it will exit the loop during the first iteration."
+                )
+            )
         }
         super.visitLoopExpression(loopExpression)
     }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessaryNotNullOperator.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessaryNotNullOperator.kt
@@ -26,10 +26,12 @@ import org.jetbrains.kotlin.resolve.BindingContext
  */
 class UnnecessaryNotNullOperator(config: Config = Config.empty) : Rule(config) {
 
-    override val issue: Issue = Issue("UnnecessaryNotNullOperator",
-            Severity.Defect,
-            "Unnecessary not-null unary operator (!!) detected.",
-            Debt.FIVE_MINS)
+    override val issue: Issue = Issue(
+        "UnnecessaryNotNullOperator",
+        Severity.Defect,
+        "Unnecessary not-null unary operator (!!) detected.",
+        Debt.FIVE_MINS
+    )
 
     override fun visitUnaryExpression(expression: KtUnaryExpression) {
         super.visitUnaryExpression(expression)
@@ -37,8 +39,13 @@ class UnnecessaryNotNullOperator(config: Config = Config.empty) : Rule(config) {
 
         val compilerReports = bindingContext.diagnostics.forElement(expression.operationReference)
         if (compilerReports.any { it.factory == Errors.UNNECESSARY_NOT_NULL_ASSERTION }) {
-            report(CodeSmell(issue, Entity.from(expression), "${expression.text} contains an unnecessary " +
-                    "not-null (!!) operators"))
+            report(
+                CodeSmell(
+                    issue, Entity.from(expression),
+                    "${expression.text} contains an unnecessary " +
+                        "not-null (!!) operators"
+                )
+            )
         }
     }
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessarySafeCall.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessarySafeCall.kt
@@ -50,8 +50,9 @@ class UnnecessarySafeCall(config: Config = Config.empty) : Rule(config) {
         if (compilerReports.any { it.factory == Errors.UNNECESSARY_SAFE_CALL }) {
             report(
                 CodeSmell(
-                    issue, Entity.from(expression), "${expression.text} contains an unnecessary " +
-                            "safe call operator"
+                    issue, Entity.from(expression),
+                    "${expression.text} contains an unnecessary " +
+                        "safe call operator"
                 )
             )
         }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnreachableCode.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnreachableCode.kt
@@ -38,8 +38,10 @@ import org.jetbrains.kotlin.psi.KtThrowExpression
  */
 class UnreachableCode(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue("UnreachableCode", Severity.Warning,
-            "Unreachable code detected. This code should be removed", Debt.TEN_MINS)
+    override val issue = Issue(
+        "UnreachableCode", Severity.Warning,
+        "Unreachable code detected. This code should be removed", Debt.TEN_MINS
+    )
 
     override fun visitReturnExpression(expression: KtReturnExpression) {
         followedByUnreachableCode(expression)
@@ -63,8 +65,13 @@ class UnreachableCode(config: Config = Config.empty) : Rule(config) {
         val statements = (expression.parent as? KtBlockExpression)?.statements ?: return
         val indexOfStatement = statements.indexOf(expression)
         if (indexOfStatement < statements.size - 1) {
-            report(CodeSmell(issue, Entity.from(expression), "This expression is followed by unreachable " +
-                    "code which should either be used or removed."))
+            report(
+                CodeSmell(
+                    issue, Entity.from(expression),
+                    "This expression is followed by unreachable " +
+                        "code which should either be used or removed."
+                )
+            )
         }
     }
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCallOnNullableType.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCallOnNullableType.kt
@@ -34,10 +34,12 @@ import org.jetbrains.kotlin.types.typeUtil.nullability
  * @active since v1.2.0
  */
 class UnsafeCallOnNullableType(config: Config = Config.empty) : Rule(config) {
-    override val issue: Issue = Issue("UnsafeCallOnNullableType",
-            Severity.Defect,
-            "It will throw a NullPointerException at runtime if your nullable value is null.",
-            Debt.TWENTY_MINS)
+    override val issue: Issue = Issue(
+        "UnsafeCallOnNullableType",
+        Severity.Defect,
+        "It will throw a NullPointerException at runtime if your nullable value is null.",
+        Debt.TWENTY_MINS
+    )
 
     @Suppress("ReturnCount")
     override fun visitUnaryExpression(expression: KtUnaryExpression) {
@@ -47,8 +49,13 @@ class UnsafeCallOnNullableType(config: Config = Config.empty) : Rule(config) {
         if (type.nullability() != TypeNullability.NULLABLE) return
 
         if (expression.operationToken == KtTokens.EXCLEXCL) {
-            report(CodeSmell(issue, Entity.from(expression), "Calling !! on a nullable type will throw a " +
-                    "NullPointerException at runtime in case the value is null. It should be avoided."))
+            report(
+                CodeSmell(
+                    issue, Entity.from(expression),
+                    "Calling !! on a nullable type will throw a " +
+                        "NullPointerException at runtime in case the value is null. It should be avoided."
+                )
+            )
         }
     }
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCast.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCast.kt
@@ -34,19 +34,25 @@ class UnsafeCast(config: Config = Config.empty) : Rule(config) {
 
     override val defaultRuleIdAliases: Set<String> = setOf("UNCHECKED_CAST")
 
-    override val issue: Issue = Issue("UnsafeCast",
-            Severity.Defect,
-            "Cast operator throws an exception if the cast is not possible.",
-            Debt.TWENTY_MINS)
+    override val issue: Issue = Issue(
+        "UnsafeCast",
+        Severity.Defect,
+        "Cast operator throws an exception if the cast is not possible.",
+        Debt.TWENTY_MINS
+    )
 
     override fun visitBinaryWithTypeRHSExpression(expression: KtBinaryExpressionWithTypeRHS) {
         if (bindingContext == BindingContext.EMPTY) return
 
         if (bindingContext.diagnostics.forElement(expression.operationReference)
-                .any { it.factory == Errors.CAST_NEVER_SUCCEEDS }
+            .any { it.factory == Errors.CAST_NEVER_SUCCEEDS }
         ) {
-            report(CodeSmell(issue, Entity.from(expression),
-                    "${expression.left.text} cast to ${expression.right?.text ?: ""} cannot succeed."))
+            report(
+                CodeSmell(
+                    issue, Entity.from(expression),
+                    "${expression.left.text} cast to ${expression.right?.text ?: ""} cannot succeed."
+                )
+            )
         }
 
         super.visitBinaryWithTypeRHSExpression(expression)

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UselessPostfixExpression.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UselessPostfixExpression.kt
@@ -55,16 +55,18 @@ import org.jetbrains.kotlin.psi.psiUtil.isPropertyParameter
  */
 class UselessPostfixExpression(config: Config = Config.empty) : Rule(config) {
 
-    override val issue: Issue = Issue("UselessPostfixExpression", Severity.Defect,
-            "The incremented or decremented value is unused. This value is replaced with the original value.",
-            Debt.TWENTY_MINS)
+    override val issue: Issue = Issue(
+        "UselessPostfixExpression", Severity.Defect,
+        "The incremented or decremented value is unused. This value is replaced with the original value.",
+        Debt.TWENTY_MINS
+    )
 
     var properties = setOf<String?>()
 
     override fun visitClass(klass: KtClass) {
         properties = klass.getProperties()
-                .map { it.name }
-                .union(klass.primaryConstructorParameters.filter { it.isPropertyParameter() }.map { it.name })
+            .map { it.name }
+            .union(klass.primaryConstructorParameters.filter { it.isPropertyParameter() }.map { it.name })
         super.visitClass(klass)
     }
 
@@ -76,7 +78,7 @@ class UselessPostfixExpression(config: Config = Config.empty) : Rule(config) {
         }
 
         getPostfixExpressionChilds(expression.returnedExpression)
-                ?.forEach { report(it) }
+            ?.forEach { report(it) }
     }
 
     override fun visitBinaryExpression(expression: KtBinaryExpression) {
@@ -84,11 +86,12 @@ class UselessPostfixExpression(config: Config = Config.empty) : Rule(config) {
         val leftIdentifierText = expression.left?.text
         checkPostfixExpression(postfixExpression, leftIdentifierText)
         getPostfixExpressionChilds(expression.right)
-                ?.forEach { checkPostfixExpression(it, leftIdentifierText) }
+            ?.forEach { checkPostfixExpression(it, leftIdentifierText) }
     }
 
     private fun KtExpression.asPostFixExpression() = if (this is KtPostfixExpression &&
-            (operationToken === PLUSPLUS || operationToken === MINUSMINUS)) this else null
+        (operationToken === PLUSPLUS || operationToken === MINUSMINUS)
+    ) this else null
 
     private fun checkPostfixExpression(postfixExpression: KtPostfixExpression?, leftIdentifierText: String?) {
         if (postfixExpression != null && leftIdentifierText == postfixExpression.firstChild?.text) {
@@ -104,8 +107,13 @@ class UselessPostfixExpression(config: Config = Config.empty) : Rule(config) {
     }
 
     private fun report(postfixExpression: KtPostfixExpression) {
-        report(CodeSmell(issue, Entity.from(postfixExpression), "The result of the postfix expression: " +
-                "${postfixExpression.text} will not be used and is therefore useless."))
+        report(
+            CodeSmell(
+                issue, Entity.from(postfixExpression),
+                "The result of the postfix expression: " +
+                    "${postfixExpression.text} will not be used and is therefore useless."
+            )
+        )
     }
 
     private fun getPostfixExpressionChilds(expression: KtExpression?) =

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexCondition.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexCondition.kt
@@ -45,9 +45,11 @@ class ComplexCondition(
     threshold: Int = DEFAULT_CONDITIONS_COUNT
 ) : ThresholdRule(config, threshold) {
 
-    override val issue = Issue("ComplexCondition", Severity.Maintainability,
-            "Complex conditions should be simplified and extracted into well-named methods if necessary.",
-            Debt.TWENTY_MINS)
+    override val issue = Issue(
+        "ComplexCondition", Severity.Maintainability,
+        "Complex conditions should be simplified and extracted into well-named methods if necessary.",
+        Debt.TWENTY_MINS
+    )
 
     override fun visitIfExpression(expression: KtIfExpression) {
         val condition = expression.condition
@@ -77,11 +79,15 @@ class ComplexCondition(
             val conditionString = longestBinExpr.text
             val count = frequency(conditionString, "&&") + frequency(conditionString, "||") + 1
             if (count >= threshold) {
-                report(ThresholdedCodeSmell(issue,
+                report(
+                    ThresholdedCodeSmell(
+                        issue,
                         Entity.from(condition),
                         Metric("SIZE", count, threshold),
                         "This condition is too complex ($count). " +
-                                "Defined complexity threshold for conditions is set to '$threshold'"))
+                            "Defined complexity threshold for conditions is set to '$threshold'"
+                    )
+                )
             }
         }
     }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexCondition.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexCondition.kt
@@ -93,7 +93,6 @@ class ComplexCondition(
     }
 
     private fun frequency(source: String, part: String): Int {
-
         if (source.isEmpty() || part.isEmpty()) {
             return 0
         }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexInterface.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexInterface.kt
@@ -35,12 +35,14 @@ class ComplexInterface(
     threshold: Int = DEFAULT_LARGE_INTERFACE_COUNT
 ) : ThresholdRule(config, threshold) {
 
-    override val issue = Issue(javaClass.simpleName, Severity.Maintainability,
-            "An interface contains too many functions and properties. " +
-                    "Large classes tend to handle many things at once. " +
-                    "An interface should have one responsibility. " +
-                    "Split up large interfaces into smaller ones that are easier to understand.",
-            Debt.TWENTY_MINS)
+    override val issue = Issue(
+        javaClass.simpleName, Severity.Maintainability,
+        "An interface contains too many functions and properties. " +
+            "Large classes tend to handle many things at once. " +
+            "An interface should have one responsibility. " +
+            "Split up large interfaces into smaller ones that are easier to understand.",
+        Debt.TWENTY_MINS
+    )
 
     private val includeStaticDeclarations = valueOrDefault(INCLUDE_STATIC_DECLARATIONS, false)
     private val includePrivateDeclarations = valueOrDefault(INCLUDE_PRIVATE_DECLARATIONS, false)
@@ -54,10 +56,12 @@ class ComplexInterface(
             }
             if (size >= threshold) {
                 report(
-                    ThresholdedCodeSmell(issue,
+                    ThresholdedCodeSmell(
+                        issue,
                         Entity.from(klass),
                         Metric("SIZE: ", size, threshold),
-                        "The interface ${klass.name} is too complex. Consider splitting it up.")
+                        "The interface ${klass.name} is too complex. Consider splitting it up."
+                    )
                 )
             }
         }
@@ -71,7 +75,7 @@ class ComplexInterface(
 
     private fun calculateMembers(body: KtClassBody): Int {
         fun PsiElement.considerPrivate() = includePrivateDeclarations ||
-                this is KtTypeParameterListOwner && !this.isPrivate()
+            this is KtTypeParameterListOwner && !this.isPrivate()
 
         fun PsiElement.isMember() = this is KtNamedFunction || this is KtProperty
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexMethod.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexMethod.kt
@@ -52,10 +52,12 @@ class ComplexMethod(
     threshold: Int = DEFAULT_THRESHOLD_METHOD_COMPLEXITY
 ) : ThresholdRule(config, threshold) {
 
-    override val issue = Issue("ComplexMethod",
+    override val issue = Issue(
+        "ComplexMethod",
         Severity.Maintainability,
         "Prefer splitting up complex methods into smaller, easier to understand methods.",
-        Debt.TWENTY_MINS)
+        Debt.TWENTY_MINS
+    )
 
     private val ignoreSingleWhenExpression = valueOrDefault(IGNORE_SINGLE_WHEN_EXPRESSION, false)
     private val ignoreSimpleWhenEntries = valueOrDefault(IGNORE_SIMPLE_WHEN_ENTRIES, false)
@@ -81,7 +83,7 @@ class ComplexMethod(
                     Entity.atName(function),
                     Metric("MCC", complexity, threshold),
                     "The function ${function.nameAsSafeName} appears to be too complex ($complexity). " +
-                            "Defined complexity threshold for methods is set to '$threshold'"
+                        "Defined complexity threshold for methods is set to '$threshold'"
                 )
             )
         }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LabeledExpression.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LabeledExpression.kt
@@ -63,10 +63,12 @@ import org.jetbrains.kotlin.psi.psiUtil.isExtensionDeclaration
  */
 class LabeledExpression(config: Config = Config.empty) : Rule(config) {
 
-    override val issue: Issue = Issue("LabeledExpression",
-            Severity.Maintainability,
-            "Expression with labels increase complexity and affect maintainability.",
-            Debt.TWENTY_MINS)
+    override val issue: Issue = Issue(
+        "LabeledExpression",
+        Severity.Maintainability,
+        "Expression with labels increase complexity and affect maintainability.",
+        Debt.TWENTY_MINS
+    )
 
     private val ignoredLabels = valueOrDefaultCommaSeparated(IGNORED_LABELS, emptyList())
         .map { it.removePrefix("*").removeSuffix("*") }
@@ -94,7 +96,7 @@ class LabeledExpression(config: Config = Config.empty) : Rule(config) {
 
     private fun isAllowedToReferenceContainingClass(klass: KtClass, expression: KtExpressionWithLabel): Boolean {
         return !klass.isInner() ||
-                expression.getStrictParentOfType<KtNamedFunction>()?.isExtensionDeclaration() == true
+            expression.getStrictParentOfType<KtNamedFunction>()?.isExtensionDeclaration() == true
     }
 
     private fun getClassHierarchy(element: KtElement, classes: MutableList<KtClass>) {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LargeClass.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LargeClass.kt
@@ -30,11 +30,13 @@ class LargeClass(
     threshold: Int = DEFAULT_THRESHOLD_CLASS_LENGTH
 ) : ThresholdRule(config, threshold) {
 
-    override val issue = Issue("LargeClass",
-            Severity.Maintainability,
-            "One class should have one responsibility. Large classes tend to handle many things at once. " +
-                    "Split up large classes into smaller classes that are easier to understand.",
-            Debt.TWENTY_MINS)
+    override val issue = Issue(
+        "LargeClass",
+        Severity.Maintainability,
+        "One class should have one responsibility. Large classes tend to handle many things at once. " +
+            "Split up large classes into smaller classes that are easier to understand.",
+        Debt.TWENTY_MINS
+    )
 
     private val classToLinesCache = IdentityHashMap<KtClassOrObject, Int>()
     private val nestedClassTracking = IdentityHashMap<KtClassOrObject, HashSet<KtClassOrObject>>()
@@ -52,7 +54,8 @@ class LargeClass(
                         issue,
                         Entity.atName(clazz),
                         Metric("SIZE", lines, threshold),
-                        "Class ${clazz.name} is too large. Consider splitting it into smaller pieces.")
+                        "Class ${clazz.name} is too large. Consider splitting it into smaller pieces."
+                    )
                 )
             }
         }
@@ -62,12 +65,12 @@ class LargeClass(
         val lines = classOrObject.linesOfCode()
         classToLinesCache[classOrObject] = lines
         classOrObject.getStrictParentOfType<KtClassOrObject>()
-                ?.let { nestedClassTracking.getOrPut(it) { HashSet() }.add(classOrObject) }
+            ?.let { nestedClassTracking.getOrPut(it) { HashSet() }.add(classOrObject) }
         super.visitClassOrObject(classOrObject)
         findAllNestedClasses(classOrObject)
-                .fold(0) { acc, next -> acc + (classToLinesCache[next] ?: 0) }
-                .takeIf { it > 0 }
-                ?.let { classToLinesCache[classOrObject] = lines - it }
+            .fold(0) { acc, next -> acc + (classToLinesCache[next] ?: 0) }
+            .takeIf { it > 0 }
+            ?.let { classToLinesCache[classOrObject] = lines - it }
     }
 
     private fun findAllNestedClasses(startClass: KtClassOrObject): Sequence<KtClassOrObject> = sequence {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongMethod.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongMethod.kt
@@ -30,11 +30,13 @@ class LongMethod(
     threshold: Int = DEFAULT_THRESHOLD_METHOD_LENGTH
 ) : ThresholdRule(config, threshold) {
 
-    override val issue = Issue("LongMethod",
-            Severity.Maintainability,
-            "One method should have one responsibility. Long methods tend to handle many things at once. " +
-                    "Prefer smaller methods to make them easier to understand.",
-            Debt.TWENTY_MINS)
+    override val issue = Issue(
+        "LongMethod",
+        Severity.Maintainability,
+        "One method should have one responsibility. Long methods tend to handle many things at once. " +
+            "Prefer smaller methods to make them easier to understand.",
+        Debt.TWENTY_MINS
+    )
 
     private val functionToLinesCache = HashMap<KtNamedFunction, Int>()
     private val nestedFunctionTracking = IdentityHashMap<KtNamedFunction, HashSet<KtNamedFunction>>()
@@ -64,12 +66,12 @@ class LongMethod(
         val lines = function.linesOfCode()
         functionToLinesCache[function] = lines
         function.getStrictParentOfType<KtNamedFunction>()
-                ?.let { nestedFunctionTracking.getOrPut(it) { HashSet() }.add(function) }
+            ?.let { nestedFunctionTracking.getOrPut(it) { HashSet() }.add(function) }
         super.visitNamedFunction(function)
         findAllNestedFunctions(function)
-                .fold(0) { acc, next -> acc + (functionToLinesCache[next] ?: 0) }
-                .takeIf { it > 0 }
-                ?.let { functionToLinesCache[function] = lines - it }
+            .fold(0) { acc, next -> acc + (functionToLinesCache[next] ?: 0) }
+            .takeIf { it > 0 }
+            ?.let { functionToLinesCache[function] = lines - it }
     }
 
     private fun findAllNestedFunctions(startFunction: KtNamedFunction): Sequence<KtNamedFunction> = sequence {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterList.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterList.kt
@@ -40,12 +40,14 @@ class LongParameterList(
     config: Config = Config.empty
 ) : Rule(config) {
 
-    override val issue = Issue("LongParameterList",
-            Severity.Maintainability,
-            "The more parameters a function has the more complex it is. Long parameter lists are often " +
-                    "used to control complex algorithms and violate the Single Responsibility Principle. " +
-                    "Prefer functions with short parameter lists.",
-            Debt.TWENTY_MINS)
+    override val issue = Issue(
+        "LongParameterList",
+        Severity.Maintainability,
+        "The more parameters a function has the more complex it is. Long parameter lists are often " +
+            "used to control complex algorithms and violate the Single Responsibility Principle. " +
+            "Prefer functions with short parameter lists.",
+        Debt.TWENTY_MINS
+    )
 
     private val functionThreshold: Int =
         valueOrDefault(FUNCTION_THRESHOLD, valueOrDefault(THRESHOLD, DEFAULT_FUNCTION_THRESHOLD))
@@ -104,14 +106,18 @@ class LongParameterList(
 
         if (parameterNumber >= threshold) {
             val parameterPrint = function.valueParameters.joinToString(separator = ", ") {
-                    it.nameAsSafeName.identifier + ": " + it.typeReference?.text
+                it.nameAsSafeName.identifier + ": " + it.typeReference?.text
             }
 
-            report(ThresholdedCodeSmell(issue,
+            report(
+                ThresholdedCodeSmell(
+                    issue,
                     Entity.from(parameterList),
                     Metric("SIZE", parameterNumber, threshold),
                     "The $identifier($parameterPrint) has too many parameters. " +
-                            "The current threshold is set to $threshold."))
+                        "The current threshold is set to $threshold."
+                )
+            )
         }
     }
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/MethodOverloading.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/MethodOverloading.kt
@@ -31,11 +31,13 @@ class MethodOverloading(
     threshold: Int = DEFAULT_THRESHOLD_OVERLOAD_COUNT
 ) : ThresholdRule(config, threshold) {
 
-    override val issue = Issue("MethodOverloading", Severity.Maintainability,
-            "Methods which are overloaded often might be harder to maintain. " +
-                    "Furthermore, these methods are tightly coupled. " +
-                    "Refactor these methods and try to use optional parameters.",
-            Debt.TWENTY_MINS)
+    override val issue = Issue(
+        "MethodOverloading", Severity.Maintainability,
+        "Methods which are overloaded often might be harder to maintain. " +
+            "Furthermore, these methods are tightly coupled. " +
+            "Refactor these methods and try to use optional parameters.",
+        Debt.TWENTY_MINS
+    )
 
     override fun visitKtFile(file: KtFile) {
         val visitor = OverloadedMethodVisitor()

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedBlockDepth.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedBlockDepth.kt
@@ -34,11 +34,13 @@ class NestedBlockDepth(
     threshold: Int = DEFAULT_THRESHOLD_NESTING
 ) : ThresholdRule(config, threshold) {
 
-    override val issue = Issue("NestedBlockDepth",
-            Severity.Maintainability,
-            "Excessive nesting leads to hidden complexity. " +
-                    "Prefer extracting code to make it easier to understand.",
-            Debt.TWENTY_MINS)
+    override val issue = Issue(
+        "NestedBlockDepth",
+        Severity.Maintainability,
+        "Excessive nesting leads to hidden complexity. " +
+            "Prefer extracting code to make it easier to understand.",
+        Debt.TWENTY_MINS
+    )
 
     override fun visitNamedFunction(function: KtNamedFunction) {
         val visitor = FunctionDepthVisitor(threshold)

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/StringLiteralDuplication.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/StringLiteralDuplication.kt
@@ -69,11 +69,14 @@ class StringLiteralDuplication(
         val type = "SIZE: "
         for ((name, value) in visitor.getLiteralsOverThreshold()) {
             val (main, references) = visitor.entitiesForLiteral(name)
-            report(ThresholdedCodeSmell(issue,
-                main,
-                Metric(type + name, value, threshold),
-                issue.description,
-                references)
+            report(
+                ThresholdedCodeSmell(
+                    issue,
+                    main,
+                    Metric(type + name, value, threshold),
+                    issue.description,
+                    references
+                )
             )
         }
     }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/TooManyFunctions.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/TooManyFunctions.kt
@@ -37,12 +37,14 @@ import org.jetbrains.kotlin.psi.psiUtil.isPrivate
  */
 class TooManyFunctions(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue("TooManyFunctions",
-            Severity.Maintainability,
-            "Too many functions inside a/an file/class/object/interface always indicate a violation of " +
-                    "the single responsibility principle. Maybe the file/class/object/interface wants to manage too " +
-                    "many things at once. Extract functionality which clearly belongs together.",
-            Debt.TWENTY_MINS)
+    override val issue = Issue(
+        "TooManyFunctions",
+        Severity.Maintainability,
+        "Too many functions inside a/an file/class/object/interface always indicate a violation of " +
+            "the single responsibility principle. Maybe the file/class/object/interface wants to manage too " +
+            "many things at once. Extract functionality which clearly belongs together.",
+        Debt.TWENTY_MINS
+    )
 
     private val thresholdInFiles = valueOrDefault(THRESHOLD_IN_FILES, DEFAULT_THRESHOLD)
     private val thresholdInClasses = valueOrDefault(THRESHOLD_IN_CLASSES, DEFAULT_THRESHOLD)
@@ -58,11 +60,15 @@ class TooManyFunctions(config: Config = Config.empty) : Rule(config) {
     override fun visitKtFile(file: KtFile) {
         super.visitKtFile(file)
         if (amountOfTopLevelFunctions >= thresholdInFiles) {
-            report(ThresholdedCodeSmell(issue,
+            report(
+                ThresholdedCodeSmell(
+                    issue,
                     Entity.atPackageOrFirstDecl(file),
                     Metric("SIZE", amountOfTopLevelFunctions, thresholdInFiles),
                     "File '${file.name}' with '$amountOfTopLevelFunctions' functions detected. " +
-                            "Defined threshold inside files is set to '$thresholdInFiles'"))
+                        "Defined threshold inside files is set to '$thresholdInFiles'"
+                )
+            )
         }
         amountOfTopLevelFunctions = 0
     }
@@ -78,31 +84,43 @@ class TooManyFunctions(config: Config = Config.empty) : Rule(config) {
         when {
             klass.isInterface() -> {
                 if (amount >= thresholdInInterfaces) {
-                    report(ThresholdedCodeSmell(issue,
-                        Entity.from(klass.nameIdentifier!!),
-                        Metric("SIZE", amount, thresholdInInterfaces),
-                        "Interface '${klass.name}' with '$amount' functions detected. " +
+                    report(
+                        ThresholdedCodeSmell(
+                            issue,
+                            Entity.from(klass.nameIdentifier!!),
+                            Metric("SIZE", amount, thresholdInInterfaces),
+                            "Interface '${klass.name}' with '$amount' functions detected. " +
                                 "Defined threshold inside interfaces is set to " +
-                                "'$thresholdInInterfaces'"))
+                                "'$thresholdInInterfaces'"
+                        )
+                    )
                 }
             }
             klass.isEnum() -> {
                 if (amount >= thresholdInEnums) {
-                    report(ThresholdedCodeSmell(issue,
-                        Entity.from(klass.nameIdentifier!!),
-                        Metric("SIZE", amount, thresholdInEnums),
-                        "Enum class '${klass.name}' with '$amount' functions detected. " +
+                    report(
+                        ThresholdedCodeSmell(
+                            issue,
+                            Entity.from(klass.nameIdentifier!!),
+                            Metric("SIZE", amount, thresholdInEnums),
+                            "Enum class '${klass.name}' with '$amount' functions detected. " +
                                 "Defined threshold inside enum classes is set to " +
-                                "'$thresholdInEnums'"))
+                                "'$thresholdInEnums'"
+                        )
+                    )
                 }
             }
             else -> {
                 if (amount >= thresholdInClasses) {
-                    report(ThresholdedCodeSmell(issue,
+                    report(
+                        ThresholdedCodeSmell(
+                            issue,
                             Entity.from(klass.nameIdentifier!!),
                             Metric("SIZE", amount, thresholdInClasses),
                             "Class '${klass.name}' with '$amount' functions detected. " +
-                                    "Defined threshold inside classes is set to '$thresholdInClasses'"))
+                                "Defined threshold inside classes is set to '$thresholdInClasses'"
+                        )
+                    )
                 }
             }
         }
@@ -112,19 +130,23 @@ class TooManyFunctions(config: Config = Config.empty) : Rule(config) {
     override fun visitObjectDeclaration(declaration: KtObjectDeclaration) {
         val amount = calcFunctions(declaration)
         if (amount >= thresholdInObjects) {
-            report(ThresholdedCodeSmell(issue,
+            report(
+                ThresholdedCodeSmell(
+                    issue,
                     Entity.from(declaration.nameIdentifier ?: declaration),
                     Metric("SIZE", amount, thresholdInObjects),
                     "Object '${declaration.name}' with '$amount' functions detected. " +
-                            "Defined threshold inside objects is set to '$thresholdInObjects'"))
+                        "Defined threshold inside objects is set to '$thresholdInObjects'"
+                )
+            )
         }
         super.visitObjectDeclaration(declaration)
     }
 
     private fun calcFunctions(classOrObject: KtClassOrObject): Int = classOrObject.body?.declarations
-            ?.filterIsInstance<KtNamedFunction>()
-            ?.filter { !isIgnoredFunction(it) }
-            ?.size ?: 0
+        ?.filterIsInstance<KtNamedFunction>()
+        ?.filter { !isIgnoredFunction(it) }
+        ?.size ?: 0
 
     private fun isIgnoredFunction(function: KtNamedFunction): Boolean = when {
         ignoreDeprecated && function.hasAnnotation(DEPRECATED) -> true

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/GlobalCoroutineUsage.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/GlobalCoroutineUsage.kt
@@ -49,7 +49,8 @@ class GlobalCoroutineUsage(config: Config = Config.empty) : Rule(config) {
 
     override fun visitDotQualifiedExpression(expression: KtDotQualifiedExpression) {
         if (expression.receiverExpression.text == "GlobalScope" &&
-            expression.getCalleeExpressionIfAny()?.text in listOf("launch", "async")) {
+            expression.getCalleeExpressionIfAny()?.text in listOf("launch", "async")
+        ) {
             report(CodeSmell(issue, Entity.from(expression), MESSAGE))
         }
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/AbsentOrWrongFileLicense.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/AbsentOrWrongFileLicense.kt
@@ -29,11 +29,13 @@ class AbsentOrWrongFileLicense(config: Config = Config.empty) : Rule(config) {
 
     override fun visitKtFile(file: KtFile) {
         if (!file.hasValidLicense()) {
-            report(CodeSmell(
-                issue,
-                Entity.atPackageOrFirstDecl(file),
-                "Expected license not found or incorrect in the file: ${file.name}."
-            ))
+            report(
+                CodeSmell(
+                    issue,
+                    Entity.atPackageOrFirstDecl(file),
+                    "Expected license not found or incorrect in the file: ${file.name}."
+                )
+            )
         }
     }
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentOverPrivateFunction.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentOverPrivateFunction.kt
@@ -21,12 +21,14 @@ import org.jetbrains.kotlin.psi.KtNamedFunction
  */
 class CommentOverPrivateFunction(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue("CommentOverPrivateFunction",
-            Severity.Maintainability,
-            "Comments for private functions should be avoided. " +
-                    "Prefer giving the function an expressive name. " +
-                    "Split it up in smaller, self-explaining functions if necessary.",
-            Debt.TWENTY_MINS)
+    override val issue = Issue(
+        "CommentOverPrivateFunction",
+        Severity.Maintainability,
+        "Comments for private functions should be avoided. " +
+            "Prefer giving the function an expressive name. " +
+            "Split it up in smaller, self-explaining functions if necessary.",
+        Debt.TWENTY_MINS
+    )
 
     override fun visitNamedFunction(function: KtNamedFunction) {
         if (function.hasCommentInPrivateMember()) {
@@ -36,7 +38,8 @@ class CommentOverPrivateFunction(config: Config = Config.empty) : Rule(config) {
                     Entity.atName(function),
                     "The function ${function.nameAsSafeName} " +
                         "has a comment. Prefer renaming the function giving it a more self-explanatory name."
-                ))
+                )
+            )
         }
     }
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentOverPrivateProperty.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentOverPrivateProperty.kt
@@ -21,10 +21,12 @@ import org.jetbrains.kotlin.psi.KtProperty
  */
 class CommentOverPrivateProperty(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue("CommentOverPrivateProperty",
-            Severity.Maintainability,
-            "Private properties should be named such that they explain themselves even without a comment.",
-            Debt.TWENTY_MINS)
+    override val issue = Issue(
+        "CommentOverPrivateProperty",
+        Severity.Maintainability,
+        "Private properties should be named such that they explain themselves even without a comment.",
+        Debt.TWENTY_MINS
+    )
 
     override fun visitProperty(property: KtProperty) {
         if (property.hasCommentInPrivateMember()) {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/EndOfSentenceFormat.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/EndOfSentenceFormat.kt
@@ -16,7 +16,7 @@ class KDocStyle(config: Config = Config.empty) : MultiRule() {
     private val endOfSentenceFormat = EndOfSentenceFormat(config)
 
     override val rules = listOf(
-            endOfSentenceFormat
+        endOfSentenceFormat
     )
 
     override fun visitDeclaration(dcl: KtDeclaration) {
@@ -35,13 +35,15 @@ class KDocStyle(config: Config = Config.empty) : MultiRule() {
 @Suppress("MemberNameEqualsClassName")
 class EndOfSentenceFormat(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue(javaClass.simpleName,
-            Severity.Maintainability,
-            "The first sentence in a KDoc comment should end with correct punctuation.",
-            Debt.FIVE_MINS)
+    override val issue = Issue(
+        javaClass.simpleName,
+        Severity.Maintainability,
+        "The first sentence in a KDoc comment should end with correct punctuation.",
+        Debt.FIVE_MINS
+    )
 
     private val endOfSentenceFormat =
-            Regex(valueOrDefault(END_OF_SENTENCE_FORMAT, "([.?!][ \\t\\n\\r\\f<])|([.?!:]\$)"))
+        Regex(valueOrDefault(END_OF_SENTENCE_FORMAT, "([.?!][ \\t\\n\\r\\f<])|([.?!:]\$)"))
     private val htmlTag = Regex("<.+>")
 
     fun verify(declaration: KtDeclaration) {
@@ -51,8 +53,12 @@ class EndOfSentenceFormat(config: Config = Config.empty) : Rule(config) {
                 return
             }
             if (!endOfSentenceFormat.containsMatchIn(text) && !text.lastArgumentMatchesUrl()) {
-                report(CodeSmell(issue, Entity.from(declaration),
-                        "The first sentence of this KDoc does not end with the correct punctuation."))
+                report(
+                    CodeSmell(
+                        issue, Entity.from(declaration),
+                        "The first sentence of this KDoc does not end with the correct punctuation."
+                    )
+                )
             }
         }
     }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/LicenceHeaderLoaderExtension.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/LicenceHeaderLoaderExtension.kt
@@ -47,7 +47,7 @@ class LicenceHeaderLoaderExtension : FileProcessListener {
                 """
                 Rule '$RULE_NAME': License template file not found at `${templateFile.toAbsolutePath()}`.
                 Create file license header file or check your running path.
-            """.trimIndent()
+                """.trimIndent()
             }
 
             return Files.newBufferedReader(templateFile)

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicClass.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicClass.kt
@@ -28,10 +28,12 @@ import org.jetbrains.kotlin.psi.KtObjectDeclaration
  */
 class UndocumentedPublicClass(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue(javaClass.simpleName,
-            Severity.Maintainability,
-            "Public classes, interfaces and objects require documentation.",
-            Debt.TWENTY_MINS)
+    override val issue = Issue(
+        javaClass.simpleName,
+        Severity.Maintainability,
+        "Public classes, interfaces and objects require documentation.",
+        Debt.TWENTY_MINS
+    )
 
     private val searchInNestedClass = valueOrDefault(SEARCH_IN_NESTED_CLASS, true)
     private val searchInInnerClass = valueOrDefault(SEARCH_IN_INNER_CLASS, true)
@@ -62,7 +64,8 @@ class UndocumentedPublicClass(config: Config = Config.empty) : Rule(config) {
     private fun reportIfUndocumented(element: KtClassOrObject) {
         if (isPublicAndPublicInherited(element) &&
             element.notEnumEntry() &&
-            element.docComment == null) {
+            element.docComment == null
+        ) {
             report(
                 CodeSmell(
                     issue,
@@ -77,7 +80,7 @@ class UndocumentedPublicClass(config: Config = Config.empty) : Rule(config) {
         element.isPublicInherited() && element.isPublicNotOverridden()
 
     private fun KtObjectDeclaration.isCompanionWithoutName() =
-            isCompanion() && nameAsSafeName.asString() == "Companion"
+        isCompanion() && nameAsSafeName.asString() == "Companion"
 
     private fun KtClass.isNestedClass() = !isInterface() && !isTopLevel() && !isInner() && searchInNestedClass
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicFunction.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicFunction.kt
@@ -19,9 +19,11 @@ import org.jetbrains.kotlin.psi.psiUtil.isPublic
  */
 class UndocumentedPublicFunction(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue(javaClass.simpleName,
+    override val issue = Issue(
+        javaClass.simpleName,
         Severity.Maintainability,
-        "Public functions require documentation.", Debt.TWENTY_MINS)
+        "Public functions require documentation.", Debt.TWENTY_MINS
+    )
 
     override fun visitNamedFunction(function: KtNamedFunction) {
         if (function.funKeyword == null && function.isLocal) return

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicProperty.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicProperty.kt
@@ -25,9 +25,11 @@ import org.jetbrains.kotlin.psi.psiUtil.isPublic
  */
 class UndocumentedPublicProperty(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue(javaClass.simpleName,
-            Severity.Maintainability,
-            "Public properties require documentation.", Debt.TWENTY_MINS)
+    override val issue = Issue(
+        javaClass.simpleName,
+        Severity.Maintainability,
+        "Public properties require documentation.", Debt.TWENTY_MINS
+    )
 
     override fun visitPrimaryConstructor(constructor: KtPrimaryConstructor) {
         if (constructor.isPublicInherited()) {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyBlocks.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyBlocks.kt
@@ -48,21 +48,21 @@ class EmptyBlocks(val config: Config = Config.empty) : MultiRule() {
     private val emptyWhileBlock = EmptyWhileBlock(config)
 
     override val rules: List<Rule> = listOf(
-            emptyCatchBlock,
-            emptyClassBlock,
-            emptyDefaultConstructor,
-            emptyDoWhileBlock,
-            emptyElseBlock,
-            emptyFinallyBlock,
-            emptyForBlock,
-            emptyFunctionBlock,
-            emptyIfBlock,
-            emptyInitBlock,
-            emptyKtFile,
-            emptySecondaryConstructorBlock,
-            emptyTryBlock,
-            emptyWhenBlock,
-            emptyWhileBlock
+        emptyCatchBlock,
+        emptyClassBlock,
+        emptyDefaultConstructor,
+        emptyDoWhileBlock,
+        emptyElseBlock,
+        emptyFinallyBlock,
+        emptyForBlock,
+        emptyFunctionBlock,
+        emptyIfBlock,
+        emptyInitBlock,
+        emptyKtFile,
+        emptySecondaryConstructorBlock,
+        emptyTryBlock,
+        emptyWhenBlock,
+        emptyWhileBlock
     )
 
     override fun visitKtFile(file: KtFile) {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyCatchBlock.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyCatchBlock.kt
@@ -19,10 +19,10 @@ class EmptyCatchBlock(config: Config) : EmptyRule(
     config = config,
     description =
         "Empty catch block detected. " +
-        "Empty catch blocks indicate that an exception is ignored and not handled.",
+            "Empty catch blocks indicate that an exception is ignored and not handled.",
     codeSmellMessage =
         "Empty catch block detected. If the exception can be safely ignored, " +
-        "name the exception according to one of the exemptions as per the configuration of this rule."
+            "name the exception according to one of the exemptions as per the configuration of this rule."
 ) {
 
     private val allowedExceptionNameRegex by LazyRegex(ALLOWED_EXCEPTION_NAME_REGEX, ALLOWED_EXCEPTION_NAME)

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyClassBlock.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyClassBlock.kt
@@ -21,8 +21,12 @@ class EmptyClassBlock(config: Config) : EmptyRule(config) {
 
         classOrObject.body?.let { body ->
             if (body.declarations.isEmpty()) {
-                report(CodeSmell(issue, Entity.from(body),
-                    "The class or object ${classOrObject.name} is empty."))
+                report(
+                    CodeSmell(
+                        issue, Entity.from(body),
+                        "The class or object ${classOrObject.name} is empty."
+                    )
+                )
             }
         }
     }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyDefaultConstructor.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyDefaultConstructor.kt
@@ -20,8 +20,9 @@ class EmptyDefaultConstructor(config: Config) : EmptyRule(config = config) {
 
     override fun visitPrimaryConstructor(constructor: KtPrimaryConstructor) {
         if (hasSuitableSignature(constructor) &&
-                isNotCalled(constructor) &&
-                !isExpectedAnnotationClass(constructor)) {
+            isNotCalled(constructor) &&
+            !isExpectedAnnotationClass(constructor)
+        ) {
             report(CodeSmell(issue, Entity.from(constructor), "An empty default constructor can be removed."))
         }
     }
@@ -38,9 +39,9 @@ class EmptyDefaultConstructor(config: Config) : EmptyRule(config = config) {
     }
 
     private fun hasSuitableSignature(constructor: KtPrimaryConstructor) =
-            hasPublicVisibility(constructor.visibilityModifierType()) &&
-                    constructor.annotationEntries.isEmpty() &&
-                    constructor.valueParameters.isEmpty()
+        hasPublicVisibility(constructor.visibilityModifierType()) &&
+            constructor.annotationEntries.isEmpty() &&
+            constructor.valueParameters.isEmpty()
 
     private fun hasPublicVisibility(visibility: KtModifierKeywordToken?): Boolean {
         return visibility == null || visibility == KtTokens.PUBLIC_KEYWORD

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyKtFile.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyKtFile.kt
@@ -14,11 +14,13 @@ class EmptyKtFile(config: Config) : EmptyRule(config) {
 
     override fun visitKtFile(file: KtFile) {
         if (file.text.isNullOrBlank()) {
-            report(CodeSmell(
-                issue,
-                Entity.atPackageOrFirstDecl(file),
-                "The empty Kotlin file ${file.name} can be removed."
-            ))
+            report(
+                CodeSmell(
+                    issue,
+                    Entity.atPackageOrFirstDecl(file),
+                    "The empty Kotlin file ${file.name} can be removed."
+                )
+            )
         }
     }
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyRule.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyRule.kt
@@ -20,10 +20,12 @@ abstract class EmptyRule(
     private val codeSmellMessage: String = "This empty block of code can be removed."
 ) : Rule(config) {
 
-    override val issue = Issue(javaClass.simpleName,
-            Severity.Minor,
-            description,
-            Debt.FIVE_MINS)
+    override val issue = Issue(
+        javaClass.simpleName,
+        Severity.Minor,
+        description,
+        Debt.FIVE_MINS
+    )
 
     fun KtExpression.addFindingIfBlockExprIsEmpty() {
         checkBlockExpr(false)

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ExceptionRaisedInUnexpectedLocation.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ExceptionRaisedInUnexpectedLocation.kt
@@ -33,13 +33,16 @@ import org.jetbrains.kotlin.psi.psiUtil.anyDescendantOfType
  */
 class ExceptionRaisedInUnexpectedLocation(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue("ExceptionRaisedInUnexpectedLocation", Severity.CodeSmell,
-            "This method is not expected to throw exceptions. This can cause weird behavior.",
-            Debt.TWENTY_MINS)
+    override val issue = Issue(
+        "ExceptionRaisedInUnexpectedLocation", Severity.CodeSmell,
+        "This method is not expected to throw exceptions. This can cause weird behavior.",
+        Debt.TWENTY_MINS
+    )
 
     private val methods = valueOrDefaultCommaSeparated(
         METHOD_NAMES,
-        listOf("toString", "hashCode", "equals", "finalize"))
+        listOf("toString", "hashCode", "equals", "finalize")
+    )
 
     override fun visitNamedFunction(function: KtNamedFunction) {
         if (isPotentialMethod(function) && hasThrowExpression(function.bodyExpression)) {
@@ -56,7 +59,7 @@ class ExceptionRaisedInUnexpectedLocation(config: Config = Config.empty) : Rule(
     private fun isPotentialMethod(function: KtNamedFunction) = methods.any { function.name == it }
 
     private fun hasThrowExpression(declaration: KtExpression?) =
-            declaration?.anyDescendantOfType<KtThrowExpression>() == true
+        declaration?.anyDescendantOfType<KtThrowExpression>() == true
 
     companion object {
         const val METHOD_NAMES = "methodNames"

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/InstanceOfCheckForException.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/InstanceOfCheckForException.kt
@@ -45,10 +45,12 @@ import org.jetbrains.kotlin.types.typeUtil.isSubtypeOf
  */
 class InstanceOfCheckForException(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue("InstanceOfCheckForException", Severity.CodeSmell,
-            "Instead of checking for a general exception type and checking for a specific exception type " +
-                    "use multiple catch blocks.",
-            Debt.TWENTY_MINS)
+    override val issue = Issue(
+        "InstanceOfCheckForException", Severity.CodeSmell,
+        "Instead of checking for a general exception type and checking for a specific exception type " +
+            "use multiple catch blocks.",
+        Debt.TWENTY_MINS
+    )
 
     override fun visitCatchSection(catchClause: KtCatchClause) {
         val catchParameter = catchClause.catchParameter ?: return

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/NotImplementedDeclaration.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/NotImplementedDeclaration.kt
@@ -29,12 +29,14 @@ import org.jetbrains.kotlin.resolve.calls.callUtil.getCalleeExpressionIfAny
  */
 class NotImplementedDeclaration(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue("NotImplementedDeclaration", Severity.CodeSmell,
-            "The NotImplementedDeclaration should only be used when a method stub is necessary. " +
-                    "This defers the development of the functionality of this function. " +
-                    "Hence, the NotImplementedDeclaration should only serve as a temporary declaration. " +
-                    "Before releasing, this type of declaration should be removed.",
-            Debt.TWENTY_MINS)
+    override val issue = Issue(
+        "NotImplementedDeclaration", Severity.CodeSmell,
+        "The NotImplementedDeclaration should only be used when a method stub is necessary. " +
+            "This defers the development of the functionality of this function. " +
+            "Hence, the NotImplementedDeclaration should only serve as a temporary declaration. " +
+            "Before releasing, this type of declaration should be removed.",
+        Debt.TWENTY_MINS
+    )
 
     override fun visitThrowExpression(expression: KtThrowExpression) {
         val calleeExpression = expression.thrownExpression?.getCalleeExpressionIfAny()

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/PrintStackTrace.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/PrintStackTrace.kt
@@ -46,15 +46,18 @@ import org.jetbrains.kotlin.psi.psiUtil.getReceiverExpression
  */
 class PrintStackTrace(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue("PrintStackTrace", Severity.CodeSmell,
-            "Do not print an stack trace. " +
-                    "These debug statements should be replaced with a logger or removed.",
-            Debt.TWENTY_MINS)
+    override val issue = Issue(
+        "PrintStackTrace", Severity.CodeSmell,
+        "Do not print an stack trace. " +
+            "These debug statements should be replaced with a logger or removed.",
+        Debt.TWENTY_MINS
+    )
 
     override fun visitCallExpression(expression: KtCallExpression) {
         val callNameExpression = expression.getCallNameExpression()
         if (callNameExpression?.text == "dumpStack" &&
-                callNameExpression.getReceiverExpression()?.text == "Thread") {
+            callNameExpression.getReceiverExpression()?.text == "Thread"
+        ) {
             report(CodeSmell(issue, Entity.from(expression), issue.description))
         }
     }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/RethrowCaughtException.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/RethrowCaughtException.kt
@@ -48,9 +48,11 @@ import org.jetbrains.kotlin.psi.KtThrowExpression
  */
 class RethrowCaughtException(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue("RethrowCaughtException", Severity.CodeSmell,
-            "Do not rethrow a caught exception of the same type.",
-            Debt.FIVE_MINS)
+    override val issue = Issue(
+        "RethrowCaughtException", Severity.CodeSmell,
+        "Do not rethrow a caught exception of the same type.",
+        Debt.FIVE_MINS
+    )
 
     override fun visitCatchSection(catchClause: KtCatchClause) {
         val exceptionName = catchClause.catchParameter?.name ?: return

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ReturnFromFinally.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ReturnFromFinally.kt
@@ -31,8 +31,10 @@ import org.jetbrains.kotlin.psi.psiUtil.parents
  */
 class ReturnFromFinally(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue("ReturnFromFinally", Severity.Defect,
-        "Do not return within a finally statement. This can discard exceptions.", Debt.TWENTY_MINS)
+    override val issue = Issue(
+        "ReturnFromFinally", Severity.Defect,
+        "Do not return within a finally statement. This can discard exceptions.", Debt.TWENTY_MINS
+    )
 
     private val ignoreLabeled = valueOrDefault(IGNORE_LABELED, false)
 
@@ -40,8 +42,10 @@ class ReturnFromFinally(config: Config = Config.empty) : Rule(config) {
         val innerFunctions = finallySection.finalExpression
             .collectDescendantsOfType<KtNamedFunction>()
         finallySection.finalExpression
-            .collectDescendantsOfType<KtReturnExpression> { isNotInInnerFunction(it, innerFunctions) &&
-                    canFilterLabeledExpression(it) }
+            .collectDescendantsOfType<KtReturnExpression> {
+                isNotInInnerFunction(it, innerFunctions) &&
+                    canFilterLabeledExpression(it)
+            }
             .forEach { report(CodeSmell(issue, Entity.from(it), issue.description)) }
     }
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedException.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedException.kt
@@ -73,9 +73,11 @@ import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
  */
 class SwallowedException(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue("SwallowedException", Severity.CodeSmell,
+    override val issue = Issue(
+        "SwallowedException", Severity.CodeSmell,
         "The caught exception is swallowed. The original exception could be lost.",
-        Debt.TWENTY_MINS)
+        Debt.TWENTY_MINS
+    )
 
     private val ignoredExceptionTypes = valueOrDefaultCommaSeparated(IGNORED_EXCEPTION_TYPES, emptyList())
         .map { it.removePrefix("*").removeSuffix("*") }
@@ -86,7 +88,8 @@ class SwallowedException(config: Config = Config.empty) : Rule(config) {
         val exceptionType = catchClause.catchParameter?.typeReference?.text
         if (!ignoredExceptionTypes.any { exceptionType?.contains(it, ignoreCase = true) == true } &&
             isExceptionSwallowedOrUnused(catchClause) &&
-            !catchClause.isAllowedExceptionName(allowedExceptionNameRegex)) {
+            !catchClause.isAllowedExceptionName(allowedExceptionNameRegex)
+        ) {
             report(CodeSmell(issue, Entity.from(catchClause), issue.description))
         }
     }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionFromFinally.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionFromFinally.kt
@@ -27,9 +27,11 @@ import org.jetbrains.kotlin.psi.psiUtil.forEachDescendantOfType
  */
 class ThrowingExceptionFromFinally(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue("ThrowingExceptionFromFinally", Severity.Defect,
-            "Do not throw an exception within a finally statement. This can discard exceptions and is confusing.",
-            Debt.TWENTY_MINS)
+    override val issue = Issue(
+        "ThrowingExceptionFromFinally", Severity.Defect,
+        "Do not throw an exception within a finally statement. This can discard exceptions and is confusing.",
+        Debt.TWENTY_MINS
+    )
 
     override fun visitFinallySection(finallySection: KtFinallySection) {
         finallySection.finalExpression.forEachDescendantOfType<KtThrowExpression> {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionInMain.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionInMain.kt
@@ -25,8 +25,10 @@ import org.jetbrains.kotlin.psi.psiUtil.anyDescendantOfType
  */
 class ThrowingExceptionInMain(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue("ThrowingExceptionInMain", Severity.CodeSmell,
-            "The main method should not throw an exception.", Debt.TWENTY_MINS)
+    override val issue = Issue(
+        "ThrowingExceptionInMain", Severity.CodeSmell,
+        "The main method should not throw an exception.", Debt.TWENTY_MINS
+    )
 
     override fun visitNamedFunction(function: KtNamedFunction) {
         if (function.isMainFunction() && containsThrowExpression(function)) {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionsWithoutMessageOrCause.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionsWithoutMessageOrCause.kt
@@ -41,18 +41,21 @@ import org.jetbrains.kotlin.psi.KtCallExpression
  */
 class ThrowingExceptionsWithoutMessageOrCause(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue("ThrowingExceptionsWithoutMessageOrCause", Severity.Warning,
-            "A call to the default constructor of an exception was detected. " +
-                    "Instead one of the constructor overloads should be called. " +
-                    "This allows to provide more meaningful exceptions.",
-            Debt.FIVE_MINS)
+    override val issue = Issue(
+        "ThrowingExceptionsWithoutMessageOrCause", Severity.Warning,
+        "A call to the default constructor of an exception was detected. " +
+            "Instead one of the constructor overloads should be called. " +
+            "This allows to provide more meaningful exceptions.",
+        Debt.FIVE_MINS
+    )
 
     private val exceptions = valueOrDefaultCommaSeparated(EXCEPTIONS, emptyList())
 
     override fun visitCallExpression(expression: KtCallExpression) {
         val calleeExpressionText = expression.calleeExpression?.text
         if (exceptions.any { calleeExpressionText?.equals(it, ignoreCase = true) == true } &&
-            expression.valueArguments.isEmpty()) {
+            expression.valueArguments.isEmpty()
+        ) {
             report(CodeSmell(issue, Entity.from(expression), issue.description))
         }
         super.visitCallExpression(expression)

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingNewInstanceOfSameException.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingNewInstanceOfSameException.kt
@@ -39,9 +39,11 @@ import org.jetbrains.kotlin.psi.psiUtil.findDescendantOfType
  */
 class ThrowingNewInstanceOfSameException(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue("ThrowingNewInstanceOfSameException", Severity.Defect,
-            "Avoid catch blocks that rethrow a caught exception wrapped inside a new instance of the same exception.",
-            Debt.FIVE_MINS)
+    override val issue = Issue(
+        "ThrowingNewInstanceOfSameException", Severity.Defect,
+        "Avoid catch blocks that rethrow a caught exception wrapped inside a new instance of the same exception.",
+        Debt.FIVE_MINS
+    )
 
     override fun visitCatchSection(catchClause: KtCatchClause) {
         val parameterName = catchClause.catchParameter?.name
@@ -49,8 +51,8 @@ class ThrowingNewInstanceOfSameException(config: Config = Config.empty) : Rule(c
         val throwExpression = catchClause.catchBody?.findDescendantOfType<KtThrowExpression> {
             val thrownExpression = it.thrownExpression as? KtCallExpression
             thrownExpression != null &&
-                    createsSameExceptionType(thrownExpression, typeReference) &&
-                    hasSameExceptionParameter(thrownExpression.valueArguments, parameterName)
+                createsSameExceptionType(thrownExpression, typeReference) &&
+                hasSameExceptionParameter(thrownExpression.valueArguments, parameterName)
         }
         if (throwExpression != null) {
             report(CodeSmell(issue, Entity.from(throwExpression), issue.description))

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionCaught.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionCaught.kt
@@ -49,21 +49,25 @@ import org.jetbrains.kotlin.psi.KtTypeReference
  */
 class TooGenericExceptionCaught(config: Config) : Rule(config) {
 
-    override val issue = Issue(javaClass.simpleName,
-            Severity.Defect,
-            "Caught exception is too generic. " +
-                    "Prefer catching specific exceptions to the case that is currently handled.",
-            Debt.TWENTY_MINS)
+    override val issue = Issue(
+        javaClass.simpleName,
+        Severity.Defect,
+        "Caught exception is too generic. " +
+            "Prefer catching specific exceptions to the case that is currently handled.",
+        Debt.TWENTY_MINS
+    )
 
     private val exceptions: Set<String> = valueOrDefault(
-            CAUGHT_EXCEPTIONS_PROPERTY, caughtExceptionDefaults).toHashSet()
+        CAUGHT_EXCEPTIONS_PROPERTY, caughtExceptionDefaults
+    ).toHashSet()
 
     private val allowedExceptionNameRegex by LazyRegex(ALLOWED_EXCEPTION_NAME_REGEX, ALLOWED_EXCEPTION_NAME)
 
     override fun visitCatchSection(catchClause: KtCatchClause) {
         catchClause.catchParameter?.let {
             if (isTooGenericException(it.typeReference) &&
-                !catchClause.isAllowedExceptionName(allowedExceptionNameRegex)) {
+                !catchClause.isAllowedExceptionName(allowedExceptionNameRegex)
+            ) {
                 report(CodeSmell(issue, Entity.from(it), issue.description))
             }
         }
@@ -81,12 +85,12 @@ class TooGenericExceptionCaught(config: Config) : Rule(config) {
 }
 
 val caughtExceptionDefaults = listOf(
-        "ArrayIndexOutOfBoundsException",
-        "Error",
-        "Exception",
-        "IllegalMonitorStateException",
-        "NullPointerException",
-        "IndexOutOfBoundsException",
-        "RuntimeException",
-        "Throwable"
+    "ArrayIndexOutOfBoundsException",
+    "Error",
+    "Exception",
+    "IllegalMonitorStateException",
+    "NullPointerException",
+    "IndexOutOfBoundsException",
+    "RuntimeException",
+    "Throwable"
 )

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionThrown.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionThrown.kt
@@ -42,18 +42,25 @@ import org.jetbrains.kotlin.psi.psiUtil.referenceExpression
  */
 class TooGenericExceptionThrown(config: Config) : Rule(config) {
 
-    override val issue = Issue(javaClass.simpleName,
-            Severity.Defect,
-            "Thrown exception is too generic. Prefer throwing project specific exceptions to handle error cases.",
-            Debt.TWENTY_MINS)
+    override val issue = Issue(
+        javaClass.simpleName,
+        Severity.Defect,
+        "Thrown exception is too generic. Prefer throwing project specific exceptions to handle error cases.",
+        Debt.TWENTY_MINS
+    )
 
     private val exceptions: Set<String> =
         valueOrDefault(THROWN_EXCEPTIONS_PROPERTY, thrownExceptionDefaults).toHashSet()
 
     override fun visitThrowExpression(expression: KtThrowExpression) {
         expression.thrownExpression?.referenceExpression()?.text?.let {
-            if (it in exceptions) report(CodeSmell(issue, Entity.from(expression), "$it is a too generic " +
-                    "Exception. Prefer throwing specific exceptions that indicate a specific error case."))
+            if (it in exceptions) report(
+                CodeSmell(
+                    issue, Entity.from(expression),
+                    "$it is a too generic " +
+                        "Exception. Prefer throwing specific exceptions that indicate a specific error case."
+                )
+            )
         }
         super.visitThrowExpression(expression)
     }
@@ -64,8 +71,8 @@ class TooGenericExceptionThrown(config: Config) : Rule(config) {
 }
 
 val thrownExceptionDefaults = listOf(
-        "Error",
-        "Exception",
-        "Throwable",
-        "RuntimeException"
+    "Error",
+    "Exception",
+    "Throwable",
+    "RuntimeException"
 )

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ClassNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ClassNaming.kt
@@ -19,18 +19,23 @@ import org.jetbrains.kotlin.psi.KtClassOrObject
  */
 class ClassNaming(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue(javaClass.simpleName,
-            Severity.Style,
-            "A class or object's name should fit the naming pattern defined in the projects configuration.",
-            debt = Debt.FIVE_MINS)
+    override val issue = Issue(
+        javaClass.simpleName,
+        Severity.Style,
+        "A class or object's name should fit the naming pattern defined in the projects configuration.",
+        debt = Debt.FIVE_MINS
+    )
     private val classPattern by LazyRegex(CLASS_PATTERN, "[A-Z][a-zA-Z0-9]*")
 
     override fun visitClassOrObject(classOrObject: KtClassOrObject) {
         if (!classOrObject.identifierName().matches(classPattern)) {
-            report(CodeSmell(
+            report(
+                CodeSmell(
                     issue,
                     Entity.atName(classOrObject),
-                    message = "Class and Object names should match the pattern: $classPattern"))
+                    message = "Class and Object names should match the pattern: $classPattern"
+                )
+            )
         }
     }
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ConstructorParameterNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ConstructorParameterNaming.kt
@@ -26,10 +26,12 @@ import org.jetbrains.kotlin.psi.psiUtil.isPrivate
  */
 class ConstructorParameterNaming(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue(javaClass.simpleName,
-            Severity.Style,
-            "Constructor parameter names should follow the naming convention set in the projects configuration.",
-            debt = Debt.FIVE_MINS)
+    override val issue = Issue(
+        javaClass.simpleName,
+        Severity.Style,
+        "Constructor parameter names should follow the naming convention set in the projects configuration.",
+        debt = Debt.FIVE_MINS
+    )
 
     private val parameterPattern by LazyRegex(PARAMETER_PATTERN, "[a-z][A-Za-z\\d]*")
     private val privateParameterPattern by LazyRegex(PRIVATE_PARAMETER_PATTERN, "[a-z][A-Za-z\\d]*")
@@ -44,18 +46,24 @@ class ConstructorParameterNaming(config: Config = Config.empty) : Rule(config) {
         val identifier = parameter.identifierName()
         if (parameter.isPrivate()) {
             if (!identifier.matches(privateParameterPattern)) {
-                report(CodeSmell(
+                report(
+                    CodeSmell(
                         issue,
                         Entity.from(parameter),
                         message = "Constructor private parameter names should " +
-                                "match the pattern: $privateParameterPattern"))
+                            "match the pattern: $privateParameterPattern"
+                    )
+                )
             }
         } else {
             if (!identifier.matches(parameterPattern)) {
-                report(CodeSmell(
+                report(
+                    CodeSmell(
                         issue,
                         Entity.from(parameter),
-                        message = "Constructor parameter names should match the pattern: $parameterPattern"))
+                        message = "Constructor parameter names should match the pattern: $parameterPattern"
+                    )
+                )
             }
         }
     }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/EnumNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/EnumNaming.kt
@@ -19,19 +19,24 @@ import org.jetbrains.kotlin.psi.KtEnumEntry
  */
 class EnumNaming(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue(javaClass.simpleName,
-            Severity.Style,
-            "Enum names should follow the naming convention set in the projects configuration.",
-            debt = Debt.FIVE_MINS)
+    override val issue = Issue(
+        javaClass.simpleName,
+        Severity.Style,
+        "Enum names should follow the naming convention set in the projects configuration.",
+        debt = Debt.FIVE_MINS
+    )
 
     private val enumEntryPattern by LazyRegex(ENUM_PATTERN, "[A-Z][_a-zA-Z0-9]*")
 
     override fun visitEnumEntry(enumEntry: KtEnumEntry) {
         if (!enumEntry.identifierName().matches(enumEntryPattern)) {
-            report(CodeSmell(
+            report(
+                CodeSmell(
                     issue,
                     Entity.from(enumEntry.nameIdentifier ?: enumEntry),
-                    message = "Enum entry names should match the pattern: $enumEntryPattern"))
+                    message = "Enum entry names should match the pattern: $enumEntryPattern"
+                )
+            )
         }
     }
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ForbiddenClassName.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ForbiddenClassName.kt
@@ -19,9 +19,11 @@ import org.jetbrains.kotlin.psi.KtClassOrObject
  */
 class ForbiddenClassName(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue(javaClass.simpleName, Severity.Style,
-            "Forbidden class name as per configuration detected.",
-            Debt.FIVE_MINS)
+    override val issue = Issue(
+        javaClass.simpleName, Severity.Style,
+        "Forbidden class name as per configuration detected.",
+        Debt.FIVE_MINS
+    )
     private val forbiddenNames = valueOrDefaultCommaSeparated(FORBIDDEN_NAME, emptyList())
         .map { it.removePrefix("*").removeSuffix("*") }
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionMaxLength.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionMaxLength.kt
@@ -33,7 +33,8 @@ class FunctionMaxLength(config: Config = Config.empty) : Rule(config) {
                 CodeSmell(
                     issue,
                     Entity.atName(function),
-                    message = "Function names should be at most $maximumFunctionNameLength characters long.")
+                    message = "Function names should be at most $maximumFunctionNameLength characters long."
+                )
             )
         }
     }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionMinLength.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionMinLength.kt
@@ -33,7 +33,8 @@ class FunctionMinLength(config: Config = Config.empty) : Rule(config) {
                 CodeSmell(
                     issue,
                     Entity.atName(function),
-                    message = "Function names should be at least $minimumFunctionNameLength characters long.")
+                    message = "Function names should be at least $minimumFunctionNameLength characters long."
+                )
             )
         }
     }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNaming.kt
@@ -28,10 +28,12 @@ class FunctionNaming(config: Config = Config.empty) : Rule(config) {
 
     override val defaultRuleIdAliases: Set<String> = setOf("FunctionName")
 
-    override val issue = Issue(javaClass.simpleName,
-            Severity.Style,
-            "Function names should follow the naming convention set in the configuration.",
-            debt = Debt.FIVE_MINS)
+    override val issue = Issue(
+        javaClass.simpleName,
+        Severity.Style,
+        "Function names should follow the naming convention set in the configuration.",
+        debt = Debt.FIVE_MINS
+    )
 
     private val functionPattern by LazyRegex(FUNCTION_PATTERN, "([a-z][a-zA-Z0-9]*)|(`.*`)")
     private val excludeClassPattern by LazyRegex(EXCLUDE_CLASS_PATTERN, "$^")
@@ -46,12 +48,14 @@ class FunctionNaming(config: Config = Config.empty) : Rule(config) {
 
         if (!function.isContainingExcludedClassOrObject(excludeClassPattern) &&
             !function.identifierName().matches(functionPattern) &&
-            function.identifierName() != function.typeReference?.name) {
+            function.identifierName() != function.typeReference?.name
+        ) {
             report(
                 CodeSmell(
                     issue,
                     Entity.atName(function),
-                    message = "Function names should match the pattern: $functionPattern")
+                    message = "Function names should match the pattern: $functionPattern"
+                )
             )
         }
     }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionParameterNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionParameterNaming.kt
@@ -27,10 +27,12 @@ import org.jetbrains.kotlin.psi.KtParameter
  */
 class FunctionParameterNaming(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue(javaClass.simpleName,
-            Severity.Style,
-            "Function parameter names should follow the naming convention set in the projects configuration.",
-            debt = Debt.FIVE_MINS)
+    override val issue = Issue(
+        javaClass.simpleName,
+        Severity.Style,
+        "Function parameter names should follow the naming convention set in the projects configuration.",
+        debt = Debt.FIVE_MINS
+    )
 
     private val parameterPattern by LazyRegex(PARAMETER_PATTERN, "[a-z][A-Za-z\\d]*")
     private val excludeClassPattern by LazyRegex(EXCLUDE_CLASS_PATTERN, "$^")
@@ -47,10 +49,13 @@ class FunctionParameterNaming(config: Config = Config.empty) : Rule(config) {
 
         val identifier = parameter.identifierName()
         if (!identifier.matches(parameterPattern)) {
-            report(CodeSmell(
+            report(
+                CodeSmell(
                     issue,
                     Entity.from(parameter),
-                    message = "Function parameter names should match the pattern: $parameterPattern"))
+                    message = "Function parameter names should match the pattern: $parameterPattern"
+                )
+            )
         }
     }
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MatchingDeclarationName.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MatchingDeclarationName.kt
@@ -78,8 +78,13 @@ class MatchingDeclarationName(config: Config = Config.empty) : Rule(config) {
             val filename = file.name.removeSuffix(KOTLIN_SUFFIX)
             if (declarationName != filename && hasNoMatchingTypeAlias(filename)) {
                 val entity = Entity.from(declaration).copy(ktElement = file)
-                report(CodeSmell(issue, entity, "The file name '${file.name}' " +
-                    "does not match the name of the single top-level declaration '$declarationName'."))
+                report(
+                    CodeSmell(
+                        issue, entity,
+                        "The file name '${file.name}' " +
+                            "does not match the name of the single top-level declaration '$declarationName'."
+                    )
+                )
             }
         }
     }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MemberNameEqualsClassName.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MemberNameEqualsClassName.kt
@@ -57,21 +57,23 @@ import org.jetbrains.kotlin.resolve.BindingContext
  */
 class MemberNameEqualsClassName(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue(javaClass.simpleName, Severity.Style,
-            "A member should not be given the same name as its parent class or object.",
-            Debt.FIVE_MINS)
+    override val issue = Issue(
+        javaClass.simpleName, Severity.Style,
+        "A member should not be given the same name as its parent class or object.",
+        Debt.FIVE_MINS
+    )
 
     private val classMessage = "A member is named after the class. This might result in confusion. " +
-            "Either rename the member or change it to a constructor."
+        "Either rename the member or change it to a constructor."
     private val objectMessage = "A member is named after the object. " +
-            "This might result in confusion. Please rename the member."
+        "This might result in confusion. Please rename the member."
 
     private val ignoreOverridden = valueOrDefault(IGNORE_OVERRIDDEN, valueOrDefault(IGNORE_OVERRIDDEN_FUNCTION, true))
 
     override fun visitClass(klass: KtClass) {
         if (!klass.isInterface()) {
             (getMisnamedMembers(klass, klass.name) + getMisnamedCompanionObjectMembers(klass))
-                    .forEach { report(CodeSmell(issue, Entity.from(it), classMessage)) }
+                .forEach { report(CodeSmell(issue, Entity.from(it), classMessage)) }
         }
         super.visitClass(klass)
     }
@@ -79,7 +81,7 @@ class MemberNameEqualsClassName(config: Config = Config.empty) : Rule(config) {
     override fun visitObjectDeclaration(declaration: KtObjectDeclaration) {
         if (!declaration.isCompanion()) {
             getMisnamedMembers(declaration, declaration.name)
-                    .forEach { report(CodeSmell(issue, Entity.from(it), objectMessage)) }
+                .forEach { report(CodeSmell(issue, Entity.from(it), objectMessage)) }
         }
         super.visitObjectDeclaration(declaration)
     }
@@ -93,9 +95,9 @@ class MemberNameEqualsClassName(config: Config = Config.empty) : Rule(config) {
 
     private fun getMisnamedCompanionObjectMembers(klass: KtClass): Sequence<KtNamedDeclaration> {
         return klass.companionObjects
-                .asSequence()
-                .flatMap { getMisnamedMembers(it, klass.name) }
-                .filterNot { it is KtNamedFunction && isFactoryMethod(it, klass) }
+            .asSequence()
+            .flatMap { getMisnamedMembers(it, klass.name) }
+            .filterNot { it is KtNamedFunction && isFactoryMethod(it, klass) }
     }
 
     private fun isFactoryMethod(function: KtNamedFunction, klass: KtClass): Boolean {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingRules.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingRules.kt
@@ -33,20 +33,20 @@ class NamingRules(config: Config = Config.empty) : MultiRule() {
     private val functionParameterNamingRule = FunctionParameterNaming(config)
 
     override val rules: List<Rule> = listOf(
-            variableNamingRule,
-            variableMinNameLengthRule,
-            variableMaxNameLengthRule,
-            topLevelPropertyRule,
-            objectConstantNamingRule,
-            packageNamingRule,
-            classOrObjectNamingRule,
-            enumEntryNamingRule,
-            functionNamingRule,
-            functionMaxNameLengthRule,
-            functionMinNameLengthRule,
-            forbiddenClassNameRule,
-            constructorParameterNamingRule,
-            functionParameterNamingRule
+        variableNamingRule,
+        variableMinNameLengthRule,
+        variableMaxNameLengthRule,
+        topLevelPropertyRule,
+        objectConstantNamingRule,
+        packageNamingRule,
+        classOrObjectNamingRule,
+        enumEntryNamingRule,
+        functionNamingRule,
+        functionMaxNameLengthRule,
+        functionMinNameLengthRule,
+        forbiddenClassNameRule,
+        constructorParameterNamingRule,
+        functionParameterNamingRule
     )
 
     override fun visitPackageDirective(directive: KtPackageDirective) {
@@ -100,5 +100,5 @@ class NamingRules(config: Config = Config.empty) : MultiRule() {
     }
 
     private fun KtVariableDeclaration.withinObjectDeclaration(): Boolean =
-            this.getNonStrictParentOfType<KtObjectDeclaration>() != null
+        this.getNonStrictParentOfType<KtObjectDeclaration>() != null
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/PackageNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/PackageNaming.kt
@@ -18,19 +18,24 @@ import org.jetbrains.kotlin.psi.KtPackageDirective
  */
 class PackageNaming(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue(javaClass.simpleName,
-            Severity.Style,
-            "Package names should match the naming convention set in the configuration.",
-            debt = Debt.FIVE_MINS)
+    override val issue = Issue(
+        javaClass.simpleName,
+        Severity.Style,
+        "Package names should match the naming convention set in the configuration.",
+        debt = Debt.FIVE_MINS
+    )
     private val packagePattern by LazyRegex(PACKAGE_PATTERN, "[a-z]+(\\.[a-z][A-Za-z0-9]*)*")
 
     override fun visitPackageDirective(directive: KtPackageDirective) {
         val name = directive.qualifiedName
         if (name.isNotEmpty() && !name.matches(packagePattern)) {
-            report(CodeSmell(
+            report(
+                CodeSmell(
                     issue,
                     Entity.from(directive),
-                    message = "Package name should match the pattern: $packagePattern"))
+                    message = "Package name should match the pattern: $packagePattern"
+                )
+            )
         }
     }
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/TopLevelPropertyNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/TopLevelPropertyNaming.kt
@@ -24,10 +24,12 @@ import org.jetbrains.kotlin.psi.psiUtil.isPrivate
  */
 class TopLevelPropertyNaming(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue(javaClass.simpleName,
-            Severity.Style,
-            "Top level property names should follow the naming convention set in the projects configuration.",
-            debt = Debt.FIVE_MINS)
+    override val issue = Issue(
+        javaClass.simpleName,
+        Severity.Style,
+        "Top level property names should follow the naming convention set in the projects configuration.",
+        debt = Debt.FIVE_MINS
+    )
 
     private val constantPattern by LazyRegex(CONSTANT_PATTERN, "[A-Z][_A-Z0-9]*")
     private val propertyPattern by LazyRegex(PROPERTY_PATTERN, "[A-Za-z][_A-Za-z0-9]*")

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableNaming.kt
@@ -27,10 +27,12 @@ import org.jetbrains.kotlin.resolve.calls.util.isSingleUnderscore
  */
 class VariableNaming(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue(javaClass.simpleName,
-            Severity.Style,
-            "Variable names should follow the naming convention set in the projects configuration.",
-            debt = Debt.FIVE_MINS)
+    override val issue = Issue(
+        javaClass.simpleName,
+        Severity.Style,
+        "Variable names should follow the naming convention set in the projects configuration.",
+        debt = Debt.FIVE_MINS
+    )
 
     private val variablePattern by LazyRegex(VARIABLE_PATTERN, "[a-z][A-Za-z0-9]*")
     private val privateVariablePattern by LazyRegex(PRIVATE_VARIABLE_PATTERN, "(_)?[a-z][A-Za-z0-9]*")
@@ -59,10 +61,13 @@ class VariableNaming(config: Config = Config.empty) : Rule(config) {
     }
 
     private fun report(property: KtProperty, message: String) {
-        report(CodeSmell(
-            issue,
-            Entity.atName(property),
-            message = message))
+        report(
+            CodeSmell(
+                issue,
+                Entity.atName(property),
+                message = message
+            )
+        )
     }
 
     companion object {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/util/ExcludeClass.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/util/ExcludeClass.kt
@@ -6,7 +6,7 @@ import org.jetbrains.kotlin.psi.psiUtil.containingClass
 import org.jetbrains.kotlin.psi.psiUtil.containingClassOrObject
 
 internal fun KtDeclaration.isContainingExcludedClassOrObject(pattern: Regex) =
-        containingClassOrObject?.identifierName()?.matches(pattern) == true
+    containingClassOrObject?.identifierName()?.matches(pattern) == true
 
 internal fun KtDeclaration.isContainingExcludedClass(pattern: Regex) =
-        containingClass()?.identifierName()?.matches(pattern) == true
+    containingClass()?.identifierName()?.matches(pattern) == true

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/ArrayPrimitive.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/ArrayPrimitive.kt
@@ -36,19 +36,21 @@ import org.jetbrains.kotlin.psi.psiUtil.collectDescendantsOfType
  */
 class ArrayPrimitive(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue("ArrayPrimitive",
-            Severity.Performance,
-            "Using Array<Primitive> leads to implicit boxing and a performance hit",
-            Debt.FIVE_MINS)
+    override val issue = Issue(
+        "ArrayPrimitive",
+        Severity.Performance,
+        "Using Array<Primitive> leads to implicit boxing and a performance hit",
+        Debt.FIVE_MINS
+    )
 
     private val primitiveTypes = hashSetOf(
-            "Int",
-            "Double",
-            "Float",
-            "Short",
-            "Byte",
-            "Long",
-            "Char"
+        "Int",
+        "Double",
+        "Float",
+        "Short",
+        "Byte",
+        "Long",
+        "Char"
     )
 
     override fun visitParameter(parameter: KtParameter) {
@@ -71,8 +73,8 @@ class ArrayPrimitive(config: Config = Config.empty) : Rule(config) {
 
     private fun reportArrayPrimitives(element: KtElement) {
         return element
-                .collectDescendantsOfType<KtTypeReference> { isArrayPrimitive(it) }
-                .forEach { report(CodeSmell(issue, Entity.from(it), issue.description)) }
+            .collectDescendantsOfType<KtTypeReference> { isArrayPrimitive(it) }
+            .forEach { report(CodeSmell(issue, Entity.from(it), issue.description)) }
     }
 
     private fun isArrayPrimitive(it: KtTypeReference): Boolean {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/ForEachOnRange.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/ForEachOnRange.kt
@@ -45,10 +45,12 @@ import org.jetbrains.kotlin.psi.psiUtil.getReceiverExpression
  */
 class ForEachOnRange(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue("ForEachOnRange",
-            Severity.Performance,
-            "Using the forEach method on ranges has a heavy performance cost. Prefer using simple for loops.",
-            Debt.FIVE_MINS)
+    override val issue = Issue(
+        "ForEachOnRange",
+        Severity.Performance,
+        "Using the forEach method on ranges has a heavy performance cost. Prefer using simple for loops.",
+        Debt.FIVE_MINS
+    )
 
     private val minimumRangeSize = 3
     private val rangeOperators = setOf("..", "downTo", "until", "step")

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/SpreadOperator.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/SpreadOperator.kt
@@ -49,10 +49,12 @@ import org.jetbrains.kotlin.resolve.calls.callUtil.getResolvedCall
  */
 class SpreadOperator(config: Config = Config.empty) : Rule(config) {
 
-    override val issue: Issue = Issue("SpreadOperator", Severity.Performance,
-            "In most cases using a spread operator causes a full copy of the array to be created before calling a " +
-                    "method which has a very high performance penalty.",
-            Debt.TWENTY_MINS)
+    override val issue: Issue = Issue(
+        "SpreadOperator", Severity.Performance,
+        "In most cases using a spread operator causes a full copy of the array to be created before calling a " +
+            "method which has a very high performance penalty.",
+        Debt.TWENTY_MINS
+    )
 
     override fun visitValueArgumentList(list: KtValueArgumentList) {
         super.visitValueArgumentList(list)
@@ -70,7 +72,7 @@ class SpreadOperator(config: Config = Config.empty) : Rule(config) {
                             issue,
                             Entity.from(list),
                             "Used in this way a spread operator causes a full copy of the array to be created before " +
-                                    "calling a method which has a very high performance penalty."
+                                "calling a method which has a very high performance penalty."
                         )
                     )
                 }
@@ -85,7 +87,7 @@ class SpreadOperator(config: Config = Config.empty) : Rule(config) {
         val resolvedCall = getArgumentExpression().getResolvedCall(bindingContext) ?: return false
         val calleeDescriptor = resolvedCall.resultingDescriptor
         return calleeDescriptor is ConstructorDescriptor ||
-                CompileTimeConstantUtils.isArrayFunctionCall(resolvedCall) ||
-                DescriptorUtils.getFqName(calleeDescriptor).asString() == "kotlin.arrayOfNulls"
+            CompileTimeConstantUtils.isArrayFunctionCall(resolvedCall) ||
+            DescriptorUtils.getFqName(calleeDescriptor).asString() == "kotlin.arrayOfNulls"
     }
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/UnnecessaryTemporaryInstantiation.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/UnnecessaryTemporaryInstantiation.kt
@@ -28,15 +28,18 @@ import org.jetbrains.kotlin.psi.KtExpression
  */
 class UnnecessaryTemporaryInstantiation(config: Config = Config.empty) : Rule(config) {
 
-    override val issue: Issue = Issue("UnnecessaryTemporaryInstantiation", Severity.Performance,
-            "Avoid temporary objects when converting primitive types to String.",
-            Debt.FIVE_MINS)
+    override val issue: Issue = Issue(
+        "UnnecessaryTemporaryInstantiation", Severity.Performance,
+        "Avoid temporary objects when converting primitive types to String.",
+        Debt.FIVE_MINS
+    )
 
     private val types: Set<String> = hashSetOf("Boolean", "Byte", "Short", "Integer", "Long", "Float", "Double")
 
     override fun visitCallExpression(expression: KtCallExpression) {
         if (isPrimitiveWrapperType(expression.calleeExpression) &&
-                isToStringMethod(expression.nextSibling?.nextSibling)) {
+            isToStringMethod(expression.nextSibling?.nextSibling)
+        ) {
             report(CodeSmell(issue, Entity.from(expression), issue.description))
         }
     }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/CommentSmellProvider.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/CommentSmellProvider.kt
@@ -22,7 +22,9 @@ class CommentSmellProvider : DefaultRuleSetProvider {
     override val ruleSetId: String = "comments"
 
     override fun instance(config: Config): RuleSet {
-        return RuleSet(ruleSetId, listOf(
+        return RuleSet(
+            ruleSetId,
+            listOf(
                 CommentOverPrivateFunction(config),
                 CommentOverPrivateProperty(config),
                 KDocStyle(config),
@@ -30,6 +32,7 @@ class CommentSmellProvider : DefaultRuleSetProvider {
                 UndocumentedPublicFunction(config),
                 UndocumentedPublicProperty(config),
                 AbsentOrWrongFileLicense(config)
-        ))
+            )
+        )
     }
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/ComplexityProvider.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/ComplexityProvider.kt
@@ -25,7 +25,9 @@ class ComplexityProvider : DefaultRuleSetProvider {
     override val ruleSetId: String = "complexity"
 
     override fun instance(config: Config): RuleSet {
-        return RuleSet(ruleSetId, listOf(
+        return RuleSet(
+            ruleSetId,
+            listOf(
                 LongParameterList(config),
                 LongMethod(config),
                 LargeClass(config),
@@ -37,6 +39,7 @@ class ComplexityProvider : DefaultRuleSetProvider {
                 TooManyFunctions(config),
                 ComplexCondition(config),
                 LabeledExpression(config)
-        ))
+            )
+        )
     }
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/CoroutinesProvider.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/CoroutinesProvider.kt
@@ -15,9 +15,12 @@ class CoroutinesProvider : DefaultRuleSetProvider {
     override val ruleSetId: String = "coroutines"
 
     override fun instance(config: Config): RuleSet {
-        return RuleSet(ruleSetId, listOf(
-            GlobalCoroutineUsage(config),
-            RedundantSuspendModifier(config)
-        ))
+        return RuleSet(
+            ruleSetId,
+            listOf(
+                GlobalCoroutineUsage(config),
+                RedundantSuspendModifier(config)
+            )
+        )
     }
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/EmptyCodeProvider.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/EmptyCodeProvider.kt
@@ -16,8 +16,11 @@ class EmptyCodeProvider : DefaultRuleSetProvider {
     override val ruleSetId: String = "empty-blocks"
 
     override fun instance(config: Config): RuleSet {
-        return RuleSet(ruleSetId, listOf(
+        return RuleSet(
+            ruleSetId,
+            listOf(
                 EmptyBlocks(config)
-        ))
+            )
+        )
     }
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/ExceptionsProvider.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/ExceptionsProvider.kt
@@ -27,7 +27,9 @@ class ExceptionsProvider : DefaultRuleSetProvider {
     override val ruleSetId: String = "exceptions"
 
     override fun instance(config: Config): RuleSet {
-        return RuleSet(ruleSetId, listOf(
+        return RuleSet(
+            ruleSetId,
+            listOf(
                 TooGenericExceptionCaught(config),
                 ExceptionRaisedInUnexpectedLocation(config),
                 TooGenericExceptionThrown(config),
@@ -41,6 +43,7 @@ class ExceptionsProvider : DefaultRuleSetProvider {
                 RethrowCaughtException(config),
                 ThrowingNewInstanceOfSameException(config),
                 SwallowedException(config)
-        ))
+            )
+        )
     }
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/NamingProvider.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/NamingProvider.kt
@@ -19,7 +19,8 @@ class NamingProvider : DefaultRuleSetProvider {
 
     override fun instance(config: Config): RuleSet {
         return RuleSet(
-            ruleSetId, listOf(
+            ruleSetId,
+            listOf(
                 MatchingDeclarationName(config),
                 MemberNameEqualsClassName(config),
                 NamingRules(config),

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/PerformanceProvider.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/PerformanceProvider.kt
@@ -18,11 +18,14 @@ class PerformanceProvider : DefaultRuleSetProvider {
     override val ruleSetId: String = "performance"
 
     override fun instance(config: Config): RuleSet {
-        return RuleSet(ruleSetId, listOf(
+        return RuleSet(
+            ruleSetId,
+            listOf(
                 ForEachOnRange(config),
                 SpreadOperator(config),
                 UnnecessaryTemporaryInstantiation(config),
                 ArrayPrimitive(config)
-        ))
+            )
+        )
     }
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/PotentialBugProvider.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/PotentialBugProvider.kt
@@ -36,7 +36,9 @@ class PotentialBugProvider : DefaultRuleSetProvider {
     override val ruleSetId: String = "potential-bugs"
 
     override fun instance(config: Config): RuleSet {
-        return RuleSet(ruleSetId, listOf(
+        return RuleSet(
+            ruleSetId,
+            listOf(
                 Deprecation(config),
                 DuplicateCaseInWhenExpression(config),
                 EqualsAlwaysReturnsTrueOrFalse(config),
@@ -59,6 +61,7 @@ class PotentialBugProvider : DefaultRuleSetProvider {
                 UnsafeCast(config),
                 UselessPostfixExpression(config),
                 WrongEqualsTypeParameter(config)
-        ))
+            )
+        )
     }
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/CollapsibleIfStatements.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/CollapsibleIfStatements.kt
@@ -37,10 +37,12 @@ import org.jetbrains.kotlin.psi.psiUtil.getChildrenOfType
  */
 class CollapsibleIfStatements(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue("CollapsibleIfStatements", Severity.Style,
-            "Two if statements which could be collapsed were detected. " +
-                    "These statements can be merged to improve readability.",
-            Debt.FIVE_MINS)
+    override val issue = Issue(
+        "CollapsibleIfStatements", Severity.Style,
+        "Two if statements which could be collapsed were detected. " +
+            "These statements can be merged to improve readability.",
+        Debt.FIVE_MINS
+    )
 
     override fun visitIfExpression(expression: KtIfExpression) {
         if (isNotElseIfOrElse(expression) && hasOneKtIfExpression(expression)) {
@@ -50,7 +52,7 @@ class CollapsibleIfStatements(config: Config = Config.empty) : Rule(config) {
     }
 
     private fun isNotElseIfOrElse(expression: KtIfExpression) =
-            expression.`else` == null && expression.parent !is KtContainerNodeForControlStructureBody
+        expression.`else` == null && expression.parent !is KtContainerNodeForControlStructureBody
 
     private fun hasOneKtIfExpression(expression: KtIfExpression): Boolean {
         val statement = expression.then?.getChildrenOfType<KtExpression>()?.singleOrNull()

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/DataClassContainsFunctions.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/DataClassContainsFunctions.kt
@@ -29,19 +29,21 @@ import org.jetbrains.kotlin.psi.KtNamedFunction
  */
 class DataClassContainsFunctions(config: Config = Config.empty) : Rule(config) {
 
-    override val issue: Issue = Issue("DataClassContainsFunctions",
-            Severity.Style,
-            "Data classes should mainly be used to store data and should not have any extra functions. " +
-                    "(Compiler will automatically generate equals, toString and hashCode functions)",
-            Debt.TWENTY_MINS)
+    override val issue: Issue = Issue(
+        "DataClassContainsFunctions",
+        Severity.Style,
+        "Data classes should mainly be used to store data and should not have any extra functions. " +
+            "(Compiler will automatically generate equals, toString and hashCode functions)",
+        Debt.TWENTY_MINS
+    )
 
     private val conversionFunctionPrefix = SplitPattern(valueOrDefault(CONVERSION_FUNCTION_PREFIX, ""))
 
     override fun visitClass(klass: KtClass) {
         if (klass.isData()) {
             klass.body?.declarations
-                    ?.filterIsInstance<KtNamedFunction>()
-                    ?.forEach { checkFunction(klass, it) }
+                ?.filterIsInstance<KtNamedFunction>()
+                ?.forEach { checkFunction(klass, it) }
         }
         super.visitClass(klass)
     }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/DataClassShouldBeImmutable.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/DataClassShouldBeImmutable.kt
@@ -35,7 +35,7 @@ class DataClassShouldBeImmutable(config: Config = Config.empty) : Rule(config) {
         "DataClassShouldBeImmutable",
         Severity.Style,
         "Data classes should mainly be immutable and should not have any side effects. " +
-                "(To copy an object altering some of its properties use the copy function)",
+            "(To copy an object altering some of its properties use the copy function)",
         Debt.TWENTY_MINS
     )
 
@@ -58,7 +58,7 @@ class DataClassShouldBeImmutable(config: Config = Config.empty) : Rule(config) {
                 issue,
                 Entity.from(element),
                 "The data class $className contains a mutable property. " +
-                        "The offending property is called $propertyName"
+                    "The offending property is called $propertyName"
             )
         )
     }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/EqualsNullCall.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/EqualsNullCall.kt
@@ -25,9 +25,11 @@ import org.jetbrains.kotlin.psi.KtCallExpression
  */
 class EqualsNullCall(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue("EqualsNullCall", Severity.Style,
-            "Equals() method is called with null as parameter. Consider using == to compare to null.",
-            Debt.FIVE_MINS)
+    override val issue = Issue(
+        "EqualsNullCall", Severity.Style,
+        "Equals() method is called with null as parameter. Consider using == to compare to null.",
+        Debt.FIVE_MINS
+    )
 
     override fun visitCallExpression(expression: KtCallExpression) {
         if (expression.calleeExpression?.text == "equals" && hasNullParameter(expression)) {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitItLambdaParameter.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitItLambdaParameter.kt
@@ -42,17 +42,21 @@ import org.jetbrains.kotlin.psi.KtLambdaExpression
  * </compliant>
  */
 class ExplicitItLambdaParameter(val config: Config) : Rule(config) {
-    override val issue = Issue(javaClass.simpleName, Severity.Style,
-            "Declaring lambda parameters as `it` is redundant.", Debt.FIVE_MINS)
+    override val issue = Issue(
+        javaClass.simpleName, Severity.Style,
+        "Declaring lambda parameters as `it` is redundant.", Debt.FIVE_MINS
+    )
 
     override fun visitLambdaExpression(lambdaExpression: KtLambdaExpression) {
         super.visitLambdaExpression(lambdaExpression)
         val parameterNames = lambdaExpression.valueParameters.map { it.name }
         if (IT_LITERAL in parameterNames) {
-            report(CodeSmell(
+            report(
+                CodeSmell(
                     issue, Entity.from(lambdaExpression),
                     "This explicit usage of `it` as the lambda parameter name can be omitted."
-            ))
+                )
+            )
         }
     }
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExpressionBodySyntax.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExpressionBodySyntax.kt
@@ -45,7 +45,8 @@ class ExpressionBodySyntax(config: Config = Config.empty) : Rule(config) {
         Severity.Style,
         "Functions with exact one statement, the return statement," +
             " can be rewritten with ExpressionBodySyntax.",
-        Debt.FIVE_MINS)
+        Debt.FIVE_MINS
+    )
 
     private val includeLineWrapping = valueOrDefault(INCLUDE_LINE_WRAPPING, false)
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenComment.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenComment.kt
@@ -28,10 +28,12 @@ import org.jetbrains.kotlin.com.intellij.psi.PsiComment
  */
 class ForbiddenComment(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue(javaClass.simpleName,
-            Severity.Style,
-            "Flags a forbidden comment. Defaults values are TODO:, FIXME: or STOPSHIP:",
-            Debt.TEN_MINS)
+    override val issue = Issue(
+        javaClass.simpleName,
+        Severity.Style,
+        "Flags a forbidden comment. Defaults values are TODO:, FIXME: or STOPSHIP:",
+        Debt.TEN_MINS
+    )
 
     private val values: List<String> = valueOrDefaultCommaSeparated(VALUES, listOf("TODO:", "FIXME:", "STOPSHIP:"))
 
@@ -46,8 +48,13 @@ class ForbiddenComment(config: Config = Config.empty) : Rule(config) {
 
         values.forEach {
             if (text.contains(it, ignoreCase = true)) {
-                report(CodeSmell(issue, Entity.from(comment), "This comment contains text that has been " +
-                        "defined as forbidden in detekt."))
+                report(
+                    CodeSmell(
+                        issue, Entity.from(comment),
+                        "This comment contains text that has been " +
+                            "defined as forbidden in detekt."
+                    )
+                )
             }
         }
     }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenImport.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenImport.kt
@@ -31,7 +31,7 @@ class ForbiddenImport(config: Config = Config.empty) : Rule(config) {
         javaClass.simpleName,
         Severity.Style,
         "Mark forbidden imports. A forbidden import could be an import for an unstable / experimental api" +
-                "and hence you might want to mark it as forbidden in order to get warned about the usage.",
+            "and hence you might want to mark it as forbidden in order to get warned about the usage.",
         Debt.TEN_MINS
     )
 
@@ -48,8 +48,9 @@ class ForbiddenImport(config: Config = Config.empty) : Rule(config) {
         if (forbiddenImports.any { it.matches(import) } || containsForbiddenPattern(import)) {
             report(
                 CodeSmell(
-                    issue, Entity.from(importDirective), "The import " +
-                            "$import has been forbidden in the Detekt config."
+                    issue, Entity.from(importDirective),
+                    "The import " +
+                        "$import has been forbidden in the Detekt config."
                 )
             )
         }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCall.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCall.kt
@@ -33,7 +33,7 @@ class ForbiddenMethodCall(config: Config = Config.empty) : Rule(config) {
         javaClass.simpleName,
         Severity.Style,
         "Mark forbidden methods. A forbidden method could be an invocation of an unstable / experimental " +
-                "method and hence you might want to mark it as forbidden in order to get warned about the usage.",
+            "method and hence you might want to mark it as forbidden in order to get warned about the usage.",
         Debt.TEN_MINS
     )
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenVoid.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenVoid.kt
@@ -65,7 +65,7 @@ class ForbiddenVoid(config: Config = Config.empty) : Rule(config) {
 
     private fun KtTypeReference.isPartOfOverriddenSignature() =
         (isPartOfReturnTypeOfFunction() || isParameterTypeOfFunction()) &&
-                getStrictParentOfType<KtNamedFunction>()?.isOverride() == true
+            getStrictParentOfType<KtNamedFunction>()?.isOverride() == true
 
     private fun KtTypeReference.isPartOfReturnTypeOfFunction() =
         getStrictParentOfType<KtNamedFunction>()

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/FunctionOnlyReturningConstant.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/FunctionOnlyReturningConstant.kt
@@ -41,15 +41,18 @@ import org.jetbrains.kotlin.psi.psiUtil.containingClass
  */
 class FunctionOnlyReturningConstant(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue(javaClass.simpleName, Severity.Style,
+    override val issue = Issue(
+        javaClass.simpleName, Severity.Style,
         "A function that only returns a constant is misleading. " +
             "Consider declaring a constant instead",
-        Debt.TEN_MINS)
+        Debt.TEN_MINS
+    )
 
     private val ignoreOverridableFunction = valueOrDefault(IGNORE_OVERRIDABLE_FUNCTION, true)
     private val excludedFunctions = SplitPattern(valueOrDefault(EXCLUDED_FUNCTIONS, ""))
     private val excludeAnnotatedFunctions = valueOrDefaultCommaSeparated(
-            EXCLUDE_ANNOTATED_FUNCTION, listOf("dagger.Provides"))
+        EXCLUDE_ANNOTATED_FUNCTION, listOf("dagger.Provides")
+    )
         .map { it.removePrefix("*").removeSuffix("*") }
     private lateinit var annotationExcluder: AnnotationExcluder
 
@@ -61,13 +64,15 @@ class FunctionOnlyReturningConstant(config: Config = Config.empty) : Rule(config
     override fun visitNamedFunction(function: KtNamedFunction) {
         if (checkOverridableFunction(function) &&
             isNotExcluded(function) &&
-            isReturningAConstant(function)) {
+            isReturningAConstant(function)
+        ) {
             report(
                 CodeSmell(
                     issue,
                     Entity.atName(function),
                     "${function.nameAsSafeName} is returning a constant. Prefer declaring a constant instead."
-                ))
+                )
+            )
         }
         super.visitNamedFunction(function)
     }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/Junk.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/Junk.kt
@@ -13,6 +13,6 @@ import org.jetbrains.kotlin.psi.psiUtil.getNonStrictParentOfType
  */
 internal fun findFirstKtElementInParents(file: KtFile, offset: Int, line: String): PsiElement? {
     return file.elementsInRange(TextRange.create(offset - line.length, offset))
-            .mapNotNull { it.getNonStrictParentOfType<KtElement>() }
-            .firstOrNull()
+        .mapNotNull { it.getNonStrictParentOfType<KtElement>() }
+        .firstOrNull()
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/LibraryCodeMustSpecifyReturnType.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/LibraryCodeMustSpecifyReturnType.kt
@@ -52,11 +52,13 @@ class LibraryCodeMustSpecifyReturnType(config: Config = Config.empty) : Rule(con
 
     override fun visitProperty(property: KtProperty) {
         if (!property.isLocal && property.isPublic && property.typeReference == null) {
-            report(CodeSmell(
-                issue,
-                Entity.atName(property),
-                "Library property '${property.nameAsSafeName}' without explicit return type."
-            ))
+            report(
+                CodeSmell(
+                    issue,
+                    Entity.atName(property),
+                    "Library property '${property.nameAsSafeName}' without explicit return type."
+                )
+            )
         }
         super.visitProperty(property)
     }
@@ -64,7 +66,8 @@ class LibraryCodeMustSpecifyReturnType(config: Config = Config.empty) : Rule(con
     override fun visitNamedFunction(function: KtNamedFunction) {
         if (!function.isLocal &&
             function.isPublic &&
-            function.hasExpressionBodyWithoutExplicitReturnType()) {
+            function.hasExpressionBodyWithoutExplicitReturnType()
+        ) {
             report(
                 CodeSmell(
                     issue,

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/LoopWithTooManyJumpStatements.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/LoopWithTooManyJumpStatements.kt
@@ -35,9 +35,12 @@ import org.jetbrains.kotlin.psi.KtLoopExpression
  */
 class LoopWithTooManyJumpStatements(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue(javaClass.simpleName, Severity.Style,
-            "The loop contains more than one break or continue statement. " +
-                    "The code should be refactored to increase readability.", Debt.TEN_MINS)
+    override val issue = Issue(
+        javaClass.simpleName, Severity.Style,
+        "The loop contains more than one break or continue statement. " +
+            "The code should be refactored to increase readability.",
+        Debt.TEN_MINS
+    )
 
     private val maxJumpCount = valueOrDefault(MAX_JUMP_COUNT, 1)
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumber.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumber.kt
@@ -87,15 +87,18 @@ import java.util.Locale
 @Suppress("TooManyFunctions")
 class MagicNumber(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue(javaClass.simpleName, Severity.Style,
-            "Report magic numbers. Magic number is a numeric literal that is not defined as a constant " +
-                    "and hence it's unclear what the purpose of this number is. " +
-                    "It's better to declare such numbers as constants and give them a proper name. " +
-                    "By default, -1, 0, 1, and 2 are not considered to be magic numbers.", Debt.TEN_MINS)
+    override val issue = Issue(
+        javaClass.simpleName, Severity.Style,
+        "Report magic numbers. Magic number is a numeric literal that is not defined as a constant " +
+            "and hence it's unclear what the purpose of this number is. " +
+            "It's better to declare such numbers as constants and give them a proper name. " +
+            "By default, -1, 0, 1, and 2 are not considered to be magic numbers.",
+        Debt.TEN_MINS
+    )
 
     private val ignoredNumbers = valueOrDefaultCommaSeparated(IGNORE_NUMBERS, listOf("-1", "0", "1", "2"))
-            .map { parseAsDouble(it) }
-            .sorted()
+        .map { parseAsDouble(it) }
+        .sorted()
 
     private val ignoreAnnotation = valueOrDefault(IGNORE_ANNOTATION, false)
     private val ignoreHashCodeFunction = valueOrDefault(IGNORE_HASH_CODE, true)
@@ -105,12 +108,13 @@ class MagicNumber(config: Config = Config.empty) : Rule(config) {
     private val ignoreEnums = valueOrDefault(IGNORE_ENUMS, false)
     private val ignoreConstantDeclaration = valueOrDefault(IGNORE_CONSTANT_DECLARATION, true)
     private val ignoreCompanionObjectPropertyDeclaration =
-            valueOrDefault(IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION, true)
+        valueOrDefault(IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION, true)
     private val ignoreRanges = valueOrDefault(IGNORE_RANGES, false)
 
     override fun visitConstantExpression(expression: KtConstantExpression) {
         if (isIgnoredByConfig(expression) || expression.isPartOfFunctionReturnConstant() ||
-                expression.isPartOfConstructorOrFunctionConstant()) {
+            expression.isPartOfConstructorOrFunctionConstant()
+        ) {
             return
         }
 
@@ -123,8 +127,13 @@ class MagicNumber(config: Config = Config.empty) : Rule(config) {
 
         val number = parseAsDoubleOrNull(rawNumber) ?: return
         if (!ignoredNumbers.contains(number)) {
-            report(CodeSmell(issue, Entity.from(expression), "This expression contains a magic number." +
-                    " Consider defining it to a well named constant."))
+            report(
+                CodeSmell(
+                    issue, Entity.from(expression),
+                    "This expression contains a magic number." +
+                        " Consider defining it to a well named constant."
+                )
+            )
         }
     }
 
@@ -160,11 +169,11 @@ class MagicNumber(config: Config = Config.empty) : Rule(config) {
 
     private fun normalizeForParsingAsDouble(text: String): String {
         return text.trim()
-                .toLowerCase(Locale.US)
-                .replace("_", "")
-                .removeSuffix("l")
-                .removeSuffix("d")
-                .removeSuffix("f")
+            .toLowerCase(Locale.US)
+            .replace("_", "")
+            .removeSuffix("l")
+            .removeSuffix("d")
+            .removeSuffix("f")
     }
 
     private fun KtConstantExpression.isNamedArgument(): Boolean {
@@ -185,17 +194,17 @@ class MagicNumber(config: Config = Config.empty) : Rule(config) {
 
     private fun KtConstantExpression.isPartOfConstructorOrFunctionConstant(): Boolean {
         return parent is KtParameter &&
-                when (parent.parent.parent) {
-                    is KtNamedFunction, is KtPrimaryConstructor, is KtSecondaryConstructor -> true
-                    else -> false
-                }
+            when (parent.parent.parent) {
+                is KtNamedFunction, is KtPrimaryConstructor, is KtSecondaryConstructor -> true
+                else -> false
+            }
     }
 
     private fun KtConstantExpression.isPartOfRange(): Boolean {
         val theParent = parent
         val rangeOperators = setOf("downTo", "until", "step")
         return if (theParent is KtBinaryExpression) theParent.operationToken == KtTokens.RANGE ||
-                theParent.operationReference.getReferencedName() in rangeOperators
+            theParent.operationReference.getReferencedName() in rangeOperators
         else false
     }
 
@@ -219,7 +228,7 @@ class MagicNumber(config: Config = Config.empty) : Rule(config) {
         isProperty() && getNonStrictParentOfType<KtProperty>()?.isConstant() ?: false
 
     private fun PsiElement.hasUnaryMinusPrefix(): Boolean = this is KtPrefixExpression &&
-            (firstChild as? KtOperationReferenceExpression)?.operationSignTokenType == KtTokens.MINUS
+        (firstChild as? KtOperationReferenceExpression)?.operationSignTokenType == KtTokens.MINUS
 
     companion object {
         const val IGNORE_NUMBERS = "ignoreNumbers"

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLength.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLength.kt
@@ -27,19 +27,21 @@ data class KtFileContent(val file: KtFile, val content: Sequence<String>)
  */
 class MaxLineLength(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue(javaClass.simpleName,
-            Severity.Style,
-            "Line detected that is longer than the defined maximum line length in the code style.",
-            Debt.FIVE_MINS)
+    override val issue = Issue(
+        javaClass.simpleName,
+        Severity.Style,
+        "Line detected that is longer than the defined maximum line length in the code style.",
+        Debt.FIVE_MINS
+    )
 
     private val lengthThreshold: Int =
-            valueOrDefault(MAX_LINE_LENGTH, DEFAULT_IDEA_LINE_LENGTH)
+        valueOrDefault(MAX_LINE_LENGTH, DEFAULT_IDEA_LINE_LENGTH)
     private val excludePackageStatements: Boolean =
-            valueOrDefault(EXCLUDE_PACKAGE_STATEMENTS, true)
+        valueOrDefault(EXCLUDE_PACKAGE_STATEMENTS, true)
     private val excludeImportStatements: Boolean =
-            valueOrDefault(EXCLUDE_IMPORT_STATEMENTS, true)
+        valueOrDefault(EXCLUDE_IMPORT_STATEMENTS, true)
     private val excludeCommentStatements: Boolean =
-            valueOrDefault(EXCLUDE_COMMENT_STATEMENTS, false)
+        valueOrDefault(EXCLUDE_COMMENT_STATEMENTS, false)
 
     fun visit(element: KtFileContent) {
         var offset = 0
@@ -68,8 +70,8 @@ class MaxLineLength(config: Config = Config.empty) : Rule(config) {
 
     private fun isIgnoredStatement(line: String): Boolean {
         return containsIgnoredPackageStatement(line) ||
-                containsIgnoredImportStatement(line) ||
-                containsIgnoredCommentStatement(line)
+            containsIgnoredImportStatement(line) ||
+            containsIgnoredCommentStatement(line)
     }
 
     private fun containsIgnoredPackageStatement(line: String): Boolean {
@@ -88,8 +90,8 @@ class MaxLineLength(config: Config = Config.empty) : Rule(config) {
         if (!excludeCommentStatements) return false
 
         return line.trimStart().startsWith("//") ||
-                line.trimStart().startsWith("/*") ||
-                line.trimStart().startsWith("*")
+            line.trimStart().startsWith("/*") ||
+            line.trimStart().startsWith("*")
     }
 
     companion object {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MayBeConst.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MayBeConst.kt
@@ -38,13 +38,17 @@ import org.jetbrains.kotlin.psi.psiUtil.containingClassOrObject
  */
 class MayBeConst(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue(javaClass.simpleName,
-            Severity.Style,
-            "Reports vals that can be const val instead.",
-            Debt.FIVE_MINS)
+    override val issue = Issue(
+        javaClass.simpleName,
+        Severity.Style,
+        "Reports vals that can be const val instead.",
+        Debt.FIVE_MINS
+    )
 
-    private val binaryTokens = hashSetOf<KtSingleValueToken>(KtTokens.PLUS, KtTokens.MINUS, KtTokens.MUL,
-            KtTokens.DIV, KtTokens.PERC)
+    private val binaryTokens = hashSetOf<KtSingleValueToken>(
+        KtTokens.PLUS, KtTokens.MINUS, KtTokens.MUL,
+        KtTokens.DIV, KtTokens.PERC
+    )
 
     private val topLevelConstants = HashSet<String?>()
     private val companionObjectConstants = HashSet<String?>()
@@ -52,18 +56,18 @@ class MayBeConst(config: Config = Config.empty) : Rule(config) {
     override fun visitKtFile(file: KtFile) {
         topLevelConstants.clear()
         val topLevelProperties = file.declarations
-                .filterIsInstance<KtProperty>()
-                .filter { it.isTopLevel && it.isConstant() }
-                .mapNotNull { it.name }
+            .filterIsInstance<KtProperty>()
+            .filter { it.isTopLevel && it.isConstant() }
+            .mapNotNull { it.name }
         topLevelConstants.addAll(topLevelProperties)
         super.visitKtFile(file)
     }
 
     override fun visitObjectDeclaration(declaration: KtObjectDeclaration) {
         val constProperties = declaration.declarations
-                .filterIsInstance<KtProperty>()
-                .filter { it.isConstant() }
-                .mapNotNull { it.name }
+            .filterIsInstance<KtProperty>()
+            .filter { it.isConstant() }
+            .mapNotNull { it.name }
         companionObjectConstants.addAll(constProperties)
         super.visitObjectDeclaration(declaration)
         companionObjectConstants.removeAll(constProperties)
@@ -97,35 +101,35 @@ class MayBeConst(config: Config = Config.empty) : Rule(config) {
 
     private fun KtProperty.cannotBeConstant(): Boolean {
         return isLocal ||
-                isVar ||
-                getter != null ||
-                isConstant() ||
-                isOverride()
+            isVar ||
+            getter != null ||
+            isConstant() ||
+            isOverride()
     }
 
     private fun KtProperty.isInObject() =
-            !isTopLevel && containingClassOrObject !is KtObjectDeclaration
+        !isTopLevel && containingClassOrObject !is KtObjectDeclaration
 
     private fun KtExpression.isConstantExpression(): Boolean {
         return this is KtStringTemplateExpression && !hasInterpolation() ||
-                node.elementType == KtNodeTypes.BOOLEAN_CONSTANT ||
-                node.elementType == KtNodeTypes.INTEGER_CONSTANT ||
-                node.elementType == KtNodeTypes.CHARACTER_CONSTANT ||
-                node.elementType == KtNodeTypes.FLOAT_CONSTANT ||
-                topLevelConstants.contains(text) ||
-                companionObjectConstants.contains(text) ||
-                isBinaryExpression(this) ||
-                isParenthesizedExpression(this)
+            node.elementType == KtNodeTypes.BOOLEAN_CONSTANT ||
+            node.elementType == KtNodeTypes.INTEGER_CONSTANT ||
+            node.elementType == KtNodeTypes.CHARACTER_CONSTANT ||
+            node.elementType == KtNodeTypes.FLOAT_CONSTANT ||
+            topLevelConstants.contains(text) ||
+            companionObjectConstants.contains(text) ||
+            isBinaryExpression(this) ||
+            isParenthesizedExpression(this)
     }
 
     private fun isParenthesizedExpression(expression: KtExpression) =
-            (expression as? KtParenthesizedExpression)?.expression?.isConstantExpression() == true
+        (expression as? KtParenthesizedExpression)?.expression?.isConstantExpression() == true
 
     private fun isBinaryExpression(expression: KtExpression): Boolean {
         return expression is KtBinaryExpression &&
-                expression.node.elementType == KtNodeTypes.BINARY_EXPRESSION &&
-                binaryTokens.contains(expression.operationToken) &&
-                expression.left?.isConstantExpression() == true &&
-                expression.right?.isConstantExpression() == true
+            expression.node.elementType == KtNodeTypes.BINARY_EXPRESSION &&
+            binaryTokens.contains(expression.operationToken) &&
+            expression.left?.isConstantExpression() == true &&
+            expression.right?.isConstantExpression() == true
     }
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ModifierOrder.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ModifierOrder.kt
@@ -52,29 +52,31 @@ import org.jetbrains.kotlin.psi.psiUtil.allChildren
  */
 class ModifierOrder(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue(javaClass.simpleName,
-            Severity.Style,
-            "Modifiers are not in the correct order.",
-            Debt.FIVE_MINS)
+    override val issue = Issue(
+        javaClass.simpleName,
+        Severity.Style,
+        "Modifiers are not in the correct order.",
+        Debt.FIVE_MINS
+    )
 
     // subset of KtTokens.MODIFIER_KEYWORDS_ARRAY
     private val order = arrayOf(
-            PUBLIC_KEYWORD, PROTECTED_KEYWORD, PRIVATE_KEYWORD, INTERNAL_KEYWORD,
-            EXPECT_KEYWORD, ACTUAL_KEYWORD,
-            FINAL_KEYWORD, OPEN_KEYWORD, ABSTRACT_KEYWORD, SEALED_KEYWORD, CONST_KEYWORD,
-            EXTERNAL_KEYWORD,
-            OVERRIDE_KEYWORD,
-            LATEINIT_KEYWORD,
-            TAILREC_KEYWORD,
-            VARARG_KEYWORD,
-            SUSPEND_KEYWORD,
-            INNER_KEYWORD,
-            ENUM_KEYWORD, ANNOTATION_KEYWORD,
-            COMPANION_KEYWORD,
-            INLINE_KEYWORD,
-            INFIX_KEYWORD,
-            OPERATOR_KEYWORD,
-            DATA_KEYWORD
+        PUBLIC_KEYWORD, PROTECTED_KEYWORD, PRIVATE_KEYWORD, INTERNAL_KEYWORD,
+        EXPECT_KEYWORD, ACTUAL_KEYWORD,
+        FINAL_KEYWORD, OPEN_KEYWORD, ABSTRACT_KEYWORD, SEALED_KEYWORD, CONST_KEYWORD,
+        EXTERNAL_KEYWORD,
+        OVERRIDE_KEYWORD,
+        LATEINIT_KEYWORD,
+        TAILREC_KEYWORD,
+        VARARG_KEYWORD,
+        SUSPEND_KEYWORD,
+        INNER_KEYWORD,
+        ENUM_KEYWORD, ANNOTATION_KEYWORD,
+        COMPANION_KEYWORD,
+        INLINE_KEYWORD,
+        INFIX_KEYWORD,
+        OPERATOR_KEYWORD,
+        DATA_KEYWORD
     )
 
     override fun visitModifierList(list: KtModifierList) {
@@ -89,9 +91,16 @@ class ModifierOrder(config: Config = Config.empty) : Rule(config) {
         if (modifiers != sortedModifiers) {
             val modifierString = sortedModifiers.joinToString(" ") { it.text }
 
-            report(CodeSmell(Issue(javaClass.simpleName, Severity.Style,
-                    "Modifier order should be: $modifierString", Debt(mins = 1)), Entity.from(list),
-                    "Modifier order should be: $modifierString"))
+            report(
+                CodeSmell(
+                    Issue(
+                        javaClass.simpleName, Severity.Style,
+                        "Modifier order should be: $modifierString", Debt(mins = 1)
+                    ),
+                    Entity.from(list),
+                    "Modifier order should be: $modifierString"
+                )
+            )
         }
     }
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/NestedClassesVisibility.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/NestedClassesVisibility.kt
@@ -37,9 +37,11 @@ import org.jetbrains.kotlin.psi.KtEnumEntry
  */
 class NestedClassesVisibility(config: Config = Config.empty) : Rule(config) {
 
-    override val issue: Issue = Issue("NestedClassesVisibility", Severity.Style,
-            "The explicit public modifier still results in an internal nested class.",
-            Debt.FIVE_MINS)
+    override val issue: Issue = Issue(
+        "NestedClassesVisibility", Severity.Style,
+        "The explicit public modifier still results in an internal nested class.",
+        Debt.FIVE_MINS
+    )
 
     override fun visitClass(klass: KtClass) {
         if (!klass.isInterface() && klass.isTopLevel() && klass.isInternal()) {
@@ -49,9 +51,9 @@ class NestedClassesVisibility(config: Config = Config.empty) : Rule(config) {
 
     private fun checkDeclarations(klass: KtClass) {
         klass.declarations
-                .filterIsInstance<KtClassOrObject>()
-                .filter { it.hasModifier(KtTokens.PUBLIC_KEYWORD) && it.isNoEnum() && it.isNoCompanionObj() }
-                .forEach { report(CodeSmell(issue, Entity.from(it), issue.description)) }
+            .filterIsInstance<KtClassOrObject>()
+            .filter { it.hasModifier(KtTokens.PUBLIC_KEYWORD) && it.isNoEnum() && it.isNoCompanionObj() }
+            .forEach { report(CodeSmell(issue, Entity.from(it), issue.description)) }
     }
 
     private fun KtClassOrObject.isNoEnum() = !this.hasModifier(KtTokens.ENUM_KEYWORD) && this !is KtEnumEntry

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/NewLineAtEndOfFile.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/NewLineAtEndOfFile.kt
@@ -16,16 +16,22 @@ import org.jetbrains.kotlin.psi.KtFile
  */
 class NewLineAtEndOfFile(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue(javaClass.simpleName,
+    override val issue = Issue(
+        javaClass.simpleName,
         Severity.Style,
         "Checks whether files end with a line separator.",
-        Debt.FIVE_MINS)
+        Debt.FIVE_MINS
+    )
 
     override fun visitKtFile(file: KtFile) {
         val text = file.text
         if (text.isNotEmpty() && text.last() != '\n') {
-            report(CodeSmell(issue, Entity.atPackageOrFirstDecl(file),
-                "The file ${file.name} is not ending with a new line."))
+            report(
+                CodeSmell(
+                    issue, Entity.atPackageOrFirstDecl(file),
+                    "The file ${file.name} is not ending with a new line."
+                )
+            )
         }
     }
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/NoTabs.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/NoTabs.kt
@@ -23,15 +23,17 @@ import org.jetbrains.kotlin.psi.KtStringTemplateEntryWithExpression
  */
 class NoTabs(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue(javaClass.simpleName,
-            Severity.Style,
-            "Checks if tabs are used in Kotlin files.",
-            Debt.FIVE_MINS)
+    override val issue = Issue(
+        javaClass.simpleName,
+        Severity.Style,
+        "Checks if tabs are used in Kotlin files.",
+        Debt.FIVE_MINS
+    )
 
     fun findTabs(file: KtFile) {
         file.collectWhitespaces()
-                .filter { it.isTab() }
-                .forEach { report(CodeSmell(issue, Entity.from(it), "Tab character is in use.")) }
+            .filter { it.isTab() }
+            .forEach { report(CodeSmell(issue, Entity.from(it), "Tab character is in use.")) }
     }
 
     private fun KtFile.collectWhitespaces(): List<PsiWhiteSpace> {
@@ -52,5 +54,5 @@ class NoTabs(config: Config = Config.empty) : Rule(config) {
     }
 
     private fun PsiWhiteSpace.isStringInterpolated(): Boolean =
-            this.isPartOf<KtStringTemplateEntryWithExpression>()
+        this.isPartOf<KtStringTemplateEntryWithExpression>()
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/OptionalAbstractKeyword.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/OptionalAbstractKeyword.kt
@@ -36,8 +36,10 @@ import org.jetbrains.kotlin.psi.psiUtil.getChildrenOfType
  */
 class OptionalAbstractKeyword(config: Config = Config.empty) : Rule(config) {
 
-    override val issue: Issue = Issue(javaClass.simpleName, Severity.Style,
-            "Unnecessary abstract modifier in interface", Debt.FIVE_MINS)
+    override val issue: Issue = Issue(
+        javaClass.simpleName, Severity.Style,
+        "Unnecessary abstract modifier in interface", Debt.FIVE_MINS
+    )
 
     override fun visitClass(klass: KtClass) {
         if (klass.isInterface()) {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/OptionalWhenBraces.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/OptionalWhenBraces.kt
@@ -33,10 +33,12 @@ import org.jetbrains.kotlin.psi.KtWhenExpression
  */
 class OptionalWhenBraces(config: Config = Config.empty) : Rule(config) {
 
-    override val issue: Issue = Issue(javaClass.simpleName,
-            Severity.Style,
-            "Optional braces in when expression",
-            Debt.FIVE_MINS)
+    override val issue: Issue = Issue(
+        javaClass.simpleName,
+        Severity.Style,
+        "Optional braces in when expression",
+        Debt.FIVE_MINS
+    )
 
     override fun visitWhenExpression(expression: KtWhenExpression) {
         for (entry in expression.entries) {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ProtectedMemberInFinalClass.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ProtectedMemberInFinalClass.kt
@@ -38,7 +38,7 @@ class ProtectedMemberInFinalClass(config: Config = Config.empty) : Rule(config) 
     override val issue = Issue(
         javaClass.simpleName, Severity.Warning,
         "Member with protected visibility in final class is private. " +
-                "Consider using private or internal as modifier.",
+            "Consider using private or internal as modifier.",
         Debt.FIVE_MINS
     )
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantVisibilityModifierRule.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantVisibilityModifierRule.kt
@@ -80,7 +80,8 @@ class RedundantVisibilityModifierRule(config: Config = Config.empty) : Rule(conf
             super.visitNamedFunction(function)
             if (function.isExplicitlyPublicNotOverridden()) {
                 report(
-                    CodeSmell(issue,
+                    CodeSmell(
+                        issue,
                         Entity.atName(function),
                         message = "${function.name} is explicitly marked as public. " +
                             "Functions are public by default so this modifier is redundant."

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/SafeCast.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/SafeCast.kt
@@ -36,10 +36,10 @@ import org.jetbrains.kotlin.psi.KtNameReferenceExpression
 class SafeCast(config: Config = Config.empty) : Rule(config) {
 
     override val issue = Issue(
-            javaClass.simpleName,
-            Severity.Style,
-            "Safe cast instead of if-else-null",
-            Debt.FIVE_MINS
+        javaClass.simpleName,
+        Severity.Style,
+        "Safe cast instead of if-else-null",
+        Debt.FIVE_MINS
     )
 
     override fun visitIfExpression(expression: KtIfExpression) {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/SerialVersionUIDInSerializableClass.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/SerialVersionUIDInSerializableClass.kt
@@ -40,10 +40,12 @@ import org.jetbrains.kotlin.psi.KtProperty
  */
 class SerialVersionUIDInSerializableClass(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue(javaClass.simpleName, Severity.Warning,
-            "A class which implements the Serializable interface does not define a correct serialVersionUID field. " +
-                    "The serialVersionUID field should be a constant long value inside a companion object.",
-            Debt.FIVE_MINS)
+    override val issue = Issue(
+        javaClass.simpleName, Severity.Warning,
+        "A class which implements the Serializable interface does not define a correct serialVersionUID field. " +
+            "The serialVersionUID field should be a constant long value inside a companion object.",
+        Debt.FIVE_MINS
+    )
 
     private val versionUID = "serialVersionUID"
 
@@ -51,8 +53,13 @@ class SerialVersionUIDInSerializableClass(config: Config = Config.empty) : Rule(
         if (!klass.isInterface() && isImplementingSerializable(klass)) {
             val companionObject = klass.companionObject()
             if (companionObject == null || !hasCorrectSerialVersionUUID(companionObject)) {
-                report(CodeSmell(issue, Entity.from(klass), "The class ${klass.nameAsSafeName} implements" +
-                        " the Serializable interface and should thus define a serialVersionUID."))
+                report(
+                    CodeSmell(
+                        issue, Entity.from(klass),
+                        "The class ${klass.nameAsSafeName} implements" +
+                            " the Serializable interface and should thus define a serialVersionUID."
+                    )
+                )
             }
         }
         super.visitClass(klass)
@@ -60,16 +67,22 @@ class SerialVersionUIDInSerializableClass(config: Config = Config.empty) : Rule(
 
     override fun visitObjectDeclaration(declaration: KtObjectDeclaration) {
         if (!declaration.isCompanion() &&
-                isImplementingSerializable(declaration) &&
-                !hasCorrectSerialVersionUUID(declaration)) {
-            report(CodeSmell(issue, Entity.from(declaration), "The object ${declaration.nameAsSafeName} " +
-                    "implements the Serializable interface and should thus define a serialVersionUID."))
+            isImplementingSerializable(declaration) &&
+            !hasCorrectSerialVersionUUID(declaration)
+        ) {
+            report(
+                CodeSmell(
+                    issue, Entity.from(declaration),
+                    "The object ${declaration.nameAsSafeName} " +
+                        "implements the Serializable interface and should thus define a serialVersionUID."
+                )
+            )
         }
         super.visitObjectDeclaration(declaration)
     }
 
     private fun isImplementingSerializable(classOrObject: KtClassOrObject) =
-            classOrObject.superTypeListEntries.any { it.text == "Serializable" }
+        classOrObject.superTypeListEntries.any { it.text == "Serializable" }
 
     private fun hasCorrectSerialVersionUUID(declaration: KtObjectDeclaration): Boolean {
         val property = declaration.body?.properties?.firstOrNull { it.name == versionUID }
@@ -82,8 +95,8 @@ class SerialVersionUIDInSerializableClass(config: Config = Config.empty) : Rule(
 
     private fun hasLongAssignment(property: KtProperty): Boolean {
         val assignmentText = property.children
-                .singleOrNull { it is KtConstantExpression || it is KtPrefixExpression }?.text
+            .singleOrNull { it is KtConstantExpression || it is KtPrefixExpression }?.text
         return assignmentText != null && assignmentText.last() == 'L' &&
-                assignmentText.substring(0, assignmentText.length - 1).toLongOrNull() != null
+            assignmentText.substring(0, assignmentText.length - 1).toLongOrNull() != null
     }
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/SpacingBetweenPackageAndImports.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/SpacingBetweenPackageAndImports.kt
@@ -37,9 +37,11 @@ import org.jetbrains.kotlin.psi.psiUtil.siblings
  */
 class SpacingBetweenPackageAndImports(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue(javaClass.simpleName, Severity.Style,
-            "Violation of the package declaration style.",
-            Debt.FIVE_MINS)
+    override val issue = Issue(
+        javaClass.simpleName, Severity.Style,
+        "Violation of the package declaration style.",
+        Debt.FIVE_MINS
+    )
 
     override fun visitKtFile(file: KtFile) {
         if (file.hasPackage() && file.anyDescendantOfType<KtClassOrObject>()) {
@@ -57,13 +59,16 @@ class SpacingBetweenPackageAndImports(config: Config = Config.empty) : Rule(conf
     private fun checkPackageDeclaration(importList: KtImportList) {
         val prevSibling = importList.prevSibling
         if (isPackageDeclaration(prevSibling) || prevSibling is PsiWhiteSpace) {
-            checkLinebreakAfterElement(prevSibling, "There should be exactly one empty line in between the " +
-                    "package declaration and the list of imports.")
+            checkLinebreakAfterElement(
+                prevSibling,
+                "There should be exactly one empty line in between the " +
+                    "package declaration and the list of imports."
+            )
         }
     }
 
     private fun isPackageDeclaration(element: PsiElement?) =
-            element is KtPackageDirective && element.text.isNotEmpty()
+        element is KtPackageDirective && element.text.isNotEmpty()
 
     private fun checkKtElementsDeclaration(importList: KtImportList) {
         val ktElement = importList.siblings(withItself = false).filterIsInstance<KtElement>().firstOrNull() ?: return
@@ -71,8 +76,11 @@ class SpacingBetweenPackageAndImports(config: Config = Config.empty) : Rule(conf
         if (nextSibling is PsiWhiteSpace || nextSibling is KtElement) {
             val name = (ktElement as? KtClassOrObject)?.name ?: "the class or object"
 
-            checkLinebreakAfterElement(nextSibling, "There should be exactly one empty line in between the " +
-                    "list of imports and the declaration of $name.")
+            checkLinebreakAfterElement(
+                nextSibling,
+                "There should be exactly one empty line in between the " +
+                    "list of imports and the declaration of $name."
+            )
         }
     }
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ThrowsCount.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ThrowsCount.kt
@@ -42,9 +42,11 @@ import org.jetbrains.kotlin.psi.psiUtil.collectDescendantsOfType
  */
 class ThrowsCount(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue(javaClass.simpleName, Severity.Style,
-            "Restrict the number of throw statements in methods.",
-            Debt.TEN_MINS)
+    override val issue = Issue(
+        javaClass.simpleName, Severity.Style,
+        "Restrict the number of throw statements in methods.",
+        Debt.TEN_MINS
+    )
 
     private val max = valueOrDefault(MAX, 2)
     private val excludeGuardClauses = valueOrDefault(EXCLUDE_GUARD_CLAUSES, false)

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/TrailingWhitespace.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/TrailingWhitespace.kt
@@ -14,10 +14,12 @@ import io.gitlab.arturbosch.detekt.rules.isPartOfString
  */
 class TrailingWhitespace(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue(javaClass.simpleName,
-            Severity.Style,
-            "Checks which lines end with a whitespace.",
-            Debt.FIVE_MINS)
+    override val issue = Issue(
+        javaClass.simpleName,
+        Severity.Style,
+        "Checks which lines end with a whitespace.",
+        Debt.FIVE_MINS
+    )
 
     fun visit(fileContent: KtFileContent) {
         var offset = 0

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiterals.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiterals.kt
@@ -37,10 +37,13 @@ import java.util.Locale
  */
 class UnderscoresInNumericLiterals(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue(javaClass.simpleName, Severity.Style,
-            "Report missing or invalid underscores in decimal base 10 numeric literals. Numeric literals " +
-                    "should be underscore separated to increase readability. Underscores that do not make groups of " +
-                    "3 digits are also reported.", Debt.FIVE_MINS)
+    override val issue = Issue(
+        javaClass.simpleName, Severity.Style,
+        "Report missing or invalid underscores in decimal base 10 numeric literals. Numeric literals " +
+            "should be underscore separated to increase readability. Underscores that do not make groups of " +
+            "3 digits are also reported.",
+        Debt.FIVE_MINS
+    )
 
     private val underscoreNumberRegex = Regex("[0-9]{1,3}(_[0-9]{3})*")
 
@@ -62,14 +65,19 @@ class UnderscoresInNumericLiterals(config: Config = Config.empty) : Rule(config)
 
     private fun reportIfInvalidUnderscorePattern(expression: KtConstantExpression, numberString: String) {
         if (!numberString.matches(underscoreNumberRegex)) {
-            report(CodeSmell(issue, Entity.from(expression), "This numeric literal should be separated " +
-                    "by underscores in order to increase readability."))
+            report(
+                CodeSmell(
+                    issue, Entity.from(expression),
+                    "This numeric literal should be separated " +
+                        "by underscores in order to increase readability."
+                )
+            )
         }
     }
 
     private fun isNotDecimalNumber(rawText: String): Boolean {
         return rawText.replace("_", "").toDoubleOrNull() == null || rawText.startsWith(HEX_PREFIX) ||
-                rawText.startsWith(BIN_PREFIX)
+            rawText.startsWith(BIN_PREFIX)
     }
 
     private fun KtConstantExpression.isSerialUidProperty(): Boolean {
@@ -90,10 +98,10 @@ class UnderscoresInNumericLiterals(config: Config = Config.empty) : Rule(config)
 
     private fun normalizeForMatching(text: String): String {
         return text.trim()
-                .toLowerCase(Locale.US)
-                .removeSuffix("l")
-                .removeSuffix("d")
-                .removeSuffix("f")
+            .toLowerCase(Locale.US)
+            .removeSuffix("l")
+            .removeSuffix("d")
+            .removeSuffix("f")
     }
 
     companion object {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAbstractClass.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAbstractClass.kt
@@ -53,14 +53,17 @@ class UnnecessaryAbstractClass(config: Config = Config.empty) : Rule(config) {
     private val noAbstractMember = "An abstract class without an abstract member can be refactored to a concrete class."
 
     override val issue =
-            Issue("UnnecessaryAbstractClass", Severity.Style,
-                    "An abstract class is unnecessary and can be refactored. " +
-                            "An abstract class should have both abstract and concrete properties or functions. " +
-                            noConcreteMember + " " + noAbstractMember,
-                    Debt.FIVE_MINS)
+        Issue(
+            "UnnecessaryAbstractClass", Severity.Style,
+            "An abstract class is unnecessary and can be refactored. " +
+                "An abstract class should have both abstract and concrete properties or functions. " +
+                noConcreteMember + " " + noAbstractMember,
+            Debt.FIVE_MINS
+        )
 
     private val excludeAnnotatedClasses = valueOrDefaultCommaSeparated(
-            EXCLUDE_ANNOTATED_CLASSES, listOf("dagger.Module"))
+        EXCLUDE_ANNOTATED_CLASSES, listOf("dagger.Module")
+    )
         .map { it.removePrefix("*").removeSuffix("*") }
     private lateinit var annotationExcluder: AnnotationExcluder
 
@@ -109,7 +112,7 @@ class UnnecessaryAbstractClass(config: Config = Config.empty) : Rule(config) {
             members.indexOfFirst { it is KtNamedDeclaration && it.isAbstract() == isAbstract }
 
         private fun isAbstractClassWithoutConcreteMembers(indexOfFirstAbstractMember: Int) =
-                indexOfFirstAbstractMember == 0 && hasNoConcreteMemberLeft() && hasNoConstructorParameter(klass)
+            indexOfFirstAbstractMember == 0 && hasNoConcreteMemberLeft() && hasNoConstructorParameter(klass)
 
         private fun hasNoConcreteMemberLeft() = indexOfFirstMember(false, namedMembers.drop(1)) == -1
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryApply.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryApply.kt
@@ -68,7 +68,6 @@ private fun KtCallExpression.receiverIsUnused(context: BindingContext): Boolean 
     } ?: false
 
 private fun KtCallExpression.hasOnlyOneMemberAccessStatement(): Boolean {
-
     fun KtExpression.notAnAssignment() =
         safeAs<KtBinaryExpression>()
             ?.operationToken != KtTokens.EQ

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryApply.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryApply.kt
@@ -38,19 +38,24 @@ import org.jetbrains.kotlin.resolve.bindingContextUtil.isUsedAsExpression
  */
 class UnnecessaryApply(config: Config) : Rule(config) {
 
-    override val issue = Issue(javaClass.simpleName, Severity.Style,
-            "The `apply` usage is unnecessary", Debt.FIVE_MINS)
+    override val issue = Issue(
+        javaClass.simpleName, Severity.Style,
+        "The `apply` usage is unnecessary", Debt.FIVE_MINS
+    )
 
     override fun visitCallExpression(expression: KtCallExpression) {
         super.visitCallExpression(expression)
 
         if (expression.isApplyExpr() &&
-                expression.hasOnlyOneMemberAccessStatement() &&
-                expression.receiverIsUnused(bindingContext)) {
-            report(CodeSmell(
+            expression.hasOnlyOneMemberAccessStatement() &&
+            expression.receiverIsUnused(bindingContext)
+        ) {
+            report(
+                CodeSmell(
                     issue, Entity.from(expression),
                     "apply expression can be omitted"
-            ))
+                )
+            )
         }
     }
 }
@@ -65,13 +70,13 @@ private fun KtCallExpression.receiverIsUnused(context: BindingContext): Boolean 
 private fun KtCallExpression.hasOnlyOneMemberAccessStatement(): Boolean {
 
     fun KtExpression.notAnAssignment() =
-            safeAs<KtBinaryExpression>()
-                    ?.operationToken != KtTokens.EQ
+        safeAs<KtBinaryExpression>()
+            ?.operationToken != KtTokens.EQ
 
     fun KtExpression.isMemberAccess() =
-            this is KtReferenceExpression ||
-                    this is KtCallExpression ||
-                    this.safeAs<KtDotQualifiedExpression>()?.receiverExpression is KtThisExpression
+        this is KtReferenceExpression ||
+            this is KtCallExpression ||
+            this.safeAs<KtDotQualifiedExpression>()?.receiverExpression is KtThisExpression
 
     val lambdaBody = firstLambdaArg?.bodyExpression
     if (lambdaBody?.children?.size == 1) {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryInheritance.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryInheritance.kt
@@ -22,8 +22,10 @@ import org.jetbrains.kotlin.psi.KtClassOrObject
  */
 class UnnecessaryInheritance(config: Config = Config.empty) : Rule(config) {
 
-    override val issue: Issue = Issue(javaClass.simpleName, Severity.Style,
-            "The extended super type is unnecessary.", Debt.FIVE_MINS)
+    override val issue: Issue = Issue(
+        javaClass.simpleName, Severity.Style,
+        "The extended super type is unnecessary.", Debt.FIVE_MINS
+    )
 
     override fun visitClassOrObject(classOrObject: KtClassOrObject) {
         for (superEntry in classOrObject.superTypeListEntries) {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLet.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLet.kt
@@ -40,8 +40,10 @@ import org.jetbrains.kotlin.psi.KtLambdaExpression
  */
 class UnnecessaryLet(config: Config) : Rule(config) {
 
-    override val issue = Issue(javaClass.simpleName, Severity.Style,
-            "The `let` usage is unnecessary", Debt.FIVE_MINS)
+    override val issue = Issue(
+        javaClass.simpleName, Severity.Style,
+        "The `let` usage is unnecessary", Debt.FIVE_MINS
+    )
 
     override fun visitCallExpression(expression: KtCallExpression) {
         super.visitCallExpression(expression)
@@ -64,10 +66,12 @@ class UnnecessaryLet(config: Config) : Rule(config) {
                 val hasOneRef = lambdaBody.countVarRefs(lambdaParameter?.text ?: IT_LITERAL) == 1
 
                 if ((isLetWithExplicitParam || isLetWithImplicitParam) && hasOneRef) {
-                    report(CodeSmell(
+                    report(
+                        CodeSmell(
                             issue, Entity.from(expression),
                             "let expression can be omitted"
-                    ))
+                        )
+                    )
                 }
             }
         }
@@ -83,4 +87,4 @@ private val KtLambdaExpression.firstParameter get() = valueParameters.firstOrNul
 private fun KtBlockExpression?.hasOnlyOneStatement() = this?.children?.size == 1
 
 private fun PsiElement.countVarRefs(varName: String): Int =
-        children.sumBy { it.countVarRefs(varName) + if (it.textMatches(varName)) 1 else 0 }
+    children.sumBy { it.countVarRefs(varName) + if (it.textMatches(varName)) 1 else 0 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryParentheses.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryParentheses.kt
@@ -38,9 +38,11 @@ import org.jetbrains.kotlin.psi.KtPsiUtil
  */
 class UnnecessaryParentheses(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue("UnnecessaryParentheses", Severity.Style,
-            "Unnecessary parentheses don't add any value to the code and should be removed.",
-            Debt.FIVE_MINS)
+    override val issue = Issue(
+        "UnnecessaryParentheses", Severity.Style,
+        "Unnecessary parentheses don't add any value to the code and should be removed.",
+        Debt.FIVE_MINS
+    )
 
     override fun visitParenthesizedExpression(expression: KtParenthesizedExpression) {
         super.visitParenthesizedExpression(expression)
@@ -49,7 +51,7 @@ class UnnecessaryParentheses(config: Config = Config.empty) : Rule(config) {
 
         if (KtPsiUtil.areParenthesesUseless(expression)) {
             val message = "Parentheses in ${expression.text} are unnecessary and can be replaced with: " +
-                    "${KtPsiUtil.deparenthesize(expression)?.text}"
+                "${KtPsiUtil.deparenthesize(expression)?.text}"
             report(CodeSmell(issue, Entity.from(expression), message))
         }
     }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UntilInsteadOfRangeTo.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UntilInsteadOfRangeTo.kt
@@ -30,10 +30,12 @@ import org.jetbrains.kotlin.psi.KtOperationReferenceExpression
  */
 class UntilInsteadOfRangeTo(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue(javaClass.simpleName,
-            Severity.Style,
-            "'..' call can be replaced with 'until'",
-            Debt.FIVE_MINS)
+    override val issue = Issue(
+        javaClass.simpleName,
+        Severity.Style,
+        "'..' call can be replaced with 'until'",
+        Debt.FIVE_MINS
+    )
 
     private val minimumSize = 3
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedImports.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedImports.kt
@@ -27,15 +27,18 @@ import org.jetbrains.kotlin.psi.psiUtil.getChildrenOfType
 class UnusedImports(config: Config) : Rule(config) {
 
     override val issue = Issue(
-            javaClass.simpleName,
-            Severity.Style,
-            "Unused Imports are dead code and should be removed.",
-            Debt.FIVE_MINS)
+        javaClass.simpleName,
+        Severity.Style,
+        "Unused Imports are dead code and should be removed.",
+        Debt.FIVE_MINS
+    )
 
     companion object {
-        private val operatorSet = setOf("unaryPlus", "unaryMinus", "not", "inc", "dec", "plus", "minus", "times", "div",
-                "mod", "rangeTo", "contains", "get", "set", "invoke", "plusAssign", "minusAssign", "timesAssign",
-                "divAssign", "modAssign", "equals", "compareTo", "iterator", "getValue", "setValue", "provideDelegate")
+        private val operatorSet = setOf(
+            "unaryPlus", "unaryMinus", "not", "inc", "dec", "plus", "minus", "times", "div",
+            "mod", "rangeTo", "contains", "get", "set", "invoke", "plusAssign", "minusAssign", "timesAssign",
+            "divAssign", "modAssign", "equals", "compareTo", "iterator", "getValue", "setValue", "provideDelegate"
+        )
 
         private val kotlinDocReferencesRegExp = Regex("\\[([^]]+)](?!\\[)")
         private val kotlinDocBlockTagReferenceRegExp = Regex("^@(see|throws|exception) (.+)")
@@ -60,10 +63,10 @@ class UnusedImports(config: Config) : Rule(config) {
 
         fun unusedImports(): List<KtImportDirective> {
             fun KtImportDirective.isFromSamePackage() =
-                    importedFqName?.parent() == currentPackage && alias == null
+                importedFqName?.parent() == currentPackage && alias == null
 
             fun KtImportDirective.isNotUsed() =
-                    aliasName !in namedReferences && identifier() !in namedReferences
+                aliasName !in namedReferences && identifier() !in namedReferences
 
             return imports?.filter { it.isFromSamePackage() || it.isNotUsed() }.orEmpty()
         }
@@ -85,9 +88,9 @@ class UnusedImports(config: Config) : Rule(config) {
 
         override fun visitReferenceExpression(expression: KtReferenceExpression) {
             expression
-                    .takeIf { !it.isPartOf<KtImportDirective>() && !it.isPartOf<KtPackageDirective>() }
-                    ?.takeIf { it.children.isEmpty() }
-                    ?.run { namedReferences.add(text.trim('`')) }
+                .takeIf { !it.isPartOf<KtImportDirective>() && !it.isPartOf<KtPackageDirective>() }
+                ?.takeIf { it.children.isEmpty() }
+                ?.run { namedReferences.add(text.trim('`')) }
             super.visitReferenceExpression(expression)
         }
 
@@ -95,8 +98,8 @@ class UnusedImports(config: Config) : Rule(config) {
             val kdoc = dcl.docComment?.getDefaultSection()
 
             kdoc?.getChildrenOfType<KDocTag>()
-                    ?.map { it.text }
-                    ?.forEach { handleKDoc(it) }
+                ?.map { it.text }
+                ?.forEach { handleKDoc(it) }
 
             kdoc?.getContent()?.let {
                 handleKDoc(it)
@@ -106,8 +109,8 @@ class UnusedImports(config: Config) : Rule(config) {
 
         private fun handleKDoc(content: String) {
             kotlinDocReferencesRegExp.findAll(content, 0)
-                    .map { it.groupValues[1] }
-                    .forEach { namedReferences.add(it.split(".")[0]) }
+                .map { it.groupValues[1] }
+                .forEach { namedReferences.add(it.split(".")[0]) }
             kotlinDocBlockTagReferenceRegExp.find(content)?.let {
                 val str = it.groupValues[2].split(whiteSpaceRegex)[0]
                 namedReferences.add(str.split(".")[0])

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateClass.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateClass.kt
@@ -42,10 +42,12 @@ class UnusedPrivateClass(config: Config = Config.empty) : Rule(config) {
 
     override val defaultRuleIdAliases: Set<String> = setOf("unused")
 
-    override val issue: Issue = Issue("UnusedPrivateClass",
-            Severity.Maintainability,
-            "Private class is unused.",
-            Debt.FIVE_MINS)
+    override val issue: Issue = Issue(
+        "UnusedPrivateClass",
+        Severity.Maintainability,
+        "Private class is unused.",
+        Debt.FIVE_MINS
+    )
 
     override fun visit(root: KtFile) {
         super.visit(root)
@@ -73,8 +75,8 @@ class UnusedPrivateClass(config: Config = Config.empty) : Rule(config) {
                 privateClasses.add(klass)
             }
             klass.getSuperTypeList()?.entries
-                    ?.mapNotNull { it.typeReference }
-                    ?.forEach { registerAccess(it) }
+                ?.mapNotNull { it.typeReference }
+                ?.forEach { registerAccess(it) }
             super.visitClass(klass)
         }
 
@@ -89,19 +91,19 @@ class UnusedPrivateClass(config: Config = Config.empty) : Rule(config) {
 
             // Try with the type with generics (e.g. Foo<Any>, Foo<Any>?)
             (typeReference.typeElement?.orInnerType() as? KtUserType)
-                    ?.referencedName
-                    ?.run { namedClasses.add(this) }
+                ?.referencedName
+                ?.run { namedClasses.add(this) }
 
             // Try with the type being a generic argument of other type (e.g. List<Foo>, List<Foo?>)
             typeReference.typeElement?.typeArgumentsAsTypes
-                    ?.asSequence()
-                    ?.filterNotNull()
-                    ?.map { it.orInnerType() }
-                    ?.forEach {
-                        namedClasses.add(it.text)
-                        // Recursively register for nested generic types (e.g. List<List<Foo>>)
-                        if (it is KtTypeReference) registerAccess(it)
-                    }
+                ?.asSequence()
+                ?.filterNotNull()
+                ?.map { it.orInnerType() }
+                ?.forEach {
+                    namedClasses.add(it.text)
+                    // Recursively register for nested generic types (e.g. List<List<Foo>>)
+                    if (it is KtTypeReference) registerAccess(it)
+                }
         }
 
         override fun visitParameter(parameter: KtParameter) {
@@ -144,18 +146,18 @@ class UnusedPrivateClass(config: Config = Config.empty) : Rule(config) {
             checkReceiverForClassUsage(expression.receiverExpression)
             if (expression.isEmptyLHS) {
                 expression.safeAs<KtCallableReferenceExpression>()
-                        ?.callableReference
-                        ?.takeIf { looksLikeAClassName(it.getReferencedName()) }
-                        ?.let { namedClasses.add(it.getReferencedName()) }
+                    ?.callableReference
+                    ?.takeIf { looksLikeAClassName(it.getReferencedName()) }
+                    ?.let { namedClasses.add(it.getReferencedName()) }
             }
             super.visitDoubleColonExpression(expression)
         }
 
         private fun checkReceiverForClassUsage(receiver: KtExpression?) {
             (receiver as? KtNameReferenceExpression)
-                    ?.text
-                    ?.takeIf { looksLikeAClassName(it) }
-                    ?.let { namedClasses.add(it) }
+                ?.text
+                ?.takeIf { looksLikeAClassName(it) }
+                ?.let { namedClasses.add(it) }
         }
 
         override fun visitDotQualifiedExpression(expression: KtDotQualifiedExpression) {
@@ -166,7 +168,7 @@ class UnusedPrivateClass(config: Config = Config.empty) : Rule(config) {
         // Without symbol solving it is hard to tell if this is really a class or part of a package.
         // We use "first char is uppercase" as a heuristic in conjunction with "KtNameReferenceExpression"
         private fun looksLikeAClassName(maybeClassName: String) =
-                maybeClassName.firstOrNull()?.isUpperCase() == true
+            maybeClassName.firstOrNull()?.isUpperCase() == true
     }
 }
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
@@ -53,10 +53,12 @@ class UnusedPrivateMember(config: Config = Config.empty) : Rule(config) {
 
     override val defaultRuleIdAliases: Set<String> = setOf("UNUSED_VARIABLE", "UNUSED_PARAMETER", "unused")
 
-    override val issue: Issue = Issue("UnusedPrivateMember",
-            Severity.Maintainability,
-            "Private member is unused.",
-            Debt.FIVE_MINS)
+    override val issue: Issue = Issue(
+        "UnusedPrivateMember",
+        Severity.Maintainability,
+        "Private member is unused.",
+        Debt.FIVE_MINS
+    )
 
     private val allowedNames by LazyRegex(ALLOWED_NAMES_PATTERN, "(_|ignored|expected|serialVersionUID)")
 
@@ -204,7 +206,7 @@ private class UnusedParameterVisitor(allowedNames: Regex) : UnusedMemberVisitor(
     private fun KtNamedFunction.isRelevant() = !isAllowedToHaveUnusedParameters()
 
     private fun KtNamedFunction.isAllowedToHaveUnusedParameters() =
-            isAbstract() || isOpen() || isOverride() || isOperator() || isMainFunction() || isExternal() || isExpect()
+        isAbstract() || isOpen() || isOverride() || isOperator() || isMainFunction() || isExternal() || isExpect()
 }
 
 private class UnusedPropertyVisitor(allowedNames: Regex) : UnusedMemberVisitor(allowedNames) {
@@ -214,9 +216,13 @@ private class UnusedPropertyVisitor(allowedNames: Regex) : UnusedMemberVisitor(a
 
     override fun getUnusedReports(issue: Issue): List<CodeSmell> {
         return properties
-                .filter { it.nameAsSafeName.identifier !in nameAccesses }
-                .map { CodeSmell(issue, Entity.from(it),
-                    "Private property ${it.nameAsSafeName.identifier} is unused.") }
+            .filter { it.nameAsSafeName.identifier !in nameAccesses }
+            .map {
+                CodeSmell(
+                    issue, Entity.from(it),
+                    "Private property ${it.nameAsSafeName.identifier} is unused."
+                )
+            }
     }
 
     override fun visitParameter(parameter: KtParameter) {
@@ -236,8 +242,8 @@ private class UnusedPropertyVisitor(allowedNames: Regex) : UnusedMemberVisitor(a
     override fun visitPrimaryConstructor(constructor: KtPrimaryConstructor) {
         super.visitPrimaryConstructor(constructor)
         constructor.valueParameters
-                .filter { (it.isPrivate() || !it.hasValOrVar()) && it.containingClassOrObject?.isExpect() == false }
-                .forEach { maybeAddUnusedProperty(it) }
+            .filter { (it.isPrivate() || !it.hasValOrVar()) && it.containingClassOrObject?.isExpect() == false }
+            .forEach { maybeAddUnusedProperty(it) }
     }
 
     override fun visitSecondaryConstructor(constructor: KtSecondaryConstructor) {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseCheckOrError.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseCheckOrError.kt
@@ -48,7 +48,8 @@ class UseCheckOrError(config: Config = Config.empty) : Rule(config) {
         if (expression.isOnlyExpressionInLambda()) return
 
         if (expression.isIllegalStateException() &&
-            expression.arguments.isEmptyOrSingleStringArgument(bindingContext)) {
+            expression.arguments.isEmptyOrSingleStringArgument(bindingContext)
+        ) {
             report(CodeSmell(issue, Entity.from(expression), issue.description))
         }
     }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseDataClass.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseDataClass.kt
@@ -49,10 +49,12 @@ import org.jetbrains.kotlin.types.KotlinType
  */
 class UseDataClass(config: Config = Config.empty) : Rule(config) {
 
-    override val issue: Issue = Issue("UseDataClass",
-            Severity.Style,
-            "Classes that do nothing but hold data should be replaced with a data class.",
-            Debt.FIVE_MINS)
+    override val issue: Issue = Issue(
+        "UseDataClass",
+        Severity.Style,
+        "Classes that do nothing but hold data should be replaced with a data class.",
+        Debt.FIVE_MINS
+    )
 
     private val excludeAnnotatedClasses = valueOrDefaultCommaSeparated(EXCLUDE_ANNOTATED_CLASSES, emptyList())
         .map { it.removePrefix("*").removeSuffix("*") }
@@ -71,7 +73,8 @@ class UseDataClass(config: Config = Config.empty) : Rule(config) {
             return
         }
         if (klass.isClosedForExtension() && klass.doesNotExtendAnything() &&
-                !annotationExcluder.shouldExclude(klass.annotationEntries)) {
+            !annotationExcluder.shouldExclude(klass.annotationEntries)
+        ) {
             val declarations = klass.extractDeclarations()
             val properties = declarations.filterIsInstance<KtProperty>()
             val functions = declarations.filterIsInstance<KtNamedFunction>()
@@ -79,7 +82,7 @@ class UseDataClass(config: Config = Config.empty) : Rule(config) {
             val propertyParameters = klass.extractConstructorPropertyParameters()
 
             val primaryConstructor = bindingContext[BindingContext.DECLARATION_TO_DESCRIPTOR, klass.primaryConstructor]
-                    as? ClassConstructorDescriptor
+                as? ClassConstructorDescriptor
             val primaryConstructorParameterTypes = primaryConstructor?.valueParameters?.map { it.type }.orEmpty()
             val classType = primaryConstructor?.containingDeclaration?.defaultType
             val containsFunctions = functions.all { it.isDefaultFunction(classType, primaryConstructorParameterTypes) }
@@ -93,8 +96,9 @@ class UseDataClass(config: Config = Config.empty) : Rule(config) {
                 }
                 report(
                     CodeSmell(
-                        issue, Entity.from(klass), "The class ${klass.nameAsSafeName} defines no " +
-                                "functionality and only holds data. Consider converting it to a data class."
+                        issue, Entity.from(klass),
+                        "The class ${klass.nameAsSafeName} defines no " +
+                            "functionality and only holds data. Consider converting it to a data class."
                     )
                 )
             }
@@ -102,23 +106,23 @@ class UseDataClass(config: Config = Config.empty) : Rule(config) {
     }
 
     private fun isIncorrectClassType(klass: KtClass) =
-            klass.isData() ||
-                    klass.isEnum() ||
-                    klass.isAnnotation() ||
-                    klass.isSealed() ||
-                    klass.isInline()
+        klass.isData() ||
+            klass.isEnum() ||
+            klass.isAnnotation() ||
+            klass.isSealed() ||
+            klass.isInline()
 
     private fun hasOnlyPrivateConstructors(klass: KtClass): Boolean {
         val primaryConstructor = klass.primaryConstructor
         return (primaryConstructor == null || primaryConstructor.isPrivate()) &&
-                klass.secondaryConstructors.all { it.isPrivate() }
+            klass.secondaryConstructors.all { it.isPrivate() }
     }
 
     private fun KtClass.extractConstructorPropertyParameters(): List<KtParameter> =
-            getPrimaryConstructorParameterList()
-                    ?.parameters
-                    ?.filter { it.isPropertyParameter() }
-                    .orEmpty()
+        getPrimaryConstructorParameterList()
+            ?.parameters
+            ?.filter { it.isPropertyParameter() }
+            .orEmpty()
 
     private fun KtNamedFunction.isDefaultFunction(
         classType: KotlinType?,
@@ -133,8 +137,8 @@ class UseDataClass(config: Config = Config.empty) : Rule(config) {
                     val returnType = descriptor?.returnType
                     val parameterTypes = descriptor?.valueParameters?.map { it.type }.orEmpty()
                     returnType == classType &&
-                            parameterTypes.size == primaryConstructorParameterTypes.size &&
-                            parameterTypes.zip(primaryConstructorParameterTypes).all { it.first == it.second }
+                        parameterTypes.size == primaryConstructorParameterTypes.size &&
+                        parameterTypes.zip(primaryConstructorParameterTypes).all { it.first == it.second }
                 } else {
                     true
                 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIfInsteadOfWhen.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIfInsteadOfWhen.kt
@@ -27,17 +27,20 @@ import org.jetbrains.kotlin.psi.KtWhenExpression
  */
 class UseIfInsteadOfWhen(config: Config = Config.empty) : Rule(config) {
 
-    override val issue: Issue = Issue("UseIfInsteadOfWhen",
-            Severity.Style,
-            "Binary expressions are better expressed using an 'if' expression than a 'when' expression.",
-            Debt.FIVE_MINS)
+    override val issue: Issue = Issue(
+        "UseIfInsteadOfWhen",
+        Severity.Style,
+        "Binary expressions are better expressed using an 'if' expression than a 'when' expression.",
+        Debt.FIVE_MINS
+    )
 
     override fun visitWhenExpression(expression: KtWhenExpression) {
         super.visitWhenExpression(expression)
 
         if (expression.entries.size == 2 &&
             expression.elseExpression != null &&
-            expression.entries.none { it.conditions.size > 1 }) {
+            expression.entries.none { it.conditions.size > 1 }
+        ) {
             report(
                 CodeSmell(
                     issue,

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseRequire.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseRequire.kt
@@ -43,7 +43,8 @@ class UseRequire(config: Config = Config.empty) : Rule(config) {
         if (expression.isOnlyExpressionInBlock()) return
 
         if (expression.isEnclosedByConditionalStatement() &&
-            expression.arguments.isEmptyOrSingleStringArgument(bindingContext)) {
+            expression.arguments.isEmptyOrSingleStringArgument(bindingContext)
+        ) {
             report(CodeSmell(issue, Entity.from(expression), issue.description))
         }
     }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UselessCallOnNotNull.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UselessCallOnNotNull.kt
@@ -43,8 +43,8 @@ class UselessCallOnNotNull(config: Config = Config.empty) : Rule(config) {
         "UselessCallOnNotNull",
         Severity.Performance,
         "This call on non-null reference may be reduced or removed. Some calls are intended to be called on nullable " +
-                "collection or text types (e.g. String?). When this call is used on a reference to a non-null type " +
-                "(e.g. String) it is redundant and will have no effect, so it can be removed.",
+            "collection or text types (e.g. String?). When this call is used on a reference to a non-null type " +
+            "(e.g. String) it is redundant and will have no effect, so it can be removed.",
         Debt.FIVE_MINS
     )
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UtilityClassWithPublicConstructor.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UtilityClassWithPublicConstructor.kt
@@ -60,11 +60,13 @@ import org.jetbrains.kotlin.psi.psiUtil.isPublic
  */
 class UtilityClassWithPublicConstructor(config: Config = Config.empty) : Rule(config) {
 
-    override val issue: Issue = Issue(javaClass.simpleName,
-            Severity.Style,
-            "The class declaration is unnecessary because it only contains utility functions. " +
-                    "An object declaration should be used instead.",
-            Debt.FIVE_MINS)
+    override val issue: Issue = Issue(
+        javaClass.simpleName,
+        Severity.Style,
+        "The class declaration is unnecessary because it only contains utility functions. " +
+            "An object declaration should be used instead.",
+        Debt.FIVE_MINS
+    )
 
     override fun visitClass(klass: KtClass) {
         if (canBeCheckedForUtilityClass(klass)) {
@@ -72,12 +74,20 @@ class UtilityClassWithPublicConstructor(config: Config = Config.empty) : Rule(co
             val declarations = klass.body?.declarations
             if (hasOnlyUtilityClassMembers(declarations)) {
                 if (utilityClassConstructor.hasPublicConstructorWithoutParameters()) {
-                    report(CodeSmell(issue, Entity.from(klass),
+                    report(
+                        CodeSmell(
+                            issue, Entity.from(klass),
                             "The class ${klass.nameAsSafeName} only contains" +
-                                    " utility functions. Consider defining it as an object."))
+                                " utility functions. Consider defining it as an object."
+                        )
+                    )
                 } else if (klass.isOpen() && utilityClassConstructor.hasNonPublicConstructorWithoutParameters()) {
-                    report(CodeSmell(issue, Entity.from(klass),
-                            "The utility class ${klass.nameAsSafeName} should be final."))
+                    report(
+                        CodeSmell(
+                            issue, Entity.from(klass),
+                            "The utility class ${klass.nameAsSafeName} should be final."
+                        )
+                    )
                 }
             }
         }
@@ -86,9 +96,9 @@ class UtilityClassWithPublicConstructor(config: Config = Config.empty) : Rule(co
 
     private fun canBeCheckedForUtilityClass(klass: KtClass): Boolean {
         return !klass.isInterface() &&
-                !klass.superTypeListEntries.any() &&
-                !klass.isAnnotation() &&
-                !klass.isSealed()
+            !klass.superTypeListEntries.any() &&
+            !klass.isAnnotation() &&
+            !klass.isSealed()
     }
 
     private fun hasOnlyUtilityClassMembers(declarations: List<KtDeclaration>?): Boolean {
@@ -108,7 +118,7 @@ class UtilityClassWithPublicConstructor(config: Config = Config.empty) : Rule(co
     }
 
     private fun isCompanionObject(declaration: KtDeclaration) =
-            (declaration as? KtObjectDeclaration)?.isCompanion() == true
+        (declaration as? KtObjectDeclaration)?.isCompanion() == true
 
     internal class UtilityClassConstructor(private val klass: KtClass) {
 
@@ -123,7 +133,7 @@ class UtilityClassWithPublicConstructor(config: Config = Config.empty) : Rule(co
             }
             val secondaryConstructors = klass.secondaryConstructors
             return secondaryConstructors.isEmpty() ||
-                    secondaryConstructors.any { it.isPublic == publicModifier && it.valueParameters.isEmpty() }
+                secondaryConstructors.any { it.isPublic == publicModifier && it.valueParameters.isEmpty() }
         }
     }
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/VarCouldBeVal.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/VarCouldBeVal.kt
@@ -43,10 +43,12 @@ class VarCouldBeVal(config: Config = Config.empty) : Rule(config) {
 
     override val defaultRuleIdAliases: Set<String> = setOf("CanBeVal")
 
-    override val issue: Issue = Issue("VarCouldBeVal",
-            Severity.Maintainability,
-            "Var declaration could be val.",
-            Debt.FIVE_MINS)
+    override val issue: Issue = Issue(
+        "VarCouldBeVal",
+        Severity.Maintainability,
+        "Var declaration could be val.",
+        Debt.FIVE_MINS
+    )
 
     override fun visitNamedFunction(function: KtNamedFunction) {
         if (function.isSomehowNested()) {
@@ -63,7 +65,7 @@ class VarCouldBeVal(config: Config = Config.empty) : Rule(config) {
     }
 
     private fun KtNamedFunction.isSomehowNested() =
-            getStrictParentOfType<KtNamedFunction>() != null
+        getStrictParentOfType<KtNamedFunction>() != null
 
     private class AssignmentVisitor : DetektVisitor() {
 
@@ -75,7 +77,7 @@ class VarCouldBeVal(config: Config = Config.empty) : Rule(config) {
         fun getNonReAssignedDeclarations(): List<KtNamedDeclaration> {
             return declarations.filter { declaration ->
                 assignments[declaration.nameAsSafeName.identifier]
-                        ?.let { declaration.parent !in it }
+                    ?.let { declaration.parent !in it }
                     ?: true
             }
         }
@@ -112,7 +114,8 @@ class VarCouldBeVal(config: Config = Config.empty) : Rule(config) {
         private fun extractAssignedName(expression: KtBinaryExpression): String? {
             val leftSide = expression.left
             if (leftSide is KtDotQualifiedExpression &&
-                    leftSide.receiverExpression is KtThisExpression) {
+                leftSide.receiverExpression is KtThisExpression
+            ) {
                 return leftSide.selectorExpression?.text
             }
             return leftSide?.text

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/WildcardImport.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/WildcardImport.kt
@@ -46,16 +46,19 @@ import org.jetbrains.kotlin.psi.KtImportDirective
  */
 class WildcardImport(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue(javaClass.simpleName,
-            Severity.Style,
-            "Wildcard imports should be replaced with imports using fully qualified class names. " +
-                    "Wildcard imports can lead to naming conflicts. " +
-                    "A library update can introduce naming clashes with your classes which " +
-                    "results in compilation errors.",
-            Debt.FIVE_MINS)
+    override val issue = Issue(
+        javaClass.simpleName,
+        Severity.Style,
+        "Wildcard imports should be replaced with imports using fully qualified class names. " +
+            "Wildcard imports can lead to naming conflicts. " +
+            "A library update can introduce naming clashes with your classes which " +
+            "results in compilation errors.",
+        Debt.FIVE_MINS
+    )
 
     private val excludedImports = valueOrDefaultCommaSeparated(
-            EXCLUDED_IMPORTS, listOf("java.util.*", "kotlinx.android.synthetic.*"))
+        EXCLUDED_IMPORTS, listOf("java.util.*", "kotlinx.android.synthetic.*")
+    )
         .map { it.removePrefix("*").removeSuffix("*") }
 
     override fun visitImportDirective(importDirective: KtImportDirective) {
@@ -68,8 +71,13 @@ class WildcardImport(config: Config = Config.empty) : Rule(config) {
             if (excludedImports.any { import.contains(it, ignoreCase = true) }) {
                 return
             }
-            report(CodeSmell(issue, Entity.from(importDirective), "$import " +
-                    "is a wildcard import. Replace it with fully qualified imports."))
+            report(
+                CodeSmell(
+                    issue, Entity.from(importDirective),
+                    "$import " +
+                        "is a wildcard import. Replace it with fully qualified imports."
+                )
+            )
         }
     }
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/MandatoryBracesIfStatements.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/MandatoryBracesIfStatements.kt
@@ -14,7 +14,7 @@ import org.jetbrains.kotlin.psi.KtIfExpression
 import org.jetbrains.kotlin.psi.psiUtil.siblings
 
 private const val DESCRIPTION = "Multi-line if statement was found that does not have braces. " +
-        "These should be added to improve readability."
+    "These should be added to improve readability."
 
 /**
  * This rule detects multi-line `if` statements which do not have braces.
@@ -47,15 +47,15 @@ class MandatoryBracesIfStatements(config: Config = Config.empty) : Rule(config) 
     }
 
     private fun hasNewLine(element: PsiElement?): Boolean =
-            element?.siblings(forward = true, withItself = false)
-                    ?.takeWhile { it.text != "else" }
-                    ?.filterIsInstance<PsiWhiteSpace>()
-                    ?.firstOrNull { it.textContains('\n') } != null
+        element?.siblings(forward = true, withItself = false)
+            ?.takeWhile { it.text != "else" }
+            ?.filterIsInstance<PsiWhiteSpace>()
+            ?.firstOrNull { it.textContains('\n') } != null
 
     private fun KtIfExpression.isNotBlockExpression(): Boolean = this.then !is KtBlockExpression
 
     private fun KtIfExpression.isNotBlockOrIfExpression(): Boolean =
-            this.`else` != null &&
-                    this.`else` !is KtIfExpression &&
-                    this.`else` !is KtBlockExpression
+        this.`else` != null &&
+            this.`else` !is KtIfExpression &&
+            this.`else` !is KtBlockExpression
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/OptionalUnit.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/OptionalUnit.kt
@@ -40,10 +40,11 @@ import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
 class OptionalUnit(config: Config = Config.empty) : Rule(config) {
 
     override val issue = Issue(
-            javaClass.simpleName,
-            Severity.Style,
-            "Return type of 'Unit' is unnecessary and can be safely removed.",
-            Debt.FIVE_MINS)
+        javaClass.simpleName,
+        Severity.Style,
+        "Return type of 'Unit' is unnecessary and can be safely removed.",
+        Debt.FIVE_MINS
+    )
 
     override fun visitNamedFunction(function: KtNamedFunction) {
         if (function.funKeyword == null) return
@@ -58,11 +59,15 @@ class OptionalUnit(config: Config = Config.empty) : Rule(config) {
 
     override fun visitBlockExpression(expression: KtBlockExpression) {
         expression.statements
-                .filter { it is KtNameReferenceExpression && it.text == UNIT }
-                .onEach {
-                    report(CodeSmell(issue, Entity.from(expression),
-                            "A single Unit expression is unnecessary and can safely be removed"))
-                }
+            .filter { it is KtNameReferenceExpression && it.text == UNIT }
+            .onEach {
+                report(
+                    CodeSmell(
+                        issue, Entity.from(expression),
+                        "A single Unit expression is unnecessary and can safely be removed"
+                    )
+                )
+            }
         super.visitBlockExpression(expression)
     }
 
@@ -85,7 +90,7 @@ class OptionalUnit(config: Config = Config.empty) : Rule(config) {
         function.getStrictParentOfType<KtClass>()?.isInterface() ?: false
 
     private fun createMessage(function: KtNamedFunction) = "The function ${function.name} " +
-            "defines a return type of Unit. This is unnecessary and can safely be removed."
+        "defines a return type of Unit. This is unnecessary and can safely be removed."
 
     companion object {
         private const val UNIT = "Unit"

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/PreferToOverPairSyntax.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/PreferToOverPairSyntax.kt
@@ -29,9 +29,11 @@ import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameOrNull
  * </compliant>
  */
 class PreferToOverPairSyntax(config: Config = Config.empty) : Rule(config) {
-    override val issue = Issue("PreferToOverPairSyntax", Severity.Style,
-            "Pair was created using the Pair constructor, using the to syntax is preferred.",
-            Debt.FIVE_MINS)
+    override val issue = Issue(
+        "PreferToOverPairSyntax", Severity.Style,
+        "Pair was created using the Pair constructor, using the to syntax is preferred.",
+        Debt.FIVE_MINS
+    )
 
     @Suppress("ReturnCount")
     override fun visitSimpleNameExpression(expression: KtSimpleNameExpression) {
@@ -43,9 +45,13 @@ class PreferToOverPairSyntax(config: Config = Config.empty) : Rule(config) {
         if (subjectType.fqNameOrNull()?.asString() == PAIR_CONSTRUCTOR_REFERENCE_NAME) {
             val (firstArg, secondArg) = callReference.valueArguments.map { it.text }
 
-            report(CodeSmell(issue, Entity.from(expression),
+            report(
+                CodeSmell(
+                    issue, Entity.from(expression),
                     message = "Pair is created by using the pair constructor. " +
-                            "This can replaced by `$firstArg to $secondArg`"))
+                        "This can replaced by `$firstArg to $secondArg`"
+                )
+            )
         }
 
         super.visitSimpleNameExpression(expression)

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/InclusionExclusionPatternsSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/InclusionExclusionPatternsSpec.kt
@@ -69,9 +69,12 @@ class InclusionExclusionPatternsSpec : Spek({
     describe("rule should only run on included files") {
 
         it("should only run on dummies") {
-            val config = TestConfig(mapOf(
-                Config.INCLUDES_KEY to "**Dummy*.kt",
-                Config.EXCLUDES_KEY to "**/library/**"))
+            val config = TestConfig(
+                mapOf(
+                    Config.INCLUDES_KEY to "**Dummy*.kt",
+                    Config.EXCLUDES_KEY to "**/library/**"
+                )
+            )
 
             OnlyLibraryTrackingRule(config).apply {
                 Files.walk(Case.Library.path().parent)
@@ -83,9 +86,12 @@ class InclusionExclusionPatternsSpec : Spek({
         }
 
         it("should only run on library file") {
-            val config = TestConfig(mapOf(
-                Config.INCLUDES_KEY to "**Library.kt",
-                Config.EXCLUDES_KEY to "**/library/**"))
+            val config = TestConfig(
+                mapOf(
+                    Config.INCLUDES_KEY to "**Library.kt",
+                    Config.EXCLUDES_KEY to "**/library/**"
+                )
+            )
 
             OnlyLibraryTrackingRule(config).apply {
                 Files.walk(Case.Library.path().parent)

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DeprecationSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DeprecationSpec.kt
@@ -18,7 +18,8 @@ object DeprecationSpec : Spek({
     describe("Deprecation detection") {
 
         it("reports when supertype is deprecated") {
-            val code = """
+            val code =
+                """
                 @Deprecated("deprecation message")
                 abstract class Foo {
                     abstract fun bar() : Int
@@ -36,7 +37,8 @@ object DeprecationSpec : Spek({
         }
 
         it("does not report when supertype is not deprecated") {
-            val code = """
+            val code =
+                """
                 abstract class Oof : Foo() {
                     fun spam() {
                     }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DuplicateCaseInWhenExpressionSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DuplicateCaseInWhenExpressionSpec.kt
@@ -12,7 +12,8 @@ class DuplicateCaseInWhenExpressionSpec : Spek({
     describe("Duplicate Case In When Expression rule") {
 
         it("reports duplicated label in when") {
-            val code = """
+            val code =
+                """
                 fun f() {
                     when (1) {
                         1 -> println()
@@ -28,7 +29,8 @@ class DuplicateCaseInWhenExpressionSpec : Spek({
         }
 
         it("does not report duplicated label in when") {
-            val code = """
+            val code =
+                """
                 fun f() {
                     when (1) {
                         1 -> println()

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsAlwaysReturnsTrueOrFalseSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsAlwaysReturnsTrueOrFalseSpec.kt
@@ -22,7 +22,8 @@ class EqualsAlwaysReturnsTrueOrFalseSpec : Spek({
         }
 
         it("detects and doesn't crash when return expression is annotated - #2021") {
-            val code = """
+            val code =
+                """
                 class C {
                     override fun equals(other: Any?): Boolean {
                         @Suppress("UnsafeCallOnNullableType")
@@ -34,7 +35,8 @@ class EqualsAlwaysReturnsTrueOrFalseSpec : Spek({
         }
 
         it("detects and doesn't crash when the equals method contains no return expression - #2103") {
-            val code = """
+            val code =
+                """
                 open class SuperClass
                 
                 data class Item(val text: String) : SuperClass() {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsWithHashCodeExistSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsWithHashCodeExistSpec.kt
@@ -14,7 +14,8 @@ class EqualsWithHashCodeExistSpec : Spek({
         context("some classes with equals() and hashCode() functions") {
 
             it("reports hashCode() without equals() function") {
-                val code = """
+                val code =
+                    """
                 class A {
                     override fun hashCode(): Int { return super.hashCode() }
                 }"""
@@ -22,7 +23,8 @@ class EqualsWithHashCodeExistSpec : Spek({
             }
 
             it("reports equals() without hashCode() function") {
-                val code = """
+                val code =
+                    """
                 class A {
                     override fun equals(other: Any?): Boolean { return super.equals(other) }
                 }"""
@@ -30,7 +32,8 @@ class EqualsWithHashCodeExistSpec : Spek({
             }
 
             it("reports a different equals() function signature") {
-                val code = """
+                val code =
+                    """
                 class A {
                     fun equals(other: Any?, i: Int): Boolean { return super.equals(other) }
                     override fun hashCode(): Int { return super.hashCode() }
@@ -39,7 +42,8 @@ class EqualsWithHashCodeExistSpec : Spek({
             }
 
             it("reports a different hashcode() function signature") {
-                val code = """
+                val code =
+                    """
                 class A {
                     override fun equals(other: Any?): Boolean { return super.equals(other) }
                     fun hashCode(i: Int): Int { return super.hashCode() }
@@ -48,7 +52,8 @@ class EqualsWithHashCodeExistSpec : Spek({
             }
 
             it("reports a different overridden equals() function signature") {
-                val code = """
+                val code =
+                    """
                 interface I {
                     fun equals(other: Any?, i: Int): Boolean
                 }                    
@@ -61,7 +66,8 @@ class EqualsWithHashCodeExistSpec : Spek({
             }
 
             it("reports a different overridden hashCode() function signature") {
-                val code = """
+                val code =
+                    """
                 interface I {
                     fun hashCode(i: Int): Int
                 }                    
@@ -74,7 +80,8 @@ class EqualsWithHashCodeExistSpec : Spek({
             }
 
             it("does not report equals() with hashCode() function") {
-                val code = """
+                val code =
+                    """
                 class A {
                     override fun equals(other: Any?): Boolean { return super.equals(other) }
                     override fun hashCode(): Int { return super.hashCode() }
@@ -83,7 +90,8 @@ class EqualsWithHashCodeExistSpec : Spek({
             }
 
             it("does not report when using kotlin.Any?") {
-                val code = """
+                val code =
+                    """
                 class A {
                     override fun equals(other: kotlin.Any?): Boolean { return super.equals(other) }
                     override fun hashCode(): Int { return super.hashCode() }
@@ -95,7 +103,8 @@ class EqualsWithHashCodeExistSpec : Spek({
         context("a data class") {
 
             it("does not report equals() or hashcode() violation on data class") {
-                val code = """
+                val code =
+                    """
                 data class EqualsData(val i: Int) {
                     override fun equals(other: Any?): Boolean {
                         return super.equals(other)

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ExplicitGarbageCollectionCallSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ExplicitGarbageCollectionCallSpec.kt
@@ -12,7 +12,8 @@ class ExplicitGarbageCollectionCallSpec : Spek({
     describe("ExplicitGarbageCollectionCall rule") {
 
         it("reports garbage collector calls") {
-            val code = """
+            val code =
+                """
                 fun f() {
                     System.gc()
                     Runtime.getRuntime().gc()

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/HasPlatformTypeSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/HasPlatformTypeSpec.kt
@@ -18,7 +18,8 @@ object HasPlatformTypeSpec : Spek({
     describe("Deprecation detection") {
 
         it("reports when public function returns expression of platform type") {
-            val code = """
+            val code =
+                """
                 class Person {
                     fun apiCall() = System.getProperty("propertyName")
                 }
@@ -27,7 +28,8 @@ object HasPlatformTypeSpec : Spek({
         }
 
         it("does not report when private") {
-            val code = """
+            val code =
+                """
                 class Person {
                     private fun apiCall() = System.getProperty("propertyName")
                 }
@@ -36,7 +38,8 @@ object HasPlatformTypeSpec : Spek({
         }
 
         it("does not report when public function returns expression of platform type and type explicitly declared") {
-            val code = """
+            val code =
+                """
                 class Person {
                     fun apiCall(): String = System.getProperty("propertyName")
                 }
@@ -45,7 +48,8 @@ object HasPlatformTypeSpec : Spek({
         }
 
         it("reports when property initiated with platform type") {
-            val code = """
+            val code =
+                """
                 class Person {
                     val name = System.getProperty("name")
                 }
@@ -54,7 +58,8 @@ object HasPlatformTypeSpec : Spek({
         }
 
         it("does not report when private") {
-            val code = """
+            val code =
+                """
                 class Person {
                     private val name = System.getProperty("name")
                 }
@@ -63,7 +68,8 @@ object HasPlatformTypeSpec : Spek({
         }
 
         it("does not report when property initiated with platform type and type explicitly declared") {
-            val code = """
+            val code =
+                """
                 class Person {
                     val name: String = System.getProperty("name")
                 }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ImplicitDefaultLocaleSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ImplicitDefaultLocaleSpec.kt
@@ -18,7 +18,8 @@ class ImplicitDefaultLocaleSpec : Spek({
     describe("ImplicitDefault rule") {
 
         it("reports String.format call with template but without explicit locale") {
-            val code = """
+            val code =
+                """
                 fun x() {
                     String.format("%d", 1)
                 }"""
@@ -26,7 +27,8 @@ class ImplicitDefaultLocaleSpec : Spek({
         }
 
         it("does not report String.format call with explicit locale") {
-            val code = """
+            val code =
+                """
                 import java.util.Locale
                 fun x() {
                     String.format(Locale.US, "%d", 1)
@@ -35,7 +37,8 @@ class ImplicitDefaultLocaleSpec : Spek({
         }
 
         it("reports String.toUpperCase() call without explicit locale") {
-            val code = """
+            val code =
+                """
                 fun x() {
                     val s = "deadbeef"
                     s.toUpperCase()
@@ -44,7 +47,8 @@ class ImplicitDefaultLocaleSpec : Spek({
         }
 
         it("does not report String.toUpperCase() call with explicit locale") {
-            val code = """
+            val code =
+                """
                 import java.util.Locale
                 fun x() {
                     val s = "deadbeef"
@@ -54,7 +58,8 @@ class ImplicitDefaultLocaleSpec : Spek({
         }
 
         it("reports String.toLowerCase() call without explicit locale") {
-            val code = """
+            val code =
+                """
                 fun x() {
                     val s = "deadbeef"
                     s.toLowerCase()
@@ -63,7 +68,8 @@ class ImplicitDefaultLocaleSpec : Spek({
         }
 
         it("does not report String.toLowerCase() call with explicit locale") {
-            val code = """
+            val code =
+                """
                 import java.util.Locale
                 fun x() {
                     val s = "deadbeef"
@@ -73,7 +79,8 @@ class ImplicitDefaultLocaleSpec : Spek({
         }
 
         it("reports String?.toUpperCase() call without explicit locale") {
-            val code = """
+            val code =
+                """
                 fun x() {
                     val s: String? = "deadbeef"
                     s?.toUpperCase()
@@ -82,7 +89,8 @@ class ImplicitDefaultLocaleSpec : Spek({
         }
 
         it("reports String?.toLowerCase() call without explicit locale") {
-            val code = """
+            val code =
+                """
                 fun x() {
                     val s: String? = "deadbeef"
                     s?.toLowerCase()

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/InvalidRangeSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/InvalidRangeSpec.kt
@@ -12,7 +12,8 @@ class InvalidRangeSpec : Spek({
     describe("check for loop conditions") {
 
         it("does not report correct bounds in for loop conditions") {
-            val code = """
+            val code =
+                """
                 fun f() {
                     for (i in 2..2) {}
                     for (i in 2 downTo 2) {}
@@ -24,7 +25,8 @@ class InvalidRangeSpec : Spek({
         }
 
         it("reports incorrect bounds in for loop conditions") {
-            val code = """
+            val code =
+                """
                 fun f() {
                     for (i in 2..1) { }
                     for (i in 1 downTo 2) { }
@@ -35,7 +37,8 @@ class InvalidRangeSpec : Spek({
         }
 
         it("reports nested loops with incorrect bounds in for loop conditions") {
-            val code = """
+            val code =
+                """
                 fun f() {
                     for (i in 2..2) {
                         for (i in 2..1) { }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/LateinitUsageSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/LateinitUsageSpec.kt
@@ -11,7 +11,8 @@ import java.util.regex.PatternSyntaxException
 class LateinitUsageSpec : Spek({
 
     describe("LateinitUsage rule") {
-        val code = """
+        val code =
+            """
             import kotlin.SinceKotlin
 
             class SomeRandomTest {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MapGetWithNotNullAssertSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MapGetWithNotNullAssertSpec.kt
@@ -18,7 +18,8 @@ class MapGetWithNotNullAssertSpec : Spek({
     describe("check for MapGetWithNotNullAssert") {
 
         it("reports map[] with not null assertion") {
-            val code = """
+            val code =
+                """
                 fun f() {
                     val map = emptyMap<Any, Any>()
                     val value = map["key"]!!
@@ -27,7 +28,8 @@ class MapGetWithNotNullAssertSpec : Spek({
         }
 
         it("reports map.get() with not null assertion") {
-            val code = """
+            val code =
+                """
                 fun f() {
                     val map = emptyMap<Any, Any>()
                     val value = map.get("key")!!
@@ -36,7 +38,8 @@ class MapGetWithNotNullAssertSpec : Spek({
         }
 
         it("does not report map[] call without not-null assert") {
-            val code = """
+            val code =
+                """
                 fun f() {
                     val map = emptyMap<String, String>()
                     map["key"]
@@ -45,7 +48,8 @@ class MapGetWithNotNullAssertSpec : Spek({
         }
 
         it("does not report map.getValue() call") {
-            val code = """
+            val code =
+                """
                 fun f() {
                     val map = emptyMap<String, String>()
                     map.getValue("key")
@@ -54,7 +58,8 @@ class MapGetWithNotNullAssertSpec : Spek({
         }
 
         it("does not report map.getOrDefault() call") {
-            val code = """
+            val code =
+                """
                 fun f() {
                     val map = emptyMap<String, String>()
                     map.getOrDefault("key", "")
@@ -63,7 +68,8 @@ class MapGetWithNotNullAssertSpec : Spek({
         }
 
         it("does not report map.getOrElse() call") {
-            val code = """
+            val code =
+                """
                 fun f() {
                     val map = emptyMap<String, String>()
                     map.getOrElse("key", { "" })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingWhenCaseSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingWhenCaseSpec.kt
@@ -18,7 +18,8 @@ object MissingWhenCaseSpec : Spek({
     describe("MissingWhenCase rule") {
         context("enum") {
             it("reports when `when` expression used as statement and not all cases covered") {
-                val code = """
+                val code =
+                    """
                 enum class Color {
                     RED,
                     GREEN,
@@ -39,7 +40,8 @@ object MissingWhenCaseSpec : Spek({
             }
 
             it("does not report when `when` expression used as statement and all cases covered") {
-                val code = """
+                val code =
+                    """
                 enum class Color {
                     RED,
                     GREEN,
@@ -66,7 +68,8 @@ object MissingWhenCaseSpec : Spek({
         }
         context("sealed classes") {
             it("reports when `when` expression used as statement and not all cases covered") {
-                val code = """
+                val code =
+                    """
                     sealed class Variant {
                         object VariantA : Variant()
                         class VariantB : Variant()
@@ -87,7 +90,8 @@ object MissingWhenCaseSpec : Spek({
             }
 
             it("does not report when `when` expression used as statement and all cases covered") {
-                val code = """
+                val code =
+                    """
                     sealed class Variant {
                         object VariantA : Variant()
                         class VariantB : Variant()
@@ -115,7 +119,8 @@ object MissingWhenCaseSpec : Spek({
         }
         context("standard when") {
             it("does not report when `when` not checking for missing cases") {
-                val code = """
+                val code =
+                    """
                     fun whenChecks() {
                         val x = 3
                         val s = "3"

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/RedundantElseInWhenSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/RedundantElseInWhenSpec.kt
@@ -18,7 +18,8 @@ object RedundantElseInWhenSpec : Spek({
     describe("RedundantElseInWhen rule") {
         context("enum") {
             it("reports when `when` expression used as statement contains `else` case when all cases already covered") {
-                val code = """
+                val code =
+                    """
                 enum class Color {
                     RED,
                     GREEN,
@@ -39,7 +40,8 @@ object RedundantElseInWhenSpec : Spek({
             }
 
             it("reports when `when` expression contains `else` case when all cases already covered") {
-                val code = """
+                val code =
+                    """
                 enum class Color {
                     RED,
                     GREEN,
@@ -60,7 +62,8 @@ object RedundantElseInWhenSpec : Spek({
             }
 
             it("does not report when `when` expression contains `else` case when not all cases explicitly covered") {
-                val code = """
+                val code =
+                    """
                 enum class Color {
                     RED,
                     GREEN,
@@ -85,7 +88,8 @@ object RedundantElseInWhenSpec : Spek({
             }
 
             it("does not report when `when` expression does not contain else case") {
-                val code = """
+                val code =
+                    """
                 enum class Color {
                     RED,
                     GREEN,
@@ -118,7 +122,8 @@ object RedundantElseInWhenSpec : Spek({
         }
         context("sealed classes") {
             it("reports when `when` expression used as statement contains `else` case when all cases already covered") {
-                val code = """
+                val code =
+                    """
                     sealed class Variant {
                         object VariantA : Variant()
                         class VariantB : Variant()
@@ -139,7 +144,8 @@ object RedundantElseInWhenSpec : Spek({
             }
 
             it("reports when `when` expression contains `else` case when all cases already covered") {
-                val code = """
+                val code =
+                    """
                     sealed class Variant {
                         object VariantA : Variant()
                         class VariantB : Variant()
@@ -160,7 +166,8 @@ object RedundantElseInWhenSpec : Spek({
             }
 
             it("does not report when `when` expression contains `else` case when not all cases explicitly covered") {
-                val code = """
+                val code =
+                    """
                     sealed class Variant {
                         object VariantA : Variant()
                         class VariantB : Variant()
@@ -184,7 +191,8 @@ object RedundantElseInWhenSpec : Spek({
                 assertThat(subject.compileAndLintWithContext(wrapper.env, code)).isEmpty()
             }
             it("does not report when `when` expression does not contain else case") {
-                val code = """
+                val code =
+                    """
                     sealed class Variant {
                         object VariantA : Variant()
                         class VariantB : Variant()
@@ -203,7 +211,8 @@ object RedundantElseInWhenSpec : Spek({
         }
         context("standard when") {
             it("does not report when `when` not checking for missing cases") {
-                val code = """
+                val code =
+                    """
                     fun whenChecks() {
                         val x = 3
                         val s = "3"

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/RedundantSuspendModifierSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/RedundantSuspendModifierSpec.kt
@@ -23,7 +23,8 @@ object RedundantSuspendModifierSpec : Spek({
     describe("RedundantSuspendModifier") {
 
         it("reports when public function returns expression of platform type") {
-            val code = """
+            val code =
+                """
                 import kotlin.coroutines.Continuation
                 import kotlin.coroutines.resume
                 import kotlin.coroutines.suspendCoroutine
@@ -42,7 +43,8 @@ object RedundantSuspendModifierSpec : Spek({
         }
 
         it("does not report when private") {
-            val code = """
+            val code =
+                """
                 import kotlin.coroutines.Continuation
                 import kotlin.coroutines.resume
                 import kotlin.coroutines.suspendCoroutine
@@ -59,7 +61,8 @@ object RedundantSuspendModifierSpec : Spek({
         }
 
         it("does not report when public function returns expression of platform type") {
-            val code = """
+            val code =
+                """
                 class RedundantClass {
                     open suspend fun redundantSuspend() {
                         println("hello world")
@@ -70,7 +73,8 @@ object RedundantSuspendModifierSpec : Spek({
         }
 
         it("ignores when iterator is suspending") {
-            val code = """
+            val code =
+                """
                 class SuspendingIterator {
                     suspend operator fun iterator(): Iterator<Any> = iterator { yield("value") }
                 }
@@ -85,7 +89,8 @@ object RedundantSuspendModifierSpec : Spek({
         }
 
         it("ignores when suspending function used in property delegate") {
-            val code = """
+            val code =
+                """
                 class SuspendingIterator {
                     suspend operator fun iterator(): Iterator<Any> = iterator { yield("value") }
                 }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnconditionalJumpStatementInLoopSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnconditionalJumpStatementInLoopSpec.kt
@@ -22,25 +22,29 @@ class UnconditionalJumpStatementInLoopSpec : Spek({
         }
 
         it("does not report an conditional elvis continue") {
-            val findings = subject.lint("""
+            val findings = subject.lint(
+                """
                 fun main() {
                     fun compute(i: Int) = null
                     for (i in 1..5)  
                         return compute(i) ?: continue
                 }
-            """.trimIndent())
+                """.trimIndent()
+            )
 
             assertThat(findings).isEmpty()
         }
 
         it("reports conditional elvis return") {
-            val findings = subject.lint("""
+            val findings = subject.lint(
+                """
                 fun main() {
                     fun compute(i: Int) = null
                     for (i in 1..5)  
                         return compute(i) ?: return
                 }
-            """.trimIndent())
+                """.trimIndent()
+            )
 
             assertThat(findings).hasSize(1)
         }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessaryNotNullOperatorSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessaryNotNullOperatorSpec.kt
@@ -17,7 +17,8 @@ class UnnecessaryNotNullOperatorSpec : Spek({
     describe("check unnecessary not null operators") {
 
         it("reports a simple not null operator usage") {
-            val code = """
+            val code =
+                """
                 val a = 1
                 val b = a!!
                 """
@@ -27,7 +28,8 @@ class UnnecessaryNotNullOperatorSpec : Spek({
         }
 
         it("reports a chained not null operator usage") {
-            val code = """
+            val code =
+                """
                 val a = 1
                 val b = a!!.plus(42)
                 """
@@ -37,7 +39,8 @@ class UnnecessaryNotNullOperatorSpec : Spek({
         }
 
         it("reports multiple chained not null operator usage") {
-            val code = """
+            val code =
+                """
                 val a = 1
                 val b = a!!.plus(42)!!
                 """
@@ -50,7 +53,8 @@ class UnnecessaryNotNullOperatorSpec : Spek({
     describe("check valid not null operators usage") {
 
         it("does not report a simple not null operator usage on nullable type") {
-            val code = """
+            val code =
+                """
                 val a : Int? = 1
                 val b = a!!
                 """

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessarySafeCallSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessarySafeCallSpec.kt
@@ -17,7 +17,8 @@ class UnnecessarySafeCallSpec : Spek({
     describe("check unnecessary safe operators") {
 
         it("reports a simple safe operator usage") {
-            val code = """
+            val code =
+                """
                 fun test(s: String) {
                     val a = 1
                     val b = a?.toString()
@@ -28,7 +29,8 @@ class UnnecessarySafeCallSpec : Spek({
         }
 
         it("reports a chained safe operator usage") {
-            val code = """
+            val code =
+                """
                 fun test(s: String) {
                     val a = 1
                     val b = a?.plus(42)
@@ -39,7 +41,8 @@ class UnnecessarySafeCallSpec : Spek({
         }
 
         it("reports multiple chained safe operator usage") {
-            val code = """
+            val code =
+                """
                 fun test(s: String) {
                     val a = 1
                     val b = a?.plus(42)?.minus(24)
@@ -53,7 +56,8 @@ class UnnecessarySafeCallSpec : Spek({
     describe("check valid safe operators usage") {
 
         it("does not report a simple safe operator usage on nullable type") {
-            val code = """
+            val code =
+                """
                 fun test(s: String) {
                     val a : Int? = 1
                     val b = a?.plus(42)

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnreachableCodeSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnreachableCodeSpec.kt
@@ -12,7 +12,8 @@ class UnreachableCodeSpec : Spek({
     describe("UnreachableCode rule") {
 
         it("reports unreachable code after return") {
-            val code = """
+            val code =
+                """
                 fun f(i: Int) {
                     if (i == 0) {
                         return
@@ -24,7 +25,8 @@ class UnreachableCodeSpec : Spek({
         }
 
         it("reports unreachable code after return in lambda") {
-            val code = """
+            val code =
+                """
                 fun f(s: String): Boolean {
                     s.let {
                         return it.length < 3
@@ -37,7 +39,8 @@ class UnreachableCodeSpec : Spek({
         }
 
         it("reports unreachable code after return with label") {
-            val code = """
+            val code =
+                """
                 fun f(ints: List<Int>): List<Int> {
                     return ints.map f@{
                         if (it == 0) {
@@ -52,7 +55,8 @@ class UnreachableCodeSpec : Spek({
         }
 
         it("reports unreachable code after throwing an exception") {
-            val code = """
+            val code =
+                """
                 fun f(i: Int) {
                     if (i == 0) {
                         throw IllegalArgumentException()
@@ -64,7 +68,8 @@ class UnreachableCodeSpec : Spek({
         }
 
         it("reports unreachable code after break and continue") {
-            val code = """
+            val code =
+                """
                 fun f() {
                     for (i in 1..2) {
                         break
@@ -80,7 +85,8 @@ class UnreachableCodeSpec : Spek({
         }
 
         it("does not report reachable code after conditional return with label") {
-            val code = """
+            val code =
+                """
                 fun f(ints: List<Int>) {
                     ints.forEach {
                         if (it == 0) return@forEach
@@ -92,7 +98,8 @@ class UnreachableCodeSpec : Spek({
         }
 
         it("does not report reachable code after if") {
-            val code = """
+            val code =
+                """
                 fun f(i: Int) {
                     if (i == 0) {
                         println()
@@ -104,7 +111,8 @@ class UnreachableCodeSpec : Spek({
         }
 
         it("does not report reachable code in if body") {
-            val code = """
+            val code =
+                """
                 fun f(i: Int) {
                     if (i == 0) {
                         println(i)

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCallOnNullableTypeSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCallOnNullableTypeSpec.kt
@@ -17,7 +17,8 @@ class UnsafeCallOnNullableTypeSpec : Spek({
     describe("check all variants of safe/unsafe calls on nullable types") {
 
         it("reports unsafe call on nullable type") {
-            val code = """
+            val code =
+                """
                 fun test(str: String?) {
                     println(str!!.length)
                 }
@@ -26,7 +27,8 @@ class UnsafeCallOnNullableTypeSpec : Spek({
         }
 
         it("does not report unsafe call on platform type") {
-            val code = """
+            val code =
+                """
                 import java.util.UUID
 
                 val version = UUID.randomUUID()!!
@@ -35,7 +37,8 @@ class UnsafeCallOnNullableTypeSpec : Spek({
         }
 
         it("does not report safe call on nullable type") {
-            val code = """
+            val code =
+                """
                 fun test(str: String?) {
                     println(str?.length)
                 }
@@ -44,7 +47,8 @@ class UnsafeCallOnNullableTypeSpec : Spek({
         }
 
         it("does not report safe call in combination with the elvis operator") {
-            val code = """
+            val code =
+                """
                 fun test(str: String?) {
                     println(str?.length ?: 0)
                 }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCastSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCastSpec.kt
@@ -17,7 +17,8 @@ class UnsafeCastSpec : Spek({
     describe("check safe and unsafe casts") {
 
         it("reports cast that cannot succeed") {
-            val code = """
+            val code =
+                """
                 fun test(s: String) {
                     println(s as Int)
                 }"""
@@ -25,7 +26,8 @@ class UnsafeCastSpec : Spek({
         }
 
         it("reports 'safe' cast that cannot succeed") {
-            val code = """
+            val code =
+                """
                 fun test(s: String) {
                     println((s as? Int) ?: 0)
                 }"""
@@ -33,7 +35,8 @@ class UnsafeCastSpec : Spek({
         }
 
         it("does not report cast that might succeed") {
-            val code = """
+            val code =
+                """
                 fun test(s: Any) {
                     println(s as Int)
                 }"""
@@ -41,7 +44,8 @@ class UnsafeCastSpec : Spek({
         }
 
         it("does not report 'safe' cast that might succeed") {
-            val code = """
+            val code =
+                """
                 fun test(s: Any) {
                     println((s as? Int) ?: 0)
                 }"""

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UselessPostfixExpressionSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UselessPostfixExpressionSpec.kt
@@ -11,7 +11,8 @@ class UselessPostfixExpressionSpec : Spek({
     describe("check several types of postfix increments") {
 
         it("overrides the incremented integer") {
-            val code = """
+            val code =
+                """
                 fun f() {
                     var i = 0
                     i = i-- // invalid
@@ -22,7 +23,8 @@ class UselessPostfixExpressionSpec : Spek({
         }
 
         it("does not override the incremented integer") {
-            val code = """
+            val code =
+                """
                 fun f() {
                     var i = 0
                     var j = 0
@@ -32,7 +34,8 @@ class UselessPostfixExpressionSpec : Spek({
         }
 
         it("returns no incremented value") {
-            val code = """
+            val code =
+                """
                 fun f(): Int {
                     var i = 0
                     var j = 0
@@ -43,7 +46,8 @@ class UselessPostfixExpressionSpec : Spek({
         }
 
         it("should not report field increments") {
-            val code = """
+            val code =
+                """
                 class Test {
                     private var runningId: Long = 0
 
@@ -66,7 +70,8 @@ class UselessPostfixExpressionSpec : Spek({
         }
 
         it("should detect properties shadowing fields that are incremented") {
-            val code = """
+            val code =
+                """
                 class Test {
                     private var runningId: Long = 0
 
@@ -90,7 +95,8 @@ class UselessPostfixExpressionSpec : Spek({
     describe("Only ++ and -- postfix operators should be considered") {
 
         it("should not report !! in a return statement") {
-            val code = """
+            val code =
+                """
                 val str: String? = ""
 
                 fun f1(): String {
@@ -105,7 +111,8 @@ class UselessPostfixExpressionSpec : Spek({
         }
 
         it("should not report !! in a standalone expression") {
-            val code = """
+            val code =
+                """
                 fun f() {
                     val str: String? = ""
                     str!!

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/WrongEqualsTypeParameterSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/WrongEqualsTypeParameterSpec.kt
@@ -12,7 +12,8 @@ class WrongEqualsTypeParameterSpec : Spek({
     describe("WrongEqualsTypeParameter rule") {
 
         it("does not report Any? as parameter") {
-            val code = """
+            val code =
+                """
                 class A {
                     override fun equals(other: Any?): Boolean {
                         return super.equals(other)
@@ -22,7 +23,8 @@ class WrongEqualsTypeParameterSpec : Spek({
         }
 
         it("reports a String as parameter") {
-            val code = """
+            val code =
+                """
                 class A {
                     fun equals(other: String): Boolean {
                         return super.equals(other)
@@ -32,7 +34,8 @@ class WrongEqualsTypeParameterSpec : Spek({
         }
 
         it("does not report equals() with an additional parameter") {
-            val code = """
+            val code =
+                """
                 class A {
                     fun equals(other: Any?, i: Int): Boolean {
                         return super.equals(other)
@@ -42,7 +45,8 @@ class WrongEqualsTypeParameterSpec : Spek({
         }
 
         it("does not report an overridden equals() with a different signature") {
-            val code = """
+            val code =
+                """
                 interface I {
                     fun equals(other: Any?, i: Int): Boolean
                     fun equals(): Boolean
@@ -59,7 +63,8 @@ class WrongEqualsTypeParameterSpec : Spek({
         }
 
         it("does not report an interface declaration") {
-            val code = """
+            val code =
+                """
                 interface I {
                     fun equals(other: String)
                 }"""
@@ -67,7 +72,8 @@ class WrongEqualsTypeParameterSpec : Spek({
         }
 
         it("does not report top level functions") {
-            val code = """
+            val code =
+                """
                 fun equals(other: String) {}
                 fun equals(other: Any?) {}
                 """

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexConditionSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexConditionSpec.kt
@@ -9,7 +9,8 @@ class ComplexConditionSpec : Spek({
 
     describe("ComplexCondition rule") {
 
-        val code = """
+        val code =
+            """
             val a = if (5 > 4 && 4 < 6 || (3 < 5 || 2 < 5)) { 42 } else { 24 }
 
             fun complexConditions() {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexInterfaceSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexInterfaceSpec.kt
@@ -15,7 +15,8 @@ class ComplexInterfaceSpec : Spek({
     describe("ComplexInterface rule positives") {
 
         context("interface members") {
-            val code = """
+            val code =
+                """
                 interface I {
                     fun f1()
                     fun f2()
@@ -35,7 +36,8 @@ class ComplexInterfaceSpec : Spek({
         }
 
         context("nested interface members") {
-            val code = """
+            val code =
+                """
                 class I {
                     interface Nested {
                         fun f1()
@@ -57,7 +59,8 @@ class ComplexInterfaceSpec : Spek({
         }
 
         context("interface with static declarations") {
-            val code = """
+            val code =
+                """
                 interface I {
                     fun f1()
                     companion object {
@@ -79,7 +82,8 @@ class ComplexInterfaceSpec : Spek({
         }
 
         context("private functions") {
-            val code = """
+            val code =
+                """
                 interface I {
                     fun f1()
                     fun f2()
@@ -99,7 +103,8 @@ class ComplexInterfaceSpec : Spek({
         }
 
         context("private members") {
-            val code = """
+            val code =
+                """
                 interface I {
                     fun f1()
                     fun f2()
@@ -123,7 +128,8 @@ class ComplexInterfaceSpec : Spek({
     describe("ComplexInterface rule negatives") {
 
         it("does not report a simple interface ") {
-            val code = """
+            val code =
+                """
                 interface I {
                     fun f()
                     fun fImpl() {
@@ -138,7 +144,8 @@ class ComplexInterfaceSpec : Spek({
         }
 
         it("does not report a simple interface with a companion object") {
-            val code = """
+            val code =
+                """
                 interface I {
                     fun f()
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexMethodSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexMethodSpec.kt
@@ -19,30 +19,35 @@ class ComplexMethodSpec : Spek({
         context("different complex constructs") {
 
             it("counts different loops") {
-                val findings = ComplexMethod(threshold = 1).compileAndLint("""
+                val findings = ComplexMethod(threshold = 1).compileAndLint(
+                    """
                     fun test() {
                         for (i in 1..10) {}
                         while (true) {}
                         do {} while(true)
                         (1..10).forEach {}
                     }
-                """.trimIndent())
+                    """.trimIndent()
+                )
 
                 assertThat(findings.first()).isThresholded().withValue(defaultComplexity + 4)
             }
 
             it("counts catch blocks") {
-                val findings = ComplexMethod(threshold = 1).compileAndLint("""
+                val findings = ComplexMethod(threshold = 1).compileAndLint(
+                    """
                     fun test() {
                         try {} catch(e: IllegalArgumentException) {} catch(e: Exception) {} finally {}
                     }
-                """.trimIndent())
+                    """.trimIndent()
+                )
 
                 assertThat(findings.first()).isThresholded().withValue(defaultComplexity + 2)
             }
 
             it("counts nested conditional statements") {
-                val findings = ComplexMethod(threshold = 1).compileAndLint("""
+                val findings = ComplexMethod(threshold = 1).compileAndLint(
+                    """
                     fun test() {
                         try {
                             while (true) {
@@ -57,7 +62,8 @@ class ComplexMethodSpec : Spek({
                             // only catches count
                         }
                     }
-                """.trimIndent())
+                    """.trimIndent()
+                )
 
                 assertThat(findings.first()).isThresholded().withValue(defaultComplexity + 4)
             }
@@ -65,11 +71,12 @@ class ComplexMethodSpec : Spek({
 
         context("nesting functions") {
 
-            val code = """
-                    fun test() {
-                        for (i in 1..10) {}
-                        (1..10).forEach {}
-                    }
+            val code =
+                """
+                fun test() {
+                    for (i in 1..10) {}
+                    (1..10).forEach {}
+                }
                 """.trimIndent()
 
             fun execute(config: TestConfig, expectedValue: Int) {
@@ -114,8 +121,11 @@ class ComplexMethodSpec : Spek({
             val path = Case.ComplexMethods.path()
 
             it("does not report complex methods with a single when expression") {
-                val config = TestConfig(mapOf(
-                    ComplexMethod.IGNORE_SINGLE_WHEN_EXPRESSION to "true"))
+                val config = TestConfig(
+                    mapOf(
+                        ComplexMethod.IGNORE_SINGLE_WHEN_EXPRESSION to "true"
+                    )
+                )
                 val subject = ComplexMethod(config, threshold = 4)
 
                 assertThat(subject.lint(path)).hasSourceLocations(SourceLocation(43, 5))
@@ -136,7 +146,8 @@ class ComplexMethodSpec : Spek({
             it("does not trip for a reasonable amount of simple when entries when ignoreSimpleWhenEntries is true") {
                 val config = TestConfig(mapOf(ComplexMethod.IGNORE_SIMPLE_WHEN_ENTRIES to "true"))
                 val subject = ComplexMethod(config)
-                val code = """
+                val code =
+                    """
                      fun f() {
                         val map = HashMap<Any, String>()
                         for ((key, value) in map) {
@@ -162,7 +173,8 @@ class ComplexMethodSpec : Spek({
 
         context("function containing object literal with many overridden functions") {
 
-            val code = """
+            val code =
+                """
             fun f(): List<Any> {
                 return object : List<Any> {
                     override val size: Int get() = TODO("not implemented")

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LabeledExpressionSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LabeledExpressionSpec.kt
@@ -13,7 +13,8 @@ class LabeledExpressionSpec : Spek({
     describe("LabeledExpression rule") {
 
         it("reports break and continue labels") {
-            val code = """
+            val code =
+                """
                 fun f() {
                     loop@ for (i in 1..3) {
                         for (j in 1..3) {
@@ -27,7 +28,8 @@ class LabeledExpressionSpec : Spek({
         }
 
         it("reports implicit return label") {
-            val code = """
+            val code =
+                """
                 fun f(range: IntRange) {
                     range.forEach {
                         if (it == 5) return@forEach
@@ -39,7 +41,8 @@ class LabeledExpressionSpec : Spek({
         }
 
         it("reports explicit return label") {
-            val code = """
+            val code =
+                """
                 fun f(range: IntRange) {
                     range.forEach label@{
                         if (it == 5) return@label
@@ -51,7 +54,8 @@ class LabeledExpressionSpec : Spek({
         }
 
         it("reports labels referencing inner and outer class") {
-            val code = """
+            val code =
+                """
                 class Outer {
                     inner class Inner {
                         fun f() {
@@ -69,7 +73,8 @@ class LabeledExpressionSpec : Spek({
         }
 
         it("does not report inner class referencing outer class") {
-            val code = """
+            val code =
+                """
             class Outer {
                 inner class Inner {
                     fun f() {
@@ -82,7 +87,8 @@ class LabeledExpressionSpec : Spek({
         }
 
         it("does not report inner class referencing outer class in extension function") {
-            val code = """
+            val code =
+                """
             class Outer {
                 inner class Inner {
                     fun Int.f() {
@@ -96,7 +102,8 @@ class LabeledExpressionSpec : Spek({
         }
 
         it("does not report nested class referencing outer class in extension function") {
-            val code = """
+            val code =
+                """
             class Outer {
                 class Nested {
                     fun Int.f() {
@@ -109,7 +116,8 @@ class LabeledExpressionSpec : Spek({
         }
 
         it("does not report inner classes referencing outer class in extension function") {
-            val code = """
+            val code =
+                """
             class Outer {
                 inner class Inner {
                     inner class InnerInner {
@@ -129,7 +137,8 @@ class LabeledExpressionSpec : Spek({
         }
 
         it("does not report excluded label") {
-            val code = """
+            val code =
+                """
                 fun f() {
                     loop@ for (i in 1..5) {}
                 }
@@ -140,7 +149,8 @@ class LabeledExpressionSpec : Spek({
         }
 
         it("does not report excluded label config with string") {
-            val code = """
+            val code =
+                """
                 fun f() {
                     loop@ for (i in 1..5) {}
                 }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LargeClassSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LargeClassSpec.kt
@@ -22,7 +22,8 @@ class LargeClassSpec : Spek({
     describe("files without classes should not be considered") {
 
         it("should not report anything in files without classes") {
-            val code = """
+            val code =
+                """
                 val i = 0 
 
                 fun f() {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongMethodSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongMethodSpec.kt
@@ -12,7 +12,8 @@ class LongMethodSpec : Spek({
     describe("nested functions can be long") {
 
         it("should find two long methods") {
-            val code = """
+            val code =
+                """
                 fun longMethod() { // 5 lines
                     println()
                     println()
@@ -32,7 +33,8 @@ class LongMethodSpec : Spek({
         }
 
         it("should not find too long methods") {
-            val code = """
+            val code =
+                """
                 fun methodOk() { // 3 lines
                     println()
                     fun localMethodOk() { // 4 lines

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterListSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterListSpec.kt
@@ -9,19 +9,21 @@ import org.spekframework.spek2.style.specification.describe
 class LongParameterListSpec : Spek({
 
     val defaultThreshold = 2
-    val defaultConfig = TestConfig(mapOf(
-        LongParameterList.FUNCTION_THRESHOLD to defaultThreshold,
-        LongParameterList.CONSTRUCTOR_THRESHOLD to defaultThreshold
-    ))
+    val defaultConfig = TestConfig(
+        mapOf(
+            LongParameterList.FUNCTION_THRESHOLD to defaultThreshold,
+            LongParameterList.CONSTRUCTOR_THRESHOLD to defaultThreshold
+        )
+    )
 
     val subject by memoized { LongParameterList(defaultConfig) }
 
     describe("LongParameterList rule") {
 
         val reportMessageForFunction = "The function long(a: Int, b: Int) has too many parameters. " +
-                "The current threshold is set to $defaultThreshold."
+            "The current threshold is set to $defaultThreshold."
         val reportMessageForConstructor = "The constructor(a: Int, b: Int) has too many parameters. " +
-                "The current threshold is set to $defaultThreshold."
+            "The current threshold is set to $defaultThreshold."
 
         it("reports too long parameter list") {
             val code = "fun long(a: Int, b: Int) {}"
@@ -79,10 +81,12 @@ class LongParameterListSpec : Spek({
         }
 
         it("does not report long parameter list for constructors of data classes if asked") {
-            val config = TestConfig(mapOf(
-                LongParameterList.IGNORE_DATA_CLASSES to "true",
-                LongParameterList.CONSTRUCTOR_THRESHOLD to "1"
-            ))
+            val config = TestConfig(
+                mapOf(
+                    LongParameterList.IGNORE_DATA_CLASSES to "true",
+                    LongParameterList.CONSTRUCTOR_THRESHOLD to "1"
+                )
+            )
             val rule = LongParameterList(config)
             val code = "data class Data(val a: Int)"
             assertThat(rule.compileAndLint(code)).isEmpty()
@@ -90,11 +94,13 @@ class LongParameterListSpec : Spek({
 
         describe("constructors and functions with ignored annotations") {
 
-            val config = TestConfig(mapOf(
-                LongParameterList.IGNORE_ANNOTATED to listOf("javax.annotation.Generated", "kotlin.Deprecated"),
-                LongParameterList.FUNCTION_THRESHOLD to 1,
-                LongParameterList.CONSTRUCTOR_THRESHOLD to 1
-            ))
+            val config = TestConfig(
+                mapOf(
+                    LongParameterList.IGNORE_ANNOTATED to listOf("javax.annotation.Generated", "kotlin.Deprecated"),
+                    LongParameterList.FUNCTION_THRESHOLD to 1,
+                    LongParameterList.CONSTRUCTOR_THRESHOLD to 1
+                )
+            )
             val rule = LongParameterList(config)
 
             it("does not report long parameter list for constructors if file is annotated with ignored annotation") {
@@ -103,7 +109,8 @@ class LongParameterListSpec : Spek({
             }
 
             it("does not report long parameter list for functions if file is annotated with ignored annotation") {
-                val code = """
+                val code =
+                    """
                     @file:javax.annotation.Generated 
                     class Data { 
                         fun foo(a: Int) {} 
@@ -118,7 +125,8 @@ class LongParameterListSpec : Spek({
             }
 
             it("does not report long parameter list for functions if class is annotated with ignored annotation") {
-                val code = """
+                val code =
+                    """
                     @javax.annotation.Generated class Data { 
                         fun foo(a: Int) {} 
                     }
@@ -132,7 +140,8 @@ class LongParameterListSpec : Spek({
             }
 
             it("does not report long parameter list for functions if function is annotated with ignored annotation") {
-                val code = """class Data {
+                val code =
+                    """class Data {
                     @kotlin.Deprecated(message = "") fun foo(a: Int, b: Int, c: Int, d: Int, e: Int, f: Int, g: Int) {} }
                 """
                 assertThat(rule.compileAndLint(code)).isEmpty()

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/MethodOverloadingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/MethodOverloadingSpec.kt
@@ -14,7 +14,8 @@ class MethodOverloadingSpec : Spek({
         context("several overloaded methods") {
 
             it("reports overloaded methods which exceed the threshold") {
-                val code = """
+                val code =
+                    """
                     class Test {
                         fun x() {}
                         fun x(i: Int) {}
@@ -27,7 +28,8 @@ class MethodOverloadingSpec : Spek({
             }
 
             it("reports overloaded top level methods which exceed the threshold") {
-                val code = """
+                val code =
+                    """
                     fun x() {}
                     fun x(i: Int) {}
                     fun x(i: Int, j: Int) {}
@@ -36,11 +38,13 @@ class MethodOverloadingSpec : Spek({
             }
 
             it("does not report overloaded methods which do not exceed the threshold") {
-                subject.compileAndLint("""
+                subject.compileAndLint(
+                    """
                 class Test {
                     fun x() { }
                     fun x(i: Int) { }
-                }""")
+                }"""
+                )
                 assertThat(subject.findings.size).isZero()
             }
         }
@@ -48,18 +52,22 @@ class MethodOverloadingSpec : Spek({
         context("several overloaded extensions methods") {
 
             it("does not report extension methods with a different receiver") {
-                subject.compileAndLint("""
+                subject.compileAndLint(
+                    """
                 fun Boolean.foo() {}
                 fun Int.foo() {}
-                fun Long.foo() {}""")
+                fun Long.foo() {}"""
+                )
                 assertThat(subject.findings.size).isZero()
             }
 
             it("reports extension methods with the same receiver") {
-                subject.compileAndLint("""
+                subject.compileAndLint(
+                    """
                 fun Int.foo() {}
                 fun Int.foo(i: Int) {}
-                fun Int.foo(i: String) {}""")
+                fun Int.foo(i: String) {}"""
+                )
                 assertThat(subject.findings.size).isEqualTo(1)
             }
         }
@@ -67,7 +75,8 @@ class MethodOverloadingSpec : Spek({
         context("several nested overloaded methods") {
 
             it("reports nested overloaded methods which exceed the threshold") {
-                val code = """
+                val code =
+                    """
                     class Outer {
                         internal class Inner {
                             fun f() {}
@@ -80,7 +89,8 @@ class MethodOverloadingSpec : Spek({
             }
 
             it("does not report nested overloaded methods which do not exceed the threshold") {
-                val code = """
+                val code =
+                    """
                     class Outer {
 
                         fun f() {}
@@ -98,7 +108,8 @@ class MethodOverloadingSpec : Spek({
         context("several overloaded methods inside objects") {
 
             it("reports overloaded methods inside an object which exceed the threshold") {
-                val code = """
+                val code =
+                    """
                     object Test {
                         fun f() {}
                         fun f(i: Int) {}
@@ -109,7 +120,8 @@ class MethodOverloadingSpec : Spek({
             }
 
             it("does not report overloaded methods inside an object which do not exceed the threshold") {
-                val code = """
+                val code =
+                    """
                     object Test {
                         fun f() {}
                         fun f(i: Int) {}
@@ -119,7 +131,8 @@ class MethodOverloadingSpec : Spek({
             }
 
             it("reports overloaded methods inside a companion object which exceed the threshold") {
-                val code = """
+                val code =
+                    """
                     class Test {
                         companion object {
                             fun f() {}
@@ -132,7 +145,8 @@ class MethodOverloadingSpec : Spek({
             }
 
             it("does not report overloaded methods in a companion object that do not exceed the threshold") {
-                val code = """
+                val code =
+                    """
                     class Test {
                         companion object {
                             fun f() {}
@@ -144,7 +158,8 @@ class MethodOverloadingSpec : Spek({
             }
 
             it("does not report overloaded methods in classes/objects that do not exceed the threshold") {
-                val code = """
+                val code =
+                    """
                     class Test {
 
                         fun f() {}
@@ -159,7 +174,8 @@ class MethodOverloadingSpec : Spek({
             }
 
             it("reports overloaded methods inside an anonymous object expression") {
-                val code = """
+                val code =
+                    """
                     class A {
                     
                         fun f() {
@@ -178,7 +194,8 @@ class MethodOverloadingSpec : Spek({
         context("several overloaded methods inside enum classes") {
 
             it("does not report overridden methods inside enum entries") {
-                val code = """
+                val code =
+                    """
                     enum class Test {
                         E1 {
                             override fun f() {}
@@ -197,7 +214,8 @@ class MethodOverloadingSpec : Spek({
             }
 
             it("reports overloaded methods in enum entry") {
-                val code = """
+                val code =
+                    """
                     enum class Test {
                         E {
                             fun f(i: Int) {}
@@ -210,7 +228,8 @@ class MethodOverloadingSpec : Spek({
             }
 
             it("reports overloaded methods in enum class") {
-                val code = """
+                val code =
+                    """
                     enum class Test {
                         E;
                     
@@ -229,7 +248,8 @@ class MethodOverloadingSpec : Spek({
         }
 
         it("does not report overloaded local functions") {
-            val code = """
+            val code =
+                """
                 fun top() {
                     fun f() {}
                     fun f(i: Int) {}

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedBlockDepthSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedBlockDepthSpec.kt
@@ -21,7 +21,8 @@ class NestedBlockDepthSpec : Spek({
         }
 
         it("should detect too nested block depth") {
-            val code = """
+            val code =
+                """
                 fun f() {
                     if (true) {
                         if (true) {
@@ -39,7 +40,8 @@ class NestedBlockDepthSpec : Spek({
         }
 
         it("should not detect valid nested block depth") {
-            val code = """
+            val code =
+                """
                 fun f() {
                     if (true) {
                         if (true) {
@@ -52,7 +54,8 @@ class NestedBlockDepthSpec : Spek({
         }
 
         it("does not report valid nested if else branches") {
-            val code = """
+            val code =
+                """
                 fun f() {
                     if (true) {
                         if (true) {
@@ -66,7 +69,8 @@ class NestedBlockDepthSpec : Spek({
         }
 
         it("reports deeply nested if else branches") {
-            val code = """
+            val code =
+                """
                 fun f() {
                     if (true) {
                         if (true) {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/StringLiteralDuplicationSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/StringLiteralDuplicationSpec.kt
@@ -17,7 +17,8 @@ class StringLiteralDuplicationSpec : Spek({
         context("many hardcoded strings") {
 
             it("reports 3 equal hardcoded strings") {
-                val code = """
+                val code =
+                    """
                 class Duplication {
                     var s1 = "lorem"
                     fun f(s: String = "lorem") {
@@ -28,14 +29,16 @@ class StringLiteralDuplicationSpec : Spek({
             }
 
             it("does not report 2 equal hardcoded strings") {
-                val code = """val str = "lorem" + "lorem" + "ipsum""""
+                val code =
+                    """val str = "lorem" + "lorem" + "ipsum""""
                 assertThat(subject.compileAndLint(code)).isEmpty()
             }
         }
 
         context("strings in annotations") {
 
-            val code = """
+            val code =
+                """
                 @Suppress("unused")
                 class A
                 @Suppress("unused")
@@ -56,7 +59,8 @@ class StringLiteralDuplicationSpec : Spek({
 
         context("strings with less than 5 characters") {
 
-            val code = """val str = "amet" + "amet" + "amet""""
+            val code =
+                """val str = "amet" + "amet" + "amet""""
 
             it("does not report strings with 4 characters") {
                 assertThat(subject.compileAndLint(code)).isEmpty()
@@ -70,13 +74,15 @@ class StringLiteralDuplicationSpec : Spek({
 
         context("strings with values to match for the regex") {
 
-            val regexTestingCode = """
+            val regexTestingCode =
+                """
                 val str1 = "lorem" + "lorem" + "lorem"
                 val str2 = "ipsum" + "ipsum" + "ipsum"
             """
 
             it("does not report lorem or ipsum according to config in regex") {
-                val code = """
+                val code =
+                    """
                     val str1 = "lorem" + "lorem" + "lorem"
                     val str2 = "ipsum" + "ipsum" + "ipsum"
                 """
@@ -86,8 +92,8 @@ class StringLiteralDuplicationSpec : Spek({
 
             it("should not fail with invalid regex when disabled") {
                 val configValues = mapOf(
-                        "active" to "false",
-                        StringLiteralDuplication.IGNORE_STRINGS_REGEX to "*lorem"
+                    "active" to "false",
+                    StringLiteralDuplication.IGNORE_STRINGS_REGEX to "*lorem"
                 )
                 val config = TestConfig(configValues)
                 assertFindingWithConfig(regexTestingCode, config, 0)
@@ -104,7 +110,8 @@ class StringLiteralDuplicationSpec : Spek({
         describe("saves string literal references") {
 
             it("reports 3 locations for 'lorem'") {
-                val code = """
+                val code =
+                    """
                 class Duplication {
                     var s1 = "lorem"
                     fun f(s: String = "lorem") {
@@ -120,7 +127,8 @@ class StringLiteralDuplicationSpec : Spek({
         describe("multiline strings with string interpolation") {
 
             it("does not report duplicated parts in multiline strings") {
-                val code = """
+                val code =
+                    """
                     // does not report because it treats the multiline string parts as one string
                     val str = ""${'"'}
                         |

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/TooManyFunctionsSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/TooManyFunctionsSpec.kt
@@ -10,16 +10,21 @@ class TooManyFunctionsSpec : Spek({
 
     describe("different declarations with one function as threshold") {
 
-        val rule = TooManyFunctions(TestConfig(mapOf(
-                TooManyFunctions.THRESHOLD_IN_CLASSES to "1",
-                TooManyFunctions.THRESHOLD_IN_ENUMS to "1",
-                TooManyFunctions.THRESHOLD_IN_FILES to "1",
-                TooManyFunctions.THRESHOLD_IN_INTERFACES to "1",
-                TooManyFunctions.THRESHOLD_IN_OBJECTS to "1"
-        )))
+        val rule = TooManyFunctions(
+            TestConfig(
+                mapOf(
+                    TooManyFunctions.THRESHOLD_IN_CLASSES to "1",
+                    TooManyFunctions.THRESHOLD_IN_ENUMS to "1",
+                    TooManyFunctions.THRESHOLD_IN_FILES to "1",
+                    TooManyFunctions.THRESHOLD_IN_INTERFACES to "1",
+                    TooManyFunctions.THRESHOLD_IN_OBJECTS to "1"
+                )
+            )
+        )
 
         it("finds one function in class") {
-            val code = """
+            val code =
+                """
                 class A {
                     fun a() = Unit
                 }
@@ -31,7 +36,8 @@ class TooManyFunctionsSpec : Spek({
         }
 
         it("finds one function in object") {
-            val code = """
+            val code =
+                """
                 object O {
                     fun o() = Unit
                 }
@@ -43,7 +49,8 @@ class TooManyFunctionsSpec : Spek({
         }
 
         it("finds one function in interface") {
-            val code = """
+            val code =
+                """
                 interface I {
                     fun i()
                 }
@@ -55,7 +62,8 @@ class TooManyFunctionsSpec : Spek({
         }
 
         it("finds one function in enum") {
-            val code = """
+            val code =
+                """
                 enum class E {
                     A;
                     fun e() {}
@@ -74,7 +82,8 @@ class TooManyFunctionsSpec : Spek({
         }
 
         it("finds one function in file ignoring other declarations") {
-            val code = """
+            val code =
+                """
                 fun f1() = Unit
                 class C
                 object O
@@ -88,7 +97,8 @@ class TooManyFunctionsSpec : Spek({
         }
 
         it("finds one function in nested class") {
-            val code = """
+            val code =
+                """
                 class A {
                     class B {
                         fun a() = Unit
@@ -102,7 +112,8 @@ class TooManyFunctionsSpec : Spek({
         }
 
         describe("different deprecated functions") {
-            val code = """
+            val code =
+                """
                 @Deprecated("")
                 fun f() {
                 }
@@ -119,18 +130,23 @@ class TooManyFunctionsSpec : Spek({
             }
 
             it("finds no deprecated functions") {
-                val configuredRule = TooManyFunctions(TestConfig(mapOf(
-                        TooManyFunctions.THRESHOLD_IN_CLASSES to "1",
-                        TooManyFunctions.THRESHOLD_IN_FILES to "1",
-                        TooManyFunctions.IGNORE_DEPRECATED to "true"
-                )))
+                val configuredRule = TooManyFunctions(
+                    TestConfig(
+                        mapOf(
+                            TooManyFunctions.THRESHOLD_IN_CLASSES to "1",
+                            TooManyFunctions.THRESHOLD_IN_FILES to "1",
+                            TooManyFunctions.IGNORE_DEPRECATED to "true"
+                        )
+                    )
+                )
                 assertThat(configuredRule.compileAndLint(code)).isEmpty()
             }
         }
 
         describe("different private functions") {
 
-            val code = """
+            val code =
+                """
                 class A {
                     private fun f() {}
                 }
@@ -141,11 +157,15 @@ class TooManyFunctionsSpec : Spek({
             }
 
             it("finds no private functions") {
-                val configuredRule = TooManyFunctions(TestConfig(mapOf(
-                        TooManyFunctions.THRESHOLD_IN_CLASSES to "1",
-                        TooManyFunctions.THRESHOLD_IN_FILES to "1",
-                        TooManyFunctions.IGNORE_PRIVATE to "true"
-                )))
+                val configuredRule = TooManyFunctions(
+                    TestConfig(
+                        mapOf(
+                            TooManyFunctions.THRESHOLD_IN_CLASSES to "1",
+                            TooManyFunctions.THRESHOLD_IN_FILES to "1",
+                            TooManyFunctions.IGNORE_PRIVATE to "true"
+                        )
+                    )
+                )
                 assertThat(configuredRule.compileAndLint(code)).isEmpty()
             }
         }
@@ -153,7 +173,8 @@ class TooManyFunctionsSpec : Spek({
         describe("false negative when private and deprecated functions are ignored - #1439") {
 
             it("should not report when file has no public functions") {
-                val code = """
+                val code =
+                    """
                     class A {
                         private fun a() = Unit
                         private fun b() = Unit
@@ -171,20 +192,25 @@ class TooManyFunctionsSpec : Spek({
                         override fun b() = Unit
                     }
                 """
-                val configuredRule = TooManyFunctions(TestConfig(mapOf(
-                        TooManyFunctions.THRESHOLD_IN_CLASSES to "1",
-                        TooManyFunctions.THRESHOLD_IN_FILES to "1",
-                        TooManyFunctions.IGNORE_PRIVATE to "true",
-                        TooManyFunctions.IGNORE_DEPRECATED to "true",
-                        TooManyFunctions.IGNORE_OVERRIDDEN to "true"
-                )))
+                val configuredRule = TooManyFunctions(
+                    TestConfig(
+                        mapOf(
+                            TooManyFunctions.THRESHOLD_IN_CLASSES to "1",
+                            TooManyFunctions.THRESHOLD_IN_FILES to "1",
+                            TooManyFunctions.IGNORE_PRIVATE to "true",
+                            TooManyFunctions.IGNORE_DEPRECATED to "true",
+                            TooManyFunctions.IGNORE_OVERRIDDEN to "true"
+                        )
+                    )
+                )
                 assertThat(configuredRule.compileAndLint(code)).isEmpty()
             }
         }
 
         describe("overridden functions") {
 
-            val code = """
+            val code =
+                """
                     interface I1 {
                         fun func1()
                         fun func2()
@@ -197,20 +223,28 @@ class TooManyFunctionsSpec : Spek({
                 """
 
             it("should not report class with overridden functions, if ignoreOverridden is enabled") {
-                val configuredRule = TooManyFunctions(TestConfig(mapOf(
-                        TooManyFunctions.THRESHOLD_IN_CLASSES to "1",
-                        TooManyFunctions.THRESHOLD_IN_FILES to "1",
-                        TooManyFunctions.IGNORE_OVERRIDDEN to "true"
-                )))
+                val configuredRule = TooManyFunctions(
+                    TestConfig(
+                        mapOf(
+                            TooManyFunctions.THRESHOLD_IN_CLASSES to "1",
+                            TooManyFunctions.THRESHOLD_IN_FILES to "1",
+                            TooManyFunctions.IGNORE_OVERRIDDEN to "true"
+                        )
+                    )
+                )
                 assertThat(configuredRule.compileAndLint(code)).isEmpty()
             }
 
             it("should count overridden functions, if ignoreOverridden is disabled") {
-                val configuredRule = TooManyFunctions(TestConfig(mapOf(
-                        TooManyFunctions.THRESHOLD_IN_CLASSES to "1",
-                        TooManyFunctions.THRESHOLD_IN_FILES to "1",
-                        TooManyFunctions.IGNORE_OVERRIDDEN to "false"
-                )))
+                val configuredRule = TooManyFunctions(
+                    TestConfig(
+                        mapOf(
+                            TooManyFunctions.THRESHOLD_IN_CLASSES to "1",
+                            TooManyFunctions.THRESHOLD_IN_FILES to "1",
+                            TooManyFunctions.IGNORE_OVERRIDDEN to "false"
+                        )
+                    )
+                )
                 assertThat(configuredRule.compileAndLint(code)).hasSize(1)
             }
         }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/GlobalCoroutineUsageSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/GlobalCoroutineUsageSpec.kt
@@ -12,7 +12,8 @@ object GlobalCoroutineUsageSpec : Spek({
     describe("GlobalCoroutineUsage rule") {
 
         it("should report GlobalScope.launch") {
-            val code = """
+            val code =
+                """
                 import kotlinx.coroutines.delay
                 import kotlinx.coroutines.GlobalScope
                 import kotlinx.coroutines.launch
@@ -25,7 +26,8 @@ object GlobalCoroutineUsageSpec : Spek({
         }
 
         it("should report GlobalScope.async") {
-            val code = """
+            val code =
+                """
                 import kotlinx.coroutines.async
                 import kotlinx.coroutines.delay
                 import kotlinx.coroutines.GlobalScope
@@ -38,7 +40,8 @@ object GlobalCoroutineUsageSpec : Spek({
         }
 
         it("should not report bar(GlobalScope)") {
-            val code = """
+            val code =
+                """
                 import kotlinx.coroutines.CoroutineScope
                 import kotlinx.coroutines.GlobalScope
 
@@ -52,7 +55,8 @@ object GlobalCoroutineUsageSpec : Spek({
         }
 
         it("should not report `val scope = GlobalScope`") {
-            val code = """
+            val code =
+                """
                 import kotlinx.coroutines.CoroutineScope
                 import kotlinx.coroutines.GlobalScope
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/AbsentOrWrongFileLicenseSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/AbsentOrWrongFileLicenseSpec.kt
@@ -21,10 +21,12 @@ internal class AbsentOrWrongFileLicenseSpec : Spek({
     describe("AbsentOrWrongFileLicense rule") {
         context("file with correct license header") {
             it("reports nothing") {
-                val findings = checkLicence("""
+                val findings = checkLicence(
+                    """
                     /* LICENSE */
                     package cases
-                """.trimIndent())
+                    """.trimIndent()
+                )
 
                 assertThat(findings).isEmpty()
             }
@@ -32,10 +34,12 @@ internal class AbsentOrWrongFileLicenseSpec : Spek({
 
         context("file with incorrect license header") {
             it("reports missed license header") {
-                val findings = checkLicence("""
+                val findings = checkLicence(
+                    """
                     /* WRONG LICENSE */
                     package cases
-                """.trimIndent())
+                    """.trimIndent()
+                )
 
                 assertThat(findings).hasSize(1)
             }
@@ -43,9 +47,11 @@ internal class AbsentOrWrongFileLicenseSpec : Spek({
 
         context("file with absent license header") {
             it("reports missed license header") {
-                val findings = checkLicence("""
+                val findings = checkLicence(
+                    """
                     package cases
-                """.trimIndent())
+                    """.trimIndent()
+                )
 
                 assertThat(findings).hasSize(1)
             }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentOverPrivateMethodSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentOverPrivateMethodSpec.kt
@@ -11,7 +11,8 @@ class CommentOverPrivateMethodSpec : Spek({
     describe("CommentOverPrivateFunction rule") {
 
         it("reports private method with a comment") {
-            val code = """
+            val code =
+                """
                 class Test {
                     /**
                      * asdf
@@ -22,7 +23,8 @@ class CommentOverPrivateMethodSpec : Spek({
         }
 
         it("does not report public method with a comment") {
-            val code = """
+            val code =
+                """
                 /**
                  * asdf
                  */
@@ -31,7 +33,8 @@ class CommentOverPrivateMethodSpec : Spek({
         }
 
         it("does not report public method in a class with a comment") {
-            val code = """
+            val code =
+                """
                 class Test {
                     /**
                      * asdf

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentOverPrivatePropertiesSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentOverPrivatePropertiesSpec.kt
@@ -11,7 +11,8 @@ class CommentOverPrivatePropertiesSpec : Spek({
     describe("CommentOverPrivateProperty rule") {
 
         it("reports private property with a comment") {
-            val code = """
+            val code =
+                """
                 /**
                  * asdf
                  */
@@ -20,7 +21,8 @@ class CommentOverPrivatePropertiesSpec : Spek({
         }
 
         it("does not report public property with a comment") {
-            val code = """
+            val code =
+                """
                 /**
                  * asdf
                  */
@@ -29,7 +31,8 @@ class CommentOverPrivatePropertiesSpec : Spek({
         }
 
         it("reports private property in class with a comment") {
-            val code = """
+            val code =
+                """
                     class Test {
                     /**
                      * asdf
@@ -40,7 +43,8 @@ class CommentOverPrivatePropertiesSpec : Spek({
         }
 
         it("does not report public property with a comment") {
-            val code = """
+            val code =
+                """
                 class Test {
                     /**
                      * asdf

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/EndOfSentenceFormatSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/EndOfSentenceFormatSpec.kt
@@ -11,7 +11,8 @@ class EndOfSentenceFormatSpec : Spek({
     describe("KDocStyle rule") {
 
         it("reports invalid KDoc endings on classes") {
-            val code = """
+            val code =
+                """
             /** Some doc */
             class Test {
             }
@@ -20,7 +21,8 @@ class EndOfSentenceFormatSpec : Spek({
         }
 
         it("reports invalid KDoc endings on objects") {
-            val code = """
+            val code =
+                """
             /** Some doc */
             object Test {
             }
@@ -29,7 +31,8 @@ class EndOfSentenceFormatSpec : Spek({
         }
 
         it("reports invalid KDoc endings on properties") {
-            val code = """
+            val code =
+                """
             class Test {
                 /** Some doc */
                 val test = 3
@@ -39,7 +42,8 @@ class EndOfSentenceFormatSpec : Spek({
         }
 
         it("reports invalid KDoc endings on top-level functions") {
-            val code = """
+            val code =
+                """
             /** Some doc */
             fun test() = 3
             """
@@ -47,7 +51,8 @@ class EndOfSentenceFormatSpec : Spek({
         }
 
         it("reports invalid KDoc endings on functions") {
-            val code = """
+            val code =
+                """
             class Test {
                 /** Some doc */
                 fun test() = 3
@@ -57,7 +62,8 @@ class EndOfSentenceFormatSpec : Spek({
         }
 
         it("reports invalid KDoc endings") {
-            val code = """
+            val code =
+                """
             class Test {
                 /** Some doc-- */
                 fun test() = 3
@@ -67,7 +73,8 @@ class EndOfSentenceFormatSpec : Spek({
         }
 
         it("reports invalid KDoc endings in block") {
-            val code = """
+            val code =
+                """
             /**
              * Something off abc@@
              */
@@ -78,7 +85,8 @@ class EndOfSentenceFormatSpec : Spek({
         }
 
         it("does not validate first sentence KDoc endings in a multi sentence comment") {
-            val code = """
+            val code =
+                """
             /**
              * This sentence is correct.
              *
@@ -91,7 +99,8 @@ class EndOfSentenceFormatSpec : Spek({
         }
 
         it("does not report KDoc which doesn't contain any real sentence") {
-            val code = """
+            val code =
+                """
             /**
              */
             class Test {
@@ -101,7 +110,8 @@ class EndOfSentenceFormatSpec : Spek({
         }
 
         it("does not report KDoc which doesn't contain any real sentence but many tags") {
-            val code = """
+            val code =
+                """
             /**
              * @configuration this - just an example (default: `150`)
              *
@@ -114,7 +124,8 @@ class EndOfSentenceFormatSpec : Spek({
         }
 
         it("does not report KDoc which doesn't contain any real sentence but html tags") {
-            val code = """
+            val code =
+                """
             /**
              *
              * <noncompliant>
@@ -133,7 +144,8 @@ class EndOfSentenceFormatSpec : Spek({
         }
 
         it("does not report KDoc ending with periods") {
-            val code = """
+            val code =
+                """
             /**
              * Something correct.
              */
@@ -144,7 +156,8 @@ class EndOfSentenceFormatSpec : Spek({
         }
 
         it("does not report KDoc ending with questionmarks") {
-            val code = """
+            val code =
+                """
             /**
              * Something correct?
              */
@@ -155,7 +168,8 @@ class EndOfSentenceFormatSpec : Spek({
         }
 
         it("does not report KDoc ending with exclamation marks") {
-            val code = """
+            val code =
+                """
             /**
              * Something correct!
              */
@@ -166,7 +180,8 @@ class EndOfSentenceFormatSpec : Spek({
         }
 
         it("does not report KDoc ending with colon") {
-            val code = """
+            val code =
+                """
             /**
              * Something correct:
              */
@@ -177,7 +192,8 @@ class EndOfSentenceFormatSpec : Spek({
         }
 
         it("does not report URLs in comments") {
-            val code = """
+            val code =
+                """
             /** http://www.google.com */
             class Test1 {
             }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicClassSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicClassSpec.kt
@@ -9,38 +9,44 @@ import org.spekframework.spek2.style.specification.describe
 class UndocumentedPublicClassSpec : Spek({
     val subject by memoized { UndocumentedPublicClass() }
 
-    val inner = """
+    val inner =
+        """
             /** Some doc */
             class TestInner {
                 inner class Inner
             }"""
 
-    val innerObject = """
+    val innerObject =
+        """
             /** Some doc */
             class TestInner {
                 object Inner
             }"""
 
-    val innerInterface = """
+    val innerInterface =
+        """
             /** Some doc */
             class TestInner {
                 interface Something
             }"""
 
-    val nested = """
+    val nested =
+        """
             /** Some doc */
             class TestNested {
                 class Nested
             }"""
 
-    val nestedPublic = """
+    val nestedPublic =
+        """
             /** Some doc */
             class TestNested {
                 public class Nested
             }
             """
 
-    val nestedPrivate = """
+    val nestedPrivate =
+        """
             /** Some doc */
             class TestNested {
                 private class Nested
@@ -109,7 +115,8 @@ class UndocumentedPublicClassSpec : Spek({
         }
 
         it("should not report non-public nested classes") {
-            val code = """
+            val code =
+                """
             internal class Outer {
                 class Nested
                 inner class Inner
@@ -119,7 +126,8 @@ class UndocumentedPublicClassSpec : Spek({
         }
 
         it("should not report non-public nested interfaces") {
-            val code = """
+            val code =
+                """
             internal class Outer {
                 interface Inner
             }
@@ -128,7 +136,8 @@ class UndocumentedPublicClassSpec : Spek({
         }
 
         it("should not report non-public nested objects") {
-            val code = """
+            val code =
+                """
             internal class Outer {
                 object Inner
             }
@@ -137,7 +146,8 @@ class UndocumentedPublicClassSpec : Spek({
         }
 
         it("should not report for documented public object") {
-            val code = """
+            val code =
+                """
             /**
              * Class docs not being recognized.
              */
@@ -156,7 +166,8 @@ class UndocumentedPublicClassSpec : Spek({
         }
 
         it("should not report for anonymous objects") {
-            val code = """
+            val code =
+                """
             fun main(args: Array<String>) {
                 val value = object : Iterator<Int> {
                     override fun hasNext() = true
@@ -168,7 +179,8 @@ class UndocumentedPublicClassSpec : Spek({
         }
 
         it("should report for enum classes") {
-            val code = """
+            val code =
+                """
             enum class Enum {
                 CONSTANT
             }
@@ -177,7 +189,8 @@ class UndocumentedPublicClassSpec : Spek({
         }
 
         it("should not report for enum constants") {
-            val code = """
+            val code =
+                """
             /** Some doc */
             enum class Enum {
                 CONSTANT

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicFunctionSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicFunctionSpec.kt
@@ -11,14 +11,16 @@ class UndocumentedPublicFunctionSpec : Spek({
     describe("UndocumentedPublicFunction rule") {
 
         it("reports undocumented public functions") {
-            val code = """
+            val code =
+                """
                 fun noComment1() {}
             """
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
         it("reports undocumented public functions in companion object") {
-            val code = """
+            val code =
+                """
                 class Test {
                     companion object {
                         fun noComment1() {}
@@ -30,7 +32,8 @@ class UndocumentedPublicFunctionSpec : Spek({
         }
 
         it("does not report documented public function") {
-            val code = """
+            val code =
+                """
                 /**
                  * Comment
                  */
@@ -40,7 +43,8 @@ class UndocumentedPublicFunctionSpec : Spek({
         }
 
         it("does not report documented public function in class") {
-            val code = """
+            val code =
+                """
 				class Test {
 					/**
 					*
@@ -52,7 +56,8 @@ class UndocumentedPublicFunctionSpec : Spek({
         }
 
         it("does not report undocumented internal and private function") {
-            val code = """
+            val code =
+                """
                 class Test {
                     internal fun no1(){}
                     private fun no2(){}
@@ -62,7 +67,8 @@ class UndocumentedPublicFunctionSpec : Spek({
         }
 
         it("does not report undocumented nested function") {
-            val code = """
+            val code =
+                """
                 /**
                  * Comment
                  */
@@ -74,7 +80,8 @@ class UndocumentedPublicFunctionSpec : Spek({
         }
 
         it("does not report public functions in internal class") {
-            val code = """
+            val code =
+                """
     			internal class NoComments {
 					fun nope1() {}
 					public fun nope2() {}
@@ -84,7 +91,8 @@ class UndocumentedPublicFunctionSpec : Spek({
         }
 
         it("does not report public functions in private class") {
-            val code = """
+            val code =
+                """
     			private class NoComments {
 					fun nope1() {}
 					public fun nope2() {}

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicPropertySpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicPropertySpec.kt
@@ -16,7 +16,8 @@ class UndocumentedPublicPropertySpec : Spek({
         }
 
         it("reports undocumented public properties in companion object") {
-            val code = """
+            val code =
+                """
                 class Test {
                     companion object {
                         val a = 1
@@ -38,7 +39,8 @@ class UndocumentedPublicPropertySpec : Spek({
         }
 
         it("does not report documented public property") {
-            val code = """
+            val code =
+                """
                 /**
                  * Comment
                  */
@@ -48,7 +50,8 @@ class UndocumentedPublicPropertySpec : Spek({
         }
 
         it("does not report documented public property in class") {
-            val code = """
+            val code =
+                """
                 class Test {
                     /**
                     * Comment
@@ -60,7 +63,8 @@ class UndocumentedPublicPropertySpec : Spek({
         }
 
         it("does not report undocumented, public and overridden property in class") {
-            val code = """
+            val code =
+                """
                 interface I {
                     /**
                      * Comment
@@ -76,7 +80,8 @@ class UndocumentedPublicPropertySpec : Spek({
         }
 
         it("does not report undocumented internal and private property") {
-            val code = """
+            val code =
+                """
                 class Test {
                     internal val a = 1
                     private val b = 1
@@ -86,7 +91,8 @@ class UndocumentedPublicPropertySpec : Spek({
         }
 
         it("does not report local variables") {
-            val code = """
+            val code =
+                """
                 fun commented(x: Int) {
                     var a = x
                 }
@@ -95,7 +101,8 @@ class UndocumentedPublicPropertySpec : Spek({
         }
 
         it("does not report public properties in internal class") {
-            val code = """
+            val code =
+                """
                 internal class NoComments {
                     public val a = 1
                     val b = 1
@@ -105,7 +112,8 @@ class UndocumentedPublicPropertySpec : Spek({
         }
 
         it("does not report public properties in private class") {
-            val code = """
+            val code =
+                """
                 private class NoComments {
                     public val a = 1
                     val b = 1
@@ -115,7 +123,8 @@ class UndocumentedPublicPropertySpec : Spek({
         }
 
         it("does not report properties in a secondary constructor") {
-            val code = """
+            val code =
+                """
                 class Test() {
                     constructor(a: Int) : this()
                 }
@@ -124,7 +133,8 @@ class UndocumentedPublicPropertySpec : Spek({
         }
 
         it("does not report undocumented non-public properties in a primary constructor") {
-            val code = """
+            val code =
+                """
                 class Test1(internal val a: Int)
                 class Test2(b: Int)
             """
@@ -137,7 +147,8 @@ class UndocumentedPublicPropertySpec : Spek({
         }
 
         it("does not report documented public properties in a primary constructor") {
-            val code = """
+            val code =
+                """
                 /**
                 * @property a int1
                 * [b] int2
@@ -152,7 +163,8 @@ class UndocumentedPublicPropertySpec : Spek({
         describe("public properties in nested classes") {
 
             it("reports undocumented public properties in nested classes") {
-                val code = """
+                val code =
+                    """
                 class Outer { 
                     class Inner {
                         val i = 0
@@ -167,7 +179,8 @@ class UndocumentedPublicPropertySpec : Spek({
             }
 
             it("reports undocumented public properties in inner classes") {
-                val code = """
+                val code =
+                    """
                 class Outer {
                     inner class Inner {
                         val i = 0
@@ -178,7 +191,8 @@ class UndocumentedPublicPropertySpec : Spek({
             }
 
             it("reports undocumented public properties inside objects") {
-                val code = """
+                val code =
+                    """
                 object Outer {
                     class Inner {
                         val i = 0
@@ -189,7 +203,8 @@ class UndocumentedPublicPropertySpec : Spek({
             }
 
             it("does not report undocumented and non-public properties in nested classes") {
-                val code = """
+                val code =
+                    """
                 internal class Outer {
                     class Inner {
                         val i = 0
@@ -200,7 +215,8 @@ class UndocumentedPublicPropertySpec : Spek({
             }
 
             it("does not report undocumented and non-public properties in inner classes") {
-                val code = """
+                val code =
+                    """
                 internal class Outer {
                     inner class Inner {
                         val i = 0
@@ -214,7 +230,8 @@ class UndocumentedPublicPropertySpec : Spek({
         describe("public properties in primary constructors inside nested classes") {
 
             it("reports undocumented public properties in nested classes") {
-                val code = """
+                val code =
+                    """
                 class Outer(val a: Int) {
                     class Inner(val b: Int) {
                         class InnerInner(val c: Int)
@@ -225,7 +242,8 @@ class UndocumentedPublicPropertySpec : Spek({
             }
 
             it("reports undocumented public properties in inner classes") {
-                val code = """
+                val code =
+                    """
                 class Outer(val a: Int) {
                     inner class Inner(val b: Int)
                 }
@@ -234,7 +252,8 @@ class UndocumentedPublicPropertySpec : Spek({
             }
 
             it("reports undocumented public properties inside objects") {
-                val code = """
+                val code =
+                    """
                 object Outer {
                     class Inner(val a: Int)
                 }
@@ -243,7 +262,8 @@ class UndocumentedPublicPropertySpec : Spek({
             }
 
             it("does not report undocumented and non-public properties in nested classes") {
-                val code = """
+                val code =
+                    """
                 internal class Outer(val a: Int) {
                     class Inner(val b: Int)
                 }
@@ -252,7 +272,8 @@ class UndocumentedPublicPropertySpec : Spek({
             }
 
             it("does not report undocumented and non-public properties in inner classes") {
-                val code = """
+                val code =
+                    """
                 internal class Outer(val a: Int) {
                     inner class Inner(val b: Int)
                 }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyBlocksMultiRuleSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyBlocksMultiRuleSpec.kt
@@ -41,7 +41,8 @@ class EmptyBlocksMultiRuleSpec : Spek({
         }
 
         it("reports no duplicated findings - issue #1605") {
-            val findings = subject.compileAndLint("""
+            val findings = subject.compileAndLint(
+                """
                 class EmptyBlocks {
                     class EmptyClass {}
                     fun exceptionHandling() {
@@ -51,7 +52,8 @@ class EmptyBlocksMultiRuleSpec : Spek({
                         }
                     }
                 }
-            """)
+            """
+            )
             assertThat(findings).hasSize(2)
         }
     }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyClassBlockSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyClassBlockSpec.kt
@@ -18,7 +18,8 @@ class EmptyClassBlockSpec : Spek({
         }
 
         it("does not report class with comments in the body") {
-            val code = """
+            val code =
+                """
                 class SomeClass {
                     // Some comment to explain what this class is supposed to do
                 }
@@ -27,7 +28,8 @@ class EmptyClassBlockSpec : Spek({
         }
 
         it("does not report class with multiline comments in the body") {
-            val code = """
+            val code =
+                """
                 class SomeClass {
                     /*
                     Some comment to explain what this class is supposed to do
@@ -38,7 +40,8 @@ class EmptyClassBlockSpec : Spek({
         }
 
         it("reports the empty nested class body") {
-            val code = """
+            val code =
+                """
                 class SomeClass {
                     class EmptyClass {}
                 }
@@ -54,7 +57,8 @@ class EmptyClassBlockSpec : Spek({
         }
 
         it("does not report the object if it is of an anonymous class") {
-            val code = """
+            val code =
+                """
                 open class Open
 
                 fun f() {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyCodeSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyCodeSpec.kt
@@ -15,7 +15,8 @@ import java.util.regex.PatternSyntaxException
 
 class EmptyCodeSpec : Spek({
 
-    val regexTestingCode = """
+    val regexTestingCode =
+        """
             fun f() {
                 try {
                 } catch (foo: Exception) {
@@ -29,7 +30,8 @@ class EmptyCodeSpec : Spek({
         }
 
         it("findsEmptyNestedCatch") {
-            val code = """
+            val code =
+                """
             fun f() {
                 try {
                 } catch (ignore: Exception) {
@@ -42,7 +44,8 @@ class EmptyCodeSpec : Spek({
         }
 
         it("doesNotReportIgnoredOrExpectedException") {
-            val code = """
+            val code =
+                """
             fun f() {
                 try {
                 } catch (ignore: IllegalArgumentException) {
@@ -53,7 +56,8 @@ class EmptyCodeSpec : Spek({
         }
 
         it("doesNotReportEmptyCatchWithConfig") {
-            val code = """
+            val code =
+                """
             fun f() {
                 try {
                 } catch (foo: Exception) {
@@ -124,8 +128,10 @@ class EmptyCodeSpec : Spek({
         }
 
         it("doesNotFailWithInvalidRegexWhenDisabled") {
-            val configValues = mapOf("active" to "false",
-                    EmptyCatchBlock.ALLOWED_EXCEPTION_NAME_REGEX to "*foo")
+            val configValues = mapOf(
+                "active" to "false",
+                EmptyCatchBlock.ALLOWED_EXCEPTION_NAME_REGEX to "*foo"
+            )
             val config = TestConfig(configValues)
             assertThat(EmptyCatchBlock(config).compileAndLint(regexTestingCode)).isEmpty()
         }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyConstructorSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyConstructorSpec.kt
@@ -12,7 +12,8 @@ class EmptyConstructorSpec : Spek({
     describe("EmptyDefaultConstructor rule") {
 
         it("should not report empty constructors for annotation classes with expect or actual keyword - #1362") {
-            val code = """
+            val code =
+                """
             expect annotation class NeedsConstructor()
             actual annotation class NeedsConstructor actual constructor()
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyFunctionBlockSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyFunctionBlockSpec.kt
@@ -14,7 +14,8 @@ class EmptyFunctionBlockSpec : Spek({
     describe("EmptyFunctionBlock rule") {
 
         it("should flag function with protected modifier") {
-            val code = """
+            val code =
+                """
                 class A {
                     protected fun stuff() {}
                 }"""
@@ -22,7 +23,8 @@ class EmptyFunctionBlockSpec : Spek({
         }
 
         it("should not flag function with open modifier") {
-            val code = """
+            val code =
+                """
                 open class A {
                     open fun stuff() {}
                 }"""
@@ -30,7 +32,8 @@ class EmptyFunctionBlockSpec : Spek({
         }
 
         it("should not flag a default function in an interface") {
-            val code = """
+            val code =
+                """
                 interface I {
                     fun stuff() {}
                 }"""
@@ -38,7 +41,8 @@ class EmptyFunctionBlockSpec : Spek({
         }
 
         it("should flag the nested empty function") {
-            val code = """
+            val code =
+                """
                 fun a() {
                     fun b() {}
                 }"""
@@ -47,7 +51,8 @@ class EmptyFunctionBlockSpec : Spek({
 
         context("some overridden functions") {
 
-            val code = """
+            val code =
+                """
                 fun empty() {}
 
                 open class Base {
@@ -81,7 +86,8 @@ class EmptyFunctionBlockSpec : Spek({
         }
 
         context("some overridden functions") {
-            val code = """
+            val code =
+                """
                 private interface Listener {
                     fun listenThis()
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyIfBlockSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyIfBlockSpec.kt
@@ -13,7 +13,8 @@ class EmptyIfBlockSpec : Spek({
     describe("EmptyIfBlock rule") {
 
         it("reports empty if with trailing semicolon") {
-            val code = """
+            val code =
+                """
                 fun f() {
                     var i = 0
                     if (i == 0);
@@ -24,7 +25,8 @@ class EmptyIfBlockSpec : Spek({
         }
 
         it("reports empty if with trailing semicolon on new line") {
-            val code = """
+            val code =
+                """
                 fun f() {
                     var i = 0
                     if (i == 0)
@@ -36,7 +38,8 @@ class EmptyIfBlockSpec : Spek({
         }
 
         it("reports empty if with trailing semicolon and braces") {
-            val code = """
+            val code =
+                """
                 fun f() {
                     var i = 0
                     if (i == 0); {
@@ -48,7 +51,8 @@ class EmptyIfBlockSpec : Spek({
         }
 
         it("does not report nonempty if with braces") {
-            val code = """
+            val code =
+                """
                 fun f() {
                     var i = 0
                     if (i == 0) {
@@ -60,7 +64,8 @@ class EmptyIfBlockSpec : Spek({
         }
 
         it("does not report nonempty if without braces") {
-            val code = """
+            val code =
+                """
                 fun f() {
                     var i = 0
                     if (i == 0) i++
@@ -70,7 +75,8 @@ class EmptyIfBlockSpec : Spek({
         }
 
         it("does not report nonempty if without braces but semicolon") {
-            val code = """
+            val code =
+                """
                 fun f() {
                     var i = 0
                     if (i == 0) i++;
@@ -80,7 +86,8 @@ class EmptyIfBlockSpec : Spek({
         }
 
         it("does not report empty if but nonempty else") {
-            val code = """
+            val code =
+                """
                 fun f() {
                     var i = 0
                     if (i == 0) ;
@@ -91,7 +98,8 @@ class EmptyIfBlockSpec : Spek({
         }
 
         it("does not report empty if and else-if but nonempty else") {
-            val code = """
+            val code =
+                """
                 fun f() {
                     var i = 0
                     if (i == 0) ;

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ExceptionRaisedInUnexpectedLocationSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ExceptionRaisedInUnexpectedLocationSpec.kt
@@ -25,19 +25,23 @@ class ExceptionRaisedInUnexpectedLocationSpec : Spek({
 
         it("reports the configured method") {
             val config = TestConfig(mapOf(ExceptionRaisedInUnexpectedLocation.METHOD_NAMES to listOf("toDo", "todo2")))
-            val findings = ExceptionRaisedInUnexpectedLocation(config).compileAndLint("""
+            val findings = ExceptionRaisedInUnexpectedLocation(config).compileAndLint(
+                """
             fun toDo() {
                 throw IllegalStateException()
-            }""")
+            }"""
+            )
             assertThat(findings).hasSize(1)
         }
 
         it("reports the configured method with String") {
             val config = TestConfig(mapOf(ExceptionRaisedInUnexpectedLocation.METHOD_NAMES to "toDo,todo2"))
-            val findings = ExceptionRaisedInUnexpectedLocation(config).compileAndLint("""
+            val findings = ExceptionRaisedInUnexpectedLocation(config).compileAndLint(
+                """
             fun toDo() {
                 throw IllegalStateException()
-            }""")
+            }"""
+            )
             assertThat(findings).hasSize(1)
         }
     }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/InstanceOfCheckForExceptionSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/InstanceOfCheckForExceptionSpec.kt
@@ -18,7 +18,8 @@ class InstanceOfCheckForExceptionSpec : Spek({
 
         it("has is and as checks") {
 
-            val code = """
+            val code =
+                """
                 fun x() {
                     try {
                     } catch(e: Exception) {
@@ -32,7 +33,8 @@ class InstanceOfCheckForExceptionSpec : Spek({
         }
 
         it("has nested is and as checks") {
-            val code = """
+            val code =
+                """
                 fun x() {
                     try {
                     } catch(e: Exception) {
@@ -46,7 +48,8 @@ class InstanceOfCheckForExceptionSpec : Spek({
         }
 
         it("has no instance of check") {
-            val code = """
+            val code =
+                """
                 fun x() {
                     try {
                     } catch(e: Exception) {
@@ -62,7 +65,8 @@ class InstanceOfCheckForExceptionSpec : Spek({
         }
 
         it("has no checks for the subtype of an exception") {
-            val code = """
+            val code =
+                """
                 interface I
                 
                 fun foo() {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/NotImplementedDeclarationSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/NotImplementedDeclarationSpec.kt
@@ -11,7 +11,8 @@ class NotImplementedDeclarationSpec : Spek({
     describe("NotImplementedDeclaration rule") {
 
         it("reports NotImplementedErrors") {
-            val code = """
+            val code =
+                """
             fun f() {
                 if (1 == 1) throw NotImplementedError()
                 throw NotImplementedError()
@@ -20,7 +21,8 @@ class NotImplementedDeclarationSpec : Spek({
         }
 
         it("reports TODO method calls") {
-            val code = """
+            val code =
+                """
             fun f() {
                 TODO("not implemented")
                 TODO()
@@ -29,7 +31,8 @@ class NotImplementedDeclarationSpec : Spek({
         }
 
         it("does not report TODO comments") {
-            val code = """
+            val code =
+                """
             fun f() {
                 // TODO
             }"""

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/PrintStackTraceSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/PrintStackTraceSpec.kt
@@ -13,7 +13,8 @@ class PrintStackTraceSpec : Spek({
         context("catch clauses with printStacktrace methods") {
 
             it("prints a stacktrace") {
-                val code = """
+                val code =
+                    """
                 fun x() {
                     try {
                     } catch (e: Exception) {
@@ -24,7 +25,8 @@ class PrintStackTraceSpec : Spek({
             }
 
             it("does not print a stacktrace") {
-                val code = """
+                val code =
+                    """
                 fun x() {
                     try {
                     } catch (e: Exception) {
@@ -42,7 +44,8 @@ class PrintStackTraceSpec : Spek({
         context("a stacktrace printed by a thread") {
 
             it("prints one") {
-                val code = """
+                val code =
+                    """
                 fun x() {
                     Thread.dumpStack()
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/RethrowCaughtExceptionSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/RethrowCaughtExceptionSpec.kt
@@ -11,7 +11,8 @@ class RethrowCaughtExceptionSpec : Spek({
     describe("RethrowCaughtException rule") {
 
         it("reports when the same exception is rethrown") {
-            val code = """
+            val code =
+                """
                 fun f() {
                     try {
                     } catch (e: IllegalStateException) {
@@ -23,7 +24,8 @@ class RethrowCaughtExceptionSpec : Spek({
         }
 
         it("reports when the same exception succeeded by dead code is rethrown") {
-            val code = """
+            val code =
+                """
                 fun f() {
                     try {
                     } catch (e: IllegalStateException) {
@@ -36,7 +38,8 @@ class RethrowCaughtExceptionSpec : Spek({
         }
 
         it("reports when the same nested exception is rethrown") {
-            val code = """
+            val code =
+                """
                 fun f() {
                     try {
                     } catch (outer: IllegalStateException) {
@@ -51,7 +54,8 @@ class RethrowCaughtExceptionSpec : Spek({
         }
 
         it("does not report a wrapped exception") {
-            val code = """
+            val code =
+                """
                 fun f() {
                     try {
                     } catch (e: IllegalStateException) {
@@ -63,7 +67,8 @@ class RethrowCaughtExceptionSpec : Spek({
         }
 
         it("does not report wrapped exceptions") {
-            val code = """
+            val code =
+                """
                 fun f() {
                     try {
                     } catch (e: IllegalStateException) {
@@ -77,7 +82,8 @@ class RethrowCaughtExceptionSpec : Spek({
         }
 
         it("does not report logged exceptions") {
-            val code = """
+            val code =
+                """
                 fun f() {
                     try {
                     } catch (e: IllegalStateException) {
@@ -92,7 +98,8 @@ class RethrowCaughtExceptionSpec : Spek({
         }
 
         it("does not report when taking specific actions before throwing the exception") {
-            val code = """
+            val code =
+                """
                 fun f() {
                     try {
                     } catch (e: IllegalStateException) {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ReturnFromFinallySpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ReturnFromFinallySpec.kt
@@ -12,7 +12,8 @@ class ReturnFromFinallySpec : Spek({
     describe("ReturnFromFinally rule") {
 
         context("a finally block with a return statement") {
-            val code = """
+            val code =
+                """
             fun x() {
                 try {
                 } finally {
@@ -28,7 +29,8 @@ class ReturnFromFinallySpec : Spek({
         }
 
         context("a finally block with no return statement") {
-            val code = """
+            val code =
+                """
             fun x() {
                 try {
                 } finally {
@@ -43,7 +45,8 @@ class ReturnFromFinallySpec : Spek({
         }
 
         context("a finally block with a nested return statement") {
-            val code = """
+            val code =
+                """
             fun x() {
                 try {
                 } finally {
@@ -61,7 +64,8 @@ class ReturnFromFinallySpec : Spek({
         }
 
         context("a finally block with a return in an inner function") {
-            val code = """
+            val code =
+                """
             fun x() {
                 try {
                 } finally {
@@ -80,7 +84,8 @@ class ReturnFromFinallySpec : Spek({
         }
 
         context("a finally block with a return as labelled expression") {
-            val code = """
+            val code =
+                """
             fun x() {
                 try {
                 } finally {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedExceptionSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedExceptionSpec.kt
@@ -12,7 +12,8 @@ class SwallowedExceptionSpec : Spek({
     describe("SwallowedException rule") {
 
         it("reports a swallowed exception") {
-            val code = """
+            val code =
+                """
                 fun f() {
                     try {
                     } catch (e: Exception) {
@@ -24,7 +25,8 @@ class SwallowedExceptionSpec : Spek({
         }
 
         it("reports swallowed exceptions only using exception strings") {
-            val code = """
+            val code =
+                """
                 fun f() {
                     try {
                     } catch (e: IllegalStateException) {
@@ -38,7 +40,8 @@ class SwallowedExceptionSpec : Spek({
         }
 
         it("reports swallowed exceptions only using exception strings via variables") {
-            val code = """
+            val code =
+                """
                 fun f() {
                     try {
                     } catch (e: IllegalStateException) {
@@ -54,7 +57,8 @@ class SwallowedExceptionSpec : Spek({
         }
 
         it("reports swallowed exceptions only using exception strings via variables in 'if' block") {
-            val code = """
+            val code =
+                """
                 fun f() {
                     try {
                     } catch (e: IllegalStateException) {
@@ -74,7 +78,8 @@ class SwallowedExceptionSpec : Spek({
         }
 
         it("reports swallowed exceptions when it has multiple throw expressions") {
-            val code = """
+            val code =
+                """
                 fun f(condition: Boolean) {
                     try {
                         println()
@@ -90,7 +95,8 @@ class SwallowedExceptionSpec : Spek({
         }
 
         it("reports swallowed exceptions when it has multiple throw expressions 2") {
-            val code = """
+            val code =
+                """
                 fun f(condition: Boolean) {
                     try {
                         println()
@@ -106,7 +112,8 @@ class SwallowedExceptionSpec : Spek({
         }
 
         it("reports a swallowed exception that is not logged") {
-            val code = """
+            val code =
+                """
                 fun f() {
                     try {
                     } catch (e: Exception) {
@@ -124,7 +131,8 @@ class SwallowedExceptionSpec : Spek({
                 val rule = SwallowedException(config)
 
                 it("ignores given exception type in configuration") {
-                    val code = """
+                    val code =
+                        """
                     fun f() {
                         try {
                         } catch (e: IllegalArgumentException) {
@@ -135,7 +143,8 @@ class SwallowedExceptionSpec : Spek({
                 }
 
                 it("reports exception type that is missing in the configuration") {
-                    val code = """
+                    val code =
+                        """
                     fun f() {
                         try {
                         } catch (e: Exception) {
@@ -153,7 +162,8 @@ class SwallowedExceptionSpec : Spek({
             val rule = SwallowedException(config)
 
             it("ignores given exception name") {
-                val code = """
+                val code =
+                    """
                     fun f() {
                         try {
                         } catch (myIgnore: IllegalArgumentException) {
@@ -164,7 +174,8 @@ class SwallowedExceptionSpec : Spek({
             }
 
             it("reports exception name") {
-                val code = """
+                val code =
+                    """
                     fun f() {
                         try {
                         } catch (e: IllegalArgumentException) {
@@ -176,7 +187,8 @@ class SwallowedExceptionSpec : Spek({
         }
 
         it("does not report wrapped exceptions") {
-            val code = """
+            val code =
+                """
                 fun f() {
                     try {
                     } catch (e: IllegalStateException) {
@@ -190,7 +202,8 @@ class SwallowedExceptionSpec : Spek({
         }
 
         it("does not report used exception variables") {
-            val code = """
+            val code =
+                """
                 fun f() {
                     try {
                     } catch (e: IllegalArgumentException) {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionFromFinallySpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionFromFinallySpec.kt
@@ -11,7 +11,8 @@ class ThrowingExceptionFromFinallySpec : Spek({
     describe("ThrowingExceptionFromFinally rule") {
 
         it("should report a throw expression") {
-            val code = """
+            val code =
+                """
                 fun x() {
                     try {
                     } finally {
@@ -24,7 +25,8 @@ class ThrowingExceptionFromFinallySpec : Spek({
         }
 
         it("should report a nested throw expression") {
-            val code = """
+            val code =
+                """
                 fun x() {
                     try {
                     } finally {
@@ -35,7 +37,8 @@ class ThrowingExceptionFromFinallySpec : Spek({
         }
 
         it("should not report a finally expression without a throw expression") {
-            val code = """
+            val code =
+                """
                 fun x() {
                     try {
                     } finally {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionInMainSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionInMainSpec.kt
@@ -12,7 +12,8 @@ class ThrowingExceptionInMainSpec : Spek({
     describe("ThrowingExceptionInMain rule") {
 
         it("reports a runnable main function which throws an exception") {
-            val code = """
+            val code =
+                """
                 fun main(args: Array<String>) { throw IllegalArgumentException() }
                 fun main() { throw IllegalArgumentException() }
             """
@@ -20,7 +21,8 @@ class ThrowingExceptionInMainSpec : Spek({
         }
 
         it("reports runnable main functions with @JvmStatic annotation which throw an exception") {
-            val code = """
+            val code =
+                """
                 class A {
                     companion object {
                         @JvmStatic
@@ -44,7 +46,8 @@ class ThrowingExceptionInMainSpec : Spek({
         }
 
         it("does not report top level main functions with a wrong signature") {
-            val code = """
+            val code =
+                """
                 private fun main(args: Array<String>) { throw IllegalArgumentException() }
                 private fun main() { throw IllegalArgumentException() }
                 fun mai() { throw IllegalArgumentException() }
@@ -54,7 +57,8 @@ class ThrowingExceptionInMainSpec : Spek({
         }
 
         it("does not report top level main functions which throw no exception") {
-            val code = """
+            val code =
+                """
                 fun main(args: Array<String>) { }
                 fun main() { }
                 fun mai() { }
@@ -63,7 +67,8 @@ class ThrowingExceptionInMainSpec : Spek({
         }
 
         it("does not report top level main functions with expression body which throw no exception") {
-            val code = """
+            val code =
+                """
                 fun main(args: Array<String>) = ""
                 fun main() = Unit
             """
@@ -71,7 +76,8 @@ class ThrowingExceptionInMainSpec : Spek({
         }
 
         it("does not report main functions with no @JvmStatic annotation inside a class") {
-            val code = """
+            val code =
+                """
             class A {
                 fun main(args: Array<String>) { throw IllegalArgumentException() }
                 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionsWithoutMessageOrCauseSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionsWithoutMessageOrCauseSpec.kt
@@ -9,7 +9,7 @@ import org.spekframework.spek2.style.specification.describe
 class ThrowingExceptionsWithoutMessageOrCauseSpec : Spek({
     val subject by memoized {
         ThrowingExceptionsWithoutMessageOrCause(
-                TestConfig(ThrowingExceptionsWithoutMessageOrCause.EXCEPTIONS to listOf("IllegalArgumentException"))
+            TestConfig(ThrowingExceptionsWithoutMessageOrCause.EXCEPTIONS to listOf("IllegalArgumentException"))
         )
     }
 
@@ -17,7 +17,8 @@ class ThrowingExceptionsWithoutMessageOrCauseSpec : Spek({
 
         context("several exception calls") {
 
-            val code = """
+            val code =
+                """
                 fun x() {
                     IllegalArgumentException(IllegalArgumentException())
                     IllegalArgumentException("foo")
@@ -38,7 +39,8 @@ class ThrowingExceptionsWithoutMessageOrCauseSpec : Spek({
         context("a test code which asserts an exception") {
 
             it("does not report a call to this exception") {
-                val code = """
+                val code =
+                    """
                 fun test() {
                     org.assertj.core.api.Assertions.assertThatIllegalArgumentException().isThrownBy { println() }
                 }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingNewInstanceOfSameExceptionSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingNewInstanceOfSameExceptionSpec.kt
@@ -11,7 +11,8 @@ class ThrowingNewInstanceOfSameExceptionSpec : Spek({
     describe("ThrowingNewInstanceOfSameException rule") {
 
         context("a catch block which rethrows a new instance of the caught exception") {
-            val code = """
+            val code =
+                """
             fun x() {
                 try {
                 } catch (e: IllegalStateException) {
@@ -27,7 +28,8 @@ class ThrowingNewInstanceOfSameExceptionSpec : Spek({
         }
 
         context("a catch block which rethrows a new instance of another exception") {
-            val code = """
+            val code =
+                """
             fun x() {
                 try {
                 } catch (e: IllegalStateException) {
@@ -43,7 +45,8 @@ class ThrowingNewInstanceOfSameExceptionSpec : Spek({
         }
 
         context("a catch block which throws a new instance of the same exception type without wrapping the caught exception") {
-            val code = """
+            val code =
+                """
             fun x() {
                 try {
                 } catch (e: IllegalStateException) {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionCaughtSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionCaughtSpec.kt
@@ -24,7 +24,8 @@ class TooGenericExceptionCaughtSpec : Spek({
 
     describe("a file with a caught exception which is ignored") {
 
-        val code = """
+        val code =
+            """
             class MyTooGenericException : RuntimeException()
 
             fun f() {
@@ -56,8 +57,8 @@ class TooGenericExceptionCaughtSpec : Spek({
 
         it("should not fail when disabled with invalid regex on allowed exception names") {
             val configRules = mapOf(
-                    "active" to "false",
-                    TooGenericExceptionCaught.ALLOWED_EXCEPTION_NAME_REGEX to "*MyException"
+                "active" to "false",
+                TooGenericExceptionCaught.ALLOWED_EXCEPTION_NAME_REGEX to "*MyException"
             )
             val config = TestConfig(configRules)
             val rule = TooGenericExceptionCaught(config)

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionSpec.kt
@@ -26,7 +26,8 @@ class TooGenericExceptionSpec : Spek({
     }
 })
 
-const val tooGenericExceptionCode = """
+const val tooGenericExceptionCode =
+    """
         fun main() {
         try {
             throw Throwable()

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ClassNamingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ClassNamingSpec.kt
@@ -11,7 +11,7 @@ class ClassNamingSpec : Spek({
 
         it("should detect no violations") {
             val findings = ClassNaming().compileAndLint(
-                    """
+                """
                     class MyClassWithNumbers5
 
                     class NamingConventions {
@@ -23,7 +23,7 @@ class ClassNamingSpec : Spek({
 
         it("should find two violations") {
             val findings = ClassNaming().compileAndLint(
-                    """
+                """
                     class _NamingConventions
 
                     class namingConventions {}

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ConstructorParameterNamingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ConstructorParameterNamingSpec.kt
@@ -11,7 +11,8 @@ class ConstructorParameterNamingSpec : Spek({
     describe("parameters in a constructor of a class") {
 
         it("should detect no violations") {
-            val code = """
+            val code =
+                """
                 class C(val param: String, private val privateParam: String)
 
                 class D {
@@ -23,7 +24,8 @@ class ConstructorParameterNamingSpec : Spek({
         }
 
         it("should find some violations") {
-            val code = """
+            val code =
+                """
                 class C(val PARAM: String, private val PRIVATE_PARAM: String)
 
                 class C {
@@ -35,14 +37,16 @@ class ConstructorParameterNamingSpec : Spek({
         }
 
         it("should find a violation in the correct text locaction") {
-            val code = """
+            val code =
+                """
                 class C(val PARAM: String)
             """
             assertThat(ConstructorParameterNaming().compileAndLint(code)).hasTextLocations(8 to 25)
         }
 
         it("should not complain about override") {
-            val code = """
+            val code =
+                """
                 class C(override val PARAM: String) : I
 
                 interface I { val PARAM: String }
@@ -51,7 +55,8 @@ class ConstructorParameterNamingSpec : Spek({
         }
 
         it("should not complain about override") {
-            val code = """
+            val code =
+                """
                 class C(override val PARAM: String) : I
 
                 interface I { val PARAM: String }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/EnumNamingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/EnumNamingSpec.kt
@@ -11,7 +11,7 @@ class EnumNamingSpec : Spek({
 
         it("should detect no violation") {
             val findings = EnumNaming().compileAndLint(
-                    """
+                """
                 enum class WorkFlow {
                     ACTIVE, NOT_ACTIVE, Unknown, Number1
                 }
@@ -21,7 +21,8 @@ class EnumNamingSpec : Spek({
         }
 
         it("enum name that start with lowercase") {
-            val code = """
+            val code =
+                """
                 enum class WorkFlow {
                     default
                 }"""
@@ -29,7 +30,8 @@ class EnumNamingSpec : Spek({
         }
 
         it("reports an underscore in enum name") {
-            val code = """
+            val code =
+                """
                 enum class WorkFlow {
                     _Default
                 }"""
@@ -37,7 +39,8 @@ class EnumNamingSpec : Spek({
         }
 
         it("no reports an underscore in enum name because it's suppressed") {
-            val code = """
+            val code =
+                """
                 enum class WorkFlow {
                     @Suppress("EnumNaming") _Default
                 }"""
@@ -45,7 +48,8 @@ class EnumNamingSpec : Spek({
         }
 
         it("reports the correct text location in enum name") {
-            val code = """
+            val code =
+                """
                 enum class WorkFlow {
                     _Default,
                 }"""

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ForbiddenClassNameSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ForbiddenClassNameSpec.kt
@@ -12,29 +12,37 @@ class ForbiddenClassNameSpec : Spek({
     describe("ForbiddenClassName rule") {
 
         it("should report classes with forbidden names") {
-            val code = """
+            val code =
+                """
                 class TestManager {} // violation
                 class TestProvider {} // violation
                 class TestHolder"""
-            assertThat(ForbiddenClassName(TestConfig(mapOf(FORBIDDEN_NAME to listOf("Manager", "Provider"))))
-                    .compileAndLint(code))
-                    .hasSize(2)
+            assertThat(
+                ForbiddenClassName(TestConfig(mapOf(FORBIDDEN_NAME to listOf("Manager", "Provider"))))
+                    .compileAndLint(code)
+            )
+                .hasSize(2)
         }
 
         it("should report a class that starts with a forbidden name") {
             val code = "class TestProvider {}"
-            assertThat(ForbiddenClassName(TestConfig(mapOf(FORBIDDEN_NAME to listOf("test"))))
-                    .compileAndLint(code))
-                    .hasSize(1)
+            assertThat(
+                ForbiddenClassName(TestConfig(mapOf(FORBIDDEN_NAME to listOf("test"))))
+                    .compileAndLint(code)
+            )
+                .hasSize(1)
         }
 
         it("should report classes with forbidden names using config string") {
-            val code = """
+            val code =
+                """
                 class TestManager {} // violation
                 class TestProvider {} // violation
                 class TestHolder"""
-            assertThat(ForbiddenClassName(TestConfig(mapOf(FORBIDDEN_NAME to "Manager, Provider")))
-                .compileAndLint(code))
+            assertThat(
+                ForbiddenClassName(TestConfig(mapOf(FORBIDDEN_NAME to "Manager, Provider")))
+                    .compileAndLint(code)
+            )
                 .hasSize(2)
         }
     }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNamingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNamingSpec.kt
@@ -12,7 +12,8 @@ class FunctionNamingSpec : Spek({
     describe("FunctionNaming rule") {
 
         it("allows FunctionName as alias for suppressing") {
-            val code = """
+            val code =
+                """
             @Suppress("FunctionName")
             fun MY_FUN() {}
         """
@@ -20,7 +21,8 @@ class FunctionNamingSpec : Spek({
         }
 
         it("ignores functions in classes matching excludeClassPattern") {
-            val code = """
+            val code =
+                """
             class WhateverTest {
                 fun SHOULD_NOT_BE_FLAGGED() {}
             }
@@ -30,7 +32,8 @@ class FunctionNamingSpec : Spek({
         }
 
         it("flags functions inside functions") {
-            val code = """
+            val code =
+                """
             class C : I {
                 override fun shouldNotBeFlagged() {
                     fun SHOULD_BE_FLAGGED() { }
@@ -42,7 +45,8 @@ class FunctionNamingSpec : Spek({
         }
 
         it("ignores overridden functions by default") {
-            val code = """
+            val code =
+                """
             class C : I {
                 override fun SHOULD_NOT_BE_FLAGGED() {}
             }
@@ -52,7 +56,8 @@ class FunctionNamingSpec : Spek({
         }
 
         it("does not report when the function name is identical to the type of the result") {
-            val code = """
+            val code =
+                """
             interface Foo
             private class FooImpl : Foo
 
@@ -63,7 +68,8 @@ class FunctionNamingSpec : Spek({
         }
 
         it("flags functions with bad names inside overridden functions by default") {
-            val code = """
+            val code =
+                """
             class C : I {
                 override fun SHOULD_BE_FLAGGED() {
                     fun SHOULD_BE_FLAGGED() {}
@@ -75,7 +81,8 @@ class FunctionNamingSpec : Spek({
         }
 
         it("doesn't ignore overridden functions if ignoreOverridden is false") {
-            val code = """
+            val code =
+                """
             class C : I {
                 override fun SHOULD_BE_FLAGGED() {}
             }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionParameterNamingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionParameterNamingSpec.kt
@@ -11,7 +11,8 @@ class FunctionParameterNamingSpec : Spek({
     describe("parameters in a function of a class") {
 
         it("should detect no violations") {
-            val code = """
+            val code =
+                """
                 class C {
                     fun someStuff(param: String) {}
                 }
@@ -20,7 +21,8 @@ class FunctionParameterNamingSpec : Spek({
         }
 
         it("should not detect violations in overridden function by default") {
-            val code = """
+            val code =
+                """
                 class C : I {
                     override fun someStuff(`object`: String) {}
                 }
@@ -30,7 +32,8 @@ class FunctionParameterNamingSpec : Spek({
         }
 
         it("should detect violations in overridden function if ignoreOverridden is false") {
-            val code = """
+            val code =
+                """
                 class C : I {
                     override fun someStuff(`object`: String) {}
                 }
@@ -41,7 +44,8 @@ class FunctionParameterNamingSpec : Spek({
         }
 
         it("should find some violations") {
-            val code = """
+            val code =
+                """
                 class C {
                     fun someStuff(PARAM: String) {}
                 }
@@ -55,7 +59,8 @@ class FunctionParameterNamingSpec : Spek({
         val config = TestConfig(mapOf(FunctionParameterNaming.EXCLUDE_CLASS_PATTERN to "Excluded"))
 
         it("should not detect function parameter") {
-            val code = """
+            val code =
+                """
                 class Excluded {
                     fun f(PARAM: Int) {}
                 }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/InvalidPackageDeclarationSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/InvalidPackageDeclarationSpec.kt
@@ -20,7 +20,8 @@ internal class InvalidPackageDeclarationSpec : Spek({
     describe("InvalidPackageDeclaration rule") {
 
         it("should pass if package declaration is correct") {
-            val source = """
+            val source =
+                """
                 package foo.bar
                 
                 class C
@@ -38,7 +39,8 @@ internal class InvalidPackageDeclarationSpec : Spek({
         }
 
         it("should report if package declaration does not match source location") {
-            val source = """
+            val source =
+                """
                 package foo
                 
                 class C
@@ -54,7 +56,8 @@ internal class InvalidPackageDeclarationSpec : Spek({
             val config = TestConfig(mapOf(ROOT_PACKAGE to "com.example"))
 
             it("should pass if file is located within the root package") {
-                val source = """
+                val source =
+                    """
                     package com.example
                     
                     class C
@@ -65,7 +68,8 @@ internal class InvalidPackageDeclarationSpec : Spek({
             }
 
             it("should pass if file is located relative to root package") {
-                val source = """
+                val source =
+                    """
                     package com.example.foo.bar
                     
                     class C
@@ -77,7 +81,8 @@ internal class InvalidPackageDeclarationSpec : Spek({
             }
 
             it("should pass if file is located in directory corresponding to package declaration") {
-                val source = """
+                val source =
+                    """
                     package com.example.foo.bar
                     
                     class C
@@ -89,7 +94,8 @@ internal class InvalidPackageDeclarationSpec : Spek({
             }
 
             it("should report if package declaration does not match") {
-                val source = """
+                val source =
+                    """
                     package com.example.foo.baz
                     
                     class C
@@ -100,7 +106,8 @@ internal class InvalidPackageDeclarationSpec : Spek({
                 assertThat(findings).hasSize(1)
             }
             it("should report if file path matches root package but package declaration differs") {
-                val source = """
+                val source =
+                    """
                     package io.foo.bar
                     
                     class C

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MatchingDeclarationNameSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MatchingDeclarationNameSpec.kt
@@ -22,7 +22,8 @@ internal class MatchingDeclarationNameSpec : Spek({
             it("should pass for suppress") {
                 val ktFile = compileContentForTest(
                     """@file:Suppress("MatchingDeclarationName") object O""",
-                    filename = "Objects.kt")
+                    filename = "Objects.kt"
+                )
                 val findings = MatchingDeclarationName().lint(ktFile)
                 assertThat(findings).isEmpty()
             }
@@ -40,56 +41,72 @@ internal class MatchingDeclarationNameSpec : Spek({
             }
 
             it("should pass for enum declaration") {
-                val ktFile = compileContentForTest("""
+                val ktFile = compileContentForTest(
+                    """
                     enum class E {
                         ONE, TWO, THREE
                     }
-                """, filename = "E.kt")
+                """,
+                    filename = "E.kt"
+                )
                 val findings = MatchingDeclarationName().lint(ktFile)
                 assertThat(findings).isEmpty()
             }
 
             it("should pass for multiple declaration") {
-                val ktFile = compileContentForTest("""
+                val ktFile = compileContentForTest(
+                    """
                     class C
                     object O
                     fun a() = 5
-                """, filename = "MultiDeclarations.kt")
+                """,
+                    filename = "MultiDeclarations.kt"
+                )
                 val findings = MatchingDeclarationName().lint(ktFile)
                 assertThat(findings).isEmpty()
             }
 
             it("should pass for class declaration with utility functions") {
-                val ktFile = compileContentForTest("""
+                val ktFile = compileContentForTest(
+                    """
                     class C
                     fun a() = 5
                     fun C.b() = 5
-                """, filename = "C.kt")
+                """,
+                    filename = "C.kt"
+                )
                 val findings = MatchingDeclarationName().lint(ktFile)
                 assertThat(findings).isEmpty()
             }
 
             it("should pass for class declaration not as first declaration with utility functions") {
-                val ktFile = compileContentForTest("""
+                val ktFile = compileContentForTest(
+                    """
                     fun a() = 5
                     fun C.b() = 5
                     class C
-                """, filename = "Classes.kt")
+                """,
+                    filename = "Classes.kt"
+                )
                 val findings = MatchingDeclarationName().lint(ktFile)
                 assertThat(findings).isEmpty()
             }
 
             it("should pass for private class declaration") {
-                val ktFile = compileContentForTest("""
+                val ktFile = compileContentForTest(
+                    """
                 private class C
                 fun a() = 5
-            """, filename = "b.kt")
+            """,
+                    filename = "b.kt"
+                )
                 val findings = MatchingDeclarationName().lint(ktFile)
                 assertThat(findings).isEmpty()
             }
 
             it("should pass for a class with a typealias") {
-                val code = """
+                val code =
+                    """
                 typealias Foo = FooImpl
 
                 class FooImpl {}"""
@@ -110,7 +127,8 @@ internal class MatchingDeclarationNameSpec : Spek({
             it("should not pass for object declaration even with suppress on the object") {
                 val ktFile = compileContentForTest(
                     """@Suppress("MatchingDeclarationName") object O""",
-                    filename = "Objects.kt")
+                    filename = "Objects.kt"
+                )
                 val findings = MatchingDeclarationName().lint(ktFile)
                 assertThat(findings).hasSourceLocation(1, 1)
             }
@@ -122,11 +140,14 @@ internal class MatchingDeclarationNameSpec : Spek({
             }
 
             it("should not pass for class declaration as first declaration with utility functions") {
-                val ktFile = compileContentForTest("""
+                val ktFile = compileContentForTest(
+                    """
                     class C
                     fun a() = 5
                     fun C.b() = 5
-                """.trimIndent(), filename = "ClassUtils.kt")
+                    """.trimIndent(),
+                    filename = "ClassUtils.kt"
+                )
                 val findings = MatchingDeclarationName().lint(ktFile)
                 assertThat(findings).hasSourceLocation(1, 1)
             }
@@ -138,17 +159,21 @@ internal class MatchingDeclarationNameSpec : Spek({
             }
 
             it("should not pass for enum declaration") {
-                val ktFile = compileContentForTest("""
+                val ktFile = compileContentForTest(
+                    """
                     enum class NOT_E {
                         ONE, TWO, THREE
                     }
-                """.trimIndent(), filename = "E.kt")
+                    """.trimIndent(),
+                    filename = "E.kt"
+                )
                 val findings = MatchingDeclarationName().lint(ktFile)
                 assertThat(findings).hasSourceLocation(1, 1)
             }
 
             it("should not pass for a typealias with a different name") {
-                val code = """
+                val code =
+                    """
                     class FooImpl {}
                     typealias Bar = FooImpl
                 """
@@ -157,15 +182,20 @@ internal class MatchingDeclarationNameSpec : Spek({
                 assertThat(findings).hasSize(1)
             }
 
-            it("""
+            it(
+                """
                 should not pass for class declaration not as first declaration with utility functions
                 when mustBeFirst is false.
-            """.trimIndent()) {
-                val ktFile = compileContentForTest("""
+                """.trimIndent()
+            ) {
+                val ktFile = compileContentForTest(
+                    """
                     fun a() = 5
                     fun C.b() = 5
                     class C
-                """, filename = "Classes.kt")
+                """,
+                    filename = "Classes.kt"
+                )
                 val findings = MatchingDeclarationName(
                     TestConfig("mustBeFirst" to "false")
                 ).lint(ktFile)

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MemberNameEqualsClassNameSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MemberNameEqualsClassNameSpec.kt
@@ -28,7 +28,8 @@ class MemberNameEqualsClassNameSpec : Spek({
         context("some classes with methods which don't have the same name") {
 
             it("does not report a nested function with the same name as the class") {
-                val code = """
+                val code =
+                    """
                     class MethodNameNotEqualsClassName {
                         fun nestedFunction() {
                             fun MethodNameNotEqualsClassName() {}
@@ -39,7 +40,8 @@ class MemberNameEqualsClassNameSpec : Spek({
             }
 
             it("does not report a function with same name in nested class") {
-                val code = """
+                val code =
+                    """
                     class MethodNameNotEqualsClassName {
                         class NestedNameEqualsTopClassName {
                             fun MethodNameNotEqualsClassName() {}
@@ -50,7 +52,8 @@ class MemberNameEqualsClassNameSpec : Spek({
             }
 
             it("does not report a function with the same name as a companion object") {
-                val code = """
+                val code =
+                    """
                     class StaticMethodNameEqualsObjectName {
                         companion object A {
                             fun A() {}
@@ -64,7 +67,8 @@ class MemberNameEqualsClassNameSpec : Spek({
         context("some classes with members which have the same name") {
 
             it("reports a method which is named after the class") {
-                val code = """
+                val code =
+                    """
                     class MethodNameEqualsClassName {
                         fun methodNameEqualsClassName() {}
                     }
@@ -73,7 +77,8 @@ class MemberNameEqualsClassNameSpec : Spek({
             }
 
             it("reports a method which is named after the object") {
-                val code = """
+                val code =
+                    """
                     object MethodNameEqualsObjectName {
                         fun MethodNameEqualsObjectName() {}
                     }
@@ -82,7 +87,8 @@ class MemberNameEqualsClassNameSpec : Spek({
             }
 
             it("reports a property which is named after the class") {
-                val code = """
+                val code =
+                    """
                     class PropertyNameEqualsClassName {
                         val propertyNameEqualsClassName = 0
                     }
@@ -91,7 +97,8 @@ class MemberNameEqualsClassNameSpec : Spek({
             }
 
             it("reports a property which is named after the object") {
-                val code = """
+                val code =
+                    """
                     object PropertyNameEqualsObjectName {
                         val propertyNameEqualsObjectName = 0
                     }
@@ -100,7 +107,8 @@ class MemberNameEqualsClassNameSpec : Spek({
             }
 
             it("reports a companion object function which is named after the class") {
-                val code = """
+                val code =
+                    """
                     class StaticMethodNameEqualsClassName {
                         companion object {
                             fun StaticMethodNameEqualsClassName() {}
@@ -111,7 +119,8 @@ class MemberNameEqualsClassNameSpec : Spek({
             }
 
             it("reports a method which is named after the class even when it's inside another one") {
-                val code = """
+                val code =
+                    """
                     class MethodNameContainer {
                         class MethodNameEqualsNestedClassName {
                             fun MethodNameEqualsNestedClassName() {}
@@ -122,7 +131,8 @@ class MemberNameEqualsClassNameSpec : Spek({
             }
 
             it("doesn't report overridden methods which are named after the class") {
-                val code = """
+                val code =
+                    """
                     class AbstractMethodNameEqualsClassName : BaseClassForMethodNameEqualsClassName() {
                         override fun AbstractMethodNameEqualsClassName() {}
                     }
@@ -134,7 +144,8 @@ class MemberNameEqualsClassNameSpec : Spek({
             }
 
             it("doesn't report an methods which are named after the interface") {
-                val code = """
+                val code =
+                    """
                     interface MethodNameEqualsInterfaceName {
                         fun MethodNameEqualsInterfaceName() {}
                     }
@@ -143,7 +154,8 @@ class MemberNameEqualsClassNameSpec : Spek({
             }
 
             it("reports overridden methods which are named after the class if they are not ignored") {
-                val code = """
+                val code =
+                    """
                     class AbstractMethodNameEqualsClassName : BaseClassForMethodNameEqualsClassName() {
                         override fun AbstractMethodNameEqualsClassName() {}
                     }
@@ -155,7 +167,8 @@ class MemberNameEqualsClassNameSpec : Spek({
             }
 
             it("doesn't report overridden properties which are named after the class") {
-                val code = """
+                val code =
+                    """
                     class AbstractMethodNameEqualsClassName : BaseClassForMethodNameEqualsClassName() {
                         override val AbstractMethodNameEqualsClassName = ""
                     }
@@ -167,7 +180,8 @@ class MemberNameEqualsClassNameSpec : Spek({
             }
 
             it("reports overridden properties which are named after the class if they are not ignored") {
-                val code = """
+                val code =
+                    """
                     class AbstractMethodNameEqualsClassName : BaseClassForMethodNameEqualsClassName() {
                         override val AbstractMethodNameEqualsClassName = ""
                     }
@@ -182,7 +196,8 @@ class MemberNameEqualsClassNameSpec : Spek({
         context("some companion object functions named after the class (factory functions)") {
 
             it("reports a function which has no return type") {
-                val code = """
+                val code =
+                    """
                     class WrongFactoryClass1 {
 
                         companion object {
@@ -194,7 +209,8 @@ class MemberNameEqualsClassNameSpec : Spek({
             }
 
             it("reports a function which has the wrong return type") {
-                val code = """
+                val code =
+                    """
                     class WrongFactoryClass2 {
 
                         companion object {
@@ -208,7 +224,8 @@ class MemberNameEqualsClassNameSpec : Spek({
             }
 
             it("reports a body-less function which has the wrong return type") {
-                val code = """
+                val code =
+                    """
                     class WrongFactoryClass3 {
                     
                         companion object {
@@ -220,7 +237,8 @@ class MemberNameEqualsClassNameSpec : Spek({
             }
 
             it("doesn't report a factory function") {
-                val code = """
+                val code =
+                    """
                     open class A {
                         companion object {
                             fun a(condition: Boolean): A {
@@ -237,7 +255,8 @@ class MemberNameEqualsClassNameSpec : Spek({
             }
 
             it("doesn't report a body-less factory function") {
-                val code = """
+                val code =
+                    """
                     open class A {
                       companion object {
                         fun a(condition: Boolean) = if (condition) B() else C()

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingConventionCustomPatternTest.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingConventionCustomPatternTest.kt
@@ -11,39 +11,40 @@ import java.util.regex.PatternSyntaxException
 class NamingConventionCustomPatternTest : Spek({
 
     val configCustomRules =
-            object : TestConfig() {
-                override fun subConfig(key: String): TestConfig = this
+        object : TestConfig() {
+            override fun subConfig(key: String): TestConfig = this
 
-                @Suppress("UNCHECKED_CAST")
-                override fun <T : Any> valueOrDefault(key: String, default: T): T =
-                        when (key) {
-                            FunctionNaming.FUNCTION_PATTERN -> "^`.+`$" as T
-                            ClassNaming.CLASS_PATTERN -> "^aBbD$" as T
-                            VariableNaming.VARIABLE_PATTERN -> "^123var$" as T
-                            TopLevelPropertyNaming.CONSTANT_PATTERN -> "^lowerCaseConst$" as T
-                            EnumNaming.ENUM_PATTERN -> "^(enum1)|(enum2)$" as T
-                            PackageNaming.PACKAGE_PATTERN -> "^(package_1)$" as T
-                            FunctionMaxLength.MAXIMUM_FUNCTION_NAME_LENGTH -> 50 as T
-                            else -> default
-                        }
-            }
+            @Suppress("UNCHECKED_CAST")
+            override fun <T : Any> valueOrDefault(key: String, default: T): T =
+                when (key) {
+                    FunctionNaming.FUNCTION_PATTERN -> "^`.+`$" as T
+                    ClassNaming.CLASS_PATTERN -> "^aBbD$" as T
+                    VariableNaming.VARIABLE_PATTERN -> "^123var$" as T
+                    TopLevelPropertyNaming.CONSTANT_PATTERN -> "^lowerCaseConst$" as T
+                    EnumNaming.ENUM_PATTERN -> "^(enum1)|(enum2)$" as T
+                    PackageNaming.PACKAGE_PATTERN -> "^(package_1)$" as T
+                    FunctionMaxLength.MAXIMUM_FUNCTION_NAME_LENGTH -> 50 as T
+                    else -> default
+                }
+        }
     val testConfig = object : TestConfig() {
         override fun subConfig(key: String): TestConfig =
-                when (key) {
-                    FunctionNaming::class.simpleName -> configCustomRules
-                    FunctionMaxLength::class.simpleName -> configCustomRules
-                    ClassNaming::class.simpleName -> configCustomRules
-                    VariableNaming::class.simpleName -> configCustomRules
-                    TopLevelPropertyNaming::class.simpleName -> configCustomRules
-                    EnumNaming::class.simpleName -> configCustomRules
-                    PackageNaming::class.simpleName -> configCustomRules
-                    else -> this
-                }
+            when (key) {
+                FunctionNaming::class.simpleName -> configCustomRules
+                FunctionMaxLength::class.simpleName -> configCustomRules
+                ClassNaming::class.simpleName -> configCustomRules
+                VariableNaming::class.simpleName -> configCustomRules
+                TopLevelPropertyNaming::class.simpleName -> configCustomRules
+                EnumNaming::class.simpleName -> configCustomRules
+                PackageNaming::class.simpleName -> configCustomRules
+                else -> this
+            }
 
         override fun <T : Any> valueOrDefault(key: String, default: T): T = default
     }
 
-    val excludeClassPatternVariableRegexCode = """
+    val excludeClassPatternVariableRegexCode =
+        """
             class Bar {
                 val MYVar = 3
             }
@@ -52,7 +53,8 @@ class NamingConventionCustomPatternTest : Spek({
                 val MYVar = 3
             }"""
 
-    val excludeClassPatternFunctionRegexCode = """
+    val excludeClassPatternFunctionRegexCode =
+        """
             class Bar {
                 fun MYFun() {}
             }
@@ -65,7 +67,9 @@ class NamingConventionCustomPatternTest : Spek({
 
         it("should use custom name for method and class") {
             val rule = NamingRules(testConfig)
-            assertThat(rule.compileAndLint("""
+            assertThat(
+                rule.compileAndLint(
+                    """
             class aBbD{
                 fun `name with back ticks`(){
                   val `123var` = ""
@@ -75,29 +79,39 @@ class NamingConventionCustomPatternTest : Spek({
                   const val lowerCaseConst = ""
                 }
             }
-        """)).isEmpty()
+        """
+                )
+            ).isEmpty()
         }
 
         it("should use custom name for constant") {
             val rule = NamingRules(testConfig)
-            assertThat(rule.compileAndLint("""
+            assertThat(
+                rule.compileAndLint(
+                    """
             class aBbD{
                 companion object {
                   const val lowerCaseConst = ""
                 }
             }
-        """)).isEmpty()
+        """
+                )
+            ).isEmpty()
         }
 
         it("should use custom name for enum") {
             val rule = NamingRules(testConfig)
-            assertThat(rule.compileAndLint("""
+            assertThat(
+                rule.compileAndLint(
+                    """
             class aBbD{
                 enum class aBbD {
                     enum1, enum2
                 }
             }
-        """)).isEmpty()
+        """
+                )
+            ).isEmpty()
         }
 
         it("should use custom name for package") {
@@ -106,7 +120,8 @@ class NamingConventionCustomPatternTest : Spek({
         }
 
         it("shouldExcludeClassesFromVariableNaming") {
-            val code = """
+            val code =
+                """
             class Bar {
                 val MYVar = 3
             }
@@ -120,8 +135,8 @@ class NamingConventionCustomPatternTest : Spek({
 
         it("shouldNotFailWithInvalidRegexWhenDisabledVariableNaming") {
             val configValues = mapOf(
-                    "active" to "false",
-                    VariableNaming.EXCLUDE_CLASS_PATTERN to "*Foo"
+                "active" to "false",
+                VariableNaming.EXCLUDE_CLASS_PATTERN to "*Foo"
             )
             val config = TestConfig(configValues)
             assertThat(VariableNaming(config).compileAndLint(excludeClassPatternVariableRegexCode)).isEmpty()
@@ -135,7 +150,8 @@ class NamingConventionCustomPatternTest : Spek({
         }
 
         it("shouldExcludeClassesFromFunctionNaming") {
-            val code = """
+            val code =
+                """
             class Bar {
                 fun MYFun() {}
             }
@@ -149,8 +165,8 @@ class NamingConventionCustomPatternTest : Spek({
 
         it("shouldNotFailWithInvalidRegexWhenDisabledFunctionNaming") {
             val configRules = mapOf(
-                    "active" to "false",
-                    FunctionNaming.EXCLUDE_CLASS_PATTERN to "*Foo"
+                "active" to "false",
+                FunctionNaming.EXCLUDE_CLASS_PATTERN to "*Foo"
             )
             val config = TestConfig(configRules)
             assertThat(FunctionNaming(config).compileAndLint(excludeClassPatternFunctionRegexCode)).isEmpty()

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingConventionLengthSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingConventionLengthSpec.kt
@@ -13,7 +13,8 @@ class NamingConventionLengthSpec : Spek({
     describe("NamingRules rule") {
 
         it("should not report underscore variable names") {
-            val code = """
+            val code =
+                """
                 fun getResult(): Pair<String, String> = TODO()
                 fun function() {
                     val (_, status) = getResult()
@@ -39,7 +40,8 @@ class NamingConventionLengthSpec : Spek({
             }
 
             it("does not report a variable with only a single underscore") {
-                val code = """
+                val code =
+                    """
             class C {
                 val prop: (Int) -> Unit = { _ -> Unit }
             }"""

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingRulesSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingRulesSpec.kt
@@ -9,7 +9,8 @@ class NamingRulesSpec : Spek({
 
     describe("naming like in constants is allowed for destructuring and lambdas") {
         it("should not detect any") {
-            val code = """
+            val code =
+                """
                 data class D(val i: Int, val j: Int)
                 fun doStuff() {
                     val (_, HOLY_GRAIL) = D(5, 4)

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNamingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNamingSpec.kt
@@ -13,7 +13,8 @@ class ObjectPropertyNamingSpec : Spek({
         val subject by memoized { ObjectPropertyNaming() }
 
         it("should not detect public constants complying to the naming rules") {
-            val code = """
+            val code =
+                """
                 object O {
                     ${PublicConst.negative}
                 }
@@ -22,7 +23,8 @@ class ObjectPropertyNamingSpec : Spek({
         }
 
         it("should detect public constants not complying to the naming rules") {
-            val code = """
+            val code =
+                """
                 object O {
                     ${PublicConst.positive}
                 }
@@ -31,7 +33,8 @@ class ObjectPropertyNamingSpec : Spek({
         }
 
         it("should not detect private constants complying to the naming rules") {
-            val code = """
+            val code =
+                """
                 object O {
                     ${PrivateConst.negative}
                 }
@@ -40,7 +43,8 @@ class ObjectPropertyNamingSpec : Spek({
         }
 
         it("should detect private constants not complying to the naming rules") {
-            val code = """
+            val code =
+                """
                 object O {
                     ${PrivateConst.positive}
                 }
@@ -49,7 +53,8 @@ class ObjectPropertyNamingSpec : Spek({
         }
 
         it("should report constants not complying to the naming rules at the right position") {
-            val code = """
+            val code =
+                """
                 object O {
                     ${PublicConst.positive}
                 }
@@ -63,7 +68,8 @@ class ObjectPropertyNamingSpec : Spek({
         val subject by memoized { ObjectPropertyNaming() }
 
         it("should not detect public constants complying to the naming rules") {
-            val code = """
+            val code =
+                """
                 class C {
                     companion object {
                         ${PublicConst.negative}
@@ -74,7 +80,8 @@ class ObjectPropertyNamingSpec : Spek({
         }
 
         it("should detect public constants not complying to the naming rules") {
-            val code = """
+            val code =
+                """
                 class C {
                     companion object {
                         ${PublicConst.positive}
@@ -85,7 +92,8 @@ class ObjectPropertyNamingSpec : Spek({
         }
 
         it("should not detect private constants complying to the naming rules") {
-            val code = """
+            val code =
+                """
                 class C {
                     companion object {
                         ${PrivateConst.negative}
@@ -96,7 +104,8 @@ class ObjectPropertyNamingSpec : Spek({
         }
 
         it("should detect private constants not complying to the naming rules") {
-            val code = """
+            val code =
+                """
                 class C {
                     companion object {
                         ${PrivateConst.positive}
@@ -107,7 +116,8 @@ class ObjectPropertyNamingSpec : Spek({
         }
 
         it("should report constants not complying to the naming rules at the right position") {
-            val code = """
+            val code =
+                """
                 class C {
                     companion object {
                         ${PublicConst.positive}
@@ -123,7 +133,8 @@ class ObjectPropertyNamingSpec : Spek({
         val subject by memoized { ObjectPropertyNaming() }
 
         it("should not detect public variables complying to the naming rules") {
-            val code = """
+            val code =
+                """
                 object O {
                     ${PublicVal.negative}
                 }
@@ -132,7 +143,8 @@ class ObjectPropertyNamingSpec : Spek({
         }
 
         it("should detect public variables not complying to the naming rules") {
-            val code = """
+            val code =
+                """
                 object O {
                     ${PublicVal.positive}
                 }
@@ -141,7 +153,8 @@ class ObjectPropertyNamingSpec : Spek({
         }
 
         it("should not detect private variables complying to the naming rules") {
-            val code = """
+            val code =
+                """
                 object O {
                     ${PrivateVal.negative}
                 }
@@ -150,7 +163,8 @@ class ObjectPropertyNamingSpec : Spek({
         }
 
         it("should detect private variables not complying to the naming rules") {
-            val code = """
+            val code =
+                """
                 object O {
                     private val __NAME = "Artur"
                 }
@@ -161,14 +175,17 @@ class ObjectPropertyNamingSpec : Spek({
 
     describe("variables and constants in objects with custom config") {
 
-        val config = TestConfig(mapOf(
+        val config = TestConfig(
+            mapOf(
                 ObjectPropertyNaming.CONSTANT_PATTERN to "_[A-Za-z]*",
                 ObjectPropertyNaming.PRIVATE_PROPERTY_PATTERN to ".*"
-        ))
+            )
+        )
         val subject = ObjectPropertyNaming(config)
 
         it("should not detect constants in object with underscores") {
-            val code = """
+            val code =
+                """
                 object O {
                     const val _NAME = "Artur"
                     const val _name = "Artur"
@@ -178,7 +195,8 @@ class ObjectPropertyNamingSpec : Spek({
         }
 
         it("should not detect private properties in object") {
-            val code = """
+            val code =
+                """
                 object O {
                     private val __NAME = "Artur"
                     private val _1234 = "Artur"
@@ -190,12 +208,15 @@ class ObjectPropertyNamingSpec : Spek({
 
     describe("local properties") {
         it("should not detect local properties") {
-            val config = TestConfig(mapOf(
-                ObjectPropertyNaming.PROPERTY_PATTERN to "valid"
-            ))
+            val config = TestConfig(
+                mapOf(
+                    ObjectPropertyNaming.PROPERTY_PATTERN to "valid"
+                )
+            )
             val subject = ObjectPropertyNaming(config)
 
-            val code = """
+            val code =
+                """
                 object O {
                     fun foo() {
                         val somethingElse = 1
@@ -211,14 +232,16 @@ class ObjectPropertyNamingSpec : Spek({
 @Suppress("UnnecessaryAbstractClass")
 abstract class NamingSnippet(private val isPrivate: Boolean, private val isConst: Boolean) {
 
-    val negative = """
+    val negative =
+        """
                     ${visibility()}${const()}val MY_NAME_8 = "Artur"
                     ${visibility()}${const()}val MYNAME = "Artur"
                     ${visibility()}${const()}val MyNAME = "Artur"
                     ${visibility()}${const()}val name = "Artur"
                     ${visibility()}${const()}val nAme = "Artur"
                     ${visibility()}${const()}val serialVersionUID = 42L"""
-    val positive = """${visibility()}${const()}val _nAme = "Artur""""
+    val positive =
+        """${visibility()}${const()}val _nAme = "Artur""""
 
     private fun visibility() = if (isPrivate) "private " else ""
     private fun const() = if (isConst) "const " else ""

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/TopLevelPropertyNamingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/TopLevelPropertyNamingSpec.kt
@@ -12,7 +12,8 @@ class TopLevelPropertyNamingSpec : Spek({
     describe("constants on top level") {
 
         it("should not detect any constants not complying to the naming rules") {
-            val code = """
+            val code =
+                """
                 const val MY_NAME_8 = "Artur"
                 const val MYNAME = "Artur"
             """
@@ -20,7 +21,8 @@ class TopLevelPropertyNamingSpec : Spek({
         }
 
         it("should detect five constants not complying to the naming rules") {
-            val code = """
+            val code =
+                """
                 const val MyNAME = "Artur"
                 const val name = "Artur"
                 const val nAme = "Artur"
@@ -34,7 +36,8 @@ class TopLevelPropertyNamingSpec : Spek({
     describe("variables on top level") {
 
         it("should not report any") {
-            val code = """
+            val code =
+                """
                 val name = "Artur"
                 val nAme8 = "Artur"
                 private val _name = "Artur"
@@ -50,14 +53,16 @@ class TopLevelPropertyNamingSpec : Spek({
         }
 
         it("should report non private top level property using underscore") {
-            val code = """
+            val code =
+                """
                 val _nAme = "Artur"
             """
             assertThat(subject.lint(code)).hasSize(1)
         }
 
         it("should report private top level property using two underscores") {
-            val code = """
+            val code =
+                """
                 private val __NAME = "Artur"
             """
             io.gitlab.arturbosch.detekt.test.assertThat(subject.lint(code)).hasSize(1)

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableNamingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableNamingSpec.kt
@@ -12,7 +12,8 @@ class VariableNamingSpec : Spek({
     describe("properties in classes") {
 
         it("should detect all positive cases") {
-            val code = """
+            val code =
+                """
                 class C {
                     private val _FIELD = 5
                     val FIELD get() = _FIELD
@@ -28,7 +29,8 @@ class VariableNamingSpec : Spek({
         }
 
         it("checks all negative cases") {
-            val code = """
+            val code =
+                """
                 class C {
                     private val _field = 5
                     val field get() = _field
@@ -39,7 +41,8 @@ class VariableNamingSpec : Spek({
         }
 
         it("should not flag overridden member properties by default") {
-            val code = """
+            val code =
+                """
                 class C : I {
                     override val SHOULD_NOT_BE_FLAGGED = "banana"
                 }
@@ -54,7 +57,8 @@ class VariableNamingSpec : Spek({
         }
 
         it("doesn't ignore overridden member properties if ignoreOverridden is false") {
-            val code = """
+            val code =
+                """
                 class C : I {
                     override val SHOULD_BE_FLAGGED = "banana"
                 }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/ForEachOnRangeSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/ForEachOnRangeSpec.kt
@@ -10,7 +10,8 @@ class ForEachOnRangeSpec : Spek({
     describe("ForEachOnRange rule") {
 
         context("a kt file with using a forEach on a range") {
-            val code = """
+            val code =
+                """
             fun test() {
                 (1..10).forEach {
                     println(it)
@@ -34,7 +35,8 @@ class ForEachOnRangeSpec : Spek({
         }
 
         context("a kt file with using any other method on a range") {
-            val code = """
+            val code =
+                """
             fun test() {
                 (1..10).isEmpty()
             }
@@ -47,7 +49,8 @@ class ForEachOnRangeSpec : Spek({
         }
 
         context("a kt file with using a forEach on a list") {
-            val code = """
+            val code =
+                """
             fun test() {
                 listOf(1, 2, 3).forEach {
                     println(it)

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/SpreadOperatorSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/SpreadOperatorSpec.kt
@@ -23,10 +23,11 @@ class SpreadOperatorSpec : Spek({
             )
 
             val typeResolutionEnabledMessage = "Used in this way a spread operator causes a full copy of the array to" +
-                    " be created before calling a method which has a very high performance penalty."
+                " be created before calling a method which has a very high performance penalty."
 
             it("reports when array copy required using named parameters") {
-                val code = """
+                val code =
+                    """
                     val xsArray = intArrayOf(1)
                     fun foo(vararg xs: Int) {}
                     val testVal = foo(xs = *xsArray)
@@ -36,7 +37,8 @@ class SpreadOperatorSpec : Spek({
                 assertThat(actual.first().message).isEqualTo(typeResolutionEnabledMessage)
             }
             it("reports when array copy required without using named parameters") {
-                val code = """
+                val code =
+                    """
                     val xsArray = intArrayOf(1)
                     fun foo(vararg xs: Int) {}
                     val testVal = foo(*xsArray)
@@ -46,7 +48,8 @@ class SpreadOperatorSpec : Spek({
                 assertThat(actual.first().message).isEqualTo(typeResolutionEnabledMessage)
             }
             it("doesn't report when using array constructor with spread operator") {
-                val code = """
+                val code =
+                    """
                     fun foo(vararg xs: Int) {}
                     val testVal = foo(xs = *intArrayOf(1))
                 """
@@ -54,7 +57,8 @@ class SpreadOperatorSpec : Spek({
             }
 
             it("doesn't report when using array constructor with spread operator when varargs parameter comes first") {
-                val code = """
+                val code =
+                    """
                     fun <T> asList(vararg ts: T, stringValue: String): List<Int> = listOf(1,2,3)
                     val list = asList(-1, 0, *arrayOf(1, 2, 3), 4, stringValue = "5")
                 """
@@ -62,7 +66,8 @@ class SpreadOperatorSpec : Spek({
             }
 
             it("doesn't report when passing values directly") {
-                val code = """
+                val code =
+                    """
                     fun <T> asList(vararg ts: T, stringValue: String): List<Int> = listOf(1,2,3)
                     val list = asList(-1, 0, 1, 2, 3, 4, stringValue = "5")
                 """
@@ -70,7 +75,8 @@ class SpreadOperatorSpec : Spek({
             }
 
             it("doesn't report when function doesn't take a vararg parameter") {
-                val code = """
+                val code =
+                    """
                 fun test0(strs: Array<String>) {
                     test(strs)
                 }
@@ -83,7 +89,8 @@ class SpreadOperatorSpec : Spek({
             }
 
             it("doesn't report with expression inside params") {
-                val code = """
+                val code =
+                    """
                 fun test0(strs: Array<String>) {
                     test(2*2)
                 }
@@ -99,10 +106,11 @@ class SpreadOperatorSpec : Spek({
         context("without type resolution") {
 
             val typeResolutionDisabledMessage = "In most cases using a spread operator causes a full copy of the " +
-                    "array to be created before calling a method which has a very high performance penalty."
+                "array to be created before calling a method which has a very high performance penalty."
 
             it("reports when array copy required using named parameters") {
-                val code = """
+                val code =
+                    """
                     val xsArray = intArrayOf(1)
                     fun foo(vararg xs: Int) {}
                     val testVal = foo(xs = *xsArray)
@@ -112,7 +120,8 @@ class SpreadOperatorSpec : Spek({
                 assertThat(actual.first().message).isEqualTo(typeResolutionDisabledMessage)
             }
             it("reports when array copy required without using named parameters") {
-                val code = """
+                val code =
+                    """
                     val xsArray = intArrayOf(1)
                     fun foo(vararg xs: Int) {}
                     val testVal = foo(*xsArray)
@@ -122,7 +131,8 @@ class SpreadOperatorSpec : Spek({
                 assertThat(actual.first().message).isEqualTo(typeResolutionDisabledMessage)
             }
             it("doesn't report when using array constructor with spread operator") {
-                val code = """
+                val code =
+                    """
                     fun foo(vararg xs: Int) {}
                     val testVal = foo(xs = *intArrayOf(1))
                 """
@@ -132,7 +142,8 @@ class SpreadOperatorSpec : Spek({
             }
 
             it("doesn't report when using array constructor with spread operator when varargs parameter comes first") {
-                val code = """
+                val code =
+                    """
                     fun <T> asList(vararg ts: T, stringValue: String): List<Int> = listOf(1,2,3)
                     val list = asList(-1, 0, *arrayOf(1, 2, 3), 4, stringValue = "5")
                 """
@@ -142,7 +153,8 @@ class SpreadOperatorSpec : Spek({
             }
 
             it("doesn't report when passing values directly") {
-                val code = """
+                val code =
+                    """
                     fun <T> asList(vararg ts: T, stringValue: String): List<Int> = listOf(1,2,3)
                     val list = asList(-1, 0, 1, 2, 3, 4, stringValue = "5")
                 """
@@ -150,7 +162,8 @@ class SpreadOperatorSpec : Spek({
             }
 
             it("doesn't report when function doesn't take a vararg parameter") {
-                val code = """
+                val code =
+                    """
                 fun test0(strs: Array<String>) {
                     test(strs)
                 }
@@ -163,7 +176,8 @@ class SpreadOperatorSpec : Spek({
             }
 
             it("doesn't report with expression inside params") {
-                val code = """
+                val code =
+                    """
                 fun test0(strs: Array<String>) {
                     test(2*2)
                 }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/CollapsibleIfStatementsSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/CollapsibleIfStatementsSpec.kt
@@ -12,7 +12,8 @@ class CollapsibleIfStatementsSpec : Spek({
     describe("CollapsibleIfStatements rule") {
 
         it("reports if statements which can be merged") {
-            val code = """
+            val code =
+                """
                 fun f() {
                     if (true) {
                         if (1 == 1) {}
@@ -24,7 +25,8 @@ class CollapsibleIfStatementsSpec : Spek({
         }
 
         it("reports nested if statements which can be merged") {
-            val code = """
+            val code =
+                """
                 fun f() {
                     if (true) {
                         if (1 == 1) {
@@ -38,7 +40,8 @@ class CollapsibleIfStatementsSpec : Spek({
         }
 
         it("does not report else-if") {
-            val code = """
+            val code =
+                """
                 fun f() {
                     if (true) {}
                     else if (1 == 1) {
@@ -50,7 +53,8 @@ class CollapsibleIfStatementsSpec : Spek({
         }
 
         it("does not report if-else") {
-            val code = """
+            val code =
+                """
                 fun f() {
                     if (true) {
                         if (1 == 1) {}
@@ -61,7 +65,8 @@ class CollapsibleIfStatementsSpec : Spek({
         }
 
         it("does not report if-elseif-else") {
-            val code = """
+            val code =
+                """
                 fun f() {
                     if (true) {
                         if (1 == 1) {}
@@ -73,7 +78,8 @@ class CollapsibleIfStatementsSpec : Spek({
         }
 
         it("does not report if with statements in the if body") {
-            val code = """
+            val code =
+                """
                 fun f() {
                     if (true) {
                         if (1 == 1) ;
@@ -85,7 +91,8 @@ class CollapsibleIfStatementsSpec : Spek({
         }
 
         it("does not report nested if-else") {
-            val code = """
+            val code =
+                """
                 fun f() {
                     if (true) {
                         if (1 == 1) {
@@ -97,7 +104,8 @@ class CollapsibleIfStatementsSpec : Spek({
         }
 
         it("does not report nested if-elseif") {
-            val code = """
+            val code =
+                """
                 fun f() {
                     if (true) {
                         if (1 == 1) {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/DataClassContainsFunctionsSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/DataClassContainsFunctionsSpec.kt
@@ -12,7 +12,8 @@ class DataClassContainsFunctionsSpec : Spek({
     describe("DataClassContainsFunctions rule") {
 
         context("flagged functions in data class") {
-            val code = """
+            val code =
+                """
                 data class C(val s: String) {
                     fun f() {}
 
@@ -39,7 +40,8 @@ class DataClassContainsFunctionsSpec : Spek({
         }
 
         it("does not report a non-data class without a function") {
-            val code = """
+            val code =
+                """
                 class C {
                     fun f() {}
                 }
@@ -48,7 +50,8 @@ class DataClassContainsFunctionsSpec : Spek({
         }
 
         it("does not report a data class with overridden functions") {
-            val code = """
+            val code =
+                """
                 data class C(val i: Int) {
 
                     override fun hashCode(): Int {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/DataClassShouldBeImmutableSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/DataClassShouldBeImmutableSpec.kt
@@ -16,7 +16,8 @@ class DataClassShouldBeImmutableSpec : Spek({
         }
 
         it("reports mutable property in class body") {
-            val code = """
+            val code =
+                """
                 data class C(val i: Int) {
                     var s: String? = null
                 }
@@ -25,7 +26,8 @@ class DataClassShouldBeImmutableSpec : Spek({
         }
 
         it("reports mutable private property in class body") {
-            val code = """
+            val code =
+                """
                 data class C(val i: Int) {
                     var s: String = ""
                         private set
@@ -35,7 +37,8 @@ class DataClassShouldBeImmutableSpec : Spek({
         }
 
         it("reports lateinit property in class body") {
-            val code = """
+            val code =
+                """
                 data class C(val i: Int) {
                     lateinit var s: String
                 }
@@ -49,7 +52,8 @@ class DataClassShouldBeImmutableSpec : Spek({
         }
 
         it("does not report readonly property in class body") {
-            val code = """
+            val code =
+                """
                 data class C(val i: Int) {
                     val s: String? = null
                 }
@@ -58,7 +62,8 @@ class DataClassShouldBeImmutableSpec : Spek({
         }
 
         it("does not report lazy property in class body") {
-            val code = """
+            val code =
+                """
                 data class C(val i: Int) {
                     val s: String by lazy { "" }
                 }
@@ -67,7 +72,8 @@ class DataClassShouldBeImmutableSpec : Spek({
         }
 
         it("does not report mutable variables in non-data classes") {
-            val code = """
+            val code =
+                """
                 class C(var i: Int) {
                     val s: String by lazy { "" }
                 }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/EqualsNullCallSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/EqualsNullCallSpec.kt
@@ -12,7 +12,8 @@ class EqualsNullCallSpec : Spek({
     describe("EqualsNullCall rule") {
 
         it("reports equals call with null as parameter") {
-            val code = """
+            val code =
+                """
                 fun x(a: String) {
                     a.equals(null)
                 }"""
@@ -20,7 +21,8 @@ class EqualsNullCallSpec : Spek({
         }
 
         it("reports nested equals call with null as parameter") {
-            val code = """
+            val code =
+                """
                 fun x(a: String, b: String) {
                     a.equals(b.equals(null))
                 }"""
@@ -28,7 +30,8 @@ class EqualsNullCallSpec : Spek({
         }
 
         it("does not report equals call with parameter of type string") {
-            val code = """
+            val code =
+                """
                 fun x(a: String, b: String) {
                     a.equals(b)
                 }"""

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/EqualsOnSignatureLineSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/EqualsOnSignatureLineSpec.kt
@@ -13,27 +13,32 @@ class EqualsOnSignatureLineSpec : Spek({
 
         context("with expression syntax and without a return type") {
             it("reports when the equals is on a new line") {
-                val findings = subject.compileAndLint("""
+                val findings = subject.compileAndLint(
+                    """
                     fun foo()
                         = 1
-                """)
+                """
+                )
                 assertThat(findings).hasSize(1)
             }
 
             it("does not report when the equals is on the same line") {
-                val findings = subject.compileAndLint("""
+                val findings = subject.compileAndLint(
+                    """
                 fun foo() = 1
 
                 fun bar() =
                     2
-                """)
+                """
+                )
                 assertThat(findings).isEmpty()
             }
         }
 
         context("with expression syntax and with a return type") {
             it("reports when the equals is on a new line") {
-                val findings = subject.compileAndLint("""
+                val findings = subject.compileAndLint(
+                    """
                 fun one(): Int
                     = 1
 
@@ -46,12 +51,14 @@ class EqualsOnSignatureLineSpec : Spek({
                     foo: String
                 ): Int
                     = 3
-                """)
+                """
+                )
                 assertThat(findings).hasSize(3)
             }
 
             it("does not report when the equals is on the same line") {
-                val findings = subject.compileAndLint("""
+                val findings = subject.compileAndLint(
+                    """
                 fun one(): Int =
                     1
 
@@ -80,14 +87,16 @@ class EqualsOnSignatureLineSpec : Spek({
                 :
                 Int =
                     6
-                """)
+                """
+                )
                 assertThat(findings).isEmpty()
             }
         }
 
         context("with expression syntax and with a where clause") {
             it("reports when the equals is on a new line") {
-                val findings = subject.compileAndLint("""
+                val findings = subject.compileAndLint(
+                    """
                 fun <V> one(): Int where V : Number
                     = 1
 
@@ -101,12 +110,14 @@ class EqualsOnSignatureLineSpec : Spek({
                 ): Int
                     where V : Number
                     = 3
-                """)
+                """
+                )
                 assertThat(findings).hasSize(3)
             }
 
             it("does not report when the equals is on the same line") {
-                val findings = subject.compileAndLint("""
+                val findings = subject.compileAndLint(
+                    """
                 fun <V> one(): Int where V : Number =
                     1
 
@@ -114,13 +125,15 @@ class EqualsOnSignatureLineSpec : Spek({
                     where V : Number =
                     2
 
-                """)
+                """
+                )
                 assertThat(findings).isEmpty()
             }
         }
 
         it("does not report non-expression functions") {
-            val findings = subject.compileAndLint("""
+            val findings = subject.compileAndLint(
+                """
             fun foo() {
             }
 
@@ -133,7 +146,8 @@ class EqualsOnSignatureLineSpec : Spek({
             Unit
             {
             }
-            """)
+            """
+            )
             assertThat(findings).isEmpty()
         }
     }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitCollectionElementAccessMethodSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitCollectionElementAccessMethodSpec.kt
@@ -19,7 +19,8 @@ class ExplicitCollectionElementAccessMethodSpec : Spek({
     describe("Kotlin map") {
 
         it("reports map element access with get method") {
-            val code = """
+            val code =
+                """
                     fun f() {
                         val map = mapOf<String, String>() 
                         val value = map.get("key") 
@@ -28,7 +29,8 @@ class ExplicitCollectionElementAccessMethodSpec : Spek({
         }
 
         it("does not report safe map element access") {
-            val code = """
+            val code =
+                """
                     fun f() {
                         val map = mapOf<String, String>() 
                         val value = map?.get("key") 
@@ -37,7 +39,8 @@ class ExplicitCollectionElementAccessMethodSpec : Spek({
         }
 
         it("reports map put method usage") {
-            val code = """
+            val code =
+                """
                     fun f() {
                         val map = mutableMapOf<String, String>()
                         map.put("key", "val") 
@@ -46,7 +49,8 @@ class ExplicitCollectionElementAccessMethodSpec : Spek({
         }
 
         it("reports map element access with get method of non-abstract map") {
-            val code = """
+            val code =
+                """
                     fun f() {
                         val map = hashMapOf<String, String>() 
                         val value = map.get("key") 
@@ -55,7 +59,8 @@ class ExplicitCollectionElementAccessMethodSpec : Spek({
         }
 
         it("reports map element insert with put method of non-abstract map") {
-            val code = """
+            val code =
+                """
                     fun f() {
                         val map = hashMapOf<String, String>() 
                         val value = map.put("key", "value") 
@@ -64,7 +69,8 @@ class ExplicitCollectionElementAccessMethodSpec : Spek({
         }
 
         it("does not report map access with []") {
-            val code = """
+            val code =
+                """
                     fun f() {
                         val map = mapOf<String, String>()
                         val value = map["key"] 
@@ -73,7 +79,8 @@ class ExplicitCollectionElementAccessMethodSpec : Spek({
         }
 
         it("does not report map insert with []") {
-            val code = """
+            val code =
+                """
                     fun f() {
                         val map = mutableMapOf<String, String>()
                         map["key"] = "value" 
@@ -82,7 +89,8 @@ class ExplicitCollectionElementAccessMethodSpec : Spek({
         }
 
         it("reports map element access with get method from map in a chain") {
-            val code = """
+            val code =
+                """
                     fun f() {
                         val map = mapOf<String, String>()
                         val value = listOf("1", "2").associateBy { it }.get("1")
@@ -91,7 +99,8 @@ class ExplicitCollectionElementAccessMethodSpec : Spek({
         }
 
         it("reports map element access with get method from non-abstract map") {
-            val code = """
+            val code =
+                """
                     fun f() {
                         val map = linkedMapOf<String, String>()
                         val value = map.get("key") 
@@ -102,7 +111,8 @@ class ExplicitCollectionElementAccessMethodSpec : Spek({
 
     describe("Kotlin list") {
         it("reports list element access with get method") {
-            val code = """
+            val code =
+                """
                     fun f() {
                         val list = listOf<String>() 
                         val value = list.get(0) 
@@ -111,7 +121,8 @@ class ExplicitCollectionElementAccessMethodSpec : Spek({
         }
 
         it("reports mutable list element access with get method") {
-            val code = """
+            val code =
+                """
                     fun f() {
                         val list = mutableListOf<String>()
                         val value = list.get(0) 
@@ -120,7 +131,8 @@ class ExplicitCollectionElementAccessMethodSpec : Spek({
         }
 
         it("does not report element access with []") {
-            val code = """
+            val code =
+                """
                     fun f() {
                         val list = listOf<String>() 
                         val value = list[0] 
@@ -129,7 +141,8 @@ class ExplicitCollectionElementAccessMethodSpec : Spek({
         }
 
         it("reports element access with get method of non-abstract list") {
-            val code = """
+            val code =
+                """
                     fun f() {
                         val list = arrayListOf<String>() 
                         val value = list.get(0) 
@@ -141,7 +154,8 @@ class ExplicitCollectionElementAccessMethodSpec : Spek({
     describe("Java map") {
 
         it("reports map element access with get method") {
-            val code = """
+            val code =
+                """
                     fun f() {
                         val map = java.util.HashMap<String, String>() 
                         val value = map.get("key") 
@@ -150,7 +164,8 @@ class ExplicitCollectionElementAccessMethodSpec : Spek({
         }
 
         it("reports map put method usage") {
-            val code = """
+            val code =
+                """
                     fun f() {
                         val map = java.util.HashMap<String, String>() 
                         map.put("key", "val") 
@@ -159,7 +174,8 @@ class ExplicitCollectionElementAccessMethodSpec : Spek({
         }
 
         it("does not report map access with []") {
-            val code = """
+            val code =
+                """
                     fun f() {
                         val map = java.util.HashMap<String, String>() 
                         val value = map["key"] 
@@ -168,7 +184,8 @@ class ExplicitCollectionElementAccessMethodSpec : Spek({
         }
 
         it("does not report map insert with []") {
-            val code = """
+            val code =
+                """
                     fun f() {
                         val map = java.util.HashMap<String, String>() 
                         map["key"] = "value" 
@@ -177,7 +194,8 @@ class ExplicitCollectionElementAccessMethodSpec : Spek({
         }
 
         it("reports map element access with get method from map in a chain") {
-            val code = """
+            val code =
+                """
                     fun f() {
                         val map = java.util.HashMap<String, String>() 
                         val value = listOf("1", "2").associateBy { it }.get("1") 
@@ -189,7 +207,8 @@ class ExplicitCollectionElementAccessMethodSpec : Spek({
     describe("Java list") {
 
         it("reports list element access with get method") {
-            val code = """
+            val code =
+                """
                     fun f() {
                         val list = java.util.ArrayList<String>() 
                         val value = list.get(0) 
@@ -198,7 +217,8 @@ class ExplicitCollectionElementAccessMethodSpec : Spek({
         }
 
         it("does not report element access with []") {
-            val code = """
+            val code =
+                """
                     fun f() {
                         val list = java.util.ArrayList<String>() 
                         val value = list[0] 
@@ -210,7 +230,8 @@ class ExplicitCollectionElementAccessMethodSpec : Spek({
     describe("getters") {
 
         it("does not crash for getter") {
-            val code = """
+            val code =
+                """
                 class A {
                     val i: Int get() = 1 + 2
                     val c: Char? get() = "".first() ?: throw IllegalArgumentException("getter")
@@ -223,7 +244,8 @@ class ExplicitCollectionElementAccessMethodSpec : Spek({
     describe("fluent api doesn't crash") {
 
         it("does not crash for fluent api") {
-            val code = """
+            val code =
+                """
                 val string = ""
                     .toString()
             """

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitItLambdaParameterSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitItLambdaParameterSpec.kt
@@ -12,45 +12,55 @@ class ExplicitItLambdaParameterSpec : Spek({
     describe("ExplicitItLambdaParameter rule") {
         context("single parameter lambda with name `it` declared explicitly") {
             it("reports when parameter type is not declared") {
-                val findings = subject.compileAndLint("""
+                val findings = subject.compileAndLint(
+                    """
                 fun f() {
                     val digits = 1234.let { it -> listOf(it) }
-                }""")
+                }"""
+                )
                 assertThat(findings).hasSize(1)
             }
             it("reports when parameter type is declared explicitly") {
-                val findings = subject.compileAndLint("""
+                val findings = subject.compileAndLint(
+                    """
                 fun f() {
                     val lambda = { it: Int -> it.toString() }
-                }""")
+                }"""
+                )
                 assertThat(findings).hasSize(1)
             }
         }
         context("no parameter declared explicitly") {
             it("does not report implicit `it` parameter usage") {
-                val findings = subject.compileAndLint("""
+                val findings = subject.compileAndLint(
+                    """
                 fun f() {
                     val lambda = { i: Int -> i.toString() }
                     val digits = 1234.let { lambda(it) }.toList()
                     val flat = listOf(listOf(1), listOf(2)).flatMap { it }
-                }""")
+                }"""
+                )
                 assertThat(findings).isEmpty()
             }
         }
 
         context("multiple parameters one of which with name `it` declared explicitly") {
             it("reports when parameter types are not declared") {
-                val findings = subject.compileAndLint("""
+                val findings = subject.compileAndLint(
+                    """
                 fun f() {
                     val flat = listOf(listOf(1), listOf(2)).mapIndexed { index, it -> it + index }
-                }""")
+                }"""
+                )
                 assertThat(findings).hasSize(1)
             }
             it("reports when parameter types are declared explicitly") {
-                val findings = subject.compileAndLint("""
+                val findings = subject.compileAndLint(
+                    """
                 fun f() {
                     val lambda = { it: Int, that: String -> it.toString() + that }
-                }""")
+                }"""
+                )
                 assertThat(findings).hasSize(1)
             }
         }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExpressionBodySyntaxSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExpressionBodySyntaxSpec.kt
@@ -15,57 +15,76 @@ class ExpressionBodySyntaxSpec : Spek({
         context("several return statements") {
 
             it("reports constant return") {
-                assertThat(subject.compileAndLint("""
+                assertThat(
+                    subject.compileAndLint(
+                        """
                     fun stuff(): Int {
                         return 5
                     }
                 """
-                )).hasSize(1)
+                    )
+                ).hasSize(1)
             }
 
             it("reports return statement with method chain") {
-                assertThat(subject.compileAndLint("""
+                assertThat(
+                    subject.compileAndLint(
+                        """
                     fun stuff(): String {
                         return StringBuilder().append(0).toString()
                     }
                 """
-                )).hasSize(1)
+                    )
+                ).hasSize(1)
             }
 
             it("reports return statements with conditionals") {
-                assertThat(subject.compileAndLint("""
+                assertThat(
+                    subject.compileAndLint(
+                        """
                     fun stuff(): Int {
                         return if (true) return 5 else return 3
                     }
                     fun stuff(): Int {
                         return try { return 5 } catch (e: Exception) { return 3 }
                     }
-                """)).hasSize(2)
+                """
+                    )
+                ).hasSize(2)
             }
 
             it("does not report multiple if statements") {
-                assertThat(subject.compileAndLint("""
+                assertThat(
+                    subject.compileAndLint(
+                        """
                     fun stuff(): Boolean {
                         if (true) return true
                         return false
                     }
-                """)).isEmpty()
+                """
+                    )
+                ).isEmpty()
             }
 
             it("does not report when using shortcut return") {
-                assertThat(subject.compileAndLint("""
+                assertThat(
+                    subject.compileAndLint(
+                        """
                     fun caller(): String {
                         return callee("" as String? ?: return "")
                     }
 
                     fun callee(a: String): String = ""
-                """)).isEmpty()
+                """
+                    )
+                ).isEmpty()
             }
         }
 
         context("several return statements with multiline method chain") {
 
-            val code = """
+            val code =
+                """
                 fun stuff(): String {
                     return StringBuilder()
                         .append(1)
@@ -84,7 +103,8 @@ class ExpressionBodySyntaxSpec : Spek({
 
         context("several return statements with multiline when expression") {
 
-            val code = """
+            val code =
+                """
                 fun stuff(arg: Int): Int {
                     return when(arg) {
                         0 -> 0
@@ -104,7 +124,8 @@ class ExpressionBodySyntaxSpec : Spek({
 
         context("several return statements with multiline if expression") {
 
-            val code = """
+            val code =
+                """
                 fun stuff(arg: Int): Int {
                     return if (arg == 0) 0
                     else 1

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenCommentSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenCommentSpec.kt
@@ -52,7 +52,8 @@ class ForbiddenCommentSpec : Spek({
             }
 
             it("should report violation in multiline comment") {
-                val code = """
+                val code =
+                    """
                    /*
                     TODO: I need to fix this.
                     */
@@ -62,7 +63,8 @@ class ForbiddenCommentSpec : Spek({
             }
 
             it("should report violation in KDoc") {
-                val code = """
+                val code =
+                    """
                     /*
                      * TODO: I need to fix this.
                      */
@@ -77,7 +79,8 @@ class ForbiddenCommentSpec : Spek({
 
             listOf(
                 TestConfig(mapOf(ForbiddenComment.VALUES to "Banana")),
-                TestConfig(mapOf(ForbiddenComment.VALUES to listOf("Banana"))))
+                TestConfig(mapOf(ForbiddenComment.VALUES to listOf("Banana")))
+            )
                 .forEach { config ->
                     val banana = "// Banana."
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenImportSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenImportSpec.kt
@@ -8,7 +8,8 @@ import org.spekframework.spek2.style.specification.describe
 
 class ForbiddenImportSpec : Spek({
     describe("ForbiddenImport rule") {
-        val code = """
+        val code =
+            """
             package foo
 
             import kotlin.jvm.JvmField
@@ -55,8 +56,13 @@ class ForbiddenImportSpec : Spek({
 
         it("should report kotlin.SinceKotlin and kotlin.jvm.JvmField when specified via fully qualified names list") {
             val findings =
-                ForbiddenImport(TestConfig(mapOf(
-                    ForbiddenImport.IMPORTS to listOf("kotlin.SinceKotlin", "kotlin.jvm.JvmField")))).lint(code)
+                ForbiddenImport(
+                    TestConfig(
+                        mapOf(
+                            ForbiddenImport.IMPORTS to listOf("kotlin.SinceKotlin", "kotlin.jvm.JvmField")
+                        )
+                    )
+                ).lint(code)
             assertThat(findings).hasSize(2)
         }
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCallSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCallSpec.kt
@@ -17,7 +17,8 @@ class ForbiddenMethodCallSpec : Spek({
     describe("ForbiddenMethodCall rule") {
 
         it("should report nothing by default") {
-            val code = """
+            val code =
+                """
             import java.lang.System
             fun main() {
             System.out.println("hello")
@@ -28,7 +29,8 @@ class ForbiddenMethodCallSpec : Spek({
         }
 
         it("should report nothing when methods are blank") {
-            val code = """
+            val code =
+                """
             import java.lang.System
             fun main() {
             System.out.println("hello")
@@ -43,7 +45,8 @@ class ForbiddenMethodCallSpec : Spek({
         }
 
         it("should report nothing when methods do not match") {
-            val code = """
+            val code =
+                """
             import java.lang.System
             fun main() {
             System.out.println("hello")
@@ -56,7 +59,8 @@ class ForbiddenMethodCallSpec : Spek({
         }
 
         it("should report method call when using the fully qualified name") {
-            val code = """
+            val code =
+                """
             fun main() {
             java.lang.System.out.println("hello")
             }
@@ -69,7 +73,8 @@ class ForbiddenMethodCallSpec : Spek({
         }
 
         it("should report method call when not using the fully qualified name") {
-            val code = """
+            val code =
+                """
             import java.lang.System.out
             fun main() {
             out.println("hello")
@@ -83,7 +88,8 @@ class ForbiddenMethodCallSpec : Spek({
         }
 
         it("should report multiple different methods") {
-            val code = """
+            val code =
+                """
             import java.lang.System
             fun main() {
             System.out.println("hello")
@@ -98,7 +104,8 @@ class ForbiddenMethodCallSpec : Spek({
         }
 
         it("should report multiple different methods config with sting") {
-            val code = """
+            val code =
+                """
             import java.lang.System
             fun main() {
             System.out.println("hello")

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenPublicDataClassSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenPublicDataClassSpec.kt
@@ -10,7 +10,8 @@ import org.spekframework.spek2.style.specification.describe
 class ForbiddenPublicDataClassSpec : Spek({
     describe("ForbiddenPublicDataClass rule") {
         it("public data class should pass without explicit filters set") {
-            val code = """
+            val code =
+                """
                 data class C(val a: String)                
             """
 
@@ -22,7 +23,8 @@ class ForbiddenPublicDataClassSpec : Spek({
         }
 
         it("public data class should fail") {
-            val code = """
+            val code =
+                """
                 data class C(val a: String)                
             """
 
@@ -30,7 +32,8 @@ class ForbiddenPublicDataClassSpec : Spek({
         }
 
         it("private data class should pass") {
-            val code = """
+            val code =
+                """
                 private data class C(val a: String)                
             """
 
@@ -38,7 +41,8 @@ class ForbiddenPublicDataClassSpec : Spek({
         }
 
         it("internal data class should pass") {
-            val code = """
+            val code =
+                """
                 internal data class C(val a: String)                
             """
 
@@ -46,7 +50,8 @@ class ForbiddenPublicDataClassSpec : Spek({
         }
 
         it("public class should pass") {
-            val code = """
+            val code =
+                """
                 class C(val a: String) 
             """
 
@@ -54,7 +59,8 @@ class ForbiddenPublicDataClassSpec : Spek({
         }
 
         it("private data class inside a public class should pass") {
-            val code = """
+            val code =
+                """
                 class C {
                     private data class D(val a: String)   
                 }
@@ -64,7 +70,8 @@ class ForbiddenPublicDataClassSpec : Spek({
         }
 
         it("public data class inside a public class should fail") {
-            val code = """
+            val code =
+                """
                 class C {
                     data class D(val a: String)   
                 }
@@ -74,7 +81,8 @@ class ForbiddenPublicDataClassSpec : Spek({
         }
 
         it("protected data class inside a public class should fail") {
-            val code = """
+            val code =
+                """
                 open class C {
                     protected data class D(val a: String)   
                 }
@@ -84,7 +92,8 @@ class ForbiddenPublicDataClassSpec : Spek({
         }
 
         it("public data class inside an internal class should pass") {
-            val code = """
+            val code =
+                """
                 internal class C {
                     data class D(val a: String)   
                 }
@@ -94,7 +103,8 @@ class ForbiddenPublicDataClassSpec : Spek({
         }
 
         it("public data class inside an internal package should pass") {
-            val code = """
+            val code =
+                """
                 package com.example.internal
 
                 data class C(val a: String)                
@@ -104,7 +114,8 @@ class ForbiddenPublicDataClassSpec : Spek({
         }
 
         it("public data class inside an internal subpackage should pass") {
-            val code = """
+            val code =
+                """
                 package com.example.internal.other
 
                 data class C(val a: String)                
@@ -114,7 +125,8 @@ class ForbiddenPublicDataClassSpec : Spek({
         }
 
         it("public data class inside an internalise package should fail") {
-            val code = """
+            val code =
+                """
                 package com.example.internalise
 
                 data class C(val a: String)                
@@ -124,7 +136,8 @@ class ForbiddenPublicDataClassSpec : Spek({
         }
 
         it("public data class inside a random package should fail") {
-            val code = """
+            val code =
+                """
                 package com.example
 
                 data class C(val a: String)                
@@ -134,7 +147,8 @@ class ForbiddenPublicDataClassSpec : Spek({
         }
 
         it("public data class inside an ignored package should pass") {
-            val code = """
+            val code =
+                """
                 package com.example
 
                 data class C(val a: String)                
@@ -142,12 +156,14 @@ class ForbiddenPublicDataClassSpec : Spek({
 
             val config = TestConfig(
                 "ignorePackages" to listOf("*.hello", "com.example"),
-                Config.INCLUDES_KEY to "*.kt")
+                Config.INCLUDES_KEY to "*.kt"
+            )
             assertThat(ForbiddenPublicDataClass(config).compileAndLint(code)).isEmpty()
         }
 
         it("public data class inside an ignored package should pass config as string") {
-            val code = """
+            val code =
+                """
                 package com.example
 
                 data class C(val a: String)                

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenVoidSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenVoidSpec.kt
@@ -19,7 +19,8 @@ class ForbiddenVoidSpec : Spek({
 
     describe("ForbiddenVoid rule") {
         it("should report all Void type usage") {
-            val code = """
+            val code =
+                """
                 lateinit var c: () -> Void
 
                 fun method(param: Void) {
@@ -32,7 +33,8 @@ class ForbiddenVoidSpec : Spek({
         }
 
         it("should not report Void class literal") {
-            val code = """
+            val code =
+                """
                 val clazz = java.lang.Void::class
                 val klass = Void::class
             """
@@ -41,7 +43,8 @@ class ForbiddenVoidSpec : Spek({
         }
 
         it("does not report when functions or classes are called 'Void'") {
-            val code = """
+            val code =
+                """
                 class Void {
                     fun void() {}
                     val void = "string"
@@ -62,7 +65,8 @@ class ForbiddenVoidSpec : Spek({
             val config = TestConfig(mapOf(ForbiddenVoid.IGNORE_OVERRIDDEN to "true"))
 
             it("should not report Void in overriding function declarations") {
-                val code = """
+                val code =
+                    """
                     abstract class A {
                         @Suppress("ForbiddenVoid")
                         abstract fun method(param: Void) : Void
@@ -80,7 +84,8 @@ class ForbiddenVoidSpec : Spek({
             }
 
             it("should not report Void in overriding function declarations with parameterized types") {
-                val code = """
+                val code =
+                    """
                     class Foo<T> {}
 
                     abstract class A {
@@ -100,7 +105,8 @@ class ForbiddenVoidSpec : Spek({
             }
 
             it("should report Void in body of overriding function even") {
-                val code = """
+                val code =
+                    """
                     abstract class A {
                         abstract fun method(param: String)
                     }
@@ -117,7 +123,8 @@ class ForbiddenVoidSpec : Spek({
             }
 
             it("should report Void in not overridden function declarations") {
-                val code = """
+                val code =
+                    """
                     fun method(param: Void) : Void {
                         return param
                     }
@@ -131,7 +138,8 @@ class ForbiddenVoidSpec : Spek({
             val config = TestConfig(mapOf(ForbiddenVoid.IGNORE_USAGE_IN_GENERICS to "true"))
 
             it("should not report Void in generic type declaration") {
-                val code = """
+                val code =
+                    """
                     interface A<T>
 
                     class B {
@@ -152,7 +160,8 @@ class ForbiddenVoidSpec : Spek({
             }
 
             it("should not report Void in nested generic type definition") {
-                val code = """
+                val code =
+                    """
                     interface A<T>
                     interface B<T>
                     class C : A<B<Void>>
@@ -163,7 +172,8 @@ class ForbiddenVoidSpec : Spek({
             }
 
             it("should not report Void in definition with multiple generic parameters") {
-                val code = """
+                val code =
+                    """
                     val foo = mutableMapOf<Int, Void>()
                 """
 
@@ -172,7 +182,8 @@ class ForbiddenVoidSpec : Spek({
             }
 
             it("should report non-generic Void type usage") {
-                val code = """
+                val code =
+                    """
                     lateinit var c: () -> Void
 
                     fun method(param: Void) {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/FunctionOnlyReturningConstantSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/FunctionOnlyReturningConstantSpec.kt
@@ -37,15 +37,16 @@ class FunctionOnlyReturningConstantSpec : Spek({
             TestConfig(mapOf(FunctionOnlyReturningConstant.EXCLUDE_ANNOTATED_FUNCTION to listOf("kotlin.SinceKotlin")))
         ).forEach { config ->
             it("does not report excluded annotated function which returns a constant") {
-                val code = """
-                import kotlin.SinceKotlin
-                class Test {
-                    @SinceKotlin("1.0.0")
-                    fun someIgnoredFun(): String {
-                        return "I am a constant"
+                val code =
+                    """
+                    import kotlin.SinceKotlin
+                    class Test {
+                        @SinceKotlin("1.0.0")
+                        fun someIgnoredFun(): String {
+                            return "I am a constant"
+                        }
                     }
-                }
-            """.trimIndent()
+                    """.trimIndent()
                 val rule = FunctionOnlyReturningConstant(config)
                 assertThat(rule.compileAndLint(code)).isEmpty()
             }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/LibraryCodeMustSpecifyReturnTypeSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/LibraryCodeMustSpecifyReturnTypeSpec.kt
@@ -13,14 +13,18 @@ internal class LibraryCodeMustSpecifyReturnTypeSpec : Spek({
     describe("library code must have explicit return types") {
 
         it("should not report without explicit filters set") {
-            assertThat(LibraryCodeMustSpecifyReturnType().compileAndLint("""
+            assertThat(
+                LibraryCodeMustSpecifyReturnType().compileAndLint(
+                    """
                 fun foo() = 5
                 val bar = 5
                 class A {
                     fun b() = 2
                     val c = 2
                 }
-            """)).isEmpty()
+            """
+                )
+            ).isEmpty()
         }
 
         val subject by memoized {
@@ -30,74 +34,112 @@ internal class LibraryCodeMustSpecifyReturnTypeSpec : Spek({
         describe("positive cases") {
 
             it("should report a top level function") {
-                assertThat(subject.compileAndLint("""
+                assertThat(
+                    subject.compileAndLint(
+                        """
                     fun foo() = 5
-                """)).hasSize(1)
+                """
+                    )
+                ).hasSize(1)
             }
 
             it("should report a top level property") {
-                assertThat(subject.compileAndLint("""
+                assertThat(
+                    subject.compileAndLint(
+                        """
                     val foo = 5
-                """)).hasSize(1)
+                """
+                    )
+                ).hasSize(1)
             }
 
             it("should report a public class with public members") {
-                assertThat(subject.compileAndLint("""
+                assertThat(
+                    subject.compileAndLint(
+                        """
                     class A {
                         val foo = 5
                         fun bar() = 5
                     }
-                """)).hasSize(2)
+                """
+                    )
+                ).hasSize(2)
             }
         }
 
         describe("negative cases with public scope") {
 
             it("should not report a top level function") {
-                assertThat(subject.compileAndLint("""
+                assertThat(
+                    subject.compileAndLint(
+                        """
                     fun foo(): Int = 5
-                """)).isEmpty()
+                """
+                    )
+                ).isEmpty()
             }
 
             it("should not report a non expression function") {
-                assertThat(subject.compileAndLint("""
+                assertThat(
+                    subject.compileAndLint(
+                        """
                     fun foo() {}
-                """)).isEmpty()
+                """
+                    )
+                ).isEmpty()
             }
 
             it("should not report a top level property") {
-                assertThat(subject.compileAndLint("""
+                assertThat(
+                    subject.compileAndLint(
+                        """
                     val foo: Int = 5
-                """)).isEmpty()
+                """
+                    )
+                ).isEmpty()
             }
 
             it("should not report a public class with public members") {
-                assertThat(subject.compileAndLint("""
+                assertThat(
+                    subject.compileAndLint(
+                        """
                     class A {
                         val foo: Int = 5
                         fun bar(): Int = 5
                     }
-                """)).isEmpty()
+                """
+                    )
+                ).isEmpty()
             }
         }
         describe("negative cases with no public scope") {
 
             it("should not report a private top level function") {
                 // Kotlin Script Engine reports wrongly local functions here
-                assertThat(subject.lint("""
+                assertThat(
+                    subject.lint(
+                        """
                     internal fun bar() = 5
                     private fun foo() = 5
-                """)).isEmpty()
+                """
+                    )
+                ).isEmpty()
             }
 
             it("should not report a internal top level property") {
-                assertThat(subject.compileAndLint("""
+                assertThat(
+                    subject.compileAndLint(
+                        """
                     internal val foo = 5
-                """)).isEmpty()
+                """
+                    )
+                ).isEmpty()
             }
 
             it("should not report members and local variables") {
-                assertThat(subject.compileAndLint("""
+                assertThat(
+                    subject.compileAndLint(
+                        """
                     internal class A {
                         internal val foo = 5
                         private fun bar() {
@@ -105,7 +147,9 @@ internal class LibraryCodeMustSpecifyReturnTypeSpec : Spek({
                             val a = 5
                         }
                     }
-                """)).isEmpty()
+                """
+                    )
+                ).isEmpty()
             }
         }
     }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumberSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumberSpec.kt
@@ -269,7 +269,8 @@ class MagicNumberSpec : Spek({
         }
 
         context("a when statement with magic numbers") {
-            val code = """
+            val code =
+                """
             fun test(x: Int) {
                 when (x) {
                     5 -> return 5
@@ -293,7 +294,8 @@ class MagicNumberSpec : Spek({
         }
 
         context("a method containing variables with magic numbers") {
-            val code = """
+            val code =
+                """
             fun test(x: Int) {
                 val i = 5
             }
@@ -306,7 +308,8 @@ class MagicNumberSpec : Spek({
         }
 
         context("a boolean value") {
-            val code = """
+            val code =
+                """
             fun test() : Boolean {
                 return true;
             }
@@ -367,7 +370,8 @@ class MagicNumberSpec : Spek({
         }
 
         context("ignoring properties") {
-            val code = """
+            val code =
+                """
             @Magic(number = 69)
             class A {
                 val boringNumber = 42
@@ -386,13 +390,13 @@ class MagicNumberSpec : Spek({
 
             it("should report all without ignore flags") {
                 val config = TestConfig(
-                        mapOf(
-                                MagicNumber.IGNORE_PROPERTY_DECLARATION to "false",
-                                MagicNumber.IGNORE_ANNOTATION to "false",
-                                MagicNumber.IGNORE_HASH_CODE to "false",
-                                MagicNumber.IGNORE_CONSTANT_DECLARATION to "false",
-                                MagicNumber.IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "false"
-                        )
+                    mapOf(
+                        MagicNumber.IGNORE_PROPERTY_DECLARATION to "false",
+                        MagicNumber.IGNORE_ANNOTATION to "false",
+                        MagicNumber.IGNORE_HASH_CODE to "false",
+                        MagicNumber.IGNORE_CONSTANT_DECLARATION to "false",
+                        MagicNumber.IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "false"
+                    )
                 )
 
                 val findings = MagicNumber(config).lint(code)
@@ -409,13 +413,13 @@ class MagicNumberSpec : Spek({
 
             it("should not report any issues with all ignore flags") {
                 val config = TestConfig(
-                        mapOf(
-                                MagicNumber.IGNORE_PROPERTY_DECLARATION to "true",
-                                MagicNumber.IGNORE_ANNOTATION to "true",
-                                MagicNumber.IGNORE_HASH_CODE to "true",
-                                MagicNumber.IGNORE_CONSTANT_DECLARATION to "true",
-                                MagicNumber.IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "true"
-                        )
+                    mapOf(
+                        MagicNumber.IGNORE_PROPERTY_DECLARATION to "true",
+                        MagicNumber.IGNORE_ANNOTATION to "true",
+                        MagicNumber.IGNORE_HASH_CODE to "true",
+                        MagicNumber.IGNORE_CONSTANT_DECLARATION to "true",
+                        MagicNumber.IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "true"
+                    )
                 )
 
                 val findings = MagicNumber(config).lint(code)
@@ -424,7 +428,8 @@ class MagicNumberSpec : Spek({
         }
 
         context("magic numbers in companion object property assignments") {
-            val code = """
+            val code =
+                """
             class A {
 
                 companion object {
@@ -441,11 +446,11 @@ class MagicNumberSpec : Spek({
 
             it("should not report any issues when ignoring properties but not constants nor companion objects") {
                 val config = TestConfig(
-                        mapOf(
-                                MagicNumber.IGNORE_PROPERTY_DECLARATION to "true",
-                                MagicNumber.IGNORE_CONSTANT_DECLARATION to "false",
-                                MagicNumber.IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "false"
-                        )
+                    mapOf(
+                        MagicNumber.IGNORE_PROPERTY_DECLARATION to "true",
+                        MagicNumber.IGNORE_CONSTANT_DECLARATION to "false",
+                        MagicNumber.IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "false"
+                    )
                 )
 
                 val findings = MagicNumber(config).lint(code)
@@ -454,11 +459,11 @@ class MagicNumberSpec : Spek({
 
             it("should not report any issues when ignoring properties and constants but not companion objects") {
                 val config = TestConfig(
-                        mapOf(
-                                MagicNumber.IGNORE_PROPERTY_DECLARATION to "true",
-                                MagicNumber.IGNORE_CONSTANT_DECLARATION to "true",
-                                MagicNumber.IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "false"
-                        )
+                    mapOf(
+                        MagicNumber.IGNORE_PROPERTY_DECLARATION to "true",
+                        MagicNumber.IGNORE_CONSTANT_DECLARATION to "true",
+                        MagicNumber.IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "false"
+                    )
                 )
 
                 val findings = MagicNumber(config).lint(code)
@@ -467,11 +472,11 @@ class MagicNumberSpec : Spek({
 
             it("should not report any issues when ignoring properties, constants and companion objects") {
                 val config = TestConfig(
-                        mapOf(
-                                MagicNumber.IGNORE_PROPERTY_DECLARATION to "true",
-                                MagicNumber.IGNORE_CONSTANT_DECLARATION to "true",
-                                MagicNumber.IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "true"
-                        )
+                    mapOf(
+                        MagicNumber.IGNORE_PROPERTY_DECLARATION to "true",
+                        MagicNumber.IGNORE_CONSTANT_DECLARATION to "true",
+                        MagicNumber.IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "true"
+                    )
                 )
 
                 val findings = MagicNumber(config).lint(code)
@@ -480,11 +485,11 @@ class MagicNumberSpec : Spek({
 
             it("should not report any issues when ignoring companion objects but not properties and constants") {
                 val config = TestConfig(
-                        mapOf(
-                                MagicNumber.IGNORE_PROPERTY_DECLARATION to "false",
-                                MagicNumber.IGNORE_CONSTANT_DECLARATION to "false",
-                                MagicNumber.IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "true"
-                        )
+                    mapOf(
+                        MagicNumber.IGNORE_PROPERTY_DECLARATION to "false",
+                        MagicNumber.IGNORE_CONSTANT_DECLARATION to "false",
+                        MagicNumber.IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "true"
+                    )
                 )
 
                 val findings = MagicNumber(config).lint(code)
@@ -493,11 +498,11 @@ class MagicNumberSpec : Spek({
 
             it("should report property when ignoring constants but not properties and companion objects") {
                 val config = TestConfig(
-                        mapOf(
-                                MagicNumber.IGNORE_PROPERTY_DECLARATION to "false",
-                                MagicNumber.IGNORE_CONSTANT_DECLARATION to "true",
-                                MagicNumber.IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "false"
-                        )
+                    mapOf(
+                        MagicNumber.IGNORE_PROPERTY_DECLARATION to "false",
+                        MagicNumber.IGNORE_CONSTANT_DECLARATION to "true",
+                        MagicNumber.IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "false"
+                    )
                 )
 
                 val findings = MagicNumber(config).lint(code)
@@ -506,11 +511,11 @@ class MagicNumberSpec : Spek({
 
             it("should report property and constant when not ignoring properties, constants nor companion objects") {
                 val config = TestConfig(
-                        mapOf(
-                                MagicNumber.IGNORE_PROPERTY_DECLARATION to "false",
-                                MagicNumber.IGNORE_CONSTANT_DECLARATION to "false",
-                                MagicNumber.IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "false"
-                        )
+                    mapOf(
+                        MagicNumber.IGNORE_PROPERTY_DECLARATION to "false",
+                        MagicNumber.IGNORE_CONSTANT_DECLARATION to "false",
+                        MagicNumber.IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "false"
+                    )
                 )
 
                 val findings = MagicNumber(config).lint(code)
@@ -533,7 +538,8 @@ class MagicNumberSpec : Spek({
 
         context("ignoring named arguments") {
             context("in constructor invocation") {
-                fun code(numberString: String) = """
+                fun code(numberString: String) =
+                    """
                 data class Model(
                         val someVal: Int,
                         val other: String = "default"
@@ -569,7 +575,8 @@ class MagicNumberSpec : Spek({
                 }
 
                 it("should ignore named arguments in inheritance - #992") {
-                    val code = """
+                    val code =
+                        """
                     abstract class A(n: Int)
 
                     object B : A(n = 5)
@@ -580,17 +587,18 @@ class MagicNumberSpec : Spek({
 
                 it("should ignore named arguments in parameter annotations - #1115") {
                     val code =
-                            "@JvmStatic fun setCustomDimension(@IntRange(from = 0, to = 19) index: Int, value: String?) {}"
+                        "@JvmStatic fun setCustomDimension(@IntRange(from = 0, to = 19) index: Int, value: String?) {}"
                     MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NAMED_ARGUMENT to "true")))
-                            .lint(code)
-                            .assert()
-                            .isEmpty()
+                        .lint(code)
+                        .assert()
+                        .isEmpty()
                 }
             }
 
             context("Issue#659 - false-negative reporting on unnamed argument when ignore is true") {
 
-                fun code(numberString: String) = """
+                fun code(numberString: String) =
+                    """
                 data class Model(
                         val someVal: Int,
                         val other: String = "default"
@@ -606,7 +614,8 @@ class MagicNumberSpec : Spek({
             }
 
             context("in function invocation") {
-                fun code(number: Number) = """
+                fun code(number: Number) =
+                    """
                 fun tested(someVal: Int, other: String = "default")
 
                 tested(someVal = $number)
@@ -628,7 +637,8 @@ class MagicNumberSpec : Spek({
                 }
             }
             context("in enum constructor argument") {
-                val code = """
+                val code =
+                    """
                 enum class Bag(id: Int) {
                     SMALL(1),
                     EXTRA_LARGE(5)
@@ -643,7 +653,8 @@ class MagicNumberSpec : Spek({
                 }
             }
             context("in enum constructor as named argument") {
-                val code = """
+                val code =
+                    """
                 enum class Bag(id: Int) {
                     SMALL(id = 1),
                     EXTRA_LARGE(id = 5)
@@ -662,14 +673,16 @@ class MagicNumberSpec : Spek({
         context("functions with and without braces which return values") {
 
             it("does not report functions that always returns a constant value") {
-                val code = """
+                val code =
+                    """
                 fun x() = 9
                 fun y(): Int { return 9 }"""
                 assertThat(MagicNumber().compileAndLint(code)).isEmpty()
             }
 
             it("reports functions that does not return a constant value") {
-                val code = """
+                val code =
+                    """
                 fun x() = 9 + 1
                 fun y(): Int { return 9 + 1 }"""
                 assertThat(MagicNumber().compileAndLint(code)).hasSize(2)
@@ -692,7 +705,8 @@ class MagicNumberSpec : Spek({
         context("default parameters in secondary constructor") {
 
             it("reports no finding") {
-                val code = """
+                val code =
+                    """
                 class SomeClassWithDefault {
                     constructor(val defaultValue: Int = 10) { }
                 }"""
@@ -711,13 +725,13 @@ class MagicNumberSpec : Spek({
         context("a number as part of a range") {
 
             val magicNumberInRangeExpressions = listOf(
-                    "val range = 1..27",
-                    "val range = (1..27)",
-                    "val range = 27 downTo 1",
-                    "val range = 1 until 27 step 1",
-                    "val inRange = 1 in 1..27",
-                    "val inRange = (1 in 27 downTo 0 step 1)",
-                    "val inRange = (1..27 step 1).last"
+                "val range = 1..27",
+                "val range = (1..27)",
+                "val range = 27 downTo 1",
+                "val range = 1 until 27 step 1",
+                "val inRange = 1 in 1..27",
+                "val inRange = (1 in 27 downTo 0 step 1)",
+                "val inRange = (1..27 step 1).last"
             )
 
             magicNumberInRangeExpressions.forEach { codeWithMagicNumberInRange ->
@@ -728,12 +742,12 @@ class MagicNumberSpec : Spek({
                 it("'$codeWithMagicNumberInRange' reports a code smell if ranges are not ignored") {
                     val code = codeWithMagicNumberInRange
                     assertThat(MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_RANGES to "false"))).lint(code))
-                            .hasSize(1)
+                        .hasSize(1)
                 }
                 it("'$codeWithMagicNumberInRange' reports no finding if ranges are ignored") {
                     val code = codeWithMagicNumberInRange
                     assertThat(MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_RANGES to "true"))).lint(code))
-                            .isEmpty()
+                        .isEmpty()
                 }
             }
 
@@ -749,7 +763,8 @@ class MagicNumberSpec : Spek({
 
         context("a number assigned to a local variable") {
 
-            val code = """fun f() { val a = 3; }"""
+            val code =
+                """fun f() { val a = 3; }"""
 
             it("reports 3 due to the assignment to a local variable") {
                 val rule = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_LOCAL_VARIABLES to "false")))
@@ -764,9 +779,14 @@ class MagicNumberSpec : Spek({
 
         context("meaningful variables - #1536") {
 
-            val rule = MagicNumber(TestConfig(mapOf(
-                MagicNumber.IGNORE_LOCAL_VARIABLES to "true",
-                MagicNumber.IGNORE_NAMED_ARGUMENT to "true")))
+            val rule = MagicNumber(
+                TestConfig(
+                    mapOf(
+                        MagicNumber.IGNORE_LOCAL_VARIABLES to "true",
+                        MagicNumber.IGNORE_NAMED_ARGUMENT to "true"
+                    )
+                )
+            )
 
             it("should report 3") {
                 assertThat(rule.compileAndLint("""fun bar() { foo(3) }; fun foo(n: Int) {}""")).hasSize(1)

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLengthSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLengthSpec.kt
@@ -47,7 +47,8 @@ class MaxLineLengthSpec : Spek({
         }
 
         context("a kt file with a long package name and long import statements") {
-            val code = """
+            val code =
+                """
             package anIncrediblyLongAndComplexPackageNameThatProbablyShouldBeMuchShorterButForTheSakeOfTheTestItsNot
 
             import anIncrediblyLongAndComplexImportNameThatProbablyShouldBeMuchShorterButForTheSakeOfTheTestItsNot
@@ -61,31 +62,43 @@ class MaxLineLengthSpec : Spek({
             val fileContent = KtFileContent(file, lines)
 
             it("should not report the package statement and import statements by default") {
-                val rule = MaxLineLength(TestConfig(mapOf(
-                        MaxLineLength.MAX_LINE_LENGTH to "60"
-                )))
+                val rule = MaxLineLength(
+                    TestConfig(
+                        mapOf(
+                            MaxLineLength.MAX_LINE_LENGTH to "60"
+                        )
+                    )
+                )
 
                 rule.visit(fileContent)
                 assertThat(rule.findings).isEmpty()
             }
 
             it("should report the package statement and import statements if they're enabled") {
-                val rule = MaxLineLength(TestConfig(mapOf(
-                        MaxLineLength.MAX_LINE_LENGTH to "60",
-                        MaxLineLength.EXCLUDE_PACKAGE_STATEMENTS to "false",
-                        MaxLineLength.EXCLUDE_IMPORT_STATEMENTS to "false"
-                )))
+                val rule = MaxLineLength(
+                    TestConfig(
+                        mapOf(
+                            MaxLineLength.MAX_LINE_LENGTH to "60",
+                            MaxLineLength.EXCLUDE_PACKAGE_STATEMENTS to "false",
+                            MaxLineLength.EXCLUDE_IMPORT_STATEMENTS to "false"
+                        )
+                    )
+                )
 
                 rule.visit(fileContent)
                 assertThat(rule.findings).hasSize(2)
             }
 
             it("should not report anything if both package and import statements are disabled") {
-                val rule = MaxLineLength(TestConfig(mapOf(
-                        MaxLineLength.MAX_LINE_LENGTH to "60",
-                        MaxLineLength.EXCLUDE_PACKAGE_STATEMENTS to "true",
-                        MaxLineLength.EXCLUDE_IMPORT_STATEMENTS to "true"
-                )))
+                val rule = MaxLineLength(
+                    TestConfig(
+                        mapOf(
+                            MaxLineLength.MAX_LINE_LENGTH to "60",
+                            MaxLineLength.EXCLUDE_PACKAGE_STATEMENTS to "true",
+                            MaxLineLength.EXCLUDE_IMPORT_STATEMENTS to "true"
+                        )
+                    )
+                )
 
                 rule.visit(fileContent)
                 assertThat(rule.findings).isEmpty()
@@ -98,31 +111,43 @@ class MaxLineLengthSpec : Spek({
             val fileContent = KtFileContent(file, lines)
 
             it("should report the package statement, import statements, line and comments by default") {
-                val rule = MaxLineLength(TestConfig(mapOf(
-                        MaxLineLength.MAX_LINE_LENGTH to "60"
-                )))
+                val rule = MaxLineLength(
+                    TestConfig(
+                        mapOf(
+                            MaxLineLength.MAX_LINE_LENGTH to "60"
+                        )
+                    )
+                )
 
                 rule.visit(fileContent)
                 assertThat(rule.findings).hasSize(8)
             }
 
             it("should report the package statement, import statements, line and comments if they're enabled") {
-                val rule = MaxLineLength(TestConfig(mapOf(
-                        MaxLineLength.MAX_LINE_LENGTH to "60",
-                        MaxLineLength.EXCLUDE_PACKAGE_STATEMENTS to "false",
-                        MaxLineLength.EXCLUDE_IMPORT_STATEMENTS to "false",
-                        MaxLineLength.EXCLUDE_COMMENT_STATEMENTS to "false"
-                )))
+                val rule = MaxLineLength(
+                    TestConfig(
+                        mapOf(
+                            MaxLineLength.MAX_LINE_LENGTH to "60",
+                            MaxLineLength.EXCLUDE_PACKAGE_STATEMENTS to "false",
+                            MaxLineLength.EXCLUDE_IMPORT_STATEMENTS to "false",
+                            MaxLineLength.EXCLUDE_COMMENT_STATEMENTS to "false"
+                        )
+                    )
+                )
 
                 rule.visit(fileContent)
                 assertThat(rule.findings).hasSize(8)
             }
 
             it("should not report comments if they're disabled") {
-                val rule = MaxLineLength(TestConfig(mapOf(
-                        MaxLineLength.MAX_LINE_LENGTH to "60",
-                        MaxLineLength.EXCLUDE_COMMENT_STATEMENTS to "true"
-                )))
+                val rule = MaxLineLength(
+                    TestConfig(
+                        mapOf(
+                            MaxLineLength.MAX_LINE_LENGTH to "60",
+                            MaxLineLength.EXCLUDE_COMMENT_STATEMENTS to "true"
+                        )
+                    )
+                )
 
                 rule.visit(fileContent)
                 assertThat(rule.findings).hasSize(5)
@@ -130,7 +155,8 @@ class MaxLineLengthSpec : Spek({
         }
 
         context("a kt file with a long package name, long import statements and a long line") {
-            val code = """
+            val code =
+                """
             package anIncrediblyLongAndComplexPackageNameThatProbablyShouldBeMuchShorterButForTheSakeOfTheTestItsNot
 
             import anIncrediblyLongAndComplexImportNameThatProbablyShouldBeMuchShorterButForTheSakeOfTheTestItsNot
@@ -145,42 +171,58 @@ class MaxLineLengthSpec : Spek({
             val fileContent = KtFileContent(file, lines)
 
             it("should only the function line by default") {
-                val rule = MaxLineLength(TestConfig(mapOf(
-                        MaxLineLength.MAX_LINE_LENGTH to "60"
-                )))
+                val rule = MaxLineLength(
+                    TestConfig(
+                        mapOf(
+                            MaxLineLength.MAX_LINE_LENGTH to "60"
+                        )
+                    )
+                )
 
                 rule.visit(fileContent)
                 assertThat(rule.findings).hasSize(1)
             }
 
             it("should report the package statement, import statements and line if they're not excluded") {
-                val rule = MaxLineLength(TestConfig(mapOf(
-                        MaxLineLength.MAX_LINE_LENGTH to "60",
-                        MaxLineLength.EXCLUDE_PACKAGE_STATEMENTS to "false",
-                        MaxLineLength.EXCLUDE_IMPORT_STATEMENTS to "false"
-                )))
+                val rule = MaxLineLength(
+                    TestConfig(
+                        mapOf(
+                            MaxLineLength.MAX_LINE_LENGTH to "60",
+                            MaxLineLength.EXCLUDE_PACKAGE_STATEMENTS to "false",
+                            MaxLineLength.EXCLUDE_IMPORT_STATEMENTS to "false"
+                        )
+                    )
+                )
 
                 rule.visit(fileContent)
                 assertThat(rule.findings).hasSize(3)
             }
 
             it("should report only method if both package and import statements are disabled") {
-                val rule = MaxLineLength(TestConfig(mapOf(
-                        MaxLineLength.MAX_LINE_LENGTH to "60",
-                        MaxLineLength.EXCLUDE_PACKAGE_STATEMENTS to "true",
-                        MaxLineLength.EXCLUDE_IMPORT_STATEMENTS to "true"
-                )))
+                val rule = MaxLineLength(
+                    TestConfig(
+                        mapOf(
+                            MaxLineLength.MAX_LINE_LENGTH to "60",
+                            MaxLineLength.EXCLUDE_PACKAGE_STATEMENTS to "true",
+                            MaxLineLength.EXCLUDE_IMPORT_STATEMENTS to "true"
+                        )
+                    )
+                )
 
                 rule.visit(fileContent)
                 assertThat(rule.findings).hasSize(1)
             }
 
             it("should report correct line and column for function with excessive length") {
-                val rule = MaxLineLength(TestConfig(mapOf(
-                        MaxLineLength.MAX_LINE_LENGTH to "60",
-                        MaxLineLength.EXCLUDE_PACKAGE_STATEMENTS to "true",
-                        MaxLineLength.EXCLUDE_IMPORT_STATEMENTS to "true"
-                )))
+                val rule = MaxLineLength(
+                    TestConfig(
+                        mapOf(
+                            MaxLineLength.MAX_LINE_LENGTH to "60",
+                            MaxLineLength.EXCLUDE_PACKAGE_STATEMENTS to "true",
+                            MaxLineLength.EXCLUDE_IMPORT_STATEMENTS to "true"
+                        )
+                    )
+                )
 
                 rule.visit(fileContent)
                 assertThat(rule.findings).hasSize(1)

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MayBeConstSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MayBeConstSpec.kt
@@ -14,13 +14,15 @@ class MayBeConstSpec : Spek({
 
         context("some valid constants") {
             it("is a valid constant") {
-                val code = """const val X = 42"""
+                val code =
+                    """const val X = 42"""
                 subject.lint(code)
                 assertThat(subject.findings).isEmpty()
             }
 
             it("is const vals in object") {
-                val code = """
+                val code =
+                    """
                 object Test {
                     const val TEST = "Test"
                 }
@@ -30,7 +32,8 @@ class MayBeConstSpec : Spek({
             }
 
             it("isconst vals in companion objects") {
-                val code = """
+                val code =
+                    """
                 class Test {
                     companion object {
                         const val B = 1
@@ -42,7 +45,8 @@ class MayBeConstSpec : Spek({
             }
 
             it("does not report const vals that use other const vals") {
-                val code = """
+                val code =
+                    """
                 const val a = 0
 
                 class Test {
@@ -57,7 +61,8 @@ class MayBeConstSpec : Spek({
             }
 
             it("does not report none const val candidates") {
-                val code = """
+                val code =
+                    """
                 const val a = 0
                 val p = Pair(a, a + a)
                 val p2 = emptyList<Int>().plus(a)
@@ -69,7 +74,8 @@ class MayBeConstSpec : Spek({
 
         context("some vals that could be constants") {
             it("is a simple val") {
-                val code = """
+                val code =
+                    """
                 val x = 1
                 """
                 subject.lint(code)
@@ -77,7 +83,8 @@ class MayBeConstSpec : Spek({
             }
 
             it("is a simple JvmField val") {
-                val code = """
+                val code =
+                    """
                 @JvmField val x = 1
                 """
                 subject.lint(code)
@@ -85,7 +92,8 @@ class MayBeConstSpec : Spek({
             }
 
             it("is a field in an object") {
-                val code = """
+                val code =
+                    """
                 object Test {
                     @JvmField val test = "Test"
                 }
@@ -95,7 +103,8 @@ class MayBeConstSpec : Spek({
             }
 
             it("reports vals in companion objects") {
-                val code = """
+                val code =
+                    """
                 class Test {
                     companion object {
                         val b = 1
@@ -109,7 +118,8 @@ class MayBeConstSpec : Spek({
 
         context("vals that can be constants but detekt doesn't handle yet") {
             it("is a constant binary expression") {
-                val code = """
+                val code =
+                    """
                 const val one = 1
                 val two = one * 2
                 """
@@ -118,7 +128,8 @@ class MayBeConstSpec : Spek({
             }
 
             it("is a constant binary expression in a companion object") {
-                val code = """
+                val code =
+                    """
                 class Test {
                     companion object {
                         const val one = 1
@@ -131,7 +142,8 @@ class MayBeConstSpec : Spek({
             }
 
             it("is a nested constant binary expression") {
-                val code = """
+                val code =
+                    """
                 const val one = 1
                 val two = one * 2 + 1
                 """
@@ -140,7 +152,8 @@ class MayBeConstSpec : Spek({
             }
 
             it("is a nested constant parenthesised expression") {
-                val code = """
+                val code =
+                    """
                 const val one = 1
                 val two = one * (2 + 1)
                 """
@@ -149,7 +162,8 @@ class MayBeConstSpec : Spek({
             }
 
             it("reports vals that use other const vals") {
-                val code = """
+                val code =
+                    """
                 const val a = 0
 
                 class Test {
@@ -164,7 +178,8 @@ class MayBeConstSpec : Spek({
             }
 
             it("reports concatenated string vals") {
-                val code = """
+                val code =
+                    """
                 private const val A = "a"
                 private val B = A + "b"
                 """
@@ -199,7 +214,8 @@ class MayBeConstSpec : Spek({
             }
 
             it("is a JvmField in a class") {
-                val code = """
+                val code =
+                    """
                 class Test {
                     @JvmField val a = 3
                 }
@@ -209,7 +225,8 @@ class MayBeConstSpec : Spek({
             }
 
             it("has some annotation") {
-                val code = """
+                val code =
+                    """
                 annotation class A
 
                 @A val a = 55
@@ -219,7 +236,8 @@ class MayBeConstSpec : Spek({
             }
 
             it("overrides something") {
-                val code = """
+                val code =
+                    """
                 interface Base {
                     val property: Int
                 }
@@ -233,7 +251,8 @@ class MayBeConstSpec : Spek({
             }
 
             it("does not detect just a dollar as interpolation") {
-                val code = """ val hasDollar = "$" """
+                val code =
+                    """ val hasDollar = "$" """
                 subject.lint(code)
                 assertThat(subject.findings).hasSize(1)
             }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ModifierOrderSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ModifierOrderSpec.kt
@@ -54,7 +54,8 @@ class ModifierOrderSpec : Spek({
         context("an overridden function") {
 
             it("should report incorrectly ordered modifiers") {
-                val code = """
+                val code =
+                    """
                     abstract class A {
                         abstract fun test()
                     }
@@ -65,7 +66,8 @@ class ModifierOrderSpec : Spek({
             }
 
             it("should not report correctly ordered modifiers") {
-                val code = """
+                val code =
+                    """
                     abstract class A {
                         abstract fun test()
                     }
@@ -79,7 +81,8 @@ class ModifierOrderSpec : Spek({
         context("a tailrec function") {
 
             it("should report incorrectly ordered modifiers") {
-                val code = """
+                val code =
+                    """
                     public class A {
                         tailrec private fun foo(x: Double = 1.0): Double = 1.0
                     }
@@ -88,7 +91,8 @@ class ModifierOrderSpec : Spek({
             }
 
             it("should not report correctly ordered modifiers") {
-                val code = """
+                val code =
+                    """
                     public class A {
                         private tailrec fun foo(x: Double = 1.0): Double = 1.0
                     }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/NestedClassesVisibilitySpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/NestedClassesVisibilitySpec.kt
@@ -11,7 +11,8 @@ class NestedClassesVisibilitySpec : Spek({
     describe("NestedClassesVisibility rule") {
 
         it("reports explicit public visibility in nested objects/classes/interfaces") {
-            val code = """
+            val code =
+                """
                 internal class Outer {
                     public interface A
                     public object B
@@ -22,7 +23,8 @@ class NestedClassesVisibilitySpec : Spek({
         }
 
         it("reports explicit public visibility in nested classes inside an enum") {
-            val code = """
+            val code =
+                """
                 internal enum class Outer {
                     A;
                     public class C
@@ -32,7 +34,8 @@ class NestedClassesVisibilitySpec : Spek({
         }
 
         it("does not report nested internal classes and interfaces") {
-            val code = """
+            val code =
+                """
                 internal class Outer {
                      class A
                      internal class B
@@ -44,7 +47,8 @@ class NestedClassesVisibilitySpec : Spek({
         }
 
         it("does not report nested private classes") {
-            val code = """
+            val code =
+                """
                 internal class Outer {
                     private class A
                 }
@@ -53,7 +57,8 @@ class NestedClassesVisibilitySpec : Spek({
         }
 
         it("does not report nested public enums") {
-            val code = """
+            val code =
+                """
                 internal class Outer {
                     public enum class E { E1; }
                 }
@@ -62,7 +67,8 @@ class NestedClassesVisibilitySpec : Spek({
         }
 
         it("does not report companion object that is explicitly public") {
-            val code = """
+            val code =
+                """
                 internal class Outer {
                     public companion object C
                 } 
@@ -71,7 +77,8 @@ class NestedClassesVisibilitySpec : Spek({
         }
 
         it("does not report companion object") {
-            val code = """
+            val code =
+                """
                 internal class Outer {
                     companion object C
                 } 
@@ -80,7 +87,8 @@ class NestedClassesVisibilitySpec : Spek({
         }
 
         it("does not report nested classes inside a private class") {
-            val code = """
+            val code =
+                """
                 private class Outer {
                      class A
                 }
@@ -89,7 +97,8 @@ class NestedClassesVisibilitySpec : Spek({
         }
 
         it("does not report nested internal classes inside an interface") {
-            val code = """
+            val code =
+                """
                 internal interface Outer {
                      class A
                 }
@@ -98,7 +107,8 @@ class NestedClassesVisibilitySpec : Spek({
         }
 
         it("does not report nested classes with a nesting depth higher than 1") {
-            val code = """
+            val code =
+                """
                 internal class Outer {
                     class C1 {
                         public class C2

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/OptionalAbstractKeywordSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/OptionalAbstractKeywordSpec.kt
@@ -29,7 +29,8 @@ class OptionalAbstractKeywordSpec : Spek({
         }
 
         it("reports nested abstract interface") {
-            val code = """
+            val code =
+                """
                 class A {
                     abstract interface B {
                         abstract fun x()
@@ -44,7 +45,8 @@ class OptionalAbstractKeywordSpec : Spek({
         }
 
         it("does not report a nested abstract class function") {
-            val code = """
+            val code =
+                """
                 interface I {
                     abstract class A {
                         abstract fun dependency()

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/OptionalWhenBracesSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/OptionalWhenBracesSpec.kt
@@ -11,7 +11,8 @@ class OptionalWhenBracesSpec : Spek({
     describe("check optional braces in when expression") {
 
         it("does not report necessary braces") {
-            val code = """
+            val code =
+                """
                 fun x() {
                     when (1) {
                         1 -> print(1)
@@ -29,7 +30,8 @@ class OptionalWhenBracesSpec : Spek({
         }
 
         it("reports unnecessary braces") {
-            val code = """
+            val code =
+                """
                 fun x() {
                     when (1) {
                         1 -> { print(1) }
@@ -41,7 +43,8 @@ class OptionalWhenBracesSpec : Spek({
 
         context("the statement is a lambda expression") {
             it("does not report if the lambda has no arrow") {
-                val code = """
+                val code =
+                    """
                     fun test(b: Boolean): (Int) -> Int {
                         return when (b) {
                             true -> { { it + 100 } }
@@ -53,7 +56,8 @@ class OptionalWhenBracesSpec : Spek({
             }
 
             it("reports if the lambda has an arrow") {
-                val code = """
+                val code =
+                    """
                     fun test(b: Boolean): (Int) -> Int {
                         return when (b) {
                             true -> { { i -> i + 100 } }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantExplicitTypeSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantExplicitTypeSpec.kt
@@ -18,7 +18,8 @@ object RedundantExplicitTypeSpec : Spek({
     describe("RedundantExplicitType") {
 
         it("reports explicit type for boolean") {
-            val code = """
+            val code =
+                """
                 fun function() {
                     val x: Boolean = true
                 }
@@ -27,7 +28,8 @@ object RedundantExplicitTypeSpec : Spek({
         }
 
         it("reports explicit type for integer") {
-            val code = """
+            val code =
+                """
                 fun function() {
                     val x: Int = 3
                 }
@@ -36,7 +38,8 @@ object RedundantExplicitTypeSpec : Spek({
         }
 
         it("reports explicit type for long") {
-            val code = """
+            val code =
+                """
                 fun function() {
                     val x: Long = 3L
                 }
@@ -45,7 +48,8 @@ object RedundantExplicitTypeSpec : Spek({
         }
 
         it("reports explicit type for float") {
-            val code = """
+            val code =
+                """
                 fun function() {
                     val x: Float = 3.0f
                 }
@@ -54,7 +58,8 @@ object RedundantExplicitTypeSpec : Spek({
         }
 
         it("reports explicit type for double") {
-            val code = """
+            val code =
+                """
                 fun function() {
                     val x: Double = 3.0
                 }
@@ -63,7 +68,8 @@ object RedundantExplicitTypeSpec : Spek({
         }
 
         it("reports explicit type for char") {
-            val code = """
+            val code =
+                """
                 fun function() {
                     val x: Char = 'f'
                 }
@@ -73,7 +79,8 @@ object RedundantExplicitTypeSpec : Spek({
 
         it("reports explicit type for string template") {
             val substitute = "\$x"
-            val code = """
+            val code =
+                """
                 fun function() {
                     val x = 3
                     val y: String = "$substitute"
@@ -83,7 +90,8 @@ object RedundantExplicitTypeSpec : Spek({
         }
 
         it("reports explicit type for name reference expression") {
-            val code = """
+            val code =
+                """
                 object Test
 
                 fun foo() {
@@ -94,7 +102,8 @@ object RedundantExplicitTypeSpec : Spek({
         }
 
         it("reports explicit type for call expression") {
-            val code = """
+            val code =
+                """
                 interface Person {
                     val firstName: String
                 }
@@ -109,7 +118,8 @@ object RedundantExplicitTypeSpec : Spek({
         }
 
         it("does not report explicit type for call expression when type is an interface") {
-            val code = """
+            val code =
+                """
                 interface Person {
                     val firstName: String
                 }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantVisibilityModifierRuleSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantVisibilityModifierRuleSpec.kt
@@ -10,7 +10,8 @@ class RedundantVisibilityModifierRuleSpec : Spek({
 
     describe("RedundantVisibilityModifier rule") {
         it("does not report overridden function of abstract class w/ public modifier") {
-            val code = """
+            val code =
+                """
                 abstract class A {
                     abstract protected fun A()
                 }
@@ -23,7 +24,8 @@ class RedundantVisibilityModifierRuleSpec : Spek({
         }
 
         it("does not report overridden function of abstract class w/o public modifier") {
-            val code = """
+            val code =
+                """
                 abstract class A {
                     abstract protected fun A()
                 }
@@ -36,7 +38,8 @@ class RedundantVisibilityModifierRuleSpec : Spek({
         }
 
         it("does not report overridden function of interface") {
-            val code = """
+            val code =
+                """
                 interface A {
                     fun A()
                 }
@@ -49,7 +52,8 @@ class RedundantVisibilityModifierRuleSpec : Spek({
         }
 
         it("reports public function in class") {
-            val code = """
+            val code =
+                """
                 class Test{
                     public fun A() {}
                 }
@@ -58,7 +62,8 @@ class RedundantVisibilityModifierRuleSpec : Spek({
         }
 
         it("does not report function in class w/o modifier") {
-            val code = """
+            val code =
+                """
                 class Test{
                     fun A() {}
                 }
@@ -67,7 +72,8 @@ class RedundantVisibilityModifierRuleSpec : Spek({
         }
 
         it("reports public class") {
-            val code = """
+            val code =
+                """
                 public class Test(){
                     fun test(){}
                 }
@@ -76,7 +82,8 @@ class RedundantVisibilityModifierRuleSpec : Spek({
         }
 
         it("reports interface w/ public modifier") {
-            val code = """
+            val code =
+                """
                 public interface Test{
                     public fun test()
                 }
@@ -85,7 +92,8 @@ class RedundantVisibilityModifierRuleSpec : Spek({
         }
 
         it("reports field w/ public modifier") {
-            val code = """
+            val code =
+                """
                 class Test{
                     public val str : String = "test"
                 }
@@ -94,7 +102,8 @@ class RedundantVisibilityModifierRuleSpec : Spek({
         }
 
         it("does not report field w/o public modifier") {
-            val code = """
+            val code =
+                """
                 class Test{
                     val str : String = "test"
                 }
@@ -103,7 +112,8 @@ class RedundantVisibilityModifierRuleSpec : Spek({
         }
 
         it("does not report overridden field w/o public modifier") {
-            val code = """
+            val code =
+                """
                 abstract class A {
                     abstract val test: String
                 }
@@ -116,7 +126,8 @@ class RedundantVisibilityModifierRuleSpec : Spek({
         }
 
         it("does not report overridden field w/ public modifier") {
-            val code = """
+            val code =
+                """
                 abstract class A {
                     abstract val test: String
                 }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCountSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCountSpec.kt
@@ -12,7 +12,8 @@ class ReturnCountSpec : Spek({
     describe("ReturnCount rule") {
 
         context("a file with an if condition guard clause and 2 returns") {
-            val code = """
+            val code =
+                """
             fun test(x: Int): Int {
                 if (x < 4) return 0
                 when (x) {
@@ -31,7 +32,8 @@ class ReturnCountSpec : Spek({
         }
 
         context("a file with an if condition guard clause with body and 2 returns") {
-            val code = """
+            val code =
+                """
             fun test(x: Int): Int {
                 if (x < 4) {
                     println("x x is less than 4")
@@ -59,7 +61,8 @@ class ReturnCountSpec : Spek({
         }
 
         context("too-complicated if does not count as a guard clause") {
-            val code = """
+            val code =
+                """
             fun test(x: Int): Int {
                 if (x < 4) {
                     println("x x is less than 4")
@@ -91,7 +94,8 @@ class ReturnCountSpec : Spek({
         }
 
         context("a file with an ELVIS operator guard clause and 2 returns") {
-            val code = """
+            val code =
+                """
             fun test(x: Int): Int {
                 val y = x ?: return 0
                 when (x) {
@@ -110,7 +114,8 @@ class ReturnCountSpec : Spek({
         }
 
         context("a file with 2 returns and an if condition guard clause which is not the first statement") {
-            val code = """
+            val code =
+                """
             fun test(x: Int): Int {
                 when (x) {
                     5 -> println("x=5")
@@ -129,7 +134,8 @@ class ReturnCountSpec : Spek({
         }
 
         context("a file with 2 returns and an ELVIS guard clause which is not the first statement") {
-            val code = """
+            val code =
+                """
             fun test(x: Int): Int {
                 when (x) {
                     5 -> println("x=5")
@@ -148,7 +154,8 @@ class ReturnCountSpec : Spek({
         }
 
         context("a file with multiple guard clauses") {
-            val code = """
+            val code =
+                """
                 fun multipleGuards(a: Int?, b: Any?, c: Int?) {
                     if(a == null) return
                     val models = b as? Int ?: return
@@ -160,25 +167,30 @@ class ReturnCountSpec : Spek({
 
                     return
                 }
-            """.trimIndent()
+                """.trimIndent()
 
             it("should not count all four guard clauses") {
-                val findings = ReturnCount(TestConfig(
-                    ReturnCount.EXCLUDE_GUARD_CLAUSES to "true"
-                )).compileAndLint(code)
+                val findings = ReturnCount(
+                    TestConfig(
+                        ReturnCount.EXCLUDE_GUARD_CLAUSES to "true"
+                    )
+                ).compileAndLint(code)
                 assertThat(findings).isEmpty()
             }
 
             it("should count all four guard clauses") {
-                val findings = ReturnCount(TestConfig(
-                    ReturnCount.EXCLUDE_GUARD_CLAUSES to "false"
-                )).compileAndLint(code)
+                val findings = ReturnCount(
+                    TestConfig(
+                        ReturnCount.EXCLUDE_GUARD_CLAUSES to "false"
+                    )
+                ).compileAndLint(code)
                 assertThat(findings).hasSize(1)
             }
         }
 
         context("a file with 3 returns") {
-            val code = """
+            val code =
+                """
             fun test(x: Int): Int {
                 when (x) {
                     5 -> println("x=5")
@@ -206,7 +218,8 @@ class ReturnCountSpec : Spek({
         }
 
         context("a file with 2 returns") {
-            val code = """
+            val code =
+                """
             fun test(x: Int): Int {
                 when (x) {
                     5 -> println("x=5")
@@ -233,7 +246,8 @@ class ReturnCountSpec : Spek({
         }
 
         context("a function is ignored") {
-            val code = """
+            val code =
+                """
             fun test(x: Int): Int {
                 when (x) {
                     5 -> println("x=5")
@@ -245,16 +259,21 @@ class ReturnCountSpec : Spek({
         """
 
             it("should not get flagged") {
-                val findings = ReturnCount(TestConfig(mapOf(
-                    ReturnCount.MAX to "2",
-                    ReturnCount.EXCLUDED_FUNCTIONS to "test")
-                )).compileAndLint(code)
+                val findings = ReturnCount(
+                    TestConfig(
+                        mapOf(
+                            ReturnCount.MAX to "2",
+                            ReturnCount.EXCLUDED_FUNCTIONS to "test"
+                        )
+                    )
+                ).compileAndLint(code)
                 assertThat(findings).isEmpty()
             }
         }
 
         context("a subset of functions are ignored") {
-            val code = """
+            val code =
+                """
             fun test1(x: Int): Int {
                 when (x) {
                     5 -> println("x=5")
@@ -284,16 +303,21 @@ class ReturnCountSpec : Spek({
         """
 
             it("should flag none of the ignored functions") {
-                val findings = ReturnCount(TestConfig(mapOf(
-                    ReturnCount.MAX to "2",
-                    ReturnCount.EXCLUDED_FUNCTIONS to "test1,test2")
-                )).compileAndLint(code)
+                val findings = ReturnCount(
+                    TestConfig(
+                        mapOf(
+                            ReturnCount.MAX to "2",
+                            ReturnCount.EXCLUDED_FUNCTIONS to "test1,test2"
+                        )
+                    )
+                ).compileAndLint(code)
                 assertThat(findings).hasSize(1)
             }
         }
 
         context("a function with inner object") {
-            val code = """
+            val code =
+                """
             fun test(x: Int): Int {
                 val a = object {
                     fun test2(x: Int): Int {
@@ -319,7 +343,8 @@ class ReturnCountSpec : Spek({
         }
 
         context("a function with 2 inner object") {
-            val code = """
+            val code =
+                """
             fun test(x: Int): Int {
                 val a = object {
                     fun test2(x: Int): Int {
@@ -354,7 +379,8 @@ class ReturnCountSpec : Spek({
         }
 
         context("a function with 2 inner object and exceeded max") {
-            val code = """
+            val code =
+                """
             fun test(x: Int): Int {
                 val a = object {
                     fun test2(x: Int): Int {
@@ -392,7 +418,8 @@ class ReturnCountSpec : Spek({
 
         context("function with multiple labeled return statements") {
 
-            val code = """
+            val code =
+                """
             fun readUsers(name: String): Flowable<User> {
             return userDao.read(name)
                 .flatMap {
@@ -409,16 +436,20 @@ class ReturnCountSpec : Spek({
 
             it("should count labeled returns from lambda when activated") {
                 val findings = ReturnCount(
-                    TestConfig(mapOf(ReturnCount.EXCLUDE_RETURN_FROM_LAMBDA to "false"))).lint(code)
+                    TestConfig(mapOf(ReturnCount.EXCLUDE_RETURN_FROM_LAMBDA to "false"))
+                ).lint(code)
                 assertThat(findings).hasSize(1)
             }
 
             it("should be empty when labeled returns are de-activated") {
                 val findings = ReturnCount(
-                    TestConfig(mapOf(
-                        ReturnCount.EXCLUDE_LABELED to "true",
-                        ReturnCount.EXCLUDE_RETURN_FROM_LAMBDA to "false"
-                    ))).lint(code)
+                    TestConfig(
+                        mapOf(
+                            ReturnCount.EXCLUDE_LABELED to "true",
+                            ReturnCount.EXCLUDE_RETURN_FROM_LAMBDA to "false"
+                        )
+                    )
+                ).lint(code)
                 assertThat(findings).isEmpty()
             }
         }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/SafeCastSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/SafeCastSpec.kt
@@ -11,7 +11,8 @@ class SafeCastSpec : Spek({
     describe("SafeCast rule") {
 
         it("reports negated expression") {
-            val code = """
+            val code =
+                """
                 fun test(element: Int) {
                     val cast = if (element !is Number) {
                         null
@@ -23,7 +24,8 @@ class SafeCastSpec : Spek({
         }
 
         it("reports expression") {
-            val code = """
+            val code =
+                """
                 fun test(element: Int) {
                     val cast = if (element is Number) {
                         element
@@ -35,7 +37,8 @@ class SafeCastSpec : Spek({
         }
 
         it("does not report wrong condition") {
-            val code = """
+            val code =
+                """
                 fun test(element: Int) {
                     val other = 3
                     val cast = if (element == other) {
@@ -48,7 +51,8 @@ class SafeCastSpec : Spek({
         }
 
         it("does not report wrong else clause") {
-            val code = """
+            val code =
+                """
                 fun test(element: Int) {
                     val cast = if (element is Number) {
                         element

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/SerialVersionUIDInSerializableClassSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/SerialVersionUIDInSerializableClassSpec.kt
@@ -12,7 +12,8 @@ class SerialVersionUIDInSerializableClassSpec : Spek({
     describe("SerialVersionUIDInSerializableClass rule") {
 
         it("reports class with no serialVersionUID") {
-            val code = """
+            val code =
+                """
                 import java.io.Serializable
 
                 class C : Serializable
@@ -21,7 +22,8 @@ class SerialVersionUIDInSerializableClassSpec : Spek({
         }
 
         it("reports class with wrong datatype") {
-            val code = """
+            val code =
+                """
                 import java.io.Serializable
 
                 class C : Serializable {
@@ -34,7 +36,8 @@ class SerialVersionUIDInSerializableClassSpec : Spek({
         }
 
         it("reports class with wrong explicitly defined datatype") {
-            val code = """
+            val code =
+                """
                 import java.io.Serializable
 
                 class C : Serializable {
@@ -47,7 +50,8 @@ class SerialVersionUIDInSerializableClassSpec : Spek({
         }
 
         it("reports class with wrong naming and without const modifier") {
-            val code = """
+            val code =
+                """
                 import java.io.Serializable
 
                 class C : Serializable {
@@ -69,7 +73,8 @@ class SerialVersionUIDInSerializableClassSpec : Spek({
         }
 
         it("does not report an interface that implements Serializable") {
-            val code = """
+            val code =
+                """
                 import java.io.Serializable
 
                 interface I : Serializable
@@ -78,7 +83,8 @@ class SerialVersionUIDInSerializableClassSpec : Spek({
         }
 
         it("does not report UID constant with positive value") {
-            val code = """
+            val code =
+                """
                 import java.io.Serializable
 
                 class C : Serializable {
@@ -91,7 +97,8 @@ class SerialVersionUIDInSerializableClassSpec : Spek({
         }
 
         it("does not report UID constant with negative value") {
-            val code = """
+            val code =
+                """
                 import java.io.Serializable
 
                 class C : Serializable {
@@ -104,7 +111,8 @@ class SerialVersionUIDInSerializableClassSpec : Spek({
         }
 
         it("does not report UID constant with explicit Long type") {
-            val code = """
+            val code =
+                """
                 import java.io.Serializable
 
                 class C : Serializable {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/SpacingBetweenPackageAndImportsSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/SpacingBetweenPackageAndImportsSpec.kt
@@ -89,7 +89,8 @@ class SpacingBetweenPackageAndImportsSpec : Spek({
         }
 
         it("has multiple imports in file") {
-            val code = """
+            val code =
+                """
                 package com.my
 
                 import kotlin.collections.List
@@ -101,7 +102,8 @@ class SpacingBetweenPackageAndImportsSpec : Spek({
         }
 
         it("has no class") {
-            val code = """
+            val code =
+                """
                 package com.my
 
                 import kotlin.collections.List

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ThrowsCountSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ThrowsCountSpec.kt
@@ -11,7 +11,8 @@ class ThrowsCountSpec : Spek({
 
     describe("ThrowsCount rule") {
 
-        val code = """
+        val code =
+            """
             fun f1(x: Int) {
                 when (x) {
                     1 -> throw IOException()

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/TrailingWhitespaceSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/TrailingWhitespaceSpec.kt
@@ -37,7 +37,8 @@ class TrailingWhitespaceSpec : Spek({
         context("negative cases") {
 
             it("does not report a class and function declaration with no whitespaces at the end") {
-                val code = """
+                val code =
+                    """
                     class C {
 
                         fun f() {
@@ -45,13 +46,14 @@ class TrailingWhitespaceSpec : Spek({
                             println("Another message") ;
                         }
                     }
-                """.trimIndent()
+                    """.trimIndent()
                 rule.visit(code.toKtFileContent())
                 assertThat(rule.findings).isEmpty()
             }
 
             it("does not report an indentation inside multi-line strings") {
-                val code = """
+                val code =
+                    """
                     val multiLineStringWithIndents = ""${'"'}
                         Should ignore indent on the next line
                         

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiteralsSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiteralsSpec.kt
@@ -19,7 +19,7 @@ class UnderscoresInNumericLiteralsSpec : Spek({
 
         it("should be reported if acceptableDecimalLength is 4") {
             val findings = UnderscoresInNumericLiterals(
-                    TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "4"))
+                TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "4"))
             ).compileAndLint(code)
             assertThat(findings).isNotEmpty
         }
@@ -44,7 +44,7 @@ class UnderscoresInNumericLiteralsSpec : Spek({
 
         it("should not be reported if acceptableDecimalLength is 8") {
             val findings = UnderscoresInNumericLiterals(
-                    TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "8"))
+                TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "8"))
             ).compileAndLint(code)
             assertThat(findings).isEmpty()
         }
@@ -60,7 +60,7 @@ class UnderscoresInNumericLiteralsSpec : Spek({
 
         it("should be reported if acceptableDecimalLength is 4") {
             val findings = UnderscoresInNumericLiterals(
-                    TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "4"))
+                TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "4"))
             ).compileAndLint(code)
             assertThat(findings).isNotEmpty
         }
@@ -76,7 +76,7 @@ class UnderscoresInNumericLiteralsSpec : Spek({
 
         it("should be reported if acceptableDecimalLength is 4") {
             val findings = UnderscoresInNumericLiterals(
-                    TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "4"))
+                TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "4"))
             ).compileAndLint(code)
             assertThat(findings).isNotEmpty
         }
@@ -101,7 +101,7 @@ class UnderscoresInNumericLiteralsSpec : Spek({
 
         it("should not be reported if ignored acceptableDecimalLength is 8") {
             val findings = UnderscoresInNumericLiterals(
-                    TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "8"))
+                TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "8"))
             ).compileAndLint(code)
             assertThat(findings).isEmpty()
         }
@@ -126,7 +126,7 @@ class UnderscoresInNumericLiteralsSpec : Spek({
 
         it("should be reported if acceptableDecimalLength is 4") {
             val findings = UnderscoresInNumericLiterals(
-                    TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "4"))
+                TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "4"))
             ).compileAndLint(code)
             assertThat(findings).isNotEmpty
         }
@@ -160,7 +160,7 @@ class UnderscoresInNumericLiteralsSpec : Spek({
 
         it("should still be reported even if acceptableDecimalLength is 7") {
             val findings = UnderscoresInNumericLiterals(
-                    TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "7"))
+                TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "7"))
             ).compileAndLint(code)
             assertThat(findings).isNotEmpty
         }
@@ -194,7 +194,8 @@ class UnderscoresInNumericLiteralsSpec : Spek({
     }
 
     describe("a property named serialVersionUID in an object that implements Serializable") {
-        val code = """
+        val code =
+            """
             import java.io.Serializable
             
             object TestSerializable : Serializable {
@@ -209,7 +210,8 @@ class UnderscoresInNumericLiteralsSpec : Spek({
     }
 
     describe("a property named serialVersionUID in an object that does not implement Serializable") {
-        val code = """
+        val code =
+            """
             object TestSerializable {
                 private val serialVersionUID = 314159L
             }
@@ -222,7 +224,8 @@ class UnderscoresInNumericLiteralsSpec : Spek({
     }
 
     describe("a property named serialVersionUID in an object that does not implement Serializable") {
-        val code = """
+        val code =
+            """
             object TestSerializable {
                 private val serialVersionUID = 314_159L
             }
@@ -237,7 +240,8 @@ class UnderscoresInNumericLiteralsSpec : Spek({
     describe("a property named serialVersionUID in a companion object inside a serializable class") {
 
         it("does not report a negative serialVersionUID number") {
-            val code = """
+            val code =
+                """
                 import java.io.Serializable
                 
                 class Test : Serializable {
@@ -250,7 +254,8 @@ class UnderscoresInNumericLiteralsSpec : Spek({
         }
 
         it("does not report a positive serialVersionUID number") {
-            val code = """
+            val code =
+                """
                 import java.io.Serializable
                 
                 class Test : Serializable {
@@ -266,7 +271,8 @@ class UnderscoresInNumericLiteralsSpec : Spek({
     describe("a property named serialVersionUID number in a serializable class") {
 
         it("does not report a negative serialVersionUID number") {
-            val code = """
+            val code =
+                """
                 import java.io.Serializable
                 
                 class Test : Serializable {
@@ -278,7 +284,8 @@ class UnderscoresInNumericLiteralsSpec : Spek({
         }
 
         it("does not report a positive serialVersionUID number") {
-            val code = """
+            val code =
+                """
                 import java.io.Serializable
                 
                 class Test : Serializable {
@@ -300,7 +307,7 @@ class UnderscoresInNumericLiteralsSpec : Spek({
 
         it("should not be reported if acceptableDecimalLength is 6") {
             val findings = UnderscoresInNumericLiterals(
-                    TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "6"))
+                TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "6"))
             ).compileAndLint(code)
             assertThat(findings).isEmpty()
         }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAbstractClassSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAbstractClassSpec.kt
@@ -11,9 +11,13 @@ import org.spekframework.spek2.style.specification.describe
 class UnnecessaryAbstractClassSpec : Spek({
 
     val subject by memoized {
-        UnnecessaryAbstractClass(TestConfig(mapOf(
-                UnnecessaryAbstractClass.EXCLUDE_ANNOTATED_CLASSES to listOf("jdk.nashorn.internal.ir.annotations.Ignore")
-        )))
+        UnnecessaryAbstractClass(
+            TestConfig(
+                mapOf(
+                    UnnecessaryAbstractClass.EXCLUDE_ANNOTATED_CLASSES to listOf("jdk.nashorn.internal.ir.annotations.Ignore")
+                )
+            )
+        )
     }
 
     val wrapper by memoized(
@@ -26,7 +30,8 @@ class UnnecessaryAbstractClassSpec : Spek({
         context("abstract classes with no concrete members") {
 
             it("reports an abstract class with no concrete member") {
-                val code = """
+                val code =
+                    """
                     abstract class A {
                         abstract val i: Int
                         abstract fun f()
@@ -40,7 +45,8 @@ class UnnecessaryAbstractClassSpec : Spek({
             }
 
             it("does not report an abstract class with concrete members derived from a base class") {
-                val code = """
+                val code =
+                    """
                     abstract class A {
                         abstract fun f()
                         val i: Int = 0
@@ -59,7 +65,8 @@ class UnnecessaryAbstractClassSpec : Spek({
             val message = "An abstract class without an abstract member can be refactored to a concrete class."
 
             it("reports no abstract members in abstract class") {
-                val code = """
+                val code =
+                    """
                     abstract class A {
                         val i: Int = 0
                         fun f() {}
@@ -70,7 +77,8 @@ class UnnecessaryAbstractClassSpec : Spek({
             }
 
             it("reports no abstract members in nested abstract class inside a concrete class") {
-                val code = """
+                val code =
+                    """
                     class Outer {
                         abstract class Inner {
                             fun f() {}
@@ -82,7 +90,8 @@ class UnnecessaryAbstractClassSpec : Spek({
             }
 
             it("reports no abstract members in nested abstract class inside an interface") {
-                val code = """
+                val code =
+                    """
                     interface Inner {
                         abstract class A {
                             fun f() {}
@@ -106,7 +115,8 @@ class UnnecessaryAbstractClassSpec : Spek({
             }
 
             it("reports an abstract class with no abstract member derived from a class with abstract members") {
-                val code = """
+                val code =
+                    """
                     abstract class Base {
                         abstract val i: Int
                         abstract fun f()
@@ -130,7 +140,8 @@ class UnnecessaryAbstractClassSpec : Spek({
         context("abstract classes with members") {
 
             it("does not report an abstract class with members and an abstract class derived from it") {
-                val code = """
+                val code =
+                    """
                     abstract class A {
                         abstract val i: Int
                         fun f() {}
@@ -144,7 +155,8 @@ class UnnecessaryAbstractClassSpec : Spek({
             }
 
             it("does not report an abstract class with a constructor and an abstract class derived from it") {
-                val code = """
+                val code =
+                    """
                     abstract class A(val i: Int) {
                         abstract fun f()
                     }
@@ -157,7 +169,8 @@ class UnnecessaryAbstractClassSpec : Spek({
             }
 
             it("does not report an abstract class with a function derived from an interface") {
-                val code = """
+                val code =
+                    """
                     abstract class A : Interface {
                         fun g() {}
                     }
@@ -170,7 +183,8 @@ class UnnecessaryAbstractClassSpec : Spek({
             }
 
             it("does not report empty abstract classes") {
-                val code = """
+                val code =
+                    """
                     abstract class A
                     abstract class B()
                 """
@@ -178,7 +192,8 @@ class UnnecessaryAbstractClassSpec : Spek({
             }
 
             it("does not report abstract classes with module annotation") {
-                val code = """
+                val code =
+                    """
                     import jdk.nashorn.internal.ir.annotations.Ignore
                     
                     @Ignore

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAnnotationUseSiteTargetSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAnnotationUseSiteTargetSpec.kt
@@ -10,7 +10,8 @@ class UnnecessaryAnnotationUseSiteTargetSpec : Spek({
     describe("UnnecessaryAnnotationUseSiteTarget rule") {
 
         context("Unnecessary @param: in a property constructor") {
-            val code = """
+            val code =
+                """
                 class C(@param:Asdf private val foo: String)
 
                 annotation class Asdf
@@ -19,7 +20,8 @@ class UnnecessaryAnnotationUseSiteTargetSpec : Spek({
         }
 
         context("Unnecessary @param: in a constructor") {
-            val code = """
+            val code =
+                """
                 class C(@param:Asdf foo: String)
 
                 annotation class Asdf
@@ -28,7 +30,8 @@ class UnnecessaryAnnotationUseSiteTargetSpec : Spek({
         }
 
         context("Necessary @get:") {
-            val code = """
+            val code =
+                """
                 class C(@get:Asdf private val foo: String)
 
                 annotation class Asdf
@@ -37,7 +40,8 @@ class UnnecessaryAnnotationUseSiteTargetSpec : Spek({
         }
 
         context("Necessary @property:") {
-            val code = """
+            val code =
+                """
                 class C(@property:Asdf private val foo: String)
 
                 annotation class Asdf
@@ -46,7 +50,8 @@ class UnnecessaryAnnotationUseSiteTargetSpec : Spek({
         }
 
         context("Unnecessary @property:") {
-            val code = """
+            val code =
+                """
                 class C {
                     @property:Asdf private val foo: String = "bar"
                 }
@@ -57,7 +62,8 @@ class UnnecessaryAnnotationUseSiteTargetSpec : Spek({
         }
 
         context("Unnecessary @property: at a top level property") {
-            val code = """
+            val code =
+                """
                 @property:Asdf private val foo: String = "bar"
 
                 annotation class Asdf

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryApplySpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryApplySpec.kt
@@ -22,18 +22,24 @@ class UnnecessaryApplySpec : Spek({
         context("unnecessary apply expressions that can be changed to ordinary method call") {
 
             it("reports an apply on non-nullable type") {
-                assertThat(subject.compileAndLint("""
+                assertThat(
+                    subject.compileAndLint(
+                        """
                     fun f() {
                         val a : Int = 0
                         a.apply {
                             plus(1)
                         }
                     }
-                """)).hasSize(1)
+                """
+                    )
+                ).hasSize(1)
             }
 
             it("reports an apply on nullable type") {
-                assertThat(subject.compileAndLint("""
+                assertThat(
+                    subject.compileAndLint(
+                        """
                     fun f() {
                         val a : Int? = null
                         // Resolution: we can't say here if plus is on 'this' or just a side effect when a is not null
@@ -42,11 +48,15 @@ class UnnecessaryApplySpec : Spek({
                             plus(1)
                         }
                     }
-                """)).hasSize(1)
+                """
+                    )
+                ).hasSize(1)
             }
 
             it("reports a false negative apply on nullable type - #1485") {
-                assertThat(subject.compileAndLint("""
+                assertThat(
+                    subject.compileAndLint(
+                        """
                     val a: Any? = Any()
                     fun Any.b() = Unit
                     
@@ -55,22 +65,30 @@ class UnnecessaryApplySpec : Spek({
                             b()
                         }
                     }
-                """)).hasSize(1)
+                """
+                    )
+                ).hasSize(1)
             }
 
             it("does not report an apply with lambda block") {
-                assertThat(subject.compileAndLint("""
+                assertThat(
+                    subject.compileAndLint(
+                        """
                     fun f() {
                         val a: Int? = null
                         a?.apply({
                             plus(1)
                         })
                     }
-                """)).isEmpty()
+                """
+                    )
+                ).isEmpty()
             }
 
             it("does report single statement in apply used as function argument") {
-                assertThat(subject.compileAndLint("""
+                assertThat(
+                    subject.compileAndLint(
+                        """
                     fun b(i : Int?) {}
 
                     fun main() {
@@ -79,11 +97,15 @@ class UnnecessaryApplySpec : Spek({
                             toString()
                         })
                     }
-               """)).isEmpty()
+               """
+                    )
+                ).isEmpty()
             }
 
             it("does report single assignment statement in apply used as function argument - #1517") {
-                assertThat(subject.compileAndLint("""
+                assertThat(
+                    subject.compileAndLint(
+                        """
                     class C {
                         var prop = 0
                     }
@@ -101,11 +123,14 @@ class UnnecessaryApplySpec : Spek({
                         )
                     }
                 """
-                )).isEmpty()
+                    )
+                ).isEmpty()
             }
 
             it("does not report applies with lambda body containing more than one statement") {
-                assertThat(subject.compileAndLint("""
+                assertThat(
+                    subject.compileAndLint(
+                        """
                     fun b(i : Int?) {}
 
                     fun main() {
@@ -123,64 +148,88 @@ class UnnecessaryApplySpec : Spek({
                             plus(2)
                         })
                     }
-                """)).isEmpty()
+                """
+                    )
+                ).isEmpty()
             }
         }
 
         context("reported false positives - #1305") {
 
             it("is used within an assignment expr itself") {
-                assertThat(subject.compileAndLint("""
+                assertThat(
+                    subject.compileAndLint(
+                        """
                     class C {
                         fun f() = true
                     }
                     
                     val a = C().apply { f() }
-                """)).isEmpty()
+                """
+                    )
+                ).isEmpty()
             }
 
             it("is used as return type of extension function") {
-                assertThat(subject.compileAndLint("""
+                assertThat(
+                    subject.compileAndLint(
+                        """
                     class C(var prop: Int)
                     
                     fun Int.f() = C(5).apply { prop = 10 }
-                """)).isEmpty()
+                """
+                    )
+                ).isEmpty()
             }
 
             it("should not flag apply when assigning property on this") {
-                assertThat(subject.compileAndLint("""
+                assertThat(
+                    subject.compileAndLint(
+                        """
                     class C(var prop: Int) {
                         private val c by lazy {
                             C(1).apply { prop = 3 }
                         }
                     }
-                """)).isEmpty()
+                """
+                    )
+                ).isEmpty()
             }
 
             it("should not report apply when using it after returning something") {
-                assertThat(subject.compileAndLint("""
+                assertThat(
+                    subject.compileAndLint(
+                        """
                     class C(var prop: Int)
                     
                     fun f() = (C(5)).apply { prop = 10 }
-                """)).isEmpty()
+                """
+                    )
+                ).isEmpty()
             }
 
             it("should not report apply usage inside safe chained expressions") {
-                assertThat(subject.compileAndLint("""
+                assertThat(
+                    subject.compileAndLint(
+                        """
                     fun f() {
                         val arguments = listOf(1,2,3)
                             ?.map { it * 2 }
                             ?.apply { if (true) 4 }
                             ?: listOf(0)
                     }
-                """)).isEmpty()
+                """
+                    )
+                ).isEmpty()
             }
         }
 
         context("false positive in single nesting expressions - #1473") {
 
             it("should not report the if expression") {
-                assertThat(subject.compileAndLint("""
+                assertThat(
+                    subject.compileAndLint(
+                        """
                     class C {
                         fun has() = true
                     }
@@ -192,11 +241,15 @@ class UnnecessaryApplySpec : Spek({
                             }
                         }
                     }
-                """)).isEmpty()
+                """
+                    )
+                ).isEmpty()
             }
 
             it("should report reference expressions") {
-                assertThat(subject.compileAndLint("""
+                assertThat(
+                    subject.compileAndLint(
+                        """
                     class C { 
                     	val prop = 5 
                     }
@@ -210,14 +263,19 @@ class UnnecessaryApplySpec : Spek({
                             this.prop
                         }
                     }
-                """)).hasSize(2)
+                """
+                    )
+                ).hasSize(2)
             }
         }
 
         context("false positive when it's used as an expression - #2435") {
 
             it("do not report when it's used as an assignment") {
-                assertThat(subject.compileAndLintWithContext(wrapper.env, """
+                assertThat(
+                    subject.compileAndLintWithContext(
+                        wrapper.env,
+                        """
                     class C {
                         fun f() {}
                     }
@@ -230,11 +288,15 @@ class UnnecessaryApplySpec : Spek({
                         }
                     }
                 """
-                )).isEmpty()
+                    )
+                ).isEmpty()
             }
 
             it("do not report when it's used as the last statement of a block inside lambda") {
-                assertThat(subject.compileAndLintWithContext(wrapper.env, """
+                assertThat(
+                    subject.compileAndLintWithContext(
+                        wrapper.env,
+                        """
                     class C {
                         fun f() {}
                     }
@@ -250,7 +312,8 @@ class UnnecessaryApplySpec : Spek({
                         }
                     }
                 """
-                )).isEmpty()
+                    )
+                ).isEmpty()
             }
         }
     }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryInheritanceSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryInheritanceSpec.kt
@@ -12,9 +12,11 @@ class UnnecessaryInheritanceSpec : Spek({
     describe("check inherit classes") {
 
         it("has unnecessary super type declarations") {
-            val findings = subject.lint("""
+            val findings = subject.lint(
+                """
                 class A : Any()
-                class B : Object()""")
+                class B : Object()"""
+            )
             assertThat(findings).hasSize(2)
         }
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLetSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLetSpec.kt
@@ -11,7 +11,8 @@ class UnnecessaryLetSpec : Spek({
 
     describe("UnnecessaryLet rule") {
         it("reports unnecessary lets that can be changed to ordinary method call") {
-            val findings = subject.lint("""
+            val findings = subject.lint(
+                """
                 fun f() {
                     val a : Int? = null
                     a.let { it.plus(1) }
@@ -19,11 +20,13 @@ class UnnecessaryLetSpec : Spek({
                     a.let { that -> that.plus(1) }
                     a?.let { that -> that.plus(1) }
                     a?.let { that -> that.plus(1) }?.let { it.plus(1) }
-                }""")
+                }"""
+            )
             assertThat(findings).hasSize(6)
         }
         it("does not report lets used for function calls") {
-            val findings = subject.lint("""
+            val findings = subject.lint(
+                """
                 fun f() {
                     val a : Int? = null
                     a.let { print(it) }
@@ -31,11 +34,13 @@ class UnnecessaryLetSpec : Spek({
                     a.let { that -> print(that) }
                     a?.let { that -> 1.plus(that) }
                     a?.let { that -> 1.plus(that) }?.let { print(it) }
-                }""")
+                }"""
+            )
             assertThat(findings).isEmpty()
         }
         it("does not report lets with lambda body containing more than one statement") {
-            val findings = subject.lint("""
+            val findings = subject.lint(
+                """
                 fun f() {
                     val a : Int? = null
                     a.let { it.plus(1)
@@ -49,16 +54,19 @@ class UnnecessaryLetSpec : Spek({
                     a?.let { that -> 1.plus(that) }
                      ?.let { it.plus(1)
                              it.plus(2) }
-                }""")
+                }"""
+            )
             assertThat(findings).isEmpty()
         }
         it("does not report lets where it is used multiple times") {
-            val findings = subject.lint("""
+            val findings = subject.lint(
+                """
                 fun f() {
                     val a : Int? = null
                     a?.let { it.plus(it) }
                     a?.let { foo -> foo.plus(foo) }
-                }""")
+                }"""
+            )
             assertThat(findings).isEmpty()
         }
     }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryParenthesesSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryParenthesesSpec.kt
@@ -27,7 +27,8 @@ class UnnecessaryParenthesesSpec : Spek({
         }
 
         it("unnecessary parentheses in other parentheses") {
-            val code = """
+            val code =
+                """
                 fun x(a: String, b: String) {
                     if ((a equals b)) {
                         println("Test")
@@ -37,7 +38,8 @@ class UnnecessaryParenthesesSpec : Spek({
         }
 
         it("does not report unnecessary parentheses around lambdas") {
-            val code = """
+            val code =
+                """
                 fun function (a: (input: String) -> Unit) {
                     a.invoke("TEST")
                 }
@@ -50,7 +52,8 @@ class UnnecessaryParenthesesSpec : Spek({
         }
 
         it("doesn't report function calls containing lambdas and other parameters") {
-            val code = """
+            val code =
+                """
                 fun function (integer: Int, a: (input: String) -> Unit) {
                     a.invoke("TEST")
                 }
@@ -63,7 +66,8 @@ class UnnecessaryParenthesesSpec : Spek({
         }
 
         it("does not report unnecessary parentheses when assigning a lambda to a val") {
-            val code = """
+            val code =
+                """
                 fun f() {
                     instance.copy(value = { false })
                 }"""
@@ -71,7 +75,8 @@ class UnnecessaryParenthesesSpec : Spek({
         }
 
         it("does not report well behaved parentheses") {
-            val code = """
+            val code =
+                """
                 fun x(a: String, b: String) {
                     if (a equals b) {
                         println("Test")
@@ -81,7 +86,8 @@ class UnnecessaryParenthesesSpec : Spek({
         }
 
         it("does not report well behaved parentheses in super constructors") {
-            val code = """
+            val code =
+                """
                 class TestSpek : SubjectSpek({
                     describe("a simple test") {
                         it("should do something") {
@@ -93,7 +99,8 @@ class UnnecessaryParenthesesSpec : Spek({
         }
 
         it("does not report well behaved parentheses in constructors") {
-            val code = """
+            val code =
+                """
                 class TestSpek({
                     describe("a simple test") {
                         it("should do something") {
@@ -105,7 +112,8 @@ class UnnecessaryParenthesesSpec : Spek({
         }
 
         it("should not report lambdas within super constructor calls") {
-            val code = """
+            val code =
+                """
                 class Clazz(
                     private val func: (X, Y) -> Z
                 ) {
@@ -116,7 +124,8 @@ class UnnecessaryParenthesesSpec : Spek({
         }
 
         it("should not report call to function with two lambda parameters with one as block body") {
-            val code = """
+            val code =
+                """
                 class Clazz {
                     fun test(first: (Int) -> Unit, second: (Int) -> Unit) {
                         first(1)
@@ -132,7 +141,8 @@ class UnnecessaryParenthesesSpec : Spek({
         }
 
         it("should not report call to function with two lambda parameters") {
-            val code = """
+            val code =
+                """
                 class Clazz {
                     fun test(first: (Int) -> Unit, second: (Int) -> Unit) {
                         first(1)
@@ -148,7 +158,8 @@ class UnnecessaryParenthesesSpec : Spek({
         }
 
         it("should not report call to function with multiple lambdas as parameters but also other parameters") {
-            val code = """
+            val code =
+                """
                 class Clazz {
                     fun test(text: String, first: () -> Unit, second: () -> Unit) {
                         first()

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UntilInsteadOfRangeToSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UntilInsteadOfRangeToSpec.kt
@@ -12,7 +12,8 @@ class UntilInsteadOfRangeToSpec : Spek({
     describe("UntilInsteadOfRangeTo rule") {
 
         it("reports for '..'") {
-            val code = """
+            val code =
+                """
                 fun f() {
                     for (i in 0 .. 10 - 1) {}
                 }"""
@@ -20,7 +21,8 @@ class UntilInsteadOfRangeToSpec : Spek({
         }
 
         it("does not report if rangeTo not used") {
-            val code = """
+            val code =
+                """
                 fun f() {
                     for (i in 0 until 10 - 1) {}
                     for (i in 10 downTo 2 - 1) {}
@@ -29,7 +31,8 @@ class UntilInsteadOfRangeToSpec : Spek({
         }
 
         it("does not report if upper value isn't a binary expression") {
-            val code = """
+            val code =
+                """
                 fun f() {
                     for (i in 0 .. 10) {}
                 }"""
@@ -37,7 +40,8 @@ class UntilInsteadOfRangeToSpec : Spek({
         }
 
         it("does not report if not minus one") {
-            val code = """
+            val code =
+                """
                 fun f() {
                     for (i in 0 .. 10 + 1) {}
                     for (i in 0 .. 10 - 2) {}

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedImportsSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedImportsSpec.kt
@@ -12,7 +12,9 @@ class UnusedImportsSpec : Spek({
     describe("UnusedImports rule") {
 
         it("does not report infix operators") {
-            assertThat(subject.lint("""
+            assertThat(
+                subject.lint(
+                    """
                 import tasks.success
 
                 fun main() {
@@ -20,11 +22,14 @@ class UnusedImportsSpec : Spek({
                     } success {
                     }
                 }"""
-            )).isEmpty()
+                )
+            ).isEmpty()
         }
 
         it("does not report imports in documentation") {
-            assertThat(subject.lint("""
+            assertThat(
+                subject.lint(
+                    """
                 import tasks.success
                 import tasks.failure
                 import tasks.undefined
@@ -41,11 +46,13 @@ class UnusedImportsSpec : Spek({
                   }
                 }
                 """
-            )).isEmpty()
+                )
+            ).isEmpty()
         }
 
         it("should ignore import for link") {
-            val lint = subject.lint("""
+            val lint = subject.lint(
+                """
                 import tasks.success
                 import tasks.failure
                 import tasks.undefined
@@ -67,7 +74,8 @@ class UnusedImportsSpec : Spek({
         }
 
         it("reports imports from the current package") {
-            val lint = subject.lint("""
+            val lint = subject.lint(
+                """
                 package test
                 import test.SomeClass
 
@@ -81,7 +89,8 @@ class UnusedImportsSpec : Spek({
         }
 
         it("does not report KDoc references with method calls") {
-            val code = """
+            val code =
+                """
                 package com.example
 
                 import android.text.TextWatcher
@@ -98,7 +107,8 @@ class UnusedImportsSpec : Spek({
         }
 
         it("reports imports with different cases") {
-            val lint = subject.lint("""
+            val lint = subject.lint(
+                """
                 import p.a
                 import p.B6 // positive
                 import p.B as B12 // positive
@@ -125,7 +135,8 @@ class UnusedImportsSpec : Spek({
         }
 
         it("does not report imports in same package when inner") {
-            val lint = subject.lint("""
+            val lint = subject.lint(
+                """
                 package test
 
                 import test.Outer.Inner
@@ -140,7 +151,8 @@ class UnusedImportsSpec : Spek({
         }
 
         it("does not report KDoc @see annotation linking to class") {
-            val code = """
+            val code =
+                """
                 import tasks.success
 
                 /**
@@ -153,7 +165,8 @@ class UnusedImportsSpec : Spek({
         }
 
         it("does not report KDoc @see annotation linking to class with description") {
-            val code = """
+            val code =
+                """
                 import tasks.success
 
                 /**
@@ -166,7 +179,8 @@ class UnusedImportsSpec : Spek({
         }
 
         it("reports KDoc @see annotation that does not link to class") {
-            val code = """
+            val code =
+                """
                 import tasks.success
 
                 /**
@@ -179,7 +193,8 @@ class UnusedImportsSpec : Spek({
         }
 
         it("reports KDoc @see annotation that links after description") {
-            val code = """
+            val code =
+                """
                 import tasks.success
 
                 /**
@@ -192,7 +207,8 @@ class UnusedImportsSpec : Spek({
         }
 
         it("does not report imports in KDoc") {
-            val code = """
+            val code =
+                """
                 import tasks.success   // here
                 import tasks.undefined // and here
 
@@ -209,7 +225,8 @@ class UnusedImportsSpec : Spek({
         }
 
         it("should not report import alias as unused when the alias is used") {
-            val code = """
+            val code =
+                """
                 import test.forEach as foreach
                 fun foo() = listOf().iterator().foreach {}
             """
@@ -217,7 +234,8 @@ class UnusedImportsSpec : Spek({
         }
 
         it("should not report used alias even when import is from same package") {
-            val code = """
+            val code =
+                """
                 package com.example
 
                 import com.example.foo as myFoo // from same package but with alias, check alias usage
@@ -231,7 +249,8 @@ class UnusedImportsSpec : Spek({
         }
 
         it("should not report import of provideDelegate operator overload - #1608") {
-            val code = """
+            val code =
+                """
                 import org.gradle.api.tasks.WriteProperties
                 import org.gradle.kotlin.dsl.getValue
                 import org.gradle.kotlin.dsl.provideDelegate // this line specifically should not be reported
@@ -245,7 +264,8 @@ class UnusedImportsSpec : Spek({
         }
 
         it("should not report import of componentN operator") {
-            val code = """
+            val code =
+                """
                 import com.example.MyClass.component1
                 import com.example.MyClass.component2
                 import com.example.MyClass.component543

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateClassSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateClassSpec.kt
@@ -11,7 +11,8 @@ class UnusedPrivateClassSpec : Spek({
 
     describe("top level interfaces") {
         it("should report them if not used") {
-            val code = """
+            val code =
+                """
                 private interface Foo
                 class Bar
                 """
@@ -27,7 +28,8 @@ class UnusedPrivateClassSpec : Spek({
         describe("top level private classes") {
 
             it("should report them if not used") {
-                val code = """
+                val code =
+                    """
                 private class Foo
                 class Bar
                 """
@@ -41,7 +43,8 @@ class UnusedPrivateClassSpec : Spek({
             }
 
             it("should not report them if used as parent") {
-                val code = """
+                val code =
+                    """
                 private open class Foo
                 private class Bar : Foo()
                 """
@@ -55,7 +58,8 @@ class UnusedPrivateClassSpec : Spek({
             }
 
             it("should not report them used as generic parent type") {
-                val code = """
+                val code =
+                    """
                 class Bar
                 private interface Foo<in T> {
                     operator fun invoke(b: T): Unit
@@ -73,7 +77,8 @@ class UnusedPrivateClassSpec : Spek({
         }
 
         it("should not report them if used inside a function") {
-            val code = """
+            val code =
+                """
                 private class Foo
                 fun something() {
                     val foo: Foo = Foo()
@@ -86,7 +91,8 @@ class UnusedPrivateClassSpec : Spek({
         }
 
         it("should not report them if used as function parameter") {
-            val code = """
+            val code =
+                """
                 private class Foo
                 private object Bar {
                   fun bar(foo: Foo) = Unit
@@ -99,7 +105,8 @@ class UnusedPrivateClassSpec : Spek({
         }
 
         it("should not report them if used as nullable variable type") {
-            val code = """
+            val code =
+                """
                 private class Foo
                 private val a: Foo? = null
                 """
@@ -110,7 +117,8 @@ class UnusedPrivateClassSpec : Spek({
         }
 
         it("should not report them if used as variable type") {
-            val code = """
+            val code =
+                """
                 private class Foo
                 private lateinit var a: Foo
                 """
@@ -121,7 +129,8 @@ class UnusedPrivateClassSpec : Spek({
         }
 
         it("should not report them if used as generic type") {
-            val code = """
+            val code =
+                """
                 private class Foo
                 private lateinit var foos: List<Foo>
                 """
@@ -132,7 +141,8 @@ class UnusedPrivateClassSpec : Spek({
         }
 
         it("should not report them if used as generic type in functions") {
-            val code = """
+            val code =
+                """
                 private class Foo
                 private var a = bar<Foo>()
 
@@ -147,7 +157,8 @@ class UnusedPrivateClassSpec : Spek({
         }
 
         it("should not report them if used as nested generic type") {
-            val code = """
+            val code =
+                """
                 private class Foo
                 private lateinit var foos: List<List<Foo>>
                 """
@@ -158,7 +169,8 @@ class UnusedPrivateClassSpec : Spek({
         }
 
         it("should not report them if used as type with generics") {
-            val code = """
+            val code =
+                """
                 private class Foo<T>
                 private lateinit var foos: Foo<String>
                 """
@@ -169,7 +181,8 @@ class UnusedPrivateClassSpec : Spek({
         }
 
         it("should not report them if used as nullable type with generics") {
-            val code = """
+            val code =
+                """
                 private class Foo<T>
                 private var foos: Foo<String>? = Foo()
                 """
@@ -180,7 +193,8 @@ class UnusedPrivateClassSpec : Spek({
         }
 
         it("should not report them if used as non-argument constructor") {
-            val code = """
+            val code =
+                """
                 private class Foo
                 private val a = Foo()
                 """
@@ -191,7 +205,8 @@ class UnusedPrivateClassSpec : Spek({
         }
 
         it("should not report them if used as constructor with arguments") {
-            val code = """
+            val code =
+                """
                 private class Foo(val a: String)
                 private val a = Foo("test")
                 """
@@ -202,7 +217,8 @@ class UnusedPrivateClassSpec : Spek({
         }
 
         it("should not report them if used as function return type") {
-            val code = """
+            val code =
+                """
                 private class Foo(val a: String)
                 private object Bar {
                   fun foo(): Foo? = null
@@ -215,7 +231,8 @@ class UnusedPrivateClassSpec : Spek({
         }
 
         it("should not report them if used as lambda declaration parameter") {
-            val code = """
+            val code =
+                """
                 private class Foo
                 private val lambda: ((Foo) -> Unit)? = null
                 """
@@ -226,7 +243,8 @@ class UnusedPrivateClassSpec : Spek({
         }
 
         it("should not report them if used as lambda declaration return type") {
-            val code = """
+            val code =
+                """
                 private class Foo
                 private val lambda: (() -> Foo)? = null
                 """
@@ -237,7 +255,8 @@ class UnusedPrivateClassSpec : Spek({
         }
 
         it("should not report them if used as lambda declaration generic type") {
-            val code = """
+            val code =
+                """
                 private class Foo
                 private val lambda: (() -> List<Foo>)? = null
                 """
@@ -248,7 +267,8 @@ class UnusedPrivateClassSpec : Spek({
         }
 
         it("should not report them if used as inline object type") {
-            val code = """
+            val code =
+                """
                 private abstract class Foo {
                     abstract fun bar()
                 }
@@ -269,7 +289,8 @@ class UnusedPrivateClassSpec : Spek({
     describe("testcase for reported false positives") {
 
         it("does not crash when using wildcards in generics - #1345") {
-            val code = """
+            val code =
+                """
                 import kotlin.reflect.KClass
                 
                 private class Foo
@@ -282,7 +303,8 @@ class UnusedPrivateClassSpec : Spek({
         }
 
         it("does not report (companion-)object/named-dot references - #1347") {
-            val code = """
+            val code =
+                """
                     class Test {
                         val items = Item.values().map { it.text }.toList()
                     }
@@ -300,7 +322,8 @@ class UnusedPrivateClassSpec : Spek({
         }
 
         it("does not report classes that are used with ::class - #1390") {
-            val code = """
+            val code =
+                """
                     class UnusedPrivateClassTest {
 
                         private data class SomeClass(val name: String)
@@ -323,7 +346,8 @@ class UnusedPrivateClassSpec : Spek({
         }
 
         it("does not report used private annotations - #2093") {
-            val code = """
+            val code =
+                """
                 private annotation class Test1
                 private annotation class Test2
                 private annotation class Test3

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMemberSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMemberSpec.kt
@@ -20,7 +20,8 @@ class UnusedPrivateMemberSpec : Spek({
         destructor = { it.dispose() }
     )
 
-    val regexTestingCode = """
+    val regexTestingCode =
+        """
                 class Test {
                     private val used = "This is used"
                     private val unused = "This is not used"
@@ -45,7 +46,8 @@ class UnusedPrivateMemberSpec : Spek({
     describe("interface functions") {
 
         it("should not report parameters in interface functions") {
-            val code = """
+            val code =
+                """
                 interface UserPlugin {
                     fun plug(application: Application)
                     fun unplug()
@@ -58,7 +60,8 @@ class UnusedPrivateMemberSpec : Spek({
     describe("expect functions") {
 
         it("should not report parameters in expect class functions") {
-            val code = """
+            val code =
+                """
                 expect class Foo {
                     fun bar(i: Int)
                     fun baz(i: Int, s: String)
@@ -68,7 +71,8 @@ class UnusedPrivateMemberSpec : Spek({
         }
 
         it("should not report parameters in expect functions") {
-            val code = """
+            val code =
+                """
                 expect fun bar(i: Int)
                 expect fun baz(i: Int, s: String)
             """
@@ -76,7 +80,8 @@ class UnusedPrivateMemberSpec : Spek({
         }
 
         it("should not report parameters in expect class with constructor") {
-            val code = """
+            val code =
+                """
                 expect class Foo1(private val bar: String) {}
                 expect class Foo2(bar: String) {}
             """
@@ -87,7 +92,8 @@ class UnusedPrivateMemberSpec : Spek({
     describe("actual functions") {
 
         it("reports unused parameters in actual functions") {
-            val code = """
+            val code =
+                """
                 actual class Foo {
                     actual fun bar(i: Int) {}
                     actual fun baz(i: Int, s: String) {}
@@ -97,7 +103,8 @@ class UnusedPrivateMemberSpec : Spek({
         }
 
         it("reports unused parameters in constructors") {
-            val code = """
+            val code =
+                """
                 actual class Foo actual constructor(private val bar: String) {}
             """
             assertThat(subject.lint(code)).hasSize(1)
@@ -115,7 +122,8 @@ class UnusedPrivateMemberSpec : Spek({
     describe("overridden functions") {
 
         it("should not report parameters in not private functions") {
-            val code = """
+            val code =
+                """
                 override fun funA() {
                     objectA.resolve(valA, object : MyCallback {
                         override fun onResolveFailed(throwable: Throwable) {
@@ -131,7 +139,8 @@ class UnusedPrivateMemberSpec : Spek({
     describe("classes accessing constants from companion objects") {
 
         it("should not report used constants") {
-            val code = """
+            val code =
+                """
                 class A {
                     companion object {
                         private const val MY_CONST = 42
@@ -150,7 +159,8 @@ class UnusedPrivateMemberSpec : Spek({
     describe("several classes with properties") {
 
         it("reports an unused member") {
-            val code = """
+            val code =
+                """
                 class Test {
                     private val unused = "This is not used"
 
@@ -163,7 +173,8 @@ class UnusedPrivateMemberSpec : Spek({
         }
 
         it("does not report unused public members") {
-            val code = """
+            val code =
+                """
                 class Test {
                     val unused = "This is not used"
 
@@ -176,7 +187,8 @@ class UnusedPrivateMemberSpec : Spek({
         }
 
         it("does not report used members") {
-            val code = """
+            val code =
+                """
                 class Test {
                     private val used = "This is used"
 
@@ -189,7 +201,8 @@ class UnusedPrivateMemberSpec : Spek({
         }
 
         it("does not report used members but reports unused members") {
-            val code = """
+            val code =
+                """
                 class Test {
                     private val used = "This is used"
                     private val unused = "This is not used"
@@ -222,7 +235,8 @@ class UnusedPrivateMemberSpec : Spek({
     describe("several classes with properties and local properties") {
 
         it("reports an unused member") {
-            val code = """
+            val code =
+                """
                 class Test {
                     private val unused = "This is not used"
 
@@ -236,7 +250,8 @@ class UnusedPrivateMemberSpec : Spek({
         }
 
         it("does not report used members") {
-            val code = """
+            val code =
+                """
                 class Test {
                     private val used = "This is used"
 
@@ -250,7 +265,8 @@ class UnusedPrivateMemberSpec : Spek({
         }
 
         it("reports unused local properties") {
-            val code = """
+            val code =
+                """
                 class Test {
                     private val used = "This is used"
 
@@ -267,7 +283,8 @@ class UnusedPrivateMemberSpec : Spek({
     describe("loop iterators") {
 
         it("should not depend on evaluation order of functions or properties") {
-            val code = """
+            val code =
+                """
                 fun RuleSetProvider.provided() = ruleSetId in defaultRuleSetIds
 
                 val defaultRuleSetIds = listOf("comments", "complexity", "empty-blocks",
@@ -277,7 +294,8 @@ class UnusedPrivateMemberSpec : Spek({
         }
 
         it("doesn't report loop properties") {
-            val code = """
+            val code =
+                """
                 class Test {
                     fun use() {
                         for (i in 0 until 10) {
@@ -290,7 +308,8 @@ class UnusedPrivateMemberSpec : Spek({
         }
 
         it("reports unused loop property") {
-            val code = """
+            val code =
+                """
                 class Test {
                     fun use() {
                         for (i in 0 until 10) {
@@ -302,7 +321,8 @@ class UnusedPrivateMemberSpec : Spek({
         }
 
         it("reports unused loop property in indexed array") {
-            val code = """
+            val code =
+                """
                 class Test {
                     fun use() {
                         val array = intArrayOf(1, 2, 3)
@@ -316,7 +336,8 @@ class UnusedPrivateMemberSpec : Spek({
         }
 
         it("reports all unused loop properties in indexed array") {
-            val code = """
+            val code =
+                """
                 class Test {
                     fun use() {
                         val array = intArrayOf(1, 2, 3)
@@ -329,7 +350,8 @@ class UnusedPrivateMemberSpec : Spek({
         }
 
         it("does not report used loop properties in indexed array") {
-            val code = """
+            val code =
+                """
                 class Test {
                     fun use() {
                         val array = intArrayOf(1, 2, 3)
@@ -347,7 +369,8 @@ class UnusedPrivateMemberSpec : Spek({
     describe("properties used to initialize other properties") {
 
         it("does not report properties used by other properties") {
-            val code = """
+            val code =
+                """
                 class Test {
                     private val used = "This is used"
                     private val text = used
@@ -361,7 +384,8 @@ class UnusedPrivateMemberSpec : Spek({
         }
 
         it("does not report properties used by inner classes") {
-            val code = """
+            val code =
+                """
                 class Test {
                     private val unused = "This is not used"
 
@@ -376,7 +400,8 @@ class UnusedPrivateMemberSpec : Spek({
 
     describe("function parameters") {
         it("reports single parameters if they are unused") {
-            val code = """
+            val code =
+                """
             class Test {
                 val value = usedMethod(1)
 
@@ -390,7 +415,8 @@ class UnusedPrivateMemberSpec : Spek({
         }
 
         it("reports two parameters if they are unused and called the same in different methods") {
-            val code = """
+            val code =
+                """
             class Test {
                 val value = usedMethod(1)
                 val value2 = usedMethod2(1)
@@ -409,7 +435,8 @@ class UnusedPrivateMemberSpec : Spek({
         }
 
         it("does not report single parameters if they used in return statement") {
-            val code = """
+            val code =
+                """
             class Test {
                 val value = usedMethod(1)
 
@@ -423,7 +450,8 @@ class UnusedPrivateMemberSpec : Spek({
         }
 
         it("does not report single parameters if they used in function") {
-            val code = """
+            val code =
+                """
             class Test {
                 val value = usedMethod(1)
 
@@ -437,7 +465,8 @@ class UnusedPrivateMemberSpec : Spek({
         }
 
         it("reports parameters that are unused in return statement") {
-            val code = """
+            val code =
+                """
             class Test {
                 val value = usedMethod(1, 2)
 
@@ -451,7 +480,8 @@ class UnusedPrivateMemberSpec : Spek({
         }
 
         it("reports parameters that are unused in function") {
-            val code = """
+            val code =
+                """
             class Test {
                 val value = usedMethod(1, 2)
 
@@ -467,7 +497,8 @@ class UnusedPrivateMemberSpec : Spek({
 
     describe("top level function parameters") {
         it("reports single parameters if they are unused") {
-            val code = """
+            val code =
+                """
             fun function(unusedParameter: Int): Int {
                 return 5
             }
@@ -477,7 +508,8 @@ class UnusedPrivateMemberSpec : Spek({
         }
 
         it("does not report single parameters if they used in return statement") {
-            val code = """
+            val code =
+                """
             fun function(used: Int): Int {
                 return used
             }
@@ -487,7 +519,8 @@ class UnusedPrivateMemberSpec : Spek({
         }
 
         it("does not report single parameters if they used in function") {
-            val code = """
+            val code =
+                """
             fun function(used: Int) {
                 println(used)
             }
@@ -497,7 +530,8 @@ class UnusedPrivateMemberSpec : Spek({
         }
 
         it("reports parameters that are unused in return statement") {
-            val code = """
+            val code =
+                """
             fun function(unusedParameter: Int, usedParameter: Int): Int {
                 return usedParameter
             }
@@ -507,7 +541,8 @@ class UnusedPrivateMemberSpec : Spek({
         }
 
         it("reports parameters that are unused in function") {
-            val code = """
+            val code =
+                """
             fun function(unusedParameter: Int, usedParameter: Int) {
                 println(usedParameter)
             }
@@ -519,7 +554,8 @@ class UnusedPrivateMemberSpec : Spek({
 
     describe("unused private functions") {
         it("does not report used private functions") {
-            val code = """
+            val code =
+                """
             class Test {
                 val value = usedMethod()
 
@@ -533,7 +569,8 @@ class UnusedPrivateMemberSpec : Spek({
         }
 
         it("reports unused private functions") {
-            val code = """
+            val code =
+                """
             class Test {
                 private fun unusedFunction(): Int {
                     return 5
@@ -545,7 +582,8 @@ class UnusedPrivateMemberSpec : Spek({
         }
 
         it("does not report function used in interface - #1613") {
-            val code = """
+            val code =
+                """
                 interface Bar {
                     fun doSomething() {
                         doSomethingElse()
@@ -561,7 +599,8 @@ class UnusedPrivateMemberSpec : Spek({
     describe("private functions only used by unused private functions") {
 
         it("reports the non called private function") {
-            val code = """
+            val code =
+                """
             class Test {
                 private fun unusedFunction(): Int {
                     return someOtherUnusedFunction()
@@ -580,7 +619,8 @@ class UnusedPrivateMemberSpec : Spek({
     describe("unused class declarations which are allowed") {
 
         it("does not report the unused private property") {
-            val code = """
+            val code =
+                """
                 class Test {
                     private val ignored = ""
                 }"""
@@ -588,7 +628,8 @@ class UnusedPrivateMemberSpec : Spek({
         }
 
         it("does not report the unused private function and parameter") {
-            val code = """
+            val code =
+                """
                 class Test {
                     private fun ignored(ignored: Int) {}
                 }"""
@@ -599,7 +640,8 @@ class UnusedPrivateMemberSpec : Spek({
     describe("nested class declarations") {
 
         it("reports unused nested private property") {
-            val code = """
+            val code =
+                """
                 class Test {
                     class Inner {
                         private val unused = 1
@@ -609,7 +651,8 @@ class UnusedPrivateMemberSpec : Spek({
         }
 
         it("does not report used nested private property") {
-            val code = """
+            val code =
+                """
                 class Test {
                     class Inner {
                         private val used = 1
@@ -622,21 +665,24 @@ class UnusedPrivateMemberSpec : Spek({
 
     describe("parameters in primary constructors") {
         it("reports unused private property") {
-            val code = """
+            val code =
+                """
                 class Test(private val unused: Any)
                 """
             assertThat(subject.lint(code)).hasSize(1)
         }
 
         it("reports unused parameter") {
-            val code = """
+            val code =
+                """
                 class Test(unused: Any)
                 """
             assertThat(subject.lint(code)).hasSize(1)
         }
 
         it("does not report used parameter for calling super") {
-            val code = """
+            val code =
+                """
                 class Parent(val ignored: Any)
                 class Test(used: Any) : Parent(used)
                 """
@@ -644,7 +690,8 @@ class UnusedPrivateMemberSpec : Spek({
         }
 
         it("does not report used parameter in init block") {
-            val code = """
+            val code =
+                """
                 class Test(used: Any) {
                     init {
                         used.toString()
@@ -655,7 +702,8 @@ class UnusedPrivateMemberSpec : Spek({
         }
 
         it("does not report used parameter to initialize property") {
-            val code = """
+            val code =
+                """
                 class Test(used: Any) {
                     val usedString = used.toString()
                 }
@@ -664,14 +712,16 @@ class UnusedPrivateMemberSpec : Spek({
         }
 
         it("does not report public property") {
-            val code = """
+            val code =
+                """
                 class Test(val unused: Any)
                 """
             assertThat(subject.lint(code)).isEmpty()
         }
 
         it("does not report private property used in init block") {
-            val code = """
+            val code =
+                """
                 class Test(private val used: Any) {
                     init { used.toString() }
                 }
@@ -680,7 +730,8 @@ class UnusedPrivateMemberSpec : Spek({
         }
 
         it("does not report private property used in function") {
-            val code = """
+            val code =
+                """
                 class Test(private val used: Any) {
                     fun something() {
                         used.toString()
@@ -693,7 +744,8 @@ class UnusedPrivateMemberSpec : Spek({
 
     describe("error messages") {
         it("are specific for function parameters") {
-            val code = """
+            val code =
+                """
                 fun foo(unused: Int){}
             """
 
@@ -703,7 +755,8 @@ class UnusedPrivateMemberSpec : Spek({
         }
 
         it("are specific for local variables") {
-            val code = """
+            val code =
+                """
                 fun foo(){ val unused = 1 }
             """
 
@@ -713,7 +766,8 @@ class UnusedPrivateMemberSpec : Spek({
         }
 
         it("are specific for private functions") {
-            val code = """
+            val code =
+                """
             class Test {
                 private fun unusedFunction(): Int {
                     return 5
@@ -729,7 +783,8 @@ class UnusedPrivateMemberSpec : Spek({
 
     describe("suppress unused parameter warning annotations") {
         it("does not report annotated parameters") {
-            val code = """
+            val code =
+                """
                 fun foo(@Suppress("UNUSED_PARAMETER") unused: String){}
             """
 
@@ -737,7 +792,8 @@ class UnusedPrivateMemberSpec : Spek({
         }
 
         it("reports parameters without annotation") {
-            val code = """
+            val code =
+                """
                 fun foo(@Suppress("UNUSED_PARAMETER") unused: String, unusedWithoutAnnotation: String){}
             """
 
@@ -748,7 +804,8 @@ class UnusedPrivateMemberSpec : Spek({
         }
 
         it("does not report parameters in annotated function") {
-            val code = """
+            val code =
+                """
                 @Suppress("UNUSED_PARAMETER")
                 fun foo(unused: String, otherUnused: String){}
             """
@@ -757,7 +814,8 @@ class UnusedPrivateMemberSpec : Spek({
         }
 
         it("does not report parameters in annotated class") {
-            val code = """
+            val code =
+                """
                 @Suppress("UNUSED_PARAMETER")
                 class Test {
                     fun foo(unused: String, otherUnused: String){}
@@ -769,7 +827,8 @@ class UnusedPrivateMemberSpec : Spek({
         }
 
         it("does not report parameters in annotated object") {
-            val code = """
+            val code =
+                """
                 @Suppress("UNUSED_PARAMETER")
                 object Test {
                     fun foo(unused: String){}
@@ -780,7 +839,8 @@ class UnusedPrivateMemberSpec : Spek({
         }
 
         it("does not report parameters in class with annotated outer class") {
-            val code = """
+            val code =
+                """
                 @Suppress("UNUSED_PARAMETER")
                 class Test {
                     fun foo(unused: String){}
@@ -795,7 +855,8 @@ class UnusedPrivateMemberSpec : Spek({
         }
 
         it("does not report parameters in annotated file") {
-            val code = """
+            val code =
+                """
                 @file:Suppress("UNUSED_PARAMETER")
 
                 class Test {
@@ -813,7 +874,8 @@ class UnusedPrivateMemberSpec : Spek({
 
     describe("suppress unused property warning annotations") {
         it("does not report annotated private constructor properties") {
-            val code = """
+            val code =
+                """
                 class Test(@Suppress("unused") private val foo: String) {}
             """
 
@@ -821,7 +883,8 @@ class UnusedPrivateMemberSpec : Spek({
         }
 
         it("reports private constructor properties without annotation") {
-            val code = """
+            val code =
+                """
                 class Test(
                     @Suppress("unused") private val foo: String,
                     private val bar: String
@@ -835,7 +898,8 @@ class UnusedPrivateMemberSpec : Spek({
         }
 
         it("does not report private constructor properties in annotated class") {
-            val code = """
+            val code =
+                """
                 @Suppress("unused")
                 class Test(
                     private val foo: String,
@@ -847,7 +911,8 @@ class UnusedPrivateMemberSpec : Spek({
         }
 
         it("does not report private constructor properties in class with annotated outer class") {
-            val code = """
+            val code =
+                """
                 @Suppress("unused")
                 class Test(
                     private val foo: String,
@@ -863,7 +928,8 @@ class UnusedPrivateMemberSpec : Spek({
         }
 
         it("does not report private constructor properties in annotated file") {
-            val code = """
+            val code =
+                """
                 @file:Suppress("unused")
 
                 class Test(
@@ -880,7 +946,8 @@ class UnusedPrivateMemberSpec : Spek({
         }
 
         it("does not report annotated private properties") {
-            val code = """
+            val code =
+                """
                 class Test {
                     @Suppress("unused") private val foo: String
                 }
@@ -890,7 +957,8 @@ class UnusedPrivateMemberSpec : Spek({
         }
 
         it("reports private properties without annotation") {
-            val code = """
+            val code =
+                """
                 class Test {
                     @Suppress("unused") private val foo: String
                     private val bar: String
@@ -904,7 +972,8 @@ class UnusedPrivateMemberSpec : Spek({
         }
 
         it("does not report private properties in annotated class") {
-            val code = """
+            val code =
+                """
                 @Suppress("unused")
                 class Test {
                     private val foo: String
@@ -916,7 +985,8 @@ class UnusedPrivateMemberSpec : Spek({
         }
 
         it("does not report private properties in class with annotated outer class") {
-            val code = """
+            val code =
+                """
                 @Suppress("unused")
                 class Test {
                     private val foo: String
@@ -932,7 +1002,8 @@ class UnusedPrivateMemberSpec : Spek({
         }
 
         it("does not report private properties in annotated file") {
-            val code = """
+            val code =
+                """
                 @file:Suppress("unused")
 
                 class Test {
@@ -951,7 +1022,8 @@ class UnusedPrivateMemberSpec : Spek({
 
     describe("suppress unused function warning annotations") {
         it("does not report annotated private functions") {
-            val code = """
+            val code =
+                """
                 @Suppress("unused")
                 private fun foo(): String = ""
             """
@@ -960,7 +1032,8 @@ class UnusedPrivateMemberSpec : Spek({
         }
 
         it("reports private functions without annotation") {
-            val code = """
+            val code =
+                """
                 private fun foo(): String = ""
             """
 
@@ -971,7 +1044,8 @@ class UnusedPrivateMemberSpec : Spek({
         }
 
         it("does not report private functions in annotated class") {
-            val code = """
+            val code =
+                """
                 @Suppress("unused")
                 class Test {
                     private fun foo(): String = ""
@@ -982,7 +1056,8 @@ class UnusedPrivateMemberSpec : Spek({
         }
 
         it("does not report private functions in class with annotated outer class") {
-            val code = """
+            val code =
+                """
                 @Suppress("unused")
                 class Test {
                     private fun foo(): String = ""
@@ -998,7 +1073,8 @@ class UnusedPrivateMemberSpec : Spek({
         }
 
         it("does not report private functions in annotated file") {
-            val code = """
+            val code =
+                """
                 @file:Suppress("unused")
                 class Test {
                     private fun foo(): String = ""
@@ -1017,7 +1093,8 @@ class UnusedPrivateMemberSpec : Spek({
     describe("main methods") {
 
         it("does not report the args parameter of the main function inside an object") {
-            val code = """
+            val code =
+                """
                 object O {
 
                     @JvmStatic
@@ -1030,7 +1107,8 @@ class UnusedPrivateMemberSpec : Spek({
         }
 
         it("does not report the args parameter of the main function as top level function") {
-            val code = """
+            val code =
+                """
                 fun main(args: Array<String>) {
                     println("b")
                 }
@@ -1042,7 +1120,8 @@ class UnusedPrivateMemberSpec : Spek({
     describe("operators") {
 
         it("does not report used plus operator - #1354") {
-            val code = """
+            val code =
+                """
                 import java.util.Date
                 class Foo {
                     val bla: Date = Date(System.currentTimeMillis()) + 300L
@@ -1055,7 +1134,8 @@ class UnusedPrivateMemberSpec : Spek({
         }
 
         it("report unused minus operator") {
-            val code = """
+            val code =
+                """
                 import java.util.Date
                 class Foo {
                     companion object {
@@ -1070,7 +1150,8 @@ class UnusedPrivateMemberSpec : Spek({
     describe("same named functions") {
 
         it("report it when the file has same named functions") {
-            val code = """
+            val code =
+                """
                 class Test {
                     private fun f(): Int {
                         return 5
@@ -1087,7 +1168,8 @@ class UnusedPrivateMemberSpec : Spek({
         }
 
         it("report it when the class has same named functions") {
-            val code = """
+            val code =
+                """
                 class Test {
                     val value = f(1)
 
@@ -1108,7 +1190,8 @@ class UnusedPrivateMemberSpec : Spek({
         }
 
         it("report it when the class has same named extension functions") {
-            val code = """
+            val code =
+                """
                 class Test {
                     val value = 1.f()
                 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseArrayLiteralsInAnnotationsSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseArrayLiteralsInAnnotationsSpec.kt
@@ -12,21 +12,25 @@ class UseArrayLiteralsInAnnotationsSpec : Spek({
     describe("suggests replacing arrayOf with [] syntax") {
 
         it("finds an arrayOf usage") {
-            val findings = subject.compileAndLint("""
-            annotation class Test(val values: Array<String>)
-            @Test(arrayOf("value"))
-            fun test() = Unit
-        """.trimIndent())
+            val findings = subject.compileAndLint(
+                """
+                annotation class Test(val values: Array<String>)
+                @Test(arrayOf("value"))
+                fun test() = Unit
+                """.trimIndent()
+            )
 
             assertThat(findings).hasSize(1)
         }
 
         it("expects [] syntax") {
-            val findings = subject.compileAndLint("""
-            annotation class Test(val values: Array<String>)
-            @Test(["value"])
-            fun test() = Unit
-        """.trimIndent())
+            val findings = subject.compileAndLint(
+                """
+                annotation class Test(val values: Array<String>)
+                @Test(["value"])
+                fun test() = Unit
+                """.trimIndent()
+            )
 
             assertThat(findings).isEmpty()
         }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseCheckOrErrorSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseCheckOrErrorSpec.kt
@@ -21,7 +21,8 @@ class UseCheckOrErrorSpec : Spek({
     describe("UseCheckOrError rule") {
 
         it("reports if a an IllegalStateException is thrown") {
-            val code = """
+            val code =
+                """
                 fun x() {
                     doSomething()
                     if (a < 0) throw IllegalStateException()
@@ -30,7 +31,8 @@ class UseCheckOrErrorSpec : Spek({
         }
 
         it("reports if a an IllegalStateException is thrown with an error message") {
-            val code = """
+            val code =
+                """
                 fun x() {
                     doSomething()
                     if (a < 0) throw IllegalStateException("More details")
@@ -39,7 +41,8 @@ class UseCheckOrErrorSpec : Spek({
         }
 
         it("reports if a an IllegalStateException is thrown as default case of a when expression") {
-            val code = """
+            val code =
+                """
                 fun x(a: Int) =
                     when (a) {
                         1 -> doSomething()
@@ -49,7 +52,8 @@ class UseCheckOrErrorSpec : Spek({
         }
 
         it("reports if an IllegalStateException is thrown by its fully qualified name") {
-            val code = """
+            val code =
+                """
                 fun x() {
                     doSomething()
                     if (a < 0) throw java.lang.IllegalStateException()
@@ -58,7 +62,8 @@ class UseCheckOrErrorSpec : Spek({
         }
 
         it("reports if an IllegalStateException is thrown by its fully qualified name using the kotlin type alias") {
-            val code = """
+            val code =
+                """
                 fun x() {
                     doSomething()
                     if (a < 0) throw kotlin.IllegalStateException()
@@ -67,7 +72,8 @@ class UseCheckOrErrorSpec : Spek({
         }
 
         it("does not report if any other kind of exception is thrown") {
-            val code = """
+            val code =
+                """
                 fun x() {
                     doSomething()
                     if (a < 0) throw SomeBusinessException()
@@ -76,7 +82,8 @@ class UseCheckOrErrorSpec : Spek({
         }
 
         it("does not report an issue if the exception thrown has a message and a cause") {
-            val code = """
+            val code =
+                """
                 private fun missing(): Nothing {
                     if  (cause != null) {
                         throw IllegalStateException("message", cause)
@@ -86,7 +93,8 @@ class UseCheckOrErrorSpec : Spek({
         }
 
         it("does not report an issue if the exception thrown as the only action in a block") {
-            val code = """
+            val code =
+                """
                 fun unsafeRunSync(): A =
                     unsafeRunTimed(Duration.INFINITE)
                         .fold({ throw IllegalStateException("message") }, ::identity)"""
@@ -94,17 +102,20 @@ class UseCheckOrErrorSpec : Spek({
         }
 
         it("reports an issue if the exception thrown as the only action in a function") {
-            val code = """fun doThrow() = throw IllegalStateException("message")"""
+            val code =
+                """fun doThrow() = throw IllegalStateException("message")"""
             assertThat(subject.lint(code)).hasSourceLocation(1, 17)
         }
 
         it("reports an issue if the exception thrown as the only action in a function block") {
-            val code = """fun doThrow() { throw IllegalStateException("message") }"""
+            val code =
+                """fun doThrow() { throw IllegalStateException("message") }"""
             assertThat(subject.lint(code)).hasSourceLocation(1, 17)
         }
 
         it("does not report if the exception thrown has a non-String argument") {
-            val code = """
+            val code =
+                """
                 fun test(throwable: Throwable) {
                     when(throwable) {
                         is NumberFormatException -> println("a")
@@ -116,7 +127,8 @@ class UseCheckOrErrorSpec : Spek({
         }
 
         it("does not report if the exception thrown has a String literal argument and a non-String argument") {
-            val code = """
+            val code =
+                """
                 fun test(throwable: Throwable) {
                     when(throwable) {
                         is NumberFormatException -> println("a")
@@ -128,7 +140,8 @@ class UseCheckOrErrorSpec : Spek({
         }
 
         it("does not report if the exception thrown has a non-String literal argument") {
-            val code = """
+            val code =
+                """
                 fun test(throwable: Throwable) {
                     when(throwable) {
                         is NumberFormatException -> println("a")
@@ -142,7 +155,8 @@ class UseCheckOrErrorSpec : Spek({
         context("with binding context") {
 
             it("does not report if the exception thrown has a non-String argument") {
-                val code = """
+                val code =
+                    """
                     fun test(throwable: Throwable) {
                         when(throwable) {
                             is NumberFormatException -> println("a")
@@ -154,7 +168,8 @@ class UseCheckOrErrorSpec : Spek({
             }
 
             it("does not report if the exception thrown has a String literal argument and a non-String argument") {
-                val code = """
+                val code =
+                    """
                     fun test(throwable: Throwable) {
                         when(throwable) {
                             is NumberFormatException -> println("a")
@@ -166,7 +181,8 @@ class UseCheckOrErrorSpec : Spek({
             }
 
             it("reports if the exception thrown has a non-String literal argument") {
-                val code = """
+                val code =
+                    """
                     fun test(throwable: Throwable) {
                         when(throwable) {
                             is NumberFormatException -> println("a")

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseDataClassSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseDataClassSpec.kt
@@ -24,7 +24,8 @@ class UseDataClassSpec : Spek({
         describe("does not report invalid data class candidates") {
 
             it("does not report a valid class") {
-                val code = """
+                val code =
+                    """
                     class NoDataClassCandidate(val i: Int) {
                         val i2: Int = 0
                         fun f() {
@@ -37,7 +38,8 @@ class UseDataClassSpec : Spek({
             }
 
             it("does not report a candidate class with additional method") {
-                val code = """
+                val code =
+                    """
                     class NoDataClassCandidateWithAdditionalMethod(val i: Int) {
                         fun f1() {
                             println()
@@ -48,14 +50,16 @@ class UseDataClassSpec : Spek({
             }
 
             it("does not report a candidate class with a private constructor") {
-                val code = """
+                val code =
+                    """
                     class NoDataClassCandidateWithOnlyPrivateCtor1 private constructor(val i: Int)
                 """
                 assertThat(subject.compileAndLint(code)).isEmpty()
             }
 
             it("does not report a candidate class with a private explicit constructor") {
-                val code = """
+                val code =
+                    """
                     class NoDataClassCandidateWithOnlyPrivateCtor2 {
                         private constructor(i: Int)
                     }
@@ -64,7 +68,8 @@ class UseDataClassSpec : Spek({
             }
 
             it("does not report a candidate sealed class") {
-                val code = """
+                val code =
+                    """
                     sealed class NoDataClassBecauseItsSealed {
                         data class Success(val any: Any) : NoDataClassBecauseItsSealed()
                         data class Error(val error: Throwable) : NoDataClassBecauseItsSealed()
@@ -74,7 +79,8 @@ class UseDataClassSpec : Spek({
             }
 
             it("does not report a candidate enum class") {
-                val code = """
+                val code =
+                    """
                     enum class EnumNoDataClass(val i: Int) {
                         FIRST(1), SECOND(2);
                     }
@@ -83,7 +89,8 @@ class UseDataClassSpec : Spek({
             }
 
             it("does not report a candidate annotation class") {
-                val code = """
+                val code =
+                    """
                     annotation class AnnotationNoDataClass(val i: Int)
                 """
                 assertThat(subject.compileAndLint(code)).isEmpty()
@@ -93,14 +100,16 @@ class UseDataClassSpec : Spek({
         describe("does report data class candidates") {
 
             it("does report a data class candidate") {
-                val code = """
+                val code =
+                    """
                     class DataClassCandidate1(val i: Int)
                 """
                 assertThat(subject.compileAndLint(code)).hasSize(1)
             }
 
             it("does report a candidate class with extra property") {
-                val code = """
+                val code =
+                    """
                     class DataClassCandidateWithProperties(val i: Int) {
                         val i2: Int = 0
                     }
@@ -109,7 +118,8 @@ class UseDataClassSpec : Spek({
             }
 
             it("does report a candidate class with extra public constructor") {
-                val code = """
+                val code =
+                    """
                     class DataClassCandidate2(val s: String) {
                         private constructor(i: Int) : this(i.toString())
                     }
@@ -118,7 +128,8 @@ class UseDataClassSpec : Spek({
             }
 
             it("does report a candidate class with both a private and public constructor") {
-                val code = """
+                val code =
+                    """
                     class DataClassCandidate3 private constructor(val s: String) {
                         constructor(i: Int) : this(i.toString())
                     }
@@ -127,7 +138,8 @@ class UseDataClassSpec : Spek({
             }
 
             it("does report a candidate class with overridden data class methods") {
-                val code = """
+                val code =
+                    """
                     class DataClassCandidateWithOverriddenMethods(val i: Int) {
                         override fun equals(other: Any?): Boolean {
                             return super.equals(other)
@@ -147,7 +159,8 @@ class UseDataClassSpec : Spek({
         describe("copy method") {
 
             it("does report with copy method") {
-                val code = """
+                val code =
+                    """
                     class D(val a: Int, val b: String) {
                         fun copy(a: Int, b: String): D = D(a, b)
                     }
@@ -156,7 +169,8 @@ class UseDataClassSpec : Spek({
             }
 
             it("does report with copy method which has an implicit return type") {
-                val code = """
+                val code =
+                    """
                     class D(val a: Int, val b: String) {
                         fun copy(a: Int, b: String) = D(a, b)
                     }
@@ -165,7 +179,8 @@ class UseDataClassSpec : Spek({
             }
 
             it("does not report with copy method which has no parameters") {
-                val code = """
+                val code =
+                    """
                     class D(val a: Int, val b: String) {
                         fun copy(): D = D(0, "")
                     }
@@ -174,7 +189,8 @@ class UseDataClassSpec : Spek({
             }
 
             it("does not report with copy method which has more parameters than the primary constructor") {
-                val code = """
+                val code =
+                    """
                     class D(val a: Int, val b: String) {
                         fun copy(a: Int, b: String, c: String): D = D(a, b + c)
                     }
@@ -183,7 +199,8 @@ class UseDataClassSpec : Spek({
             }
 
             it("does not report with copy method which has different parameter types") {
-                val code = """
+                val code =
+                    """
                     class D(val a: Int, val b: String) {
                         fun copy(a: Int, b: Int): D = D(a, b.toString())
                     }
@@ -192,7 +209,8 @@ class UseDataClassSpec : Spek({
             }
 
             it("does not report with copy method which has different parameter types 2") {
-                val code = """
+                val code =
+                    """
                     class D(val a: Int, val b: String) {
                         fun copy(a: Int, b: String?): D = D(a, b.toString())
                     }
@@ -201,7 +219,8 @@ class UseDataClassSpec : Spek({
             }
 
             it("does not report with copy method which has a different return type") {
-                val code = """
+                val code =
+                    """
                     class D(val a: Int, val b: String) {
                         fun copy(a: Int, b: String) {
                         }
@@ -214,13 +233,15 @@ class UseDataClassSpec : Spek({
         describe("does report class with vars and allowVars") {
 
             it("does not report class with mutable constructor parameter") {
-                val code = """class DataClassCandidateWithVar(var i: Int)"""
+                val code =
+                    """class DataClassCandidateWithVar(var i: Int)"""
                 val config = TestConfig(mapOf(UseDataClass.ALLOW_VARS to "true"))
                 assertThat(UseDataClass(config).compileAndLint(code)).isEmpty()
             }
 
             it("does not report class with mutable properties") {
-                val code = """
+                val code =
+                    """
                     class DataClassCandidateWithProperties(var i: Int) {
                         var i2: Int = 0
                     }
@@ -230,7 +251,8 @@ class UseDataClassSpec : Spek({
             }
 
             it("does not report class with both mutable property and immutable parameters") {
-                val code = """
+                val code =
+                    """
                     class DataClassCandidateWithMixedProperties(val i: Int) {
                         var i2: Int = 0
                     }
@@ -240,7 +262,8 @@ class UseDataClassSpec : Spek({
             }
 
             it("does not report class with both mutable parameter and immutable property") {
-                val code = """
+                val code =
+                    """
                     class DataClassCandidateWithMixedProperties(var i: Int) {
                         val i2: Int = 0
                     }
@@ -255,7 +278,8 @@ class UseDataClassSpec : Spek({
         }
 
         it("does not report a class which has an ignored annotation") {
-            val code = """
+            val code =
+                """
                 import kotlin.SinceKotlin
 
                 @SinceKotlin("1.0.0")
@@ -266,7 +290,8 @@ class UseDataClassSpec : Spek({
         }
 
         it("does not report a class with a delegated property") {
-            val code = """
+            val code =
+                """
                 import kotlin.properties.Delegates
                 class C(val i: Int) {
                     var prop: String by Delegates.observable("") {
@@ -278,7 +303,8 @@ class UseDataClassSpec : Spek({
         }
 
         it("reports class with nested delegation") {
-            val code = """
+            val code =
+                """
                 import kotlin.properties.Delegates
                 class C(val i: Int) {
                     var prop: C = C(1).apply {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIfInsteadOfWhenSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIfInsteadOfWhenSpec.kt
@@ -12,7 +12,8 @@ object UseIfInsteadOfWhenSpec : Spek({
     describe("UseIfInsteadOfWhen rule") {
 
         it("reports when using two branches") {
-            val code = """
+            val code =
+                """
                 fun function(): Boolean? {
                     val x = null
                     when (x) {
@@ -25,7 +26,8 @@ object UseIfInsteadOfWhenSpec : Spek({
         }
 
         it("does not report when using one branch") {
-            val code = """
+            val code =
+                """
                 fun function(): Boolean? {
                     val x = null
                     when (x) {
@@ -37,7 +39,8 @@ object UseIfInsteadOfWhenSpec : Spek({
         }
 
         it("does not report when using more than two branches") {
-            val code = """
+            val code =
+                """
                 fun function(): Boolean? {
                     val x = null
                     when (x) {
@@ -51,7 +54,8 @@ object UseIfInsteadOfWhenSpec : Spek({
         }
 
         it("does not report when second branch is not 'else'") {
-            val code = """
+            val code =
+                """
                 fun function(): Boolean? {
                     val x = null
                     when (x) {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseRequireSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseRequireSpec.kt
@@ -21,7 +21,8 @@ class UseRequireSpec : Spek({
     describe("UseRequire rule") {
 
         it("reports if a precondition throws an IllegalArgumentException") {
-            val code = """
+            val code =
+                """
                 fun x(a: Int) {
                     if (a < 0) throw IllegalArgumentException()
                     doSomething()
@@ -30,7 +31,8 @@ class UseRequireSpec : Spek({
         }
 
         it("reports if a precondition throws an IllegalArgumentException with more details") {
-            val code = """
+            val code =
+                """
                 fun x(a: Int) {
                     if (a < 0) throw IllegalArgumentException("More details")
                     doSomething()
@@ -39,7 +41,8 @@ class UseRequireSpec : Spek({
         }
 
         it("reports if a precondition throws a fully qualified IllegalArgumentException") {
-            val code = """
+            val code =
+                """
                 fun x(a: Int) {
                     if (a < 0) throw java.lang.IllegalArgumentException()
                     doSomething()
@@ -48,7 +51,8 @@ class UseRequireSpec : Spek({
         }
 
         it("reports if a precondition throws a fully qualified IllegalArgumentException using the kotlin type alias") {
-            val code = """
+            val code =
+                """
                 fun x(a: Int) {
                     if (a < 0) throw kotlin.IllegalArgumentException()
                     doSomething()
@@ -57,7 +61,8 @@ class UseRequireSpec : Spek({
         }
 
         it("does not report if a precondition throws a different kind of exception") {
-            val code = """
+            val code =
+                """
                 fun x(a: Int) {
                     if (a < 0) throw SomeBusinessException()
                     doSomething()
@@ -66,7 +71,8 @@ class UseRequireSpec : Spek({
         }
 
         it("does not report an issue if the exception thrown has a message and a cause") {
-            val code = """
+            val code =
+                """
                 private fun x(a: Int): Nothing {
                     doSomething()
                     throw IllegalArgumentException("message", cause)
@@ -75,24 +81,28 @@ class UseRequireSpec : Spek({
         }
 
         it("does not report an issue if the exception thrown as the only action in a block") {
-            val code = """
+            val code =
+                """
                 fun unsafeRunSync(): A =
                     foo.fold({ throw IllegalArgumentException("message") }, ::identity)"""
             assertThat(subject.lint(code)).isEmpty()
         }
 
         it("does not report an issue if the exception thrown unconditionally") {
-            val code = """fun doThrow() = throw IllegalArgumentException("message")"""
+            val code =
+                """fun doThrow() = throw IllegalArgumentException("message")"""
             assertThat(subject.lint(code)).isEmpty()
         }
 
         it("does not report an issue if the exception thrown unconditionally in a function block") {
-            val code = """fun doThrow() { throw IllegalArgumentException("message") }"""
+            val code =
+                """fun doThrow() { throw IllegalArgumentException("message") }"""
             assertThat(subject.lint(code)).isEmpty()
         }
 
         it("does not report if the exception thrown has a non-String argument") {
-            val code = """
+            val code =
+                """
                 fun test(throwable: Throwable) {
                     if (throwable !is NumberFormatException) throw IllegalArgumentException(throwable)
                 }
@@ -101,7 +111,8 @@ class UseRequireSpec : Spek({
         }
 
         it("does not report if the exception thrown has a String literal argument and a non-String argument") {
-            val code = """
+            val code =
+                """
                 fun test(throwable: Throwable) {
                     if (throwable !is NumberFormatException) throw IllegalArgumentException("a", throwable)
                 }
@@ -110,7 +121,8 @@ class UseRequireSpec : Spek({
         }
 
         it("does not report if the exception thrown has a non-String literal argument") {
-            val code = """
+            val code =
+                """
                 fun test(throwable: Throwable) {
                     val s = ""
                     if (throwable !is NumberFormatException) throw IllegalArgumentException(s)
@@ -122,7 +134,8 @@ class UseRequireSpec : Spek({
         context("with binding context") {
 
             it("does not report if the exception thrown has a non-String argument") {
-                val code = """
+                val code =
+                    """
                     fun test(throwable: Throwable) {
                         if (throwable !is NumberFormatException) throw IllegalArgumentException(throwable)
                     }
@@ -131,7 +144,8 @@ class UseRequireSpec : Spek({
             }
 
             it("does not report if the exception thrown has a String literal argument and a non-String argument") {
-                val code = """
+                val code =
+                    """
                     fun test(throwable: Throwable) {
                         if (throwable !is NumberFormatException) throw IllegalArgumentException("a", throwable)
                     }
@@ -140,7 +154,8 @@ class UseRequireSpec : Spek({
             }
 
             it("reports if the exception thrown has a non-String literal argument") {
-                val code = """
+                val code =
+                    """
                     fun test(throwable: Throwable) {
                         val s = ""
                         if (throwable !is NumberFormatException) throw IllegalArgumentException(s)
@@ -153,7 +168,8 @@ class UseRequireSpec : Spek({
         context("throw is not after a precondition") {
 
             it("does not report an issue if the exception is inside a when") {
-                val code = """
+                val code =
+                    """
                     fun whenOrThrow(item : List<*>) = when(item) {
                         is ArrayList<*> -> 1
                         is LinkedList<*> -> 2
@@ -164,7 +180,8 @@ class UseRequireSpec : Spek({
             }
 
             it("does not report an issue if the exception is after a block") {
-                val code = """
+                val code =
+                    """
                     fun doSomethingOrThrow(test: Int): Int {
                         var index = 0
                         repeat(test){
@@ -178,7 +195,8 @@ class UseRequireSpec : Spek({
             }
 
             it("does not report an issue if the exception is after a elvis operator") {
-                val code = """
+                val code =
+                    """
                     fun tryToCastOrThrow(list: List<*>) : LinkedList<*> {
                         val subclass = list as? LinkedList
                             ?: throw IllegalArgumentException("List is not a LinkedList")

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UselessCallOnNotNullSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UselessCallOnNotNullSpec.kt
@@ -17,53 +17,63 @@ object UselessCallOnNotNullSpec : Spek({
 
     describe("UselessCallOnNotNull rule") {
         it("reports when calling orEmpty on a list") {
-            val code = """val testList = listOf("string").orEmpty()"""
+            val code =
+                """val testList = listOf("string").orEmpty()"""
             assertThat(subject.compileAndLintWithContext(wrapper.env, code)).hasSize(1)
         }
 
         it("reports when calling orEmpty on a nullable list") {
-            val code = """val testList = listOf("string")?.orEmpty()"""
+            val code =
+                """val testList = listOf("string")?.orEmpty()"""
             assertThat(subject.compileAndLintWithContext(wrapper.env, code)).hasSize(1)
         }
 
         it("reports when calling orEmpty in a chain") {
-            val code = """val testList = listOf("string").orEmpty().map { }"""
+            val code =
+                """val testList = listOf("string").orEmpty().map { }"""
             assertThat(subject.compileAndLintWithContext(wrapper.env, code)).hasSize(1)
         }
 
         it("reports when calling isNullOrBlank on a nullable type") {
-            val code = """val testString = ""?.isNullOrBlank()"""
+            val code =
+                """val testString = ""?.isNullOrBlank()"""
             assertThat(subject.compileAndLintWithContext(wrapper.env, code)).hasSize(1)
         }
 
         it("reports when calling isNullOrEmpty on a nullable type") {
-            val code = """val testString = ""?.isNullOrEmpty()"""
+            val code =
+                """val testString = ""?.isNullOrEmpty()"""
             assertThat(subject.compileAndLintWithContext(wrapper.env, code)).hasSize(1)
         }
 
         it("reports when calling isNullOrEmpty on a string") {
-            val code = """val testString = "".isNullOrEmpty()"""
+            val code =
+                """val testString = "".isNullOrEmpty()"""
             assertThat(subject.compileAndLintWithContext(wrapper.env, code)).hasSize(1)
         }
 
         it("reports when calling orEmpty on a string") {
-            val code = """val testString = "".orEmpty()"""
+            val code =
+                """val testString = "".orEmpty()"""
             assertThat(subject.compileAndLintWithContext(wrapper.env, code)).hasSize(1)
         }
 
         it("reports when calling orEmpty on a sequence") {
-            val code = """val testSequence = listOf(1).asSequence().orEmpty()"""
+            val code =
+                """val testSequence = listOf(1).asSequence().orEmpty()"""
             assertThat(subject.compileAndLintWithContext(wrapper.env, code)).hasSize(1)
         }
 
         it("reports when calling orEmpty on a list with a platform type") {
             // System.getenv().keys.toList() will be of type List<String!>.
-            val code = """val testSequence = System.getenv().keys.toList().orEmpty()"""
+            val code =
+                """val testSequence = System.getenv().keys.toList().orEmpty()"""
             assertThat(subject.compileAndLintWithContext(wrapper.env, code)).hasSize(1)
         }
 
         it("only reports on a Kotlin list") {
-            val code = """
+            val code =
+                """
                 fun String.orEmpty(): List<Char> = this.toCharArray().asList()
 
                 val noList = "str".orEmpty()

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UtilityClassWithPublicConstructorSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UtilityClassWithPublicConstructorSpec.kt
@@ -42,7 +42,8 @@ class UtilityClassWithPublicConstructorSpec : Spek({
         context("annotations class") {
 
             it("should not get triggered for utility class") {
-                val code = """
+                val code =
+                    """
                 @Retention(AnnotationRetention.SOURCE)
                 @StringDef(
                     Gender.MALE,

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/VarCouldBeValSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/VarCouldBeValSpec.kt
@@ -12,7 +12,8 @@ class VarCouldBeValSpec : Spek({
     describe("local declarations in functions") {
 
         it("does not report variables that are re-assigned") {
-            val code = """
+            val code =
+                """
             fun test() {
                 var a = 1
                 a = 2
@@ -22,7 +23,8 @@ class VarCouldBeValSpec : Spek({
         }
 
         it("does not report variables that are re-assigned with assignment operator") {
-            val code = """
+            val code =
+                """
             fun test() {
                 var a = 1
                 a += 2
@@ -32,7 +34,8 @@ class VarCouldBeValSpec : Spek({
         }
 
         it("does not report variables that are re-assigned with postfix operators") {
-            val code = """
+            val code =
+                """
             fun test() {
                 var a = 1
                 a++
@@ -42,7 +45,8 @@ class VarCouldBeValSpec : Spek({
         }
 
         it("does not report variables that are re-assigned with infix operators") {
-            val code = """
+            val code =
+                """
             fun test() {
                 var a = 1
                 --a
@@ -52,7 +56,8 @@ class VarCouldBeValSpec : Spek({
         }
 
         it("does not report variables that are re-assigned inside scope functions") {
-            val code = """
+            val code =
+                """
             fun test() {
                 var a = 1
                 a.also {
@@ -64,7 +69,8 @@ class VarCouldBeValSpec : Spek({
         }
 
         it("reports variables that are not re-assigned, but used in expressions") {
-            val code = """
+            val code =
+                """
             fun test() {
                 var a = 1
                 val b = a + 2
@@ -77,7 +83,8 @@ class VarCouldBeValSpec : Spek({
         }
 
         it("reports variables that are not re-assigned, but used in function calls") {
-            val code = """
+            val code =
+                """
             fun test() {
                 var a = 1
                 something(a)
@@ -90,7 +97,8 @@ class VarCouldBeValSpec : Spek({
         }
 
         it("reports variables that are not re-assigned, but shadowed by one that is") {
-            val code = """
+            val code =
+                """
             fun test() {
                 var shadowed = 1
                 fun nestedFunction() {
@@ -111,7 +119,8 @@ class VarCouldBeValSpec : Spek({
     describe("this-prefixed properties - #1257") {
 
         it("finds unused field and local") {
-            val code = """
+            val code =
+                """
                 fun createObject() = object {
                     private var myVar: String? = null
                     fun assign(value: String?) {
@@ -123,7 +132,8 @@ class VarCouldBeValSpec : Spek({
         }
 
         it("should not report this-prefixed property") {
-            val code = """
+            val code =
+                """
                 fun createObject() = object {
                     private var myVar: String? = null
                     fun assign(value: String?) {
@@ -135,7 +145,8 @@ class VarCouldBeValSpec : Spek({
         }
 
         it("should report unused local variable") {
-            val code = """
+            val code =
+                """
                 fun createObject() = object {
                     private var myVar: String? = null
                     fun assign(value: String?) {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/WildcardImportSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/WildcardImportSpec.kt
@@ -14,7 +14,8 @@ class WildcardImportSpec : Spek({
     describe("WildcardImport rule") {
 
         context("a kt file with wildcard imports") {
-            val code = """
+            val code =
+                """
                 package org
 
                 import io.gitlab.arturbosch.detekt.*
@@ -67,7 +68,8 @@ class WildcardImportSpec : Spek({
             }
 
             it("ignores the default values") {
-                val code2 = """
+                val code2 =
+                    """
                     import java.util.*
                     import kotlinx.android.synthetic.*
                 """
@@ -78,7 +80,8 @@ class WildcardImportSpec : Spek({
         }
 
         context("a kt file with no wildcard imports") {
-            val code = """
+            val code =
+                """
             package org
 
             import org.spekframework.spek2.Spek

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/MandatoryBracesIfStatementsSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/MandatoryBracesIfStatementsSpec.kt
@@ -12,33 +12,38 @@ class MandatoryBracesIfStatementsSpec : Spek({
     describe("if statements which should have braces") {
 
         it("reports a simple if") {
-            val findings = subject.compileAndLint("""
+            val findings = subject.compileAndLint(
+                """
             fun f() {
                 if (true)
                     println()
             }
-            """)
+            """
+            )
 
             assertThat(findings).hasSize(1)
             assertThat(findings).hasTextLocations(32 to 41)
         }
 
         it("reports if-else") {
-            val findings = subject.compileAndLint("""
+            val findings = subject.compileAndLint(
+                """
             fun f() {
                 if (true)
                     println()
                 else
                     println()
             }
-            """)
+            """
+            )
 
             assertThat(findings).hasSize(2)
             assertThat(findings).hasTextLocations(32 to 41, 59 to 68)
         }
 
         it("reports if-else with else-if") {
-            val findings = subject.compileAndLint("""
+            val findings = subject.compileAndLint(
+                """
             fun f() {
                 if (true)
                     println()
@@ -47,28 +52,32 @@ class MandatoryBracesIfStatementsSpec : Spek({
                 else
                     println()
             }
-            """)
+            """
+            )
 
             assertThat(findings).hasSize(3)
             assertThat(findings).hasTextLocations(32 to 41, 70 to 79, 97 to 106)
         }
 
         it("reports if with braces but else without") {
-            val findings = subject.compileAndLint("""
+            val findings = subject.compileAndLint(
+                """
             fun f() {
                 if (true) {
                     println()
                 } else
                     println()
             }
-            """)
+            """
+            )
 
             assertThat(findings).hasSize(1)
             assertThat(findings).hasTextLocations(63 to 72)
         }
 
         it("reports else with braces but if without") {
-            val findings = subject.compileAndLint("""
+            val findings = subject.compileAndLint(
+                """
             fun f() {
                 if (true)
                     println()
@@ -76,31 +85,36 @@ class MandatoryBracesIfStatementsSpec : Spek({
                     println()
                 }
             }
-            """)
+            """
+            )
 
             assertThat(findings).hasSize(1)
             assertThat(findings).hasTextLocations(32 to 41)
         }
 
         it("reports else in new line") {
-            val findings = subject.compileAndLint("""
+            val findings = subject.compileAndLint(
+                """
             fun f() {
                 if (true) println()
                 else println()
             }
-            """)
+            """
+            )
 
             assertThat(findings).hasSize(1)
             assertThat(findings).hasTextLocations(24 to 33)
         }
 
         it("reports only else body on new line") {
-            val findings = subject.compileAndLint("""
+            val findings = subject.compileAndLint(
+                """
             fun f() {
                 if (true) println() else
                     println()
             }
-            """)
+            """
+            )
 
             assertThat(findings).hasSize(1)
             assertThat(findings).hasTextLocations(47 to 56)
@@ -110,7 +124,8 @@ class MandatoryBracesIfStatementsSpec : Spek({
     describe("if statements with braces") {
 
         it("does not report if statements with braces") {
-            val code = """
+            val code =
+                """
                 fun f() {
                 	if (true) {
                 		println()
@@ -129,7 +144,8 @@ class MandatoryBracesIfStatementsSpec : Spek({
     describe("single-line if statements which don't need braces") {
 
         it("does not report single-line if statements") {
-            val code = """
+            val code =
+                """
                 fun f() {
                 	if (true) println()
                 	if (true) println() else println()

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/MandatoryBracesLoopsSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/MandatoryBracesLoopsSpec.kt
@@ -12,7 +12,8 @@ class MandatoryBracesLoopsSpec : Spek({
     describe("MandatoryBracesLoops rule for `for` loops") {
 
         it("does not report with braces") {
-            val code = """
+            val code =
+                """
             fun test() {
                 for (i in 0..10) {
                     println(i)
@@ -24,7 +25,8 @@ class MandatoryBracesLoopsSpec : Spek({
         }
 
         it("does not report full loop on single line") {
-            val code = """
+            val code =
+                """
             fun test() {
                 for (i in 0..10) println(i)
             }
@@ -34,7 +36,8 @@ class MandatoryBracesLoopsSpec : Spek({
         }
 
         it("does not report full loop on single line with multiple statements") {
-            val code = """
+            val code =
+                """
             fun test() {
                 for (i in 0..10) println(i); print(' ')
             }
@@ -44,7 +47,8 @@ class MandatoryBracesLoopsSpec : Spek({
         }
 
         it("reports multi-line without braces") {
-            val code = """
+            val code =
+                """
             fun test() {
                 for (i in 0..10)
                     println(i)
@@ -59,7 +63,8 @@ class MandatoryBracesLoopsSpec : Spek({
         }
 
         it("does not report on suppression") {
-            val code = """
+            val code =
+                """
             fun test() {
                 @Suppress("MandatoryBracesLoops")
                 for (i in 0..10)
@@ -71,7 +76,8 @@ class MandatoryBracesLoopsSpec : Spek({
         }
 
         it("does not report nested loops with braces") {
-            val code = """
+            val code =
+                """
             fun test() {
                 for (i in 0..10) {
                     for (j in 0..10) {
@@ -85,7 +91,8 @@ class MandatoryBracesLoopsSpec : Spek({
         }
 
         it("does not report nested loops on single line") {
-            val code = """
+            val code =
+                """
             fun test() {
                 for (i in 0..10) for (j in 0..10) println()
             }
@@ -95,7 +102,8 @@ class MandatoryBracesLoopsSpec : Spek({
         }
 
         it("reports in nested loop outer") {
-            val code = """
+            val code =
+                """
             fun test() {
                 for (i in 0..10) 
                     for (j in 0..10) {
@@ -112,7 +120,8 @@ class MandatoryBracesLoopsSpec : Spek({
         }
 
         it("reports in nested loop inner") {
-            val code = """
+            val code =
+                """
             fun test() {
                 for (i in 0..10) {
                     for (j in 0..10)
@@ -128,7 +137,8 @@ class MandatoryBracesLoopsSpec : Spek({
         }
 
         it("reports both violations in nested loop") {
-            val code = """
+            val code =
+                """
             fun test() {
                 for (i in 0..10)
                     for (j in 0..10)
@@ -147,7 +157,8 @@ class MandatoryBracesLoopsSpec : Spek({
         }
 
         it("reports with multi-line if statement") {
-            val code = """
+            val code =
+                """
             fun test() {
                 // because if statements are expressions, this code properly prints "Odd" and "Even" 
                 for (i in 0..10) 
@@ -167,7 +178,8 @@ class MandatoryBracesLoopsSpec : Spek({
         }
 
         it("reports inside of if statement without braces") {
-            val code = """
+            val code =
+                """
             fun test() {
                 // this if statement would also be reported, but we're only checking the loop
                 val i = 2
@@ -191,7 +203,8 @@ class MandatoryBracesLoopsSpec : Spek({
     describe("MandatoryBracesLoops rule for `while` loops") {
 
         it("does not report with braces") {
-            val code = """
+            val code =
+                """
             fun test() {
                 while(true) {
                     println()
@@ -203,7 +216,8 @@ class MandatoryBracesLoopsSpec : Spek({
         }
 
         it("does not report full loop on single line") {
-            val code = """
+            val code =
+                """
             fun test() {
                 while(true) println()
             }
@@ -213,7 +227,8 @@ class MandatoryBracesLoopsSpec : Spek({
         }
 
         it("reports multi-line without braces") {
-            val code = """
+            val code =
+                """
             fun test() {
                 while (true)
                     println()
@@ -228,7 +243,8 @@ class MandatoryBracesLoopsSpec : Spek({
         }
 
         it("does not report on suppression") {
-            val code = """
+            val code =
+                """
             fun test() {
                 @Suppress("MandatoryBracesLoops")
                 while(true)
@@ -240,7 +256,8 @@ class MandatoryBracesLoopsSpec : Spek({
         }
 
         it("reports in nested loop inner") {
-            val code = """
+            val code =
+                """
             fun test() {
                 while (true) {
                     while (true)
@@ -259,7 +276,8 @@ class MandatoryBracesLoopsSpec : Spek({
     describe("MandatoryBracesLoops rule for `do while` loops") {
 
         it("does not report with braces") {
-            val code = """
+            val code =
+                """
             fun test() {
                 do {
                     println()
@@ -271,7 +289,8 @@ class MandatoryBracesLoopsSpec : Spek({
         }
 
         it("does not report full loop on single line") {
-            val code = """
+            val code =
+                """
             fun test() {
                 do println() while(true)
             }
@@ -281,7 +300,8 @@ class MandatoryBracesLoopsSpec : Spek({
         }
 
         it("reports multi-line without braces") {
-            val code = """
+            val code =
+                """
             fun test() {
                 do
                     println()
@@ -297,7 +317,8 @@ class MandatoryBracesLoopsSpec : Spek({
         }
 
         it("does not report on suppression") {
-            val code = """
+            val code =
+                """
             fun test() {
                 @Suppress("MandatoryBracesLoops")
                 do
@@ -310,7 +331,8 @@ class MandatoryBracesLoopsSpec : Spek({
         }
 
         it("does not report nested loops with braces") {
-            val code = """		
+            val code =
+                """		
             fun test() {		
                 do {		
                     while (true) {		
@@ -324,7 +346,8 @@ class MandatoryBracesLoopsSpec : Spek({
         }
 
         it("does not report nested loops on single line") {
-            val code = """		
+            val code =
+                """		
             fun test() {		
                 var i = 0
                 do do i += 1 while(i < 5) while (i < 5)	
@@ -335,7 +358,8 @@ class MandatoryBracesLoopsSpec : Spek({
         }
 
         it("reports in nested loop outer") {
-            val code = """		
+            val code =
+                """		
             fun test() {		
                 do 		
                     do {		
@@ -353,7 +377,8 @@ class MandatoryBracesLoopsSpec : Spek({
         }
 
         it("reports in nested loop inner") {
-            val code = """
+            val code =
+                """
             fun test() {
                 do {
                     do

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/OptionalUnitSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/OptionalUnitSpec.kt
@@ -14,7 +14,8 @@ class OptionalUnitSpec : Spek({
 
         context("several functions which return Unit") {
 
-            val code = """
+            val code =
+                """
                 fun returnsUnit1(): Unit {
                     fun returnsUnitNested(): Unit {
                         return Unit
@@ -37,7 +38,8 @@ class OptionalUnitSpec : Spek({
             it("should report the correct violation message") {
                 findings.forEach {
                     assertThat(it.message).endsWith(
-                        " defines a return type of Unit. This is unnecessary and can safely be removed.")
+                        " defines a return type of Unit. This is unnecessary and can safely be removed."
+                    )
                 }
             }
         }
@@ -45,7 +47,8 @@ class OptionalUnitSpec : Spek({
         context("an overridden function which returns Unit") {
 
             it("should not report Unit return type in overridden function") {
-                val code = """
+                val code =
+                    """
                     interface I {
                         fun returnsUnit()
                     }
@@ -60,7 +63,8 @@ class OptionalUnitSpec : Spek({
 
         context("several lone Unit statements") {
 
-            val code = """
+            val code =
+                """
                 fun returnsNothing() {
                     Unit
                     val i: (Int) -> Unit = { _ -> Unit }
@@ -95,7 +99,8 @@ class OptionalUnitSpec : Spek({
         context("several Unit references") {
 
             it("should not report Unit reference") {
-                val findings = subject.compileAndLint("""
+                val findings = subject.compileAndLint(
+                    """
                     fun returnsNothing(u: Unit, us: () -> String) {
                         val u1 = u is Unit
                         val u2: Unit = Unit
@@ -103,14 +108,16 @@ class OptionalUnitSpec : Spek({
                         Unit.equals(null)
                         val i: (Int) -> Unit = { _ -> }
                     }
-                """)
+                """
+                )
                 assertThat(findings).isEmpty()
             }
         }
 
         context("a default interface implementation") {
             it("should not report Unit as part of default interface implementations") {
-                val code = """
+                val code =
+                    """
                     interface Foo {
                         fun method(i: Int) = Unit
                     }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/PreferToOverPairSyntaxSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/PreferToOverPairSyntaxSpec.kt
@@ -18,7 +18,8 @@ object PreferToOverPairSyntaxSpec : Spek({
     describe("PreferToOverPairSyntax rule") {
 
         it("reports if pair is created using pair constructor") {
-            val code = """
+            val code =
+                """
                 val pair1 = Pair(1, 2)
                 val pair2: Pair<Int, Int> = Pair(1, 2)
                 val pair3 = Pair(Pair(1, 2), Pair(3, 4))
@@ -32,7 +33,8 @@ object PreferToOverPairSyntaxSpec : Spek({
         }
 
         it("does not report if a non-Kotlin Pair class was used") {
-            val code = """
+            val code =
+                """
                 val pair1 = Pair(1, 2)
                 val pair2: Pair<Int, Int> = Pair(1, 2)
                 val pair3 = Pair(Pair(1, 2), Pair(3, 4))

--- a/detekt-sample-extensions/src/main/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/rules/TooManyFunctions.kt
+++ b/detekt-sample-extensions/src/main/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/rules/TooManyFunctions.kt
@@ -26,9 +26,13 @@ class TooManyFunctions : Rule() {
     override fun visitKtFile(file: KtFile) {
         super.visitKtFile(file)
         if (amount > THRESHOLD) {
-            report(CodeSmell(issue, Entity.atPackageOrFirstDecl(file),
-                message = "The file ${file.name} has $amount function declarations. " +
-                    "Threshold is specified with $THRESHOLD."))
+            report(
+                CodeSmell(
+                    issue, Entity.atPackageOrFirstDecl(file),
+                    message = "The file ${file.name} has $amount function declarations. " +
+                        "Threshold is specified with $THRESHOLD."
+                )
+            )
         }
         amount = 0
     }

--- a/detekt-sample-extensions/src/main/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/rules/TooManyFunctionsTwo.kt
+++ b/detekt-sample-extensions/src/main/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/rules/TooManyFunctionsTwo.kt
@@ -32,12 +32,15 @@ class TooManyFunctionsTwo(config: Config) : ThresholdRule(config, THRESHOLD) {
     override fun visitKtFile(file: KtFile) {
         super.visitKtFile(file)
         if (amount > threshold) {
-            report(ThresholdedCodeSmell(issue,
-                entity = Entity.from(file),
-                metric = Metric(type = "SIZE", value = amount, threshold = THRESHOLD),
-                message = "The file ${file.name} has $amount function declarations. " +
-                    "Threshold is specified with $THRESHOLD.",
-                references = emptyList())
+            report(
+                ThresholdedCodeSmell(
+                    issue,
+                    entity = Entity.from(file),
+                    metric = Metric(type = "SIZE", value = amount, threshold = THRESHOLD),
+                    message = "The file ${file.name} has $amount function declarations. " +
+                        "Threshold is specified with $THRESHOLD.",
+                    references = emptyList()
+                )
             )
         }
         amount = 0

--- a/detekt-sample-extensions/src/test/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/processors/NumberOfLoopsProcessorSpec.kt
+++ b/detekt-sample-extensions/src/test/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/processors/NumberOfLoopsProcessorSpec.kt
@@ -11,7 +11,8 @@ class NumberOfLoopsProcessorSpec : Spek({
     describe("Number of Loops sample rule") {
 
         it("should expect two loops") {
-            val code = """
+            val code =
+                """
             fun main() {
                 for (i in 0..10) {
                     while (i < 5) {

--- a/detekt-sample-extensions/src/test/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/processors/QualifiedNameProcessorTest.kt
+++ b/detekt-sample-extensions/src/test/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/processors/QualifiedNameProcessorTest.kt
@@ -53,7 +53,8 @@ private val result = object : Detektion {
     }
 }
 
-const val code = """
+const val code =
+    """
     package io.gitlab.arturbosch.detekt.sample
 
     class Foo {}

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/FindingsAssertions.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/FindingsAssertions.kt
@@ -14,25 +14,25 @@ fun assertThat(finding: Finding) = FindingAssert(finding)
 fun List<Finding>.assert() = FindingsAssert(this)
 
 class FindingsAssert(actual: List<Finding>) :
-        AbstractListAssert<FindingsAssert, List<Finding>,
-                Finding, FindingAssert>(actual, FindingsAssert::class.java) {
+    AbstractListAssert<FindingsAssert, List<Finding>,
+        Finding, FindingAssert>(actual, FindingsAssert::class.java) {
 
     override fun newAbstractIterableAssert(iterable: MutableIterable<Finding>): FindingsAssert {
         throw UnsupportedOperationException("not implemented")
     }
 
     override fun toAssert(value: Finding?, description: String?): FindingAssert =
-            FindingAssert(value).`as`(description)
+        FindingAssert(value).`as`(description)
 
     fun hasSourceLocations(vararg expected: SourceLocation) = apply {
         isNotNull
 
         val actualSources = actual.asSequence()
-                .map { it.location.source }
-                .sortedWith(compareBy({ it.line }, { it.column }))
+            .map { it.location.source }
+            .sortedWith(compareBy({ it.line }, { it.column }))
 
         val expectedSources = expected.asSequence()
-                .sortedWith(compareBy({ it.line }, { it.column }))
+            .sortedWith(compareBy({ it.line }, { it.column }))
 
         if (!areEqual(actualSources.toList(), expectedSources.toList())) {
             failWithMessage("Expected source locations to be ${expectedSources.toList()} but was ${actualSources.toList()}")
@@ -47,12 +47,12 @@ class FindingsAssert(actual: List<Finding>) :
         isNotNull
 
         val actualSources = actual.asSequence()
-                .map { it.location.text }
-                .sortedWith(compareBy({ it.start }, { it.end }))
+            .map { it.location.text }
+            .sortedWith(compareBy({ it.start }, { it.end }))
 
         val expectedSources = expected.asSequence()
-                .map { (start, end) -> TextLocation(start, end) }
-                .sortedWith(compareBy({ it.start }, { it.end }))
+            .map { (start, end) -> TextLocation(start, end) }
+            .sortedWith(compareBy({ it.start }, { it.end }))
 
         if (!areEqual(actualSources.toList(), expectedSources.toList())) {
             failWithMessage("Expected text locations to be ${expectedSources.toList()} but was ${actualSources.toList()}")

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/KtTestCompiler.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/KtTestCompiler.kt
@@ -36,7 +36,8 @@ object KtTestCompiler : KtCompiler() {
         val file = psiFileFactory.createFileFromText(
             filename,
             KotlinLanguage.INSTANCE,
-            StringUtilRt.convertLineSeparators(content)) as? KtFile
+            StringUtilRt.convertLineSeparators(content)
+        ) as? KtFile
         file?.putUserData(ABSOLUTE_PATH, filename)
         return file ?: error("kotlin file expected")
     }

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/ThresholdedCodeSmellAssert.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/ThresholdedCodeSmellAssert.kt
@@ -13,7 +13,8 @@ fun FindingAssert.isThresholded(): ThresholdedCodeSmellAssert {
 
 class ThresholdedCodeSmellAssert(actual: ThresholdedCodeSmell?) :
     AbstractAssert<ThresholdedCodeSmellAssert, ThresholdedCodeSmell>(
-        actual, ThresholdedCodeSmellAssert::class.java) {
+        actual, ThresholdedCodeSmellAssert::class.java
+    ) {
 
     fun withValue(expected: Int) = hasValue(expected).let { this }
 

--- a/scripts/compare_releases.kts
+++ b/scripts/compare_releases.kts
@@ -1,5 +1,5 @@
 // kotlinc throws a "const is only allowed for top level properties" for unknown reasons
-@file:Suppress("detekt.VariableNaming")
+@file:Suppress("detekt.VariableNaming", "AnnotationOnSeparateLine")
 
 import java.nio.file.Files
 import java.nio.file.Path


### PR DESCRIPTION
Needs #2709 to merge first.

@schalkms @BraisGabin I'm trying to fix all the formatting issue reports here.
With the last PR I noticed we used the wrong Indentation rule all the time.
With that fixed we also can now check for a consistent indentation on CI.
However we lose a lot of history. Should we still merge this?

 I've activated the rule in detekt.yml and format.yml