### PR TITLE
Smarter Caching on Github Actions

### DIFF
--- a/.github/workflows/deploy-snapshot.yaml
+++ b/.github/workflows/deploy-snapshot.yaml
@@ -21,7 +21,7 @@ jobs:
         path: |
           ~/.gradle/caches/
           ~/.gradle/wrapper/
-        key: cache-gradle-${{ hashFiles('buildSrc/src/main/kotlin/Versions.kt') }}
+        key: cache-gradle-${{ hashFiles('detekt-bom/build.gradle.kts') }}
         restore-keys: |
           cache-gradle-
 

--- a/.github/workflows/deploy-snapshot.yaml
+++ b/.github/workflows/deploy-snapshot.yaml
@@ -15,16 +15,15 @@ jobs:
     - name: Checkout Repo
       uses: actions/checkout@v2
 
-    - name: Cache Gradle Caches
+    - name: Cache Gradle Folders
       uses: actions/cache@v2
       with:
-        path: ~/.gradle/caches/
-        key: cache-gradle-deploy-snapshot
-    - name: Cache Gradle Wrapper
-      uses: actions/cache@v2
-      with:
-        path: ~/.gradle/wrapper/
-        key: cache-wrapper-deploy-snapshot
+        path: |
+          ~/.gradle/caches/
+          ~/.gradle/wrapper/
+        key: cache-gradle-${{ hashFiles('buildSrc/src/main/kotlin/Versions.kt') }}
+        restore-keys: |
+          cache-gradle-
 
     - name: Setup Java
       uses: actions/setup-java@v1

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -35,16 +35,17 @@ jobs:
         rm -rf ~/.gradle/wrapper/
 
 
-    - name: Cache Gradle Caches
+    - name: Cache Gradle Folders
       uses: actions/cache@v2
       with:
-        path: ~/.gradle/caches/
-        key: cache-clean-gradle-${{ matrix.os }}-${{ matrix.jdk }}
-    - name: Cache Gradle Wrapper
-      uses: actions/cache@v2
-      with:
-        path: ~/.gradle/wrapper/
-        key: cache-clean-wrapper-${{ matrix.os }}-${{ matrix.jdk }}
+        path: |
+          ~/.gradle/caches/
+          ~/.gradle/wrapper/
+        key: cache-gradle-${{ matrix.os }}-${{ matrix.jdk }}-${{ hashFiles('buildSrc/src/main/kotlin/Versions.kt') }}
+        restore-keys: |
+          cache-gradle-${{ matrix.os }}-${{ matrix.jdk }}-
+          cache-gradle-${{ matrix.os }}-
+          cache-gradle-
 
 
     - name: Setup Java

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -41,7 +41,7 @@ jobs:
         path: |
           ~/.gradle/caches/
           ~/.gradle/wrapper/
-        key: cache-gradle-${{ matrix.os }}-${{ matrix.jdk }}-${{ hashFiles('buildSrc/src/main/kotlin/Versions.kt') }}
+        key: cache-gradle-${{ matrix.os }}-${{ matrix.jdk }}-${{ hashFiles('detekt-bom/build.gradle.kts') }}
         restore-keys: |
           cache-gradle-${{ matrix.os }}-${{ matrix.jdk }}-
           cache-gradle-${{ matrix.os }}-


### PR DESCRIPTION
Currently our Github Actions setup relies on a static key for caching.

This means that we restore an old Gradle cache that doesn't contain the version of Gradle we need (it gets re-downloaded every time).

Given that we don't have a lockfile (should we consider it?), I'm hashing 'buildSrc/src/main/kotlin/Versions.kt' and adding it to the cache key. So the cache will be partially invalidated whenever we release a new version (or whenever we bump a library).