### PR TITLE
Fix ModifierOrder for false positive reported by ModifierOrder when using fun interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ If you contributed to detekt but your name is not in the list, please feel free 
 - [Zachary Moore](https://github.com/zsmoore) - Rule, cli, gradle plugin, and config improvements
 - [Veyndan Stuart](https://github.com/veyndan) - New rule: UseEmptyCounterpart; Rule improvement: UselessCallOnNotNull
 - [Parimatch Tech](https://github.com/parimatchtech) - New rule: LibraryEntitiesShouldNotBePublic
+- [Chao Zhang](https://github.com/chao2zhang) - Rule improvement: ImplicitDefaultLocale, ModifierOrder.
 
 ### Mentions
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ModifierOrder.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ModifierOrder.kt
@@ -18,6 +18,7 @@ import org.jetbrains.kotlin.lexer.KtTokens.ENUM_KEYWORD
 import org.jetbrains.kotlin.lexer.KtTokens.EXPECT_KEYWORD
 import org.jetbrains.kotlin.lexer.KtTokens.EXTERNAL_KEYWORD
 import org.jetbrains.kotlin.lexer.KtTokens.FINAL_KEYWORD
+import org.jetbrains.kotlin.lexer.KtTokens.FUN_KEYWORD
 import org.jetbrains.kotlin.lexer.KtTokens.INFIX_KEYWORD
 import org.jetbrains.kotlin.lexer.KtTokens.INLINE_KEYWORD
 import org.jetbrains.kotlin.lexer.KtTokens.INNER_KEYWORD
@@ -74,7 +75,8 @@ class ModifierOrder(config: Config = Config.empty) : Rule(config) {
             INLINE_KEYWORD,
             INFIX_KEYWORD,
             OPERATOR_KEYWORD,
-            DATA_KEYWORD
+            DATA_KEYWORD,
+            FUN_KEYWORD
     )
 
     override fun visitModifierList(list: KtModifierList) {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ModifierOrderSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ModifierOrderSpec.kt
@@ -120,15 +120,6 @@ class ModifierOrderSpec : Spek({
                 """.trimIndent()
                 assertThat(subject.compileAndLint(code)).isEmpty()
             }
-
-            it("should report incorrectly ordered modifiers") {
-                val code = """
-                    expect internal fun interface LoadMoreCallback {
-                        fun loadMore(): Boolean
-                    }
-                """.trimIndent()
-                assertThat(subject.compileAndLint(code)).hasSize(1)
-            }
         }
     }
 })

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ModifierOrderSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ModifierOrderSpec.kt
@@ -109,5 +109,26 @@ class ModifierOrderSpec : Spek({
                 assertThat(subject.compileAndLint(code)).isEmpty()
             }
         }
+
+        context("fun interface") {
+
+            it("should not report correctly ordered modifiers") {
+                val code = """
+                    private fun interface LoadMoreCallback {
+                        fun loadMore(): Boolean
+                    }
+                """.trimIndent()
+                assertThat(subject.compileAndLint(code)).isEmpty()
+            }
+
+            it("should report incorrectly ordered modifiers") {
+                val code = """
+                    expect internal fun interface LoadMoreCallback {
+                        fun loadMore(): Boolean
+                    }
+                """.trimIndent()
+                assertThat(subject.compileAndLint(code)).hasSize(1)
+            }
+        }
     }
 })


### PR DESCRIPTION
This fixes #3050 

Most of the modifiers in ModifierOrder.order are not compatible with the `interface`, but `fun` is a modifier. Hence the change is to append `fun` in the list after the visibility and expected/actual.

I have also added a negative test case. The positive test case of mixing a visibility modifier and another modifier is likely to be fabricated and does not work in an actual project.

For `./gradlew build -x dokka` and `./gradlew detekt`, both passed locally.

 