### PR TITLE
IgnoreReturnValue: config options

### DIFF
--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -434,7 +434,7 @@ potential-bugs:
   IgnoredReturnValue:
     active: false
     restrictToAnnotatedMethods: true
-    returnValueAnnotations: ["*.CheckReturnValue", "*.CheckResult"]
+    returnValueAnnotations: ['*.CheckReturnValue', '*.CheckResult']
   ImplicitDefaultLocale:
     active: false
   InvalidRange:

--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -433,6 +433,8 @@ potential-bugs:
     active: false
   IgnoredReturnValue:
     active: false
+    restrictToAnnotatedMethods: true
+    returnValueAnnotations: ["*.CheckReturnValue", "*.CheckResult"]
   ImplicitDefaultLocale:
     active: false
   InvalidRange:

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValue.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValue.kt
@@ -43,7 +43,7 @@ import org.jetbrains.kotlin.types.typeUtil.isUnit
  * @configuration restrictToAnnotatedMethods - if the rule should check only annotated methods. (default: `true`)
  * @configuration returnValueAnnotations - List of glob patterns to be used as inspection annotation (default: `['*.CheckReturnValue', '*.CheckResult']`)
  */
-class IgnoredReturnValue(val config: Config = Config.empty) : Rule(config) {
+class IgnoredReturnValue(config: Config = Config.empty) : Rule(config) {
 
     override val issue: Issue = Issue(
             "IgnoredReturnValue",

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValue.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValue.kt
@@ -41,7 +41,7 @@ import org.jetbrains.kotlin.types.typeUtil.isUnit
  * </compliant>
  *
  * @configuration restrictToAnnotatedMethods - if the rule should check only annotated methods. (default: `true`)
- * @configuration returnValueAnnotations - List of glob patterns to be used as inspection annotation (default: `["*.CheckReturnValue", "*.CheckResult"]`)
+ * @configuration returnValueAnnotations - List of glob patterns to be used as inspection annotation (default: `['*.CheckReturnValue', '*.CheckResult']`)
  */
 class IgnoredReturnValue(val config: Config = Config.empty) : Rule(config) {
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValue.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValue.kt
@@ -7,6 +7,8 @@ import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.simplePatternToRegex
+import io.gitlab.arturbosch.detekt.rules.valueOrDefaultCommaSeparated
 import org.jetbrains.kotlin.com.intellij.psi.PsiComment
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
@@ -37,19 +39,29 @@ import org.jetbrains.kotlin.types.typeUtil.isUnit
  *     if (42 == returnsValue()) {}
  *     val x = returnsValue()
  * </compliant>
+ *
+ * @configuration restrictToAnnotatedMethods - if the rule should check only annotated methods. (default: `true`)
+ * @configuration returnValueAnnotations - List of glob patterns to be used as inspection annotation (default: `["*.CheckReturnValue", "*.CheckResult"]`)
  */
-class IgnoredReturnValue(config: Config = Config.empty) : Rule(config) {
-
-    private val requiredAnnotations = listOf(
-            "CheckReturnValue",
-            "CheckResult"
-    )
+class IgnoredReturnValue(val config: Config = Config.empty) : Rule(config) {
 
     override val issue: Issue = Issue(
             "IgnoredReturnValue",
             Severity.Defect,
             "This call returns a value which is ignored",
             Debt.TWENTY_MINS
+    )
+
+    private val annotationsRegexes = valueOrDefaultCommaSeparated(
+                RETURN_VALUE_ANNOTATIONS,
+                DEFAULT_RETURN_VALUE_ANNOTATIONS
+            )
+            .distinct()
+            .map { it.simplePatternToRegex() }
+
+    private val restrictToAnnotatedMethods = valueOrDefault(
+        RESTRICT_TO_ANNOTATED_METHODS,
+        DEFAULT_RESTRICT_TO_ANNOTATED_METHODS
     )
 
     @Suppress("ReturnCount")
@@ -59,12 +71,13 @@ class IgnoredReturnValue(config: Config = Config.empty) : Rule(config) {
         if (bindingContext == BindingContext.EMPTY) return
         val resolvedCall = expression.getResolvedCall(bindingContext) ?: return
         val returnType = resolvedCall.resultingDescriptor.returnType ?: return
-        val annotations = resolvedCall.resultingDescriptor.annotations
+        val annotations = resolvedCall.resultingDescriptor.annotations.mapNotNull { it.fqName?.asString() }
 
         if (returnType.isUnit()) {
             return
         }
-        if (annotations.none { (it.fqName?.pathSegments()?.last()?.asString() in requiredAnnotations) }) {
+        if (restrictToAnnotatedMethods &&
+                annotations.none { annotation -> annotationsRegexes.any { it.matches(annotation) } }) {
             return
         }
 
@@ -87,6 +100,13 @@ class IgnoredReturnValue(config: Config = Config.empty) : Rule(config) {
                     )
             )
         }
+    }
+
+    companion object {
+        const val RESTRICT_TO_ANNOTATED_METHODS = "restrictToAnnotatedMethods"
+        const val DEFAULT_RESTRICT_TO_ANNOTATED_METHODS = true
+        const val RETURN_VALUE_ANNOTATIONS = "returnValueAnnotations"
+        val DEFAULT_RETURN_VALUE_ANNOTATIONS = listOf("*.CheckReturnValue", "*.CheckResult")
     }
 }
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValueSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValueSpec.kt
@@ -478,7 +478,7 @@ object IgnoredReturnValueSpec : Spek({
             assertThat(findings).hasSourceLocation(8, 5)
         }
 
-        it("does not report when a function is not annotated") {
+        it("reports when a function is not annotated") {
             val code = """
                 fun listOfChecked(value: String) = listOf(value)
                 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValueSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValueSpec.kt
@@ -91,7 +91,7 @@ object IgnoredReturnValueSpec : Spek({
 
         it("does not report when the return value is assigned to a pre-existing variable") {
             val code = """
-                package com.example
+                package com.test.ignoredreturnvalue
                 
                 annotation class CheckReturnValue
                 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValueSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValueSpec.kt
@@ -174,9 +174,9 @@ object IgnoredReturnValueSpec : Spek({
                 @CheckReturnValue
                 fun listOfChecked(value: String) = listOf(value)
                 
-                fun foo() : Int {
+                fun foo() {
                     listOfChecked("hello")
-                    return 42
+                    println("foo")
                 }
             """
             val findings = subject.compileAndLintWithContext(wrapper.env, code)
@@ -410,7 +410,7 @@ object IgnoredReturnValueSpec : Spek({
 
         it("reports when a function is annotated with the custom annotation") {
             val code = """
-                package test
+                package com.custom
                 annotation class CustomReturn
                 
                 @CustomReturn
@@ -462,7 +462,7 @@ object IgnoredReturnValueSpec : Spek({
 
         it("reports when a function is annotated with a custom annotation") {
             val code = """
-                package test
+                package com.custom
                 annotation class CheckReturnValue
                 
                 @CheckReturnValue

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValueSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValueSpec.kt
@@ -22,7 +22,7 @@ object IgnoredReturnValueSpec : Spek({
                 fun foo() {
                     listOf("hello")
                 }
-            """.trimIndent()
+            """
             val findings = subject.compileAndLintWithContext(wrapper.env, code)
             assertThat(findings).isEmpty()
         }
@@ -33,7 +33,7 @@ object IgnoredReturnValueSpec : Spek({
                     listOf("hello")
                     return 42
                 }
-            """.trimIndent()
+            """
             val findings = subject.compileAndLintWithContext(wrapper.env, code)
             assertThat(findings).isEmpty()
         }
@@ -43,7 +43,7 @@ object IgnoredReturnValueSpec : Spek({
                 fun foo() {
                     listOf("hello").isEmpty().not()
                 }
-            """.trimIndent()
+            """
             val findings = subject.compileAndLintWithContext(wrapper.env, code)
             assertThat(findings).isEmpty()
         }
@@ -53,7 +53,7 @@ object IgnoredReturnValueSpec : Spek({
                 fun foo() {
                     listOf("hello");println("foo")
                 }
-            """.trimIndent()
+            """
             val findings = subject.compileAndLintWithContext(wrapper.env, code)
             assertThat(findings).isEmpty()
         }
@@ -63,7 +63,7 @@ object IgnoredReturnValueSpec : Spek({
                 fun foo() {
                     println("foo");listOf("hello")
                 }
-            """.trimIndent()
+            """
             val findings = subject.compileAndLintWithContext(wrapper.env, code)
             assertThat(findings).isEmpty()
         }
@@ -73,7 +73,7 @@ object IgnoredReturnValueSpec : Spek({
                 fun foo() {
                     listOf("hello")//foo
                 }
-            """.trimIndent()
+            """
             val findings = subject.compileAndLintWithContext(wrapper.env, code)
             assertThat(findings).isEmpty()
         }
@@ -84,7 +84,7 @@ object IgnoredReturnValueSpec : Spek({
                 fun foo(input: Int) {
                     input.isTheAnswer()
                 }
-            """.trimIndent()
+            """
             val findings = subject.compileAndLintWithContext(wrapper.env, code)
             assertThat(findings).isEmpty()
         }
@@ -103,7 +103,7 @@ object IgnoredReturnValueSpec : Spek({
                     var x: List<String>
                     x = listA()
                 }
-            """.trimIndent()
+            """
             val findings = subject.compileAndLintWithContext(wrapper.env, code)
             assertThat(findings).isEmpty()
         }
@@ -115,7 +115,7 @@ object IgnoredReturnValueSpec : Spek({
                 fun foo() {
                     noReturnValue()
                 }
-            """.trimIndent()
+            """
             val findings = subject.compileAndLintWithContext(wrapper.env, code)
             assertThat(findings).isEmpty()
         }
@@ -127,7 +127,7 @@ object IgnoredReturnValueSpec : Spek({
                 if (returnsBoolean()) {
                     // no-op
                 }
-            """.trimIndent()
+            """
             val findings = subject.compileAndLintWithContext(wrapper.env, code)
             assertThat(findings).isEmpty()
         }
@@ -139,7 +139,7 @@ object IgnoredReturnValueSpec : Spek({
                 if (42 == returnsInt()) {
                     // no-op
                 }
-            """.trimIndent()
+            """
             val findings = subject.compileAndLintWithContext(wrapper.env, code)
             assertThat(findings).isEmpty()
         }
@@ -149,7 +149,7 @@ object IgnoredReturnValueSpec : Spek({
                 fun returnsInt() = 42
                 
                 println(returnsInt())
-            """.trimIndent()
+            """
             val findings = subject.compileAndLintWithContext(wrapper.env, code)
             assertThat(findings).isEmpty()
         }
@@ -159,7 +159,7 @@ object IgnoredReturnValueSpec : Spek({
                 fun returnsInt() = 42
                 
                 println(message = returnsInt())
-            """.trimIndent()
+            """
             val findings = subject.compileAndLintWithContext(wrapper.env, code)
             assertThat(findings).isEmpty()
         }
@@ -178,7 +178,7 @@ object IgnoredReturnValueSpec : Spek({
                     listOfChecked("hello")
                     return 42
                 }
-            """.trimIndent()
+            """
             val findings = subject.compileAndLintWithContext(wrapper.env, code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasSourceLocation(8, 5)
@@ -196,7 +196,7 @@ object IgnoredReturnValueSpec : Spek({
                     listOfChecked("hello")
                     return 42
                 }
-            """.trimIndent()
+            """
             val findings = subject.compileAndLintWithContext(wrapper.env, code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasSourceLocation(8, 5)
@@ -214,7 +214,7 @@ object IgnoredReturnValueSpec : Spek({
                     listOfChecked("hello").isEmpty().not()
                     return 42
                 }
-            """.trimIndent()
+            """
             val findings = subject.compileAndLintWithContext(wrapper.env, code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasSourceLocation(8, 5)
@@ -231,7 +231,7 @@ object IgnoredReturnValueSpec : Spek({
                 fun foo() {
                     listOfChecked("hello");println("foo")
                 }
-            """.trimIndent()
+            """
             val findings = subject.compileAndLintWithContext(wrapper.env, code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasSourceLocation(8, 5)
@@ -249,7 +249,7 @@ object IgnoredReturnValueSpec : Spek({
                     println("foo");listOfChecked("hello")
                     return 42
                 }
-            """.trimIndent()
+            """
             val findings = subject.compileAndLintWithContext(wrapper.env, code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasSourceLocation(8, 20)
@@ -267,7 +267,7 @@ object IgnoredReturnValueSpec : Spek({
                     /* foo */listOfChecked("hello")//foo
                     return 42
                 }
-            """.trimIndent()
+            """
             val findings = subject.compileAndLintWithContext(wrapper.env, code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasSourceLocation(8, 14)
@@ -284,7 +284,7 @@ object IgnoredReturnValueSpec : Spek({
                     input.isTheAnswer()
                     return 42
                 }
-            """.trimIndent()
+            """
             val findings = subject.compileAndLintWithContext(wrapper.env, code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasSourceLocation(7, 11)
@@ -302,7 +302,7 @@ object IgnoredReturnValueSpec : Spek({
                     x = listOfChecked("hello")
                     return 42
                 }
-            """.trimIndent()
+            """
             val findings = subject.compileAndLintWithContext(wrapper.env, code)
             assertThat(findings).isEmpty()
         }
@@ -318,7 +318,7 @@ object IgnoredReturnValueSpec : Spek({
                     noReturnValue()
                     return 42
                 }
-            """.trimIndent()
+            """
             val findings = subject.compileAndLintWithContext(wrapper.env, code)
             assertThat(findings).isEmpty()
         }
@@ -333,7 +333,7 @@ object IgnoredReturnValueSpec : Spek({
                 if (returnsBoolean()) {
                     // no-op
                 }
-            """.trimIndent()
+            """
             val findings = subject.compileAndLintWithContext(wrapper.env, code)
             assertThat(findings).isEmpty()
         }
@@ -348,7 +348,7 @@ object IgnoredReturnValueSpec : Spek({
                 if (42 == returnsInt()) {
                     // no-op
                 }
-            """.trimIndent()
+            """
             val findings = subject.compileAndLintWithContext(wrapper.env, code)
             assertThat(findings).isEmpty()
         }
@@ -361,7 +361,7 @@ object IgnoredReturnValueSpec : Spek({
                 fun returnsInt() = 42
                 
                 println(returnsInt())
-            """.trimIndent()
+            """
             val findings = subject.compileAndLintWithContext(wrapper.env, code)
             assertThat(findings).isEmpty()
         }
@@ -374,7 +374,7 @@ object IgnoredReturnValueSpec : Spek({
                 fun returnsInt() = 42
                 
                 println(message = returnsInt())
-            """.trimIndent()
+            """
             val findings = subject.compileAndLintWithContext(wrapper.env, code)
             assertThat(findings).isEmpty()
         }
@@ -399,7 +399,7 @@ object IgnoredReturnValueSpec : Spek({
                 } else {
                     returnsInt()
                 }
-            """.trimIndent()
+            """
             val findings = subject.compileAndLintWithContext(wrapper.env, code)
             assertThat(findings).isEmpty()
         }
@@ -420,7 +420,7 @@ object IgnoredReturnValueSpec : Spek({
                     listOfChecked("hello")
                     return 42
                 }
-            """.trimIndent()
+            """
             val findings = IgnoredReturnValue(config).compileAndLintWithContext(wrapper.env, code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasSourceLocation(8, 5)
@@ -438,7 +438,7 @@ object IgnoredReturnValueSpec : Spek({
                     listOfChecked("hello")
                     return 42
                 }
-            """.trimIndent()
+            """
             val findings = IgnoredReturnValue(config).compileAndLintWithContext(wrapper.env, code)
             assertThat(findings).isEmpty()
         }
@@ -451,7 +451,7 @@ object IgnoredReturnValueSpec : Spek({
                     listOfChecked("hello")
                     return 42
                 }
-            """.trimIndent()
+            """
             val findings = IgnoredReturnValue(config).compileAndLintWithContext(wrapper.env, code)
             assertThat(findings).isEmpty()
         }
@@ -472,7 +472,7 @@ object IgnoredReturnValueSpec : Spek({
                     listOfChecked("hello")
                     return 42
                 }
-            """.trimIndent()
+            """
             val findings = IgnoredReturnValue(config).compileAndLintWithContext(wrapper.env, code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasSourceLocation(8, 5)
@@ -486,7 +486,7 @@ object IgnoredReturnValueSpec : Spek({
                     listOfChecked("hello")
                     return 42
                 }
-            """.trimIndent()
+            """
             val findings = IgnoredReturnValue(config).compileAndLintWithContext(wrapper.env, code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasSourceLocation(4, 5)

--- a/docs/pages/documentation/potential-bugs.md
+++ b/docs/pages/documentation/potential-bugs.md
@@ -178,7 +178,7 @@ fun returnsNoValue() {}
 
    if the rule should check only annotated methods.
 
-* ``returnValueAnnotations`` (default: ``["*.CheckReturnValue", "*.CheckResult"]``)
+* ``returnValueAnnotations`` (default: ``['*.CheckReturnValue', '*.CheckResult']``)
 
    List of glob patterns to be used as inspection annotation
 

--- a/docs/pages/documentation/potential-bugs.md
+++ b/docs/pages/documentation/potential-bugs.md
@@ -172,6 +172,16 @@ fun returnsNoValue() {}
 
 **Debt**: 20min
 
+#### Configuration options:
+
+* ``restrictToAnnotatedMethods`` (default: ``true``)
+
+   if the rule should check only annotated methods.
+
+* ``returnValueAnnotations`` (default: ``["*.CheckReturnValue", "*.CheckResult"]``)
+
+   List of glob patterns to be used as inspection annotation
+
 #### Noncompliant Code:
 
 ```kotlin


### PR DESCRIPTION
Follow-up to #2698: adding two config to the `IgnoreReturnValue` rule:

* `restrictToAnnotatedMethods: true` to toggle the analysis only on annotated methods
* `returnValueAnnotations: ["*.CheckReturnValue", "*.CheckResult"]` to provide a list of annotations to use during the inspection.