### PR TITLE
use parallel build options

### DIFF
--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -53,7 +53,7 @@ jobs:
 
 
     - name: Build detekt (UNIX)
-      run: ./gradlew build shadowJar -PwarningsAsErrors=true
+      run: ./gradlew build shadowJar -PwarningsAsErrors=true --parallel
       if: matrix.os == 'macos-latest' || matrix.os == 'ubuntu-latest'
     - name: Run detekt-cli --help (UNIX)
       run: java -jar ./detekt-cli/build/libs/detekt-cli-*-all.jar --help
@@ -64,7 +64,7 @@ jobs:
 
 
     - name: Build detekt (WIN)
-      run: ./gradlew build installShadowDist -PwarningsAsErrors=true
+      run: ./gradlew build installShadowDist -PwarningsAsErrors=true --parallel
       if: matrix.os == 'windows-latest'
     - name: Run detekt-cli --help (WIN)
       run: detekt-cli\build\install\detekt-cli-shadow\bin\detekt-cli --help
@@ -127,4 +127,4 @@ jobs:
         with:
           java-version: 14
       - name: Build and compile test snippets
-        run: ./gradlew test -x ":detekt-gradle-plugin:test" -Pcompile-test-snippets=true
+        run: ./gradlew test -x ":detekt-gradle-plugin:test" -Pcompile-test-snippets=true --parallel


### PR DESCRIPTION
Add parallel option for gradle builds.

Probably it can improve #2680 after more and more modules introduction.

Timing examples:
* [Without parallel - ubuntu 8 - 4m 23s](https://github.com/detekt/detekt/pull/2779/checks?check_run_id=778117131).
* [With parallel - ubuntu 8 - 1m 21s](https://github.com/detekt/detekt/pull/2808/checks?check_run_id=778157588).
* [Without parallel - macos 8 - 6m 14s](https://github.com/detekt/detekt/pull/2779/checks?check_run_id=778117167).
* [With parallel - macos 8 - 3m 38s](https://github.com/detekt/detekt/pull/2808/checks?check_run_id=778157753).