### PR TITLE
New rule: ReplaceSafeCallChainWithRun

### DIFF
--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/AnnotationExcluder.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/AnnotationExcluder.kt
@@ -13,13 +13,14 @@ class AnnotationExcluder(
     private val excludes: List<String>
 ) {
 
-    private val resolvedAnnotations = root.importList
-            ?.imports
-            ?.asSequence()
-            ?.filterNot { it.isAllUnder }
-            ?.mapNotNull { it.importedFqName?.asString() }
-            ?.map { it.substringAfterLast('.') to it }
-            ?.toMap() ?: emptyMap()
+    private val resolvedAnnotations = root.importList?.run {
+        imports
+            .asSequence()
+            .filterNot { it.isAllUnder }
+            .mapNotNull { it.importedFqName?.asString() }
+            .map { it.substringAfterLast('.') to it }
+            .toMap()
+    } ?: emptyMap()
 
     constructor(root: KtFile, excludes: SplitPattern) : this(root, excludes.mapAll { it })
 

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/Suppressions.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/Suppressions.kt
@@ -47,9 +47,11 @@ fun KtAnnotated.isSuppressedBy(id: RuleId, aliases: Set<String>, ruleSetId: Rule
     acceptedSuppressionIds.addAll(aliases)
     return annotationEntries
         .find { it.typeReference?.text in suppressionAnnotations }
-        ?.valueArguments
-        ?.map { it.getArgumentExpression()?.text }
-        ?.map { it?.replace(detektSuppressionPrefixRegex, "") }
-        ?.map { it?.replace(QUOTES, "") }
-        ?.find { it in acceptedSuppressionIds } != null
+        ?.run {
+            valueArguments
+                .map { it.getArgumentExpression()?.text }
+                .map { it?.replace(detektSuppressionPrefixRegex, "") }
+                .map { it?.replace(QUOTES, "") }
+                .find { it in acceptedSuppressionIds }
+        } != null
 }

--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -102,6 +102,8 @@ complexity:
   NestedBlockDepth:
     active: true
     threshold: 4
+  ReplaceSafeCallChainWithRun:
+    active: false
   StringLiteralDuplication:
     active: false
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexityProvider.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexityProvider.kt
@@ -26,7 +26,8 @@ class ComplexityProvider : DefaultRuleSetProvider {
             NestedBlockDepth(config),
             TooManyFunctions(config),
             ComplexCondition(config),
-            LabeledExpression(config)
+            LabeledExpression(config),
+            ReplaceSafeCallChainWithRun(config),
         )
     )
 }

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ReplaceSafeCallChainWithRun.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ReplaceSafeCallChainWithRun.kt
@@ -18,20 +18,25 @@ import org.jetbrains.kotlin.types.isNullable
  * Chains of safe calls on non-nullable types are redundant and can be removed by enclosing the redundant safe calls in
  * a `run {}` block. This improves code coverage and reduces cyclomatic complexity as redundant null checks are removed.
  *
+ * This rule only checks from the end of a chain and works backwards, so it won't recommend inserting run blocks in the
+ * middle of a safe call chain as that is likely to make the code more difficult to understand.
+ *
+ * The rule will check for every opportunity to replace a safe call when it sits at the end of a chain, even if there's
+ * only one, as that will still improve code coverage and reduce cyclomatic complexity.
+ *
  * <noncompliant>
- * val x = classOrObject.body?.declarations
- *         ?.filterIsInstance<KtNamedFunction>()
- *         ?.filter { !isIgnoredFunction(it) }
- *         ?.size ?: 0
+ * val x = System.getenv()
+ *             ?.getValue("HOME")
+ *             ?.toLowerCase()
+ *             ?.split("/") ?: emptyList()
  * </noncompliant>
  *
  * <compliant>
- * val x = classOrObject.body?.run {
- *         declarations
- *             .filterIsInstance<KtNamedFunction>()
- *             .filter { !isIgnoredFunction(it) }
- *             .size
- *     } ?: 0
+ * val x = getenv()?.run {
+ *     getValue("HOME")
+ *         .toLowerCase()
+ *         .split("/")
+ * } ?: emptyList()
  * </compliant>
  *
  * @requiresTypeResolution

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/TooManyFunctions.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/TooManyFunctions.kt
@@ -121,10 +121,13 @@ class TooManyFunctions(config: Config = Config.empty) : Rule(config) {
         super.visitObjectDeclaration(declaration)
     }
 
-    private fun calcFunctions(classOrObject: KtClassOrObject): Int = classOrObject.body?.declarations
-            ?.filterIsInstance<KtNamedFunction>()
-            ?.filter { !isIgnoredFunction(it) }
-            ?.size ?: 0
+    private fun calcFunctions(classOrObject: KtClassOrObject): Int = classOrObject.body
+        ?.run {
+            declarations
+                .filterIsInstance<KtNamedFunction>()
+                .filter { !isIgnoredFunction(it) }
+                .size
+        } ?: 0
 
     private fun isIgnoredFunction(function: KtNamedFunction): Boolean = when {
         ignoreDeprecated && function.hasAnnotation(DEPRECATED) -> true

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ReplaceSafeCallChainWithRunSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ReplaceSafeCallChainWithRunSpec.kt
@@ -1,0 +1,85 @@
+package io.gitlab.arturbosch.detekt.rules.complexity
+
+import io.gitlab.arturbosch.detekt.rules.setupKotlinEnvironment
+import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+object ReplaceSafeCallChainWithRunSpec : Spek({
+    setupKotlinEnvironment()
+
+    val env: KotlinCoreEnvironment by memoized()
+    val subject by memoized { ReplaceSafeCallChainWithRun() }
+
+    describe("ReplaceSafeChainWithRun rule") {
+
+        it("reports long chain of unnecessary safe qualified expressions") {
+            val code = """
+                val x: String? = "string"
+
+                val y = x
+                    ?.asSequence()
+                    ?.map { it }
+                    ?.distinctBy { it }
+                    ?.iterator()
+                    ?.forEach(::println)
+            """
+
+            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        }
+
+        it("reports short chain of unnecessary safe qualified expressions") {
+            val code = """
+                val x: String? = "string"
+
+                val y = x
+                    ?.asSequence()
+                    ?.map { it }
+            """
+
+            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        }
+
+        it("does not report a safe call chain which is too short to benefit") {
+            val code = """
+                val x: String? = "string"
+
+                val y = x
+                    ?.asSequence()
+            """
+
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        }
+
+        it("does not report a safe call chain which is too short to benefit") {
+            val code = """
+                val x: String? = "string"
+
+                val y = x
+                    ?.asSequence()
+            """
+
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        }
+
+        it("does not report a safe call chain on left side of assignment") {
+            val code = """
+                class Something {
+                    var element: Element? = null
+                }
+
+                class Element(var list: List<String>?)
+
+                val z: Something? = Something()
+
+                fun modifyList() {
+                    z?.element?.list = listOf("strings")
+                }
+            """
+
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        }
+    }
+})

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ReplaceSafeCallChainWithRunSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ReplaceSafeCallChainWithRunSpec.kt
@@ -53,17 +53,6 @@ object ReplaceSafeCallChainWithRunSpec : Spek({
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
-        it("does not report a safe call chain which is too short to benefit") {
-            val code = """
-                val x: String? = "string"
-
-                val y = x
-                    ?.asSequence()
-            """
-
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
-        }
-
         it("does not report a safe call chain on left side of assignment") {
             val code = """
                 class Something {

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ImplicitDefaultLocale.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ImplicitDefaultLocale.kt
@@ -99,6 +99,5 @@ private fun KtQualifiedExpression.containsStringTemplate(): Boolean {
     val lastCallExpression = lastChild as? KtCallExpression
     return lastCallExpression?.valueArguments
         ?.firstOrNull()
-        ?.children
-        ?.firstOrNull() is KtStringTemplateExpression
+        ?.run { children.firstOrNull() } is KtStringTemplateExpression
 }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateClass.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateClass.kt
@@ -109,15 +109,17 @@ class UnusedPrivateClass(config: Config = Config.empty) : Rule(config) {
                     ?.run { namedClasses.add(this) }
 
             // Try with the type being a generic argument of other type (e.g. List<Foo>, List<Foo?>)
-            typeReference.typeElement?.typeArgumentsAsTypes
-                    ?.asSequence()
-                    ?.filterNotNull()
-                    ?.map { it.orInnerType() }
-                    ?.forEach {
+            typeReference.typeElement?.run {
+                typeArgumentsAsTypes
+                    .asSequence()
+                    .filterNotNull()
+                    .map { it.orInnerType() }
+                    .forEach {
                         namedClasses.add(it.text)
                         // Recursively register for nested generic types (e.g. List<List<Foo>>)
                         if (it is KtTypeReference) registerAccess(it)
                     }
+            }
         }
 
         override fun visitParameter(parameter: KtParameter) {

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/FindingsAssertions.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/FindingsAssertions.kt
@@ -68,7 +68,7 @@ class FindingsAssert(actual: List<Finding>) :
                 failWithMessage("Expected ${expected.size} findings but was 0")
             }
         }
-        val code = requireNotNull(finding?.entity?.ktElement?.containingKtFile?.text) {
+        val code = requireNotNull(finding?.entity?.ktElement?.run { containingKtFile.text }) {
             "Finding expected to provide a KtElement."
         }
 

--- a/docs/pages/documentation/complexity.md
+++ b/docs/pages/documentation/complexity.md
@@ -285,6 +285,12 @@ Prefer extracting the nested code into well-named functions to make it easier to
 Chains of safe calls on non-nullable types are redundant and can be removed by enclosing the redundant safe calls in
 a `run {}` block. This improves code coverage and reduces cyclomatic complexity as redundant null checks are removed.
 
+This rule only checks from the end of a chain and works backwards, so it won't recommend inserting run blocks in the
+middle of a safe call chain as that is likely to make the code more difficult to understand.
+
+The rule will check for every opportunity to replace a safe call when it sits at the end of a chain, even if there's
+only one, as that will still improve code coverage and reduce cyclomatic complexity.
+
 **Requires Type Resolution**
 
 **Severity**: Maintainability
@@ -294,21 +300,20 @@ a `run {}` block. This improves code coverage and reduces cyclomatic complexity 
 #### Noncompliant Code:
 
 ```kotlin
-val x = classOrObject.body?.declarations
-    ?.filterIsInstance<KtNamedFunction>()
-    ?.filter { !isIgnoredFunction(it) }
-    ?.size ?: 0
+val x = System.getenv()
+    ?.getValue("HOME")
+    ?.toLowerCase()
+    ?.split("/") ?: emptyList()
 ```
 
 #### Compliant Code:
 
 ```kotlin
-val x = classOrObject.body?.run {
-        declarations
-            .filterIsInstance<KtNamedFunction>()
-            .filter { !isIgnoredFunction(it) }
-            .size
-    } ?: 0
+val x = getenv()?.run {
+    getValue("HOME")
+        .toLowerCase()
+        .split("/")
+} ?: emptyList()
 ```
 
 ### StringLiteralDuplication

--- a/docs/pages/documentation/complexity.md
+++ b/docs/pages/documentation/complexity.md
@@ -280,6 +280,37 @@ Prefer extracting the nested code into well-named functions to make it easier to
 
    the nested depth required to trigger rule
 
+### ReplaceSafeCallChainWithRun
+
+Chains of safe calls on non-nullable types are redundant and can be removed by enclosing the redundant safe calls in
+a `run {}` block. This improves code coverage and reduces cyclomatic complexity as redundant null checks are removed.
+
+**Requires Type Resolution**
+
+**Severity**: Maintainability
+
+**Debt**: 10min
+
+#### Noncompliant Code:
+
+```kotlin
+val x = classOrObject.body?.declarations
+    ?.filterIsInstance<KtNamedFunction>()
+    ?.filter { !isIgnoredFunction(it) }
+    ?.size ?: 0
+```
+
+#### Compliant Code:
+
+```kotlin
+val x = classOrObject.body?.run {
+        declarations
+            .filterIsInstance<KtNamedFunction>()
+            .filter { !isIgnoredFunction(it) }
+            .size
+    } ?: 0
+```
+
 ### StringLiteralDuplication
 
 This rule detects and reports duplicated String literals. Repeatedly typing out the same String literal across the


### PR DESCRIPTION
I saw this neat trick while browsing Kotlin compiler source.

Instead of having a long chain of safe calls, when many of those safe calls are redundant (because the type returned by the preceding call is non-nullable), that chain of safe calls can be surrounded with `run {}` and the redundant safe calls can be removed.

This rule only checks from the end of a chain and works backwards, so it won't recommend inserting `run` blocks in the middle of a safe call chain which I think could be very confusing to read, especially since it could mean multiple `run` blocks in a very long chain.

The rule also checks for any opportunity to replace a chain by surrounding with `run`, so any redundant safe calls at the end of a chain will be reported, even if there's only one. I personally think this is fine because it still reduces complexity which I see as being the main benefit of this rule.

I'm interested in feedback on this one!