### PR TITLE
OptionalUnit: fix false positive with 'else if'

### DIFF
--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/OptionalUnit.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/OptionalUnit.kt
@@ -91,10 +91,12 @@ class OptionalUnit(config: Config = Config.empty) : Rule(config) {
 
     private fun KtExpression.canBeUsedAsValue(): Boolean {
         return when (this) {
-            is KtIfExpression ->
-                elseKeyword != null
+            is KtIfExpression -> {
+                val elseExpression = `else`
+                if (elseExpression is KtIfExpression) elseExpression.canBeUsedAsValue() else elseExpression != null
+            }
             is KtWhenExpression ->
-                entries.any { it.elseKeyword != null } || WhenChecker.getMissingCases(this, bindingContext).isEmpty()
+                entries.lastOrNull()?.elseKeyword != null || WhenChecker.getMissingCases(this, bindingContext).isEmpty()
             else ->
                 true
         }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/OptionalUnitSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/OptionalUnitSpec.kt
@@ -172,12 +172,16 @@ class OptionalUnitSpec : Spek({
                         println(this)
                     }
                     
-                    fun test(i: Int, b: Boolean) {
+                    fun test(i: Int, j: Int) {
                         when (i) {
                             0 -> println(1)
                             else -> {
-                                if (b) {
+                                if (j == 1) {
                                     println(2)
+                                } else if (j == 2) {
+                                    println(3)
+                                } else if (j == 3) {
+                                    println(4)
                                 }
                                 Unit
                             }
@@ -194,12 +198,14 @@ class OptionalUnitSpec : Spek({
                         println(this)
                     }
                     
-                    fun test(i: Int, b: Boolean) {
+                    fun test(i: Int, j: Int) {
                         when (i) {
                             0 -> println(1)
                             else -> {
-                                when {
-                                    b -> println(2)
+                                when (j) {
+                                    1 -> println(2)
+                                    2 -> println(3)
+                                    3 -> println(4)
                                 }
                                 Unit
                             }
@@ -216,14 +222,18 @@ class OptionalUnitSpec : Spek({
                         println(this)
                     }
                     
-                    fun test(i: Int, b: Boolean) {
+                    fun test(i: Int, j: Int) {
                         when (i) {
                             0 -> println(1)
                             else -> {
-                                if (b) {
+                                if (j == 1) {
                                     println(2)
-                                } else {
+                                } else if (j == 2) {
                                     println(3)
+                                } else if (j == 3) {
+                                    println(4)
+                                } else {
+                                    println(5)
                                 }
                                 Unit
                             }
@@ -240,13 +250,15 @@ class OptionalUnitSpec : Spek({
                         println(this)
                     }
                     
-                    fun test(i: Int, b: Boolean) {
+                    fun test(i: Int, j: Int) {
                         when (i) {
                             0 -> println(1)
                             else -> {
-                                when {
-                                    b -> println(2)
-                                    else -> println(3)
+                                when (j) {
+                                    1 -> println(2)
+                                    2 -> println(3)
+                                    3 -> println(4)
+                                    else -> println(5)
                                 }
                                 Unit
                             }


### PR DESCRIPTION
Fixed false positive with 'else if' :

```kotlin
fun <T> T.foo() {
    println(this)
}

fun test(i: Int, j: Int) {
    when (i) {
        0 -> println(1)
        else -> {
            if (j == 1) {
                println(2)
            } else if (j == 2) {
                println(3)
            } else if (j == 3) {
                println(4)
            }
            Unit
        }
    }.foo()
}

```

Related: https://github.com/detekt/detekt/pull/2886