### PR TITLE
Update KtLint to 0.39.0

### DIFF
--- a/detekt-bom/build.gradle.kts
+++ b/detekt-bom/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 dependencies {
     val version = object {
         val spek = "2.0.12"
-        val ktlint = "0.38.1"
+        val ktlint = "0.39.0"
     }
 
     constraints {


### PR DESCRIPTION
Bumping KtLint to the latest stable. 
I also noticed that there are two experimental rules on KtLint side that we should wrap: `AnnotationSpacingRule` and `ArgumentListWrappingRule`.
Should we do it in a separate PR?