### PR TITLE
Simplify the Code Coverage workflow

### DIFF
--- a/.github/workflows/codecoverage.yaml
+++ b/.github/workflows/codecoverage.yaml
@@ -9,13 +9,9 @@ on:
       - '*'
 
 jobs:
-  gradle:
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        jdk: [11]
-    runs-on: ${{ matrix.os }}
+  publish-code-coverage:
     if: ${{ !contains(github.event.head_commit.message, 'coverage skip') }}
+    runs-on: ubuntu-latest
     env:
       JDK_VERSION:  ${{ matrix.jdk }}
       GRADLE_OPTS: -Dorg.gradle.daemon=false
@@ -26,7 +22,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v1
         with:
-          java-version: ${{ matrix.jdk }}
+          java-version: 11
 
       - name: Generate Coverage Report
         run: ./gradlew jacocoTestReport -Dorg.gradle.caching=false


### PR DESCRIPTION
We don't need a build matrix for the codecoverage workflow, so I'm simplifying the workflow a bit.