### PR TITLE
Fix wrong bom project name in jacocoTestReport

### DIFF
--- a/buildSrc/src/main/kotlin/commons.gradle.kts
+++ b/buildSrc/src/main/kotlin/commons.gradle.kts
@@ -90,7 +90,7 @@ configure(listOf(project(":detekt-rules"), project(":detekt-formatting"))) {
 jacoco.toolVersion = Versions.JACOCO
 
 val examplesOrTestUtils = setOf(
-    "detekt-pom",
+    "detekt-bom",
     "detekt-test",
     "detekt-test-utils",
     "detekt-sample-extensions"


### PR DESCRIPTION
Seems like we do have a broken `jacocoTestReport` that is making our CI fail. The reason is a typo in the project filter used to create the `jacocoTestReport` task.
