### PR TITLE
Fix false positive (+= overload) in UnusedPrivateMember

### DIFF
--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
@@ -97,7 +97,11 @@ private class UnusedFunctionVisitor(
                         val operatorToken = OperatorConventions.getOperationSymbolForName(Name.identifier(name))
                         val operatorValue = (operatorToken as? KtSingleValueToken)?.value
                         when (operatorToken) {
-                            KtTokens.PLUS, KtTokens.MINUS, KtTokens.MUL, KtTokens.DIV, KtTokens.PERC -> operatorValue?.let {
+                            KtTokens.PLUS,
+                            KtTokens.MINUS,
+                            KtTokens.MUL,
+                            KtTokens.DIV,
+                            KtTokens.PERC -> operatorValue?.let {
                                 functionReferences[it].orEmpty() + functionReferences["$it="].orEmpty()
                             }.orEmpty()
                             else -> operatorValue?.let { functionReferences[it] }.orEmpty()

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
@@ -17,6 +17,8 @@ import io.gitlab.arturbosch.detekt.rules.isOpen
 import io.gitlab.arturbosch.detekt.rules.isOperator
 import io.gitlab.arturbosch.detekt.rules.isOverride
 import org.jetbrains.kotlin.lexer.KtSingleValueToken
+import org.jetbrains.kotlin.lexer.KtToken
+import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtFile
@@ -95,7 +97,12 @@ private class UnusedFunctionVisitor(
                     val referencesViaOperator = if (isOperator) {
                         val operatorToken = OperatorConventions.getOperationSymbolForName(Name.identifier(name))
                         val operatorValue = (operatorToken as? KtSingleValueToken)?.value
-                        operatorValue?.let { functionReferences[it] }.orEmpty()
+                        when (operatorToken) {
+                            KtTokens.PLUS, KtTokens.MINUS, KtTokens.MUL, KtTokens.DIV, KtTokens.PERC -> operatorValue?.let {
+                                functionReferences[it].orEmpty() + functionReferences["$it="].orEmpty()
+                            }.orEmpty()
+                            else -> operatorValue?.let { functionReferences[it] }.orEmpty()
+                        }
                     } else {
                         emptyList()
                     }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
@@ -96,16 +96,16 @@ private class UnusedFunctionVisitor(
                     val referencesViaOperator = if (isOperator) {
                         val operatorToken = OperatorConventions.getOperationSymbolForName(Name.identifier(name))
                         val operatorValue = (operatorToken as? KtSingleValueToken)?.value
-                        when (operatorToken) {
+                        val directReferences = operatorValue?.let { functionReferences[it] }.orEmpty()
+                        val assignmentReferences = when (operatorToken) {
                             KtTokens.PLUS,
                             KtTokens.MINUS,
                             KtTokens.MUL,
                             KtTokens.DIV,
-                            KtTokens.PERC -> operatorValue?.let {
-                                functionReferences[it].orEmpty() + functionReferences["$it="].orEmpty()
-                            }.orEmpty()
-                            else -> operatorValue?.let { functionReferences[it] }.orEmpty()
+                            KtTokens.PERC -> operatorValue?.let { functionReferences["$it="] }.orEmpty()
+                            else -> emptyList()
                         }
+                        directReferences + assignmentReferences
                     } else {
                         emptyList()
                     }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
@@ -17,7 +17,6 @@ import io.gitlab.arturbosch.detekt.rules.isOpen
 import io.gitlab.arturbosch.detekt.rules.isOperator
 import io.gitlab.arturbosch.detekt.rules.isOverride
 import org.jetbrains.kotlin.lexer.KtSingleValueToken
-import org.jetbrains.kotlin.lexer.KtToken
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.psi.KtClass

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMemberSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMemberSpec.kt
@@ -1054,6 +1054,20 @@ class UnusedPrivateMemberSpec : Spek({
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
+        it("does not report used plus operator in methods with +=") {
+            val code = """
+                import java.util.Date
+                class Foo {
+                    var number: Float? = null
+                    fun foo() {
+                        number += 3f
+                    }
+                    private operator fun Float?.plus(other: Float?) = if (this == null && other == null) null else this ?: 0f + (other ?: 0f)
+                }
+            """
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        }
+
         it("report unused minus operator") {
             val code = """
                 import java.util.Date

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMemberSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMemberSpec.kt
@@ -1054,15 +1054,22 @@ class UnusedPrivateMemberSpec : Spek({
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
-        it("does not report used plus operator in methods with +=") {
+        it("does not report used operator methods when used with the equal sign") {
             val code = """
-                import java.util.Date
-                class Foo {
-                    var number: Float? = null
-                    fun foo() {
-                        number += 3f
+                class Test {
+                    fun f() {
+                        var number: Int? = 0
+                        number += 1
+                        number -= 1
+                        number *= 1
+                        number /= 1
+                        number %= 1
                     }
-                    private operator fun Float?.plus(other: Float?) = if (this == null && other == null) null else this ?: 0f + (other ?: 0f)
+                    private operator fun Int?.plus(other: Int) = 1
+                    private operator fun Int?.minus(other: Int) = 2
+                    private operator fun Int?.times(other: Int) = 3
+                    private operator fun Int?.div(other: Int) = 4
+                    private operator fun Int?.rem(other: Int) = 5
                 }
             """
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()


### PR DESCRIPTION
Hi! I noticed that detekt emits a false positive when checking for unused members if the function is an operator function, and if it's used via an assignment operation (`+=` in the test case).

I know that the issue likely lies in `io.gitlab.arturbosch.detekt.rules.style.UnusedFunctionVisitor#getUnusedReports`:
```kotlin
val operatorToken = OperatorConventions.getOperationSymbolForName(Name.identifier(name))
```

This will return the token `+` as the name of the function is `plus`, so `+=` will get skipped and appear as unused.

I'm not too familiar with detekt internals so I'm not sure how to solve it, I'm open to ideas/suggestions though/happy to let someone else take over the PR.
