### PR TITLE
Set modifier order based on Kotlin coding conventions

### DIFF
--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ModifierOrder.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ModifierOrder.kt
@@ -70,13 +70,12 @@ class ModifierOrder(config: Config = Config.empty) : Rule(config) {
             VARARG_KEYWORD,
             SUSPEND_KEYWORD,
             INNER_KEYWORD,
-            ENUM_KEYWORD, ANNOTATION_KEYWORD,
+            ENUM_KEYWORD, ANNOTATION_KEYWORD, FUN_KEYWORD,
             COMPANION_KEYWORD,
             INLINE_KEYWORD,
             INFIX_KEYWORD,
             OPERATOR_KEYWORD,
-            DATA_KEYWORD,
-            FUN_KEYWORD
+            DATA_KEYWORD
     )
 
     override fun visitModifierList(list: KtModifierList) {


### PR DESCRIPTION
https://kotlinlang.org/docs/reference/coding-conventions.html#modifiers

> If a declaration has multiple modifiers, always put them in the following order:
```
public / protected / private / internal
expect / actual
final / open / abstract / sealed / const
external
override
lateinit
tailrec
vararg
suspend
inner
enum / annotation / fun // as a modifier in `fun interface`
companion
inline
infix
operator
data
```