### PR TITLE
Fix false negative in MandatoryBracesIfStatements

### DIFF
--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/MandatoryBracesIfStatements.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/MandatoryBracesIfStatements.kt
@@ -8,7 +8,6 @@ import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
-import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
 import org.jetbrains.kotlin.psi.KtBlockExpression
 import org.jetbrains.kotlin.psi.KtIfExpression
 import org.jetbrains.kotlin.psi.psiUtil.siblings
@@ -47,9 +46,9 @@ class MandatoryBracesIfStatements(config: Config = Config.empty) : Rule(config) 
     }
 
     private fun hasNewLine(element: PsiElement?): Boolean =
-            element?.siblings(forward = true, withItself = false)
+            element
+                    ?.siblings(forward = true, withItself = false)
                     ?.takeWhile { it.text != "else" }
-                    ?.filterIsInstance<PsiWhiteSpace>()
                     ?.firstOrNull { it.textContains('\n') } != null
 
     private fun KtIfExpression.isNotBlockExpression(): Boolean = this.then !is KtBlockExpression

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/MandatoryBracesIfStatementsSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/MandatoryBracesIfStatementsSpec.kt
@@ -23,6 +23,29 @@ class MandatoryBracesIfStatementsSpec : Spek({
             assertThat(findings).hasTextLocations(32 to 41)
         }
 
+        it("reports a simple if with a simgle statment in mutlple lines") {
+            val findings = subject.compileAndLint("""
+                fun f() {
+                	if (true) 50
+                        .toString()
+                }
+            """)
+
+            assertThat(findings).hasSize(1)
+        }
+
+        it("reports if-else with a single statment in mutlple lines") {
+            val findings = subject.compileAndLint("""
+                fun f() {
+                	if (true) 50
+                        .toString() else 50
+                        .toString()
+                }
+            """)
+
+            assertThat(findings).hasSize(2)
+        }
+
         it("reports if-else") {
             val findings = subject.compileAndLint("""
             fun f() {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/MandatoryBracesIfStatementsSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/MandatoryBracesIfStatementsSpec.kt
@@ -23,7 +23,7 @@ class MandatoryBracesIfStatementsSpec : Spek({
             assertThat(findings).hasTextLocations(32 to 41)
         }
 
-        it("reports a simple if with a simgle statment in mutlple lines") {
+        it("reports a simple if with a single statement in multiple lines") {
             val findings = subject.compileAndLint("""
                 fun f() {
                 	if (true) 50
@@ -34,7 +34,7 @@ class MandatoryBracesIfStatementsSpec : Spek({
             assertThat(findings).hasSize(1)
         }
 
-        it("reports if-else with a single statment in mutlple lines") {
+        it("reports if-else with a single statement in multiple lines") {
             val findings = subject.compileAndLint("""
                 fun f() {
                 	if (true) 50


### PR DESCRIPTION
This code should be flagged by `MandatoryBracesIfStatements`

```kotlin
if (true) 50
    .toString()
```