### PR TITLE
Fix EqualsAlwaysReturnsTrueOrFalse doc

### DIFF
--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsAlwaysReturnsTrueOrFalse.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsAlwaysReturnsTrueOrFalse.kt
@@ -32,7 +32,7 @@ import org.jetbrains.kotlin.psi.psiUtil.collectDescendantsOfType
  *
  * <compliant>
  * override fun equals(other: Any?): Boolean {
- *     return this == other
+ *     return this === other
  * }
  * </compliant>
  *

--- a/docs/pages/documentation/potential-bugs.md
+++ b/docs/pages/documentation/potential-bugs.md
@@ -72,7 +72,7 @@ override fun equals(other: Any?): Boolean {
 
 ```kotlin
 override fun equals(other: Any?): Boolean {
-    return this == other
+    return this === other
 }
 ```
 


### PR DESCRIPTION
Use `==` in equals causes infinite recursion.
