### PR TITLE
Compile Test Snippets on Java 14

### DIFF
--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -116,15 +116,15 @@ jobs:
           path: |
             ~/.gradle/caches/
             ~/.gradle/wrapper/
-          key: cache-gradle-ubuntu-latest-8-compiletestsnippets-${{ hashFiles('detekt-bom/build.gradle.kts') }}
+          key: cache-gradle-ubuntu-latest-14-compiletestsnippets-${{ hashFiles('detekt-bom/build.gradle.kts') }}
           restore-keys: |
-            cache-gradle-ubuntu-latest-8-compiletestsnippets-
-            cache-gradle-ubuntu-latest-8-
+            cache-gradle-ubuntu-latest-14-compiletestsnippets-
+            cache-gradle-ubuntu-latest-14-
             cache-gradle-ubuntu-latest-
             cache-gradle-
       - name: Setup Java
         uses: actions/setup-java@v1
         with:
-          java-version: 8
+          java-version: 14
       - name: Build and compile test snippets
         run: ./gradlew test -x ":detekt-gradle-plugin:test" -Pcompile-test-snippets=true

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterListSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterListSpec.kt
@@ -91,21 +91,24 @@ class LongParameterListSpec : Spek({
         describe("constructors and functions with ignored annotations") {
 
             val config = TestConfig(mapOf(
-                LongParameterList.IGNORE_ANNOTATED to listOf("javax.annotation.Generated", "kotlin.Deprecated"),
+                LongParameterList.IGNORE_ANNOTATED to listOf("Generated", "kotlin.Deprecated", "kotlin.jvm.JvmName"),
                 LongParameterList.FUNCTION_THRESHOLD to 1,
                 LongParameterList.CONSTRUCTOR_THRESHOLD to 1
             ))
             val rule = LongParameterList(config)
 
             it("does not report long parameter list for constructors if file is annotated with ignored annotation") {
-                val code = "@file:javax.annotation.Generated class Data(val a: Int)"
+                val code = """
+                    @file:kotlin.jvm.JvmName("test")
+                    class Data(val a: Int)
+                """
                 assertThat(rule.compileAndLint(code)).isEmpty()
             }
 
             it("does not report long parameter list for functions if file is annotated with ignored annotation") {
                 val code = """
-                    @file:javax.annotation.Generated 
-                    class Data { 
+                    @file:kotlin.jvm.JvmName("test")
+                    class Data {
                         fun foo(a: Int) {} 
                     }
                 """
@@ -113,13 +116,17 @@ class LongParameterListSpec : Spek({
             }
 
             it("does not report long parameter list for constructors if class is annotated with ignored annotation") {
-                val code = "@javax.annotation.Generated class Data(val a: Int)"
+                val code = """
+                    annotation class Generated
+                    @Generated class Data(val a: Int)
+                """
                 assertThat(rule.compileAndLint(code)).isEmpty()
             }
 
             it("does not report long parameter list for functions if class is annotated with ignored annotation") {
                 val code = """
-                    @javax.annotation.Generated class Data { 
+                    annotation class Generated
+                    @Generated class Data { 
                         fun foo(a: Int) {} 
                     }
                 """

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAbstractClassSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAbstractClassSpec.kt
@@ -15,7 +15,7 @@ class UnnecessaryAbstractClassSpec : Spek({
     val env: KotlinCoreEnvironment by memoized()
     val subject by memoized {
         UnnecessaryAbstractClass(TestConfig(mapOf(
-            UnnecessaryAbstractClass.EXCLUDE_ANNOTATED_CLASSES to listOf("jdk.nashorn.internal.ir.annotations.Ignore")
+            UnnecessaryAbstractClass.EXCLUDE_ANNOTATED_CLASSES to listOf("Deprecated")
         )))
     }
 
@@ -177,14 +177,12 @@ class UnnecessaryAbstractClassSpec : Spek({
 
             it("does not report abstract classes with module annotation") {
                 val code = """
-                    import jdk.nashorn.internal.ir.annotations.Ignore
-                    
-                    @Ignore
+                    @Deprecated("test")
                     abstract class A {
                         abstract fun f()
                     }
                     
-                    @jdk.nashorn.internal.ir.annotations.Ignore
+                    @kotlin.Deprecated("test")
                     abstract class B {
                         abstract fun f()
                     } 


### PR DESCRIPTION
As discussed in #2797, let's move `compile-test-snippets` to Java 14.
I've adapted the tests to have a green build 👍 