### PR TITLE
Implement new rule ImplictUnitReturnTypet

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -451,6 +451,9 @@ potential-bugs:
     returnValueAnnotations: ['*.CheckReturnValue', '*.CheckResult']
   ImplicitDefaultLocale:
     active: false
+  ImplicitUnitReturnType:
+    active: false
+    allowExplicitReturnType: true
   InvalidRange:
     active: true
   IteratorHasNextCallsNextMethod:

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ImplicitUnitReturnType.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ImplicitUnitReturnType.kt
@@ -1,0 +1,94 @@
+package io.gitlab.arturbosch.detekt.rules.bugs
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import org.jetbrains.kotlin.js.translate.callTranslator.getReturnType
+import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.resolve.BindingContext
+import org.jetbrains.kotlin.resolve.calls.callUtil.getResolvedCall
+
+/**
+ * Functions using expression statements have an implicit return type.
+ * Changing the type of the expression accidentally, changes the functions return type.
+ * This may lead to backward incompatibility.
+ * Use a block statement to make clear this function will never return a value.
+ *
+ * @configuration allowExplicitReturnType - if functions with explicit 'Unit' return type should be allowed
+ * (default: `true`)
+ *
+ * <noncompliant>
+ * fun errorProneUnit() = println("Hello Unit")
+ * fun errorProneUnitWithParam(param: String) = param.run { println(this) }
+ * fun String.errorProneUnitWithReceiver() = run { println(this) }
+ * </noncompliant>
+ *
+ * <compliant>
+ * fun blockStatementUnit() {
+ *     // code
+ * }
+ *
+ * // explicit Unit is compliant by default; can be configured to enforce block statement
+ * fun safeUnitReturn(): Unit = println("Hello Unit")
+ * </compliant>
+ */
+class ImplicitUnitReturnType(config: Config) : Rule(config) {
+
+    override val issue = Issue(
+        javaClass.simpleName,
+        Severity.Defect,
+        """
+            Functions using expression statements have an implicit return type.
+            Changing the type of the expression accidentally, changes the function return type.
+            This may lead to backward incompatibility.
+            Use a block statement to make clear this function will never return a value.
+        """.trimIndent(),
+        Debt.FIVE_MINS
+    )
+
+    private val allowExplicitReturnType = valueOrDefault(ALLOW_EXPLICIT_RETURN_TYPE, true)
+
+    override fun visitNamedFunction(function: KtNamedFunction) {
+        super.visitNamedFunction(function)
+        if (BindingContext.EMPTY == bindingContext) {
+            return
+        }
+
+        if (allowExplicitReturnType && function.hasDeclaredReturnType()) {
+            return
+        }
+
+        val isExpressionBody = function.bodyExpression != null
+
+        if (isExpressionBody && function.hasImplicitUnitReturnType()) {
+            val message = buildString {
+                append("'${function.name}'  has the implicit return type 'Unit'.")
+                append(" Prefer using a block statement")
+                if (allowExplicitReturnType) {
+                    append(" or specify the return type explicitly")
+                }
+                append('.')
+            }
+            report(
+                CodeSmell(
+                    issue,
+                    Entity.atName(function),
+                    message
+                )
+            )
+        }
+    }
+
+    private fun KtNamedFunction.hasImplicitUnitReturnType(): Boolean {
+        val returnType = bodyExpression.getResolvedCall(bindingContext)?.getReturnType()
+        return returnType?.toString() == "Unit"
+    }
+
+    companion object {
+        const val ALLOW_EXPLICIT_RETURN_TYPE = "allowExplicitReturnType"
+    }
+}

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ImplicitUnitReturnType.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ImplicitUnitReturnType.kt
@@ -7,7 +7,6 @@ import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
-import org.jetbrains.kotlin.js.translate.callTranslator.getReturnType
 import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.calls.callUtil.getResolvedCall
@@ -84,7 +83,9 @@ class ImplicitUnitReturnType(config: Config) : Rule(config) {
     }
 
     private fun KtNamedFunction.hasImplicitUnitReturnType(): Boolean {
-        val returnType = bodyExpression.getResolvedCall(bindingContext)?.getReturnType()
+        val returnType = bodyExpression.getResolvedCall(bindingContext)
+            ?.resultingDescriptor
+            ?.returnType
         return returnType?.toString() == "Unit"
     }
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/PotentialBugProvider.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/providers/PotentialBugProvider.kt
@@ -8,6 +8,7 @@ import io.gitlab.arturbosch.detekt.rules.bugs.DuplicateCaseInWhenExpression
 import io.gitlab.arturbosch.detekt.rules.bugs.EqualsAlwaysReturnsTrueOrFalse
 import io.gitlab.arturbosch.detekt.rules.bugs.EqualsWithHashCodeExist
 import io.gitlab.arturbosch.detekt.rules.bugs.ExplicitGarbageCollectionCall
+import io.gitlab.arturbosch.detekt.rules.bugs.ImplicitUnitReturnType
 import io.gitlab.arturbosch.detekt.rules.bugs.HasPlatformType
 import io.gitlab.arturbosch.detekt.rules.bugs.ImplicitDefaultLocale
 import io.gitlab.arturbosch.detekt.rules.bugs.IgnoredReturnValue
@@ -60,7 +61,8 @@ class PotentialBugProvider : DefaultRuleSetProvider {
                 UnsafeCast(config),
                 UselessPostfixExpression(config),
                 WrongEqualsTypeParameter(config),
-                IgnoredReturnValue(config)
+                IgnoredReturnValue(config),
+                ImplicitUnitReturnType(config)
         ))
     }
 }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ImplicitUnitReturnTypeSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ImplicitUnitReturnTypeSpec.kt
@@ -52,7 +52,7 @@ class ImplicitUnitReturnTypeSpec : Spek({
                 fun blockUnitReturn() { 
                     println("Hello Unit")
                 }
-            """.trimIndent()
+            """
 
             val findings = rule.compileAndLintWithContext(env, code)
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ImplicitUnitReturnTypeSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ImplicitUnitReturnTypeSpec.kt
@@ -27,7 +27,7 @@ class ImplicitUnitReturnTypeSpec : Spek({
 
             val findings = rule.compileAndLintWithContext(env, code)
 
-            assertThat(findings).hasSize(1)
+            assertThat(findings).hasSize(3)
         }
 
         it("does not report explicit Unit return type by default") {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ImplicitUnitReturnTypeSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ImplicitUnitReturnTypeSpec.kt
@@ -1,0 +1,62 @@
+package io.gitlab.arturbosch.detekt.rules.bugs
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.rules.bugs.ImplicitUnitReturnType.Companion.ALLOW_EXPLICIT_RETURN_TYPE
+import io.gitlab.arturbosch.detekt.rules.setupKotlinEnvironment
+import io.gitlab.arturbosch.detekt.test.TestConfig
+import io.gitlab.arturbosch.detekt.test.assertThat
+import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+class ImplicitUnitReturnTypeSpec : Spek({
+    setupKotlinEnvironment()
+
+    val env: KotlinCoreEnvironment by memoized()
+    val rule by memoized { ImplicitUnitReturnType(Config.empty) }
+
+    describe("Functions returning Unit via expression statements") {
+
+        it("reports implicit Unit return types") {
+            val code = """
+                fun errorProneUnit() = println("Hello Unit")
+                fun errorProneUnitWithParam(param: String) = param.run { println(this) }
+                fun String.errorProneUnitWithReceiver() = run { println(this) }
+            """.trimIndent()
+
+            val findings = rule.compileAndLintWithContext(env, code)
+
+            assertThat(findings).hasSize(1)
+        }
+
+        it("does not report explicit Unit return type by default") {
+            val code = """fun safeUnitReturn(): Unit = println("Hello Unit")"""
+
+            val findings = rule.compileAndLintWithContext(env, code)
+
+            assertThat(findings).isEmpty()
+        }
+
+        it("reports explicit Unit return type if configured") {
+            val code = """fun safeButStillReported(): Unit = println("Hello Unit")"""
+
+            val findings = ImplicitUnitReturnType(TestConfig(ALLOW_EXPLICIT_RETURN_TYPE to "false"))
+                .compileAndLintWithContext(env, code)
+
+            assertThat(findings).hasSize(1)
+        }
+
+        it("does not report for block statements") {
+            val code = """
+                fun blockUnitReturn() { 
+                    println("Hello Unit")
+                }
+            """.trimIndent()
+
+            val findings = rule.compileAndLintWithContext(env, code)
+
+            assertThat(findings).isEmpty()
+        }
+    }
+})

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ImplicitUnitReturnTypeSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ImplicitUnitReturnTypeSpec.kt
@@ -23,7 +23,7 @@ class ImplicitUnitReturnTypeSpec : Spek({
                 fun errorProneUnit() = println("Hello Unit")
                 fun errorProneUnitWithParam(param: String) = param.run { println(this) }
                 fun String.errorProneUnitWithReceiver() = run { println(this) }
-            """.trimIndent()
+            """
 
             val findings = rule.compileAndLintWithContext(env, code)
 

--- a/docs/pages/documentation/potential-bugs.md
+++ b/docs/pages/documentation/potential-bugs.md
@@ -229,6 +229,39 @@ str.toUpperCase(Locale.US)
 str.toLowerCase(Locale.US)
 ```
 
+### ImplicitUnitReturnType
+
+Functions using expression statements have an implicit return type.
+Changing the type of the expression accidentally, changes the functions return type.
+This may lead to backward incompatibility.
+Use a block statement to make clear this function will never return a value.
+
+**Severity**: Defect
+
+**Debt**: 5min
+
+#### Configuration options:
+
+* ``allowExplicitReturnType`` (default: ``true``)
+
+   if functions with explicit 'Unit' return type should be allowed
+
+
+<noncompliant>
+fun errorProneUnit() = println("Hello Unit")
+fun errorProneUnitWithParam(param: String) = param.run { println(this) }
+fun String.errorProneUnitWithReceiver() = run { println(this) }
+</noncompliant>
+
+<compliant>
+fun blockStatementUnit() {
+    // code
+}
+
+// explicit Unit is compliant by default; can be configured to enforce block statement
+fun safeUnitReturn(): Unit = println("Hello Unit")
+</compliant>
+
 ### InvalidRange
 
 Reports ranges which are empty.


### PR DESCRIPTION
This rule suggests to use block statements for functions when the return type is of type Unit.

