### PR TITLE
Check string arguments with TR enabled

### DIFF
--- a/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/KtValueArgument.kt
+++ b/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/KtValueArgument.kt
@@ -10,7 +10,7 @@ fun KtValueArgument.isString(bindingContext: BindingContext): Boolean {
     val argumentExpression = getArgumentExpression()
     return if (bindingContext != BindingContext.EMPTY) {
         val type = argumentExpression?.getResolvedCall(bindingContext)?.resultingDescriptor?.returnType
-        type != null && KotlinBuiltIns.isString(type)
+        argumentExpression is KtStringTemplateExpression || type != null && KotlinBuiltIns.isString(type)
     } else {
         argumentExpression is KtStringTemplateExpression
     }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseCheckOrErrorSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseCheckOrErrorSpec.kt
@@ -174,6 +174,18 @@ class UseCheckOrErrorSpec : Spek({
                 """
                 assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
             }
+
+            it("reports if the exception thrown has a string literal argument") {
+                val code = """
+                    fun test(throwable: Throwable) {
+                        when(throwable) {
+                            is NumberFormatException -> println("a")
+                            else -> throw IllegalStateException("b")
+                        }
+                    }
+                """
+                assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            }
         }
     }
 })

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseRequireSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseRequireSpec.kt
@@ -146,6 +146,14 @@ class UseRequireSpec : Spek({
                 """
                 assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
             }
+            it("reports if the exception thrown has a String literal argument") {
+                val code = """
+                    fun test(throwable: Throwable) {
+                        if (throwable !is NumberFormatException) throw IllegalArgumentException("a")
+                    }
+                """
+                assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            }
         }
 
         context("throw is not after a precondition") {


### PR DESCRIPTION
Check simple string arguments even when type resolution is enabled.
This prevented the `UseRequire` and `UseCheckOrError` checks find issues with TR enabled.
