### PR TITLE
Make sure to always target JVM 8 bytecode

### DIFF
--- a/buildSrc/src/main/kotlin/commons.gradle.kts
+++ b/buildSrc/src/main/kotlin/commons.gradle.kts
@@ -26,6 +26,11 @@ configure(subprojects.filter { it.name != "detekt-bom" }) {
         plugin("jacoco")
     }
 
+    java {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+
     // bundle detekt's version for all jars to use it at runtime
     tasks.withType<Jar>().configureEach {
         manifest {


### PR DESCRIPTION
This change was needed for the IntelliJ plugin to compile against dependencies build with JVM 14 locally.

![2020-07-07-204634_1914x442_scrot](https://user-images.githubusercontent.com/20924106/86828332-62e32400-c093-11ea-9265-b27199507126.png)
