### PR TITLE
Improve UnnecessaryApply

### DIFF
--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryApply.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryApply.kt
@@ -16,6 +16,7 @@ import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
 import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.psi.KtQualifiedExpression
 import org.jetbrains.kotlin.psi.KtReferenceExpression
+import org.jetbrains.kotlin.psi.KtSafeQualifiedExpression
 import org.jetbrains.kotlin.psi.KtThisExpression
 import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.bindingContextUtil.isUsedAsExpression
@@ -48,10 +49,12 @@ class UnnecessaryApply(config: Config) : Rule(config) {
         if (expression.isApplyExpr() &&
                 expression.hasOnlyOneMemberAccessStatement() &&
                 expression.receiverIsUnused(bindingContext)) {
-            report(CodeSmell(
-                    issue, Entity.from(expression),
-                    "apply expression can be omitted"
-            ))
+            val message = if (expression.parent is KtSafeQualifiedExpression) {
+                "apply can be replaced with let or an if"
+            } else {
+                "apply expression can be omitted"
+            }
+            report(CodeSmell(issue, Entity.from(expression), message))
         }
     }
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryApply.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryApply.kt
@@ -27,6 +27,7 @@ import org.jetbrains.kotlin.resolve.bindingContextUtil.isUsedAsExpression
  * <noncompliant>
  * config.apply { version = "1.2" } // can be replaced with `config.version = "1.2"`
  * config?.apply { environment = "test" } // can be replaced with `config?.environment = "test"`
+ * config?.apply { println(version) } // `apply` can be replaced by `let`
  * </noncompliant>
  *
  * <compliant>

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryApplySpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryApplySpec.kt
@@ -21,18 +21,20 @@ class UnnecessaryApplySpec : Spek({
         context("unnecessary apply expressions that can be changed to ordinary method call") {
 
             it("reports an apply on non-nullable type") {
-                assertThat(subject.compileAndLint("""
+                val findings = subject.compileAndLint("""
                     fun f() {
                         val a: Int = 0
                         a.apply {
                             plus(1)
                         }
                     }
-                """)).hasSize(1)
+                """)
+                assertThat(findings).hasSize(1)
+                assertThat(findings.first().message).isEqualTo("apply expression can be omitted")
             }
 
             it("reports an apply on nullable type") {
-                assertThat(subject.compileAndLint("""
+                val findings = subject.compileAndLint("""
                     fun f() {
                         val a: Int? = null
                         // Resolution: we can't say here if plus is on 'this' or just a side effect when a is not null
@@ -41,7 +43,9 @@ class UnnecessaryApplySpec : Spek({
                             plus(1)
                         }
                     }
-                """)).hasSize(1)
+                """)
+                assertThat(findings).hasSize(1)
+                assertThat(findings.first().message).isEqualTo("apply can be replaced with let or an if")
             }
 
             it("reports a false negative apply on nullable type - #1485") {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryApplySpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryApplySpec.kt
@@ -23,7 +23,7 @@ class UnnecessaryApplySpec : Spek({
             it("reports an apply on non-nullable type") {
                 assertThat(subject.compileAndLint("""
                     fun f() {
-                        val a : Int = 0
+                        val a: Int = 0
                         a.apply {
                             plus(1)
                         }
@@ -34,7 +34,7 @@ class UnnecessaryApplySpec : Spek({
             it("reports an apply on nullable type") {
                 assertThat(subject.compileAndLint("""
                     fun f() {
-                        val a : Int? = null
+                        val a: Int? = null
                         // Resolution: we can't say here if plus is on 'this' or just a side effect when a is not null
                         // However such cases should be better handled with an if-null check instead of misusing apply
                         a?.apply {
@@ -70,7 +70,7 @@ class UnnecessaryApplySpec : Spek({
 
             it("does report single statement in apply used as function argument") {
                 assertThat(subject.compileAndLint("""
-                    fun b(i : Int?) {}
+                    fun b(i: Int?) {}
 
                     fun main() {
                         val a: Int? = null
@@ -105,10 +105,10 @@ class UnnecessaryApplySpec : Spek({
 
             it("does not report applies with lambda body containing more than one statement") {
                 assertThat(subject.compileAndLint("""
-                    fun b(i : Int?) {}
+                    fun b(i: Int?) {}
 
                     fun main() {
-                        val a : Int? = null
+                        val a: Int? = null
                         a?.apply {
                             plus(1)
                             plus(2)

--- a/docs/pages/documentation/style.md
+++ b/docs/pages/documentation/style.md
@@ -1242,6 +1242,7 @@ an ordinary method/extension function call to reduce visual complexity
 ```kotlin
 config.apply { version = "1.2" } // can be replaced with `config.version = "1.2"`
 config?.apply { environment = "test" } // can be replaced with `config?.environment = "test"`
+config?.apply { println(version) } // `apply` can be replaced by `let`
 ```
 
 #### Compliant Code:


### PR DESCRIPTION
Closes #2821

This PR implements the ideas proposed int #2821 to improve `UnnecessaryApply`:

>- We can add one more example of `noncompliant` pointing that this: `config?.apply { println(version) }` should be `config?.let { println(it.version) }`
>- And we can check if the user is calling the apply using the safe null operator `?.`. In this case we can tell that he should use `let` instead of `apply`. I mean, it's not obvious why `config?.let { println(it.version) }` is better than `config?.apply { println(version) }`, so if we can point it out we will help a lot.

I'm not really sure if the messages are clear enough, so the suggestions are more than welcome (as always).