### PR TITLE
Introduce additional changelog section filtering developing/refactoring noise for the users

### DIFF
--- a/scripts/github-milestone-report.groovy
+++ b/scripts/github-milestone-report.groovy
@@ -1,43 +1,95 @@
-@groovy.lang.Grab('org.kohsuke:github-api:1.111')
+#!/usr/bin/env groovy
+import groovy.cli.commons.CliBuilder
+@groovy.lang.Grab('org.kohsuke:github-api:1.112')
 import org.kohsuke.github.*
 
-final class Report {
+// arguments parsing
 
-    static def entry(content, issueId, issueUrl) {
-        "- $content - [#$issueId]($issueUrl)"
-    }
-
-    static def footer(footer, url) {
-        "See all issues at: [$footer]($url)"
-    }
+def cli = new CliBuilder().tap {
+    user(type: String, "Github user or organization. Default: detekt")
+    project(type: String, "Github project. Default: detekt")
+    milestone(type: int, "Milestone number. Default: latest milestone.")
+    h(longOpt: 'help', "Prints this usage.")
 }
 
-if (args.size() > 3) throw new IllegalArgumentException("Usage: [userId] [repositoryId] [milestoneId]")
+def options = cli.parse(args)
 
-def user = args.size() > 0 ? args[0] : "detekt"
-def repo = args.size() > 1 ? args[1] : "detekt"
+if (options.h) {
+    cli.usage()
+    System.exit(0)
+}
 
+// formatting helpers
+
+static def entry(issue) {
+    entry(issue.title.trim(), issue.number, issue.getHtmlUrl())
+}
+
+static def entry(content, issueId, issueUrl) {
+    "- $content - [#$issueId]($issueUrl)"
+}
+
+static def formatIssues(issues) {
+    issues.collect { entry(it) }.join("\n") + "\n"
+}
+
+static def footer(footer, url) {
+    "See all issues at: [$footer]($url)"
+}
+
+static def header(name) {
+    "#### $name\n"
+}
+
+static def section(name) {
+    "##### $name\n"
+}
+
+// connect to GitHub
+
+def user = options.user ?: "detekt"
+def project = options.project ?: "detekt"
 def github = GitHub.connectAnonymously()
-def repository = github.getUser(user).getRepository(repo)
+def repository = github.getUser(user).getRepository(project)
+def milestones = repository
+        .listMilestones(GHIssueState.OPEN)
+        .sort { it.number }
+def milestoneId = options.milestone ?: milestones.last().number
 
-def milestones = repository.listMilestones(GHIssueState.OPEN)
-def sortedMilestones = milestones.sort { it.number }
-def mId = args.size() > 2 ? args[2].toInteger() : sortedMilestones.last().number
-def milestone = repository.getMilestone(mId)
+// get milestone and issue data
+
+def milestone = repository.getMilestone(milestoneId)
 def issues = repository.getIssues(GHIssueState.ALL, milestone)
 
-def header = milestone.title.trim()
-def issuesString = issues.collect { (Report.entry(it.title.trim(), it.number, it.getHtmlUrl())) }.join("\n") + "\n"
-def footer = Report.footer(header, milestone.getHtmlUrl())
+def milestoneTitle = milestone.title.trim()
+def groups = issues.groupBy { it.labels.find { it.name == "housekeeping" } == null }
+def (issuesForUsers, issuesForDevs) = [true, false].collect { groups[it] }
 
-println("#### $header\n")
-println("##### Notable Changes\n\n")
-println("##### Migration\n\n")
-println("##### Changelog\n")
-println(issuesString)
-println(footer)
+// print report
 
-println()
-def tempFile = File.createTempFile(repo, "_$milestone.title")
-tempFile.write("${("#### ${header}" + "\n")}\n$issuesString\n$footer")
-println("Content saved to $tempFile.path")
+def content = new StringBuilder().tap {
+    append(header(milestoneTitle))
+    append("\n")
+    append(section("Notable Changes"))
+    append("\n")
+    append(section("Migration"))
+    append("\n")
+    append(section("Changelog"))
+    append("\n")
+    append(formatIssues(issuesForUsers))
+    append("\n")
+    append(section("Housekeeping & Refactorings"))
+    append("\n")
+    append(formatIssues(issuesForDevs))
+    append("\n")
+    append(footer(milestoneTitle, milestone.getHtmlUrl()))
+}.toString()
+
+println(content)
+
+// write report to disk
+
+def tempFile = File.createTempFile(project, "_$milestone.title")
+tempFile.write(content)
+
+println("\nContent saved to $tempFile.path")


### PR DESCRIPTION
Example output:

```md
#### 1.10.0

##### Notable Changes

##### Migration

##### Changelog

- Support layout property for ImportOrdering rule - [#2763](https://github.com/detekt/detekt/pull/2763)
- Wrap three new experimental KtLint rules - [#2762](https://github.com/detekt/detekt/pull/2762)
- Upgrade to ktlint 0.37.0 - [#2760](https://github.com/detekt/detekt/pull/2760)
- Introduce reporting extensions - [#2755](https://github.com/detekt/detekt/pull/2755)
- Add default print methods to ForbiddenMethodCall - [#2753](https://github.com/detekt/detekt/pull/2753)
- Add the `ignoreAnnotated` array parameter to the FunctionNaming rule - [#2734](https://github.com/detekt/detekt/pull/2734)
- FunctionNaming: Needs "ignoreAnnotated" - [#2733](https://github.com/detekt/detekt/issues/2733)
- State that speeding the detekt task just applies to version < 1.7.0 - [#2730](https://github.com/detekt/detekt/pull/2730)
- Add cognitive complexity in complexity report - [#2727](https://github.com/detekt/detekt/pull/2727)
- add better documentation for the LongParameterList ignoreAnnotated - [#2714](https://github.com/detekt/detekt/pull/2714)
- IgnoreReturnValue: config options - [#2712](https://github.com/detekt/detekt/pull/2712)
- Use experimental indentation rule set instead of the unused from the standard rule set - [#2709](https://github.com/detekt/detekt/pull/2709)
- Remove idea integration - [#2706](https://github.com/detekt/detekt/pull/2706)
- Improve issue reporting/report at identifiers and package declarations - #2699 - [#2702](https://github.com/detekt/detekt/pull/2702)
- Feature request - limit number of lines for an issue to 1 - [#2699](https://github.com/detekt/detekt/issues/2699)
- New Rule: IgnoredReturnValue - [#2698](https://github.com/detekt/detekt/pull/2698)
- New rule: NoPrintStatement - [#2678](https://github.com/detekt/detekt/issues/2678)
- Add default values to SwallowedException rule - [#2661](https://github.com/detekt/detekt/pull/2661)
- [V1.6.0 -> V1.7.4] Error reading configuration file, java.util.zip.ZipException: invalid code lengths set. - [#2582](https://github.com/detekt/detekt/issues/2582)
- New rule: Warn on ignored return value - [#2239](https://github.com/detekt/detekt/issues/2239)
- File 'C\...\.idea' specified for property 'ideaExtension.path' is not a file. - [#2172](https://github.com/detekt/detekt/issues/2172)
- ktlint integration does not report most errors - [#2161](https://github.com/detekt/detekt/issues/2161)
- Non deterministic output. False positives on Indentation rule - [#1633](https://github.com/detekt/detekt/issues/1633)

##### Housekeeping & Refactorings

- Move config validation from cli to core - [#2764](https://github.com/detekt/detekt/pull/2764)
- Improve the performance of tests which use type resolution - [#2756](https://github.com/detekt/detekt/pull/2756)
- Move reporting logic to core module - [#2754](https://github.com/detekt/detekt/pull/2754)
- Cleanup tests in ProtectedMemberInFinalClass - [#2752](https://github.com/detekt/detekt/pull/2752)
- Add referential equality test case in EqualsAlwaysReturnsTrueOrFalse - [#2751](https://github.com/detekt/detekt/pull/2751)
- Extract xml and html reports to own modules - [#2750](https://github.com/detekt/detekt/pull/2750)
- Separate console and output report loading - [#2749](https://github.com/detekt/detekt/pull/2749)
- Bump actions/cache to v2 - [#2746](https://github.com/detekt/detekt/pull/2746)
- Fix EqualsAlwaysReturnsTrueOrFalse doc - [#2744](https://github.com/detekt/detekt/pull/2744)
- Simplify core facade class - [#2743](https://github.com/detekt/detekt/pull/2743)
- Mark some well known cli functions as implicit unsupported api - [#2742](https://github.com/detekt/detekt/pull/2742)
- Move baseline feature to core module - [#2741](https://github.com/detekt/detekt/pull/2741)
- Make baseline entities internal - [#2740](https://github.com/detekt/detekt/pull/2740)
- Simplify baseline data structures - [#2739](https://github.com/detekt/detekt/pull/2739)
- Move baseline utils to the baseline package - [#2738](https://github.com/detekt/detekt/pull/2738)
- Bump github-pages from 204 to 206 in /docs - [#2737](https://github.com/detekt/detekt/pull/2737)
- Update gradle scan plugin - [#2736](https://github.com/detekt/detekt/pull/2736)
- Update test dependencies - [#2735](https://github.com/detekt/detekt/pull/2735)
- Move three core-related tests to core module - [#2731](https://github.com/detekt/detekt/pull/2731)
- Update to Gradle 6.4.1 - [#2729](https://github.com/detekt/detekt/pull/2729)
- Migrate to resource function of test-utils - [#2728](https://github.com/detekt/detekt/pull/2728)
- Remove own collectByType function as Kotlin's does not crash anymore - [#2726](https://github.com/detekt/detekt/pull/2726)
- Move processors to metrics module - [#2725](https://github.com/detekt/detekt/pull/2725)
- Create publish tasks lazily - [#2723](https://github.com/detekt/detekt/pull/2723)
- Faster documentation generation - [#2722](https://github.com/detekt/detekt/pull/2722)
- Modularize test module - [#2720](https://github.com/detekt/detekt/pull/2720)
- Introduce parser and psi module - [#2716](https://github.com/detekt/detekt/pull/2716)
- Clean up code by using builtin associateBy function - [#2715](https://github.com/detekt/detekt/pull/2715)
- [Security] Bump activesupport from 6.0.2.1 to 6.0.3.1 in /docs - [#2708](https://github.com/detekt/detekt/pull/2708)
- Correct formatting issues - [#2707](https://github.com/detekt/detekt/pull/2707)
- [Gradle plugin/rule authors]: Invalidate jars on modified date changes - [#2703](https://github.com/detekt/detekt/pull/2703)

See all issues at: [1.10.0](https://github.com/detekt/detekt/milestone/67)
```