### PR TITLE
Cleanup code

### DIFF
--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/GuardClauses.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/GuardClauses.kt
@@ -30,12 +30,12 @@ fun KtExpression.isGuardClause(): Boolean {
             ?: return false
 
         return ifExpr.`else` == null &&
-                returnExpr === ifExpr.then?.lastBlockStatementOrThis()
+                returnExpr == ifExpr.then?.lastBlockStatementOrThis()
     }
 
     fun KtReturnExpression.isElvisOperatorGuardClause(): Boolean {
         val elvisExpr = this.parent as? KtBinaryExpression
-        return elvisExpr != null && elvisExpr.operationToken == KtTokens.ELVIS
+        return elvisExpr?.operationToken == KtTokens.ELVIS
     }
 
     val returnExpr = this.findDescendantOfType<KtReturnExpression>() ?: return false

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/GuardClauses.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/GuardClauses.kt
@@ -1,7 +1,11 @@
 package io.gitlab.arturbosch.detekt.rules
 
 import org.jetbrains.kotlin.lexer.KtTokens
-import org.jetbrains.kotlin.psi.*
+import org.jetbrains.kotlin.psi.KtBinaryExpression
+import org.jetbrains.kotlin.psi.KtExpression
+import org.jetbrains.kotlin.psi.KtIfExpression
+import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.KtReturnExpression
 import org.jetbrains.kotlin.psi.psiUtil.findDescendantOfType
 import org.jetbrains.kotlin.psi.psiUtil.lastBlockStatementOrThis
 

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/GuardClauses.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/GuardClauses.kt
@@ -1,11 +1,7 @@
 package io.gitlab.arturbosch.detekt.rules
 
 import org.jetbrains.kotlin.lexer.KtTokens
-import org.jetbrains.kotlin.psi.KtBinaryExpression
-import org.jetbrains.kotlin.psi.KtExpression
-import org.jetbrains.kotlin.psi.KtIfExpression
-import org.jetbrains.kotlin.psi.KtNamedFunction
-import org.jetbrains.kotlin.psi.KtReturnExpression
+import org.jetbrains.kotlin.psi.*
 import org.jetbrains.kotlin.psi.psiUtil.findDescendantOfType
 import org.jetbrains.kotlin.psi.psiUtil.lastBlockStatementOrThis
 
@@ -33,11 +29,11 @@ fun KtExpression.isGuardClause(): Boolean {
                 returnExpr === ifExpr.then?.lastBlockStatementOrThis()
     }
 
-    fun KtReturnExpression.isElvisOperatorGuardClause(): Boolean {
-        val elvisExpr = this.parent as? KtBinaryExpression
-        return elvisExpr?.operationToken == KtTokens.ELVIS
-    }
-
     val returnExpr = this.findDescendantOfType<KtReturnExpression>() ?: return false
     return isIfConditionGuardClause(returnExpr) || returnExpr.isElvisOperatorGuardClause()
+}
+
+fun KtExpression.isElvisOperatorGuardClause(): Boolean {
+    val elvisExpr = this.parent as? KtBinaryExpression
+    return elvisExpr?.operationToken == KtTokens.ELVIS
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/GuardClauses.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/GuardClauses.kt
@@ -23,7 +23,7 @@ fun KtNamedFunction.yieldStatementsSkippingGuardClauses(): Sequence<KtExpression
     }
 }
 
-fun KtExpression.isGuardClause(): Boolean {
+internal fun KtExpression.isGuardClause(): Boolean {
 
     fun isIfConditionGuardClause(returnExpr: KtReturnExpression): Boolean {
         val ifExpr = this as? KtIfExpression
@@ -37,7 +37,7 @@ fun KtExpression.isGuardClause(): Boolean {
     return isIfConditionGuardClause(returnExpr) || returnExpr.isElvisOperatorGuardClause()
 }
 
-fun KtExpression.isElvisOperatorGuardClause(): Boolean {
+internal fun KtExpression.isElvisOperatorGuardClause(): Boolean {
     val elvisExpr = this.parent as? KtBinaryExpression
     return elvisExpr?.operationToken == KtTokens.ELVIS
 }

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/GuardClauses.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/GuardClauses.kt
@@ -30,7 +30,7 @@ fun KtExpression.isGuardClause(): Boolean {
             ?: return false
 
         return ifExpr.`else` == null &&
-                returnExpr == ifExpr.then?.lastBlockStatementOrThis()
+                returnExpr === ifExpr.then?.lastBlockStatementOrThis()
     }
 
     fun KtReturnExpression.isElvisOperatorGuardClause(): Boolean {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCount.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCount.kt
@@ -1,6 +1,13 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
-import io.gitlab.arturbosch.detekt.api.*
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.SplitPattern
 import io.gitlab.arturbosch.detekt.rules.parentsOfTypeUntil
 import io.gitlab.arturbosch.detekt.rules.yieldStatementsSkippingGuardClauses
 import org.jetbrains.kotlin.psi.KtCallExpression

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCount.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCount.kt
@@ -1,13 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
-import io.gitlab.arturbosch.detekt.api.CodeSmell
-import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.Debt
-import io.gitlab.arturbosch.detekt.api.Entity
-import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.Rule
-import io.gitlab.arturbosch.detekt.api.Severity
-import io.gitlab.arturbosch.detekt.api.SplitPattern
+import io.gitlab.arturbosch.detekt.api.*
 import io.gitlab.arturbosch.detekt.rules.parentsOfTypeUntil
 import io.gitlab.arturbosch.detekt.rules.yieldStatementsSkippingGuardClauses
 import org.jetbrains.kotlin.psi.KtCallExpression

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ThrowsCount.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ThrowsCount.kt
@@ -1,15 +1,8 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
-import io.gitlab.arturbosch.detekt.api.CodeSmell
-import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.Debt
-import io.gitlab.arturbosch.detekt.api.Entity
-import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.Rule
-import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.*
+import io.gitlab.arturbosch.detekt.rules.isElvisOperatorGuardClause
 import io.gitlab.arturbosch.detekt.rules.isOverride
-import org.jetbrains.kotlin.lexer.KtTokens
-import org.jetbrains.kotlin.psi.KtBinaryExpression
 import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.KtThrowExpression
 import org.jetbrains.kotlin.psi.psiUtil.collectDescendantsOfType
@@ -54,7 +47,7 @@ class ThrowsCount(config: Config = Config.empty) : Rule(config) {
         if (!function.isOverride()) {
             val count = function
                 .collectDescendantsOfType<KtThrowExpression>()
-                .filterNot { excludeGuardClauses && it.isGuardClause() }
+                .filterNot { excludeGuardClauses && it.isElvisOperatorGuardClause() }
                 .count()
 
             if (count > max) {
@@ -68,10 +61,6 @@ class ThrowsCount(config: Config = Config.empty) : Rule(config) {
                 )
             }
         }
-    }
-
-    private fun KtThrowExpression.isGuardClause(): Boolean {
-        return (this.parent as? KtBinaryExpression)?.operationToken == KtTokens.ELVIS
     }
 
     companion object {

--- a/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ThrowsCount.kt
+++ b/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ThrowsCount.kt
@@ -1,6 +1,12 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
-import io.gitlab.arturbosch.detekt.api.*
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.rules.isElvisOperatorGuardClause
 import io.gitlab.arturbosch.detekt.rules.isOverride
 import org.jetbrains.kotlin.psi.KtNamedFunction

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCountSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCountSpec.kt
@@ -58,7 +58,7 @@ class ReturnCountSpec : Spek({
             }
         }
 
-        context("too-complicated if does not count as a guard clause") {
+        context("if statement with multiple returns doesn't qualify as a guard clause") {
             val code = """
             fun test(x: Int): Int {
                 if (x < 4) {
@@ -77,14 +77,8 @@ class ReturnCountSpec : Spek({
             }
         """
 
-            it("should get flagged for too-complicated guard clause, with EXCLUDE_GUARD_CLAUSES on") {
+            it("should get flagged for if statement with multiple returns, with EXCLUDE_GUARD_CLAUSES on") {
                 val findings = ReturnCount(TestConfig(mapOf(ReturnCount.EXCLUDE_GUARD_CLAUSES to "true")))
-                    .compileAndLint(code)
-                assertThat(findings).hasSize(1)
-            }
-
-            it("should get flagged for too-complicated guard clause, with EXCLUDE_GUARD_CLAUSES off") {
-                val findings = ReturnCount(TestConfig(mapOf(ReturnCount.EXCLUDE_GUARD_CLAUSES to "false")))
                     .compileAndLint(code)
                 assertThat(findings).hasSize(1)
             }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCountSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCountSpec.kt
@@ -58,7 +58,7 @@ class ReturnCountSpec : Spek({
             }
         }
 
-        context("if statement with multiple returns doesn't qualify as a guard clause") {
+        context("reports a too-complicated if statement for being a guard clause") {
             val code = """
             fun test(x: Int): Int {
                 if (x < 4) {
@@ -77,7 +77,7 @@ class ReturnCountSpec : Spek({
             }
         """
 
-            it("should get flagged for if statement with multiple returns, with EXCLUDE_GUARD_CLAUSES on") {
+            it("should report a too-complicated if statement for being a guard clause, with EXCLUDE_GUARD_CLAUSES on") {
                 val findings = ReturnCount(TestConfig(mapOf(ReturnCount.EXCLUDE_GUARD_CLAUSES to "true")))
                     .compileAndLint(code)
                 assertThat(findings).hasSize(1)

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ThrowsCountSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ThrowsCountSpec.kt
@@ -59,12 +59,22 @@ class ThrowsCountSpec : Spek({
             }
         }
 
-        context("should not get flagged for ELVIS operator guard clauses") {
+        context("should not get flagged for ELVIS operator guard clause") {
             val config = TestConfig(mapOf(ThrowsCount.EXCLUDE_GUARD_CLAUSES to "true"))
             val subject = ThrowsCount(config)
+            val codeWithGuardClause = """
+                fun test(x: Int): Int {
+                    val y = x ?: throw Exception()
+                    when (x) {
+                        5 -> println("x=5")
+                        4 -> throw Exception()
+                    }
+                    throw Exception()
+                }
+            """
 
-            it("reports violation by default") {
-                assertThat(subject.lint(code)).hasSize(1)
+            it("should not report violation for code with ELVIS operator guard clause") {
+                assertThat(subject.lint(codeWithGuardClause)).hasSize(0)
             }
         }
     }


### PR DESCRIPTION
This PR achieves the following:
 - Use safe access `?.` instead of null check
 - Reuse `GuardClauses.kt` common code for `ThrowsCount` and remove duplicate code.
 - Add test case for excluding guard clauses in `ThrowsCountSpek`
 - Make the extension methods `internal` (in `GuardClauses.kt`) to avoid scope pollution