### PR TITLE
Run verifyGeneratorOutput in a isolated job

### DIFF
--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -10,13 +10,13 @@ on:
 
 jobs:
   gradle:
+    if: ${{ !contains(github.event.head_commit.message, 'ci skip') }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         jdk: [8, 11, 14]
     runs-on: ${{ matrix.os }}
-    if: ${{ !contains(github.event.head_commit.message, 'ci skip') }}
     env:
       # We compile the test snippets only on Java 8.
       COMPILE_TEST_SNIPPETS: ${{ matrix.os == 'ubuntu-latest' && matrix.jdk == 8 }}
@@ -76,5 +76,29 @@ jobs:
       if: matrix.os == 'windows-latest'
 
 
+  verify-documentation:
+    if: ${{ !contains(github.event.head_commit.message, 'ci skip') }}
+    runs-on: ubuntu-latest
+    env:
+      GRADLE_OPTS: -Dorg.gradle.daemon=false
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v2
+    - name: Cache Gradle Folders
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.gradle/caches/
+          ~/.gradle/wrapper/
+        key: cache-gradle-ubuntu-latest-14-verifygenerator-${{ hashFiles('detekt-bom/build.gradle.kts') }}
+        restore-keys: |
+          cache-gradle-ubuntu-latest-14-verifygenerator-
+          cache-gradle-ubuntu-latest-14-
+          cache-gradle-ubuntu-latest-
+          cache-gradle-
+    - name: Setup Java
+      uses: actions/setup-java@v1
+      with:
+        java-version: 14
     - name: Verify Generator Output
       run: ./gradlew verifyGeneratorOutput


### PR DESCRIPTION
The idea behind this PR is to move the `verifyGeneratorOutput` gradle task outside of the Build matrix and run in a parallel job (still within the `pre-merge` workflow).

We spend ~1minute in verify the documentation on every build (and this happens 9 times, once for every job of the matrix). We could parallelise this and have a separate job that will just check the generated documentation.

This has also a nice side effect: contributors will see immediately if their build failed because of a test failure or because of missing documentation updates.