### PR TITLE
Clear findings even if we are not going to visit the file

### DIFF
--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/BaseRule.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/BaseRule.kt
@@ -24,9 +24,9 @@ abstract class BaseRule(
      * BindingContext.EMPTY will be used and it will not be possible for detekt to resolve types or symbols.
      */
     fun visitFile(root: KtFile, bindingContext: BindingContext = BindingContext.EMPTY) {
+        clearFindings()
         this.bindingContext = bindingContext
         if (visitCondition(root)) {
-            clearFindings()
             preVisit(root)
             visit(root)
             postVisit(root)


### PR DESCRIPTION
I'm not really sure about this change. And I couldn't find how to demostrate that there was an error.

But looking at how this class is used by `Detektor` we could report the same findig multiple times.

For example: if I have two files: the first have a finding and the other is excluded, right now, `Detektor` will add two findings. Am I right?