### PR TITLE
Fix false positive for UnnecessaryLet with disabled type resolution

### DIFF
--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLet.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLet.kt
@@ -17,6 +17,7 @@ import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
 import org.jetbrains.kotlin.psi.KtLambdaExpression
 import org.jetbrains.kotlin.psi.KtSafeQualifiedExpression
 import org.jetbrains.kotlin.psi.ValueArgument
+import org.jetbrains.kotlin.resolve.BindingContext
 
 /**
  * `let` expressions are used extensively in our code for null-checking and chaining functions,
@@ -48,6 +49,8 @@ class UnnecessaryLet(config: Config) : Rule(config) {
 
     override fun visitCallExpression(expression: KtCallExpression) {
         super.visitCallExpression(expression)
+
+        if (bindingContext == BindingContext.EMPTY) return
 
         if (!expression.isLetExpr()) return
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLetSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLetSpec.kt
@@ -143,6 +143,16 @@ class UnnecessaryLetSpec : Spek({
             assertThat(findings).isEmpty()
         }
 
+        it("does not report a let where returned value is used - #2987") {
+            val findings = subject.compileAndLintWithContext(env, """
+                fun f() {
+                    val a = listOf<List<String>?>(listOf(""))
+                        .map { list -> list?.let { it + it } }
+                }
+                """)
+            assertThat(findings).isEmpty()
+        }
+
         it("does not report use of let with the safe call operator when we use an argument") {
             val findings = subject.compileAndLintWithContext(env, """
                 fun f() {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLetSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLetSpec.kt
@@ -1,17 +1,23 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.rules.setupKotlinEnvironment
+import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
 import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
 class UnnecessaryLetSpec : Spek({
+
+    setupKotlinEnvironment()
+
     val subject by memoized { UnnecessaryLet(Config.empty) }
+    val env: KotlinCoreEnvironment by memoized()
 
     describe("UnnecessaryLet rule") {
         it("reports unnecessary lets that can be changed to ordinary method call 1") {
-            val findings = subject.compileAndLint("""
+            val findings = subject.compileAndLintWithContext(env, """
                 fun f() {
                     val a: Int = 1
                     a.let { it.plus(1) }
@@ -22,7 +28,7 @@ class UnnecessaryLetSpec : Spek({
         }
 
         it("reports unnecessary lets that can be changed to ordinary method call 2") {
-            val findings = subject.compileAndLint("""
+            val findings = subject.compileAndLintWithContext(env, """
                 fun f() {
                     val a: Int? = null
                     a?.let { it.plus(1) }
@@ -33,7 +39,7 @@ class UnnecessaryLetSpec : Spek({
         }
 
         it("reports unnecessary lets that can be changed to ordinary method call 3") {
-            val findings = subject.compileAndLint("""
+            val findings = subject.compileAndLintWithContext(env, """
                 fun f() {
                     val a: Int? = null
                     a?.let { that -> that.plus(1) }?.let { it.plus(1) }
@@ -43,7 +49,7 @@ class UnnecessaryLetSpec : Spek({
         }
 
         it("reports unnecessary lets that can be changed to ordinary method call 4") {
-            val findings = subject.compileAndLint("""
+            val findings = subject.compileAndLintWithContext(env, """
                 fun f() {
                     val a: Int = 1
                     a.let { 1.plus(1) }
@@ -54,7 +60,7 @@ class UnnecessaryLetSpec : Spek({
         }
 
         it("reports unnecessary lets that can be changed to ordinary method call 5" ) {
-            val findings = subject.compileAndLint("""
+            val findings = subject.compileAndLintWithContext(env, """
                 fun f() {
                     val a: Int = 1
                     val x = a.let { 1.plus(1) }
@@ -65,7 +71,7 @@ class UnnecessaryLetSpec : Spek({
         }
 
         it("reports unnecessary lets that can be replaced with an if") {
-            val findings = subject.compileAndLint("""
+            val findings = subject.compileAndLintWithContext(env, """
                 fun f() {
                     val a: Int? = null
                     a?.let { 1.plus(1) }
@@ -76,7 +82,7 @@ class UnnecessaryLetSpec : Spek({
         }
 
         it("reports unnecessary lets that can be changed to ordinary method call 7") {
-            val findings = subject.compileAndLint("""
+            val findings = subject.compileAndLintWithContext(env, """
                 fun f() {
                     val a: Int? = null
                     a.let { print(it) }
@@ -87,7 +93,7 @@ class UnnecessaryLetSpec : Spek({
         }
 
         it("reports unnecessary lets that can be changed to ordinary method call 8") {
-            val findings = subject.compileAndLint("""
+            val findings = subject.compileAndLintWithContext(env, """
                 fun f() {
                     val a: Int? = null
                     a?.let { it?.plus(1) }
@@ -98,7 +104,7 @@ class UnnecessaryLetSpec : Spek({
         }
 
         it("reports use of let without the safe call operator when we use an argument") {
-            val findings = subject.compileAndLint("""
+            val findings = subject.compileAndLintWithContext(env, """
                 fun f() {
                     val f: (Int?) -> Boolean = { true }
                     val a: Int? = null
@@ -109,7 +115,7 @@ class UnnecessaryLetSpec : Spek({
         }
 
         it("does not report lets used for function calls 1") {
-            val findings = subject.compileAndLint("""
+            val findings = subject.compileAndLintWithContext(env, """
                 fun f() {
                     val a: Int? = null
                     a?.let { print(it) }
@@ -119,7 +125,7 @@ class UnnecessaryLetSpec : Spek({
         }
 
         it("does not report lets used for function calls 2") {
-            val findings = subject.compileAndLint("""
+            val findings = subject.compileAndLintWithContext(env, """
                 fun f() {
                     val a: Int? = null
                     a?.let { that -> 1.plus(that) }?.let { print(it) }
@@ -128,7 +134,7 @@ class UnnecessaryLetSpec : Spek({
         }
 
         it("does not report \"can be replaced by if\" because you will need an else too") {
-            val findings = subject.compileAndLint("""
+            val findings = subject.compileAndLintWithContext(env, """
                 fun f() {
                     val a: Int? = null
                     val x = a?.let { 1.plus(1) }
@@ -138,7 +144,7 @@ class UnnecessaryLetSpec : Spek({
         }
 
         it("does not report use of let with the safe call operator when we use an argument") {
-            val findings = subject.compileAndLint("""
+            val findings = subject.compileAndLintWithContext(env, """
                 fun f() {
                     val f: (Int?) -> Boolean = { true }
                     val a: Int? = null
@@ -148,7 +154,7 @@ class UnnecessaryLetSpec : Spek({
         }
 
         it("does not report lets with lambda body containing more than one statement") {
-            val findings = subject.compileAndLint("""
+            val findings = subject.compileAndLintWithContext(env, """
                 fun f() {
                     val a: Int? = null
                     val b: Int = 1
@@ -180,7 +186,7 @@ class UnnecessaryLetSpec : Spek({
         }
 
         it("does not report lets where it is used multiple times") {
-            val findings = subject.compileAndLint("""
+            val findings = subject.compileAndLintWithContext(env, """
                 fun f() {
                     val a: Int? = null
                     val b: Int = 1
@@ -201,7 +207,7 @@ class UnnecessaryLetSpec : Spek({
                     foo.let { (a, b) -> a + b }
                 }
             """
-                val findings = subject.compileAndLint(content)
+                val findings = subject.compileAndLintWithContext(env, content)
                 assertThat(findings).isEmpty()
             }
 
@@ -213,7 +219,7 @@ class UnnecessaryLetSpec : Spek({
                     foo.let { (a, _) -> a + a }
                 }
             """
-                val findings = subject.compileAndLint(content)
+                val findings = subject.compileAndLintWithContext(env, content)
                 assertThat(findings).isEmpty()
             }
 
@@ -225,7 +231,7 @@ class UnnecessaryLetSpec : Spek({
                     foo.let { (a: Int, b: Int) -> a + b }
                 }
             """
-                val findings = subject.compileAndLint(content)
+                val findings = subject.compileAndLintWithContext(env, content)
                 assertThat(findings).isEmpty()
             }
 
@@ -237,7 +243,7 @@ class UnnecessaryLetSpec : Spek({
                     foo.let { (a, _) -> a }
                 }
             """
-                val findings = subject.compileAndLint(content)
+                val findings = subject.compileAndLintWithContext(env, content)
                 assertThat(findings).hasSize(1)
                 assertThat(findings).allMatch { it.message == MESSAGE_OMIT_LET }
             }
@@ -250,7 +256,7 @@ class UnnecessaryLetSpec : Spek({
                     foo?.let { (_, b) -> b.plus(1) }
                 }
             """
-                val findings = subject.compileAndLint(content)
+                val findings = subject.compileAndLintWithContext(env, content)
                 assertThat(findings).hasSize(1)
                 assertThat(findings).allMatch { it.message == MESSAGE_OMIT_LET }
             }
@@ -263,7 +269,7 @@ class UnnecessaryLetSpec : Spek({
                     foo.let { (_, _) -> 0 }
                 }
             """
-                val findings = subject.compileAndLint(content)
+                val findings = subject.compileAndLintWithContext(env, content)
                 assertThat(findings).hasSize(1)
                 assertThat(findings).allMatch { it.message == MESSAGE_OMIT_LET }
             }
@@ -276,7 +282,7 @@ class UnnecessaryLetSpec : Spek({
                     foo?.let { (_, _) -> 0 }
                 }
             """
-                val findings = subject.compileAndLint(content)
+                val findings = subject.compileAndLintWithContext(env, content)
                 assertThat(findings).hasSize(1)
                 assertThat(findings).allMatch { it.message == MESSAGE_USE_IF }
             }


### PR DESCRIPTION
The fix is the same we applied for https://github.com/detekt/detekt/issues/2938 (restricting the rule to type resolution only).

Fixes #2987 