### PR TITLE
Add the `ignoreAnnotated` array parameter to the FunctionNaming rule

### DIFF
--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -357,6 +357,7 @@ naming:
     functionPattern: '([a-z][a-zA-Z0-9]*)|(`.*`)'
     excludeClassPattern: '$^'
     ignoreOverridden: true
+    ignoreAnnotated: ['Composable']
   FunctionParameterNaming:
     active: true
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNamingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNamingSpec.kt
@@ -87,5 +87,39 @@ class FunctionNamingSpec : Spek({
                 SourceLocation(4, 19)
             )
         }
+
+        describe("annotated functions") {
+            val code = """
+                annotation class Composable
+
+                class D {
+                    fun SHOULD_BE_FLAGGED() {}
+                }
+                class E {
+                    @Suppress
+                    fun FLAGGED_IF_NOT_IGNORED() {}
+                }
+                class F {
+                    @Composable
+                    fun NOT_FLAGGED_BY_DEFAULT() {}
+                }
+
+            """
+
+            it("Ignores default annotated functions") {
+                assertThat(FunctionNaming().compileAndLint(code)).hasSourceLocations(
+                    SourceLocation(4, 9),
+                    SourceLocation(8, 9)
+                )
+            }
+    
+            it("Ignores annotated functions if ignoreAnnotated includes the given annotation class") {
+                val config = TestConfig(mapOf(FunctionNaming.IGNORE_ANNOTATED to listOf("Suppress")))
+                assertThat(FunctionNaming(config).compileAndLint(code)).hasSourceLocations(
+                    SourceLocation(4, 9),
+                    SourceLocation(12, 9)
+                )
+            }
+        }
     }
 })

--- a/docs/pages/documentation/naming.md
+++ b/docs/pages/documentation/naming.md
@@ -132,6 +132,11 @@ These factory functions can have the same name as the class being created.
 
    ignores functions that have the override modifier
 
+* ``ignoreAnnotated`` (default: ``['Composable']``)
+
+   ignore naming for functions in the context of these
+annotation class names
+
 ### FunctionParameterNaming
 
 Reports function parameter names which do not follow the specified naming convention are used.


### PR DESCRIPTION
This is intended to ease the use of Jetpack Compose.

Addresses #2733 