### PR TITLE
Disable Gradle daemon on CI

### DIFF
--- a/.github/workflows/codecoverage.yaml
+++ b/.github/workflows/codecoverage.yaml
@@ -18,6 +18,7 @@ jobs:
     if: ${{ !contains(github.event.head_commit.message, 'coverage skip') }}
     env:
       JDK_VERSION:  ${{ matrix.jdk }}
+      GRADLE_OPTS: -Dorg.gradle.daemon=false
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2

--- a/.github/workflows/deploy-snapshot.yaml
+++ b/.github/workflows/deploy-snapshot.yaml
@@ -9,6 +9,8 @@ jobs:
   gradle:
     runs-on: ubuntu-latest
     if: ${{ !contains(github.event.head_commit.message, 'ci skip') }}
+    env:
+      GRADLE_OPTS: -Dorg.gradle.daemon=false
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
@@ -38,8 +40,3 @@ jobs:
         BINTRAY_API_KEY: ${{ secrets.BINTRAY_API_KEY }}
       run: ./gradlew artifactoryPublish -Dsnapshot=true --stacktrace
       if: ${{ github.repository == 'detekt/detekt'}}
-
-    # We stop gradle at the end to make sure the cache folders
-    # don't contain any lock files and are free to be cached.
-    - name: Stop Gradle
-      run: ./gradlew --stop

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -21,6 +21,7 @@ jobs:
       # We compile the test snippets only on Java 8.
       COMPILE_TEST_SNIPPETS: ${{ matrix.os == 'ubuntu-latest' && matrix.jdk == 8 }}
       JDK_VERSION:  ${{ matrix.jdk }}
+      GRADLE_OPTS: -Dorg.gradle.daemon=false
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
@@ -76,8 +77,3 @@ jobs:
 
     - name: Verify Generator Output
       run: ./gradlew verifyGeneratorOutput
-
-    # We stop gradle at the end to make sure the cache folders
-    # don't contain any lock files and are free to be cached.
-    - name: Stop Gradle
-      run: ./gradlew --stop


### PR DESCRIPTION
To prevent CI failures like the one in https://github.com/detekt/detekt/pull/2778, let's disable the Gradle daemon on Github Actions.

We also don't need to `--stop` anymore before caching 👍 