### PR TITLE
Construct signatures based on named declaration instead of just the identifier

### DIFF
--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -2,6 +2,6 @@
 <SmellBaseline>
   <Blacklist></Blacklist>
   <Whitelist>
-    <ID>LargeClass:UnusedPrivateMemberSpec.kt$UnusedPrivateMemberSpec$UnusedPrivateMemberSpec</ID>
+    <ID>LargeClass:UnusedPrivateMemberSpec.kt$UnusedPrivateMemberSpec : Spek</ID>
   </Whitelist>
 </SmellBaseline>

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Entity.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Entity.kt
@@ -37,24 +37,33 @@ data class Entity(
         /**
          * Create an entity at the location of the identifier of given named declaration.
          */
-        fun atName(element: KtNamedDeclaration): Entity = from(element.nameIdentifier ?: element)
+        fun atName(element: KtNamedDeclaration): Entity =
+            from(element.nameIdentifier ?: element, element)
 
         /**
          * Create an entity at the location of the package, first import or first declaration.
          */
-        fun atPackageOrFirstDecl(file: KtFile): Entity = from(
-            file.packageDirective ?: file.firstChild ?: file
-        )
+        fun atPackageOrFirstDecl(file: KtFile): Entity =
+            from(file.packageDirective ?: file.firstChild ?: file, file)
 
         /**
          * Use this factory method if the location can be calculated much more precisely than
          * using the given PsiElement.
          */
-        fun from(element: PsiElement, location: Location): Entity {
-            val name = element.searchName()
-            val signature = element.buildFullSignature()
-            val clazz = element.searchClass()
-            val ktElement = element.getNonStrictParentOfType<KtElement>() ?: error("KtElement expected")
+        fun from(element: PsiElement, location: Location): Entity = from(element, element, location)
+
+        private fun from(elementToReport: PsiElement, elementForSignature: PsiElement): Entity =
+            from(elementToReport, elementForSignature, Location.from(elementToReport))
+
+        private fun from(
+            elementToReport: PsiElement,
+            elementForSignature: PsiElement,
+            location: Location
+        ): Entity {
+            val name = elementToReport.searchName()
+            val signature = elementForSignature.buildFullSignature()
+            val clazz = elementToReport.searchClass()
+            val ktElement = elementToReport.getNonStrictParentOfType<KtElement>() ?: error("KtElement expected")
             return Entity(name, clazz, signature, location, ktElement)
         }
     }

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/EntitySpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/EntitySpec.kt
@@ -1,0 +1,62 @@
+package io.gitlab.arturbosch.detekt.api
+
+import io.github.detekt.test.utils.compileContentForTest
+import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.kotlin.psi.KtClass
+import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.psiUtil.collectDescendantsOfType
+import org.jetbrains.kotlin.psi.psiUtil.findDescendantOfType
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+class EntitySpec : Spek({
+
+    describe("entity signatures") {
+
+        val code = compileContentForTest("""
+            package test
+
+            class C : Any() {
+
+                private fun memberFun(): Int = 5
+            }
+
+            fun topLevelFun(number: Int) = Unit
+        """.trimIndent())
+
+        describe("functions") {
+
+            val functions = code.collectDescendantsOfType<KtNamedFunction>()
+
+            it("includes full function header, class name and filename") {
+                val memberFunction = functions.first { it.name == "memberFun" }
+
+                assertThat(Entity.atName(memberFunction).signature)
+                    .isEqualTo("Test.kt\$C\$private fun memberFun(): Int")
+            }
+
+            it("includes full function header and filename for a top level function") {
+                val topLevelFunction = functions.first { it.name == "topLevelFun" }
+
+                assertThat(Entity.atName(topLevelFunction).signature)
+                    .isEqualTo("Test.kt\$fun topLevelFun(number: Int)")
+            }
+        }
+
+        describe("classes") {
+
+            it("includes full class signature") {
+                val clazz = requireNotNull(code.findDescendantOfType<KtClass>())
+
+                assertThat(Entity.atName(clazz).signature).isEqualTo("Test.kt\$C : Any")
+            }
+        }
+
+        describe("files") {
+
+            it("includes package and file name") {
+                assertThat(Entity.atPackageOrFirstDecl(code).signature).isEqualTo("Test.kt\$test.Test.kt")
+            }
+        }
+    }
+})


### PR DESCRIPTION
This fixes a regression introduced in #2702 for baseline files.
See the updated baseine file for an example.

Further it corrects a regression we introduced in PRs like #2061 where we changed the code to report at the identifier:
```kotlin
Entity.from(function.nameIdentifier!!)
```
in some complexity rules.

A signature should always include the whole function or class header to be unambiguous.

The signature algorithm is in fact wrong as it does not consider the whole signature of the parents of the reported elements.

See example from the testcase:
```kotlin
Test.kt\$C\$private fun memberFun(): Int
```

This signature includes the whole function header but not the package or extended types of `C`.
The right signature would be:

```kotlin
test.Test.kt\$C : Any\$private fun memberFun(): Int
```

In 99.5% of all cases this will be no problem for our users but we should consider fixing this in a major release.