### PR TITLE
Fix typo ne documentation

### DIFF
--- a/docs/pages/gettingstarted/groovydsl.md
+++ b/docs/pages/gettingstarted/groovydsl.md
@@ -61,7 +61,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:{{ site.detekt_version }}'
+        classpath 'com.android.tools.build:gradle:x.y.z'
         classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:{{ site.detekt_version }}"
     }
 


### PR DESCRIPTION
As pointed out in #2845 by @pedroql the version of Android gradle plugin is not ralated with the detekt version.