### PR TITLE
Support layout property for ImportOrdering rule

### DIFF
--- a/detekt-cli/src/main/resources/default-detekt-config.yml
+++ b/detekt-cli/src/main/resources/default-detekt-config.yml
@@ -238,6 +238,7 @@ formatting:
   ImportOrdering:
     active: false
     autoCorrect: true
+    layout: 'idea'
   Indentation:
     active: false
     autoCorrect: true

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/EditorConfigConstants.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/EditorConfigConstants.kt
@@ -1,5 +1,19 @@
 package io.gitlab.arturbosch.detekt.formatting
 
+const val INDENT_SIZE_KEY = "indent_size"
+const val CONTINUATION_INDENT_SIZE_KEY = "continuation_indent_size"
+const val MAX_LINE_LENGTH_KEY = "max_line_length"
+const val INSERT_FINAL_NEWLINE_KEY = "insert_final_newline"
+const val KOTLIN_IMPORTS_LAYOUT_KEY = "kotlin_imports_layout"
+
+val knownEditorConfigProps = setOf(
+    INDENT_SIZE_KEY,
+    CONTINUATION_INDENT_SIZE_KEY,
+    MAX_LINE_LENGTH_KEY,
+    INSERT_FINAL_NEWLINE_KEY,
+    KOTLIN_IMPORTS_LAYOUT_KEY
+)
+
 const val DEFAULT_INDENT = 4
 const val DEFAULT_CONTINUATION_INDENT = 4
 const val ANDROID_MAX_LINE_LENGTH = 100

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/EditorConfigMerge.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/EditorConfigMerge.kt
@@ -1,23 +1,27 @@
 package io.gitlab.arturbosch.detekt.formatting
 
 import com.pinterest.ktlint.core.EditorConfig
+import io.gitlab.arturbosch.detekt.formatting.wrappers.ImportOrdering
 
 /**
  * Creates new EditorConfig by merging existing EditorConfig with properties values passed by parameters.
  * Values of properties passed by parameters are more important than properties in sourceEditorConfig.
  */
+@Suppress("LongParameterList")
 fun EditorConfig.Companion.merge(
     sourceEditorConfig: EditorConfig?,
     indentSize: Int? = null,
     continuationIndentSize: Int? = null,
     maxLineLength: Int? = null,
-    insertFinalNewline: Boolean? = null
+    insertFinalNewline: Boolean? = null,
+    importLayout: String = ImportOrdering.IDEA
 ): EditorConfig = fromMap(
     HashMap<String, String>().also {
         copyProperty(it, "indent_size", indentSize, sourceEditorConfig)
         copyProperty(it, "continuation_indent_size", continuationIndentSize, sourceEditorConfig)
         copyProperty(it, "max_line_length", maxLineLength, sourceEditorConfig)
         copyProperty(it, "insert_final_newline", insertFinalNewline, sourceEditorConfig)
+        copyProperty(it, ImportOrdering.EDITOR_CONFIG_KEY, importLayout, sourceEditorConfig)
     }
 )
 

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/EditorConfigMerge.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/EditorConfigMerge.kt
@@ -1,29 +1,17 @@
 package io.gitlab.arturbosch.detekt.formatting
 
 import com.pinterest.ktlint.core.EditorConfig
-import io.gitlab.arturbosch.detekt.formatting.wrappers.ImportOrdering
 
 /**
- * Creates new EditorConfig by merging existing EditorConfig with properties values passed by parameters.
+ * Creates new EditorConfig by copying the existing EditorConfig with properties values passed by parameters.
  * Values of properties passed by parameters are more important than properties in sourceEditorConfig.
  */
-@Suppress("LongParameterList")
-fun EditorConfig.Companion.merge(
-    sourceEditorConfig: EditorConfig?,
-    indentSize: Int? = null,
-    continuationIndentSize: Int? = null,
-    maxLineLength: Int? = null,
-    insertFinalNewline: Boolean? = null,
-    importLayout: String = ImportOrdering.IDEA
-): EditorConfig = fromMap(
-    HashMap<String, String>().also {
-        copyProperty(it, "indent_size", indentSize, sourceEditorConfig)
-        copyProperty(it, "continuation_indent_size", continuationIndentSize, sourceEditorConfig)
-        copyProperty(it, "max_line_length", maxLineLength, sourceEditorConfig)
-        copyProperty(it, "insert_final_newline", insertFinalNewline, sourceEditorConfig)
-        copyProperty(it, ImportOrdering.EDITOR_CONFIG_KEY, importLayout, sourceEditorConfig)
-    }
-)
+fun EditorConfig?.copy(vararg overrides: Pair<String, Any>): EditorConfig {
+    val valuesToOverride = overrides.toMap()
+    val newValues = HashMap<String, String>()
+    knownEditorConfigProps.forEach { copyProperty(newValues, it, valuesToOverride[it], this) }
+    return EditorConfig.fromMap(newValues)
+}
 
 private fun copyProperty(
     map: MutableMap<String, String>,

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/FinalNewline.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/FinalNewline.kt
@@ -4,7 +4,8 @@ import com.pinterest.ktlint.core.EditorConfig
 import com.pinterest.ktlint.ruleset.standard.FinalNewlineRule
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
-import io.gitlab.arturbosch.detekt.formatting.merge
+import io.gitlab.arturbosch.detekt.formatting.INSERT_FINAL_NEWLINE_KEY
+import io.gitlab.arturbosch.detekt.formatting.copy
 
 /**
  * See <a href="https://ktlint.github.io">ktlint-website</a> for documentation.
@@ -23,7 +24,7 @@ class FinalNewline(config: Config) : FormattingRule(config) {
     private val insertFinalNewline = valueOrDefault(INSERT_FINAL_NEWLINE, true)
 
     override fun editorConfigUpdater(): ((oldEditorConfig: EditorConfig?) -> EditorConfig)? = {
-        EditorConfig.merge(it, insertFinalNewline = insertFinalNewline)
+        it.copy(INSERT_FINAL_NEWLINE_KEY to insertFinalNewline)
     }
 }
 

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/ImportOrdering.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/ImportOrdering.kt
@@ -1,11 +1,17 @@
 package io.gitlab.arturbosch.detekt.formatting.wrappers
 
+import com.pinterest.ktlint.core.EditorConfig
 import com.pinterest.ktlint.ruleset.standard.ImportOrderingRule
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
+import io.gitlab.arturbosch.detekt.formatting.merge
 
 /**
  * See <a href="https://ktlint.github.io">ktlint-website</a> for documentation.
+ *
+ * For defining custom import layout patterns see: https://github.com/pinterest/ktlint/blob/cdf871b6f015359f9a6f02e15ef1b85a6c442437/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/ImportOrderingRule.kt
+ *
+ * @configuration layout - the import ordering layout; use 'ascii', 'idea' or define a custom one (default: `'idea'`)
  *
  * @autoCorrect since v1.0.0
  */
@@ -13,4 +19,18 @@ class ImportOrdering(config: Config) : FormattingRule(config) {
 
     override val wrapping = ImportOrderingRule()
     override val issue = issueFor("Detects imports in non default order")
+
+    private val layout: String = valueOrNull(LAYOUT_PATTERN) ?: chooseDefaultLayout()
+
+    private fun chooseDefaultLayout() = if (isAndroid) ASCII else IDEA
+
+    override fun editorConfigUpdater(): ((oldEditorConfig: EditorConfig?) -> EditorConfig)? =
+        { EditorConfig.merge(it, importLayout = layout) }
+
+    companion object {
+        const val LAYOUT_PATTERN = "layout"
+        const val EDITOR_CONFIG_KEY = "kotlin_imports_layout"
+        const val ASCII = "ascii"
+        const val IDEA = "idea"
+    }
 }

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/ImportOrdering.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/ImportOrdering.kt
@@ -4,7 +4,8 @@ import com.pinterest.ktlint.core.EditorConfig
 import com.pinterest.ktlint.ruleset.standard.ImportOrderingRule
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
-import io.gitlab.arturbosch.detekt.formatting.merge
+import io.gitlab.arturbosch.detekt.formatting.KOTLIN_IMPORTS_LAYOUT_KEY
+import io.gitlab.arturbosch.detekt.formatting.copy
 
 /**
  * See <a href="https://ktlint.github.io">ktlint-website</a> for documentation.
@@ -25,11 +26,10 @@ class ImportOrdering(config: Config) : FormattingRule(config) {
     private fun chooseDefaultLayout() = if (isAndroid) ASCII else IDEA
 
     override fun editorConfigUpdater(): ((oldEditorConfig: EditorConfig?) -> EditorConfig)? =
-        { EditorConfig.merge(it, importLayout = layout) }
+        { it.copy(KOTLIN_IMPORTS_LAYOUT_KEY to layout) }
 
     companion object {
         const val LAYOUT_PATTERN = "layout"
-        const val EDITOR_CONFIG_KEY = "kotlin_imports_layout"
         const val ASCII = "ascii"
         const val IDEA = "idea"
     }

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/Indentation.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/Indentation.kt
@@ -3,10 +3,12 @@ package io.gitlab.arturbosch.detekt.formatting.wrappers
 import com.pinterest.ktlint.core.EditorConfig
 import com.pinterest.ktlint.ruleset.standard.IndentationRule
 import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.formatting.CONTINUATION_INDENT_SIZE_KEY
 import io.gitlab.arturbosch.detekt.formatting.DEFAULT_CONTINUATION_INDENT
 import io.gitlab.arturbosch.detekt.formatting.DEFAULT_INDENT
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
-import io.gitlab.arturbosch.detekt.formatting.merge
+import io.gitlab.arturbosch.detekt.formatting.INDENT_SIZE_KEY
+import io.gitlab.arturbosch.detekt.formatting.copy
 
 /**
  * See <a href="https://ktlint.github.io/#rule-indentation">ktlint-website</a> for documentation.
@@ -25,9 +27,9 @@ class Indentation(config: Config) : FormattingRule(config) {
     private val continuationIndentSize = valueOrDefault(CONTINUATION_INDENT_SIZE, DEFAULT_CONTINUATION_INDENT)
 
     override fun editorConfigUpdater(): ((oldEditorConfig: EditorConfig?) -> EditorConfig)? = {
-        EditorConfig.merge(it,
-                indentSize = indentSize,
-                continuationIndentSize = continuationIndentSize)
+        it.copy(
+            INDENT_SIZE_KEY to indentSize,
+            CONTINUATION_INDENT_SIZE_KEY to continuationIndentSize)
     }
 
     companion object {

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/MaximumLineLength.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/MaximumLineLength.kt
@@ -6,7 +6,8 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.formatting.ANDROID_MAX_LINE_LENGTH
 import io.gitlab.arturbosch.detekt.formatting.DEFAULT_IDEA_LINE_LENGTH
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
-import io.gitlab.arturbosch.detekt.formatting.merge
+import io.gitlab.arturbosch.detekt.formatting.MAX_LINE_LENGTH_KEY
+import io.gitlab.arturbosch.detekt.formatting.copy
 
 /**
  * See <a href="https://ktlint.github.io">ktlint-website</a> for documentation.
@@ -30,7 +31,7 @@ class MaximumLineLength(config: Config) : FormattingRule(config) {
     private val maxLineLength: Int = valueOrDefault(MAX_LINE_LENGTH, defaultMaxLineLength)
 
     override fun editorConfigUpdater(): ((oldEditorConfig: EditorConfig?) -> EditorConfig)? = {
-        EditorConfig.merge(it, maxLineLength = maxLineLength)
+        it.copy(MAX_LINE_LENGTH_KEY to maxLineLength)
     }
 
     companion object {

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/ParameterListWrapping.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/ParameterListWrapping.kt
@@ -5,7 +5,8 @@ import com.pinterest.ktlint.ruleset.standard.ParameterListWrappingRule
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.formatting.DEFAULT_INDENT
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
-import io.gitlab.arturbosch.detekt.formatting.merge
+import io.gitlab.arturbosch.detekt.formatting.INDENT_SIZE_KEY
+import io.gitlab.arturbosch.detekt.formatting.copy
 
 /**
  * See <a href="https://ktlint.github.io">ktlint-website</a> for documentation.
@@ -23,8 +24,7 @@ class ParameterListWrapping(config: Config) : FormattingRule(config) {
     private val indentSize = valueOrDefault(INDENT_SIZE, DEFAULT_INDENT)
 
     override fun editorConfigUpdater(): ((oldEditorConfig: EditorConfig?) -> EditorConfig)? = {
-        EditorConfig.merge(it,
-                indentSize = indentSize)
+        it.copy(INDENT_SIZE_KEY to indentSize)
     }
 
     companion object {

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/ImportOrderingSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/ImportOrderingSpec.kt
@@ -1,0 +1,108 @@
+package io.gitlab.arturbosch.detekt.formatting
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.formatting.wrappers.ImportOrdering
+import io.gitlab.arturbosch.detekt.test.TestConfig
+import org.assertj.core.api.Assertions.assertThat
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+/**
+ * Some test cases were used directly from KtLint to verify the wrapper rule:
+ *
+ * https://github.com/pinterest/ktlint/blob/cdf871b6f015359f9a6f02e15ef1b85a6c442437/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/importordering/ImportOrderingRuleAsciiTest.kt
+ * https://github.com/pinterest/ktlint/blob/6bdd345f204e6edcc3dec5e1b139c2d573227dad/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/importordering/ImportOrderingRuleCustomTest.kt
+ * https://github.com/pinterest/ktlint/blob/cdf871b6f015359f9a6f02e15ef1b85a6c442437/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/importordering/ImportOrderingRuleIdeaTest.kt
+ */
+class ImportOrderingSpec : Spek({
+
+    describe("different import ordering layouts") {
+
+        it("defaults to the idea layout") {
+            val findings = ImportOrdering(Config.empty).lint("""
+                import android.app.Activity
+                import android.view.View
+                import android.view.ViewGroup
+                import kotlinx.coroutines.CoroutineDispatcher
+                import ru.example.a
+                import java.util.List
+                import javax.net.ssl.SSLHandshakeException
+                import kotlin.concurrent.Thread
+                import kotlin.io.Closeable
+                import android.content.Context as Ctx
+                import androidx.fragment.app.Fragment as F
+            """.trimIndent())
+
+            assertThat(findings).isEmpty()
+        }
+
+        describe("can be configured to use the ascii one") {
+
+            val negativeCase = """
+                import a.A
+                import a.AB
+                import b.C
+            """.trimIndent()
+
+            val positiveCase = """
+                import a.A
+                import java.util.ArrayList
+                import a.AB
+            """.trimIndent()
+
+            it("passes for alphabetical order") {
+                val findings = ImportOrdering(TestConfig("layout" to "ascii")).lint(negativeCase)
+
+                assertThat(findings).isEmpty()
+            }
+
+            it("fails for non alphabetical order") {
+                val findings = ImportOrdering(TestConfig("layout" to "ascii")).lint(positiveCase)
+
+                assertThat(findings).hasSize(1)
+            }
+
+            describe("defaults to ascii if 'android'' property is set to true") {
+
+                it("passes for alphabetical order") {
+                    assertThat(ImportOrdering(TestConfig("android" to "true")).lint(negativeCase)).isEmpty()
+                }
+
+                it("fails for non alphabetical order") {
+                    assertThat(ImportOrdering(TestConfig("android" to "true")).lint(positiveCase)).hasSize(1)
+                }
+            }
+        }
+
+        describe("supports custom patterns") {
+
+            it("misses a empty line between aliases and other imports") {
+                val findings = ImportOrdering(TestConfig("layout" to "*,|,^*")).lint("""
+                    import android.app.Activity
+                    import android.view.View
+                    import android.view.ViewGroup
+                    import java.util.List
+                    import kotlin.concurrent.Thread
+                    import android.content.Context as Ctx
+                    import androidx.fragment.app.Fragment as F
+                """.trimIndent())
+
+                assertThat(findings).hasSize(1)
+            }
+            it("passes for empty line between aliases and other imports") {
+                val findings = ImportOrdering(TestConfig("layout" to "*,|,^*")).lint("""
+                    import android.app.Activity
+                    import android.view.View
+                    import android.view.ViewGroup
+                    import java.util.List
+                    import kotlin.concurrent.Thread
+
+                    import android.content.Context as Ctx
+                    import androidx.fragment.app.Fragment as F
+                """.trimIndent())
+
+                assertThat(findings).isEmpty()
+            }
+        }
+    }
+})

--- a/docs/pages/documentation/formatting.md
+++ b/docs/pages/documentation/formatting.md
@@ -49,6 +49,14 @@ See <a href="https://ktlint.github.io">ktlint-website</a> for documentation.
 
 See <a href="https://ktlint.github.io">ktlint-website</a> for documentation.
 
+For defining custom import layout patterns see: https://github.com/pinterest/ktlint/blob/cdf871b6f015359f9a6f02e15ef1b85a6c442437/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/ImportOrderingRule.kt
+
+#### Configuration options:
+
+* ``layout`` (default: ``'idea'``)
+
+   the import ordering layout; use 'ascii', 'idea' or define a custom one
+
 ### Indentation
 
 See <a href="https://ktlint.github.io/#rule-indentation">ktlint-website</a> for documentation.


### PR DESCRIPTION
Looks like we should not rush in a release featuring 0.37.0

https://github.com/pinterest/ktlint/issues/761
https://github.com/pinterest/ktlint/issues/682

I plan to prepare a release candidate 1.10.0-RC1 in the next days as we have many refactorings in this one.