### PR TITLE
Wrap new KtLint rules

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -229,6 +229,9 @@ formatting:
   AnnotationOnSeparateLine:
     active: false
     autoCorrect: true
+  AnnotationSpacing:
+    active: false
+    autoCorrect: true
   ChainWrapping:
     active: true
     autoCorrect: true

--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -232,6 +232,9 @@ formatting:
   AnnotationSpacing:
     active: false
     autoCorrect: true
+  ArgumentListWrapping:
+    active: false
+    autoCorrect: true
   ChainWrapping:
     active: true
     autoCorrect: true

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/KtLintMultiRule.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/KtLintMultiRule.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.api.MultiRule
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.formatting.wrappers.AnnotationOnSeparateLine
 import io.gitlab.arturbosch.detekt.formatting.wrappers.AnnotationSpacing
+import io.gitlab.arturbosch.detekt.formatting.wrappers.ArgumentListWrapping
 import io.gitlab.arturbosch.detekt.formatting.wrappers.ChainWrapping
 import io.gitlab.arturbosch.detekt.formatting.wrappers.CommentSpacing
 import io.gitlab.arturbosch.detekt.formatting.wrappers.EnumEntryNameCase
@@ -55,6 +56,7 @@ class KtLintMultiRule(config: Config = Config.empty) : MultiRule() {
     override val rules: List<Rule> = listOf(
         AnnotationOnSeparateLine(config),
         AnnotationSpacing(config),
+        ArgumentListWrapping(config),
         ChainWrapping(config),
         CommentSpacing(config),
         EnumEntryNameCase(config),

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/KtLintMultiRule.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/KtLintMultiRule.kt
@@ -4,6 +4,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.MultiRule
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.formatting.wrappers.AnnotationOnSeparateLine
+import io.gitlab.arturbosch.detekt.formatting.wrappers.AnnotationSpacing
 import io.gitlab.arturbosch.detekt.formatting.wrappers.ChainWrapping
 import io.gitlab.arturbosch.detekt.formatting.wrappers.CommentSpacing
 import io.gitlab.arturbosch.detekt.formatting.wrappers.EnumEntryNameCase
@@ -53,6 +54,7 @@ class KtLintMultiRule(config: Config = Config.empty) : MultiRule() {
 
     override val rules: List<Rule> = listOf(
         AnnotationOnSeparateLine(config),
+        AnnotationSpacing(config),
         ChainWrapping(config),
         CommentSpacing(config),
         EnumEntryNameCase(config),

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/AnnotationSpacing.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/AnnotationSpacing.kt
@@ -1,0 +1,17 @@
+package io.gitlab.arturbosch.detekt.formatting.wrappers
+
+import com.pinterest.ktlint.ruleset.experimental.AnnotationSpacingRule
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.formatting.FormattingRule
+
+/**
+ * See <a href="https://ktlint.github.io">ktlint-website</a> for documentation.
+ *
+ * @autoCorrect since v1.0.0
+ */
+class AnnotationSpacing(config: Config) : FormattingRule(config) {
+
+    override val wrapping = AnnotationSpacingRule()
+    override val issue =
+        issueFor("There should not be empty lines between an annotation and the object that it's annotating")
+}

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/ArgumentListWrapping.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/ArgumentListWrapping.kt
@@ -1,0 +1,16 @@
+package io.gitlab.arturbosch.detekt.formatting.wrappers
+
+import com.pinterest.ktlint.ruleset.experimental.ArgumentListWrappingRule
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.formatting.FormattingRule
+
+/**
+ * See <a href="https://ktlint.github.io">ktlint-website</a> for documentation.
+ *
+ * @autoCorrect since v1.0.0
+ */
+class ArgumentListWrapping(config: Config) : FormattingRule(config) {
+
+    override val wrapping = ArgumentListWrappingRule()
+    override val issue = issueFor("Reports incorrect argument list wrapping")
+}

--- a/docs/pages/documentation/formatting.md
+++ b/docs/pages/documentation/formatting.md
@@ -23,6 +23,10 @@ See <a href="https://ktlint.github.io">ktlint-website</a> for documentation.
 
 See <a href="https://ktlint.github.io">ktlint-website</a> for documentation.
 
+### ArgumentListWrapping
+
+See <a href="https://ktlint.github.io">ktlint-website</a> for documentation.
+
 ### ChainWrapping
 
 See <a href="https://ktlint.github.io">ktlint-website</a> for documentation.

--- a/docs/pages/documentation/formatting.md
+++ b/docs/pages/documentation/formatting.md
@@ -19,6 +19,10 @@ in the command line interface.
 
 See <a href="https://ktlint.github.io">ktlint-website</a> for documentation.
 
+### AnnotationSpacing
+
+See <a href="https://ktlint.github.io">ktlint-website</a> for documentation.
+
 ### ChainWrapping
 
 See <a href="https://ktlint.github.io">ktlint-website</a> for documentation.


### PR DESCRIPTION
They're in KtLint's experimental ruleset, so they're disabled by default.

Closes #3080
Closes #3081 