### PR TITLE
Update RedundantVisibilityModifierRule to find redundant internal modifiers

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -137,6 +137,8 @@ style:
     active: true
   ProtectedMemberInFinalClass:
     active: true
+  RedundantVisibilityModifierRule:
+    active: true
   SpacingBetweenPackageAndImports:
     active: true
   UnnecessaryAbstractClass:

--- a/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/processors/util/LLOC.kt
+++ b/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/processors/util/LLOC.kt
@@ -23,7 +23,7 @@ object LLOC {
         private var escape: Boolean = false
 
         @Suppress("LoopWithTooManyJumpStatements")
-        internal fun run(): Int {
+        fun run(): Int {
             for (line in lines) {
 
                 val trimmed = line.trim()

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedBlockDepth.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedBlockDepth.kt
@@ -58,9 +58,9 @@ class NestedBlockDepth(
 
     private class FunctionDepthVisitor(val threshold: Int) : DetektVisitor() {
 
-        internal var depth = 0
-        internal var maxDepth = 0
-        internal var isTooDeep = false
+        var depth = 0
+        var maxDepth = 0
+        var isTooDeep = false
         private fun inc() {
             depth++
             if (depth >= threshold) {

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsWithHashCodeExist.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsWithHashCodeExist.kt
@@ -59,7 +59,7 @@ class EqualsWithHashCodeExist(config: Config = Config.empty) : Rule(config) {
     private val queue = ArrayDeque<ViolationHolder>(MAXIMUM_EXPECTED_NESTED_CLASSES)
 
     private data class ViolationHolder(var equals: Boolean = false, var hashCode: Boolean = false) {
-        internal fun violation() = equals && !hashCode || !equals && hashCode
+        fun violation() = equals && !hashCode || !equals && hashCode
     }
 
     override fun visitFile(file: PsiFile?) {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantVisibilityModifierRuleSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantVisibilityModifierRuleSpec.kt
@@ -127,5 +127,27 @@ class RedundantVisibilityModifierRuleSpec : Spek({
             """
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
+
+        it("reports internal modifier on nested class in private object") {
+            val code = """
+                private object Xml10EscapeSymbolsInitializer {
+
+                    internal class XmlCodepointValidator
+
+                }
+            """
+            assertThat(subject.compileAndLint(code)).hasSize(1)
+        }
+
+        it("reports internal modifier on function declaration in private object") {
+            val code = """
+                private object Xml10EscapeSymbolsInitializer {
+
+                    internal fun xmlCodepointValidator()
+
+                }
+            """
+            assertThat(subject.compileAndLint(code)).hasSize(1)
+        }
     }
 })

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantVisibilityModifierRuleSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantVisibilityModifierRuleSpec.kt
@@ -130,9 +130,9 @@ class RedundantVisibilityModifierRuleSpec : Spek({
 
         it("reports internal modifier on nested class in private object") {
             val code = """
-                private object Xml10EscapeSymbolsInitializer {
+                private object A {
 
-                    internal class XmlCodepointValidator
+                    internal class InternalClass
 
                 }
             """
@@ -141,9 +141,9 @@ class RedundantVisibilityModifierRuleSpec : Spek({
 
         it("reports internal modifier on function declaration in private object") {
             val code = """
-                private object Xml10EscapeSymbolsInitializer {
+                private object A {
 
-                    internal fun xmlCodepointValidator()
+                    internal fun internalFunction() {}
 
                 }
             """


### PR DESCRIPTION
There were some redundant `internal` modifiers identified by the IDE that weren't picked up by detekt's own rule, so I updated the rule to find this type of usage.

I also enabled the rule for detekt self-scans and fixed the reported issues.