### PR TITLE
Move SNAPSHOT from artifactory to sonatype

### DIFF
--- a/.github/workflows/deploy-snapshot.yaml
+++ b/.github/workflows/deploy-snapshot.yaml
@@ -35,7 +35,7 @@ jobs:
 
     - name: Deploy Snapshot
       env:
-        BINTRAY_USER: ${{ secrets.BINTRAY_USER }}
-        BINTRAY_API_KEY: ${{ secrets.BINTRAY_API_KEY }}
-      run: ./gradlew artifactoryPublish -Dsnapshot=true --stacktrace
+        MAVEN_CENTRAL_USER: ${{ secrets.MAVEN_CENTRAL_USER }}
+        MAVEN_CENTRAL_PW: ${{ secrets.MAVEN_CENTRAL_PW }}
+      run: ./gradlew publishAllPublicationsToSonatypeSnapshotRepository -Dsnapshot=true --stacktrace
       if: ${{ github.repository == 'detekt/detekt'}}

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ tasks {
 }
 ```
 
-See [bintray](https://bintray.com/arturbosch/code-analysis/detekt) for releases and [artifactory](https://oss.jfrog.org/artifactory/webapp/#/artifacts/browse/tree/General/oss-snapshot-local/io/gitlab/arturbosch/detekt/detekt-cli/) for snapshots.
+See [maven central](https://search.maven.org/artifact/io.gitlab.arturbosch.detekt/detekt-cli) for releases and [sonatype](https://oss.sonatype.org/#view-repositories;snapshots~browsestorage~io.gitlab.arturbosch.detekt) for snapshots.
 
 ### Adding more rule sets
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -16,7 +16,6 @@ object Plugins {
     const val KOTLIN = "1.4.0"
     const val DETEKT = "1.13.1"
     const val GITHUB_RELEASE = "2.2.12"
-    const val ARTIFACTORY = "4.15.1"
     const val SHADOW = "5.2.0"
     const val VERSIONS = "0.28.0"
     const val SONAR = "2.8"
@@ -29,7 +28,6 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:${Plugins.KOTLIN}")
     implementation("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:${Plugins.DETEKT}")
     implementation("com.github.breadmoirai:github-release:${Plugins.GITHUB_RELEASE}")
-    implementation("org.jfrog.buildinfo:build-info-extractor-gradle:${Plugins.ARTIFACTORY}")
     implementation("com.github.jengelman.gradle.plugins:shadow:${Plugins.SHADOW}")
     implementation("com.github.ben-manes:gradle-versions-plugin:${Plugins.VERSIONS}")
     implementation("org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:${Plugins.SONAR}")


### PR DESCRIPTION
As discussed in #3060, cleaning up the Artifactory publish till we move everything over to sonatype. @arturbosch Can I ask you to setup the repository secrets for publishing (`MAVEN_CENTRAL_USER` and `MAVEN_CENTRAL_PW`)?