### PR TITLE
Fix UseDataClass to accept classes that implement interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ If you contributed to detekt but your name is not in the list, please feel free 
 - [David Phillips](https://github.com/daphil19) - New rule: MandatoryBracesLoops
 - [Volkan Şahin](https://github.com/volsahin) - Documentation improvement
 - [Remco Mokveld](https://github.com/remcomokveld) - Rename Blacklist/Whitelist to more meaningful names
+- [Zachary Moore](https://github.com/zsmoore) - Rule, cli, gradle plugin, and config improvements
 
 ### Mentions
 

--- a/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/KtClassOrObjectExtensions.kt
+++ b/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/KtClassOrObjectExtensions.kt
@@ -2,10 +2,18 @@ package io.gitlab.arturbosch.detekt.rules
 
 import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtDeclaration
+import org.jetbrains.kotlin.psi.KtSuperTypeListEntry
 import org.jetbrains.kotlin.psi.psiUtil.isAbstract
 
-fun KtClass.doesNotExtendAnything() = superTypeListEntries.isEmpty()
-
 fun KtClass.isClosedForExtension() = !isAbstract() && !isOpen()
+
+fun KtClass.onlyExtendsInterfaces(): Boolean {
+    return superTypeListEntries.all { it.isInterface() }
+}
+
+private fun KtSuperTypeListEntry.isInterface(): Boolean {
+    val matchingDeclaration = containingKtFile.declarations.firstOrNull { it.name == typeAsUserType?.referencedName }
+    return matchingDeclaration is KtClass && matchingDeclaration.isInterface()
+}
 
 fun KtClass.extractDeclarations(): List<KtDeclaration> = body?.declarations.orEmpty()

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseDataClass.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseDataClass.kt
@@ -9,10 +9,10 @@ import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.internal.valueOrDefaultCommaSeparated
-import io.gitlab.arturbosch.detekt.rules.doesNotExtendAnything
+import io.gitlab.arturbosch.detekt.rules.onlyExtendsInterfaces
+import io.gitlab.arturbosch.detekt.rules.isInline
 import io.gitlab.arturbosch.detekt.rules.extractDeclarations
 import io.gitlab.arturbosch.detekt.rules.isClosedForExtension
-import io.gitlab.arturbosch.detekt.rules.isInline
 import org.jetbrains.kotlin.descriptors.ClassConstructorDescriptor
 import org.jetbrains.kotlin.descriptors.FunctionDescriptor
 import org.jetbrains.kotlin.psi.KtClass
@@ -70,7 +70,7 @@ class UseDataClass(config: Config = Config.empty) : Rule(config) {
         if (isIncorrectClassType(klass) || hasOnlyPrivateConstructors(klass)) {
             return
         }
-        if (klass.isClosedForExtension() && klass.doesNotExtendAnything() &&
+        if (klass.isClosedForExtension() && klass.onlyExtendsInterfaces() &&
                 !annotationExcluder.shouldExclude(klass.annotationEntries)) {
             val declarations = klass.extractDeclarations()
             val properties = declarations.filterIsInstance<KtProperty>()

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseDataClassSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseDataClassSpec.kt
@@ -90,7 +90,7 @@ class UseDataClassSpec : Spek({
             it("does not report a candidate with an interface that has methods") {
                 val code = """
                     interface SomeInterface {
-                        fun foo()
+                        fun foo(): Int
                     }
                     
                     class NotDataClassBecauseItsImplementingInterfaceWithMethods(val i : Int): SomeInterface {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseDataClassSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseDataClassSpec.kt
@@ -100,6 +100,32 @@ class UseDataClassSpec : Spek({
 
                 assertThat(subject.compileAndLint(code)).isEmpty()
             }
+
+            it("does not report an existing data class candidate with an interface") {
+                val code = """
+                    interface SimpleInterface {
+                        val i: Int
+                    }
+                    
+                    data class DataClass(override val i: Int): SimpleInterface
+                """.trimIndent()
+
+                assertThat(subject.compileAndLint(code)).isEmpty()
+            }
+
+            it("does not report a class extending a class and implementing an interface") {
+                val code = """
+                    interface SimpleInterface {
+                        val i: Int
+                    }
+                    
+                    open class BaseClass(open val j: Int)
+                    
+                    class DataClass(override val i: Int, override val j: Int): SimpleInterface, BaseClass(j)
+                """.trimIndent()
+
+                assertThat(subject.compileAndLint(code)).isEmpty()
+            }
         }
 
         describe("does report data class candidates") {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseDataClassSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseDataClassSpec.kt
@@ -163,6 +163,18 @@ class UseDataClassSpec : Spek({
 
                 assertThat(subject.compileAndLint(code)).hasSize(1)
             }
+
+            it("does report a candidate class with an interface extension that overrides vals") {
+                val code = """
+                    interface SimpleInterface {
+                        val i: Int
+                    }
+                    
+                    class DataClass(override val i: Int): SimpleInterface
+                """.trimIndent()
+
+                assertThat(subject.compileAndLint(code)).hasSize(1)
+            }
         }
 
         describe("copy method") {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseDataClassSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseDataClassSpec.kt
@@ -86,6 +86,20 @@ class UseDataClassSpec : Spek({
                 """
                 assertThat(subject.compileAndLint(code)).isEmpty()
             }
+
+            it("does not report a candidate with an interface that has methods") {
+                val code = """
+                    interface SomeInterface {
+                        fun foo()
+                    }
+                    
+                    class NotDataClassBecauseItsImplementingInterfaceWithMethods(val i : Int): SomeInterface {
+                        override fun foo() = i
+                    }
+                """.trimIndent()
+
+                assertThat(subject.compileAndLint(code)).isEmpty()
+            }
         }
 
         describe("does report data class candidates") {
@@ -138,6 +152,15 @@ class UseDataClassSpec : Spek({
                         }
                     }
                 """
+                assertThat(subject.compileAndLint(code)).hasSize(1)
+            }
+
+            it("does report a candidate class with a simple interface extension") {
+                val code = """
+                    interface SimpleInterface
+                    class DataClass(val i: Int): SimpleInterface
+                """.trimIndent()
+
                 assertThat(subject.compileAndLint(code)).hasSize(1)
             }
         }


### PR DESCRIPTION
Addresses issue #2904 

Root cause is that our doesNotExtendAnything() considers interfaces.

There is not a very easy way to fix this, the fix I have done to detect interfaces is 
- Look at the UserType
- Go to the containing KT File
- Find the declaration with the referenced name
- See if that declaration is a KTClass and an interface

From what I searched PSI does not give us many tools to get class from superTypeEntry