### PR TITLE
Run compile-test-snippets in a isolated job

### DIFF
--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -125,6 +125,6 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v1
         with:
-          java-version: 8
+          java-version: 14
       - name: Build and compile test snippets
         run: ./gradlew test -x ":detekt-gradle-plugin:test" -Pcompile-test-snippets=true

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -127,4 +127,4 @@ jobs:
         with:
           java-version: 8
       - name: Build and compile test snippets
-        run: ./gradlew build -PwarningsAsErrors=true -Pcompile-test-snippets=true
+        run: ./gradlew test -x ":detekt-gradle-plugin:test" -Pcompile-test-snippets=true

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -64,7 +64,7 @@ jobs:
 
 
     - name: Build detekt (WIN)
-      run: ./gradlew build installShadowDist -PwarningsAsErrors=true -Pcompile-test-snippets=%COMPILE_TEST_SNIPPETS%
+      run: ./gradlew build installShadowDist -PwarningsAsErrors=true
       if: matrix.os == 'windows-latest'
     - name: Run detekt-cli --help (WIN)
       run: detekt-cli\build\install\detekt-cli-shadow\bin\detekt-cli --help

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -125,6 +125,6 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v1
         with:
-          java-version: 14
+          java-version: 8
       - name: Build and compile test snippets
         run: ./gradlew test -x ":detekt-gradle-plugin:test" -Pcompile-test-snippets=true

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -18,8 +18,6 @@ jobs:
         jdk: [8, 11, 14]
     runs-on: ${{ matrix.os }}
     env:
-      # We compile the test snippets only on Java 8.
-      COMPILE_TEST_SNIPPETS: ${{ matrix.os == 'ubuntu-latest' && matrix.jdk == 8 }}
       JDK_VERSION:  ${{ matrix.jdk }}
       GRADLE_OPTS: -Dorg.gradle.daemon=false
     steps:
@@ -55,7 +53,7 @@ jobs:
 
 
     - name: Build detekt (UNIX)
-      run: ./gradlew build shadowJar -PwarningsAsErrors=true -Pcompile-test-snippets=$COMPILE_TEST_SNIPPETS
+      run: ./gradlew build shadowJar -PwarningsAsErrors=true
       if: matrix.os == 'macos-latest' || matrix.os == 'ubuntu-latest'
     - name: Run detekt-cli --help (UNIX)
       run: java -jar ./detekt-cli/build/libs/detekt-cli-*-all.jar --help
@@ -102,3 +100,31 @@ jobs:
         java-version: 14
     - name: Verify Generator Output
       run: ./gradlew verifyGeneratorOutput
+
+
+  compile-test-snippets:
+    if: ${{ !contains(github.event.head_commit.message, 'ci skip') }}
+    runs-on: ubuntu-latest
+    env:
+      GRADLE_OPTS: -Dorg.gradle.daemon=false
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - name: Cache Gradle Folders
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches/
+            ~/.gradle/wrapper/
+          key: cache-gradle-ubuntu-latest-8-compiletestsnippets-${{ hashFiles('detekt-bom/build.gradle.kts') }}
+          restore-keys: |
+            cache-gradle-ubuntu-latest-8-compiletestsnippets-
+            cache-gradle-ubuntu-latest-8-
+            cache-gradle-ubuntu-latest-
+            cache-gradle-
+      - name: Setup Java
+        uses: actions/setup-java@v1
+        with:
+          java-version: 8
+      - name: Build and compile test snippets
+        run: ./gradlew build -PwarningsAsErrors=true -Pcompile-test-snippets=true


### PR DESCRIPTION
Similarly to what was done in #2796, I'm extracting a job for `compile-test-snippets` only. That's our biggest bottleneck at the moment.

This job (`compile-test-snippets`) will run in parallel with the others and should speedup the whole CI, given that we don't run `detekt-cli` on this job but just `./gradlew build -Pcompile-test-snippets=true`.

Moreover, this should provide a better hint for contributors on what's the failure of their build (i.e. they don't need to know that we compile snippets only on ubuntu-latest + java8 to understand what failed).


