### PR TITLE
Publish to Bintray using maven-publish

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -93,7 +93,7 @@ Following warning is expected until [Jekyll](https://github.com/jekyll/jekyll/is
 - `gradle increment<Patch|Minor|Major>`
 - `gradle build publishToMavenLocal -x detekt -x test` - publish to local first
 - `gradle build` - now fully build with tests and self-analysis.
-- `gradle bintrayUpload` - uploads artifacts to Bintray
+- `gradle publishDetektPublicationPublicationToBintrayRepository` - uploads artifacts to Bintray
 - `gradle publishPlugins` - uploads the Gradle Plugin to the Plugin Repositories
 - `gradle githubRelease` - creates a tag for the current version with changelog and cli jar
 - `gradle applyDocVersion applySelfAnalysisVersion`

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -17,7 +17,6 @@ object Plugins {
     const val DETEKT = "1.10.0"
     const val GITHUB_RELEASE = "2.2.12"
     const val ARTIFACTORY = "4.15.1"
-    const val BINTRAY = "1.8.4"
     const val SHADOW = "5.2.0"
     const val VERSIONS = "0.28.0"
     const val SONAR = "2.8"
@@ -30,7 +29,6 @@ dependencies {
     implementation("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:${Plugins.DETEKT}")
     implementation("com.github.breadmoirai:github-release:${Plugins.GITHUB_RELEASE}")
     implementation("org.jfrog.buildinfo:build-info-extractor-gradle:${Plugins.ARTIFACTORY}")
-    implementation("com.jfrog.bintray.gradle:gradle-bintray-plugin:${Plugins.BINTRAY}")
     implementation("com.github.jengelman.gradle.plugins:shadow:${Plugins.SHADOW}")
     implementation("com.github.ben-manes:gradle-versions-plugin:${Plugins.VERSIONS}")
     implementation("org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:${Plugins.SONAR}")

--- a/buildSrc/src/main/kotlin/packaging.gradle.kts
+++ b/buildSrc/src/main/kotlin/packaging.gradle.kts
@@ -32,7 +32,6 @@ subprojects {
         ?: System.getenv("BINTRAY_USER")
     val bintrayKey = findProperty("bintrayKey")?.toString()
         ?: System.getenv("BINTRAY_API_KEY")
-    val versionName = project.version as? String
 
     publishing {
         repositories {

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,3 +3,5 @@ systemProp.sonar.host.url=http://localhost:9000
 systemProp.file.encoding=UTF-8
 org.gradle.parallel=true
 org.gradle.caching=true
+# Needed for https://github.com/gradle/gradle/issues/11412
+systemProp.org.gradle.internal.publish.checksums.insecure=true


### PR DESCRIPTION
Moving Detekt to use only `maven-publish` for publishing and removing `gradle-bintray-plugin`.

I think this simplifies overall our setup having a couple of benefits:
- We publish the `.module` files.
- We publish the `.md5` files computed locally (partial fix for #2883)

There a couple of drawbacks:

1. Unfortunately due to https://github.com/gradle/gradle/issues/11412 I had to `systemProp.org.gradle.internal.publish.checksums.insecure=true`. That would have allowed us to publish also locally computed SHA512 for free. This unfortunately _confuses_ Bintray that we're releasing a new version for every module, that is really annoying.

2. @arturbosch you now need to manually start the Maven Central sync. If needed we can have a Gradle task that hits an HTTP endpoint to start the sync. Otherwise this has to be done manually from the Bintray UI.

Here a sample publishing:
https://bintray.com/cortinico/maven/detekt-sample-publishing/

Fixes #2878 