### PR TITLE
Simplify reporting message for IgnoredReturnValue

### DIFF
--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValue.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValue.kt
@@ -99,11 +99,12 @@ class IgnoredReturnValue(config: Config = Config.empty) : Rule(config) {
         }
 
         if (elementsToInspect.any(PsiElement::isIsolated)) {
+            val messageText = expression.calleeExpression?.text ?: expression.text
             report(
                     CodeSmell(
                             issue,
                             Entity.from(expression),
-                            message = "The call ${expression.text} is returning a value that is ignored."
+                            message = "The call $messageText is returning a value that is ignored."
                     )
             )
         }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValueSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValueSpec.kt
@@ -180,6 +180,7 @@ object IgnoredReturnValueSpec : Spek({
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasSourceLocation(8, 5)
+            assertThat(findings[0]).hasMessage("The call listOfChecked is returning a value that is ignored.")
         }
 
         it("reports when a function which returns a value is called before a valid return") {
@@ -198,6 +199,7 @@ object IgnoredReturnValueSpec : Spek({
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasSourceLocation(8, 5)
+            assertThat(findings[0]).hasMessage("The call listOfChecked is returning a value that is ignored.")
         }
 
         it("reports when a function which returns a value is called in chain as first statement and the return is ignored") {
@@ -216,6 +218,7 @@ object IgnoredReturnValueSpec : Spek({
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasSourceLocation(8, 5)
+            assertThat(findings[0]).hasMessage("The call listOfChecked is returning a value that is ignored.")
         }
 
         it("reports when a function which returns a value is called in the middle of a chain and the return is ignored") {
@@ -239,6 +242,7 @@ object IgnoredReturnValueSpec : Spek({
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasSourceLocation(11, 10)
+            assertThat(findings[0]).hasMessage("The call listOfChecked is returning a value that is ignored.")
         }
 
         it("reports when a function which returns a value is called before a semicolon") {
@@ -256,6 +260,7 @@ object IgnoredReturnValueSpec : Spek({
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasSourceLocation(8, 5)
+            assertThat(findings[0]).hasMessage("The call listOfChecked is returning a value that is ignored.")
         }
 
         it("reports when a function which returns a value is called after a semicolon") {
@@ -274,6 +279,7 @@ object IgnoredReturnValueSpec : Spek({
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasSourceLocation(8, 20)
+            assertThat(findings[0]).hasMessage("The call listOfChecked is returning a value that is ignored.")
         }
 
         it("reports when a function which returns a value is called between comments") {
@@ -292,6 +298,7 @@ object IgnoredReturnValueSpec : Spek({
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasSourceLocation(8, 14)
+            assertThat(findings[0]).hasMessage("The call listOfChecked is returning a value that is ignored.")
         }
 
         it("reports when an extension function which returns a value is called and the return is ignored") {
@@ -309,6 +316,7 @@ object IgnoredReturnValueSpec : Spek({
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasSourceLocation(7, 11)
+            assertThat(findings[0]).hasMessage("The call isTheAnswer is returning a value that is ignored.")
         }
 
         it("does not report when the return value is assigned to a pre-existing variable") {
@@ -467,6 +475,7 @@ object IgnoredReturnValueSpec : Spek({
             val findings = IgnoredReturnValue(config).compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasSourceLocation(8, 5)
+            assertThat(findings[0]).hasMessage("The call listOfChecked is returning a value that is ignored.")
         }
 
         it("does not report when a function is annotated with the not included annotation") {
@@ -519,6 +528,7 @@ object IgnoredReturnValueSpec : Spek({
             val findings = IgnoredReturnValue(config).compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasSourceLocation(8, 5)
+            assertThat(findings[0]).hasMessage("The call listOfChecked is returning a value that is ignored.")
         }
 
         it("reports when a function is not annotated") {
@@ -533,6 +543,7 @@ object IgnoredReturnValueSpec : Spek({
             val findings = IgnoredReturnValue(config).compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasSourceLocation(4, 5)
+            assertThat(findings[0]).hasMessage("The call listOfChecked is returning a value that is ignored.")
         }
     }
 })

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/FindingsAssertions.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/FindingsAssertions.kt
@@ -88,4 +88,14 @@ class FindingsAssert(actual: List<Finding>) :
     }
 }
 
-class FindingAssert(val actual: Finding?) : AbstractAssert<FindingAssert, Finding>(actual, FindingAssert::class.java)
+class FindingAssert(val actual: Finding?) : AbstractAssert<FindingAssert, Finding>(actual, FindingAssert::class.java) {
+    fun hasMessage(expectedMessage: String) = apply {
+        if (expectedMessage.isNotBlank() && actual.message.isBlank()) {
+            failWithMessage("Expected message <$expectedMessage> but finding has no message")
+        }
+
+        if (!actual.message.trim().equals(expectedMessage.trim(), ignoreCase = true)) {
+            failWithMessage("Expected message <$expectedMessage> but actual message was <${actual.message}>")
+        }
+    }
+}


### PR DESCRIPTION
Simplifies the error message for `IgnoredReturnValue` to report only the name of the caller that is affected by the finding. I also added a `hasMessage` method to our `FindingAssert` as we happen to have several scenarios where we want to asset the message in the codebase.

Fixes #3052 
