### PR TITLE
Introduce BoM to manage our own dependencies

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -2,15 +2,6 @@ object Versions {
 
     const val DETEKT: String = "1.9.1"
     const val JVM_TARGET: String = "1.8"
-    const val ASSERTJ: String = "3.16.1"
-    const val SPEK: String = "2.0.11"
-    const val REFLECTIONS: String = "0.9.12"
-    const val MOCKK: String = "1.10.0"
-    const val JUNIT: String = "1.6.2"
-    const val JCOMMANDER: String = "1.78"
-    const val SNAKEYAML: String = "1.26"
-    const val KTLINT: String = "0.37.1"
-    const val KOTLINX_HTML: String = "0.7.1"
     const val JACOCO: String = "0.8.5"
 
     fun currentOrSnapshot(): String {

--- a/buildSrc/src/main/kotlin/commons.gradle.kts
+++ b/buildSrc/src/main/kotlin/commons.gradle.kts
@@ -16,7 +16,7 @@ allprojects {
     }
 }
 
-subprojects {
+configure(subprojects.filter { it.name != "detekt-bom" }) {
 
     val project = this
 

--- a/buildSrc/src/main/kotlin/commons.gradle.kts
+++ b/buildSrc/src/main/kotlin/commons.gradle.kts
@@ -70,15 +70,16 @@ configure(subprojects.filter { it.name != "detekt-bom" }) {
     }
 
     dependencies {
+        implementation(platform(project(":detekt-bom")))
         compileOnly(kotlin("stdlib-jdk8"))
 
-        testImplementation("org.assertj:assertj-core:${Versions.ASSERTJ}")
-        testImplementation("org.spekframework.spek2:spek-dsl-jvm:${Versions.SPEK}")
-        testImplementation("org.reflections:reflections:${Versions.REFLECTIONS}")
-        testImplementation("io.mockk:mockk:${Versions.MOCKK}")
+        testImplementation("org.assertj:assertj-core")
+        testImplementation("org.spekframework.spek2:spek-dsl-jvm")
+        testImplementation("org.reflections:reflections")
+        testImplementation("io.mockk:mockk")
 
-        testRuntimeOnly("org.junit.platform:junit-platform-launcher:${Versions.JUNIT}")
-        testRuntimeOnly("org.spekframework.spek2:spek-runner-junit5:${Versions.SPEK}")
+        testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+        testRuntimeOnly("org.spekframework.spek2:spek-runner-junit5")
     }
 }
 

--- a/buildSrc/src/main/kotlin/packaging.gradle.kts
+++ b/buildSrc/src/main/kotlin/packaging.gradle.kts
@@ -26,6 +26,7 @@ project(":detekt-cli") {
 subprojects {
 
     apply {
+        plugin("java-library")
         plugin("maven-publish")
         plugin("com.jfrog.bintray")
         plugin("com.jfrog.artifactory")

--- a/buildSrc/src/main/kotlin/packaging.gradle.kts
+++ b/buildSrc/src/main/kotlin/packaging.gradle.kts
@@ -23,7 +23,7 @@ project(":detekt-cli") {
     }
 }
 
-subprojects {
+configure(subprojects.filter { it.name != "detekt-bom" }) {
 
     apply {
         plugin("java-library")

--- a/detekt-api/build.gradle.kts
+++ b/detekt-api/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 dependencies {
-    implementation("org.yaml:snakeyaml:${Versions.SNAKEYAML}")
+    implementation("org.yaml:snakeyaml")
     api(kotlin("compiler-embeddable"))
     api(project(":detekt-psi-utils"))
 

--- a/detekt-bom/build.gradle.kts
+++ b/detekt-bom/build.gradle.kts
@@ -1,0 +1,26 @@
+plugins {
+    `java-platform`
+}
+
+dependencies {
+    val version = object {
+        val spek = "2.0.11"
+        val ktlint = "0.37.1"
+    }
+
+    constraints {
+        api("org.assertj:assertj-core:3.16.1")
+        api("org.spekframework.spek2:spek-dsl-jvm:${version.spek}")
+        api("org.spekframework.spek2:spek-runner-junit5:${version.spek}")
+        api("org.reflections:reflections:0.9.12")
+        api("io.mockk:mockk:1.10.0")
+        api("org.junit.platform:junit-platform-launcher:1.6.2")
+        api("org.yaml:snakeyaml:1.26")
+        api("com.beust:jcommander:1.78")
+        api("com.pinterest.ktlint:ktlint-ruleset-standard:${version.ktlint}")
+        api("com.pinterest.ktlint:ktlint-core:${version.ktlint}")
+        api("com.pinterest.ktlint:ktlint-ruleset-experimental:${version.ktlint}")
+        api("org.jetbrains.kotlinx:kotlinx-html-jvm:0.7.1")
+        api("org.assertj:assertj-core:3.16.1")
+    }
+}

--- a/detekt-cli/build.gradle.kts
+++ b/detekt-cli/build.gradle.kts
@@ -6,7 +6,7 @@ dependencies {
     implementation(kotlin("stdlib-jdk8"))
     implementation(project(":detekt-core"))
     runtimeOnly(project(":detekt-rules"))
-    implementation("com.beust:jcommander:${Versions.JCOMMANDER}")
+    implementation("com.beust:jcommander")
 
     testImplementation(project(":detekt-test"))
     testImplementation(project(":detekt-rules"))

--- a/detekt-formatting/build.gradle.kts
+++ b/detekt-formatting/build.gradle.kts
@@ -1,12 +1,12 @@
 dependencies {
     implementation(project(":detekt-api"))
-    implementation("com.pinterest.ktlint:ktlint-ruleset-standard:${Versions.KTLINT}") {
+    implementation("com.pinterest.ktlint:ktlint-ruleset-standard") {
         exclude(group = "org.jetbrains.kotlin")
     }
-    implementation("com.pinterest.ktlint:ktlint-core:${Versions.KTLINT}") {
+    implementation("com.pinterest.ktlint:ktlint-core") {
         exclude(group = "org.jetbrains.kotlin")
     }
-    implementation("com.pinterest.ktlint:ktlint-ruleset-experimental:${Versions.KTLINT}") {
+    implementation("com.pinterest.ktlint:ktlint-ruleset-experimental") {
         exclude(group = "org.jetbrains.kotlin")
     }
 

--- a/detekt-generator/build.gradle.kts
+++ b/detekt-generator/build.gradle.kts
@@ -5,7 +5,7 @@ dependencies {
     implementation(project(":detekt-api"))
     implementation(project(":detekt-rules"))
     implementation(project(":detekt-formatting"))
-    implementation("com.beust:jcommander:${Versions.JCOMMANDER}")
+    implementation("com.beust:jcommander")
 
     testImplementation(project(":detekt-test-utils"))
 }

--- a/detekt-report-html/build.gradle.kts
+++ b/detekt-report-html/build.gradle.kts
@@ -1,7 +1,7 @@
 dependencies {
     compileOnly(project(":detekt-api"))
     compileOnly(project(":detekt-metrics"))
-    implementation("org.jetbrains.kotlinx:kotlinx-html-jvm:${Versions.KOTLINX_HTML}") {
+    implementation("org.jetbrains.kotlinx:kotlinx-html-jvm") {
         exclude(group = "org.jetbrains.kotlin")
     }
     testImplementation(project(":detekt-metrics"))

--- a/detekt-test-utils/build.gradle.kts
+++ b/detekt-test-utils/build.gradle.kts
@@ -1,6 +1,6 @@
 dependencies {
     api(kotlin("stdlib-jdk8"))
-    api("org.assertj:assertj-core:${Versions.ASSERTJ}")
+    api("org.assertj:assertj-core")
     implementation(project(":detekt-parser"))
     implementation(project(":detekt-psi-utils"))
     implementation(kotlin("script-runtime"))

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,6 +2,7 @@ rootProject.name = "detekt"
 include(
     "detekt-api",
     "detekt-cli",
+    "detekt-bom",
     "detekt-core",
     "detekt-formatting",
     "detekt-generator",


### PR DESCRIPTION
Right now this [Bill of Materials (BoM)](https://docs.gradle.org/current/userguide/platforms.html) module just manage our dependencies. We could expose it so our users can align it's dependencies easier too. If we want to do that we should iterate this file a bit more.

After this change the file `buildSrc/Versions.kt` seems kind of pointless. I think that we should be able to move all those consts to better places.