### PR TITLE
Add default print methods to ForbiddenMethodCall

### DIFF
--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -502,7 +502,7 @@ style:
     forbiddenPatterns: ''
   ForbiddenMethodCall:
     active: false
-    methods: []
+    methods: ['kotlin.io.println', 'kotlin.io.print']
   ForbiddenPublicDataClass:
     active: false
     ignorePackages: ['*.internal', '*.internal.*']

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCall.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCall.kt
@@ -8,7 +8,7 @@ import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.rules.valueOrDefaultCommaSeparated
-import org.jetbrains.kotlin.psi.KtQualifiedExpression
+import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.calls.callUtil.getResolvedCall
 import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameOrNull
@@ -25,7 +25,8 @@ import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameOrNull
  * }
  * </noncompliant>
  *
- * @configuration methods - Comma separated list of fully qualified method signatures which are forbidden (default: `[]`)
+ * @configuration methods - Comma separated list of fully qualified method signatures which are forbidden
+ *  (default: `['kotlin.io.println', 'kotlin.io.print']`)
  */
 class ForbiddenMethodCall(config: Config = Config.empty) : Rule(config) {
 
@@ -37,10 +38,10 @@ class ForbiddenMethodCall(config: Config = Config.empty) : Rule(config) {
         Debt.TEN_MINS
     )
 
-    private val forbiddenMethods = valueOrDefaultCommaSeparated(METHODS, emptyList())
+    private val forbiddenMethods = valueOrDefaultCommaSeparated(METHODS, DEFAULT_METHODS)
 
-    override fun visitQualifiedExpression(expression: KtQualifiedExpression) {
-        super.visitQualifiedExpression(expression)
+    override fun visitCallExpression(expression: KtCallExpression) {
+        super.visitCallExpression(expression)
         if (bindingContext == BindingContext.EMPTY) return
 
         val resolvedCall = expression.getResolvedCall(bindingContext) ?: return
@@ -57,5 +58,9 @@ class ForbiddenMethodCall(config: Config = Config.empty) : Rule(config) {
 
     companion object {
         const val METHODS = "methods"
+        val DEFAULT_METHODS = listOf(
+            "kotlin.io.println",
+            "kotlin.io.print"
+        )
     }
 }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCallSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCallSpec.kt
@@ -1,6 +1,7 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
 import io.github.detekt.test.utils.KtTestCompiler
+import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
@@ -16,15 +17,19 @@ class ForbiddenMethodCallSpec : Spek({
 
     describe("ForbiddenMethodCall rule") {
 
-        it("should report nothing by default") {
+        it("should report kotlin print usages by default") {
             val code = """
-            import java.lang.System
             fun main() {
-            System.out.println("hello")
+            print("3")
+            println("4")
             }
             """
             val findings = ForbiddenMethodCall(TestConfig()).compileAndLintWithContext(wrapper.env, code)
-            assertThat(findings).isEmpty()
+            assertThat(findings).hasSize(2)
+            assertThat(findings).hasSourceLocations(
+                SourceLocation(2, 1),
+                SourceLocation(3, 1)
+            )
         }
 
         it("should report nothing when methods are blank") {
@@ -65,7 +70,7 @@ class ForbiddenMethodCallSpec : Spek({
                 TestConfig(mapOf(ForbiddenMethodCall.METHODS to listOf("java.io.PrintStream.println")))
             ).compileAndLintWithContext(wrapper.env, code)
             assertThat(findings).hasSize(1)
-            assertThat(findings).hasTextLocations(13 to 50)
+            assertThat(findings).hasTextLocations(34 to 50)
         }
 
         it("should report method call when not using the fully qualified name") {
@@ -79,7 +84,7 @@ class ForbiddenMethodCallSpec : Spek({
                 TestConfig(mapOf(ForbiddenMethodCall.METHODS to listOf("java.io.PrintStream.println")))
             ).compileAndLintWithContext(wrapper.env, code)
             assertThat(findings).hasSize(1)
-            assertThat(findings).hasTextLocations(41 to 61)
+            assertThat(findings).hasTextLocations(45 to 61)
         }
 
         it("should report multiple different methods") {
@@ -94,7 +99,7 @@ class ForbiddenMethodCallSpec : Spek({
                 TestConfig(mapOf(ForbiddenMethodCall.METHODS to listOf("java.io.PrintStream.println", "java.lang.System.gc")))
             ).compileAndLintWithContext(wrapper.env, code)
             assertThat(findings).hasSize(2)
-            assertThat(findings).hasTextLocations(37 to 64, 69 to 80)
+            assertThat(findings).hasTextLocations(48 to 64, 76 to 80)
         }
 
         it("should report multiple different methods config with sting") {
@@ -109,7 +114,7 @@ class ForbiddenMethodCallSpec : Spek({
                 TestConfig(mapOf(ForbiddenMethodCall.METHODS to "java.io.PrintStream.println, java.lang.System.gc"))
             ).compileAndLintWithContext(wrapper.env, code)
             assertThat(findings).hasSize(2)
-            assertThat(findings).hasTextLocations(37 to 64, 69 to 80)
+            assertThat(findings).hasTextLocations(48 to 64, 76 to 80)
         }
     }
 })

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCallSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCallSpec.kt
@@ -20,8 +20,8 @@ class ForbiddenMethodCallSpec : Spek({
         it("should report kotlin print usages by default") {
             val code = """
             fun main() {
-            print("3")
-            println("4")
+                print("3")
+                println("4")
             }
             """
             val findings = ForbiddenMethodCall(TestConfig()).compileAndLintWithContext(wrapper.env, code)
@@ -36,7 +36,7 @@ class ForbiddenMethodCallSpec : Spek({
             val code = """
             import java.lang.System
             fun main() {
-            System.out.println("hello")
+                System.out.println("hello")
             }
             """
             val findings =
@@ -51,7 +51,7 @@ class ForbiddenMethodCallSpec : Spek({
             val code = """
             import java.lang.System
             fun main() {
-            System.out.println("hello")
+                System.out.println("hello")
             }
             """
             val findings = ForbiddenMethodCall(
@@ -63,7 +63,7 @@ class ForbiddenMethodCallSpec : Spek({
         it("should report method call when using the fully qualified name") {
             val code = """
             fun main() {
-            java.lang.System.out.println("hello")
+                java.lang.System.out.println("hello")
             }
             """
             val findings = ForbiddenMethodCall(
@@ -77,7 +77,7 @@ class ForbiddenMethodCallSpec : Spek({
             val code = """
             import java.lang.System.out
             fun main() {
-            out.println("hello")
+                out.println("hello")
             }
             """
             val findings = ForbiddenMethodCall(

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCallSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCallSpec.kt
@@ -27,8 +27,8 @@ class ForbiddenMethodCallSpec : Spek({
             val findings = ForbiddenMethodCall(TestConfig()).compileAndLintWithContext(wrapper.env, code)
             assertThat(findings).hasSize(2)
             assertThat(findings).hasSourceLocations(
-                SourceLocation(2, 1),
-                SourceLocation(3, 1)
+                SourceLocation(2, 5),
+                SourceLocation(3, 5)
             )
         }
 
@@ -70,7 +70,7 @@ class ForbiddenMethodCallSpec : Spek({
                 TestConfig(mapOf(ForbiddenMethodCall.METHODS to listOf("java.io.PrintStream.println")))
             ).compileAndLintWithContext(wrapper.env, code)
             assertThat(findings).hasSize(1)
-            assertThat(findings).hasTextLocations(34 to 50)
+            assertThat(findings).hasTextLocations(38 to 54)
         }
 
         it("should report method call when not using the fully qualified name") {
@@ -84,7 +84,7 @@ class ForbiddenMethodCallSpec : Spek({
                 TestConfig(mapOf(ForbiddenMethodCall.METHODS to listOf("java.io.PrintStream.println")))
             ).compileAndLintWithContext(wrapper.env, code)
             assertThat(findings).hasSize(1)
-            assertThat(findings).hasTextLocations(45 to 61)
+            assertThat(findings).hasTextLocations(49 to 65)
         }
 
         it("should report multiple different methods") {

--- a/docs/pages/documentation/style.md
+++ b/docs/pages/documentation/style.md
@@ -317,7 +317,7 @@ Detekt will then report all methods invocation that are forbidden.
 
 #### Configuration options:
 
-* ``methods`` (default: ``[]``)
+* ``methods`` (default: ``['kotlin.io.println', 'kotlin.io.print']``)
 
    Comma separated list of fully qualified method signatures which are forbidden
 


### PR DESCRIPTION
Adding all the variations of print/println from Java
to the ForbiddenMethodCall.

The rationale is to encourage the usage of a Logger or a PrintStream

Moreover this fixes the rule that was not catching all the method
calls due to overriding visitQualifiedExpression rather than visitCallExpression

Fixes #2678
