### PR TITLE
New rule: ClassOrdering

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -105,6 +105,8 @@ potential-bugs:
     active: true
 
 style:
+  ClassOrdering:
+    active: true
   CollapsibleIfStatements:
     active: true
   EqualsNullCall:

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/AnnotationExcluder.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/AnnotationExcluder.kt
@@ -13,8 +13,6 @@ class AnnotationExcluder(
     private val excludes: List<String>
 ) {
 
-    constructor(root: KtFile, excludes: SplitPattern) : this(root, excludes.mapAll { it })
-
     private val resolvedAnnotations = root.importList
             ?.imports
             ?.asSequence()
@@ -22,6 +20,8 @@ class AnnotationExcluder(
             ?.mapNotNull { it.importedFqName?.asString() }
             ?.map { it.substringAfterLast('.') to it }
             ?.toMap() ?: emptyMap()
+
+    constructor(root: KtFile, excludes: SplitPattern) : this(root, excludes.mapAll { it })
 
     /**
      * Is true if any given annotation name is declared in the SplitPattern

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/ConfigAware.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/ConfigAware.kt
@@ -34,17 +34,6 @@ interface ConfigAware : Config {
         get() = ruleSetConfig.subConfig(ruleId)
 
     /**
-     * If your rule supports to automatically correct the misbehaviour of underlying smell,
-     * specify your code inside this method call, to allow the user of your rule to trigger auto correction
-     * only when needed.
-     */
-    fun withAutoCorrect(block: () -> Unit) {
-        if (autoCorrect) {
-            block()
-        }
-    }
-
-    /**
      * Does this rule have auto correct specified in configuration?
      * For auto correction to work the rule set itself enable it.
      */
@@ -57,6 +46,17 @@ interface ConfigAware : Config {
      * If an rule is not specified in the underlying configuration, we assume it should not be run.
      */
     val active: Boolean get() = valueOrDefault("active", false)
+
+    /**
+     * If your rule supports to automatically correct the misbehaviour of underlying smell,
+     * specify your code inside this method call, to allow the user of your rule to trigger auto correction
+     * only when needed.
+     */
+    fun withAutoCorrect(block: () -> Unit) {
+        if (autoCorrect) {
+            block()
+        }
+    }
 
     override fun subConfig(key: String): Config =
         ruleConfig.subConfig(key)

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Debt.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Debt.kt
@@ -26,6 +26,15 @@ data class Debt(val days: Int = 0, val hours: Int = 0, val mins: Int = 0) {
         return Debt(days, hours, minutes)
     }
 
+    override fun toString(): String {
+        return with(StringBuilder()) {
+            if (days > 0) append("${days}d ")
+            if (hours > 0) append("${hours}h ")
+            if (mins > 0) append("${mins}min")
+            toString()
+        }.trimEnd()
+    }
+
     companion object {
         val TWENTY_MINS: Debt =
             Debt(0, 0, 20)
@@ -35,14 +44,5 @@ data class Debt(val days: Int = 0, val hours: Int = 0, val mins: Int = 0) {
             Debt(0, 0, 5)
         private const val HOURS_PER_DAY = 24
         private const val MINUTES_PER_HOUR = 60
-    }
-
-    override fun toString(): String {
-        return with(StringBuilder()) {
-            if (days > 0) append("${days}d ")
-            if (hours > 0) append("${hours}h ")
-            if (mins > 0) append("${mins}min")
-            toString()
-        }.trimEnd()
     }
 }

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/PathFilters.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/PathFilters.kt
@@ -10,6 +10,14 @@ class PathFilters internal constructor(
     private val excludes: Set<PathMatcher>?
 ) {
 
+    fun isIgnored(path: Path): Boolean {
+
+        fun isIncluded() = includes?.any { it.matches(path) }
+        fun isExcluded() = excludes?.any { it.matches(path) }
+
+        return isIncluded()?.not() ?: isExcluded() ?: true
+    }
+
     companion object {
         fun of(includes: List<String>, excludes: List<String>): PathFilters? {
             if (includes.isEmpty() && excludes.isEmpty()) {
@@ -26,14 +34,6 @@ class PathFilters internal constructor(
                     .map { pathMatcher(it) }
                     .toSet()
             }
-    }
-
-    fun isIgnored(path: Path): Boolean {
-
-        fun isIncluded() = includes?.any { it.matches(path) }
-        fun isExcluded() = excludes?.any { it.matches(path) }
-
-        return isIncluded()?.not() ?: isExcluded() ?: true
     }
 }
 

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/ElementPrinter.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/ElementPrinter.kt
@@ -10,14 +10,6 @@ import org.jetbrains.kotlin.psi.KtStatementExpression
 
 class ElementPrinter : DetektVisitor() {
 
-    companion object {
-        fun dump(file: KtFile): String = ElementPrinter().run {
-            sb.appendLine("0: " + file.javaClass.simpleName)
-            visitKtFile(file)
-            sb.toString()
-        }
-    }
-
     private val sb = StringBuilder()
 
     private val indentation
@@ -60,4 +52,12 @@ class ElementPrinter : DetektVisitor() {
         this is KtStatementExpression ||
             this is KtDeclarationContainer ||
             this is KtContainerNode
+
+    companion object {
+        fun dump(file: KtFile): String = ElementPrinter().run {
+            sb.appendLine("0: " + file.javaClass.simpleName)
+            visitKtFile(file)
+            sb.toString()
+        }
+    }
 }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/KtTreeCompiler.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/KtTreeCompiler.kt
@@ -18,10 +18,6 @@ class KtTreeCompiler(
     private val pathFilters: PathFilters? =
         PathFilters.of(spec.includes.toList(), spec.excludes.toList())
 
-    companion object {
-        val KT_ENDINGS = setOf("kt", "kts")
-    }
-
     fun compile(path: Path): List<KtFile> {
         require(Files.exists(path)) { "Given path $path does not exist!" }
         return when {
@@ -63,5 +59,9 @@ class KtTreeCompiler(
             settings.debug { "Ignoring file '$path'" }
         }
         return ignored ?: false
+    }
+
+    companion object {
+        val KT_ENDINGS = setOf("kt", "kts")
     }
 }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineFormat.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineFormat.kt
@@ -9,6 +9,9 @@ import javax.xml.stream.XMLStreamWriter
 
 internal class BaselineFormat {
 
+    private val XMLStreamException.positions
+        get() = location.lineNumber to location.columnNumber
+
     class InvalidState(msg: String, error: Throwable) : IllegalStateException(msg, error)
 
     fun read(path: Path): Baseline {
@@ -35,9 +38,6 @@ internal class BaselineFormat {
             throw InvalidState("Error on position $line:$column while writing the baseline xml file!", error)
         }
     }
-
-    private val XMLStreamException.positions
-        get() = location.lineNumber to location.columnNumber
 
     private fun XMLStreamWriter.save(baseline: Baseline) {
         document {

--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -507,6 +507,8 @@ potential-bugs:
 
 style:
   active: true
+  ClassOrdering:
+    active: false
   CollapsibleIfStatements:
     active: false
   DataClassContainsFunctions:

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingRule.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingRule.kt
@@ -26,9 +26,6 @@ abstract class FormattingRule(config: Config) : Rule(config) {
 
     abstract val wrapping: com.pinterest.ktlint.core.Rule
 
-    protected fun issueFor(description: String) =
-        Issue(javaClass.simpleName, Severity.Style, description, Debt.FIVE_MINS)
-
     /**
      * Should the android style guide be enforced?
      * This property is read from the ruleSet config.
@@ -38,6 +35,9 @@ abstract class FormattingRule(config: Config) : Rule(config) {
 
     private var positionByOffset: (offset: Int) -> Pair<Int, Int> by SingleAssign()
     private var root: KtFile by SingleAssign()
+
+    protected fun issueFor(description: String) =
+        Issue(javaClass.simpleName, Severity.Style, description, Debt.FIVE_MINS)
 
     override fun visit(root: KtFile) {
         this.root = root

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -60,11 +60,6 @@ open class Detekt @Inject constructor(
     @get:Classpath
     val pluginClasspath: ConfigurableFileCollection = objects.fileCollection()
 
-    @InputFiles
-    @SkipWhenEmpty
-    @PathSensitive(PathSensitivity.RELATIVE)
-    override fun getSource(): FileTree = super.getSource()
-
     @get:InputFile
     @get:Optional
     @get:PathSensitive(PathSensitivity.RELATIVE)
@@ -133,11 +128,6 @@ open class Detekt @Inject constructor(
     @get:Internal
     internal val ignoreFailuresProp: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
 
-    @Input
-    override fun getIgnoreFailures(): Boolean = ignoreFailuresProp.getOrElse(false)
-
-    override fun setIgnoreFailures(value: Boolean) = ignoreFailuresProp.set(value)
-
     @get:Internal
     internal val autoCorrectProp: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
     var autoCorrect: Boolean
@@ -147,8 +137,6 @@ open class Detekt @Inject constructor(
 
     @get:Internal
     var reports = DetektReports()
-
-    fun reports(configure: Action<DetektReports>) = configure.execute(reports)
 
     @get:Internal
     val reportsDir: Property<File> = project.objects.property(File::class.java)
@@ -182,6 +170,18 @@ open class Detekt @Inject constructor(
     }
 
     private val invoker: DetektInvoker = DetektInvoker.create(project)
+
+    @InputFiles
+    @SkipWhenEmpty
+    @PathSensitive(PathSensitivity.RELATIVE)
+    override fun getSource(): FileTree = super.getSource()
+
+    @Input
+    override fun getIgnoreFailures(): Boolean = ignoreFailuresProp.getOrElse(false)
+
+    override fun setIgnoreFailures(value: Boolean) = ignoreFailuresProp.set(value)
+
+    fun reports(configure: Action<DetektReports>) = configure.execute(reports)
 
     @Suppress("DEPRECATION")
     @TaskAction

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
@@ -21,7 +21,6 @@ open class DetektExtension @Inject constructor(objects: ObjectFactory) : CodeQua
         get() = reportsDir
 
     val reports = DetektReports()
-    fun reports(configure: Action<DetektReports>) = configure.execute(reports)
 
     var input: ConfigurableFileCollection =
         objects.fileCollection().from(DEFAULT_SRC_DIR_JAVA, DEFAULT_SRC_DIR_KOTLIN)
@@ -58,6 +57,8 @@ open class DetektExtension @Inject constructor(objects: ObjectFactory) : CodeQua
      * List of Android build flavors for which no detekt task should be created
      */
     var ignoredFlavors: List<String> = emptyList()
+
+    fun reports(configure: Action<DetektReports>) = configure.execute(reports)
 
     companion object {
         const val DEFAULT_SRC_DIR_JAVA = "src/main/java"

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektAndroid.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektAndroid.kt
@@ -52,6 +52,18 @@ internal class DetektAndroid(private val project: Project) {
         }
     }
 
+    private val BaseExtension.variants: DomainObjectSet<out BaseVariant>?
+        get() = when (this) {
+            is AppExtension -> applicationVariants
+            is LibraryExtension -> libraryVariants
+            is TestExtension -> applicationVariants
+            else -> null
+        }
+
+    private val BaseVariant.testVariants: List<BaseVariant>
+        get() = if (this is TestedVariant) listOfNotNull(testVariant, unitTestVariant)
+        else emptyList()
+
     fun registerDetektAndroidTasks(extension: DetektExtension) {
         // There is not a single Android plugin, but each registers an extension based on BaseExtension,
         // so we catch them all by looking for this one
@@ -90,18 +102,6 @@ internal class DetektAndroid(private val project: Project) {
         ignoredVariants.contains(variant.name) ||
                 ignoredBuildTypes.contains(variant.buildType.name) ||
                 ignoredFlavors.contains(variant.flavorName)
-
-    private val BaseExtension.variants: DomainObjectSet<out BaseVariant>?
-        get() = when (this) {
-            is AppExtension -> applicationVariants
-            is LibraryExtension -> libraryVariants
-            is TestExtension -> applicationVariants
-            else -> null
-        }
-
-    private val BaseVariant.testVariants: List<BaseVariant>
-        get() = if (this is TestedVariant) listOfNotNull(testVariant, unitTestVariant)
-        else emptyList()
 
     private fun Project.registerAndroidDetektTask(
         bootClasspath: FileCollection,

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/DetektInvoker.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/DetektInvoker.kt
@@ -18,6 +18,8 @@ internal interface DetektInvoker {
     )
 
     companion object {
+        private const val DRY_RUN_PROPERTY = "detekt-dry-run"
+
         fun create(project: Project): DetektInvoker =
             if (project.isDryRunEnabled()) {
                 DryRunInvoker(project.logger)
@@ -28,8 +30,6 @@ internal interface DetektInvoker {
         private fun Project.isDryRunEnabled(): Boolean {
             return hasProperty(DRY_RUN_PROPERTY) && property(DRY_RUN_PROPERTY) == "true"
         }
-
-        private const val DRY_RUN_PROPERTY = "detekt-dry-run"
     }
 }
 

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DslTestBuilder.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DslTestBuilder.kt
@@ -94,9 +94,6 @@ abstract class DslTestBuilder {
     }
 
     companion object {
-        fun kotlin(): DslTestBuilder = KotlinBuilder()
-        fun groovy(): DslTestBuilder = GroovyBuilder()
-
         private const val GROOVY_PLUGINS_SECTION = """
             |plugins {
             |   id 'java-library'
@@ -126,5 +123,8 @@ abstract class DslTestBuilder {
         private const val KOTLIN_APPLY_PLUGINS = """
             |plugins.apply("io.gitlab.arturbosch.detekt")
             |"""
+
+        fun kotlin(): DslTestBuilder = KotlinBuilder()
+        fun groovy(): DslTestBuilder = GroovyBuilder()
     }
 }

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/internal/ClassLoaderCacheSpec.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/internal/ClassLoaderCacheSpec.kt
@@ -66,11 +66,6 @@ private open class FixedDateFile(path: String) : File(path) {
 
 private class DifferentDateFile(path: String) : FixedDateFile(path) {
 
-    companion object {
-        private val random = Random(seed = 200)
-        private val cache = HashSet<Long>()
-    }
-
     override fun lastModified(): Long {
         var nextDate = random.nextLong()
         while (cache.contains(nextDate)) {
@@ -78,5 +73,10 @@ private class DifferentDateFile(path: String) : FixedDateFile(path) {
         }
         cache.add(nextDate)
         return nextDate
+    }
+
+    companion object {
+        private val random = Random(seed = 200)
+        private val cache = HashSet<Long>()
     }
 }

--- a/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/CognitiveComplexity.kt
+++ b/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/CognitiveComplexity.kt
@@ -53,6 +53,8 @@ class CognitiveComplexity private constructor() : DetektVisitor() {
 
         private var nesting: Int = 0
 
+        private var topMostBinExpr: KtBinaryExpression? = null
+
         private fun addComplexity() {
             complexity += 1 + nesting
         }
@@ -141,8 +143,6 @@ class CognitiveComplexity private constructor() : DetektVisitor() {
         override fun visitLambdaExpression(lambdaExpression: KtLambdaExpression) {
             nestAround { super.visitLambdaExpression(lambdaExpression) }
         }
-
-        private var topMostBinExpr: KtBinaryExpression? = null
 
         override fun visitBinaryExpression(expression: KtBinaryExpression) {
             if (topMostBinExpr == null) {

--- a/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/ComplexityReportGenerator.kt
+++ b/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/ComplexityReportGenerator.kt
@@ -10,11 +10,6 @@ class ComplexityReportGenerator(private val complexityMetric: ComplexityMetric) 
     private var mccPerThousandLines = 0
     private var commentSourceRatio = 0
 
-    companion object Factory {
-        fun create(detektion: Detektion): ComplexityReportGenerator =
-            ComplexityReportGenerator(ComplexityMetric(detektion))
-    }
-
     fun generate(): List<String>? {
         if (cannotGenerate()) return null
         return listOf(
@@ -48,5 +43,10 @@ class ComplexityReportGenerator(private val complexityMetric: ComplexityMetric) 
                 false
             }
         }
+    }
+
+    companion object Factory {
+        fun create(detektion: Detektion): ComplexityReportGenerator =
+            ComplexityReportGenerator(ComplexityMetric(detektion))
     }
 }

--- a/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/CyclomaticComplexity.kt
+++ b/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/CyclomaticComplexity.kt
@@ -30,30 +30,6 @@ class CyclomaticComplexity(private val config: Config) : DetektVisitor() {
         var nestingFunctions: Set<String> = DEFAULT_NESTING_FUNCTIONS
     )
 
-    companion object {
-
-        val CONDITIONALS = setOf(KtTokens.ELVIS, KtTokens.ANDAND, KtTokens.OROR)
-        val DEFAULT_NESTING_FUNCTIONS = setOf(
-            "run",
-            "let",
-            "apply",
-            "with",
-            "also",
-            "use",
-            "forEach",
-            "isNotNull",
-            "ifNull"
-        )
-
-        fun calculate(node: KtElement, configure: (Config.() -> Unit)? = null): Int {
-            val config = Config()
-            configure?.invoke(config)
-            val visitor = CyclomaticComplexity(config)
-            node.accept(visitor)
-            return visitor.complexity
-        }
-    }
-
     var complexity: Int = 0
         private set
 
@@ -123,5 +99,29 @@ class CyclomaticComplexity(private val config: Config) : DetektVisitor() {
             }
         }
         super.visitCallExpression(expression)
+    }
+
+    companion object {
+
+        val CONDITIONALS = setOf(KtTokens.ELVIS, KtTokens.ANDAND, KtTokens.OROR)
+        val DEFAULT_NESTING_FUNCTIONS = setOf(
+            "run",
+            "let",
+            "apply",
+            "with",
+            "also",
+            "use",
+            "forEach",
+            "isNotNull",
+            "ifNull"
+        )
+
+        fun calculate(node: KtElement, configure: (Config.() -> Unit)? = null): Int {
+            val config = Config()
+            configure?.invoke(config)
+            val visitor = CyclomaticComplexity(config)
+            node.accept(visitor)
+            return visitor.complexity
+        }
     }
 }

--- a/detekt-report-xml/src/main/kotlin/io/github/detekt/report/xml/XmlOutputReport.kt
+++ b/detekt-report-xml/src/main/kotlin/io/github/detekt/report/xml/XmlOutputReport.kt
@@ -15,6 +15,18 @@ class XmlOutputReport : OutputReport() {
 
     override val name = "Checkstyle XML report"
 
+    private val Finding.severityLabel: String
+        get() = when (issue.severity) {
+            Severity.CodeSmell,
+            Severity.Style,
+            Severity.Warning,
+            Severity.Maintainability,
+            Severity.Performance -> "warning"
+            Severity.Defect -> "error"
+            Severity.Minor -> "info"
+            Severity.Security -> "fatal"
+        }
+
     override fun render(detektion: Detektion): String {
         val smells = detektion.findings.flatMap { it.value }
 
@@ -39,18 +51,6 @@ class XmlOutputReport : OutputReport() {
         lines += "</checkstyle>"
         return lines.joinToString(separator = "\n")
     }
-
-    private val Finding.severityLabel: String
-        get() = when (issue.severity) {
-            Severity.CodeSmell,
-            Severity.Style,
-            Severity.Warning,
-            Severity.Maintainability,
-            Severity.Performance -> "warning"
-            Severity.Defect -> "error"
-            Severity.Minor -> "info"
-            Severity.Security -> "fatal"
-        }
 
     private fun Any.toXmlString() = XmlEscape.escapeXml(toString().trim())
 }

--- a/detekt-rules-performance/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/ArrayPrimitive.kt
+++ b/detekt-rules-performance/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/ArrayPrimitive.kt
@@ -42,12 +42,6 @@ import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameOrNull
  * @requiresTypeResolution
  */
 class ArrayPrimitive(config: Config = Config.empty) : Rule(config) {
-    companion object {
-        private val primitiveTypes = PrimitiveType.values().map { it.typeName.asString() }
-        private val factoryMethodFqNames = listOf(FqName("kotlin.arrayOf"), FqName("kotlin.emptyArray"))
-        private val factoryMethodNames = factoryMethodFqNames.map { it.shortName().asString() }
-    }
-
     override val issue = Issue(
         "ArrayPrimitive",
         Severity.Performance,
@@ -90,5 +84,11 @@ class ArrayPrimitive(config: Config = Config.empty) : Rule(config) {
             return genericTypeArguments?.singleOrNull()?.let { primitiveTypes.contains(it.text) } == true
         }
         return false
+    }
+
+    companion object {
+        private val primitiveTypes = PrimitiveType.values().map { it.typeName.asString() }
+        private val factoryMethodFqNames = listOf(FqName("kotlin.arrayOf"), FqName("kotlin.emptyArray"))
+        private val factoryMethodNames = factoryMethodFqNames.map { it.shortName().asString() }
     }
 }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ClassOrdering.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ClassOrdering.kt
@@ -66,11 +66,11 @@ class ClassOrdering(config: Config = Config.empty) : Rule(config) {
     }
 
     override fun visitClassBody(classBody: KtClassBody) {
+        super.visitClassBody(classBody)
+
         if (!classBody.declarations.isInOrder(lengthComparator)) {
             report(CodeSmell(issue, Entity.from(classBody), issue.description))
         }
-
-        super.visitClassBody(classBody)
     }
 
     @Suppress("MagicNumber")

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ClassOrdering.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ClassOrdering.kt
@@ -16,7 +16,8 @@ import org.jetbrains.kotlin.psi.KtProperty
 import org.jetbrains.kotlin.psi.KtSecondaryConstructor
 
 /**
- * This rule ensures class contents are ordered as follows as recommended by the Kotlin Coding Conventions:
+ * This rule ensures class contents are ordered as follows as recommended by the Kotlin
+ * [Coding Conventions](https://kotlinlang.org/docs/reference/coding-conventions.html#class-layout):
  * - Property declarations and initializer blocks
  * - Secondary constructors
  * - Method declarations

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ClassOrdering.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ClassOrdering.kt
@@ -1,0 +1,91 @@
+package io.gitlab.arturbosch.detekt.rules.style
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import org.jetbrains.kotlin.psi.KtClassBody
+import org.jetbrains.kotlin.psi.KtClassInitializer
+import org.jetbrains.kotlin.psi.KtDeclaration
+import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.KtObjectDeclaration
+import org.jetbrains.kotlin.psi.KtProperty
+import org.jetbrains.kotlin.psi.KtSecondaryConstructor
+
+/**
+ * This rule ensures class contents are ordered as follows as recommended by the Kotlin Coding Conventions:
+ * - Property declarations and initializer blocks
+ * - Secondary constructors
+ * - Method declarations
+ * - Companion object
+ *
+ * <noncompliant>
+ * class OutOfOrder {
+ *     companion object {
+ *         const val IMPORTANT_VALUE = 3
+ *     }
+ *
+ *     fun returnX(): Int {
+ *         return x
+ *     }
+ *
+ *     private val x = 2
+ * }
+ * </noncompliant>
+ *
+ * <compliant>
+ * class InOrder {
+ *     private val x = 2
+ *
+ *     fun returnX(): Int {
+ *         return x
+ *     }
+ *
+ *     companion object {
+ *         const val IMPORTANT_VALUE = 3
+ *     }
+ * }
+ * </compliant>
+ */
+class ClassOrdering(config: Config = Config.empty) : Rule(config) {
+
+    override val issue = Issue(
+        javaClass.simpleName, Severity.Style,
+        "Class contents should be in this order: Property declarations/initializer blocks; secondary constructors; " +
+                "method declarations then companion objects.",
+        Debt.FIVE_MINS
+    )
+
+    private val lengthComparator: Comparator<KtDeclaration> = Comparator { str1: KtDeclaration, str2: KtDeclaration ->
+        if (orderPriority(str1) == null || orderPriority(str2) == null) return@Comparator 0
+        compareValues(orderPriority(str1), orderPriority(str2))
+    }
+
+    override fun visitClassBody(classBody: KtClassBody) {
+        if (!classBody.declarations.isInOrder(lengthComparator)) {
+            report(CodeSmell(issue, Entity.from(classBody), issue.description))
+        }
+
+        super.visitClassBody(classBody)
+    }
+
+    @Suppress("MagicNumber")
+    private fun orderPriority(declaration: KtDeclaration): Int? {
+        return when (declaration) {
+            is KtProperty -> 0
+            is KtClassInitializer -> 0
+            is KtSecondaryConstructor -> 1
+            is KtNamedFunction -> 2
+            is KtObjectDeclaration -> if (declaration.isCompanion()) 3 else null
+            else -> null
+        }
+    }
+
+    private fun Iterable<KtDeclaration>.isInOrder(comparator: Comparator<KtDeclaration>): Boolean {
+        zipWithNext { a, b -> if (comparator.compare(a, b) > 0) return false }
+        return true
+    }
+}

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/LibraryEntitiesShouldNotBePublic.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/LibraryEntitiesShouldNotBePublic.kt
@@ -1,12 +1,12 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
-import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.Rule
-import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.Severity
-import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtNamedFunction
@@ -30,14 +30,14 @@ import org.jetbrains.kotlin.psi.psiUtil.isPublic
  */
 class LibraryEntitiesShouldNotBePublic(ruleSetConfig: Config = Config.empty) : Rule(ruleSetConfig) {
 
-    override fun visitCondition(root: KtFile): Boolean = super.visitCondition(root) && filters != null
-
     override val issue: Issue = Issue(
         javaClass.simpleName,
         Severity.Style,
         "Library class should not be public",
         Debt.FIVE_MINS
     )
+
+    override fun visitCondition(root: KtFile): Boolean = super.visitCondition(root) && filters != null
 
     override fun visitClass(klass: KtClass) {
         if (klass.isInner()) {

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/StyleGuideProvider.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/StyleGuideProvider.kt
@@ -23,6 +23,7 @@ class StyleGuideProvider : DefaultRuleSetProvider {
     override fun instance(config: Config): RuleSet = RuleSet(
         ruleSetId,
         listOf(
+            ClassOrdering(config),
             CollapsibleIfStatements(config),
             ReturnCount(config),
             ThrowsCount(config),

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedImports.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedImports.kt
@@ -35,17 +35,6 @@ class UnusedImports(config: Config) : Rule(config) {
             "Unused Imports are dead code and should be removed.",
             Debt.FIVE_MINS)
 
-    companion object {
-        private val operatorSet = setOf("unaryPlus", "unaryMinus", "not", "inc", "dec", "plus", "minus", "times", "div",
-                "mod", "rangeTo", "contains", "get", "set", "invoke", "plusAssign", "minusAssign", "timesAssign",
-                "divAssign", "modAssign", "equals", "compareTo", "iterator", "getValue", "setValue", "provideDelegate")
-
-        private val kotlinDocReferencesRegExp = Regex("\\[([^]]+)](?!\\[)")
-        private val kotlinDocBlockTagReferenceRegExp = Regex("^@(see|throws|exception) (.+)")
-        private val whiteSpaceRegex = Regex("\\s+")
-        private val componentNRegex = Regex("component\\d+")
-    }
-
     override fun visit(root: KtFile) {
         with(UnusedImportsVisitor(bindingContext)) {
             root.accept(this)
@@ -130,6 +119,17 @@ class UnusedImports(config: Config) : Rule(config) {
                 namedReferencesInKDoc.add(str.split(".")[0])
             }
         }
+    }
+
+    companion object {
+        private val operatorSet = setOf("unaryPlus", "unaryMinus", "not", "inc", "dec", "plus", "minus", "times", "div",
+            "mod", "rangeTo", "contains", "get", "set", "invoke", "plusAssign", "minusAssign", "timesAssign",
+            "divAssign", "modAssign", "equals", "compareTo", "iterator", "getValue", "setValue", "provideDelegate")
+
+        private val kotlinDocReferencesRegExp = Regex("\\[([^]]+)](?!\\[)")
+        private val kotlinDocBlockTagReferenceRegExp = Regex("^@(see|throws|exception) (.+)")
+        private val whiteSpaceRegex = Regex("\\s+")
+        private val componentNRegex = Regex("component\\d+")
     }
 }
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
@@ -47,10 +47,6 @@ import org.jetbrains.kotlin.types.expressions.OperatorConventions
  */
 class UnusedPrivateMember(config: Config = Config.empty) : Rule(config) {
 
-    companion object {
-        const val ALLOWED_NAMES_PATTERN = "allowedNames"
-    }
-
     override val defaultRuleIdAliases: Set<String> = setOf("UNUSED_VARIABLE", "UNUSED_PARAMETER", "unused")
 
     override val issue: Issue = Issue("UnusedPrivateMember",
@@ -70,6 +66,10 @@ class UnusedPrivateMember(config: Config = Config.empty) : Rule(config) {
     private fun KtFile.acceptUnusedMemberVisitor(visitor: UnusedMemberVisitor) {
         accept(visitor)
         visitor.getUnusedReports(issue).forEach { report(it) }
+    }
+
+    companion object {
+        const val ALLOWED_NAMES_PATTERN = "allowedNames"
     }
 }
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseCheckNotNull.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseCheckNotNull.kt
@@ -27,10 +27,6 @@ import org.jetbrains.kotlin.resolve.BindingContext
  * @requiresTypeResolution
  */
 class UseCheckNotNull(config: Config = Config.empty) : Rule(config) {
-    companion object {
-        private val checkFunctionFqName = FqName("kotlin.check")
-    }
-
     override val issue = Issue(
         "UseCheckNotNull",
         Severity.Style,
@@ -44,5 +40,9 @@ class UseCheckNotNull(config: Config = Config.empty) : Rule(config) {
         if (expression.isCallingWithNonNullCheckArgument(checkFunctionFqName, bindingContext)) {
             report(CodeSmell(issue, Entity.from(expression), issue.description))
         }
+    }
+
+    companion object {
+        private val checkFunctionFqName = FqName("kotlin.check")
     }
 }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseRequireNotNull.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseRequireNotNull.kt
@@ -27,10 +27,6 @@ import org.jetbrains.kotlin.resolve.BindingContext
  * @requiresTypeResolution
  */
 class UseRequireNotNull(config: Config = Config.empty) : Rule(config) {
-    companion object {
-        private val requireFunctionFqName = FqName("kotlin.require")
-    }
-
     override val issue = Issue(
         "UseRequireNotNull",
         Severity.Style,
@@ -44,5 +40,9 @@ class UseRequireNotNull(config: Config = Config.empty) : Rule(config) {
         if (expression.isCallingWithNonNullCheckArgument(requireFunctionFqName, bindingContext)) {
             report(CodeSmell(issue, Entity.from(expression), issue.description))
         }
+    }
+
+    companion object {
+        private val requireFunctionFqName = FqName("kotlin.require")
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ClassOrderingSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ClassOrderingSpec.kt
@@ -1,0 +1,146 @@
+package io.gitlab.arturbosch.detekt.rules.style
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.test.compileAndLint
+import org.assertj.core.api.Assertions.assertThat
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+class ClassOrderingSpec : Spek({
+    val subject by memoized { ClassOrdering(Config.empty) }
+
+    describe("ClassOrdering rule") {
+
+        it("does not report when class contents are in expected order with property first") {
+            val code = """
+                class InOrder(private val x: String) {
+                    val y = x
+
+                    init {
+                        check(x == "yes")
+                    }
+
+                    constructor(z: Int): this(z.toString())
+
+                    fun returnX() = x
+
+                    companion object {
+                        const val IMPORTANT_VALUE = 3
+                    }
+                }
+            """.trimIndent()
+
+            assertThat(subject.compileAndLint(code)).isEmpty()
+        }
+
+        it("does not report when class contents are in expected order with class initializer first") {
+            val code = """
+                class InOrder(private val x: String) {
+                    init {
+                        check(x == "yes")
+                    }
+
+                    val y = x
+
+                    constructor(z: Int): this(z.toString())
+
+                    fun returnX() = x
+
+                    companion object {
+                        const val IMPORTANT_VALUE = 3
+                    }
+                }
+            """.trimIndent()
+
+            assertThat(subject.compileAndLint(code)).isEmpty()
+        }
+
+        it("reports when class initializer block is out of order") {
+            val code = """
+                class OutOfOrder(private val x: String) {
+                    val y = x
+
+                    constructor(z: Int): this(z.toString())
+
+                    init {
+                        check(x == "yes")
+                    }
+
+                    fun returnX() = x
+
+                    companion object {
+                        const val IMPORTANT_VALUE = 3
+                    }
+                }
+            """.trimIndent()
+
+            assertThat(subject.compileAndLint(code)).hasSize(1)
+        }
+
+        it("reports when secondary constructor is out of order") {
+            val code = """
+                class OutOfOrder(private val x: String) {
+                    constructor(z: Int): this(z.toString())
+
+                    val y = x
+
+                    init {
+                        check(x == "yes")
+                    }
+
+                    fun returnX() = x
+
+                    companion object {
+                        const val IMPORTANT_VALUE = 3
+                    }
+                }
+            """.trimIndent()
+
+            assertThat(subject.compileAndLint(code)).hasSize(1)
+        }
+
+        it("reports when method is out of order") {
+            val code = """
+                class OutOfOrder(private val x: String) {
+                    fun returnX() = x
+
+                    val y = x
+
+                    init {
+                        check(x == "yes")
+                    }
+
+                    constructor(z: Int): this(z.toString())
+
+                    companion object {
+                        const val IMPORTANT_VALUE = 3
+                    }
+                }
+            """.trimIndent()
+
+            assertThat(subject.compileAndLint(code)).hasSize(1)
+        }
+
+        it("reports when companion object is out of order") {
+            val code = """
+                class OutOfOrder(private val x: String) {
+                    val y = x
+
+                    init {
+                        check(x == "yes")
+                    }
+
+                    constructor(z: Int): this(z.toString())
+
+                    companion object {
+                        const val IMPORTANT_VALUE = 3
+                    }
+
+                    fun returnX() = x
+                }
+            """.trimIndent()
+
+            assertThat(subject.compileAndLint(code)).hasSize(1)
+        }
+    }
+})

--- a/docs/pages/documentation/style.md
+++ b/docs/pages/documentation/style.md
@@ -10,6 +10,50 @@ The Style ruleset provides rules that assert the style of the code.
 This will help keep code in line with the given
 code style guidelines.
 
+### ClassOrdering
+
+This rule ensures class contents are ordered as follows as recommended by the Kotlin Coding Conventions:
+- Property declarations and initializer blocks
+- Secondary constructors
+- Method declarations
+- Companion object
+
+**Severity**: Style
+
+**Debt**: 5min
+
+#### Noncompliant Code:
+
+```kotlin
+class OutOfOrder {
+    companion object {
+        const val IMPORTANT_VALUE = 3
+    }
+
+    fun returnX(): Int {
+        return x
+    }
+
+    private val x = 2
+}
+```
+
+#### Compliant Code:
+
+```kotlin
+class InOrder {
+    private val x = 2
+
+    fun returnX(): Int {
+        return x
+    }
+
+    companion object {
+        const val IMPORTANT_VALUE = 3
+    }
+}
+```
+
 ### CollapsibleIfStatements
 
 This rule detects `if` statements which can be collapsed. This can reduce nesting and help improve readability.

--- a/docs/pages/documentation/style.md
+++ b/docs/pages/documentation/style.md
@@ -12,7 +12,8 @@ code style guidelines.
 
 ### ClassOrdering
 
-This rule ensures class contents are ordered as follows as recommended by the Kotlin Coding Conventions:
+This rule ensures class contents are ordered as follows as recommended by the Kotlin
+[Coding Conventions](https://kotlinlang.org/docs/reference/coding-conventions.html#class-layout):
 - Property declarations and initializer blocks
 - Secondary constructors
 - Method declarations


### PR DESCRIPTION
A rule to check the contents of a class match this ordering: https://kotlinlang.org/docs/reference/coding-conventions.html#class-layout

I've enabled this for detekt, and you can see in that second commit the changes that were required to comply with the new rule. I think the changes are mostly not controversial, but for those classes where they are a suppression is probably the right way to go, or perhaps changing some extension properties into extension functions.