### PR TITLE
Fix UnnecessaryLet false negatives

### DIFF
--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLet.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLet.kt
@@ -60,17 +60,17 @@ class UnnecessaryLet(config: Config) : Rule(config) {
                 report(CodeSmell(issue, Entity.from(expression), "let expression can be omitted"))
             }
         } else {
-            val count = lambdaExpr.countReferences() ?: 0
-            if (count == 0 && !expression.receiverIsUsed(bindingContext) && isNullSafeOperator) {
+            val lambdaReferenceCount = lambdaExpr.countReferences() ?: 0
+            if (lambdaReferenceCount == 0 && !expression.receiverIsUsed(bindingContext) && isNullSafeOperator) {
                 report(
                     CodeSmell(
                         issue, Entity.from(expression),
                         "let expression can be replaces with a simple if"
                     )
                 )
-            } else if (count <= 1 && !isNullSafeOperator) {
+            } else if (lambdaReferenceCount <= 1 && !isNullSafeOperator) {
                 report(CodeSmell(issue, Entity.from(expression), "let expression can be omitted"))
-            } else if (count == 1 && canBeReplacedWithCall(lambdaExpr)) {
+            } else if (lambdaReferenceCount == 1 && canBeReplacedWithCall(lambdaExpr)) {
                 report(CodeSmell(issue, Entity.from(expression), "let expression can be omitted"))
             }
         }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLet.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLet.kt
@@ -21,21 +21,18 @@ import org.jetbrains.kotlin.psi.KtLambdaExpression
  * to reduce visual complexity
  *
  * <noncompliant>
+ * a.let { print(it) } // can be replaced with `print(a)`
  * a.let { it.plus(1) } // can be replaced with `a.plus(1)`
  * a?.let { it.plus(1) } // can be replaced with `a?.plus(1)`
- * a.let { that -> that.plus(1) } // can be replaced with `a.plus(1)`
- * a?.let { that -> that.plus(1) } // can be replaced with `a?.plus(1)`
  * a?.let { that -> that.plus(1) }?.let { it.plus(1) } // can be replaced with `a?.plus(1)?.plus(1)`
+ * a.let { 1.plus(1) } // can be replaced with `1.plus(1)`
  * </noncompliant>
  *
  * <compliant>
  * a?.let { print(it) }
- * a.let { print(it) }
- * a?.let { msg -> print(msg) }
- * a.let { msg -> print(msg) }
  * a?.let { 1.plus(it) } ?.let { msg -> print(msg) }
  * a?.let { it.plus(it) }
- * a?.let { param -> param.plus(param) }
+ * a?.let { 1.plus(1) }
  * </compliant>
  */
 class UnnecessaryLet(config: Config) : Rule(config) {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLet.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLet.kt
@@ -53,20 +53,26 @@ class UnnecessaryLet(config: Config) : Rule(config) {
 
         val lambdaExpr = expression.firstLambdaArg
 
-        val count = lambdaExpr?.countReferences() ?: 0
         val isNullSafeOperator = expression.parent is KtSafeQualifiedExpression
 
-        if (count == 0 && !expression.receiverIsUsed(bindingContext) && isNullSafeOperator) {
-            report(
-                CodeSmell(
-                    issue, Entity.from(expression),
-                    "let expression can be replaces with a simple if"
+        if (lambdaExpr == null) {
+            if (!isNullSafeOperator) {
+                report(CodeSmell(issue, Entity.from(expression), "let expression can be omitted"))
+            }
+        } else {
+            val count = lambdaExpr.countReferences() ?: 0
+            if (count == 0 && !expression.receiverIsUsed(bindingContext) && isNullSafeOperator) {
+                report(
+                    CodeSmell(
+                        issue, Entity.from(expression),
+                        "let expression can be replaces with a simple if"
+                    )
                 )
-            )
-        } else if (count <= 1 && !isNullSafeOperator) {
-            report(CodeSmell(issue, Entity.from(expression), "let expression can be omitted"))
-        } else if (count == 1 && canBeReplacedWithCall(lambdaExpr)) {
-            report(CodeSmell(issue, Entity.from(expression), "let expression can be omitted"))
+            } else if (count <= 1 && !isNullSafeOperator) {
+                report(CodeSmell(issue, Entity.from(expression), "let expression can be omitted"))
+            } else if (count == 1 && canBeReplacedWithCall(lambdaExpr)) {
+                report(CodeSmell(issue, Entity.from(expression), "let expression can be omitted"))
+            }
         }
     }
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLet.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLet.kt
@@ -54,8 +54,8 @@ class UnnecessaryLet(config: Config) : Rule(config) {
         val lambdaExpr = expression.firstLambdaArg
 
         val count = lambdaExpr?.countReferences() ?: 0
-
         val isNullSafeOperator = expression.parent is KtSafeQualifiedExpression
+
         if (!isNullSafeOperator && count <= 1) {
             report(CodeSmell(issue, Entity.from(expression), "let expression can be omitted"))
         } else if ((!expression.receiverIsUsed(bindingContext) || !isNullSafeOperator) && count == 0) {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLet.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLet.kt
@@ -56,15 +56,15 @@ class UnnecessaryLet(config: Config) : Rule(config) {
         val count = lambdaExpr?.countReferences() ?: 0
         val isNullSafeOperator = expression.parent is KtSafeQualifiedExpression
 
-        if (!isNullSafeOperator && count <= 1) {
-            report(CodeSmell(issue, Entity.from(expression), "let expression can be omitted"))
-        } else if ((!expression.receiverIsUsed(bindingContext) || !isNullSafeOperator) && count == 0) {
+        if (count == 0 && !expression.receiverIsUsed(bindingContext) && isNullSafeOperator) {
             report(
                 CodeSmell(
                     issue, Entity.from(expression),
                     "let expression can be replaces with a simple if"
                 )
             )
+        } else if (count <= 1 && !isNullSafeOperator) {
+            report(CodeSmell(issue, Entity.from(expression), "let expression can be omitted"))
         } else if (count == 1 && canBeReplacedWithCall(lambdaExpr)) {
             report(CodeSmell(issue, Entity.from(expression), "let expression can be omitted"))
         }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLet.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLet.kt
@@ -59,8 +59,12 @@ class UnnecessaryLet(config: Config) : Rule(config) {
         if (!isNullSafeOperator && count <= 1) {
             report(CodeSmell(issue, Entity.from(expression), "let expression can be omitted"))
         } else if ((!expression.receiverIsUsed(bindingContext) || !isNullSafeOperator) && count == 0) {
-            report(CodeSmell(issue, Entity.from(expression),
-                "let expression can be replaces with a simple if"))
+            report(
+                CodeSmell(
+                    issue, Entity.from(expression),
+                    "let expression can be replaces with a simple if"
+                )
+            )
         } else if (count == 1 && canBeReplacedWithCall(lambdaExpr)) {
             report(CodeSmell(issue, Entity.from(expression), "let expression can be omitted"))
         }
@@ -73,9 +77,11 @@ private fun canBeReplacedWithCall(lambdaExpr: KtLambdaExpression?): Boolean {
 
     if (lambdaBody?.hasOnlyOneStatement() != true) return false
 
-    // only dot qualified expressions can be unnecessary
-    val firstExpr = lambdaBody.firstChild as? KtDotQualifiedExpression
-    val exprReceiver = firstExpr?.receiverExpression
+    val exprReceiver = when (val firstExpr = lambdaBody.firstChild) {
+        is KtDotQualifiedExpression -> firstExpr.receiverExpression
+        is KtSafeQualifiedExpression -> firstExpr.receiverExpression
+        else -> null
+    }
 
     return if (exprReceiver != null) {
         val isLetWithImplicitParam = lambdaParameter == null && exprReceiver.textMatches(IT_LITERAL)

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLetSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLetSpec.kt
@@ -10,58 +10,136 @@ class UnnecessaryLetSpec : Spek({
     val subject by memoized { UnnecessaryLet(Config.empty) }
 
     describe("UnnecessaryLet rule") {
-        it("reports unnecessary lets that can be changed to ordinary method call") {
+        it("reports unnecessary lets that can be changed to ordinary method call 1") {
+            val findings = subject.compileAndLint("""
+                fun f() {
+                    val a: Int = 1
+                    a.let { it.plus(1) }
+                    a.let { that -> that.plus(1) }
+                }""")
+            assertThat(findings).hasSize(2)
+        }
+
+        it("reports unnecessary lets that can be changed to ordinary method call 2") {
             val findings = subject.compileAndLint("""
                 fun f() {
                     val a: Int? = null
-                    val b: Int = 1
-                    b.let { it.plus(1) }
                     a?.let { it.plus(1) }
-                    b.let { that -> that.plus(1) }
                     a?.let { that -> that.plus(1) }
+                }""")
+            assertThat(findings).hasSize(2)
+        }
+
+        it("reports unnecessary lets that can be changed to ordinary method call 3") {
+            val findings = subject.compileAndLint("""
+                fun f() {
+                    val a: Int? = null
                     a?.let { that -> that.plus(1) }?.let { it.plus(1) }
-                    b.let { 1.plus(1) }
-                    b.let { that -> 1.plus(1) }
-                    val x = b.let { 1.plus(1) }
-                    val y = b.let { that -> 1.plus(1) }
+                }""")
+            assertThat(findings).hasSize(2)
+        }
+
+        it("reports unnecessary lets that can be changed to ordinary method call 4") {
+            val findings = subject.compileAndLint("""
+                fun f() {
+                    val a: Int = 1
+                    a.let { 1.plus(1) }
+                    a.let { that -> 1.plus(1) }
+                }""")
+            assertThat(findings).hasSize(2)
+        }
+
+        it("reports unnecessary lets that can be changed to ordinary method call 5" ) {
+            val findings = subject.compileAndLint("""
+                fun f() {
+                    val a: Int = 1
+                    val x = a.let { 1.plus(1) }
+                    val y = a.let { that -> 1.plus(1) }
+                }""")
+            assertThat(findings).hasSize(2)
+        }
+
+        it("reports unnecessary lets that can be replaced with an if") {
+            val findings = subject.compileAndLint("""
+                fun f() {
+                    val a: Int? = null
                     a?.let { 1.plus(1) }
                     a?.let { that -> 1.plus(1) }
+                }""")
+            assertThat(findings).hasSize(2)
+        }
+
+        it("reports unnecessary lets that can be changed to ordinary method call 7") {
+            val findings = subject.compileAndLint("""
+                fun f() {
+                    val a: Int? = null
                     a.let { print(it) }
                     a.let { that -> print(that) }
                 }""")
-            assertThat(findings).hasSize(14)
+            assertThat(findings).hasSize(2)
         }
-        it("does not report lets used for function calls") {
+
+        it("does not report lets used for function calls 1") {
             val findings = subject.compileAndLint("""
                 fun f() {
                     val a: Int? = null
                     a?.let { print(it) }
                     a?.let { that -> 1.plus(that) }
+                }""")
+            assertThat(findings).isEmpty()
+        }
+
+        it("does not report lets used for function calls 2") {
+            val findings = subject.compileAndLint("""
+                fun f() {
+                    val a: Int? = null
                     a?.let { that -> 1.plus(that) }?.let { print(it) }
+                }""")
+            assertThat(findings).isEmpty()
+        }
+
+        it("does not report \"can be replaced by if\" because you will need an else too") {
+            val findings = subject.compileAndLint("""
+                fun f() {
+                    val a: Int? = null
                     val x = a?.let { 1.plus(1) }
                     val y = a?.let { that -> 1.plus(1) }
                 }""")
             assertThat(findings).isEmpty()
         }
+
         it("does not report lets with lambda body containing more than one statement") {
             val findings = subject.compileAndLint("""
                 fun f() {
                     val a: Int? = null
                     val b: Int = 1
-                    b.let { it.plus(1)
-                            it.plus(2) }
-                    a?.let { it.plus(1)
-                             it.plus(2) }
-                    b.let { that -> that.plus(1)
-                                    that.plus(2)  }
-                    a?.let { that -> that.plus(1)
-                                     that.plus(2)  }
-                    a?.let { that -> 1.plus(that) }
-                     ?.let { it.plus(1)
-                             it.plus(2) }
+                    b.let {
+                        it.plus(1)
+                        it.plus(2)
+                    }
+                    a?.let {
+                        it.plus(1)
+                        it.plus(2)
+                    }
+                    b.let { that ->
+                        that.plus(1)
+                        that.plus(2)
+                    }
+                    a?.let { that ->
+                        that.plus(1)
+                        that.plus(2)
+                    }
+                    a?.let { that ->
+                        1.plus(that)
+                    }
+                    ?.let {
+                        it.plus(1)
+                        it.plus(2)
+                    }
                 }""")
             assertThat(findings).isEmpty()
         }
+
         it("does not report lets where it is used multiple times") {
             val findings = subject.compileAndLint("""
                 fun f() {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLetSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLetSpec.kt
@@ -79,6 +79,16 @@ class UnnecessaryLetSpec : Spek({
             assertThat(findings).hasSize(2)
         }
 
+        it("reports unnecessary lets that can be changed to ordinary method call 8") {
+            val findings = subject.compileAndLint("""
+                fun f() {
+                    val a: Int? = null
+                    a?.let { it?.plus(1) }
+                    a?.let { that -> that?.plus(1) }
+                }""")
+            assertThat(findings).hasSize(2)
+        }
+
         it("does not report lets used for function calls 1") {
             val findings = subject.compileAndLint("""
                 fun f() {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLetSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLetSpec.kt
@@ -20,8 +20,10 @@ class UnnecessaryLetSpec : Spek({
                     b.let { that -> that.plus(1) }
                     a?.let { that -> that.plus(1) }
                     a?.let { that -> that.plus(1) }?.let { it.plus(1) }
+                    b.let { 1.plus(1) }
+                    b.let { that -> 1.plus(1) }
                 }""")
-            assertThat(findings).hasSize(6)
+            assertThat(findings).hasSize(8)
         }
         it("does not report lets used for function calls") {
             val findings = subject.compileAndLint("""
@@ -32,6 +34,8 @@ class UnnecessaryLetSpec : Spek({
                     a.let { that -> print(that) }
                     a?.let { that -> 1.plus(that) }
                     a?.let { that -> 1.plus(that) }?.let { print(it) }
+                    a?.let { 1.plus(1) }
+                    a?.let { that -> 1.plus(1) }
                 }""")
             assertThat(findings).isEmpty()
         }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLetSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLetSpec.kt
@@ -22,8 +22,12 @@ class UnnecessaryLetSpec : Spek({
                     a?.let { that -> that.plus(1) }?.let { it.plus(1) }
                     b.let { 1.plus(1) }
                     b.let { that -> 1.plus(1) }
+                    val x = b.let { 1.plus(1) }
+                    val y = b.let { that -> 1.plus(1) }
+                    a?.let { 1.plus(1) }
+                    a?.let { that -> 1.plus(1) }
                 }""")
-            assertThat(findings).hasSize(8)
+            assertThat(findings).hasSize(12)
         }
         it("does not report lets used for function calls") {
             val findings = subject.compileAndLint("""
@@ -34,8 +38,8 @@ class UnnecessaryLetSpec : Spek({
                     a.let { that -> print(that) }
                     a?.let { that -> 1.plus(that) }
                     a?.let { that -> 1.plus(that) }?.let { print(it) }
-                    a?.let { 1.plus(1) }
-                    a?.let { that -> 1.plus(1) }
+                    val x = a?.let { 1.plus(1) }
+                    val y = a?.let { that -> 1.plus(1) }
                 }""")
             assertThat(findings).isEmpty()
         }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLetSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLetSpec.kt
@@ -1,7 +1,7 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.test.lint
+import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
@@ -11,21 +11,22 @@ class UnnecessaryLetSpec : Spek({
 
     describe("UnnecessaryLet rule") {
         it("reports unnecessary lets that can be changed to ordinary method call") {
-            val findings = subject.lint("""
+            val findings = subject.compileAndLint("""
                 fun f() {
-                    val a : Int? = null
-                    a.let { it.plus(1) }
+                    val a: Int? = null
+                    val b: Int = 1
+                    b.let { it.plus(1) }
                     a?.let { it.plus(1) }
-                    a.let { that -> that.plus(1) }
+                    b.let { that -> that.plus(1) }
                     a?.let { that -> that.plus(1) }
                     a?.let { that -> that.plus(1) }?.let { it.plus(1) }
                 }""")
             assertThat(findings).hasSize(6)
         }
         it("does not report lets used for function calls") {
-            val findings = subject.lint("""
+            val findings = subject.compileAndLint("""
                 fun f() {
-                    val a : Int? = null
+                    val a: Int? = null
                     a.let { print(it) }
                     a?.let { print(it) }
                     a.let { that -> print(that) }
@@ -35,14 +36,15 @@ class UnnecessaryLetSpec : Spek({
             assertThat(findings).isEmpty()
         }
         it("does not report lets with lambda body containing more than one statement") {
-            val findings = subject.lint("""
+            val findings = subject.compileAndLint("""
                 fun f() {
-                    val a : Int? = null
-                    a.let { it.plus(1)
+                    val a: Int? = null
+                    val b: Int = 1
+                    b.let { it.plus(1)
                             it.plus(2) }
                     a?.let { it.plus(1)
                              it.plus(2) }
-                    a.let { that -> that.plus(1)
+                    b.let { that -> that.plus(1)
                                     that.plus(2)  }
                     a?.let { that -> that.plus(1)
                                      that.plus(2)  }
@@ -53,9 +55,9 @@ class UnnecessaryLetSpec : Spek({
             assertThat(findings).isEmpty()
         }
         it("does not report lets where it is used multiple times") {
-            val findings = subject.lint("""
+            val findings = subject.compileAndLint("""
                 fun f() {
-                    val a : Int? = null
+                    val a: Int? = null
                     a?.let { it.plus(it) }
                     a?.let { foo -> foo.plus(foo) }
                 }""")

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLetSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLetSpec.kt
@@ -58,8 +58,11 @@ class UnnecessaryLetSpec : Spek({
             val findings = subject.compileAndLint("""
                 fun f() {
                     val a: Int? = null
+                    val b: Int = 1
                     a?.let { it.plus(it) }
+                    b.let { it.plus(it) }
                     a?.let { foo -> foo.plus(foo) }
+                    b.let { foo -> foo.plus(foo) }
                 }""")
             assertThat(findings).isEmpty()
         }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLetSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLetSpec.kt
@@ -26,16 +26,16 @@ class UnnecessaryLetSpec : Spek({
                     val y = b.let { that -> 1.plus(1) }
                     a?.let { 1.plus(1) }
                     a?.let { that -> 1.plus(1) }
+                    a.let { print(it) }
+                    a.let { that -> print(that) }
                 }""")
-            assertThat(findings).hasSize(12)
+            assertThat(findings).hasSize(14)
         }
         it("does not report lets used for function calls") {
             val findings = subject.compileAndLint("""
                 fun f() {
                     val a: Int? = null
-                    a.let { print(it) }
                     a?.let { print(it) }
-                    a.let { that -> print(that) }
                     a?.let { that -> 1.plus(that) }
                     a?.let { that -> 1.plus(that) }?.let { print(it) }
                     val x = a?.let { 1.plus(1) }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLetSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLetSpec.kt
@@ -97,6 +97,17 @@ class UnnecessaryLetSpec : Spek({
             assertThat(findings).allMatch { it.message == MESSAGE_OMIT_LET }
         }
 
+        it("reports use of let without the safe call operator when we use an argument") {
+            val findings = subject.compileAndLint("""
+                fun f() {
+                    val f: (Int?) -> Boolean = { true }
+                    val a: Int? = null
+                    a.let(f)
+                }""")
+            assertThat(findings).hasSize(1)
+            assertThat(findings).allMatch { it.message == MESSAGE_OMIT_LET }
+        }
+
         it("does not report lets used for function calls 1") {
             val findings = subject.compileAndLint("""
                 fun f() {
@@ -124,6 +135,16 @@ class UnnecessaryLetSpec : Spek({
                     val y = a?.let { that -> 1.plus(1) }
                 }""")
             assertThat(findings).isEmpty()
+        }
+
+        it("does not report use of let with the safe call operator when we use an argument") {
+            val findings = subject.compileAndLint("""
+                fun f() {
+                    val f: (Int?) -> Boolean = { true }
+                    val a: Int? = null
+                    a?.let(f)
+                }""")
+            assertThat(findings).hasSize(0)
         }
 
         it("does not report lets with lambda body containing more than one statement") {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLetSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLetSpec.kt
@@ -18,6 +18,7 @@ class UnnecessaryLetSpec : Spek({
                     a.let { that -> that.plus(1) }
                 }""")
             assertThat(findings).hasSize(2)
+            assertThat(findings).allMatch { it.message == MESSAGE_OMIT_LET }
         }
 
         it("reports unnecessary lets that can be changed to ordinary method call 2") {
@@ -28,6 +29,7 @@ class UnnecessaryLetSpec : Spek({
                     a?.let { that -> that.plus(1) }
                 }""")
             assertThat(findings).hasSize(2)
+            assertThat(findings).allMatch { it.message == MESSAGE_OMIT_LET }
         }
 
         it("reports unnecessary lets that can be changed to ordinary method call 3") {
@@ -37,6 +39,7 @@ class UnnecessaryLetSpec : Spek({
                     a?.let { that -> that.plus(1) }?.let { it.plus(1) }
                 }""")
             assertThat(findings).hasSize(2)
+            assertThat(findings).allMatch { it.message == MESSAGE_OMIT_LET }
         }
 
         it("reports unnecessary lets that can be changed to ordinary method call 4") {
@@ -47,6 +50,7 @@ class UnnecessaryLetSpec : Spek({
                     a.let { that -> 1.plus(1) }
                 }""")
             assertThat(findings).hasSize(2)
+            assertThat(findings).allMatch { it.message == MESSAGE_OMIT_LET }
         }
 
         it("reports unnecessary lets that can be changed to ordinary method call 5" ) {
@@ -57,6 +61,7 @@ class UnnecessaryLetSpec : Spek({
                     val y = a.let { that -> 1.plus(1) }
                 }""")
             assertThat(findings).hasSize(2)
+            assertThat(findings).allMatch { it.message == MESSAGE_OMIT_LET }
         }
 
         it("reports unnecessary lets that can be replaced with an if") {
@@ -67,6 +72,7 @@ class UnnecessaryLetSpec : Spek({
                     a?.let { that -> 1.plus(1) }
                 }""")
             assertThat(findings).hasSize(2)
+            assertThat(findings).allMatch { it.message == MESSAGE_USE_IF }
         }
 
         it("reports unnecessary lets that can be changed to ordinary method call 7") {
@@ -77,6 +83,7 @@ class UnnecessaryLetSpec : Spek({
                     a.let { that -> print(that) }
                 }""")
             assertThat(findings).hasSize(2)
+            assertThat(findings).allMatch { it.message == MESSAGE_OMIT_LET }
         }
 
         it("reports unnecessary lets that can be changed to ordinary method call 8") {
@@ -87,6 +94,7 @@ class UnnecessaryLetSpec : Spek({
                     a?.let { that -> that?.plus(1) }
                 }""")
             assertThat(findings).hasSize(2)
+            assertThat(findings).allMatch { it.message == MESSAGE_OMIT_LET }
         }
 
         it("does not report lets used for function calls 1") {
@@ -164,3 +172,6 @@ class UnnecessaryLetSpec : Spek({
         }
     }
 })
+
+private const val MESSAGE_OMIT_LET = "let expression can be omitted"
+private const val MESSAGE_USE_IF = "let expression can be replaces with a simple if"

--- a/docs/pages/documentation/style.md
+++ b/docs/pages/documentation/style.md
@@ -1284,22 +1284,20 @@ to reduce visual complexity
 
 ```kotlin
 a.let { print(it) } // can be replaced with `print(a)`
-a.let { msg -> print(msg) } // can be replaced with `print(a)`
 a.let { it.plus(1) } // can be replaced with `a.plus(1)`
 a?.let { it.plus(1) } // can be replaced with `a?.plus(1)`
-a.let { that -> that.plus(1) } // can be replaced with `a.plus(1)`
-a?.let { that -> that.plus(1) } // can be replaced with `a?.plus(1)`
 a?.let { that -> that.plus(1) }?.let { it.plus(1) } // can be replaced with `a?.plus(1)?.plus(1)`
+a.let { 1.plus(1) } // can be replaced with `1.plus(1)`
+a?.let { 1.plus(1) } // can be replaced with `if (a == null) 1.plus(1)`
 ```
 
 #### Compliant Code:
 
 ```kotlin
 a?.let { print(it) }
-a?.let { msg -> print(msg) }
 a?.let { 1.plus(it) } ?.let { msg -> print(msg) }
 a?.let { it.plus(it) }
-a?.let { param -> param.plus(param) }
+val b = a?.let { 1.plus(1) }
 ```
 
 ### UnnecessaryParentheses

--- a/docs/pages/documentation/style.md
+++ b/docs/pages/documentation/style.md
@@ -1283,6 +1283,8 @@ to reduce visual complexity
 #### Noncompliant Code:
 
 ```kotlin
+a.let { print(it) } // can be replaced with `print(a)`
+a.let { msg -> print(msg) } // can be replaced with `print(a)`
 a.let { it.plus(1) } // can be replaced with `a.plus(1)`
 a?.let { it.plus(1) } // can be replaced with `a?.plus(1)`
 a.let { that -> that.plus(1) } // can be replaced with `a.plus(1)`
@@ -1294,9 +1296,7 @@ a?.let { that -> that.plus(1) }?.let { it.plus(1) } // can be replaced with `a?.
 
 ```kotlin
 a?.let { print(it) }
-a.let { print(it) }
 a?.let { msg -> print(msg) }
-a.let { msg -> print(msg) }
 a?.let { 1.plus(it) } ?.let { msg -> print(msg) }
 a?.let { it.plus(it) }
 a?.let { param -> param.plus(param) }


### PR DESCRIPTION
Closes #2826

There were some false negatives in this rule:

- `a.let { 1.plus(1) } // 1.plus(1)`
- `a?.let { 1.plus(1) } // if (a != null) 1.plus(1)` This one is to avoid overuse of let when you get nothing from it.
- `a.let { println(it) } // println(it)`
- `a.let { println(it); println("hola") }`
- etc.

I know, the tests are a real mess. I'll try to refactor them.

I know that we have a script/project to run detekt over different projects to ensure that the new rule works... Where is it? I'll like to prove this on real projects.