### PR TITLE
Fix PreferToOverPairSyntax exception

### DIFF
--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/PreferToOverPairSyntax.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/PreferToOverPairSyntax.kt
@@ -43,7 +43,7 @@ class PreferToOverPairSyntax(config: Config = Config.empty) : Rule(config) {
             callReference.getType(bindingContext)?.constructor?.declarationDescriptor as? ClassDescriptor ?: return
 
         if (subjectType.fqNameOrNull()?.asString() == PAIR_CONSTRUCTOR_REFERENCE_NAME) {
-            val arg = callReference.valueArguments.joinToString("to") { it.text }
+            val arg = callReference.valueArguments.joinToString("to ") { it.text }
 
             report(CodeSmell(issue, Entity.from(expression),
                     message = "Pair is created by using the pair constructor. " +

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/PreferToOverPairSyntax.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/PreferToOverPairSyntax.kt
@@ -43,11 +43,11 @@ class PreferToOverPairSyntax(config: Config = Config.empty) : Rule(config) {
             callReference.getType(bindingContext)?.constructor?.declarationDescriptor as? ClassDescriptor ?: return
 
         if (subjectType.fqNameOrNull()?.asString() == PAIR_CONSTRUCTOR_REFERENCE_NAME) {
-            val (firstArg, secondArg) = callReference.valueArguments.map { it.text }
+            val arg = callReference.valueArguments.joinToString("to") { it.text }
 
             report(CodeSmell(issue, Entity.from(expression),
                     message = "Pair is created by using the pair constructor. " +
-                            "This can replaced by `$firstArg to $secondArg`"))
+                            "This can replaced by `$arg`"))
         }
 
         super.visitSimpleNameExpression(expression)


### PR DESCRIPTION
Closes #3044

This leads to a crash if the *valueArguments* list contains only 1 item.