### PR TITLE
Implement custom rule to check spek test discovery performance issues

### DIFF
--- a/buildSrc/src/main/kotlin/detekt.gradle.kts
+++ b/buildSrc/src/main/kotlin/detekt.gradle.kts
@@ -41,6 +41,7 @@ allprojects {
 
     dependencies {
         detekt(project(":detekt-cli"))
+        detektPlugins(project(":custom-checks"))
         detektPlugins(project(":detekt-formatting"))
     }
 }

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -1,3 +1,15 @@
+config:
+  # is automatically ignored when custom-checks.jar is on the classpath
+  # however other CI checks use the argsfile where our plugin is not applied
+  # we need to care take of this by explicitly allowing this properties
+  excludes: 'custom-checks.*'
+
+custom-checks:
+  active: true
+  SpekTestDiscovery:
+    active: true
+    includes: ['**/test/**/*Spec.kt']
+
 comments:
   CommentOverPrivateProperty:
     active: true

--- a/custom-checks/build.gradle.kts
+++ b/custom-checks/build.gradle.kts
@@ -1,0 +1,4 @@
+dependencies {
+    implementation(project(":detekt-api"))
+    testImplementation(project(":detekt-test"))
+}

--- a/custom-checks/src/main/kotlin/io/github/detekt/custom/CustomChecksConfigValidator.kt
+++ b/custom-checks/src/main/kotlin/io/github/detekt/custom/CustomChecksConfigValidator.kt
@@ -1,0 +1,37 @@
+package io.github.detekt.custom
+
+import io.github.detekt.custom.CustomChecksProvider.Companion.RULE_SET_NAME
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.ConfigValidator
+import io.gitlab.arturbosch.detekt.api.Notification
+import io.gitlab.arturbosch.detekt.api.internal.SimpleNotification
+
+class CustomChecksConfigValidator : ConfigValidator {
+
+    override fun validate(config: Config): Collection<Notification> {
+        val result = mutableListOf<Notification>()
+        val customRules = config.subConfig(RULE_SET_NAME)
+
+        fun validateSpekTestDiscoveryConfig() {
+            val rule = SpekTestDiscovery::class.java.simpleName
+            val spekRule = customRules.subConfig(rule)
+            spekRule.valueOrNull<List<String>>(SpekTestDiscovery.SCOPING_FUNCTIONS)
+                ?.filter { it.contains(".") }
+                ?.forEach {
+                    result.add(
+                        SimpleNotification("$rule>${SpekTestDiscovery.SCOPING_FUNCTIONS}: $it must not be qualified.")
+                    )
+                }
+            spekRule.valueOrNull<List<String>>(SpekTestDiscovery.ALLOWED_TYPES)
+                ?.filterNot { it.contains(".") }
+                ?.forEach {
+                    result.add(
+                        SimpleNotification("$rule>${SpekTestDiscovery.ALLOWED_TYPES}: $it must be qualified.")
+                    )
+                }
+        }
+
+        validateSpekTestDiscoveryConfig()
+        return result
+    }
+}

--- a/custom-checks/src/main/kotlin/io/github/detekt/custom/CustomChecksProvider.kt
+++ b/custom-checks/src/main/kotlin/io/github/detekt/custom/CustomChecksProvider.kt
@@ -1,0 +1,19 @@
+package io.github.detekt.custom
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.RuleSet
+import io.gitlab.arturbosch.detekt.api.RuleSetProvider
+
+class CustomChecksProvider : RuleSetProvider {
+
+    override val ruleSetId = RULE_SET_NAME
+
+    override fun instance(config: Config) = RuleSet(
+        ruleSetId,
+        listOf(SpekTestDiscovery(config))
+    )
+
+    companion object {
+        const val RULE_SET_NAME = "custom-checks"
+    }
+}

--- a/custom-checks/src/main/kotlin/io/github/detekt/custom/SpekTestDiscovery.kt
+++ b/custom-checks/src/main/kotlin/io/github/detekt/custom/SpekTestDiscovery.kt
@@ -1,0 +1,146 @@
+package io.github.detekt.custom
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.internal.valueOrDefaultCommaSeparated
+import org.jetbrains.kotlin.js.descriptorUtils.getJetTypeFqName
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtClass
+import org.jetbrains.kotlin.psi.KtLambdaExpression
+import org.jetbrains.kotlin.psi.KtProperty
+import org.jetbrains.kotlin.psi.KtSuperTypeCallEntry
+import org.jetbrains.kotlin.resolve.BindingContext
+import org.jetbrains.kotlin.resolve.calls.callUtil.getType
+
+/**
+ * Expensive setup code can slow down test discovery.
+ * Make sure to use memoization when declaring non trivial types.
+ *
+ * @configuration allowedTypes - full qualified type
+ * (default: `kotlin.String, kotlin.Nothing, kotlin.Int, kotlin.Double, java.io.File, java.nio.file.Path`)
+ * @configuration scopingFunctions - names of functions used to declare a test group (default: `describe, context`)
+ *
+ * <noncompliant>
+ * class MyTest : Spek({
+ *     describe("...") {
+ *         val ast = expensiveParse("code")
+ *
+ *         test("...") {
+ *             assertThat(ast)...
+ *         }
+ *     }
+ * })
+ * </noncompliant>
+ *
+ * <compliant>
+ * class MyTest : Spek({
+ *     val ast by memoized { expensiveParse("code") }
+ *
+ *     test("...") {
+ *         assertThat(ast)...
+ *     }
+ * })
+ * </compliant>
+ */
+class SpekTestDiscovery(config: Config = Config.empty) : Rule(config) {
+
+    override val issue = Issue(
+        javaClass.simpleName,
+        Severity.Performance,
+        """Spek tests can be quite expensive during test discovery.
+            |Compared to Junit5, Spek does not only use reflection to discover the test classes but also needs
+            |to instantiate and run the constructor closure to find tests.
+            |Try using only simple setup code to not slow down the startup of single tests or test suites.
+        """.trimMargin(),
+        Debt.TEN_MINS
+    )
+
+    private val allowedTypes = valueOrDefaultCommaSeparated(
+        ALLOWED_TYPES,
+        listOf(
+            "kotlin.Nothing",
+            "kotlin.String",
+            "kotlin.Int",
+            "kotlin.Double",
+            "java.nio.file.Path",
+            "java.io.File"
+        )
+    ).toSet()
+
+    private val scopingFunctions = valueOrDefaultCommaSeparated(
+        SCOPING_FUNCTIONS,
+        listOf("describe", "context")
+    ).toSet()
+
+    override fun visitClass(klass: KtClass) {
+        bindingContext != BindingContext.EMPTY ?: return
+        if (extendsSpek(klass)) {
+            val lambda = getInitLambda(klass) ?: return
+            inspectSpekGroup(lambda)
+        }
+    }
+
+    private fun inspectSpekGroup(lambda: KtLambdaExpression) {
+        lambda.bodyExpression?.statements?.forEach {
+            when (it) {
+                is KtProperty -> handleProperties(it)
+                is KtCallExpression -> handleScopingFunctions(it)
+            }
+        }
+    }
+
+    private fun handleProperties(property: KtProperty) {
+        if (!property.hasDelegate()) {
+            val initExpr = property.initializer
+            val fqType = initExpr?.getType(bindingContext)
+                ?.getJetTypeFqName(false)
+            if (fqType != null && fqType !in allowedTypes) {
+                report(CodeSmell(
+                    issue,
+                    Entity.atName(property),
+                    "Variable declarations which do not met the allowed types should be memoized."
+                ))
+            }
+        }
+    }
+
+    private fun handleScopingFunctions(call: KtCallExpression) {
+        val calledName = call.calleeExpression?.text
+        if (calledName in scopingFunctions && call.valueArguments.isNotEmpty()) {
+            val scopingLambda = call.valueArguments.last()
+                .getArgumentExpression()
+                as? KtLambdaExpression
+                ?: return
+            inspectSpekGroup(scopingLambda)
+        }
+    }
+
+    private fun extendsSpek(klass: KtClass): Boolean {
+        val entries = klass.superTypeListEntries
+        if (entries.size == 1) {
+            val entry = entries.first()
+            val superType = entry.typeReference?.text
+            return superType == "Spek"
+        }
+        return false
+    }
+
+    private fun getInitLambda(klass: KtClass): KtLambdaExpression? {
+        val superType = klass.superTypeListEntries.first() as? KtSuperTypeCallEntry
+        if (superType?.valueArguments?.size == 1) {
+            val expr = superType.valueArguments.first().getArgumentExpression()
+            return expr as? KtLambdaExpression
+        }
+        return null
+    }
+
+    companion object {
+        const val ALLOWED_TYPES = "allowedTypes"
+        const val SCOPING_FUNCTIONS = "scopingFunctions"
+    }
+}

--- a/custom-checks/src/main/resources/META-INF/services/io.gitlab.arturbosch.detekt.api.ConfigValidator
+++ b/custom-checks/src/main/resources/META-INF/services/io.gitlab.arturbosch.detekt.api.ConfigValidator
@@ -1,0 +1,1 @@
+io.github.detekt.custom.CustomChecksConfigValidator

--- a/custom-checks/src/main/resources/META-INF/services/io.gitlab.arturbosch.detekt.api.RuleSetProvider
+++ b/custom-checks/src/main/resources/META-INF/services/io.gitlab.arturbosch.detekt.api.RuleSetProvider
@@ -1,0 +1,1 @@
+io.github.detekt.custom.CustomChecksProvider

--- a/custom-checks/src/test/kotlin/io/github/detekt/custom/SpekTestDiscoverySpec.kt
+++ b/custom-checks/src/test/kotlin/io/github/detekt/custom/SpekTestDiscoverySpec.kt
@@ -1,0 +1,86 @@
+package io.github.detekt.custom
+
+import io.gitlab.arturbosch.detekt.rules.setupKotlinEnvironment
+import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+class SpekTestDiscoverySpec : Spek({
+    setupKotlinEnvironment()
+
+    val subject by memoized { SpekTestDiscovery() }
+    val env: KotlinCoreEnvironment by memoized()
+
+    describe("variable declarations in spek groups should only be simple") {
+
+        context("top level scope") {
+
+            it("allows strings, paths and files by default") {
+                val code = createSpekCode("""
+                    val s = "simple"
+                    val p = Paths.get("")
+                    val f = File("")
+                """.trimIndent())
+
+                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            }
+
+            it("detects disallowed types on top level scope") {
+                val code = createSpekCode("val s = Any()")
+
+                assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            }
+
+            it("allows memoized blocks") {
+                val code = createSpekCode("val s by memoized { Any() }")
+
+                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            }
+        }
+
+        context("describe and context blocks") {
+
+            setOf("describe", "context").forEach { name ->
+                it("allows strings, files and paths by default") {
+                    val code = createSpekCode("""
+                        $name("group") {
+                            val s = "simple"
+                            val p = Paths.get("")
+                            val f = File("")
+                            val m by memoized { Any() }
+                        }
+                    """.trimIndent())
+
+                    assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                }
+            }
+
+            setOf("describe", "context").forEach { name ->
+                it("disallows non memoized declarations") {
+                    val code = createSpekCode("""
+                        $name("group") {
+                            val complex = Any()
+                        }
+                    """.trimIndent())
+
+                    assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+                }
+            }
+        }
+    }
+})
+
+private fun createSpekCode(content: String) = """
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import java.io.File
+import java.nio.file.Paths
+
+class Test : Spek({
+    describe("top") {
+        $content
+    }
+})
+""".trimIndent()

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/DebtSpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/DebtSpec.kt
@@ -35,7 +35,7 @@ class DebtSpec : Spek({
 
     describe("add minutes, hours and days to debt") {
 
-        val debt = Debt(0, 22, 59)
+        val debt by memoized { Debt(0, 22, 59) }
 
         it("adds 1 min") {
             val result = debt + Debt(mins = 1)

--- a/detekt-report-html/src/test/kotlin/io/github/detekt/report/html/HtmlOutputReportSpec.kt
+++ b/detekt-report-html/src/test/kotlin/io/github/detekt/report/html/HtmlOutputReportSpec.kt
@@ -30,7 +30,7 @@ class HtmlOutputReportSpec : Spek({
 
     describe("HTML output report") {
 
-        val htmlReport = HtmlOutputReport()
+        val htmlReport by memoized { HtmlOutputReport() }
 
         it("renders the HTML headers correctly") {
             val result = htmlReport.render(TestDetektion())

--- a/detekt-report-html/src/test/kotlin/io/github/detekt/report/html/HtmlUtilsSpec.kt
+++ b/detekt-report-html/src/test/kotlin/io/github/detekt/report/html/HtmlUtilsSpec.kt
@@ -10,7 +10,8 @@ import org.spekframework.spek2.style.specification.describe
 class HtmlUtilsSpec : Spek({
 
     describe("HTML snippet code") {
-        val code = """
+        val code by memoized {
+            """
             package cases
             // reports 1 - line with just one space
 
@@ -27,7 +28,8 @@ class HtmlUtilsSpec : Spek({
                 // reports 1
                 }
             }
-        """.trimIndent().splitToSequence('\n')
+            """.trimIndent().splitToSequence('\n')
+        }
 
         it("all line") {
             val snippet = createHTML().div() {

--- a/detekt-report-xml/src/test/kotlin/io/github/detekt/report/xml/XmlOutputFormatSpec.kt
+++ b/detekt-report-xml/src/test/kotlin/io/github/detekt/report/xml/XmlOutputFormatSpec.kt
@@ -17,14 +17,18 @@ import org.spekframework.spek2.style.specification.describe
 
 class XmlOutputFormatSpec : Spek({
 
-    val entity1 = Entity("Sample1", "com.sample.Sample1", "",
+    val entity1 by memoized {
+        Entity("Sample1", "com.sample.Sample1", "",
             Location(SourceLocation(11, 1), TextLocation(0, 10),
-                    "abcd", "src/main/com/sample/Sample1.kt"))
-    val entity2 = Entity("Sample2", "com.sample.Sample2", "",
+                "abcd", "src/main/com/sample/Sample1.kt"))
+    }
+    val entity2 by memoized {
+        Entity("Sample2", "com.sample.Sample2", "",
             Location(SourceLocation(22, 2), TextLocation(0, 20),
-                    "efgh", "src/main/com/sample/Sample2.kt"))
+                "efgh", "src/main/com/sample/Sample2.kt"))
+    }
 
-    val outputFormat = XmlOutputReport()
+    val outputFormat by memoized { XmlOutputReport() }
 
     describe("XML output format") {
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,6 @@
 rootProject.name = "detekt"
 include(
+    "custom-checks",
     "detekt-api",
     "detekt-cli",
     "detekt-bom",


### PR DESCRIPTION
This PR introduces a new module `custom-checks` with for now one rule `SpekTestDiscovery`.
This rule finds variable declarations in spek tests where `memoized` would help to improve the performance.

All previous PR's improved the discovery time by ~200ms per module (500-1000ms in extreme cases like metrics and rules-style modules (parsing Kotlin files)).
In conclusion nearly every object we use to setup tests has to be considered as "heavy".
Exceptions are template strings and paths. I've excluded them from the rule.

Test frameworks like `Spek` which not only use reflection to find the tests but also need to instantiate a class and run the constructor closure are errorprone to such issues if one forgets to use `memoized` or similar concepts.