### PR TITLE
IgnoredReturnValue: Fix false positive on chained statements

### DIFF
--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValue.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValue.kt
@@ -17,7 +17,7 @@ import org.jetbrains.kotlin.lexer.KtSingleValueToken
 import org.jetbrains.kotlin.psi.KtBlockExpression
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
-import org.jetbrains.kotlin.psi.psiUtil.getParentOfType
+import org.jetbrains.kotlin.psi.psiUtil.getTopmostParentOfType
 import org.jetbrains.kotlin.psi.psiUtil.lastBlockStatementOrThis
 import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.calls.callUtil.getResolvedCall
@@ -85,7 +85,12 @@ class IgnoredReturnValue(config: Config = Config.empty) : Rule(config) {
         val parent = expression.parent
 
         if (parent is KtDotQualifiedExpression) {
-            elementsToInspect += parent.getParentOfType<KtDotQualifiedExpression>(true) ?: parent
+            val parentToInspect = parent.getTopmostParentOfType<KtDotQualifiedExpression>() ?: parent
+            val parentResolvedCall = parentToInspect.getResolvedCall(bindingContext)
+            val parentReturnType = parentResolvedCall?.resultingDescriptor?.returnType
+            if (false == parentReturnType?.isUnit()) {
+                elementsToInspect += parentToInspect
+            }
         }
         if (parent is KtBlockExpression && parent.lastBlockStatementOrThis() == expression) {
             elementsToInspect -= expression


### PR DESCRIPTION
Update the `IgnoredReturnValue` to use `getTopmostParentOfType` instead of `getParentOfType`. This allows use to capture the whole chain statement and not just the direct parent.

Moreover, I'm adding a check to make sure that chains that consumes a value (i.e. returns a `Unit`) are excluded from the inspection.

Fixes #2890 

