### PR TITLE
Bump actions/cache to v2

### DIFF
--- a/.github/workflows/deploy-snapshot.yaml
+++ b/.github/workflows/deploy-snapshot.yaml
@@ -14,12 +14,12 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Cache Gradle Caches
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         path: ~/.gradle/caches/
         key: cache-gradle-deploy-snapshot
     - name: Cache Gradle Wrapper
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         path: ~/.gradle/wrapper/
         key: cache-wrapper-deploy-snapshot

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -35,12 +35,12 @@ jobs:
 
 
     - name: Cache Gradle Caches
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         path: ~/.gradle/caches/
         key: cache-clean-gradle-${{ matrix.os }}-${{ matrix.jdk }}
     - name: Cache Gradle Wrapper
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         path: ~/.gradle/wrapper/
         key: cache-clean-wrapper-${{ matrix.os }}-${{ matrix.jdk }}


### PR DESCRIPTION
Github just released actions/cache v2:
https://github.com/actions/cache/releases/tag/v2.0.0