### PR TITLE
Mark some well known cli functions as implicit unsupported api

### DIFF
--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Configurations.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Configurations.kt
@@ -7,6 +7,7 @@ import io.gitlab.arturbosch.detekt.api.internal.DisabledAutoCorrectConfig
 import io.gitlab.arturbosch.detekt.api.internal.FailFastConfig
 import io.gitlab.arturbosch.detekt.api.internal.PathFilters
 import io.gitlab.arturbosch.detekt.api.internal.YamlConfig
+import io.gitlab.arturbosch.detekt.core.NotApiButProbablyUsedByUsers
 import java.net.URI
 import java.net.URL
 import java.nio.file.FileSystemNotFoundException
@@ -81,8 +82,10 @@ private fun parsePathConfig(configPath: String): Config {
     }
 }
 
+@NotApiButProbablyUsedByUsers
 const val DEFAULT_CONFIG = "default-detekt-config.yml"
 
+@NotApiButProbablyUsedByUsers
 fun loadDefaultConfig() = YamlConfig.loadResource(ClasspathResourceConverter().convert(DEFAULT_CONFIG))
 
 private fun initFileSystem(uri: URI) {

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Main.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Main.kt
@@ -9,6 +9,7 @@ import io.gitlab.arturbosch.detekt.cli.runners.Executable
 import io.gitlab.arturbosch.detekt.cli.runners.Runner
 import io.gitlab.arturbosch.detekt.cli.runners.SingleRuleRunner
 import io.gitlab.arturbosch.detekt.cli.runners.VersionPrinter
+import io.gitlab.arturbosch.detekt.core.NotApiButProbablyUsedByUsers
 import java.io.PrintStream
 import kotlin.system.exitProcess
 
@@ -34,6 +35,7 @@ fun main(args: Array<String>) {
     exitProcess(ExitCode.NORMAL_RUN.number)
 }
 
+@NotApiButProbablyUsedByUsers
 fun buildRunner(
     args: Array<String>,
     outputPrinter: PrintStream,

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/Runner.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/Runner.kt
@@ -17,9 +17,11 @@ import io.gitlab.arturbosch.detekt.cli.isValidAndSmallerOrEqual
 import io.gitlab.arturbosch.detekt.cli.loadConfiguration
 import io.gitlab.arturbosch.detekt.cli.maxIssues
 import io.gitlab.arturbosch.detekt.core.DetektFacade
+import io.gitlab.arturbosch.detekt.core.NotApiButProbablyUsedByUsers
 import io.gitlab.arturbosch.detekt.core.ProcessingSettings
 import java.io.PrintStream
 
+@NotApiButProbablyUsedByUsers
 class Runner(
     private val arguments: CliArgs,
     private val outputPrinter: PrintStream,

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/NotApiButProbablyUsedByUsers.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/NotApiButProbablyUsedByUsers.kt
@@ -1,0 +1,6 @@
+package io.gitlab.arturbosch.detekt.core
+
+/**
+ * Marker annotation for unsupported implicit api which may break user code.
+ */
+annotation class NotApiButProbablyUsedByUsers


### PR DESCRIPTION
Not sure if necessary but may help to remind us to not break these functions in further refactorings.