### PR TITLE
Refactor code around fail-fast

### DIFF
--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/AllActiveConfig.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/AllActiveConfig.kt
@@ -3,11 +3,11 @@ package io.gitlab.arturbosch.detekt.api.internal
 import io.gitlab.arturbosch.detekt.api.Config
 
 @Suppress("UNCHECKED_CAST")
-data class FailFastConfig(private val originalConfig: Config) :
-    Config, ValidatableConfiguration {
+data class AllActiveConfig(
+    private val originalConfig: Config
+) : Config, ValidatableConfiguration {
 
-    override fun subConfig(key: String) =
-        FailFastConfig(originalConfig.subConfig(key))
+    override fun subConfig(key: String) = AllActiveConfig(originalConfig.subConfig(key))
 
     override fun <T : Any> valueOrDefault(key: String, default: T): T {
         return when (key) {

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/FailFastConfig.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/FailFastConfig.kt
@@ -12,7 +12,6 @@ data class FailFastConfig(private val originalConfig: Config) :
     override fun <T : Any> valueOrDefault(key: String, default: T): T {
         return when (key) {
             "active" -> originalConfig.valueOrDefault(key, true) as T
-            "maxIssues" -> originalConfig.valueOrDefault(key, 0) as T
             else -> originalConfig.valueOrDefault(key, default)
         }
     }
@@ -20,7 +19,6 @@ data class FailFastConfig(private val originalConfig: Config) :
     override fun <T : Any> valueOrNull(key: String): T? {
         return when (key) {
             "active" -> originalConfig.valueOrNull(key) ?: true as? T
-            "maxIssues" -> originalConfig.valueOrNull(key) ?: 0 as? T
             else -> originalConfig.valueOrNull(key)
         }
     }

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/FailFastConfig.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/FailFastConfig.kt
@@ -3,17 +3,17 @@ package io.gitlab.arturbosch.detekt.api.internal
 import io.gitlab.arturbosch.detekt.api.Config
 
 @Suppress("UNCHECKED_CAST")
-data class FailFastConfig(private val originalConfig: Config, private val defaultConfig: Config) :
+data class FailFastConfig(private val originalConfig: Config) :
     Config, ValidatableConfiguration {
 
     override fun subConfig(key: String) =
-        FailFastConfig(originalConfig.subConfig(key), defaultConfig.subConfig(key))
+        FailFastConfig(originalConfig.subConfig(key))
 
     override fun <T : Any> valueOrDefault(key: String, default: T): T {
         return when (key) {
             "active" -> originalConfig.valueOrDefault(key, true) as T
             "maxIssues" -> originalConfig.valueOrDefault(key, 0) as T
-            else -> originalConfig.valueOrDefault(key, defaultConfig.valueOrDefault(key, default))
+            else -> originalConfig.valueOrDefault(key, default)
         }
     }
 
@@ -21,7 +21,7 @@ data class FailFastConfig(private val originalConfig: Config, private val defaul
         return when (key) {
             "active" -> originalConfig.valueOrNull(key) ?: true as? T
             "maxIssues" -> originalConfig.valueOrNull(key) ?: 0 as? T
-            else -> originalConfig.valueOrNull(key) ?: defaultConfig.valueOrNull(key)
+            else -> originalConfig.valueOrNull(key)
         }
     }
 

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Spec.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Spec.kt
@@ -34,7 +34,7 @@ internal fun CliArgs.createSpec(output: Appendable, error: Appendable): Processi
         }
 
         config {
-            useDefaultConfig = args.buildUponDefaultConfig
+            useDefaultConfig = args.buildUponDefaultConfig || args.failFast
             shouldValidateBeforeAnalysis = false
             knownPatterns = emptyList()
             // ^^ cli does not have these properties yet; specified in yaml config for now

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Spec.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Spec.kt
@@ -23,7 +23,11 @@ internal fun CliArgs.createSpec(output: Appendable, error: Appendable): Processi
         rules {
             autoCorrect = args.autoCorrect
             activateExperimentalRules = args.failFast
-            maxIssuePolicy = RulesSpec.MaxIssuePolicy.NonSpecified // not yet supported; prefer to read from config
+            maxIssuePolicy = if (args.failFast) {
+                RulesSpec.MaxIssuePolicy.NoneAllowed
+            } else {
+                RulesSpec.MaxIssuePolicy.NonSpecified // not yet supported; prefer to read from config
+            }
             excludeCorrectable = false // not yet supported; loaded from config
             runPolicy = args.toRunPolicy()
         }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/Configurations.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/Configurations.kt
@@ -19,23 +19,18 @@ internal fun ProcessingSpec.loadConfiguration(): Config = with(configSpec) {
         resources.isNotEmpty() -> parseResourceConfig(resources)
         else -> null
     }
-    var defaultConfig: Config? = null
 
-    if (useDefaultConfig) {
-        defaultConfig = DefaultConfig.newInstance()
+    if (useDefaultConfig || rulesSpec.activateExperimentalRules) {
+        val defaultConfig = DefaultConfig.newInstance()
         declaredConfig = if (declaredConfig == null) {
             defaultConfig
         } else {
             CompositeConfig(declaredConfig, defaultConfig)
         }
-    }
 
-    if (rulesSpec.activateExperimentalRules) {
-        val initializedDefaultConfig = defaultConfig ?: DefaultConfig.newInstance()
-        declaredConfig = FailFastConfig(
-            declaredConfig ?: initializedDefaultConfig,
-            initializedDefaultConfig
-        )
+        if (rulesSpec.activateExperimentalRules) {
+            declaredConfig = FailFastConfig(declaredConfig)
+        }
     }
 
     if (!rulesSpec.autoCorrect) {

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/Configurations.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/Configurations.kt
@@ -20,17 +20,17 @@ internal fun ProcessingSpec.loadConfiguration(): Config = with(configSpec) {
         else -> null
     }
 
-    if (useDefaultConfig || rulesSpec.activateExperimentalRules) {
+    if (useDefaultConfig) {
         val defaultConfig = DefaultConfig.newInstance()
         declaredConfig = if (declaredConfig == null) {
             defaultConfig
         } else {
             CompositeConfig(declaredConfig, defaultConfig)
         }
+    }
 
-        if (rulesSpec.activateExperimentalRules) {
-            declaredConfig = FailFastConfig(declaredConfig)
-        }
+    if (rulesSpec.activateExperimentalRules) {
+        declaredConfig = FailFastConfig(declaredConfig ?: DefaultConfig.newInstance())
     }
 
     if (!rulesSpec.autoCorrect) {

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/Configurations.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/Configurations.kt
@@ -5,7 +5,7 @@ import io.github.detekt.tooling.api.spec.ProcessingSpec
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.internal.CompositeConfig
 import io.gitlab.arturbosch.detekt.api.internal.DisabledAutoCorrectConfig
-import io.gitlab.arturbosch.detekt.api.internal.FailFastConfig
+import io.gitlab.arturbosch.detekt.api.internal.AllActiveConfig
 import io.gitlab.arturbosch.detekt.api.internal.YamlConfig
 import java.net.URI
 import java.net.URL
@@ -30,7 +30,7 @@ internal fun ProcessingSpec.loadConfiguration(): Config = with(configSpec) {
     }
 
     if (rulesSpec.activateExperimentalRules) {
-        declaredConfig = FailFastConfig(declaredConfig ?: DefaultConfig.newInstance())
+        declaredConfig = AllActiveConfig(declaredConfig ?: DefaultConfig.newInstance())
     }
 
     if (!rulesSpec.autoCorrect) {

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/Configurations.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/Configurations.kt
@@ -23,7 +23,11 @@ internal fun ProcessingSpec.loadConfiguration(): Config = with(configSpec) {
 
     if (useDefaultConfig) {
         defaultConfig = DefaultConfig.newInstance()
-        declaredConfig = CompositeConfig(declaredConfig ?: defaultConfig, defaultConfig)
+        declaredConfig = if (declaredConfig == null) {
+            defaultConfig
+        } else {
+            CompositeConfig(declaredConfig, defaultConfig)
+        }
     }
 
     if (rulesSpec.activateExperimentalRules) {

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/ConfigurationsSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/ConfigurationsSpec.kt
@@ -83,10 +83,6 @@ internal class ConfigurationsSpec : Spek({
                 .valueOrDefault("active", false)
             assertThat(actual).isEqualTo(true)
         }
-
-        it("should override maxIssues to 0 by default") {
-            assertThat(config.subConfig("build").valueOrDefault("maxIssues", -1)).isEqualTo(0)
-        }
     }
 
     describe("fail fast override") {

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/ConfigurationsSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/ConfigurationsSpec.kt
@@ -87,13 +87,6 @@ internal class ConfigurationsSpec : Spek({
         it("should override maxIssues to 0 by default") {
             assertThat(config.subConfig("build").valueOrDefault("maxIssues", -1)).isEqualTo(0)
         }
-
-        it("should keep config from default") {
-            val actual = config.subConfig("style")
-                .subConfig("MaxLineLength")
-                .valueOrDefault("maxLineLength", -1)
-            assertThat(actual).isEqualTo(120)
-        }
     }
 
     describe("fail fast override") {

--- a/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/api/spec/RulesSpec.kt
+++ b/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/api/spec/RulesSpec.kt
@@ -7,8 +7,6 @@ interface RulesSpec {
 
     /**
      * Activates all rules which do not have the active property set to 'true' by default.
-     *
-     * Also known as 'failFast' flag.
      */
     val activateExperimentalRules: Boolean
 


### PR DESCRIPTION
I'm working on #2267

To do that I need to make some refactors. This one does that `core` forget about what `fail-fast` is. Now is the cli that enables 3 different features when `--fail-fast` is used.

Read my comments below.