### PR TITLE
Rename IsPropertyNaming to NonBooleanPropertyPrefixedWithIs?

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -391,6 +391,9 @@ naming:
   MemberNameEqualsClassName:
     active: true
     ignoreOverridden: true
+  NonBooleanPropertyPrefixedWithIs:
+    active: false
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
   ObjectPropertyNaming:
     active: true
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingRules.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingRules.kt
@@ -22,7 +22,7 @@ class NamingRules(config: Config = Config.empty) : MultiRule() {
     private val variableMaxNameLengthRule = VariableMaxLength(config)
     private val topLevelPropertyRule = TopLevelPropertyNaming(config)
     private val objectConstantNamingRule = ObjectPropertyNaming(config)
-//    private val isPropertyNamingRule = IsPropertyNaming(config)
+    private val nonBooleanPropertyPrefixedWithIsRule = NonBooleanPropertyPrefixedWithIs(config)
     private val packageNamingRule = PackageNaming(config)
     private val classOrObjectNamingRule = ClassNaming(config)
     private val enumEntryNamingRule = EnumNaming(config)
@@ -39,7 +39,7 @@ class NamingRules(config: Config = Config.empty) : MultiRule() {
             variableMaxNameLengthRule,
             topLevelPropertyRule,
             objectConstantNamingRule,
-//            isPropertyNamingRule,
+            nonBooleanPropertyPrefixedWithIsRule,
             packageNamingRule,
             classOrObjectNamingRule,
             enumEntryNamingRule,
@@ -86,7 +86,7 @@ class NamingRules(config: Config = Config.empty) : MultiRule() {
     private fun handleProperty(declaration: KtProperty) {
         variableMaxNameLengthRule.runIfActive { visitProperty(declaration) }
         variableMinNameLengthRule.runIfActive { visitProperty(declaration) }
-//        isPropertyNamingRule.runIfActive { visitProperty(declaration) }
+        nonBooleanPropertyPrefixedWithIsRule.runIfActive { visitProperty(declaration) }
 
         when {
             declaration.isTopLevel -> topLevelPropertyRule.runIfActive { visitProperty(declaration) }

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NonBooleanPropertyPrefixedWithIs.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NonBooleanPropertyPrefixedWithIs.kt
@@ -29,8 +29,7 @@ import org.jetbrains.kotlin.resolve.typeBinding.createTypeBindingForReturnType
  *
  * @requiresTypeResolution
  */
-abstract class IsPropertyNaming(config: Config = Config.empty) : Rule(config) {
-// is abstract to not break providers test - #2819
+class NonBooleanPropertyPrefixedWithIs(config: Config = Config.empty) : Rule(config) {
 
     private val kotlinBooleanTypeName = "kotlin.Boolean"
     private val javaBooleanTypeName = "java.lang.Boolean"

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NonBooleanPropertyWithPrefixIsSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NonBooleanPropertyWithPrefixIsSpec.kt
@@ -7,10 +7,10 @@ import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
-class IsPropertyNamingSpec : Spek({
+class NonBooleanPropertyWithPrefixIsSpec : Spek({
     setupKotlinEnvironment()
 
-    val subject by memoized { object : IsPropertyNaming() {} }
+    val subject by memoized { NonBooleanPropertyPrefixedWithIs() }
     val env: KotlinCoreEnvironment by memoized()
 
     describe("IsPropertyNaming rule") {

--- a/docs/pages/documentation/naming.md
+++ b/docs/pages/documentation/naming.md
@@ -272,6 +272,29 @@ class Manager {
 }
 ```
 
+### NonBooleanPropertyPrefixedWithIs
+
+Reports when property with 'is' prefix doesn't have a boolean type.
+Please check the [chapter 8.3.2 at Java Language Specification](https://docs.oracle.com/javase/specs/jls/se8/html/jls-8.html#jls-8.3.2)
+
+**Requires Type and Symbol Solving**
+
+**Severity**: Warning
+
+**Debt**: 5min
+
+#### Noncompliant Code:
+
+```kotlin
+val isEnabled: Int = 500
+```
+
+#### Compliant Code:
+
+```kotlin
+val isEnabled: Boolean = false
+```
+
 ### ObjectPropertyNaming
 
 Reports when property names inside objects which do not follow the specified naming convention are used.


### PR DESCRIPTION
I'm not sure if this is a better name but I wanted to start a discussion if we should rename the rule.

Imo IsPropertyNaming could lead to confusion.  