### PR TITLE
ThrowingExceptionsWithoutMessageOrCause should be excluded in tests

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -186,6 +186,7 @@ exceptions:
     active: false
   ThrowingExceptionsWithoutMessageOrCause:
     active: false
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
     exceptions:
      - IllegalArgumentException
      - IllegalStateException

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/rulesetpage/TestExclusions.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/rulesetpage/TestExclusions.kt
@@ -22,7 +22,8 @@ object TestExclusions {
         "ForEachOnRange",
         "FunctionMaxLength",
         "TooGenericExceptionCaught",
-        "InstanceOfCheckForException"
+        "InstanceOfCheckForException",
+        "ThrowingExceptionsWithoutMessageOrCause"
     )
 
     fun Rule.isExcludedInTests() = name in rules || inMultiRule in rules


### PR DESCRIPTION
Close #2836

## Expected Behavior of the rule
This code should be allowed in test environments: `Single.error(Exception())`. This is just a fake. I don't care about the message. I just want to ensure that when an error is emitted I do whatever.

## Context
I already have the exclude in my config. But I think that it will have sense to add it as a default.