### PR TITLE
Unify extension debug printing

### DIFF
--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Extension.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Extension.kt
@@ -7,6 +7,7 @@ package io.gitlab.arturbosch.detekt.api
  * - [ConsoleReport]
  * - [OutputReport]
  * - [ConfigValidator]
+ * - [ReportingExtension]
  */
 interface Extension {
     /**

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/FileProcessorLocator.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/FileProcessorLocator.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.core
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.FileProcessListener
-import java.util.ServiceLoader
+import io.gitlab.arturbosch.detekt.core.extensions.loadExtensions
 
 class FileProcessorLocator(private val settings: ProcessingSettings) {
 
@@ -13,11 +13,7 @@ class FileProcessorLocator(private val settings: ProcessingSettings) {
 
     fun load(): List<FileProcessListener> =
         if (processorsActive) {
-            ServiceLoader.load(FileProcessListener::class.java, settings.pluginLoader)
-                .filter { it.id !in excludes }
-                .onEach { it.init(config); it.init(settings) }
-                .toList()
-                .also { settings.debug { "Registered file processors: $it" } }
+            loadExtensions(settings) { it.id !in excludes }
         } else {
             emptyList()
         }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/RuleSetLocator.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/RuleSetLocator.kt
@@ -2,6 +2,7 @@ package io.gitlab.arturbosch.detekt.core
 
 import io.gitlab.arturbosch.detekt.api.RuleSetProvider
 import io.gitlab.arturbosch.detekt.api.internal.DefaultRuleSetProvider
+import io.gitlab.arturbosch.detekt.core.extensions.LIST_ITEM_SPACING
 import java.util.ServiceLoader
 
 class RuleSetLocator(private val settings: ProcessingSettings) {
@@ -10,10 +11,10 @@ class RuleSetLocator(private val settings: ProcessingSettings) {
 
     fun load(): List<RuleSetProvider> =
         ServiceLoader.load(RuleSetProvider::class.java, settings.pluginLoader)
-            .mapNotNull { it.nullIfDefaultAndExcluded() }
-            .toList()
-            .also { settings.debug { "Registered rule sets: $it" } }
+            .filter(::shouldIncludeProvider)
+            .also { settings.debug { "Registered rule sets: $LIST_ITEM_SPACING${it.joinToString(LIST_ITEM_SPACING)}" } }
 
-    private fun RuleSetProvider.nullIfDefaultAndExcluded() =
-        if (excludeDefaultRuleSets && this is DefaultRuleSetProvider) null else this
+    private fun shouldIncludeProvider(provider: RuleSetProvider) =
+        !excludeDefaultRuleSets ||
+            (excludeDefaultRuleSets && provider !is DefaultRuleSetProvider)
 }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/extensions/Loading.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/extensions/Loading.kt
@@ -5,6 +5,8 @@ import io.gitlab.arturbosch.detekt.core.NL
 import io.gitlab.arturbosch.detekt.core.ProcessingSettings
 import java.util.ServiceLoader
 
+val LIST_ITEM_SPACING = "$NL    "
+
 inline fun <reified T : Extension> loadExtensions(
     settings: ProcessingSettings,
     predicate: (T) -> Boolean = { true }
@@ -14,4 +16,4 @@ inline fun <reified T : Extension> loadExtensions(
         .sortedBy { it.priority }
         .asReversed()
         .onEach { it.init(settings.config); it.init(settings) }
-        .also { settings.debug { "Loaded extensions: $NL${it.joinToString("$NL    ")}" } }
+        .also { settings.debug { "Loaded extensions: $LIST_ITEM_SPACING${it.joinToString(LIST_ITEM_SPACING)}" } }

--- a/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-extension/index.md
+++ b/docs/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-extension/index.md
@@ -15,6 +15,7 @@ Currently supported extensions are:
 * [ConsoleReport](../-console-report/index.html)
 * [OutputReport](../-output-report/index.html)
 * [ConfigValidator](../-config-validator/index.html)
+* [ReportingExtension](../-reporting-extension/index.html)
 
 ### Properties
 


### PR DESCRIPTION
Unfortunately letting `RuleSetProvider` extend `Extension` is not backwards compatible.