### PR TITLE
OptionalUnit: don't report it if Unit is used as an expression

### DIFF
--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/OptionalUnitSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/OptionalUnitSpec.kt
@@ -2,13 +2,20 @@ package io.gitlab.arturbosch.detekt.rules.style.optional
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Finding
+import io.gitlab.arturbosch.detekt.rules.setupKotlinEnvironment
 import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
 import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
 class OptionalUnitSpec : Spek({
+
+    setupKotlinEnvironment()
+
     val subject by memoized { OptionalUnit(Config.empty) }
+    val env: KotlinCoreEnvironment by memoized()
 
     describe("OptionalUnit rule") {
 
@@ -117,6 +124,162 @@ class OptionalUnitSpec : Spek({
                 """
                 val findings = subject.compileAndLint(code)
                 assertThat(findings).isEmpty()
+            }
+        }
+
+        context("last statement in block - #2452") {
+            it("unused as an expression") {
+                val code = """
+                    fun test(i: Int, b: Boolean) {
+                        when (i) {
+                            0 -> println(1)
+                            else -> {
+                                if (b) {
+                                    println(2)
+                                }
+                                Unit
+                            }
+                        }
+                    }
+                """
+                val findings = subject.compileAndLintWithContext(env, code)
+                assertThat(findings).hasSize(1)
+            }
+
+            it("used as an expression and the previous expression is not a Unit type") {
+                val code = """
+                    fun <T> T.foo() {
+                        println(this)
+                    }
+                    
+                    fun test(i: Int, b: Boolean) {
+                        when (i) {
+                            0 -> println(1)
+                            else -> {
+                                1
+                                Unit
+                            }
+                        }.foo()
+                    }
+                """
+                val findings = subject.compileAndLintWithContext(env, code)
+                assertThat(findings).isEmpty()
+            }
+
+            it("used as an expression and the previous expression cannot be used as a value") {
+                val code = """
+                    fun <T> T.foo() {
+                        println(this)
+                    }
+                    
+                    fun test(i: Int, b: Boolean) {
+                        when (i) {
+                            0 -> println(1)
+                            else -> {
+                                if (b) {
+                                    println(2)
+                                }
+                                Unit
+                            }
+                        }.foo()
+                    }
+                """
+                val findings = subject.compileAndLintWithContext(env, code)
+                assertThat(findings).isEmpty()
+            }
+
+            it("used as an expression and the previous expression cannot be used as a value 2") {
+                val code = """
+                    fun <T> T.foo() {
+                        println(this)
+                    }
+                    
+                    fun test(i: Int, b: Boolean) {
+                        when (i) {
+                            0 -> println(1)
+                            else -> {
+                                when {
+                                    b -> println(2)
+                                }
+                                Unit
+                            }
+                        }.foo()
+                    }
+                """
+                val findings = subject.compileAndLintWithContext(env, code)
+                assertThat(findings).isEmpty()
+            }
+
+            it("used as an expression and the previous expression can be used as a value") {
+                val code = """
+                    fun <T> T.foo() {
+                        println(this)
+                    }
+                    
+                    fun test(i: Int, b: Boolean) {
+                        when (i) {
+                            0 -> println(1)
+                            else -> {
+                                if (b) {
+                                    println(2)
+                                } else {
+                                    println(3)
+                                }
+                                Unit
+                            }
+                        }.foo()
+                    }
+                """
+                val findings = subject.compileAndLintWithContext(env, code)
+                assertThat(findings).hasSize(1)
+            }
+
+            it("used as an expression and the previous expression can be used as a value 2") {
+                val code = """
+                    fun <T> T.foo() {
+                        println(this)
+                    }
+                    
+                    fun test(i: Int, b: Boolean) {
+                        when (i) {
+                            0 -> println(1)
+                            else -> {
+                                when {
+                                    b -> println(2)
+                                    else -> println(3)
+                                }
+                                Unit
+                            }
+                        }.foo()
+                    }
+                """
+                val findings = subject.compileAndLintWithContext(env, code)
+                assertThat(findings).hasSize(1)
+            }
+
+            it("used as an expression and the previous expression can be used as a value 3") {
+                val code = """
+                    fun <T> T.foo() {
+                        println(this)
+                    }
+                    
+                    enum class E { A, B } 
+                    
+                    fun test(i: Int, e: E) {
+                        when (i) {
+                            0 -> println(1)
+                            else -> {
+                                when (e) {
+                                    E.A -> println(1)
+                                    E.B -> println(2)
+                                }
+                                Unit
+                            }
+                        }.foo()
+                    }
+                """
+                val findings = subject.compileAndLintWithContext(env, code)
+                assertThat(findings).hasSize(1)
             }
         }
     }


### PR DESCRIPTION
Fixes #2452 