### PR TITLE
Workaround config

### DIFF
--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Analyzer.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Analyzer.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.core
 
+import io.github.detekt.tooling.api.spec.ProcessingSpec
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.FileProcessListener
 import io.gitlab.arturbosch.detekt.api.Finding
@@ -9,6 +10,9 @@ import io.gitlab.arturbosch.detekt.api.RuleSetId
 import io.gitlab.arturbosch.detekt.api.RuleSetProvider
 import io.gitlab.arturbosch.detekt.api.internal.BaseRule
 import io.gitlab.arturbosch.detekt.api.internal.CompilerResources
+import io.gitlab.arturbosch.detekt.api.internal.DisabledAutoCorrectConfig
+import io.gitlab.arturbosch.detekt.api.internal.FailFastConfig
+import io.gitlab.arturbosch.detekt.core.config.DefaultConfig
 import io.gitlab.arturbosch.detekt.core.rules.IdMapping
 import io.gitlab.arturbosch.detekt.core.rules.associateRuleIdsToRuleSetIds
 import io.gitlab.arturbosch.detekt.core.rules.isActive
@@ -24,7 +28,7 @@ internal class Analyzer(
     private val processors: List<FileProcessListener>
 ) {
 
-    private val config: Config = settings.config
+    private val config: Config = settings.spec.workaroundConfiguration(settings.config)
     private val idMapping: IdMapping =
         associateRuleIdsToRuleSetIds(providers.associate { it.ruleSetId to it.instance(config).rules })
 
@@ -125,4 +129,24 @@ internal class Analyzer(
 
 private fun <T, U, R> Sequence<Pair<T, U>>.mapLeft(transform: (T, U) -> R): Sequence<Pair<R, U>> {
     return this.map { (first, second) -> transform(first, second) to second }
+}
+
+internal fun ProcessingSpec.workaroundConfiguration(config: Config): Config = with(configSpec) {
+    var declaredConfig: Config? = when {
+        configPaths.isNotEmpty() -> config
+        resources.isNotEmpty() -> config
+        useDefaultConfig -> config
+        else -> null
+    }
+
+    if (rulesSpec.activateExperimentalRules) {
+        val defaultConfig = DefaultConfig.newInstance()
+        declaredConfig = FailFastConfig(declaredConfig ?: defaultConfig, defaultConfig)
+    }
+
+    if (!rulesSpec.autoCorrect) {
+        declaredConfig = DisabledAutoCorrectConfig(declaredConfig ?: DefaultConfig.newInstance())
+    }
+
+    return declaredConfig ?: DefaultConfig.newInstance()
 }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/Configurations.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/Configurations.kt
@@ -23,7 +23,11 @@ internal fun ProcessingSpec.loadConfiguration(): Config = with(configSpec) {
 
     if (useDefaultConfig) {
         defaultConfig = DefaultConfig.newInstance()
-        declaredConfig = CompositeConfig(declaredConfig ?: defaultConfig, defaultConfig)
+        declaredConfig = if (declaredConfig == null) {
+            defaultConfig
+        } else {
+            CompositeConfig(declaredConfig, defaultConfig)
+        }
     }
 
     if (rulesSpec.activateExperimentalRules) {

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/Configurations.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/Configurations.kt
@@ -4,8 +4,6 @@ import io.github.detekt.tooling.api.spec.ConfigSpec
 import io.github.detekt.tooling.api.spec.ProcessingSpec
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.internal.CompositeConfig
-import io.gitlab.arturbosch.detekt.api.internal.DisabledAutoCorrectConfig
-import io.gitlab.arturbosch.detekt.api.internal.FailFastConfig
 import io.gitlab.arturbosch.detekt.api.internal.YamlConfig
 import java.net.URI
 import java.net.URL
@@ -19,27 +17,13 @@ internal fun ProcessingSpec.loadConfiguration(): Config = with(configSpec) {
         resources.isNotEmpty() -> parseResourceConfig(resources)
         else -> null
     }
-    var defaultConfig: Config? = null
 
     if (useDefaultConfig) {
-        defaultConfig = DefaultConfig.newInstance()
         declaredConfig = if (declaredConfig == null) {
-            defaultConfig
+            DefaultConfig.newInstance()
         } else {
-            CompositeConfig(declaredConfig, defaultConfig)
+            CompositeConfig(declaredConfig, DefaultConfig.newInstance())
         }
-    }
-
-    if (rulesSpec.activateExperimentalRules) {
-        val initializedDefaultConfig = defaultConfig ?: DefaultConfig.newInstance()
-        declaredConfig = FailFastConfig(
-            declaredConfig ?: initializedDefaultConfig,
-            initializedDefaultConfig
-        )
-    }
-
-    if (!rulesSpec.autoCorrect) {
-        declaredConfig = DisabledAutoCorrectConfig(declaredConfig ?: DefaultConfig.newInstance())
     }
 
     return declaredConfig ?: DefaultConfig.newInstance()

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/rules/RuleSets.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/rules/RuleSets.kt
@@ -54,12 +54,12 @@ fun associateRuleIdsToRuleSetIds(rules: Map<RuleSetId, List<BaseRule>>): IdMappi
         .toMap()
 }
 
-fun RulesSpec.RunPolicy.createRuleProviders(settings: ProcessingSettings): List<RuleSetProvider> = when (this) {
-    RulesSpec.RunPolicy.NoRestrictions -> RuleSetLocator(settings).load()
+fun ProcessingSettings.createRuleProviders(): List<RuleSetProvider> = when (val runPolicy = spec.rulesSpec.runPolicy) {
+    RulesSpec.RunPolicy.NoRestrictions -> RuleSetLocator(this).load()
     is RulesSpec.RunPolicy.RestrictToSingleRule -> {
-        val (ruleSetId, ruleId) = id
+        val (ruleSetId, ruleId) = runPolicy.id
         val realProvider = requireNotNull(
-            RuleSetLocator(settings).load().find { it.ruleSetId == ruleSetId }
+            RuleSetLocator(this).load().find { it.ruleSetId == ruleSetId }
         ) { "There was no rule set with id '$ruleSetId'." }
         listOf(SingleRuleProvider(ruleId, realProvider))
     }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/tooling/AnalysisFacade.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/tooling/AnalysisFacade.kt
@@ -35,7 +35,7 @@ class AnalysisFacade(
             DefaultLifecycle(
                 spec,
                 it,
-                parsingStrategy = { _, _ -> files.toList() },
+                parsingStrategy = { files.toList() },
                 bindingProvider = { bindingContext }
             )
         }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/tooling/AnalysisFacade.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/tooling/AnalysisFacade.kt
@@ -22,18 +22,17 @@ class AnalysisFacade(
     private val spec: ProcessingSpec
 ) : Detekt {
 
-    override fun run(): AnalysisResult = runAnalysis { DefaultLifecycle(spec, it, inputPathsToKtFiles) }
+    override fun run(): AnalysisResult = runAnalysis { DefaultLifecycle(it, inputPathsToKtFiles) }
 
     override fun run(path: Path): AnalysisResult =
-        runAnalysis { DefaultLifecycle(spec, it, pathToKtFile(path)) }
+        runAnalysis { DefaultLifecycle(it, pathToKtFile(path)) }
 
     override fun run(sourceCode: String, filename: String): AnalysisResult =
-        runAnalysis { DefaultLifecycle(spec, it, contentToKtFile(sourceCode, Paths.get(filename))) }
+        runAnalysis { DefaultLifecycle(it, contentToKtFile(sourceCode, Paths.get(filename))) }
 
     override fun run(files: Collection<KtFile>, bindingContext: BindingContext): AnalysisResult =
         runAnalysis {
             DefaultLifecycle(
-                spec,
                 it,
                 parsingStrategy = { files.toList() },
                 bindingProvider = { bindingContext }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/tooling/Lifecycle.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/tooling/Lifecycle.kt
@@ -33,7 +33,7 @@ internal interface Lifecycle {
 
     fun analyze(): Detektion {
         measure(Phase.ValidateConfig) { checkConfiguration(settings) }
-        val filesToAnalyze = measure(Phase.Parsing) { parsingStrategy.invoke(spec, settings) }
+        val filesToAnalyze = measure(Phase.Parsing) { parsingStrategy.invoke(settings) }
         val bindingContext = measure(Phase.Binding) { bindingProvider.invoke(filesToAnalyze) }
         val (processors, ruleSets) = measure(Phase.LoadingExtensions) {
             processorsProvider.invoke() to ruleSetsProvider.invoke()

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/tooling/Lifecycle.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/tooling/Lifecycle.kt
@@ -62,5 +62,5 @@ internal class DefaultLifecycle(
     override val processorsProvider: () -> List<FileProcessListener> =
         { FileProcessorLocator(settings).load() },
     override val ruleSetsProvider: () -> List<RuleSetProvider> =
-        { settings.spec.rulesSpec.runPolicy.createRuleProviders(settings) }
+        { settings.createRuleProviders() }
 ) : Lifecycle

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/tooling/Lifecycle.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/tooling/Lifecycle.kt
@@ -1,19 +1,14 @@
 package io.gitlab.arturbosch.detekt.core.tooling
 
-import io.github.detekt.tooling.api.spec.ProcessingSpec
-import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Detektion
 import io.gitlab.arturbosch.detekt.api.FileProcessListener
 import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.api.RuleSetId
 import io.gitlab.arturbosch.detekt.api.RuleSetProvider
-import io.gitlab.arturbosch.detekt.api.internal.DisabledAutoCorrectConfig
-import io.gitlab.arturbosch.detekt.api.internal.FailFastConfig
 import io.gitlab.arturbosch.detekt.core.Analyzer
 import io.gitlab.arturbosch.detekt.core.DetektResult
 import io.gitlab.arturbosch.detekt.core.FileProcessorLocator
 import io.gitlab.arturbosch.detekt.core.ProcessingSettings
-import io.gitlab.arturbosch.detekt.core.config.DefaultConfig
 import io.gitlab.arturbosch.detekt.core.config.checkConfiguration
 import io.gitlab.arturbosch.detekt.core.extensions.handleReportingExtensions
 import io.gitlab.arturbosch.detekt.core.generateBindingContext
@@ -43,7 +38,7 @@ internal interface Lifecycle {
         }
 
         val result = measure(Phase.Analyzer) {
-            val detektor = Analyzer(workaroundConfiguration(settings), ruleSets, processors)
+            val detektor = Analyzer(settings, ruleSets, processors)
             processors.forEach { it.onStart(filesToAnalyze, bindingContext) }
             val findings: Map<RuleSetId, List<Finding>> = detektor.run(filesToAnalyze, bindingContext)
             val result: Detektion = DetektResult(findings.toSortedMap())
@@ -69,27 +64,3 @@ internal class DefaultLifecycle(
     override val ruleSetsProvider: () -> List<RuleSetProvider> =
         { settings.createRuleProviders() }
 ) : Lifecycle
-
-private fun workaroundConfiguration(settings: ProcessingSettings): ProcessingSettings {
-    return ProcessingSettings(settings.spec, settings.spec.workaroundConfiguration(settings.config))
-}
-
-private fun ProcessingSpec.workaroundConfiguration(config: Config): Config = with(configSpec) {
-    var declaredConfig: Config? = when {
-        configPaths.isNotEmpty() -> config
-        resources.isNotEmpty() -> config
-        useDefaultConfig -> config
-        else -> null
-    }
-
-    if (rulesSpec.activateExperimentalRules) {
-        val defaultConfig = DefaultConfig.newInstance()
-        declaredConfig = FailFastConfig(declaredConfig ?: defaultConfig, defaultConfig)
-    }
-
-    if (!rulesSpec.autoCorrect) {
-        declaredConfig = DisabledAutoCorrectConfig(declaredConfig ?: DefaultConfig.newInstance())
-    }
-
-    return declaredConfig ?: DefaultConfig.newInstance()
-}

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/tooling/Lifecycle.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/tooling/Lifecycle.kt
@@ -1,6 +1,5 @@
 package io.gitlab.arturbosch.detekt.core.tooling
 
-import io.github.detekt.tooling.api.spec.ProcessingSpec
 import io.gitlab.arturbosch.detekt.api.Detektion
 import io.gitlab.arturbosch.detekt.api.FileProcessListener
 import io.gitlab.arturbosch.detekt.api.Finding
@@ -22,7 +21,6 @@ import org.jetbrains.kotlin.resolve.BindingContext
 
 internal interface Lifecycle {
 
-    val spec: ProcessingSpec
     val settings: ProcessingSettings
     val parsingStrategy: ParsingStrategy
     val bindingProvider: (files: List<KtFile>) -> BindingContext
@@ -57,7 +55,6 @@ internal interface Lifecycle {
 }
 
 internal class DefaultLifecycle(
-    override val spec: ProcessingSpec,
     override val settings: ProcessingSettings,
     override val parsingStrategy: ParsingStrategy,
     override val bindingProvider: (files: List<KtFile>) -> BindingContext =
@@ -65,5 +62,5 @@ internal class DefaultLifecycle(
     override val processorsProvider: () -> List<FileProcessListener> =
         { FileProcessorLocator(settings).load() },
     override val ruleSetsProvider: () -> List<RuleSetProvider> =
-        { spec.rulesSpec.runPolicy.createRuleProviders(settings) }
+        { settings.spec.rulesSpec.runPolicy.createRuleProviders(settings) }
 ) : Lifecycle

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/tooling/ParsingStrategy.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/tooling/ParsingStrategy.kt
@@ -1,7 +1,6 @@
 package io.gitlab.arturbosch.detekt.core.tooling
 
 import io.github.detekt.parser.KtCompiler
-import io.github.detekt.tooling.api.spec.ProcessingSpec
 import io.gitlab.arturbosch.detekt.core.KtTreeCompiler
 import io.gitlab.arturbosch.detekt.core.ProcessingSettings
 import org.jetbrains.kotlin.psi.KtFile

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/tooling/ParsingStrategy.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/tooling/ParsingStrategy.kt
@@ -7,23 +7,23 @@ import io.gitlab.arturbosch.detekt.core.ProcessingSettings
 import org.jetbrains.kotlin.psi.KtFile
 import java.nio.file.Path
 
-typealias ParsingStrategy = (spec: ProcessingSpec, settings: ProcessingSettings) -> List<KtFile>
+typealias ParsingStrategy = (settings: ProcessingSettings) -> List<KtFile>
 
-fun contentToKtFile(content: String, path: Path): ParsingStrategy = { spec, settings ->
+fun contentToKtFile(content: String, path: Path): ParsingStrategy = { settings ->
     listOf(
         KtCompiler(settings.environment)
-            .createKtFile(content, spec.projectSpec.basePath ?: path, path)
+            .createKtFile(content, settings.spec.projectSpec.basePath ?: path, path)
     )
 }
 
-fun pathToKtFile(path: Path): ParsingStrategy = { spec, settings ->
+fun pathToKtFile(path: Path): ParsingStrategy = { settings ->
     listOf(
         KtCompiler(settings.environment)
-            .compile(spec.projectSpec.basePath ?: path, path)
+            .compile(settings.spec.projectSpec.basePath ?: path, path)
     )
 }
 
-val inputPathsToKtFiles: ParsingStrategy = { spec, settings ->
-    val compiler = KtTreeCompiler(settings, spec.projectSpec)
-    spec.projectSpec.inputPaths.flatMap(compiler::compile)
+val inputPathsToKtFiles: ParsingStrategy = { settings ->
+    val compiler = KtTreeCompiler(settings, settings.spec.projectSpec)
+    settings.spec.projectSpec.inputPaths.flatMap(compiler::compile)
 }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/tooling/ParsingStrategy.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/tooling/ParsingStrategy.kt
@@ -9,22 +9,18 @@ import java.nio.file.Path
 
 typealias ParsingStrategy = (spec: ProcessingSpec, settings: ProcessingSettings) -> List<KtFile>
 
-val contentToKtFile: (content: String, path: Path) -> ParsingStrategy = { content, path ->
-    { spec, settings ->
-        listOf(
-            KtCompiler(settings.environment)
-                .createKtFile(content, spec.projectSpec.basePath ?: path, path)
-        )
-    }
+fun contentToKtFile(content: String, path: Path): ParsingStrategy = { spec, settings ->
+    listOf(
+        KtCompiler(settings.environment)
+            .createKtFile(content, spec.projectSpec.basePath ?: path, path)
+    )
 }
 
-val pathToKtFile: (path: Path) -> ParsingStrategy = { path ->
-    { spec, settings ->
-        listOf(
-            KtCompiler(settings.environment)
-                .compile(spec.projectSpec.basePath ?: path, path)
-        )
-    }
+fun pathToKtFile(path: Path): ParsingStrategy = { spec, settings ->
+    listOf(
+        KtCompiler(settings.environment)
+            .compile(spec.projectSpec.basePath ?: path, path)
+    )
 }
 
 val inputPathsToKtFiles: ParsingStrategy = { spec, settings ->

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/TopLevelAutoCorrectSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/TopLevelAutoCorrectSpec.kt
@@ -56,7 +56,6 @@ class TopLevelAutoCorrectSpec : Spek({
 
             AnalysisFacade(spec).runAnalysis {
                 DefaultLifecycle(
-                    spec,
                     it,
                     inputPathsToKtFiles,
                     processorsProvider = { listOf(contentChangedListener) },

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/WorkaroundConfigurationKtSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/WorkaroundConfigurationKtSpec.kt
@@ -1,0 +1,144 @@
+package io.gitlab.arturbosch.detekt.core
+
+import io.github.detekt.test.utils.resourceUrl
+import io.github.detekt.tooling.api.spec.ProcessingSpec
+import io.gitlab.arturbosch.detekt.core.config.loadConfiguration
+import org.assertj.core.api.Assertions.assertThat
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+internal class WorkaroundConfigurationKtSpec : Spek({
+
+    describe("with all rules activated by default") {
+
+        val config by memoized {
+            ProcessingSpec {
+                config { resources = listOf(resourceUrl("/configs/empty.yml")) }
+                rules { activateExperimentalRules = true }
+            }.let { spec ->
+                spec.workaroundConfiguration(spec.loadConfiguration())
+            }
+        }
+
+        it("should override active to true by default") {
+            val actual = config.subConfig("comments")
+                .subConfig("UndocumentedPublicClass")
+                .valueOrDefault("active", false)
+            assertThat(actual).isEqualTo(true)
+        }
+
+        it("should override maxIssues to 0 by default") {
+            assertThat(config.subConfig("build").valueOrDefault("maxIssues", -1)).isEqualTo(0)
+        }
+
+        it("should keep config from default") {
+            val actual = config.subConfig("style")
+                .subConfig("MaxLineLength")
+                .valueOrDefault("maxLineLength", -1)
+            assertThat(actual).isEqualTo(120)
+        }
+    }
+
+    describe("fail fast override") {
+
+        val config by memoized {
+            ProcessingSpec {
+                config { resources = listOf(resourceUrl("/configs/fail-fast-will-override-here.yml")) }
+                rules { activateExperimentalRules = true }
+            }.let { spec ->
+                spec.workaroundConfiguration(spec.loadConfiguration())
+            }
+        }
+
+        it("should override config when specified") {
+            val actual = config.subConfig("style")
+                .subConfig("MaxLineLength")
+                .valueOrDefault("maxLineLength", -1)
+            assertThat(actual).isEqualTo(100)
+        }
+
+        it("should override active when specified") {
+            val actual = config.subConfig("comments")
+                .subConfig("CommentOverPrivateMethod")
+                .valueOrDefault("active", true)
+            assertThat(actual).isEqualTo(false)
+        }
+
+        it("should override maxIssues when specified") {
+            assertThat(config.subConfig("build").valueOrDefault("maxIssues", -1)).isEqualTo(1)
+        }
+    }
+
+    describe("auto correct config") {
+
+        context("when specified it respects all autoCorrect values of rules and rule sets") {
+
+            val config by memoized {
+                ProcessingSpec {
+                    config { resources = listOf(resourceUrl("/configs/config-with-auto-correct.yml")) }
+                    rules { autoCorrect = true }
+                }.let { spec ->
+                    spec.workaroundConfiguration(spec.loadConfiguration())
+                }
+            }
+
+            val style by memoized { config.subConfig("style") }
+            val comments by memoized { config.subConfig("comments") }
+
+            it("is disabled for rule sets") {
+                assertThat(style.valueOrNull<Boolean>("autoCorrect")).isTrue()
+                assertThat(comments.valueOrNull<Boolean>("autoCorrect")).isFalse()
+            }
+
+            it("is disabled for rules") {
+                assertThat(style.subConfig("MagicNumber").valueOrNull<Boolean>("autoCorrect")).isTrue()
+                assertThat(style.subConfig("MagicString").valueOrNull<Boolean>("autoCorrect")).isFalse()
+                assertThat(comments.subConfig("ClassDoc").valueOrNull<Boolean>("autoCorrect")).isTrue()
+                assertThat(comments.subConfig("FunctionDoc").valueOrNull<Boolean>("autoCorrect")).isFalse()
+            }
+        }
+
+        mapOf(
+            ProcessingSpec {
+                config { resources = listOf(resourceUrl("/configs/config-with-auto-correct.yml")) }
+            }.let { spec ->
+                spec.workaroundConfiguration(spec.loadConfiguration())
+            } to "when not specified all autoCorrect values are overridden to false",
+            ProcessingSpec {
+                config { resources = listOf(resourceUrl("/configs/config-with-auto-correct.yml")) }
+                rules { autoCorrect = false }
+            }.let { spec ->
+                spec.workaroundConfiguration(spec.loadConfiguration())
+            } to "when specified as false, all autoCorrect values are overridden to false",
+            ProcessingSpec {
+                config {
+                    useDefaultConfig = true
+                    resources = listOf(resourceUrl("/configs/config-with-auto-correct.yml"))
+                }
+                rules {
+                    autoCorrect = false
+                    activateExperimentalRules = true
+                }
+            }.let { spec ->
+                spec.workaroundConfiguration(spec.loadConfiguration())
+            } to "regardless of other cli options, autoCorrect values are overridden to false"
+        ).forEach { (config, testContext) ->
+            context(testContext) {
+                val style = config.subConfig("style")
+                val comments = config.subConfig("comments")
+
+                it("is disabled for rule sets") {
+                    assertThat(style.valueOrNull<Boolean>("autoCorrect")).isFalse()
+                    assertThat(comments.valueOrNull<Boolean>("autoCorrect")).isFalse()
+                }
+
+                it("is disabled for rules") {
+                    assertThat(style.subConfig("MagicNumber").valueOrNull<Boolean>("autoCorrect")).isFalse()
+                    assertThat(style.subConfig("MagicString").valueOrNull<Boolean>("autoCorrect")).isFalse()
+                    assertThat(comments.subConfig("ClassDoc").valueOrNull<Boolean>("autoCorrect")).isFalse()
+                    assertThat(comments.subConfig("FunctionDoc").valueOrNull<Boolean>("autoCorrect")).isFalse()
+                }
+            }
+        }
+    }
+})

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/ConfigurationsSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/ConfigurationsSpec.kt
@@ -68,62 +68,6 @@ internal class ConfigurationsSpec : Spek({
         }
     }
 
-    describe("with all rules activated by default") {
-
-        val config by memoized {
-            ProcessingSpec {
-                config { resources = listOf(resourceUrl("/configs/empty.yml")) }
-                rules { activateExperimentalRules = true }
-            }.loadConfiguration()
-        }
-
-        it("should override active to true by default") {
-            val actual = config.subConfig("comments")
-                .subConfig("UndocumentedPublicClass")
-                .valueOrDefault("active", false)
-            assertThat(actual).isEqualTo(true)
-        }
-
-        it("should override maxIssues to 0 by default") {
-            assertThat(config.subConfig("build").valueOrDefault("maxIssues", -1)).isEqualTo(0)
-        }
-
-        it("should keep config from default") {
-            val actual = config.subConfig("style")
-                .subConfig("MaxLineLength")
-                .valueOrDefault("maxLineLength", -1)
-            assertThat(actual).isEqualTo(120)
-        }
-    }
-
-    describe("fail fast override") {
-
-        val config by memoized {
-            ProcessingSpec {
-                config { resources = listOf(resourceUrl("/configs/fail-fast-will-override-here.yml")) }
-                rules { activateExperimentalRules = true }
-            }.loadConfiguration()
-        }
-
-        it("should override config when specified") {
-            val actual = config.subConfig("style")
-                .subConfig("MaxLineLength")
-                .valueOrDefault("maxLineLength", -1)
-            assertThat(actual).isEqualTo(100)
-        }
-
-        it("should override active when specified") {
-            val actual = config.subConfig("comments")
-                .subConfig("CommentOverPrivateMethod")
-                .valueOrDefault("active", true)
-            assertThat(actual).isEqualTo(false)
-        }
-
-        it("should override maxIssues when specified") {
-            assertThat(config.subConfig("build").valueOrDefault("maxIssues", -1)).isEqualTo(1)
-        }
-    }
-
     describe("build upon default config") {
 
         val config by memoized {
@@ -155,71 +99,6 @@ internal class ConfigurationsSpec : Spek({
         it("should be maxIssues=0 by default") {
             val actual = config.subConfig("build").valueOrDefault("maxIssues", -1)
             assertThat(actual).isEqualTo(0)
-        }
-    }
-
-    describe("auto correct config") {
-
-        context("when specified it respects all autoCorrect values of rules and rule sets") {
-
-            val config by memoized {
-                ProcessingSpec {
-                    config { resources = listOf(resourceUrl("/configs/config-with-auto-correct.yml")) }
-                    rules { autoCorrect = true }
-                }.loadConfiguration()
-            }
-
-            val style by memoized { config.subConfig("style") }
-            val comments by memoized { config.subConfig("comments") }
-
-            it("is disabled for rule sets") {
-                assertThat(style.valueOrNull<Boolean>("autoCorrect")).isTrue()
-                assertThat(comments.valueOrNull<Boolean>("autoCorrect")).isFalse()
-            }
-
-            it("is disabled for rules") {
-                assertThat(style.subConfig("MagicNumber").valueOrNull<Boolean>("autoCorrect")).isTrue()
-                assertThat(style.subConfig("MagicString").valueOrNull<Boolean>("autoCorrect")).isFalse()
-                assertThat(comments.subConfig("ClassDoc").valueOrNull<Boolean>("autoCorrect")).isTrue()
-                assertThat(comments.subConfig("FunctionDoc").valueOrNull<Boolean>("autoCorrect")).isFalse()
-            }
-        }
-
-        mapOf(
-            ProcessingSpec {
-                config { resources = listOf(resourceUrl("/configs/config-with-auto-correct.yml")) }
-            }.loadConfiguration() to "when not specified all autoCorrect values are overridden to false",
-            ProcessingSpec {
-                config { resources = listOf(resourceUrl("/configs/config-with-auto-correct.yml")) }
-                rules { autoCorrect = false }
-            }.loadConfiguration() to "when specified as false, all autoCorrect values are overridden to false",
-            ProcessingSpec {
-                config {
-                    useDefaultConfig = true
-                    resources = listOf(resourceUrl("/configs/config-with-auto-correct.yml"))
-                }
-                rules {
-                    autoCorrect = false
-                    activateExperimentalRules = true
-                }
-            }.loadConfiguration() to "regardless of other cli options, autoCorrect values are overridden to false"
-        ).forEach { (config, testContext) ->
-            context(testContext) {
-                val style = config.subConfig("style")
-                val comments = config.subConfig("comments")
-
-                it("is disabled for rule sets") {
-                    assertThat(style.valueOrNull<Boolean>("autoCorrect")).isFalse()
-                    assertThat(comments.valueOrNull<Boolean>("autoCorrect")).isFalse()
-                }
-
-                it("is disabled for rules") {
-                    assertThat(style.subConfig("MagicNumber").valueOrNull<Boolean>("autoCorrect")).isFalse()
-                    assertThat(style.subConfig("MagicString").valueOrNull<Boolean>("autoCorrect")).isFalse()
-                    assertThat(comments.subConfig("ClassDoc").valueOrNull<Boolean>("autoCorrect")).isFalse()
-                    assertThat(comments.subConfig("FunctionDoc").valueOrNull<Boolean>("autoCorrect")).isFalse()
-                }
-            }
         }
     }
 })


### PR DESCRIPTION
Right now we are using `FailFastConfig` and `DisabledAutoCorrectConfig` to modify the configuration of all detekt and not just the configuration related with the rules itself.

This is kind of complex because we have all those configurations mixed. We should think about this for 2.0.

I need this refactor to implement `--all-rules`. Because I want to enable all the rules, but I don't want to enable any PostProcessor or Report. And all of them checks the same key: `"active"`.

I really don't like too much this code but I don't want to change any current behaviour.