### PR TITLE
Introduce reporting extensions

### DIFF
--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/FileProcessListener.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/FileProcessListener.kt
@@ -30,6 +30,8 @@ interface FileProcessListener : Extension {
     /**
      * Mainly use this method to save computed metrics from KtFile's to the {@link Detektion} container.
      * Do not do heavy computations here as this method is called from the main thread.
+     *
+     * This method is called before any [ReportingExtension].
      */
     fun onFinish(files: List<KtFile>, result: Detektion) {}
 }

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/PropertiesAware.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/PropertiesAware.kt
@@ -16,7 +16,7 @@ interface PropertiesAware {
     /**
      * Binds a given value with given key and stores it for later use.
      */
-    fun register(key: String, value: Any?)
+    fun register(key: String, value: Any)
 }
 
 /**

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/PropertiesAware.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/PropertiesAware.kt
@@ -1,0 +1,32 @@
+package io.gitlab.arturbosch.detekt.api
+
+import org.jetbrains.kotlin.utils.addToStdlib.safeAs
+
+/**
+ * Properties holder. Allows to store and retrieve any data.
+ */
+@UnstableApi
+interface PropertiesAware {
+
+    /**
+     * Raw properties.
+     */
+    val properties: Map<String, Any?>
+
+    /**
+     * Binds a given value with given key and stores it for later use.
+     */
+    fun register(key: String, value: Any?)
+}
+
+/**
+ * Allows to retrieve stored properties in a type safe way.
+ */
+@UnstableApi
+inline fun <reified T : Any> PropertiesAware.getOrNull(key: String): T? {
+    val value = properties[key]
+    if (value != null) {
+        return value.safeAs() ?: error("No value of type ''${T::class} for key '$key'.")
+    }
+    return null
+}

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/ReportingExtension.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/ReportingExtension.kt
@@ -1,0 +1,28 @@
+package io.gitlab.arturbosch.detekt.api
+
+/**
+ * Allows to intercept detekt's result container by listening to the initial and final state
+ * and manipulate the reported findings.
+ */
+@UnstableApi
+interface ReportingExtension : Extension {
+
+    /**
+     * Is called before any [transformFindings] calls were executed.
+     */
+    fun onRawResult(result: Detektion) {
+        // intercept for the initial results
+    }
+
+    /**
+     * Allows to transform the reported findings e.g. apply custom filtering.
+     */
+    fun transformFindings(findings: Map<RuleSetId, List<Finding>>): Map<RuleSetId, List<Finding>> = findings
+
+    /**
+     * Is called after all extensions's [transformFindings] were called.
+     */
+    fun onFinalResult(result: Detektion) {
+        // intercept for the final results
+    }
+}

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/SetupContext.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/SetupContext.kt
@@ -7,7 +7,7 @@ import java.net.URI
  * Context providing useful processing settings to initialize extensions.
  */
 @UnstableApi
-interface SetupContext {
+interface SetupContext : PropertiesAware {
     /**
      * All config locations which where used to create [config].
      */

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/PropertiesAwareSpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/PropertiesAwareSpec.kt
@@ -14,8 +14,8 @@ class PropertiesAwareSpec : Spek({
         context("Implementations can store and retrieve properties") {
 
             val store = object : PropertiesAware {
-                override val properties: MutableMap<String, Any?> = HashMap()
-                override fun register(key: String, value: Any?) {
+                override val properties: MutableMap<String, Any> = HashMap()
+                override fun register(key: String, value: Any) {
                     properties[key] = value
                 }
             }

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/PropertiesAwareSpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/PropertiesAwareSpec.kt
@@ -1,0 +1,52 @@
+package io.gitlab.arturbosch.detekt.api
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatCode
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import kotlin.random.Random
+
+@OptIn(UnstableApi::class)
+class PropertiesAwareSpec : Spek({
+
+    describe("PropertiesAware") {
+
+        context("Implementations can store and retrieve properties") {
+
+            val store = object : PropertiesAware {
+                override val properties: MutableMap<String, Any?> = HashMap()
+                override fun register(key: String, value: Any?) {
+                    properties[key] = value
+                }
+            }
+
+            val hash = Random(1).nextInt()
+
+            store.register("bool", true)
+            store.register("string", "test")
+            store.register("number", 5)
+            store.register("set", setOf(1, 2, 3))
+            store.register("any", object : Any() {
+                override fun equals(other: Any?): Boolean = hashCode() == other.hashCode()
+                override fun hashCode(): Int = hash
+            })
+
+            it("can retrieve the actual typed values") {
+                assertThat(store.getOrNull<Boolean>("bool")).isEqualTo(true)
+                assertThat(store.getOrNull<String>("string")).isEqualTo("test")
+                assertThat(store.getOrNull<Int>("number")).isEqualTo(5)
+                assertThat(store.getOrNull<Set<Int>>("set")).isEqualTo(setOf(1, 2, 3))
+                assertThat(store.getOrNull<Any>("any").hashCode()).isEqualTo(hash)
+            }
+
+            it("returns null on absent values") {
+                assertThat(store.getOrNull<Boolean>("absent")).isEqualTo(null)
+            }
+
+            it("throws an error on wrong type") {
+                assertThatCode { store.getOrNull<Double>("bool") }
+                    .isInstanceOf(IllegalStateException::class.java)
+            }
+        }
+    }
+})

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Configurations.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Configurations.kt
@@ -8,11 +8,49 @@ import io.gitlab.arturbosch.detekt.api.internal.FailFastConfig
 import io.gitlab.arturbosch.detekt.api.internal.PathFilters
 import io.gitlab.arturbosch.detekt.api.internal.YamlConfig
 import io.gitlab.arturbosch.detekt.core.NotApiButProbablyUsedByUsers
+import io.gitlab.arturbosch.detekt.core.ProcessingSettings
+import io.gitlab.arturbosch.detekt.core.baseline.DETEKT_BASELINE_CREATION_KEY
+import io.gitlab.arturbosch.detekt.core.baseline.DETEKT_BASELINE_PATH_KEY
+import io.gitlab.arturbosch.detekt.core.measure
+import io.gitlab.arturbosch.detekt.core.reporting.DETEKT_OUTPUT_REPORT_PATHS_KEY
+import java.io.PrintStream
 import java.net.URI
 import java.net.URL
 import java.nio.file.FileSystemNotFoundException
 import java.nio.file.FileSystems
 import java.nio.file.Path
+
+fun CliArgs.createSettings(
+    outputPrinter: PrintStream,
+    errorPrinter: PrintStream
+): ProcessingSettings = with(this) {
+    val (configLoadTime, configuration) = measure { loadConfiguration() }
+    val (settingsLoadTime, settings) = measure {
+        ProcessingSettings(
+            inputPaths = inputPaths,
+            config = configuration,
+            pathFilters = createFilters(),
+            parallelCompilation = parallel,
+            autoCorrect = autoCorrect,
+            excludeDefaultRuleSets = disableDefaultRuleSets,
+            pluginPaths = createPlugins(),
+            classpath = createClasspath(),
+            languageVersion = languageVersion,
+            jvmTarget = jvmTarget,
+            debug = debug,
+            outPrinter = outputPrinter,
+            errPrinter = errorPrinter,
+            configUris = extractUris()
+        ).apply {
+            register(DETEKT_BASELINE_PATH_KEY, baseline)
+            register(DETEKT_BASELINE_CREATION_KEY, createBaseline)
+            register(DETEKT_OUTPUT_REPORT_PATHS_KEY, reportPaths)
+        }
+    }
+    settings.debug { "Loading config took $configLoadTime ms" }
+    settings.debug { "Creating settings took $settingsLoadTime ms" }
+    return settings
+}
 
 fun CliArgs.createFilters(): PathFilters? = PathFilters.of(
     (includes ?: "")
@@ -88,17 +126,17 @@ const val DEFAULT_CONFIG = "default-detekt-config.yml"
 @NotApiButProbablyUsedByUsers
 fun loadDefaultConfig() = YamlConfig.loadResource(ClasspathResourceConverter().convert(DEFAULT_CONFIG))
 
-private fun initFileSystem(uri: URI) {
-    runCatching {
-        try {
-            FileSystems.getFileSystem(uri)
-        } catch (e: FileSystemNotFoundException) {
-            FileSystems.newFileSystem(uri, mapOf("create" to "true"))
+fun CliArgs.extractUris(): Collection<URI> {
+    fun initFileSystem(uri: URI) {
+        runCatching {
+            try {
+                FileSystems.getFileSystem(uri)
+            } catch (e: FileSystemNotFoundException) {
+                FileSystems.newFileSystem(uri, mapOf("create" to "true"))
+            }
         }
     }
-}
 
-fun CliArgs.extractUris(): Collection<URI> {
     val pathUris = config?.let { MultipleExistingPathConverter().convert(it).map(Path::toUri) } ?: emptyList()
     val resourceUris = configResource?.let { MultipleClasspathResourceConverter().convert(it).map(URL::toURI) }
         ?: emptyList()

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Configurations.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Configurations.kt
@@ -42,7 +42,7 @@ fun CliArgs.createSettings(
             errPrinter = errorPrinter,
             configUris = extractUris()
         ).apply {
-            register(DETEKT_BASELINE_PATH_KEY, baseline)
+            baseline?.let { register(DETEKT_BASELINE_PATH_KEY, it) }
             register(DETEKT_BASELINE_CREATION_KEY, createBaseline)
             register(DETEKT_OUTPUT_REPORT_PATHS_KEY, reportPaths)
         }

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/Runner.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/Runner.kt
@@ -4,19 +4,13 @@ import io.gitlab.arturbosch.detekt.api.Detektion
 import io.gitlab.arturbosch.detekt.cli.BuildFailure
 import io.gitlab.arturbosch.detekt.cli.CliArgs
 import io.gitlab.arturbosch.detekt.cli.config.checkConfiguration
-import io.gitlab.arturbosch.detekt.cli.createClasspath
-import io.gitlab.arturbosch.detekt.cli.createFilters
-import io.gitlab.arturbosch.detekt.cli.createPlugins
-import io.gitlab.arturbosch.detekt.cli.extractUris
+import io.gitlab.arturbosch.detekt.cli.createSettings
 import io.gitlab.arturbosch.detekt.cli.getOrComputeWeightedAmountOfIssues
 import io.gitlab.arturbosch.detekt.cli.isValidAndSmallerOrEqual
-import io.gitlab.arturbosch.detekt.cli.loadConfiguration
 import io.gitlab.arturbosch.detekt.cli.maxIssues
 import io.gitlab.arturbosch.detekt.core.DetektFacade
 import io.gitlab.arturbosch.detekt.core.NotApiButProbablyUsedByUsers
 import io.gitlab.arturbosch.detekt.core.ProcessingSettings
-import io.gitlab.arturbosch.detekt.core.baseline.DETEKT_BASELINE_CREATION_KEY
-import io.gitlab.arturbosch.detekt.core.baseline.DETEKT_BASELINE_PATH_KEY
 import io.gitlab.arturbosch.detekt.core.measure
 import io.gitlab.arturbosch.detekt.core.reporting.red
 import java.io.PrintStream
@@ -29,17 +23,18 @@ class Runner(
 ) : Executable {
 
     override fun execute() {
-        createSettings().use { settings ->
-            val (checkConfigTime) = measure { checkConfiguration(settings) }
-            settings.debug { "Checking config took $checkConfigTime ms" }
-            val (serviceLoadingTime, facade) = measure { DetektFacade.create(settings) }
-            settings.debug { "Loading services took $serviceLoadingTime ms" }
-            val (engineRunTime, result) = measure { facade.run() }
-            settings.debug { "Running core engine took $engineRunTime ms" }
-            if (!arguments.createBaseline) {
-                checkBuildFailureThreshold(result, settings)
+        arguments.createSettings(outputPrinter, errorPrinter)
+            .use { settings ->
+                val (checkConfigTime) = measure { checkConfiguration(settings) }
+                settings.debug { "Checking config took $checkConfigTime ms" }
+                val (serviceLoadingTime, facade) = measure { DetektFacade.create(settings) }
+                settings.debug { "Loading services took $serviceLoadingTime ms" }
+                val (engineRunTime, result) = measure { facade.run() }
+                settings.debug { "Running core engine took $engineRunTime ms" }
+                if (!arguments.createBaseline) {
+                    checkBuildFailureThreshold(result, settings)
+                }
             }
-        }
     }
 
     private fun checkBuildFailureThreshold(result: Detektion, settings: ProcessingSettings) {
@@ -48,34 +43,5 @@ class Runner(
         if (maxIssues.isValidAndSmallerOrEqual(amount)) {
             throw BuildFailure("Build failed with $amount weighted issues (threshold defined was $maxIssues).".red())
         }
-    }
-
-    private fun createSettings(): ProcessingSettings = with(arguments) {
-        val (configLoadTime, configuration) = measure { loadConfiguration() }
-        val (settingsLoadTime, settings) = measure {
-            ProcessingSettings(
-                inputPaths = inputPaths,
-                config = configuration,
-                pathFilters = createFilters(),
-                parallelCompilation = parallel,
-                autoCorrect = autoCorrect,
-                excludeDefaultRuleSets = disableDefaultRuleSets,
-                pluginPaths = createPlugins(),
-                classpath = createClasspath(),
-                languageVersion = languageVersion,
-                jvmTarget = jvmTarget,
-                debug = arguments.debug,
-                outPrinter = outputPrinter,
-                errPrinter = errorPrinter,
-                configUris = extractUris(),
-                reportPaths = reportPaths
-            ).apply {
-                register(DETEKT_BASELINE_PATH_KEY, baseline)
-                register(DETEKT_BASELINE_CREATION_KEY, createBaseline)
-            }
-        }
-        settings.debug { "Loading config took $configLoadTime ms" }
-        settings.debug { "Creating settings took $settingsLoadTime ms" }
-        return settings
     }
 }

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/SingleRuleRunner.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/SingleRuleRunner.kt
@@ -25,22 +25,25 @@ class SingleRuleRunner(
             arguments.runRule?.split(":")
         ) { "Unexpected empty 'runRule' argument." }
 
-        arguments.createSettings(outputPrinter, errorPrinter)
-            .use { settings ->
-                val realProvider = requireNotNull(
-                    RuleSetLocator(settings).load().find { it.ruleSetId == ruleSet }
-                ) { "There was no rule set with id '$ruleSet'." }
+        fun executeRule(settings: ProcessingSettings) {
+            val realProvider = requireNotNull(
+                RuleSetLocator(settings).load().find { it.ruleSetId == ruleSet }
+            ) { "There was no rule set with id '$ruleSet'." }
 
-                val provider = RuleProducingProvider(rule, realProvider)
+            val provider = RuleProducingProvider(rule, realProvider)
 
-                assertRuleExistsBeforeRunningItLater(provider, settings)
+            assertRuleExistsBeforeRunningItLater(provider, settings)
 
-                DetektFacade.create(
-                    settings,
-                    listOf(provider),
-                    listOf(DetektProgressListener().apply { init(settings) })
-                ).run()
-            }
+            DetektFacade.create(
+                settings,
+                listOf(provider),
+                listOf(DetektProgressListener().apply { init(settings) })
+            ).run()
+        }
+
+        arguments
+            .createSettings(outputPrinter, errorPrinter)
+            .use(::executeRule)
     }
 
     private fun assertRuleExistsBeforeRunningItLater(

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/SingleRuleRunner.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/SingleRuleRunner.kt
@@ -13,7 +13,6 @@ import io.gitlab.arturbosch.detekt.cli.loadConfiguration
 import io.gitlab.arturbosch.detekt.core.DetektFacade
 import io.gitlab.arturbosch.detekt.core.ProcessingSettings
 import io.gitlab.arturbosch.detekt.core.RuleSetLocator
-import io.gitlab.arturbosch.detekt.core.reporting.OutputFacade
 import io.gitlab.arturbosch.detekt.core.rules.createRuleSet
 import java.io.PrintStream
 
@@ -38,7 +37,9 @@ class SingleRuleRunner(
                 excludeDefaultRuleSets = disableDefaultRuleSets,
                 pluginPaths = createPlugins(),
                 outPrinter = outPrinter,
-                errPrinter = errPrinter)
+                errPrinter = errPrinter,
+                reportPaths = reportPaths
+            )
         }.use { settings ->
             val realProvider = requireNotNull(
                 RuleSetLocator(settings).load().find { it.ruleSetId == ruleSet }
@@ -48,13 +49,11 @@ class SingleRuleRunner(
 
             assertRuleExistsBeforeRunningItLater(provider, settings)
 
-            val result = DetektFacade.create(
+            DetektFacade.create(
                 settings,
                 listOf(provider),
                 listOf(DetektProgressListener().apply { init(settings) })
             ).run()
-
-            OutputFacade(arguments.reportPaths, result, settings).run()
         }
     }
 

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/ExtensionsSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/ExtensionsSpec.kt
@@ -1,10 +1,10 @@
 package io.gitlab.arturbosch.detekt.cli
 
+import io.github.detekt.test.utils.NullPrintStream
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.SetupContext
 import io.gitlab.arturbosch.detekt.api.UnstableApi
 import io.gitlab.arturbosch.detekt.rules.documentation.LicenceHeaderLoaderExtension
-import io.github.detekt.test.utils.NullPrintStream
 import org.assertj.core.api.Assertions.assertThatCode
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
@@ -27,6 +27,8 @@ class ExtensionsSpec : Spek({
                     override val config: Config = Config.empty
                     override val outPrinter: PrintStream = NullPrintStream()
                     override val errPrinter: PrintStream = NullPrintStream()
+                    override val properties: Map<String, Any?> = HashMap()
+                    override fun register(key: String, value: Any?) = TODO()
                 })
             }.doesNotThrowAnyException()
         }

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/ExtensionsSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/ExtensionsSpec.kt
@@ -28,7 +28,7 @@ class ExtensionsSpec : Spek({
                     override val outPrinter: PrintStream = NullPrintStream()
                     override val errPrinter: PrintStream = NullPrintStream()
                     override val properties: Map<String, Any?> = HashMap()
-                    override fun register(key: String, value: Any?) = TODO()
+                    override fun register(key: String, value: Any) = Unit
                 })
             }.doesNotThrowAnyException()
         }

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/RunnerSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/RunnerSpec.kt
@@ -1,12 +1,13 @@
 package io.gitlab.arturbosch.detekt.cli.runners
 
-import io.gitlab.arturbosch.detekt.cli.BuildFailure
-import io.gitlab.arturbosch.detekt.cli.config.InvalidConfig
-import io.gitlab.arturbosch.detekt.cli.createCliArgs
 import io.github.detekt.test.utils.NullPrintStream
 import io.github.detekt.test.utils.StringPrintStream
 import io.github.detekt.test.utils.createTempFileForTest
 import io.github.detekt.test.utils.resource
+import io.github.detekt.test.utils.resourceAsPath
+import io.gitlab.arturbosch.detekt.cli.BuildFailure
+import io.gitlab.arturbosch.detekt.cli.config.InvalidConfig
+import io.gitlab.arturbosch.detekt.cli.createCliArgs
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatCode
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -66,7 +67,7 @@ class RunnerSpec : Spek({
                     "--input", inputPath.toString(),
                     "--report", "txt:$tmpReport",
                     "--config-resource", "/configs/max-issues-0.yml",
-                    "--baseline", Paths.get(resource("configs/baseline-with-two-excludes.xml")).toString()
+                    "--baseline", resourceAsPath("configs/baseline-with-two-excludes.xml").toString()
                 )
 
                 Runner(cliArgs, NullPrintStream(), NullPrintStream()).execute()

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/SingleRuleRunnerSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/SingleRuleRunnerSpec.kt
@@ -1,20 +1,18 @@
 package io.gitlab.arturbosch.detekt.cli.runners
 
-import io.gitlab.arturbosch.detekt.cli.createCliArgs
 import io.github.detekt.test.utils.NullPrintStream
 import io.github.detekt.test.utils.createTempFileForTest
-import io.github.detekt.test.utils.resource
+import io.github.detekt.test.utils.resourceAsPath
+import io.gitlab.arturbosch.detekt.cli.createCliArgs
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
-import java.lang.IllegalStateException
 import java.nio.file.Files
-import java.nio.file.Paths
 
 class SingleRuleRunnerSpec : Spek({
 
-    val case = Paths.get(resource("cases/Poko.kt"))
+    val case = resourceAsPath("cases/Poko.kt")
 
     describe("single rule runner") {
 
@@ -26,7 +24,7 @@ class SingleRuleRunnerSpec : Spek({
                 "--run-rule", "test:test"
             )
 
-            SingleRuleRunner(args, NullPrintStream(), NullPrintStream()).execute()
+            SingleRuleRunner(args, System.out, System.err).execute()
 
             assertThat(Files.readAllLines(tmp)).hasSize(1)
         }

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/SingleRuleRunnerSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/SingleRuleRunnerSpec.kt
@@ -24,7 +24,7 @@ class SingleRuleRunnerSpec : Spek({
                 "--run-rule", "test:test"
             )
 
-            SingleRuleRunner(args, System.out, System.err).execute()
+            SingleRuleRunner(args, NullPrintStream(), NullPrintStream()).execute()
 
             assertThat(Files.readAllLines(tmp)).hasSize(1)
         }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/DelegatingResult.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/DelegatingResult.kt
@@ -1,0 +1,10 @@
+package io.gitlab.arturbosch.detekt.core
+
+import io.gitlab.arturbosch.detekt.api.Detektion
+import io.gitlab.arturbosch.detekt.api.Finding
+import io.gitlab.arturbosch.detekt.api.RuleSetId
+
+class DelegatingResult(
+    result: Detektion,
+    override val findings: Map<RuleSetId, List<Finding>>
+) : Detektion by result

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/DetektFacade.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/DetektFacade.kt
@@ -6,6 +6,7 @@ import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.api.RuleSetId
 import io.gitlab.arturbosch.detekt.api.RuleSetProvider
 import io.gitlab.arturbosch.detekt.core.extensions.handleReportingExtensions
+import io.gitlab.arturbosch.detekt.core.reporting.OutputFacade
 
 class DetektFacade(
     private val detektor: Detektor,
@@ -24,7 +25,7 @@ class DetektFacade(
         processors.forEach { it.onStart(filesToAnalyze) }
 
         val findings: Map<RuleSetId, List<Finding>> = detektor.run(filesToAnalyze, bindingContext)
-        val result = DetektResult(findings.toSortedMap())
+        var result: Detektion = DetektResult(findings.toSortedMap())
 
         if (saveSupported) {
             KtFileModifier().saveModifiedFiles(filesToAnalyze) { result.add(it) }
@@ -32,7 +33,9 @@ class DetektFacade(
 
         processors.forEach { it.onFinish(filesToAnalyze, result) }
 
-        return handleReportingExtensions(settings, result)
+        result = handleReportingExtensions(settings, result)
+        OutputFacade(settings).run(result)
+        return result
     }
 
     companion object {

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/DetektFacade.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/DetektFacade.kt
@@ -6,7 +6,6 @@ import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.api.RuleSetId
 import io.gitlab.arturbosch.detekt.api.RuleSetProvider
 import io.gitlab.arturbosch.detekt.core.extensions.handleReportingExtensions
-import io.gitlab.arturbosch.detekt.core.reporting.OutputFacade
 
 class DetektFacade(
     private val detektor: Detektor,
@@ -25,7 +24,7 @@ class DetektFacade(
         processors.forEach { it.onStart(filesToAnalyze) }
 
         val findings: Map<RuleSetId, List<Finding>> = detektor.run(filesToAnalyze, bindingContext)
-        var result: Detektion = DetektResult(findings.toSortedMap())
+        val result = DetektResult(findings.toSortedMap())
 
         if (saveSupported) {
             KtFileModifier().saveModifiedFiles(filesToAnalyze) { result.add(it) }
@@ -33,12 +32,7 @@ class DetektFacade(
 
         processors.forEach { it.onFinish(filesToAnalyze, result) }
 
-        result = handleReportingExtensions(settings, result)
-
-        val (outputResultsTime) = measure { OutputFacade(result, settings).run() }
-        settings.debug { "Writing results took $outputResultsTime ms" }
-
-        return result
+        return handleReportingExtensions(settings, result)
     }
 
     companion object {

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/DetektFacade.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/DetektFacade.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.api.FileProcessListener
 import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.api.RuleSetId
 import io.gitlab.arturbosch.detekt.api.RuleSetProvider
+import io.gitlab.arturbosch.detekt.core.extensions.handleReportingExtensions
 import io.gitlab.arturbosch.detekt.core.reporting.OutputFacade
 
 class DetektFacade(
@@ -24,13 +25,15 @@ class DetektFacade(
         processors.forEach { it.onStart(filesToAnalyze) }
 
         val findings: Map<RuleSetId, List<Finding>> = detektor.run(filesToAnalyze, bindingContext)
-        val result = DetektResult(findings.toSortedMap())
+        var result: Detektion = DetektResult(findings.toSortedMap())
 
         if (saveSupported) {
             KtFileModifier().saveModifiedFiles(filesToAnalyze) { result.add(it) }
         }
 
         processors.forEach { it.onFinish(filesToAnalyze, result) }
+
+        result = handleReportingExtensions(settings, result)
 
         val (outputResultsTime) = measure { OutputFacade(result, settings).run() }
         settings.debug { "Writing results took $outputResultsTime ms" }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/DetektFacade.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/DetektFacade.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.api.FileProcessListener
 import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.api.RuleSetId
 import io.gitlab.arturbosch.detekt.api.RuleSetProvider
+import io.gitlab.arturbosch.detekt.core.reporting.OutputFacade
 
 class DetektFacade(
     private val detektor: Detektor,
@@ -30,6 +31,10 @@ class DetektFacade(
         }
 
         processors.forEach { it.onFinish(filesToAnalyze, result) }
+
+        val (outputResultsTime) = measure { OutputFacade(result, settings).run() }
+        settings.debug { "Writing results took $outputResultsTime ms" }
+
         return result
     }
 

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Junk.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Junk.kt
@@ -37,3 +37,9 @@ fun createErrorMessage(file: KtFile, error: Throwable): String =
 val NL: String = System.lineSeparator()
 
 val IS_WINDOWS = System.getProperty("os.name").contains("Windows")
+
+inline fun <T> measure(block: () -> T): Pair<Long, T> {
+    val start = System.currentTimeMillis()
+    val result = block()
+    return System.currentTimeMillis() - start to result
+}

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/ProcessingSettings.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/ProcessingSettings.kt
@@ -6,7 +6,6 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.SetupContext
 import io.gitlab.arturbosch.detekt.api.UnstableApi
 import io.gitlab.arturbosch.detekt.api.internal.PathFilters
-import io.gitlab.arturbosch.detekt.core.reporting.ReportPath
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.jetbrains.kotlin.com.intellij.openapi.Disposable
 import org.jetbrains.kotlin.com.intellij.openapi.util.Disposer
@@ -44,8 +43,7 @@ class ProcessingSettings @Suppress("LongParameterList") constructor(
     override val errPrinter: PrintStream,
     val autoCorrect: Boolean = false,
     val debug: Boolean = false,
-    override val configUris: Collection<URI> = emptyList(),
-    val reportPaths: Collection<ReportPath> = emptyList()
+    override val configUris: Collection<URI> = emptyList()
 ) : AutoCloseable, Closeable, SetupContext {
 
     init {

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/ProcessingSettings.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/ProcessingSettings.kt
@@ -19,6 +19,7 @@ import java.net.URI
 import java.net.URLClassLoader
 import java.nio.file.Files
 import java.nio.file.Path
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ExecutorService
 
 /**
@@ -92,5 +93,13 @@ class ProcessingSettings @Suppress("LongParameterList") constructor(
         closeQuietly(taskPool)
         Disposer.dispose(environmentDisposable)
         closeQuietly(pluginLoader)
+    }
+
+    override val properties: MutableMap<String, Any?> = ConcurrentHashMap()
+
+    override fun register(key: String, value: Any?) {
+        if (value != null) {
+            properties[key] = value
+        }
     }
 }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/ProcessingSettings.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/ProcessingSettings.kt
@@ -6,6 +6,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.SetupContext
 import io.gitlab.arturbosch.detekt.api.UnstableApi
 import io.gitlab.arturbosch.detekt.api.internal.PathFilters
+import io.gitlab.arturbosch.detekt.core.reporting.ReportPath
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.jetbrains.kotlin.com.intellij.openapi.Disposable
 import org.jetbrains.kotlin.com.intellij.openapi.util.Disposer
@@ -42,7 +43,8 @@ class ProcessingSettings @Suppress("LongParameterList") constructor(
     override val errPrinter: PrintStream,
     val autoCorrect: Boolean = false,
     val debug: Boolean = false,
-    override val configUris: Collection<URI> = emptyList()
+    override val configUris: Collection<URI> = emptyList(),
+    val reportPaths: Collection<ReportPath> = emptyList()
 ) : AutoCloseable, Closeable, SetupContext {
 
     init {

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/ProcessingSettings.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/ProcessingSettings.kt
@@ -93,11 +93,10 @@ class ProcessingSettings @Suppress("LongParameterList") constructor(
         closeQuietly(pluginLoader)
     }
 
-    override val properties: MutableMap<String, Any?> = ConcurrentHashMap()
+    private val _properties: MutableMap<String, Any?> = ConcurrentHashMap()
+    override val properties: Map<String, Any?> = _properties
 
-    override fun register(key: String, value: Any?) {
-        if (value != null) {
-            properties[key] = value
-        }
+    override fun register(key: String, value: Any) {
+        _properties[key] = value
     }
 }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/Baseline.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/Baseline.kt
@@ -22,6 +22,9 @@ internal data class Baseline(val blacklist: FindingsIdList, val whitelist: Findi
     }
 }
 
+const val DETEKT_BASELINE_PATH_KEY = "detekt.baseline.path.key"
+const val DETEKT_BASELINE_CREATION_KEY = "detekt.baseline.creation.key"
+
 internal const val SMELL_BASELINE = "SmellBaseline"
 internal const val BLACKLIST = "Blacklist"
 internal const val WHITELIST = "Whitelist"

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineResultMapping.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineResultMapping.kt
@@ -1,0 +1,43 @@
+package io.gitlab.arturbosch.detekt.core.baseline
+
+import io.gitlab.arturbosch.detekt.api.Finding
+import io.gitlab.arturbosch.detekt.api.ReportingExtension
+import io.gitlab.arturbosch.detekt.api.RuleSetId
+import io.gitlab.arturbosch.detekt.api.SetupContext
+import io.gitlab.arturbosch.detekt.api.UnstableApi
+import io.gitlab.arturbosch.detekt.api.getOrNull
+import io.gitlab.arturbosch.detekt.core.DetektResult
+import java.nio.file.Path
+
+@OptIn(UnstableApi::class)
+class BaselineResultMapping : ReportingExtension {
+
+    private var baselineFile: Path? = null
+    private var createBaseline: Boolean = false
+
+    override fun init(context: SetupContext) {
+        baselineFile = context.getOrNull(DETEKT_BASELINE_PATH_KEY)
+        createBaseline = context.getOrNull(DETEKT_BASELINE_CREATION_KEY) ?: false
+    }
+
+    override fun transformFindings(findings: Map<RuleSetId, List<Finding>>): Map<RuleSetId, List<Finding>> {
+        require(
+            !createBaseline ||
+                (createBaseline && baselineFile != null)
+        ) { "Invalid baseline options invariant." }
+
+        if (baselineFile != null) {
+            val facade = BaselineFacade()
+            val baselinePath = checkNotNull(baselineFile)
+
+            if (createBaseline) {
+                val flatten = findings.flatMap { it.value }
+                facade.createOrUpdate(baselinePath, flatten)
+            }
+
+            return facade.transformResult(baselinePath, DetektResult(findings)).findings
+        }
+
+        return findings
+    }
+}

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/extensions/Reporting.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/extensions/Reporting.kt
@@ -12,7 +12,7 @@ fun handleReportingExtensions(settings: ProcessingSettings, initialResult: Detek
     extensions.forEach { it.onRawResult(initialResult) }
     val finalResult = extensions.fold(initialResult) { acc, extension ->
         val intermediateValue = extension.transformFindings(acc.findings)
-        return DelegatingResult(acc, intermediateValue)
+        if (intermediateValue === acc.findings) acc else DelegatingResult(acc, intermediateValue)
     }
     extensions.forEach { it.onFinalResult(finalResult) }
     return finalResult

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/extensions/Reporting.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/extensions/Reporting.kt
@@ -1,0 +1,19 @@
+package io.gitlab.arturbosch.detekt.core.extensions
+
+import io.gitlab.arturbosch.detekt.api.Detektion
+import io.gitlab.arturbosch.detekt.api.ReportingExtension
+import io.gitlab.arturbosch.detekt.api.UnstableApi
+import io.gitlab.arturbosch.detekt.core.DelegatingResult
+import io.gitlab.arturbosch.detekt.core.ProcessingSettings
+
+@OptIn(UnstableApi::class)
+fun handleReportingExtensions(settings: ProcessingSettings, initialResult: Detektion): Detektion {
+    val extensions = loadExtensions<ReportingExtension>(settings)
+    extensions.forEach { it.onRawResult(initialResult) }
+    val finalResult = extensions.fold(initialResult) { acc, extension ->
+        val intermediateValue = extension.transformFindings(acc.findings)
+        return DelegatingResult(acc, intermediateValue)
+    }
+    extensions.forEach { it.onFinalResult(finalResult) }
+    return finalResult
+}

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/OutputFacade.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/OutputFacade.kt
@@ -7,12 +7,11 @@ import io.gitlab.arturbosch.detekt.api.internal.SimpleNotification
 import io.gitlab.arturbosch.detekt.core.ProcessingSettings
 
 class OutputFacade(
-    reportPaths: List<ReportPath>,
     private val result: Detektion,
     private val settings: ProcessingSettings
 ) {
 
-    private val reports: Map<String, ReportPath> = reportPaths.associateBy { it.kind }
+    private val reports: Map<String, ReportPath> = settings.reportPaths.associateBy { it.kind }
 
     fun run() {
         OutputReportLocator(settings)

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/OutputFacade.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/OutputFacade.kt
@@ -1,9 +1,6 @@
 package io.gitlab.arturbosch.detekt.core.reporting
 
 import io.gitlab.arturbosch.detekt.api.Detektion
-import io.gitlab.arturbosch.detekt.api.ReportingExtension
-import io.gitlab.arturbosch.detekt.api.SetupContext
-import io.gitlab.arturbosch.detekt.api.SingleAssign
 import io.gitlab.arturbosch.detekt.api.UnstableApi
 import io.gitlab.arturbosch.detekt.api.getOrNull
 import io.gitlab.arturbosch.detekt.api.internal.SimpleNotification
@@ -11,21 +8,19 @@ import io.gitlab.arturbosch.detekt.core.ProcessingSettings
 import kotlin.system.measureTimeMillis
 
 @OptIn(UnstableApi::class)
-class OutputFacade : ReportingExtension {
+class OutputFacade(
+    private val settings: ProcessingSettings
+) {
 
-    override val priority: Int = Int.MIN_VALUE
+    private var reports: Map<String, ReportPath>
 
-    private var reports: Map<String, ReportPath> by SingleAssign()
-    private var settings: ProcessingSettings by SingleAssign()
-
-    override fun init(context: SetupContext) {
+    init {
         val reportPaths: Collection<ReportPath> =
-            context.getOrNull(DETEKT_OUTPUT_REPORT_PATHS_KEY) ?: emptyList()
+            settings.getOrNull(DETEKT_OUTPUT_REPORT_PATHS_KEY) ?: emptyList()
         reports = reportPaths.associateBy { it.kind }
-        settings = context as? ProcessingSettings ?: error("ProcessingSettings expected.")
     }
 
-    override fun onFinalResult(result: Detektion) {
+    fun run(result: Detektion) {
         // Always run output reports first.
         // They produce notifications which may get printed on the console.
         handleOutputReports(result)

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/OutputFacade.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/OutputFacade.kt
@@ -26,8 +26,8 @@ class OutputFacade : ReportingExtension {
     }
 
     override fun onFinalResult(result: Detektion) {
-        // always run output reports as they produce notifications
-        // which may get printed on the console
+        // Always run output reports first.
+        // They produce notifications which may get printed on the console.
         handleOutputReports(result)
         handleConsoleReports(result)
     }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/OutputFacade.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/OutputFacade.kt
@@ -13,6 +13,8 @@ import kotlin.system.measureTimeMillis
 @OptIn(UnstableApi::class)
 class OutputFacade : ReportingExtension {
 
+    override val priority: Int = Int.MIN_VALUE
+
     private var reports: Map<String, ReportPath> by SingleAssign()
     private var settings: ProcessingSettings by SingleAssign()
 

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/OutputFacade.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/OutputFacade.kt
@@ -1,36 +1,54 @@
 package io.gitlab.arturbosch.detekt.core.reporting
 
-import io.gitlab.arturbosch.detekt.api.ConsoleReport
 import io.gitlab.arturbosch.detekt.api.Detektion
-import io.gitlab.arturbosch.detekt.api.OutputReport
+import io.gitlab.arturbosch.detekt.api.ReportingExtension
+import io.gitlab.arturbosch.detekt.api.SetupContext
+import io.gitlab.arturbosch.detekt.api.SingleAssign
+import io.gitlab.arturbosch.detekt.api.UnstableApi
+import io.gitlab.arturbosch.detekt.api.getOrNull
 import io.gitlab.arturbosch.detekt.api.internal.SimpleNotification
 import io.gitlab.arturbosch.detekt.core.ProcessingSettings
+import kotlin.system.measureTimeMillis
 
-class OutputFacade(
-    private val result: Detektion,
-    private val settings: ProcessingSettings
-) {
+@OptIn(UnstableApi::class)
+class OutputFacade : ReportingExtension {
 
-    private val reports: Map<String, ReportPath> = settings.reportPaths.associateBy { it.kind }
+    private var reports: Map<String, ReportPath> by SingleAssign()
+    private var settings: ProcessingSettings by SingleAssign()
 
-    fun run() {
-        OutputReportLocator(settings)
-            .load()
-            .forEach(::handleOutputReport)
-        ConsoleReportLocator(settings)
-            .load()
-            .forEach(::handleConsoleReport)
+    override fun init(context: SetupContext) {
+        val reportPaths: Collection<ReportPath> =
+            context.getOrNull(DETEKT_OUTPUT_REPORT_PATHS_KEY) ?: emptyList()
+        reports = reportPaths.associateBy { it.kind }
+        settings = context as? ProcessingSettings ?: error("ProcessingSettings expected.")
     }
 
-    private fun handleOutputReport(report: OutputReport) {
-        val filePath = reports[report.id]?.path
-        if (filePath != null) {
-            report.write(filePath, result)
-            result.add(SimpleNotification("Successfully generated ${report.name} at $filePath"))
+    override fun onFinalResult(result: Detektion) {
+        // always run output reports as they produce notifications
+        // which may get printed on the console
+        handleOutputReports(result)
+        handleConsoleReports(result)
+    }
+
+    private fun handleConsoleReports(result: Detektion) {
+        val durationConsoleReports = measureTimeMillis {
+            val extensions = ConsoleReportLocator(settings).load()
+            extensions.forEach { it.print(settings.outPrinter, result) }
         }
+        settings.debug { "Writing console results took $durationConsoleReports ms" }
     }
 
-    private fun handleConsoleReport(report: ConsoleReport) {
-        report.print(settings.outPrinter, result)
+    private fun handleOutputReports(result: Detektion) {
+        val durationOutputReports = measureTimeMillis {
+            val extensions = OutputReportLocator(settings).load()
+            for (report in extensions) {
+                val filePath = reports[report.id]?.path
+                if (filePath != null) {
+                    report.write(filePath, result)
+                    result.add(SimpleNotification("Successfully generated ${report.name} at $filePath"))
+                }
+            }
+        }
+        settings.debug { "Writing output results took $durationOutputReports ms" }
     }
 }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/Reporting.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/Reporting.kt
@@ -32,6 +32,8 @@ internal fun printFindings(findings: Map<String, List<Finding>>): String? {
 const val BUILD = "build"
 const val EXCLUDE_CORRECTABLE = "excludeCorrectable"
 
+const val DETEKT_OUTPUT_REPORT_PATHS_KEY = "detekt.output.report.paths.key"
+
 fun Config.excludeCorrectable(): Boolean = subConfig(BUILD).valueOrDefault(EXCLUDE_CORRECTABLE, false)
 
 fun Detektion.filterEmptyIssues(config: Config): Map<RuleSetId, List<Finding>> {

--- a/detekt-core/src/main/resources/META-INF/services/io.gitlab.arturbosch.detekt.api.ReportingExtension
+++ b/detekt-core/src/main/resources/META-INF/services/io.gitlab.arturbosch.detekt.api.ReportingExtension
@@ -1,0 +1,1 @@
+io.gitlab.arturbosch.detekt.core.baseline.BaselineResultMapping

--- a/detekt-core/src/main/resources/META-INF/services/io.gitlab.arturbosch.detekt.api.ReportingExtension
+++ b/detekt-core/src/main/resources/META-INF/services/io.gitlab.arturbosch.detekt.api.ReportingExtension
@@ -1,1 +1,2 @@
+io.gitlab.arturbosch.detekt.core.reporting.OutputFacade
 io.gitlab.arturbosch.detekt.core.baseline.BaselineResultMapping

--- a/detekt-core/src/main/resources/META-INF/services/io.gitlab.arturbosch.detekt.api.ReportingExtension
+++ b/detekt-core/src/main/resources/META-INF/services/io.gitlab.arturbosch.detekt.api.ReportingExtension
@@ -1,2 +1,1 @@
-io.gitlab.arturbosch.detekt.core.reporting.OutputFacade
 io.gitlab.arturbosch.detekt.core.baseline.BaselineResultMapping

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/OutputFacadeSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/OutputFacadeSpec.kt
@@ -46,9 +46,9 @@ internal class OutputFacadeSpec : Spek({
         }
 
         it("creates all output files") {
-            val subject = OutputFacade(defaultDetektion, defaultSettings)
+            val subject = OutputFacade().apply { init(defaultSettings) }
 
-            subject.run()
+            subject.onFinalResult(defaultDetektion)
 
             assertThat(printStream.toString()).contains(
                 "Successfully generated ${TxtOutputReport().name} at $plainOutputPath$LN",

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/OutputFacadeSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/OutputFacadeSpec.kt
@@ -46,9 +46,9 @@ internal class OutputFacadeSpec : Spek({
         }
 
         it("creates all output files") {
-            val subject = OutputFacade().apply { init(defaultSettings) }
+            val subject = OutputFacade(defaultSettings)
 
-            subject.onFinalResult(defaultDetektion)
+            subject.run(defaultDetektion)
 
             assertThat(printStream.toString()).contains(
                 "Successfully generated ${TxtOutputReport().name} at $plainOutputPath$LN",

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/OutputFacadeSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/OutputFacadeSpec.kt
@@ -7,6 +7,7 @@ import io.github.detekt.test.utils.StringPrintStream
 import io.github.detekt.test.utils.createTempFileForTest
 import io.github.detekt.test.utils.resourceAsPath
 import io.gitlab.arturbosch.detekt.core.DetektResult
+import io.gitlab.arturbosch.detekt.core.ProcessingSettings
 import io.gitlab.arturbosch.detekt.test.createFinding
 import io.gitlab.arturbosch.detekt.test.createProcessingSettings
 import org.assertj.core.api.Assertions.assertThat
@@ -21,24 +22,23 @@ internal class OutputFacadeSpec : Spek({
 
         val printStream = StringPrintStream()
         val inputPath: Path = resourceAsPath("/cases")
+        val defaultDetektion = DetektResult(mapOf(Pair("Key", listOf(createFinding()))))
+
+        lateinit var defaultSettings: ProcessingSettings
         lateinit var plainOutputPath: Path
         lateinit var htmlOutputPath: Path
         lateinit var xmlOutputPath: Path
-
-        val defaultDetektion = DetektResult(mapOf(Pair("Key", listOf(createFinding()))))
-        val defaultSettings = createProcessingSettings(inputPath, outPrinter = printStream)
-
-        lateinit var reportPaths: List<ReportPath>
 
         beforeEachTest {
             plainOutputPath = createTempFileForTest("detekt", ".txt")
             htmlOutputPath = createTempFileForTest("detekt", ".html")
             xmlOutputPath = createTempFileForTest("detekt", ".xml")
-            reportPaths = listOf(
+            val reportPaths = listOf(
                 "xml:$xmlOutputPath",
                 "txt:$plainOutputPath",
                 "html:$htmlOutputPath"
             ).map { ReportPath.from(it) }
+            defaultSettings = createProcessingSettings(inputPath, outPrinter = printStream, reportPaths = reportPaths)
         }
 
         afterGroup {
@@ -46,7 +46,7 @@ internal class OutputFacadeSpec : Spek({
         }
 
         it("creates all output files") {
-            val subject = OutputFacade(reportPaths, defaultDetektion, defaultSettings)
+            val subject = OutputFacade(defaultDetektion, defaultSettings)
 
             subject.run()
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/AbsentOrWrongFileLicenseSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/AbsentOrWrongFileLicenseSpec.kt
@@ -64,6 +64,10 @@ private fun checkLicence(content: String): List<Finding> {
             override val config: Config = config
             override val outPrinter: PrintStream = NullPrintStream()
             override val errPrinter: PrintStream = NullPrintStream()
+            override val properties: MutableMap<String, Any?> = HashMap()
+            override fun register(key: String, value: Any?) {
+                properties[key] = value
+            }
         })
         onStart(listOf(file))
     }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/AbsentOrWrongFileLicenseSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/AbsentOrWrongFileLicenseSpec.kt
@@ -65,7 +65,7 @@ private fun checkLicence(content: String): List<Finding> {
             override val outPrinter: PrintStream = NullPrintStream()
             override val errPrinter: PrintStream = NullPrintStream()
             override val properties: MutableMap<String, Any?> = HashMap()
-            override fun register(key: String, value: Any?) {
+            override fun register(key: String, value: Any) {
                 properties[key] = value
             }
         })

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/ProcessingSettingsFactory.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/ProcessingSettingsFactory.kt
@@ -4,6 +4,7 @@ import io.github.detekt.test.utils.NullPrintStream
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.internal.PathFilters
 import io.gitlab.arturbosch.detekt.core.ProcessingSettings
+import io.gitlab.arturbosch.detekt.core.reporting.DETEKT_OUTPUT_REPORT_PATHS_KEY
 import io.gitlab.arturbosch.detekt.core.reporting.ReportPath
 import org.jetbrains.kotlin.config.JvmTarget
 import org.jetbrains.kotlin.config.LanguageVersion
@@ -49,6 +50,7 @@ fun createProcessingSettings(
     errPrinter = errPrinter,
     autoCorrect = autoCorrect,
     debug = debug,
-    configUris = configUris,
-    reportPaths = reportPaths
-)
+    configUris = configUris
+).apply {
+    register(DETEKT_OUTPUT_REPORT_PATHS_KEY, reportPaths)
+}

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/ProcessingSettingsFactory.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/ProcessingSettingsFactory.kt
@@ -4,6 +4,7 @@ import io.github.detekt.test.utils.NullPrintStream
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.internal.PathFilters
 import io.gitlab.arturbosch.detekt.core.ProcessingSettings
+import io.gitlab.arturbosch.detekt.core.reporting.ReportPath
 import org.jetbrains.kotlin.config.JvmTarget
 import org.jetbrains.kotlin.config.LanguageVersion
 import java.io.PrintStream
@@ -31,7 +32,8 @@ fun createProcessingSettings(
     errPrinter: PrintStream = NullPrintStream(),
     autoCorrect: Boolean = false,
     debug: Boolean = false,
-    configUris: Collection<URI> = emptyList()
+    configUris: Collection<URI> = emptyList(),
+    reportPaths: Collection<ReportPath> = emptyList()
 ) = ProcessingSettings(
     inputPaths = listOf(inputPath),
     config = config,
@@ -47,5 +49,6 @@ fun createProcessingSettings(
     errPrinter = errPrinter,
     autoCorrect = autoCorrect,
     debug = debug,
-    configUris = configUris
+    configUris = configUris,
+    reportPaths = reportPaths
 )

--- a/docs/pages/kdoc/detekt-api/alltypes/index.md
+++ b/docs/pages/kdoc/detekt-api/alltypes/index.md
@@ -309,6 +309,21 @@ Anything that can be expressed as a number value for projects.
 
 |
 
+##### [io.gitlab.arturbosch.detekt.api.PropertiesAware](../io.gitlab.arturbosch.detekt.api/-properties-aware/index.html)
+
+Properties holder. Allows to store and retrieve any data.
+
+
+|
+
+##### [io.gitlab.arturbosch.detekt.api.ReportingExtension](../io.gitlab.arturbosch.detekt.api/-reporting-extension/index.html)
+
+Allows to intercept detekt's result container by listening to the initial and final state
+and manipulate the reported findings.
+
+
+|
+
 ##### [io.gitlab.arturbosch.detekt.api.Rule](../io.gitlab.arturbosch.detekt.api/-rule/index.html)
 
 A rule defines how one specific code structure should look like. If code is found

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-extension/index.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-extension/index.md
@@ -31,4 +31,5 @@ Currently supported extensions are:
 | [ConsoleReport](../-console-report/index.html) | Extension point which describes how findings should be printed on the console.`abstract class ConsoleReport : `[`Extension`](./index.html) |
 | [FileProcessListener](../-file-process-listener/index.html) | Gather additional metrics about the analyzed kotlin file. Pay attention to the thread policy of each function!`interface FileProcessListener : `[`Extension`](./index.html) |
 | [OutputReport](../-output-report/index.html) | Translates detekt's result container - [Detektion](../-detektion/index.html) - into an output report which is written inside a file.`abstract class OutputReport : `[`Extension`](./index.html) |
+| [ReportingExtension](../-reporting-extension/index.html) | Allows to intercept detekt's result container by listening to the initial and final state and manipulate the reported findings.`interface ReportingExtension : `[`Extension`](./index.html) |
 

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-file-process-listener/on-finish.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-file-process-listener/on-finish.md
@@ -11,3 +11,5 @@ title: FileProcessListener.onFinish - detekt-api
 Mainly use this method to save computed metrics from KtFile's to the {@link Detektion} container.
 Do not do heavy computations here as this method is called from the main thread.
 
+This method is called before any [ReportingExtension](../-reporting-extension/index.html).
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-properties-aware/index.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-properties-aware/index.md
@@ -16,7 +16,7 @@ Properties holder. Allows to store and retrieve any data.
 
 ### Functions
 
-| [register](register.html) | Binds a given value with given key and stores it for later use.`abstract fun register(key: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`, value: `[`Any`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)`?): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html) |
+| [register](register.html) | Binds a given value with given key and stores it for later use.`abstract fun register(key: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`, value: `[`Any`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)`): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html) |
 
 ### Extension Functions
 

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-properties-aware/index.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-properties-aware/index.md
@@ -1,0 +1,28 @@
+---
+title: PropertiesAware - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [PropertiesAware](./index.html)
+
+# PropertiesAware
+
+`interface PropertiesAware`
+
+Properties holder. Allows to store and retrieve any data.
+
+### Properties
+
+| [properties](properties.html) | Raw properties.`abstract val properties: `[`Map`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-map/index.html)`<`[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`, `[`Any`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)`?>` |
+
+### Functions
+
+| [register](register.html) | Binds a given value with given key and stores it for later use.`abstract fun register(key: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`, value: `[`Any`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)`?): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html) |
+
+### Extension Functions
+
+| [getOrNull](../get-or-null.html) | Allows to retrieve stored properties in a type safe way.`fun <T : `[`Any`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)`> `[`PropertiesAware`](./index.html)`.getOrNull(key: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`): T?` |
+
+### Inheritors
+
+| [SetupContext](../-setup-context/index.html) | Context providing useful processing settings to initialize extensions.`interface SetupContext : `[`PropertiesAware`](./index.html) |
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-properties-aware/properties.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-properties-aware/properties.md
@@ -1,0 +1,12 @@
+---
+title: PropertiesAware.properties - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [PropertiesAware](index.html) / [properties](./properties.html)
+
+# properties
+
+`abstract val properties: `[`Map`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-map/index.html)`<`[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`, `[`Any`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)`?>`
+
+Raw properties.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-properties-aware/register.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-properties-aware/register.md
@@ -1,0 +1,12 @@
+---
+title: PropertiesAware.register - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [PropertiesAware](index.html) / [register](./register.html)
+
+# register
+
+`abstract fun register(key: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`, value: `[`Any`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)`?): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)
+
+Binds a given value with given key and stores it for later use.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-properties-aware/register.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-properties-aware/register.md
@@ -6,7 +6,7 @@ title: PropertiesAware.register - detekt-api
 
 # register
 
-`abstract fun register(key: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`, value: `[`Any`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)`?): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)
+`abstract fun register(key: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`, value: `[`Any`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)`): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)
 
 Binds a given value with given key and stores it for later use.
 

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-reporting-extension/index.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-reporting-extension/index.md
@@ -1,0 +1,19 @@
+---
+title: ReportingExtension - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [ReportingExtension](./index.html)
+
+# ReportingExtension
+
+`interface ReportingExtension : `[`Extension`](../-extension/index.html)
+
+Allows to intercept detekt's result container by listening to the initial and final state
+and manipulate the reported findings.
+
+### Functions
+
+| [onFinalResult](on-final-result.html) | Is called after all extensions's [transformFindings](transform-findings.html) were called.`open fun onFinalResult(result: `[`Detektion`](../-detektion/index.html)`): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html) |
+| [onRawResult](on-raw-result.html) | Is called before any [transformFindings](transform-findings.html) calls were executed.`open fun onRawResult(result: `[`Detektion`](../-detektion/index.html)`): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html) |
+| [transformFindings](transform-findings.html) | Allows to transform the reported findings e.g. apply custom filtering.`open fun transformFindings(findings: `[`Map`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-map/index.html)`<`[`RuleSetId`](../-rule-set-id.html)`, `[`List`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/index.html)`<`[`Finding`](../-finding/index.html)`>>): `[`Map`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-map/index.html)`<`[`RuleSetId`](../-rule-set-id.html)`, `[`List`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/index.html)`<`[`Finding`](../-finding/index.html)`>>` |
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-reporting-extension/on-final-result.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-reporting-extension/on-final-result.md
@@ -1,0 +1,12 @@
+---
+title: ReportingExtension.onFinalResult - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [ReportingExtension](index.html) / [onFinalResult](./on-final-result.html)
+
+# onFinalResult
+
+`open fun onFinalResult(result: `[`Detektion`](../-detektion/index.html)`): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)
+
+Is called after all extensions's [transformFindings](transform-findings.html) were called.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-reporting-extension/on-raw-result.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-reporting-extension/on-raw-result.md
@@ -1,0 +1,12 @@
+---
+title: ReportingExtension.onRawResult - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [ReportingExtension](index.html) / [onRawResult](./on-raw-result.html)
+
+# onRawResult
+
+`open fun onRawResult(result: `[`Detektion`](../-detektion/index.html)`): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)
+
+Is called before any [transformFindings](transform-findings.html) calls were executed.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-reporting-extension/transform-findings.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-reporting-extension/transform-findings.md
@@ -1,0 +1,12 @@
+---
+title: ReportingExtension.transformFindings - detekt-api
+---
+
+[detekt-api](../../index.html) / [io.gitlab.arturbosch.detekt.api](../index.html) / [ReportingExtension](index.html) / [transformFindings](./transform-findings.html)
+
+# transformFindings
+
+`open fun transformFindings(findings: `[`Map`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-map/index.html)`<`[`RuleSetId`](../-rule-set-id.html)`, `[`List`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/index.html)`<`[`Finding`](../-finding/index.html)`>>): `[`Map`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-map/index.html)`<`[`RuleSetId`](../-rule-set-id.html)`, `[`List`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/index.html)`<`[`Finding`](../-finding/index.html)`>>`
+
+Allows to transform the reported findings e.g. apply custom filtering.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-setup-context/index.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-setup-context/index.md
@@ -6,7 +6,7 @@ title: SetupContext - detekt-api
 
 # SetupContext
 
-`interface SetupContext`
+`interface SetupContext : `[`PropertiesAware`](../-properties-aware/index.html)
 
 Context providing useful processing settings to initialize extensions.
 
@@ -16,4 +16,8 @@ Context providing useful processing settings to initialize extensions.
 | [configUris](config-uris.html) | All config locations which where used to create [config](config.html).`abstract val configUris: `[`Collection`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-collection/index.html)`<`[`URI`](https://docs.oracle.com/javase/8/docs/api/java/net/URI.html)`>` |
 | [errPrinter](err-printer.html) | The channel to log all the errors.`abstract val errPrinter: `[`PrintStream`](https://docs.oracle.com/javase/8/docs/api/java/io/PrintStream.html) |
 | [outPrinter](out-printer.html) | The channel to log all the output.`abstract val outPrinter: `[`PrintStream`](https://docs.oracle.com/javase/8/docs/api/java/io/PrintStream.html) |
+
+### Extension Functions
+
+| [getOrNull](../get-or-null.html) | Allows to retrieve stored properties in a type safe way.`fun <T : `[`Any`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)`> `[`PropertiesAware`](../-properties-aware/index.html)`.getOrNull(key: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`): T?` |
 

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/get-or-null.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/get-or-null.md
@@ -1,0 +1,12 @@
+---
+title: getOrNull - detekt-api
+---
+
+[detekt-api](../index.html) / [io.gitlab.arturbosch.detekt.api](index.html) / [getOrNull](./get-or-null.html)
+
+# getOrNull
+
+`fun <reified T : `[`Any`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)`> `[`PropertiesAware`](-properties-aware/index.html)`.getOrNull(key: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`): T?`
+
+Allows to retrieve stored properties in a type safe way.
+

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/index.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/index.md
@@ -39,12 +39,14 @@ title: io.gitlab.arturbosch.detekt.api - detekt-api
 | [Notification](-notification/index.html) | Any kind of notification which should be printed to the console. For example when using the formatting rule set, any change to your kotlin file is a notification.`interface Notification` |
 | [OutputReport](-output-report/index.html) | Translates detekt's result container - [Detektion](-detektion/index.html) - into an output report which is written inside a file.`abstract class OutputReport : `[`Extension`](-extension/index.html) |
 | [ProjectMetric](-project-metric/index.html) | Anything that can be expressed as a number value for projects.`open class ProjectMetric` |
+| [PropertiesAware](-properties-aware/index.html) | Properties holder. Allows to store and retrieve any data.`interface PropertiesAware` |
+| [ReportingExtension](-reporting-extension/index.html) | Allows to intercept detekt's result container by listening to the initial and final state and manipulate the reported findings.`interface ReportingExtension : `[`Extension`](-extension/index.html) |
 | [Rule](-rule/index.html) | A rule defines how one specific code structure should look like. If code is found which does not meet this structure, it is considered as harmful regarding maintainability or readability.`abstract class Rule : `[`BaseRule`](../io.gitlab.arturbosch.detekt.api.internal/-base-rule/index.html)`, `[`ConfigAware`](-config-aware/index.html) |
 | [RuleId](-rule-id.html) | The type to use when referring to rule ids giving it more context then a String would.`typealias RuleId = `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html) |
 | [RuleSet](-rule-set/index.html) | A rule set is a collection of rules and must be defined within a rule set provider implementation.`class RuleSet` |
 | [RuleSetId](-rule-set-id.html) | `typealias RuleSetId = `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html) |
 | [RuleSetProvider](-rule-set-provider/index.html) | A rule set provider, as the name states, is responsible for creating rule sets.`interface RuleSetProvider` |
-| [SetupContext](-setup-context/index.html) | Context providing useful processing settings to initialize extensions.`interface SetupContext` |
+| [SetupContext](-setup-context/index.html) | Context providing useful processing settings to initialize extensions.`interface SetupContext : `[`PropertiesAware`](-properties-aware/index.html) |
 | [Severity](-severity/index.html) | Rules can classified into different severity grades. Maintainer can choose a grade which is most harmful to their projects.`enum class Severity` |
 | [SingleAssign](-single-assign/index.html) | Allows to assign a property just once. Further assignments result in [IllegalStateException](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-illegal-state-exception/index.html)'s.`class SingleAssign<T : `[`Any`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)`>` |
 | [SourceLocation](-source-location/index.html) | Stores line and column information of a location.`data class SourceLocation` |
@@ -67,4 +69,8 @@ title: io.gitlab.arturbosch.detekt.api - detekt-api
 ### Properties
 
 | [DEFAULT_FLOAT_CONVERSION_FACTOR](-d-e-f-a-u-l-t_-f-l-o-a-t_-c-o-n-v-e-r-s-i-o-n_-f-a-c-t-o-r.html) | To represent a value of 0.5, use the metric value 50 and the conversion factor of 100. (50 / 100 = 0.5)`const val DEFAULT_FLOAT_CONVERSION_FACTOR: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html) |
+
+### Functions
+
+| [getOrNull](get-or-null.html) | Allows to retrieve stored properties in a type safe way.`fun <T : `[`Any`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)`> `[`PropertiesAware`](-properties-aware/index.html)`.getOrNull(key: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`): T?` |
 


### PR DESCRIPTION
This PR introduces the concept of a `ReportingExtension`.
With this extension the user can listen to results and manipulate them.

The first two implementations are `BaselineFacade` and `OutputFacade`.
With this concept the baseline and the reporting features do not need special treatment in the `Runner` class or the Intellij or Sonarqube plugin but are just loaded from the detekt core engine and executed.

No more code like:
```kotlin
result = arguments.baseline?.let { BaselineFacade().transformResult(it, result) } ?: result	                
val (outputResultsTime) = measure { OutputFacade(arguments.reportPaths, result, settings).run() }
```

Extracting the "special @Suppress" implemention to a `ReportingExtension` is conceivable in the future.
 
This PR also introduces a concept to share data between extensions and tooling frondends (cli, gradle, sonar, intellij) via the `PropertiesAware` interface.
It allows to retrieve data in a type safe way:
```kotlin
inline fun <reified T : Any> PropertiesAware.getOrNull(key: String): T?
```
This lightweight key-value storage reduces the need for extra parameters for the `ProcessingSettings` class.

I've marked both new api interfaces as `@UnstableApi` for now.

#2680