### PR TITLE
Add additional classpaths to KtTestCompiler

### DIFF
--- a/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/KotlinCoreEnvironmentWrapper.kt
+++ b/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/KotlinCoreEnvironmentWrapper.kt
@@ -1,5 +1,6 @@
 package io.github.detekt.test.utils
 
+import java.io.File
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.jetbrains.kotlin.com.intellij.openapi.Disposable
 import org.jetbrains.kotlin.com.intellij.openapi.util.Disposer

--- a/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/KotlinCoreEnvironmentWrapper.kt
+++ b/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/KotlinCoreEnvironmentWrapper.kt
@@ -22,6 +22,11 @@ class KotlinCoreEnvironmentWrapper(
     }
 }
 
-fun createEnvironment(): KotlinCoreEnvironmentWrapper = KtTestCompiler.createEnvironment()
+/**
+ * Create a {@link KotlinCoreEnvironmentWrapper} used for test.
+ * 
+ * @param additionalRootPaths the optional JVM classpath roots list.
+ */
+fun createEnvironment(additionalRootPaths: List<File> = listOf()): KotlinCoreEnvironmentWrapper = KtTestCompiler.createEnvironment(additionalRootPaths)
 
 fun createPsiFactory(): KtPsiFactory = KtPsiFactory(KtTestCompiler.project(), false)

--- a/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/KotlinCoreEnvironmentWrapper.kt
+++ b/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/KotlinCoreEnvironmentWrapper.kt
@@ -25,7 +25,7 @@ class KotlinCoreEnvironmentWrapper(
 
 /**
  * Create a {@link KotlinCoreEnvironmentWrapper} used for test.
- * 
+ *
  * @param additionalRootPaths the optional JVM classpath roots list.
  */
 fun createEnvironment(additionalRootPaths: List<File> = listOf()): KotlinCoreEnvironmentWrapper = KtTestCompiler.createEnvironment(additionalRootPaths)

--- a/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/KtTestCompiler.kt
+++ b/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/KtTestCompiler.kt
@@ -7,6 +7,7 @@ import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.cli.jvm.compiler.EnvironmentConfigFiles
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.jetbrains.kotlin.cli.jvm.config.addJvmClasspathRoot
+import org.jetbrains.kotlin.cli.jvm.config.addJvmClasspathRoots
 import org.jetbrains.kotlin.com.intellij.openapi.project.Project
 import org.jetbrains.kotlin.com.intellij.openapi.util.Disposer
 import org.jetbrains.kotlin.com.intellij.openapi.util.text.StringUtilRt

--- a/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/KtTestCompiler.kt
+++ b/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/KtTestCompiler.kt
@@ -34,7 +34,7 @@ internal object KtTestCompiler : KtCompiler() {
      * Not sure why but this function only works from this context.
      * Somehow the Kotlin language was not yet initialized.
      */
-    fun createEnvironment(): KotlinCoreEnvironmentWrapper {
+    fun createEnvironment(additionalRootPaths: List<File> = listOf()): KotlinCoreEnvironmentWrapper {
         val configuration = CompilerConfiguration()
         configuration.put(CommonConfigurationKeys.MODULE_NAME, "test_module")
         configuration.put(CLIConfigurationKeys.MESSAGE_COLLECTOR_KEY, MessageCollector.NONE)
@@ -43,6 +43,7 @@ internal object KtTestCompiler : KtCompiler() {
         // BindingContext for rules under test.
         val path = File(CharRange::class.java.protectionDomain.codeSource.location.path)
         configuration.addJvmClasspathRoot(path)
+        configuration.addJvmClasspathRoots(additionalRootPaths)
 
         val parentDisposable = Disposer.newDisposable()
         val kotlinCoreEnvironment =


### PR DESCRIPTION
This allows additional jvm root classpaths to be provided to the compiler for test. Useful for custom rules that need shared access to prod resources.

Example
```
    val EXTRA_CLASSPATH_FILES =
        listOf(File(ImportantProdClass::class.java.protectionDomain.codeSource.location.path))

    val ENVIRONMENT = createEnvironment(EXTRA_CLASSPATH_FILES)

```

Solves #3066 