### PR TITLE
Conform the pattern of FunctionNaming to coding conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ If you contributed to detekt but your name is not in the list, please feel free 
 - [David Phillips](https://github.com/daphil19) - New rule: MandatoryBracesLoops
 - [Volkan Şahin](https://github.com/volsahin) - Documentation improvement
 - [Remco Mokveld](https://github.com/remcomokveld) - Rename Blacklist/Whitelist to more meaningful names
+- [Chao Zhang](https://github.com/chao2zhang) - Rule improvement: ImplicitDefaultLocale, FunctionNaming
 
 ### Mentions
 

--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -364,7 +364,7 @@ naming:
   FunctionNaming:
     active: true
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
-    functionPattern: '([a-z][a-zA-Z0-9]*)|(`.*`)'
+    functionPattern: '([a-zA-Z][a-zA-Z0-9]*)|(`.*`)'
     excludeClassPattern: '$^'
     ignoreOverridden: true
     ignoreAnnotated: ['Composable']

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNaming.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNaming.kt
@@ -20,7 +20,7 @@ import org.jetbrains.kotlin.psi.KtNamedFunction
  * One exception are factory functions used to create instances of classes.
  * These factory functions can have the same name as the class being created.
  *
- * @configuration functionPattern - naming pattern (default: `'([a-z][a-zA-Z0-9]*)|(`.*`)'`)
+ * @configuration functionPattern - naming pattern (default: `'([a-zA-Z][a-zA-Z0-9]*)|(`.*`)'`)
  * @configuration excludeClassPattern - ignores functions in classes which match this regex (default: `'$^'`)
  * @configuration ignoreOverridden - ignores functions that have the override modifier (default: `true`)
  * @configuration ignoreAnnotated - ignore naming for functions in the context of these
@@ -37,7 +37,7 @@ class FunctionNaming(config: Config = Config.empty) : Rule(config) {
             "Function names should follow the naming convention set in the configuration.",
             debt = Debt.FIVE_MINS)
 
-    private val functionPattern by LazyRegex(FUNCTION_PATTERN, "([a-z][a-zA-Z0-9]*)|(`.*`)")
+    private val functionPattern by LazyRegex(FUNCTION_PATTERN, "([a-zA-Z][a-zA-Z0-9]*)|(`.*`)")
     private val excludeClassPattern by LazyRegex(EXCLUDE_CLASS_PATTERN, "$^")
     private val ignoreOverridden = valueOrDefault(IGNORE_OVERRIDDEN, true)
     private val ignoreAnnotated = valueOrDefaultCommaSeparated(IGNORE_ANNOTATED, listOf("Composable"))

--- a/docs/pages/documentation/naming.md
+++ b/docs/pages/documentation/naming.md
@@ -120,7 +120,7 @@ These factory functions can have the same name as the class being created.
 
 #### Configuration options:
 
-* ``functionPattern`` (default: ``'([a-z][a-zA-Z0-9]*)|(`.*`)'``)
+* ``functionPattern`` (default: ``'([a-zA-Z][a-zA-Z0-9]*)|(`.*`)'``)
 
    naming pattern
 


### PR DESCRIPTION
Instead of the traditional camelCases, the default pattern of a function name should be PascalCase with the following rationales:

1. The page "Kotlin coding conventions" describes that factory methods can have the same name as the abstract return type.
This was actually merged and published in Oct 2017, so it has been established for over two years.
https://github.com/JetBrains/kotlin-web-site/commit/465783bf395acc5d34f089291eca594ef3d7d4ce
https://kotlinlang.org/docs/reference/coding-conventions.html#function-names

2. Jetpack Compose also uses the PascalCase in its tutorial and code examples.
https://developer.android.com/jetpack/compose/tutorial
https://codelabs.developers.google.com/codelabs/jetpack-compose-basics

3. ObjectPropertyNaming.propertyPattern also allows PascalCase, conforming to the coding convention as well that names of properties holding references to singleton objects can use the same naming style as object declarations.
https://kotlinlang.org/docs/reference/coding-conventions.html#property-names
