### PR TITLE
Introduce @requiresTypeResolution to KDoc for rules

### DIFF
--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/Rule.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/Rule.kt
@@ -12,5 +12,6 @@ data class Rule(
     val parent: String,
     val configuration: List<Configuration> = listOf(),
     val autoCorrect: Boolean = false,
-    var inMultiRule: String? = null
+    var inMultiRule: String? = null,
+    val requiresTypeResolution: Boolean = false
 )

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleVisitor.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleVisitor.kt
@@ -28,6 +28,7 @@ internal class RuleVisitor : DetektVisitor() {
     private var name = ""
     private var active = false
     private var autoCorrect = false
+    private var requiresTypeResolution = false
     private var severity = ""
     private var debt = ""
     private var aliases: String? = null
@@ -40,8 +41,20 @@ internal class RuleVisitor : DetektVisitor() {
             throw InvalidDocumentationException("Rule $name is missing a description in its KDoc.")
         }
 
-        return Rule(name, description, nonCompliant, compliant,
-                active, severity, debt, aliases, parent, configuration, autoCorrect)
+        return Rule(
+            name = name,
+            description = description,
+            nonCompliantCodeExample = nonCompliant,
+            compliantCodeExample = compliant,
+            active = active,
+            severity = severity,
+            debt = debt,
+            aliases = aliases,
+            parent = parent,
+            configuration = configuration,
+            autoCorrect = autoCorrect,
+            requiresTypeResolution = requiresTypeResolution
+        )
     }
 
     override fun visitSuperTypeList(list: KtSuperTypeList) {
@@ -77,6 +90,7 @@ internal class RuleVisitor : DetektVisitor() {
 
         active = classOrObject.kDocSection()?.findTagByName(TAG_ACTIVE) != null
         autoCorrect = classOrObject.kDocSection()?.findTagByName(TAG_AUTO_CORRECT) != null
+        requiresTypeResolution = classOrObject.kDocSection()?.findTagByName(TAG_REQUIRES_TYPE_RESOLUTION) != null
 
         val comment = classOrObject.kDocSection()?.getContent()?.trim()?.replace("@@", "@") ?: return
         extractRuleDocumentation(comment)
@@ -171,6 +185,7 @@ internal class RuleVisitor : DetektVisitor() {
 
         private const val TAG_ACTIVE = "active"
         private const val TAG_AUTO_CORRECT = "autoCorrect"
+        private const val TAG_REQUIRES_TYPE_RESOLUTION = "requiresTypeResolution"
         private const val TAG_NONCOMPLIANT = "<noncompliant>"
         private const val ENDTAG_NONCOMPLIANT = "</noncompliant>"
         private const val TAG_COMPLIANT = "<compliant>"

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/rulesetpage/RuleSetPagePrinter.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/rulesetpage/RuleSetPagePrinter.kt
@@ -42,7 +42,7 @@ object RuleSetPagePrinter : DocumentationPrinter<RuleSetPage> {
 
             if (rule.requiresTypeResolution) {
                 paragraph {
-                    bold { "Requires Type and Symbol solving" }
+                    bold { "Requires Type and Symbol Solving" }
                 }
             }
 

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/rulesetpage/RuleSetPagePrinter.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/rulesetpage/RuleSetPagePrinter.kt
@@ -40,6 +40,12 @@ object RuleSetPagePrinter : DocumentationPrinter<RuleSetPage> {
                 paragraph { "TODO: Specify description" }
             }
 
+            if (rule.requiresTypeResolution) {
+                paragraph {
+                    bold { "Requires Type and Symbol solving" }
+                }
+            }
+
             if (rule.severity.isNotEmpty()) {
                 paragraph {
                     "${bold { "Severity" }}: ${rule.severity}"

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/util/RuleSetPageCreator.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/util/RuleSetPageCreator.kt
@@ -12,13 +12,46 @@ internal fun createRuleSetPage(): RuleSetPage {
 }
 
 internal fun createRules(): List<Rule> {
-    val rule1 = Rule("WildcardImport", "a wildcard import", "import foo.*", "import foo.bar", true, "Defect",
-            "10min", "alias1, alias2", "", listOf(
-                    Configuration("conf1", "a config option", "foo", null),
-                    Configuration("conf2", "deprecated config", "false", "use conf1 instead")))
-    val rule2 = Rule("EqualsNull", "equals null", "", "", false, "",
-            "", null, "WildcardImport", emptyList())
-    val rule3 = Rule("NoUnitKeyword", "removes :Unit", "fun stuff(): Unit {}",
-            "fun stuff() {}", true, "", "5m", null, "", emptyList(), true)
+    val rule1 = Rule(
+        name = "WildcardImport",
+        description = "a wildcard import",
+        nonCompliantCodeExample = "import foo.*",
+        compliantCodeExample = "import foo.bar",
+        active = true,
+        severity = "Defect",
+        debt = "10min",
+        aliases = "alias1, alias2",
+        parent = "",
+        configuration = listOf(
+            Configuration("conf1", "a config option", "foo", null),
+            Configuration("conf2", "deprecated config", "false", "use conf1 instead")
+        )
+    )
+    val rule2 = Rule(
+        name = "EqualsNull",
+        description = "equals null",
+        nonCompliantCodeExample = "",
+        compliantCodeExample = "",
+        active = false,
+        severity = "",
+        debt = "",
+        aliases = null,
+        parent = "WildcardImport",
+        configuration = emptyList()
+    )
+    val rule3 = Rule(
+        name = "NoUnitKeyword",
+        description = "removes :Unit",
+        nonCompliantCodeExample = "fun stuff(): Unit {}",
+        compliantCodeExample = "fun stuff() {}",
+        active = true,
+        severity = "",
+        debt = "5m",
+        aliases = null,
+        parent = "",
+        configuration = emptyList(),
+        autoCorrect = true,
+        requiresTypeResolution = true
+    )
     return listOf(rule1, rule2, rule3)
 }

--- a/detekt-generator/src/test/resources/RuleSet.md
+++ b/detekt-generator/src/test/resources/RuleSet.md
@@ -42,6 +42,8 @@ equals null
 
 removes :Unit
 
+**Requires Type and Symbol solving**
+
 **Debt**: 5m
 
 #### Noncompliant Code:

--- a/detekt-generator/src/test/resources/RuleSet.md
+++ b/detekt-generator/src/test/resources/RuleSet.md
@@ -42,7 +42,7 @@ equals null
 
 removes :Unit
 
-**Requires Type and Symbol solving**
+**Requires Type and Symbol Solving**
 
 **Debt**: 5m
 

--- a/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/RedundantSuspendModifier.kt
+++ b/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/RedundantSuspendModifier.kt
@@ -49,8 +49,9 @@ import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
  *   println("string")
  * }
  * </compliant>
+ *
+ * @requiresTypeResolution
  */
-
 class RedundantSuspendModifier(config: Config) : Rule(config) {
 
     override val issue = Issue(

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/Deprecation.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/Deprecation.kt
@@ -14,6 +14,8 @@ import org.jetbrains.kotlin.resolve.BindingContext
 
 /**
  * Deprecated elements are expected to be removed in future. Alternatives should be found if possible.
+ *
+ * @requiresTypeResolution
  */
 class Deprecation(config: Config) : Rule(config) {
 

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/HasPlatformType.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/HasPlatformType.kt
@@ -33,8 +33,9 @@ import org.jetbrains.kotlin.types.isFlexible
  *   fun apiCall(): String = System.getProperty("propertyName")
  * }
  * </compliant>
+ *
+ * @requiresTypeResolution
  */
-
 class HasPlatformType(config: Config) : Rule(config) {
 
     override val issue = Issue(

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValue.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValue.kt
@@ -42,6 +42,8 @@ import org.jetbrains.kotlin.types.typeUtil.isUnit
  *
  * @configuration restrictToAnnotatedMethods - if the rule should check only annotated methods. (default: `true`)
  * @configuration returnValueAnnotations - List of glob patterns to be used as inspection annotation (default: `['*.CheckReturnValue', '*.CheckResult']`)
+ *
+ * @requiresTypeResolution
  */
 class IgnoredReturnValue(config: Config = Config.empty) : Rule(config) {
 

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ImplicitUnitReturnType.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ImplicitUnitReturnType.kt
@@ -34,6 +34,8 @@ import org.jetbrains.kotlin.resolve.calls.callUtil.getResolvedCall
  * // explicit Unit is compliant by default; can be configured to enforce block statement
  * fun safeUnitReturn(): Unit = println("Hello Unit")
  * </compliant>
+ *
+ * @requiresTypeResolution
  */
 class ImplicitUnitReturnType(config: Config) : Rule(config) {
 

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingWhenCase.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingWhenCase.kt
@@ -62,6 +62,8 @@ import org.jetbrains.kotlin.resolve.calls.callUtil.getType
  * https://github.com/JetBrains/kotlin/blob/v1.3.30/compiler/frontend/src/org/jetbrains/kotlin/cfg/ControlFlowInformationProvider.kt
  *
  * @active since v1.2.0
+ *
+ * @requiresTypeResolution
  */
 class MissingWhenCase(config: Config = Config.empty) : Rule(config) {
 

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/NullableToStringCall.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/NullableToStringCall.kt
@@ -42,6 +42,7 @@ import org.jetbrains.kotlin.types.isNullable
  * </compliant>
  *
  * @since 1.11.0
+ * @requiresTypeResolution
  */
 class NullableToStringCall(config: Config = Config.empty) : Rule(config) {
     override val issue = Issue(

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/RedundantElseInWhen.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/RedundantElseInWhen.kt
@@ -67,6 +67,7 @@ import org.jetbrains.kotlin.resolve.source.getPsi
  * </compliant>
  *
  * @active since v1.2.0
+ * @requiresTypeResolution
  */
 class RedundantElseInWhen(config: Config = Config.empty) : Rule(config) {
 

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessaryNotNullOperator.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessaryNotNullOperator.kt
@@ -23,6 +23,8 @@ import org.jetbrains.kotlin.resolve.BindingContext
  * val a = 1
  * val b = a
  * </compliant>
+ *
+ * @requiresTypeResolution
  */
 class UnnecessaryNotNullOperator(config: Config = Config.empty) : Rule(config) {
 

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessarySafeCall.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessarySafeCall.kt
@@ -26,6 +26,8 @@ import org.jetbrains.kotlin.resolve.BindingContext
  * val a: String? = null
  * val b = someValue?.length
  * </compliant>
+ *
+ * @requiresTypeResolution
  */
 class UnnecessarySafeCall(config: Config = Config.empty) : Rule(config) {
 

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCallOnNullableType.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCallOnNullableType.kt
@@ -32,6 +32,7 @@ import org.jetbrains.kotlin.types.typeUtil.nullability
  * </compliant>
  *
  * @active since v1.2.0
+ * @requiresTypeResolution
  */
 class UnsafeCallOnNullableType(config: Config = Config.empty) : Rule(config) {
     override val issue: Issue = Issue("UnsafeCallOnNullableType",

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCast.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCast.kt
@@ -29,6 +29,8 @@ import org.jetbrains.kotlin.resolve.BindingContext
  *     println(s as Int)
  * }
  * </compliant>
+ *
+ * @requiresTypeResolution
  */
 class UnsafeCast(config: Config = Config.empty) : Rule(config) {
 

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/IsPropertyNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/IsPropertyNaming.kt
@@ -26,6 +26,8 @@ import org.jetbrains.kotlin.resolve.typeBinding.createTypeBindingForReturnType
  * <compliant>
  * val isEnabled: Boolean = false
  * </compliant>
+ *
+ * @requiresTypeResolution
  */
 abstract class IsPropertyNaming(config: Config = Config.empty) : Rule(config) {
 // is abstract to not break providers test - #2819

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCall.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCall.kt
@@ -27,6 +27,8 @@ import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameOrNull
  *
  * @configuration methods - Comma separated list of fully qualified method signatures which are forbidden
  *  (default: `['kotlin.io.println', 'kotlin.io.print']`)
+ *
+ * @requiresTypeResolution
  */
 class ForbiddenMethodCall(config: Config = Config.empty) : Rule(config) {
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenVoid.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenVoid.kt
@@ -35,6 +35,8 @@ import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameOrNull
  *
  * @configuration ignoreOverridden - ignores void types in signatures of overridden functions (default: `false`)
  * @configuration ignoreUsageInGenerics - ignore void types as generic arguments (default: `false`)
+ *
+ * @requiresTypeResolution
  */
 class ForbiddenVoid(config: Config = Config.empty) : Rule(config) {
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryApply.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryApply.kt
@@ -35,6 +35,8 @@ import org.jetbrains.kotlin.resolve.BindingContext
  *     environment = "test"
  * }
  * </compliant>
+ *
+ * @requiresTypeResolution
  */
 class UnnecessaryApply(config: Config) : Rule(config) {
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLet.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLet.kt
@@ -38,6 +38,8 @@ import org.jetbrains.kotlin.psi.ValueArgument
  * a?.let { it.plus(it) }
  * val b = a?.let { 1.plus(1) }
  * </compliant>
+ *
+ * @requiresTypeResolution
  */
 class UnnecessaryLet(config: Config) : Rule(config) {
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseEmptyCounterpart.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseEmptyCounterpart.kt
@@ -30,6 +30,8 @@ import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameOrNull
  * emptySequence()
  * emptySet()
  * </compliant>
+ *
+ * @requiresTypeResolution
  */
 class UseEmptyCounterpart(config: Config) : Rule(config) {
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UselessCallOnNotNull.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UselessCallOnNotNull.kt
@@ -41,6 +41,7 @@ import org.jetbrains.kotlin.types.isNullable
  * </compliant>
  *
  * @active since v1.2.0
+ * @requiresTypeResolution
  */
 class UselessCallOnNotNull(config: Config = Config.empty) : Rule(config) {
     override val issue: Issue = Issue(

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/PreferToOverPairSyntax.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/PreferToOverPairSyntax.kt
@@ -27,6 +27,8 @@ import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameOrNull
  * <compliant>
  * val pair = 1 to 2
  * </compliant>
+ *
+ * @requiresTypeResolution
  */
 class PreferToOverPairSyntax(config: Config = Config.empty) : Rule(config) {
     override val issue = Issue("PreferToOverPairSyntax", Severity.Style,

--- a/docs/pages/documentation/coroutines.md
+++ b/docs/pages/documentation/coroutines.md
@@ -55,7 +55,7 @@ where it's not needed.
 Based on code from Kotlin project:
 https://github.com/JetBrains/kotlin/blob/v1.3.61/idea/src/org/jetbrains/kotlin/idea/inspections/RedundantSuspendModifierInspection.kt
 
-**Requires Type and Symbol solving**
+**Requires Type and Symbol Solving**
 
 **Severity**: Minor
 

--- a/docs/pages/documentation/coroutines.md
+++ b/docs/pages/documentation/coroutines.md
@@ -55,6 +55,8 @@ where it's not needed.
 Based on code from Kotlin project:
 https://github.com/JetBrains/kotlin/blob/v1.3.61/idea/src/org/jetbrains/kotlin/idea/inspections/RedundantSuspendModifierInspection.kt
 
+**Requires Type and Symbol solving**
+
 **Severity**: Minor
 
 **Debt**: 5min

--- a/docs/pages/documentation/potential-bugs.md
+++ b/docs/pages/documentation/potential-bugs.md
@@ -12,7 +12,7 @@ The potential-bugs rule set provides rules that detect potential bugs.
 
 Deprecated elements are expected to be removed in future. Alternatives should be found if possible.
 
-**Requires Type and Symbol solving**
+**Requires Type and Symbol Solving**
 
 **Severity**: Defect
 
@@ -141,7 +141,7 @@ Platform types must be declared explicitly in public APIs to prevent unexpected 
 Based on code from Kotlin project:
 https://github.com/JetBrains/kotlin/blob/1.3.50/idea/src/org/jetbrains/kotlin/idea/intentions/SpecifyTypeExplicitlyIntention.kt#L86-L107
 
-**Requires Type and Symbol solving**
+**Requires Type and Symbol Solving**
 
 **Severity**: Maintainability
 
@@ -172,7 +172,7 @@ normally so that's the rationale behind this rule.
 fun returnsValue() = 42
 fun returnsNoValue() {}
 
-**Requires Type and Symbol solving**
+**Requires Type and Symbol Solving**
 
 **Severity**: Defect
 
@@ -242,7 +242,7 @@ Changing the type of the expression accidentally, changes the functions return t
 This may lead to backward incompatibility.
 Use a block statement to make clear this function will never return a value.
 
-**Requires Type and Symbol solving**
+**Requires Type and Symbol Solving**
 
 **Severity**: Defect
 
@@ -434,7 +434,7 @@ or sealed class and the `when` expression is used as a statement.
 When this happens it's unclear what was intended when an unhandled case is reached. It is better to be explicit and
 either handle all cases or use a default `else` statement to cover the unhandled cases.
 
-**Requires Type and Symbol solving**
+**Requires Type and Symbol Solving**
 
 **Severity**: Defect
 
@@ -486,7 +486,7 @@ fun whenOnEnumCompliant2(c: Color) {
 
 Turn on this rule to flag 'toString' calls with a nullable receiver that may return the string "null".
 
-**Requires Type and Symbol solving**
+**Requires Type and Symbol Solving**
 
 **Severity**: Defect
 
@@ -524,7 +524,7 @@ verified that all cases are already covered when checking cases on an enum or se
 Based on code from Kotlin compiler:
 https://github.com/JetBrains/kotlin/blob/v1.3.30/compiler/frontend/src/org/jetbrains/kotlin/cfg/ControlFlowInformationProvider.kt
 
-**Requires Type and Symbol solving**
+**Requires Type and Symbol Solving**
 
 **Severity**: Warning
 
@@ -603,7 +603,7 @@ for (i in 1..2) {
 
 Reports unnecessary not-null operator usage (!!) that can be removed by the user.
 
-**Requires Type and Symbol solving**
+**Requires Type and Symbol Solving**
 
 **Severity**: Defect
 
@@ -627,7 +627,7 @@ val b = a
 
 Reports unnecessary safe call operators (`.?`) that can be removed by the user.
 
-**Requires Type and Symbol solving**
+**Requires Type and Symbol Solving**
 
 **Severity**: Defect
 
@@ -680,7 +680,7 @@ Reports unsafe calls on nullable types. These calls will throw a NullPointerExce
 the nullable value is null. Kotlin provides many ways to work with nullable types to increase
 null safety. Guard the code appropriately to prevent NullPointerExceptions.
 
-**Requires Type and Symbol solving**
+**Requires Type and Symbol Solving**
 
 **Severity**: Defect
 
@@ -706,7 +706,7 @@ fun foo(str: String?) {
 
 Reports casts that will never succeed.
 
-**Requires Type and Symbol solving**
+**Requires Type and Symbol Solving**
 
 **Severity**: Defect
 

--- a/docs/pages/documentation/potential-bugs.md
+++ b/docs/pages/documentation/potential-bugs.md
@@ -12,6 +12,8 @@ The potential-bugs rule set provides rules that detect potential bugs.
 
 Deprecated elements are expected to be removed in future. Alternatives should be found if possible.
 
+**Requires Type and Symbol solving**
+
 **Severity**: Defect
 
 **Debt**: 20min
@@ -139,6 +141,8 @@ Platform types must be declared explicitly in public APIs to prevent unexpected 
 Based on code from Kotlin project:
 https://github.com/JetBrains/kotlin/blob/1.3.50/idea/src/org/jetbrains/kotlin/idea/intentions/SpecifyTypeExplicitlyIntention.kt#L86-L107
 
+**Requires Type and Symbol solving**
+
 **Severity**: Maintainability
 
 **Debt**: 5min
@@ -167,6 +171,8 @@ normally so that's the rationale behind this rule.
 
 fun returnsValue() = 42
 fun returnsNoValue() {}
+
+**Requires Type and Symbol solving**
 
 **Severity**: Defect
 
@@ -235,6 +241,8 @@ Functions using expression statements have an implicit return type.
 Changing the type of the expression accidentally, changes the functions return type.
 This may lead to backward incompatibility.
 Use a block statement to make clear this function will never return a value.
+
+**Requires Type and Symbol solving**
 
 **Severity**: Defect
 
@@ -426,6 +434,8 @@ or sealed class and the `when` expression is used as a statement.
 When this happens it's unclear what was intended when an unhandled case is reached. It is better to be explicit and
 either handle all cases or use a default `else` statement to cover the unhandled cases.
 
+**Requires Type and Symbol solving**
+
 **Severity**: Defect
 
 **Debt**: 20min
@@ -476,6 +486,8 @@ fun whenOnEnumCompliant2(c: Color) {
 
 Turn on this rule to flag 'toString' calls with a nullable receiver that may return the string "null".
 
+**Requires Type and Symbol solving**
+
 **Severity**: Defect
 
 **Debt**: 5min
@@ -511,6 +523,8 @@ verified that all cases are already covered when checking cases on an enum or se
 
 Based on code from Kotlin compiler:
 https://github.com/JetBrains/kotlin/blob/v1.3.30/compiler/frontend/src/org/jetbrains/kotlin/cfg/ControlFlowInformationProvider.kt
+
+**Requires Type and Symbol solving**
 
 **Severity**: Warning
 
@@ -589,6 +603,8 @@ for (i in 1..2) {
 
 Reports unnecessary not-null operator usage (!!) that can be removed by the user.
 
+**Requires Type and Symbol solving**
+
 **Severity**: Defect
 
 **Debt**: 5min
@@ -610,6 +626,8 @@ val b = a
 ### UnnecessarySafeCall
 
 Reports unnecessary safe call operators (`.?`) that can be removed by the user.
+
+**Requires Type and Symbol solving**
 
 **Severity**: Defect
 
@@ -662,6 +680,8 @@ Reports unsafe calls on nullable types. These calls will throw a NullPointerExce
 the nullable value is null. Kotlin provides many ways to work with nullable types to increase
 null safety. Guard the code appropriately to prevent NullPointerExceptions.
 
+**Requires Type and Symbol solving**
+
 **Severity**: Defect
 
 **Debt**: 20min
@@ -685,6 +705,8 @@ fun foo(str: String?) {
 ### UnsafeCast
 
 Reports casts that will never succeed.
+
+**Requires Type and Symbol solving**
 
 **Severity**: Defect
 

--- a/docs/pages/documentation/style.md
+++ b/docs/pages/documentation/style.md
@@ -311,6 +311,8 @@ This rule allows to set a list of forbidden methods. This can be used to discour
 or deprecated methods, especially for methods imported from external libraries.
 Detekt will then report all methods invocation that are forbidden.
 
+**Requires Type and Symbol solving**
+
 **Severity**: Style
 
 **Debt**: 10min
@@ -366,6 +368,8 @@ internal data class C(val a: String)
 This rule detects usages of `Void` and reports them as forbidden.
 The Kotlin type `Unit` should be used instead. This type corresponds to the `Void` class in Java
 and has only one value - the `Unit` object.
+
+**Requires Type and Symbol solving**
 
 **Severity**: Style
 
@@ -882,6 +886,8 @@ This rule detects the usage of the Pair constructor to create pairs of values.
 
 Using <value1> to <value2> is preferred.
 
+**Requires Type and Symbol solving**
+
 **Severity**: Style
 
 **Debt**: 5min
@@ -1255,6 +1261,8 @@ class Module(@Inject private val foo: String)
 `apply` expressions are used frequently, but sometimes their usage should be replaced with
 an ordinary method/extension function call to reduce visual complexity
 
+**Requires Type and Symbol solving**
+
 **Severity**: Style
 
 **Debt**: 5min
@@ -1297,6 +1305,8 @@ class B : Object()
 `let` expressions are used extensively in our code for null-checking and chaining functions,
 but sometimes their usage should be replaced with a ordinary method/extension function call
 to reduce visual complexity
+
+**Requires Type and Symbol solving**
 
 **Severity**: Style
 
@@ -1517,6 +1527,8 @@ class A(val b: B) : I by b
 
 Instantiation of an object's "empty" state should use the object's "empty" initializer for clarity purposes.
 
+**Requires Type and Symbol solving**
+
 **Severity**: Style
 
 **Debt**: 5min
@@ -1597,6 +1609,8 @@ the calls are redundant in this case and can be removed or should be changed to 
 the value is null or not.
 
 Rule adapted from Kotlin's IntelliJ plugin: https://github.com/JetBrains/kotlin/blob/f5d0a38629e7d2e7017ee645dc4d4bee60614e93/idea/src/org/jetbrains/kotlin/idea/inspections/collections/UselessCallOnNotNullInspection.kt
+
+**Requires Type and Symbol solving**
 
 **Severity**: Performance
 

--- a/docs/pages/documentation/style.md
+++ b/docs/pages/documentation/style.md
@@ -311,7 +311,7 @@ This rule allows to set a list of forbidden methods. This can be used to discour
 or deprecated methods, especially for methods imported from external libraries.
 Detekt will then report all methods invocation that are forbidden.
 
-**Requires Type and Symbol solving**
+**Requires Type and Symbol Solving**
 
 **Severity**: Style
 
@@ -369,7 +369,7 @@ This rule detects usages of `Void` and reports them as forbidden.
 The Kotlin type `Unit` should be used instead. This type corresponds to the `Void` class in Java
 and has only one value - the `Unit` object.
 
-**Requires Type and Symbol solving**
+**Requires Type and Symbol Solving**
 
 **Severity**: Style
 
@@ -886,7 +886,7 @@ This rule detects the usage of the Pair constructor to create pairs of values.
 
 Using <value1> to <value2> is preferred.
 
-**Requires Type and Symbol solving**
+**Requires Type and Symbol Solving**
 
 **Severity**: Style
 
@@ -1261,7 +1261,7 @@ class Module(@Inject private val foo: String)
 `apply` expressions are used frequently, but sometimes their usage should be replaced with
 an ordinary method/extension function call to reduce visual complexity
 
-**Requires Type and Symbol solving**
+**Requires Type and Symbol Solving**
 
 **Severity**: Style
 
@@ -1306,7 +1306,7 @@ class B : Object()
 but sometimes their usage should be replaced with a ordinary method/extension function call
 to reduce visual complexity
 
-**Requires Type and Symbol solving**
+**Requires Type and Symbol Solving**
 
 **Severity**: Style
 
@@ -1527,7 +1527,7 @@ class A(val b: B) : I by b
 
 Instantiation of an object's "empty" state should use the object's "empty" initializer for clarity purposes.
 
-**Requires Type and Symbol solving**
+**Requires Type and Symbol Solving**
 
 **Severity**: Style
 
@@ -1610,7 +1610,7 @@ the value is null or not.
 
 Rule adapted from Kotlin's IntelliJ plugin: https://github.com/JetBrains/kotlin/blob/f5d0a38629e7d2e7017ee645dc4d4bee60614e93/idea/src/org/jetbrains/kotlin/idea/inspections/collections/UselessCallOnNotNullInspection.kt
 
-**Requires Type and Symbol solving**
+**Requires Type and Symbol Solving**
 
 **Severity**: Performance
 


### PR DESCRIPTION
Given that we received several reports of false negatives for users with type resolution disabled, I believe we should document this better.

I'm adding a `@requiresTypeResolution` KDoc annotation to rules that are strictly requiring Type and Symbol solving to execute. This tag will propagate also to the Markdown documentation. 