### PR TITLE
add better documentation for the LongParameterList ignoreAnnotated

### DIFF
--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterList.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterList.kt
@@ -32,7 +32,9 @@ import org.jetbrains.kotlin.psi.psiUtil.containingClassOrObject
  * @configuration ignoreDefaultParameters - ignore parameters that have a default value (default: `false`)
  * @configuration ignoreDataClasses - ignore long constructor parameters list for data classes (default: `true`)
  * @configuration ignoreAnnotated - ignore long parameters list for constructors or functions in the context of these
- * annotation class names (default: `[]`)
+ * annotation class names (default: `[]`); (value is a comma separated string with the annotation class names);
+ * the most common case is for Dagger constructors that are annotated with @Inject which would be specified
+ * with `Inject` (quotes are required)
  *
  * @active since v1.0.0
  */

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterList.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterList.kt
@@ -32,9 +32,8 @@ import org.jetbrains.kotlin.psi.psiUtil.containingClassOrObject
  * @configuration ignoreDefaultParameters - ignore parameters that have a default value (default: `false`)
  * @configuration ignoreDataClasses - ignore long constructor parameters list for data classes (default: `true`)
  * @configuration ignoreAnnotated - ignore long parameters list for constructors or functions in the context of these
- * annotation class names (default: `[]`); (value is a comma separated string with the annotation class names);
- * the most common case is for Dagger constructors that are annotated with @Inject which would be specified
- * with `Inject` (quotes are required)
+ * annotation class names (default: `[]`); (e.g. ['Inject', 'Module', 'Suppress']);
+ * the most common case is for dependency injection where constructors are annotated with @Inject.
  *
  * @active since v1.0.0
  */

--- a/docs/pages/documentation/complexity.md
+++ b/docs/pages/documentation/complexity.md
@@ -243,7 +243,8 @@ Reports functions and constructors which have more parameters than a certain thr
 * ``ignoreAnnotated`` (default: ``[]``)
 
    ignore long parameters list for constructors or functions in the context of these
-annotation class names
+annotation class names ; (e.g. ['Inject', 'Module', 'Suppress']);
+the most common case is for dependency injection where constructors are annotated with @Inject.
 
 ### MethodOverloading
 

--- a/docs/pages/documentation/complexity.md
+++ b/docs/pages/documentation/complexity.md
@@ -243,7 +243,13 @@ Reports functions and constructors which have more parameters than a certain thr
 * ``ignoreAnnotated`` (default: ``[]``)
 
    ignore long parameters list for constructors or functions in the context of these
-annotation class names
+annotation class names (value is a comma separated string of the annotation class name); the most common case is for Dagger constructors that are annotated with @Inject, which can be ignored by doing this:
+
+```
+complexity:
+    LongParameterList:
+       ignoreAnnotated  'Inject'
+```
 
 ### MethodOverloading
 

--- a/docs/pages/documentation/complexity.md
+++ b/docs/pages/documentation/complexity.md
@@ -243,13 +243,7 @@ Reports functions and constructors which have more parameters than a certain thr
 * ``ignoreAnnotated`` (default: ``[]``)
 
    ignore long parameters list for constructors or functions in the context of these
-annotation class names (value is a comma separated string of the annotation class name); the most common case is for Dagger constructors that are annotated with @Inject, which can be ignored by doing this:
-
-```
-complexity:
-    LongParameterList:
-       ignoreAnnotated  'Inject'
-```
+annotation class names
 
 ### MethodOverloading
 


### PR DESCRIPTION
From Kotlinlang slack discussion:
https://kotlinlang.slack.com/archives/C88E12QH4/p1589836335126300

Wasn't obvious that ignoreAnnotated should include a CSV list of class names.  Updated documentation to mention that and added an example.