### PR TITLE
Add automatic detekt tasks for Android Plugins

### DIFF
--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -3,8 +3,18 @@ plugins {
     id("com.gradle.plugin-publish") version "0.12.0"
 }
 
+repositories {
+    google()
+}
+
 dependencies {
+    val androidGradlePlugin = "com.android.tools.build:gradle:4.0.1"
     implementation(kotlin("gradle-plugin-api"))
+    compileOnly(androidGradlePlugin)
+
+    testImplementation(project(":detekt-test-utils"))
+    testImplementation(kotlin("gradle-plugin"))
+    testImplementation(androidGradlePlugin)
 }
 
 gradlePlugin {
@@ -25,7 +35,7 @@ pluginBundle {
     website = "https://detekt.github.io/detekt"
     vcsUrl = "https://github.com/detekt/detekt"
     description = "Static code analysis for Kotlin"
-    tags = listOf("kotlin", "detekt", "code-analysis", "linter", "codesmells")
+    tags = listOf("kotlin", "detekt", "code-analysis", "linter", "codesmells", "android")
 
     (plugins) {
         "detektPlugin" {

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
@@ -3,6 +3,7 @@ package io.gitlab.arturbosch.detekt
 import io.gitlab.arturbosch.detekt.invoke.AutoCorrectArgument
 import io.gitlab.arturbosch.detekt.invoke.BaselineArgument
 import io.gitlab.arturbosch.detekt.invoke.BuildUponDefaultConfigArgument
+import io.gitlab.arturbosch.detekt.invoke.ClasspathArgument
 import io.gitlab.arturbosch.detekt.invoke.ConfigArgument
 import io.gitlab.arturbosch.detekt.invoke.CreateBaselineArgument
 import io.gitlab.arturbosch.detekt.invoke.DebugArgument
@@ -10,6 +11,7 @@ import io.gitlab.arturbosch.detekt.invoke.DetektInvoker
 import io.gitlab.arturbosch.detekt.invoke.DisableDefaultRuleSetArgument
 import io.gitlab.arturbosch.detekt.invoke.FailFastArgument
 import io.gitlab.arturbosch.detekt.invoke.InputArgument
+import io.gitlab.arturbosch.detekt.invoke.JvmTargetArgument
 import io.gitlab.arturbosch.detekt.invoke.ParallelArgument
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.RegularFileProperty
@@ -50,6 +52,10 @@ open class DetektCreateBaselineTask : SourceTask() {
     @get:Classpath
     val pluginClasspath: ConfigurableFileCollection = project.objects.fileCollection()
 
+    @get:Classpath
+    @get:Optional
+    val classpath = project.configurableFileCollection()
+
     @get:Console
     val debug: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
 
@@ -76,12 +82,22 @@ open class DetektCreateBaselineTask : SourceTask() {
     @get:Optional
     val autoCorrect: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
 
+    @get:Input
+    @get:Optional
+    internal val jvmTargetProp: Property<String> = project.objects.property(String::class.javaObjectType)
+    var jvmTarget: String
+        @Internal
+        get() = jvmTargetProp.get()
+        set(value) = jvmTargetProp.set(value)
+
     private val invoker: DetektInvoker = DetektInvoker.create(project)
 
     @TaskAction
     fun baseline() {
         val arguments = mutableListOf(
             CreateBaselineArgument,
+            ClasspathArgument(classpath),
+            JvmTargetArgument(jvmTargetProp.orNull),
             BaselineArgument(baseline.get()),
             InputArgument(source),
             ConfigArgument(config),

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
@@ -54,7 +54,7 @@ open class DetektCreateBaselineTask : SourceTask() {
 
     @get:Classpath
     @get:Optional
-    val classpath = project.configurableFileCollection()
+    val classpath = project.objects.fileCollection()
 
     @get:Console
     val debug: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
@@ -1,26 +1,22 @@
 package io.gitlab.arturbosch.detekt
 
 import io.gitlab.arturbosch.detekt.extensions.DetektExtension
-import io.gitlab.arturbosch.detekt.extensions.DetektReport
-import org.gradle.api.GradleException
+import io.gitlab.arturbosch.detekt.internal.DetektAndroid
+import io.gitlab.arturbosch.detekt.internal.DetektJvm
+import io.gitlab.arturbosch.detekt.internal.registerCreateBaselineTask
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.file.FileCollection
-import org.gradle.api.internal.HasConvention
-import org.gradle.api.plugins.JavaPluginConvention
 import org.gradle.api.plugins.ReportingBasePlugin
 import org.gradle.api.provider.Provider
 import org.gradle.api.reporting.ReportingExtension
-import org.gradle.api.tasks.SourceSet
 import org.gradle.language.base.plugins.LifecycleBasePlugin
-import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
-import java.io.File
 
 class DetektPlugin : Plugin<Project> {
 
     override fun apply(project: Project) {
         project.pluginManager.apply(ReportingBasePlugin::class.java)
-        val extension = project.extensions.create(DETEKT_TASK_NAME, DetektExtension::class.java)
+        val extension = project.extensions.create(DETEKT_EXTENSION, DetektExtension::class.java)
         extension.reportsDir = project.extensions.getByType(ReportingExtension::class.java).file("detekt")
 
         val defaultConfigFile =
@@ -32,25 +28,27 @@ class DetektPlugin : Plugin<Project> {
         configurePluginDependencies(project, extension)
         setTaskDefaults(project)
 
-        registerOldDetektTask(project, extension)
-        registerDetektTasks(project, extension)
-        registerCreateBaselineTask(project, extension)
-        registerGenerateConfigTask(project)
+        project.registerOldDetektTask(extension)
+        project.registerDetektJvmTasks(extension)
+        project.registerDetektAndroidTasks(extension)
+        project.registerOldCreateBaselineTask(extension)
+        project.registerGenerateConfigTask()
     }
 
-    private fun registerDetektTasks(project: Project, extension: DetektExtension) {
-        // Kotlin JVM plugin
-        project.plugins.withId("org.jetbrains.kotlin.jvm") {
-            project.afterEvaluate {
-                project.convention.getPlugin(JavaPluginConvention::class.java).sourceSets.all { sourceSet ->
-                    registerDetektTask(project, extension, sourceSet)
-                }
-            }
+    private fun Project.registerDetektJvmTasks(extension: DetektExtension) {
+        plugins.withId("org.jetbrains.kotlin.jvm") {
+            DetektJvm(this).registerDetektJvmTasks(extension)
         }
     }
 
-    private fun registerOldDetektTask(project: Project, extension: DetektExtension) {
-        val detektTaskProvider = project.tasks.register(DETEKT_TASK_NAME, Detekt::class.java) {
+    private fun Project.registerDetektAndroidTasks(extension: DetektExtension) {
+        plugins.withId("kotlin-android") {
+            DetektAndroid(this).registerDetektAndroidTasks(extension)
+        }
+    }
+
+    private fun Project.registerOldDetektTask(extension: DetektExtension) {
+        val detektTaskProvider = tasks.register(DETEKT_TASK_NAME, Detekt::class.java) {
             it.debugProp.set(project.provider { extension.debug })
             it.parallelProp.set(project.provider { extension.parallel })
             it.disableDefaultRuleSetsProp.set(project.provider { extension.disableDefaultRuleSets })
@@ -67,58 +65,19 @@ class DetektPlugin : Plugin<Project> {
             it.ignoreFailuresProp.set(project.provider { extension.ignoreFailures })
         }
 
-        project.tasks.matching { it.name == LifecycleBasePlugin.CHECK_TASK_NAME }.configureEach {
+        tasks.matching { it.name == LifecycleBasePlugin.CHECK_TASK_NAME }.configureEach {
             it.dependsOn(detektTaskProvider)
         }
     }
 
-    private fun DetektReport.setDefaultIfUnset(default: File) {
-        if (destination == null) {
-            destination = default
-        }
-    }
-
-    private fun registerDetektTask(project: Project, extension: DetektExtension, sourceSet: SourceSet) {
-        val kotlinSourceSet = (sourceSet as HasConvention).convention.plugins["kotlin"] as? KotlinSourceSet
-            ?: throw GradleException("Kotlin source set not found. Please report on detekt's issue tracker")
-        project.tasks.register(DETEKT_TASK_NAME + sourceSet.name.capitalize(), Detekt::class.java) {
-            it.debugProp.set(project.provider { extension.debug })
-            it.parallelProp.set(project.provider { extension.parallel })
-            it.disableDefaultRuleSetsProp.set(project.provider { extension.disableDefaultRuleSets })
-            it.buildUponDefaultConfigProp.set(project.provider { extension.buildUponDefaultConfig })
-            it.failFastProp.set(project.provider { extension.failFast })
-            it.autoCorrectProp.set(project.provider { extension.autoCorrect })
-            it.config.setFrom(project.provider { extension.config })
-            it.baseline.set(project.layout.file(project.provider { extension.baseline }))
-            it.setSource(kotlinSourceSet.kotlin.files)
-            it.classpath.setFrom(sourceSet.compileClasspath, sourceSet.output.classesDirs)
-            it.reports = extension.reports
-            it.reports.xml.setDefaultIfUnset(File(extension.reportsDir, sourceSet.name + ".xml"))
-            it.reports.html.setDefaultIfUnset(File(extension.reportsDir, sourceSet.name + ".html"))
-            it.reports.txt.setDefaultIfUnset(File(extension.reportsDir, sourceSet.name + ".txt"))
-            it.ignoreFailuresProp.set(project.provider { extension.ignoreFailures })
-            it.description =
-                "EXPERIMENTAL & SLOW: Run detekt analysis for ${sourceSet.name} classes with type resolution"
-        }
-    }
-
-    private fun registerCreateBaselineTask(project: Project, extension: DetektExtension) =
-        project.tasks.register(BASELINE, DetektCreateBaselineTask::class.java) {
-            it.baseline.set(project.layout.file(project.provider { extension.baseline }))
-            it.config.setFrom(project.provider { extension.config })
-            it.debug.set(project.provider { extension.debug })
-            it.parallel.set(project.provider { extension.parallel })
-            it.disableDefaultRuleSets.set(project.provider { extension.disableDefaultRuleSets })
-            it.buildUponDefaultConfig.set(project.provider { extension.buildUponDefaultConfig })
-            it.failFast.set(project.provider { extension.failFast })
-            it.autoCorrect.set(project.provider { extension.autoCorrect })
-            it.setSource(existingInputDirectoriesProvider(project, extension))
-            it.setIncludes(defaultIncludes)
-            it.setExcludes(defaultExcludes)
+    private fun Project.registerOldCreateBaselineTask(extension: DetektExtension) =
+        registerCreateBaselineTask(BASELINE_TASK_NAME, extension) {
+            setSource(existingInputDirectoriesProvider(project, extension))
+            baseline.set(project.layout.file(project.provider { extension.baseline }))
         }
 
-    private fun registerGenerateConfigTask(project: Project) =
-        project.tasks.register(GENERATE_CONFIG, DetektGenerateConfigTask::class.java)
+    private fun Project.registerGenerateConfigTask() =
+        tasks.register(GENERATE_CONFIG, DetektGenerateConfigTask::class.java)
 
     private fun existingInputDirectoriesProvider(
         project: Project,
@@ -138,6 +97,7 @@ class DetektPlugin : Plugin<Project> {
             configuration.description = "The $CONFIGURATION_DETEKT dependencies to be used for this project."
 
             configuration.defaultDependencies { dependencySet ->
+                @Suppress("USELESS_ELVIS")
                 val version = extension.toolVersion ?: DEFAULT_DETEKT_VERSION
                 dependencySet.add(project.dependencies.create("io.gitlab.arturbosch.detekt:detekt-cli:$version"))
             }
@@ -161,11 +121,12 @@ class DetektPlugin : Plugin<Project> {
     }
 
     companion object {
-        private const val DETEKT_TASK_NAME = "detekt"
+        const val DETEKT_TASK_NAME = "detekt"
+        const val BASELINE_TASK_NAME = "detektBaseline"
+        const val DETEKT_EXTENSION = "detekt"
         private const val GENERATE_CONFIG = "detektGenerateConfig"
-        private const val BASELINE = "detektBaseline"
-        private val defaultExcludes = listOf("build/")
-        private val defaultIncludes = listOf("**/*.kt", "**/*.kts")
+        internal val defaultExcludes = listOf("build/")
+        internal val defaultIncludes = listOf("**/*.kt", "**/*.kts")
         internal const val CONFIG_DIR_NAME = "config/detekt"
         internal const val CONFIG_FILE = "detekt.yml"
     }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/KotlinExtension.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/KotlinExtension.kt
@@ -5,7 +5,9 @@ package io.gitlab.arturbosch.detekt
 import io.gitlab.arturbosch.detekt.extensions.DetektExtension
 import org.gradle.api.Project
 
-@Deprecated("""Either apply detekt plugin to root project or follow this advice:
-https://docs.gradle.org/current/userguide/kotlin_dsl.html#sec:multi_project_builds_applying_plugins""")
+@Deprecated(
+    """Either apply detekt plugin to root project or follow this advice:
+https://docs.gradle.org/current/userguide/kotlin_dsl.html#sec:multi_project_builds_applying_plugins"""
+)
 fun Project.detekt(configure: DetektExtension.() -> Unit) =
     extensions.configure(DetektExtension::class.java, configure)

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
@@ -42,6 +42,23 @@ open class DetektExtension @Inject constructor(objects: ObjectFactory) : CodeQua
 
     var autoCorrect: Boolean = DEFAULT_AUTO_CORRECT_VALUE
 
+    /**
+     * List of Android build variants for which no detekt task should be created.
+     *
+     * This is a combination of build types and flavors, such as fooDebug or barRelease.
+     */
+    var ignoredVariants: List<String> = emptyList()
+
+    /**
+     * List of Android build types for which no detekt task should be created.
+     */
+    var ignoredBuildTypes: List<String> = emptyList()
+
+    /**
+     * List of Android build flavors for which no detekt task should be created
+     */
+    var ignoredFlavors: List<String> = emptyList()
+
     companion object {
         const val DEFAULT_SRC_DIR_JAVA = "src/main/java"
         const val DEFAULT_SRC_DIR_KOTLIN = "src/main/kotlin"

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektAndroid.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektAndroid.kt
@@ -1,0 +1,137 @@
+package io.gitlab.arturbosch.detekt.internal
+
+import com.android.build.gradle.AppExtension
+import com.android.build.gradle.BaseExtension
+import com.android.build.gradle.LibraryExtension
+import com.android.build.gradle.TestExtension
+import com.android.build.gradle.api.BaseVariant
+import com.android.build.gradle.internal.api.TestedVariant
+import com.android.build.gradle.internal.tasks.factory.dependsOn
+import io.gitlab.arturbosch.detekt.Detekt
+import io.gitlab.arturbosch.detekt.DetektCreateBaselineTask
+import io.gitlab.arturbosch.detekt.DetektPlugin
+import io.gitlab.arturbosch.detekt.extensions.DetektExtension
+import org.gradle.api.DomainObjectSet
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.file.FileCollection
+import org.gradle.api.tasks.TaskProvider
+import java.io.File
+
+internal class DetektAndroid(private val project: Project) {
+
+    private val mainTaskProvider: TaskProvider<Task> by lazy {
+        project.tasks.register("${DetektPlugin.DETEKT_TASK_NAME}Main") {
+            it.group = "verification"
+            it.description = "EXPERIMENTAL: Run detekt analysis for production classes across " +
+                    "all variants with type resolution"
+        }
+    }
+
+    private val testTaskProvider: TaskProvider<Task> by lazy {
+        project.tasks.register("${DetektPlugin.DETEKT_TASK_NAME}Test") {
+            it.group = "verification"
+            it.description = "EXPERIMENTAL: Run detekt analysis for test classes across " +
+                    "all variants with type resolution"
+        }
+    }
+
+    private val mainBaselineTaskProvider: TaskProvider<Task> by lazy {
+        project.tasks.register("${DetektPlugin.BASELINE_TASK_NAME}Main") {
+            it.group = "verification"
+            it.description = "EXPERIMENTAL: Creates detekt baseline files for production classes across " +
+                    "all variants with type resolution"
+        }
+    }
+
+    private val testBaselineTaskProvider: TaskProvider<Task> by lazy {
+        project.tasks.register("${DetektPlugin.BASELINE_TASK_NAME}Test") {
+            it.group = "verification"
+            it.description = "EXPERIMENTAL: Creates detekt baseline files for test classes across " +
+                    "all variants with type resolution"
+        }
+    }
+
+    fun registerDetektAndroidTasks(extension: DetektExtension) {
+        // There is not a single Android plugin, but each registers an extension based on BaseExtension,
+        // so we catch them all by looking for this one
+        project.afterEvaluate {
+            val baseExtension = project.extensions.findByType(BaseExtension::class.java)
+            baseExtension?.let {
+                val bootClasspath = project.files(baseExtension.bootClasspath)
+                baseExtension.variants
+                    ?.matching { !extension.matchesIgnoredConfiguration(it) }
+                    ?.all { variant ->
+                        project.registerAndroidDetektTask(bootClasspath, extension, variant).also { provider ->
+                            mainTaskProvider.dependsOn(provider)
+                        }
+                        project.registerAndroidCreateBaselineTask(bootClasspath, extension, variant)
+                            .also { provider ->
+                                mainBaselineTaskProvider.dependsOn(provider)
+                            }
+                        variant.testVariants
+                            .filter { !extension.matchesIgnoredConfiguration(it) }
+                            .forEach { testVariant ->
+                                project.registerAndroidDetektTask(bootClasspath, extension, testVariant)
+                                    .also { provider ->
+                                        testTaskProvider.dependsOn(provider)
+                                    }
+                                project.registerAndroidCreateBaselineTask(bootClasspath, extension, testVariant)
+                                    .also { provider ->
+                                        testBaselineTaskProvider.dependsOn(provider)
+                                    }
+                            }
+                    }
+            }
+        }
+    }
+
+    private fun DetektExtension.matchesIgnoredConfiguration(variant: BaseVariant): Boolean =
+        ignoredVariants.contains(variant.name) ||
+                ignoredBuildTypes.contains(variant.buildType.name) ||
+                ignoredFlavors.contains(variant.flavorName)
+
+    private val BaseExtension.variants: DomainObjectSet<out BaseVariant>?
+        get() = when (this) {
+            is AppExtension -> applicationVariants
+            is LibraryExtension -> libraryVariants
+            is TestExtension -> applicationVariants
+            else -> null
+        }
+
+    private val BaseVariant.testVariants: List<BaseVariant>
+        get() = if (this is TestedVariant) listOfNotNull(testVariant, unitTestVariant)
+        else emptyList()
+
+    private fun Project.registerAndroidDetektTask(
+        bootClasspath: FileCollection,
+        extension: DetektExtension,
+        variant: BaseVariant
+    ): TaskProvider<Detekt> =
+        registerDetektTask(DetektPlugin.DETEKT_TASK_NAME + variant.name.capitalize(), extension) {
+            setSource(variant.sourceSets.map { it.javaDirectories })
+            classpath.setFrom(variant.getCompileClasspath(null).filter { it.exists() } + bootClasspath)
+            // If a baseline file is configured as input file, it must exist to be configured, otherwise the task fails.
+            // We try to find the configured baseline or alternatively a specific variant matching this task.
+            extension.baseline?.existingVariantOrBaseFile(variant.name)?.let { baselineFile ->
+                baseline.set(layout.file(project.provider { baselineFile }))
+            }
+            reports.xml.setDefaultIfUnset(File(extension.reportsDir, variant.name + ".xml"))
+            reports.html.setDefaultIfUnset(File(extension.reportsDir, variant.name + ".html"))
+            reports.txt.setDefaultIfUnset(File(extension.reportsDir, variant.name + ".txt"))
+            description = "EXPERIMENTAL: Run detekt analysis for ${variant.name} classes with type resolution"
+        }
+
+    private fun Project.registerAndroidCreateBaselineTask(
+        bootClasspath: FileCollection,
+        extension: DetektExtension,
+        variant: BaseVariant
+    ): TaskProvider<DetektCreateBaselineTask> =
+        registerCreateBaselineTask(DetektPlugin.BASELINE_TASK_NAME + variant.name.capitalize(), extension) {
+            setSource(variant.sourceSets.map { it.javaDirectories })
+            classpath.setFrom(variant.getCompileClasspath(null).filter { it.exists() } + bootClasspath)
+            val variantBaselineFile = extension.baseline?.addVariantName(variant.name)
+            baseline.set(project.layout.file(project.provider { variantBaselineFile }))
+            description = "EXPERIMENTAL: Creates detekt baseline for ${variant.name} classes with type resolution"
+        }
+}

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektJvm.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektJvm.kt
@@ -1,0 +1,52 @@
+package io.gitlab.arturbosch.detekt.internal
+
+import io.gitlab.arturbosch.detekt.DetektPlugin
+import io.gitlab.arturbosch.detekt.extensions.DetektExtension
+import org.gradle.api.GradleException
+import org.gradle.api.Project
+import org.gradle.api.internal.HasConvention
+import org.gradle.api.plugins.JavaPluginConvention
+import org.gradle.api.tasks.SourceSet
+import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
+import java.io.File
+
+internal class DetektJvm(private val project: Project) {
+    fun registerDetektJvmTasks(extension: DetektExtension) {
+        project.afterEvaluate {
+            project.convention.getPlugin(JavaPluginConvention::class.java).sourceSets.all { sourceSet ->
+                project.registerJvmDetektTask(extension, sourceSet)
+                project.registerJvmCreateBaselineTask(extension, sourceSet)
+            }
+        }
+    }
+
+    private fun Project.registerJvmDetektTask(extension: DetektExtension, sourceSet: SourceSet) {
+        val kotlinSourceSet = (sourceSet as HasConvention).convention.plugins["kotlin"] as? KotlinSourceSet
+            ?: throw GradleException("Kotlin source set not found. Please report on detekt's issue tracker")
+        registerDetektTask(DetektPlugin.DETEKT_TASK_NAME + sourceSet.name.capitalize(), extension) {
+            setSource(kotlinSourceSet.kotlin.files)
+            classpath.setFrom(sourceSet.compileClasspath, sourceSet.output.classesDirs.filter { it.exists() })
+            // If a baseline file is configured as input file, it must exist to be configured, otherwise the task fails.
+            // We try to find the configured baseline or alternatively a specific variant matching this task.
+            extension.baseline?.existingVariantOrBaseFile(sourceSet.name)?.let { baselineFile ->
+                baseline.set(layout.file(project.provider { baselineFile }))
+            }
+            reports.xml.setDefaultIfUnset(File(extension.reportsDir, sourceSet.name + ".xml"))
+            reports.html.setDefaultIfUnset(File(extension.reportsDir, sourceSet.name + ".html"))
+            reports.txt.setDefaultIfUnset(File(extension.reportsDir, sourceSet.name + ".txt"))
+            description = "EXPERIMENTAL: Run detekt analysis for ${sourceSet.name} classes with type resolution"
+        }
+    }
+
+    private fun Project.registerJvmCreateBaselineTask(extension: DetektExtension, sourceSet: SourceSet) {
+        val kotlinSourceSet = (sourceSet as HasConvention).convention.plugins["kotlin"] as? KotlinSourceSet
+            ?: throw GradleException("Kotlin source set not found. Please report on detekt's issue tracker")
+        registerCreateBaselineTask(DetektPlugin.BASELINE_TASK_NAME + sourceSet.name.capitalize(), extension) {
+            setSource(kotlinSourceSet.kotlin.files)
+            classpath.setFrom(sourceSet.compileClasspath, sourceSet.output.classesDirs.filter { it.exists() })
+            val variantBaselineFile = extension.baseline?.addVariantName(sourceSet.name)
+            baseline.set(project.layout.file(project.provider { variantBaselineFile }))
+            description = "EXPERIMENTAL: Creates detekt baseline for ${sourceSet.name} classes with type resolution"
+        }
+    }
+}

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/FileMangling.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/FileMangling.kt
@@ -1,0 +1,16 @@
+package io.gitlab.arturbosch.detekt.internal
+
+import java.io.File
+
+internal fun File?.existingVariantOrBaseFile(variant: String): File? {
+    val variantFile = this?.addVariantName(variant)
+    // if there is a file with the variant name, it has precedence
+    return when {
+        variantFile?.exists() == true -> variantFile
+        this?.exists() == true -> this
+        else -> null
+    }
+}
+
+internal fun File.addVariantName(variant: String, separator: String = "-"): File =
+    File(parent, name.substringBeforeLast(".") + "$separator$variant." + name.substringAfterLast("."))

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/SharedTasks.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/SharedTasks.kt
@@ -1,0 +1,51 @@
+package io.gitlab.arturbosch.detekt.internal
+
+import io.gitlab.arturbosch.detekt.Detekt
+import io.gitlab.arturbosch.detekt.DetektCreateBaselineTask
+import io.gitlab.arturbosch.detekt.DetektPlugin
+import io.gitlab.arturbosch.detekt.extensions.DetektExtension
+import io.gitlab.arturbosch.detekt.extensions.DetektReport
+import org.gradle.api.Project
+import org.gradle.api.tasks.TaskProvider
+import java.io.File
+
+internal fun Project.registerDetektTask(
+    name: String,
+    extension: DetektExtension,
+    configuration: Detekt.() -> Unit
+): TaskProvider<Detekt> =
+    tasks.register(name, Detekt::class.java) {
+        it.debugProp.set(provider { extension.debug })
+        it.parallelProp.set(provider { extension.parallel })
+        it.disableDefaultRuleSetsProp.set(provider { extension.disableDefaultRuleSets })
+        it.buildUponDefaultConfigProp.set(provider { extension.buildUponDefaultConfig })
+        it.failFastProp.set(provider { extension.failFast })
+        it.autoCorrectProp.set(provider { extension.autoCorrect })
+        it.config.setFrom(provider { extension.config })
+        it.ignoreFailuresProp.set(project.provider { extension.ignoreFailures })
+        configuration(it)
+    }
+
+internal fun Project.registerCreateBaselineTask(
+    name: String,
+    extension: DetektExtension,
+    configuration: DetektCreateBaselineTask.() -> Unit
+): TaskProvider<DetektCreateBaselineTask> =
+    tasks.register(name, DetektCreateBaselineTask::class.java) {
+        it.config.setFrom(project.provider { extension.config })
+        it.debug.set(project.provider { extension.debug })
+        it.parallel.set(project.provider { extension.parallel })
+        it.disableDefaultRuleSets.set(project.provider { extension.disableDefaultRuleSets })
+        it.buildUponDefaultConfig.set(project.provider { extension.buildUponDefaultConfig })
+        it.failFast.set(project.provider { extension.failFast })
+        it.autoCorrect.set(project.provider { extension.autoCorrect })
+        it.setIncludes(DetektPlugin.defaultIncludes)
+        it.setExcludes(DetektPlugin.defaultExcludes)
+        configuration(it)
+    }
+
+internal fun DetektReport.setDefaultIfUnset(default: File) {
+    if (destination == null) {
+        destination = default
+    }
+}

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektPluginTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektPluginTest.kt
@@ -1,16 +1,22 @@
 package io.gitlab.arturbosch.detekt
 
+import com.android.build.gradle.AppExtension
+import com.android.build.gradle.BaseExtension
+import com.android.build.gradle.LibraryExtension
+import com.android.build.gradle.TestExtension
+import io.gitlab.arturbosch.detekt.extensions.DetektExtension
 import org.assertj.core.api.Assertions.assertThat
+import org.gradle.api.Action
+import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.language.base.plugins.LifecycleBasePlugin
 import org.gradle.testfixtures.ProjectBuilder
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
 object DetektPluginTest : Spek({
-    describe("detekt plugin") {
-
-        fun Task.dependencies() = taskDependencies.getDependencies(this)
+    describe("detekt plugin - JVM") {
 
         it("lazily adds detekt as a dependency of the `check` task") {
             val project = ProjectBuilder.builder().build()
@@ -20,7 +26,326 @@ object DetektPluginTest : Spek({
             project.pluginManager.apply(DetektPlugin::class.java)
             project.pluginManager.apply(LifecycleBasePlugin::class.java)
 
-            assertThat(project.tasks.getAt("check").dependencies().map { it.name }).contains("detekt")
+            assertThat(project.tasks.getAt("check").dependencies()).contains("detekt")
+        }
+    }
+
+    describe("detekt plugin - Android") {
+        it("applies the base gradle plugin and creates a regular detekt task") {
+            val project = ProjectBuilder.builder().build()
+
+            with(project.pluginManager) {
+                apply(DetektPlugin::class.java)
+                apply(LifecycleBasePlugin::class.java)
+            }
+
+            assertThat(project.getTask("check").dependencies()).contains("detekt")
+        }
+
+        it("lets the base gradle plugin use it's configuration") {
+            val project = ProjectBuilder.builder().build()
+
+            with(project.pluginManager) {
+                apply(DetektPlugin::class.java)
+                apply(LifecycleBasePlugin::class.java)
+            }
+
+            project.configureExtension<DetektExtension> {
+                parallel = true
+            }
+
+            assertThat((project.getTask("detekt") as Detekt).parallel).isTrue()
+        }
+
+        it("creates experimental tasks if the Android library plugin is present") {
+            with(ProjectBuilder.builder().build()) {
+                androidPluginSetup("com.android.library")
+
+                configureExtension<LibraryExtension> {
+                    compileSdkVersion(ANDROID_COMPILE_SDK_VERSION)
+                }
+
+                evaluate()
+
+                assertThat(getTask("detektMain").dependencies())
+                    .containsExactlyInAnyOrder("detektDebug", "detektRelease")
+
+                assertThat(getTask("detektTest").dependencies())
+                    .containsExactlyInAnyOrder(
+                        "detektDebugUnitTest",
+                        "detektReleaseUnitTest",
+                        "detektDebugAndroidTest"
+                    )
+            }
+        }
+
+        it("creates experimental tasks if the Android application plugin is present") {
+            with(ProjectBuilder.builder().build()) {
+
+                androidPluginSetup("com.android.application")
+
+                configureExtension<AppExtension> {
+                    compileSdkVersion(ANDROID_COMPILE_SDK_VERSION)
+                }
+
+                evaluate()
+
+                assertThat(getTask("detektMain").dependencies())
+                    .containsExactlyInAnyOrder("detektDebug", "detektRelease")
+
+                assertThat(getTask("detektTest").dependencies())
+                    .containsExactlyInAnyOrder(
+                        "detektDebugUnitTest",
+                        "detektReleaseUnitTest",
+                        "detektDebugAndroidTest"
+                    )
+            }
+        }
+
+        it("creates experimental tasks if the Android test plugin is present") {
+            with(ProjectBuilder.builder().build()) {
+                ProjectBuilder.builder().withParent(this).withName("prod").build()
+
+                androidPluginSetup("com.android.test")
+
+                configureExtension<TestExtension> {
+                    compileSdkVersion(ANDROID_COMPILE_SDK_VERSION)
+                    targetProjectPath("prod")
+                }
+
+                evaluate()
+
+                // Test extensions by default have only the debug variant configured
+                assertThat(getTask("detektMain").dependencies())
+                    .containsExactlyInAnyOrder("detektDebug")
+
+                // There is no test code for test modules, so we don't create a task for that either
+                assertThat(tasks.findByName("detektTest")).isNull()
+            }
+        }
+
+        it("creates experimental tasks for different build variants") {
+            with(ProjectBuilder.builder().build()) {
+
+                androidPluginSetup("com.android.library")
+
+                configureExtension<LibraryExtension> {
+                    compileSdkVersion(ANDROID_COMPILE_SDK_VERSION)
+                    flavorTestSetup()
+                }
+
+                evaluate()
+
+                assertThat(getTask("detektMain").dependencies())
+                    .containsExactlyInAnyOrder(
+                        "detektYoungHarryDebug",
+                        "detektYoungHarryRelease",
+                        "detektOldHarryDebug",
+                        "detektOldHarryRelease",
+                        "detektYoungSallyDebug",
+                        "detektYoungSallyRelease",
+                        "detektOldSallyDebug",
+                        "detektOldSallyRelease"
+                    )
+
+                assertThat(getTask("detektTest").dependencies())
+                    .containsExactlyInAnyOrder(
+                        // unit tests
+                        "detektYoungHarryDebugUnitTest",
+                        "detektYoungHarryReleaseUnitTest",
+                        "detektOldHarryDebugUnitTest",
+                        "detektOldHarryReleaseUnitTest",
+                        "detektYoungSallyDebugUnitTest",
+                        "detektYoungSallyReleaseUnitTest",
+                        "detektOldSallyDebugUnitTest",
+                        "detektOldSallyReleaseUnitTest",
+                        // instrumentation tests
+                        "detektYoungHarryDebugAndroidTest",
+                        "detektOldHarryDebugAndroidTest",
+                        "detektYoungSallyDebugAndroidTest",
+                        "detektOldSallyDebugAndroidTest"
+                    )
+            }
+        }
+
+        it("creates experimental tasks for different build variants excluding ignored variants") {
+            with(ProjectBuilder.builder().build()) {
+
+                androidPluginSetup("com.android.library")
+
+                configureExtension<LibraryExtension> {
+                    compileSdkVersion(ANDROID_COMPILE_SDK_VERSION)
+                    flavorTestSetup()
+                }
+
+                configureExtension<DetektExtension> {
+                    ignoredVariants = listOf("youngHarryDebug", "oldSallyRelease")
+                }
+
+                evaluate()
+
+                assertThat(getTask("detektMain").dependencies())
+                    .containsExactlyInAnyOrder(
+                        "detektYoungHarryRelease",
+                        "detektOldHarryDebug",
+                        "detektOldHarryRelease",
+                        "detektYoungSallyDebug",
+                        "detektYoungSallyRelease",
+                        "detektOldSallyDebug"
+                    )
+
+                assertThat(getTask("detektTest").dependencies())
+                    .containsExactlyInAnyOrder(
+                        // unit tests
+                        "detektYoungHarryReleaseUnitTest",
+                        "detektOldHarryDebugUnitTest",
+                        "detektOldHarryReleaseUnitTest",
+                        "detektYoungSallyDebugUnitTest",
+                        "detektYoungSallyReleaseUnitTest",
+                        "detektOldSallyDebugUnitTest",
+                        // instrumentation tests
+                        "detektOldHarryDebugAndroidTest",
+                        "detektYoungSallyDebugAndroidTest",
+                        "detektOldSallyDebugAndroidTest"
+                    )
+            }
+        }
+
+        it("creates experimental tasks for different build variants excluding ignored build types") {
+            with(ProjectBuilder.builder().build()) {
+
+                androidPluginSetup("com.android.library")
+
+                configureExtension<LibraryExtension> {
+                    compileSdkVersion(ANDROID_COMPILE_SDK_VERSION)
+                    flavorTestSetup()
+                }
+
+                configureExtension<DetektExtension> {
+                    ignoredBuildTypes = listOf("release")
+                }
+
+                evaluate()
+
+                assertThat(getTask("detektMain").dependencies())
+                    .containsExactlyInAnyOrder(
+                        "detektYoungHarryDebug",
+                        "detektOldHarryDebug",
+                        "detektYoungSallyDebug",
+                        "detektOldSallyDebug"
+                    )
+
+                assertThat(getTask("detektTest").dependencies())
+                    .containsExactlyInAnyOrder(
+                        // unit tests
+                        "detektYoungHarryDebugUnitTest",
+                        "detektOldHarryDebugUnitTest",
+                        "detektYoungSallyDebugUnitTest",
+                        "detektOldSallyDebugUnitTest",
+                        // instrumentation tests
+                        "detektYoungHarryDebugAndroidTest",
+                        "detektOldHarryDebugAndroidTest",
+                        "detektYoungSallyDebugAndroidTest",
+                        "detektOldSallyDebugAndroidTest"
+                    )
+            }
+        }
+
+        it("creates no tasks if all build types are ignored") {
+            with(ProjectBuilder.builder().build()) {
+
+                androidPluginSetup("com.android.library")
+
+                configureExtension<LibraryExtension> {
+                    compileSdkVersion(ANDROID_COMPILE_SDK_VERSION)
+                    flavorTestSetup()
+                }
+
+                configureExtension<DetektExtension> {
+                    ignoredBuildTypes = listOf("debug", "release")
+                }
+
+                evaluate()
+
+                assertThat(tasks.findByName("detektMain")).isNull()
+                assertThat(tasks.findByName("detektTest")).isNull()
+            }
+        }
+
+        it("creates experimental tasks for different build variants excluding ignored flavors") {
+            with(ProjectBuilder.builder().build()) {
+
+                androidPluginSetup("com.android.library")
+
+                configureExtension<LibraryExtension> {
+                    compileSdkVersion(ANDROID_COMPILE_SDK_VERSION)
+                    flavorTestSetup()
+                }
+
+                configureExtension<DetektExtension> {
+                    ignoredFlavors = listOf("oldHarry", "youngSally")
+                }
+
+                evaluate()
+
+                assertThat(getTask("detektMain").dependencies())
+                    .containsExactlyInAnyOrder(
+                        "detektYoungHarryDebug",
+                        "detektYoungHarryRelease",
+                        "detektOldSallyDebug",
+                        "detektOldSallyRelease"
+                    )
+
+                assertThat(getTask("detektTest").dependencies())
+                    .containsExactlyInAnyOrder(
+                        // unit tests
+                        "detektYoungHarryDebugUnitTest",
+                        "detektYoungHarryReleaseUnitTest",
+                        "detektOldSallyDebugUnitTest",
+                        "detektOldSallyReleaseUnitTest",
+                        // instrumentation tests
+                        "detektYoungHarryDebugAndroidTest",
+                        "detektOldSallyDebugAndroidTest"
+                    )
+            }
         }
     }
 })
+
+internal const val ANDROID_COMPILE_SDK_VERSION = 29
+
+internal fun Task.dependencies() = taskDependencies.getDependencies(this).map { it.name }
+
+internal fun Project.androidPluginSetup(androidPlugin: String) {
+    with(pluginManager) {
+        apply(DetektPlugin::class.java)
+        apply(androidPlugin)
+        apply("kotlin-android")
+    }
+}
+
+internal fun Project.getTask(name: String) = project.tasks.getAt(name)
+
+internal fun Project.evaluate() = (this as ProjectInternal).evaluate()
+
+internal fun BaseExtension.flavorTestSetup() {
+    flavorDimensions("age", "name")
+    productFlavors(Action {
+        it.create("harry").apply {
+            dimension = "name"
+        }
+        it.create("sally").apply {
+            dimension = "name"
+        }
+        it.create("young").apply {
+            dimension = "age"
+        }
+        it.create("old").apply {
+            dimension = "age"
+        }
+    })
+}
+
+internal inline fun <reified T : Any> Project.configureExtension(configuration: T.() -> Unit = {}) {
+    project.extensions.findByType(T::class.java)?.apply(configuration)
+}


### PR DESCRIPTION
The Gradle Plugin was missing automatic task generation for Android modules, so I tried adding them.

While this works in general, I still get a couple of compilation issues when running the task on different modules, mainly things that stem from code generation:

```kotlin
/DownloadApiFactory.kt:7:24: error: unresolved reference: BuildConfig
import my.module.BuildConfig
                       ^
/DownloadApiFactory.kt:28:52: error: unresolved reference: BuildConfig
        .client(downloadOkHttpFactory.createClient(BuildConfig.DEBUG, readTimeOutSeconds))
```
