### PR TITLE
Gradle plugin fixes

### DIFF
--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -4,7 +4,6 @@ plugins {
 }
 
 dependencies {
-    implementation(kotlin("gradle-plugin"))
     implementation(kotlin("gradle-plugin-api"))
 }
 

--- a/detekt-gradle-plugin/gradle/wrapper/gradle-wrapper.properties
+++ b/detekt-gradle-plugin/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,0 @@
-distributionBase=GRADLE_USER_HOME
-distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.2.1-all.zip
-zipStoreBase=GRADLE_USER_HOME
-zipStorePath=wrapper/dists

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DslTestBuilder.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DslTestBuilder.kt
@@ -99,14 +99,14 @@ abstract class DslTestBuilder {
 
         private const val GROOVY_PLUGINS_SECTION = """
             |plugins {
-            |   id "org.jetbrains.kotlin.jvm"
+            |   id 'java-library'
             |   id "io.gitlab.arturbosch.detekt"
             |}
             |"""
 
         private const val KOTLIN_PLUGINS_SECTION = """
             |plugins {
-            |   kotlin("jvm")
+            |   `java-library`
             |   id("io.gitlab.arturbosch.detekt")
             |}
             |"""
@@ -120,12 +120,10 @@ abstract class DslTestBuilder {
             |"""
 
         private const val GROOVY_APPLY_PLUGINS = """
-            |apply plugin: "kotlin"
             |apply plugin: "io.gitlab.arturbosch.detekt"
             |"""
 
         private const val KOTLIN_APPLY_PLUGINS = """
-            |plugins.apply("kotlin")
             |plugins.apply("io.gitlab.arturbosch.detekt")
             |"""
     }


### PR DESCRIPTION
* Stop declaring unnecessary dependencies
* Correct the generated test Gradle build files so they're valid
* Remove unused file