### PR TITLE
Update getting started Gradle snippets

### DIFF
--- a/docs/pages/gettingstarted/groovydsl.md
+++ b/docs/pages/gettingstarted/groovydsl.md
@@ -32,7 +32,7 @@ Using the plugins DSL:
 
 ```groovy
 plugins {
-  id "io.gitlab.arturbosch.detekt" version "{{ site.detekt_version }}"
+    id "io.gitlab.arturbosch.detekt" version "{{ site.detekt_version }}"
 }
 
 repositories {
@@ -55,12 +55,12 @@ Using legacy plugin application (`buildscript{}`):
 
 ```groovy
 buildscript {
-  repositories {
-    gradlePluginPortal()
-  }
-  dependencies {
-    classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:{{ site.detekt_version }}"
-  }
+    repositories {
+        gradlePluginPortal()
+    }
+    dependencies {
+        classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:{{ site.detekt_version }}"
+    }
 }
 
 apply plugin: "io.gitlab.arturbosch.detekt"
@@ -89,15 +89,15 @@ You can configure the plugin in the same way as indicated above.
 
 ```groovy
 buildscript {
-  repositories {
-    google()
-    jcenter()
-    gradlePluginPortal()
-  }
-  dependencies {
-    classpath "com.android.tools.build:gradle:4.0.0"
-    classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:{{ site.detekt_version }}"
-  }
+    repositories {
+        google()
+        jcenter()
+        gradlePluginPortal()
+    }
+    dependencies {
+        classpath "com.android.tools.build:gradle:4.0.0"
+        classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:{{ site.detekt_version }}"
+    }
 }
 
 apply plugin: "io.gitlab.arturbosch.detekt"

--- a/docs/pages/gettingstarted/groovydsl.md
+++ b/docs/pages/gettingstarted/groovydsl.md
@@ -28,7 +28,13 @@ using the detekt closure as described [here](#closure).
 
 ##### <a name="gradlegroovy">Configuration when using Groovy DSL</a>
 
+Using the plugins DSL:
+
 ```groovy
+plugins {
+  id "io.gitlab.arturbosch.detekt" version "{{ site.detekt_version }}"
+}
+
 repositories {
     jcenter()
 
@@ -43,9 +49,35 @@ repositories {
         }
     }
 }
+```
 
-plugins {
-    id "io.gitlab.arturbosch.detekt" version "{{ site.detekt_version }}"
+Using legacy plugin application (`buildscript{}`):
+
+```groovy
+buildscript {
+  repositories {
+    gradlePluginPortal()
+  }
+  dependencies {
+    classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:{{ site.detekt_version }}"
+  }
+}
+
+apply plugin: "io.gitlab.arturbosch.detekt"
+
+repositories {
+    jcenter()
+
+    // or
+
+    mavenCentral()
+    jcenter {
+        content {
+            // just allow to include kotlinx projects
+            // detekt needs 'kotlinx-html' for the html report
+            includeGroup "org.jetbrains.kotlinx"
+        }
+    }
 }
 ```
 
@@ -54,25 +86,37 @@ plugins {
 When using Android make sure to have detekt configured in the project level build.gradle file.
 
 You can configure the plugin in the same way as indicated above.
+
 ```groovy
 buildscript {
-    repositories {
-        maven { url "https://plugins.gradle.org/m2/" }
-        jcenter()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:{{ site.detekt_version }}'
-        classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:{{ site.detekt_version }}"
-    }
-
-}
-plugins {
-    id "io.gitlab.arturbosch.detekt" version "{{ site.detekt_version }}"
+  repositories {
+    google()
+    jcenter()
+    gradlePluginPortal()
+  }
+  dependencies {
+    classpath "com.android.tools.build:gradle:4.0.0"
+    classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:{{ site.detekt_version }}"
+  }
 }
 
-apply plugin: 'io.gitlab.arturbosch.detekt'
+apply plugin: "io.gitlab.arturbosch.detekt"
+
+repositories {
+    jcenter()
+
+    // or
+
+    mavenCentral()
+    jcenter {
+        content {
+            // just allow to include kotlinx projects
+            // detekt needs 'kotlinx-html' for the html report
+            includeGroup "org.jetbrains.kotlinx"
+        }
+    }
+}
 ```
-
 
 ##### <a name="closure">Options for detekt configuration closure</a>
 

--- a/docs/pages/gettingstarted/kotlindsl.md
+++ b/docs/pages/gettingstarted/kotlindsl.md
@@ -39,12 +39,12 @@ Using legacy plugin application (`buildscript{}`):
 
 ```kotlin
 buildscript {
-  repositories {
-    gradlePluginPortal()
-  }
-  dependencies {
-    classpath("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:{{ site.detekt_version }}")
-  }
+    repositories {
+        gradlePluginPortal()
+    }
+    dependencies {
+        classpath("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:{{ site.detekt_version }}")
+    }
 }
 
 apply(plugin = "io.gitlab.arturbosch.detekt")

--- a/docs/pages/gettingstarted/kotlindsl.md
+++ b/docs/pages/gettingstarted/kotlindsl.md
@@ -12,8 +12,12 @@ DSL to apply the plugin changes slightly.
 
 ##### <a name="gradlekotlin">Configuration when using Kotlin DSL</a> 
 
+Using the plugins DSL:
+
 ```kotlin
-import io.gitlab.arturbosch.detekt.extensions.DetektExtension
+plugins {
+    id("io.gitlab.arturbosch.detekt").version("{{ site.detekt_version }}")
+}
 
 repositories {
     jcenter()
@@ -25,15 +29,45 @@ repositories {
         content {
             // just allow to include kotlinx projects
             // detekt needs 'kotlinx-html' for the html report
-            includeGroup "org.jetbrains.kotlinx"
+            includeGroup("org.jetbrains.kotlinx")
         }
     }
 }
+```
 
-plugins {
-    id("io.gitlab.arturbosch.detekt").version("{{ site.detekt_version }}")
+Using legacy plugin application (`buildscript{}`):
+
+```kotlin
+buildscript {
+  repositories {
+    gradlePluginPortal()
+  }
+  dependencies {
+    classpath("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:{{ site.detekt_version }}")
+  }
 }
 
+apply(plugin = "io.gitlab.arturbosch.detekt")
+
+repositories {
+    jcenter()
+
+    // or
+
+    mavenCentral()
+    jcenter {
+        content {
+            // just allow to include kotlinx projects
+            // detekt needs 'kotlinx-html' for the html report
+            includeGroup("org.jetbrains.kotlinx")
+        }
+    }
+}
+```
+
+##### <a name="closure">Options for detekt configuration closure</a>
+
+```kotlin
 detekt {
     toolVersion = "{{ site.detekt_version }}"                                 // Version of the Detekt CLI that will be used. When unspecified the latest detekt version found will be used. Override to stay on the same version.
     input = files("src/main/java", "src/main/kotlin")     // The directories where detekt looks for source files. Defaults to `files("src/main/java", "src/main/kotlin")`.


### PR DESCRIPTION
This is a follow-up from a discussion on Slack: https://kotlinlang.slack.com/archives/C88E12QH4/p1593875942190700

Seems like our getting started documentation is not properly working:
- The `plugins {}` block was placed after a `repository {}` which is not allowed by Gradle
- The Kotlin DSL syntax was invalid: `includeGroup "org.jetbrains.kotlinx"` without parentesis.
- For some reason the Android setup was applying the Detekt plugin twice (with the `apply:` and the `plugins{}` syntax).

I've fixed all of them, plus I'm providing snippets for setting up using Plugin DSL and Legacy plugin application both for Groovy and Kotlin flavors.