### PR TITLE
Fix false positive for UnnecessaryApply with disabled type resolution

### DIFF
--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryApply.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryApply.kt
@@ -17,6 +17,7 @@ import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.psi.KtReferenceExpression
 import org.jetbrains.kotlin.psi.KtSafeQualifiedExpression
 import org.jetbrains.kotlin.psi.KtThisExpression
+import org.jetbrains.kotlin.resolve.BindingContext
 
 /**
  * `apply` expressions are used frequently, but sometimes their usage should be replaced with
@@ -42,6 +43,8 @@ class UnnecessaryApply(config: Config) : Rule(config) {
 
     override fun visitCallExpression(expression: KtCallExpression) {
         super.visitCallExpression(expression)
+
+        if (bindingContext == BindingContext.EMPTY) return
 
         if (expression.isApplyExpr() &&
                 expression.hasOnlyOneMemberAccessStatement() &&


### PR DESCRIPTION
Restricting `UnnecessaryApply` to work only when type resolution is active. 

Currently the rule is generating false positives for scenarios where the return value of `.apply{}` is used. We actually already have the code to handle this scenario (`!expression.receiverIsUsed(bindingContext)`) but it requires type and symbol resolution to provide a meaningful result.

As a rule of thumb, we should also consider avoiding rules with "mixed" inspection if you have type resolution enabled or not.

Fixes #2938