### PR TITLE
Fix false positive for UnusedPrivateClass on generics

### DIFF
--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateClass.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateClass.kt
@@ -134,9 +134,8 @@ class UnusedPrivateClass(config: Config = Config.empty) : Rule(config) {
         override fun visitCallExpression(expression: KtCallExpression) {
             expression.calleeExpression?.text?.run { namedClasses.add(this) }
             expression.typeArguments
-                .forEach {
-                    namedClasses.add(it.text)
-                }
+                .mapNotNull { it.typeReference }
+                .forEach { registerAccess(it) }
             super.visitCallExpression(expression)
         }
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateClassSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateClassSpec.kt
@@ -131,6 +131,28 @@ class UnusedPrivateClassSpec : Spek({
             assertThat(lint).isEmpty()
         }
 
+        it("should not report them if used as inner type parameter") {
+            val code = """
+                val elements = listOf(42).filterIsInstance<Set<Item>>()
+                private class Item
+                """
+
+            val lint = subject.compileAndLint(code)
+
+            assertThat(lint).isEmpty()
+        }
+
+        it("should not report them if used as outer type parameter") {
+            val code = """
+                val elements = listOf(42).filterIsInstance<Something<Int>>()
+                private abstract class Something<E>: Collection<E>
+                """
+
+            val lint = subject.compileAndLint(code)
+
+            assertThat(lint).isEmpty()
+        }
+
         it("should not report them if used as generic type in functions") {
             val code = """
                 private class Foo

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateClassSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateClassSpec.kt
@@ -133,7 +133,7 @@ class UnusedPrivateClassSpec : Spek({
 
         it("should not report them if used as inner type parameter") {
             val code = """
-                val elements = listOf(42).filterIsInstance<Set<Item>>()
+                private val elements = listOf(42).filterIsInstance<Set<Item>>()
                 private class Item
                 """
 
@@ -144,7 +144,7 @@ class UnusedPrivateClassSpec : Spek({
 
         it("should not report them if used as outer type parameter") {
             val code = """
-                val elements = listOf(42).filterIsInstance<Something<Int>>()
+                private val elements = listOf(42).filterIsInstance<Something<Int>>()
                 private abstract class Something<E>: Collection<E>
                 """
 


### PR DESCRIPTION
Covered the scenario for more complex type parameters. I've also added a couple of tests.

Fixes #2791 

