### PR TITLE
Use File.pathSeparator to split entries in classpath

### DIFF
--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/settings/EnvironmentAware.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/settings/EnvironmentAware.kt
@@ -44,7 +44,7 @@ internal class EnvironmentFacade(
 }
 
 internal fun CompilerSpec.classpathEntries(): List<String> =
-    classpath?.split(File.pathSeparator) ?: emptyList() // support both windows ; and unix :
+    classpath?.split(File.pathSeparator) ?: emptyList()
 
 internal fun CompilerSpec.parseLanguageVersion(): LanguageVersion? {
     fun parse(value: String): LanguageVersion {

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/settings/EnvironmentAware.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/settings/EnvironmentAware.kt
@@ -10,6 +10,7 @@ import org.jetbrains.kotlin.com.intellij.openapi.util.Disposer
 import org.jetbrains.kotlin.config.JvmTarget
 import org.jetbrains.kotlin.config.LanguageVersion
 import java.io.Closeable
+import java.io.File
 
 interface EnvironmentAware {
 
@@ -43,7 +44,7 @@ internal class EnvironmentFacade(
 }
 
 internal fun CompilerSpec.classpathEntries(): List<String> =
-    classpath?.split(":", ";") ?: emptyList() // support both windows ; and unix :
+    classpath?.split(File.pathSeparator) ?: emptyList() // support both windows ; and unix :
 
 internal fun CompilerSpec.parseLanguageVersion(): LanguageVersion? {
     fun parse(value: String): LanguageVersion {

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/settings/EnvironmentFacadeSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/settings/EnvironmentFacadeSpec.kt
@@ -3,22 +3,23 @@ package io.gitlab.arturbosch.detekt.core.settings
 import io.gitlab.arturbosch.detekt.core.createNullLoggingSpec
 import io.gitlab.arturbosch.detekt.core.createProcessingSettings
 import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.kotlin.konan.file.File
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
 internal class EnvironmentFacadeSpec : Spek({
 
-    describe("classpath entries can be separated by : or ;") {
+    describe("classpath entries should be separated by platform-specific separator") {
 
-        arrayOf(
-            "supports ;" to "file1;file2;file3",
-            "supports :" to "file1:file2:file3",
-            "supports mixing ; and :" to "file1;file2:file3"
-        ).forEach { (testName, classpath) ->
-            it(testName) {
-                testSettings(classpath).use {
-                    assertThat(it.classpath).hasSize(3)
-                }
+        val classpath = when (File.pathSeparator) {
+            ":" -> "/path/to/file1:/path/to/file2:/path/to/file3"
+            ";" -> """C:\path\to\file1;C:\path\to\file2;C:\path\to\file3"""
+            else -> ""
+        }
+
+        it("supports ${File.pathSeparator}") {
+            testSettings(classpath).use {
+                assertThat(it.classpath).hasSize(3)
             }
         }
     }


### PR DESCRIPTION
This is a tiny fix for passing classpath to detekt on windows. I have found [pull request](https://github.com/detekt/detekt/pull/2977) where this issue has already been addressed, but I faced another error when passing classpath in a form `C:\Users\petertrr\.m2\repository\dependency1;C:\Users\petertrr\.m2\repository\dependency2`. Classpath string has been split by `:` and that produced messages `warning: classpath entry points to a non-existent location: C`. Usage of `File.pathSeparator` when splitting classpath string solves the issue and I was able to run detekt on windows successfully.