### PR TITLE
Improve description of AbsentOrWrongFileLicense rule

### DIFF
--- a/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/AbsentOrWrongFileLicense.kt
+++ b/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/AbsentOrWrongFileLicense.kt
@@ -10,7 +10,9 @@ import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.psi.KtFile
 
 /**
- * This rule will report every Kotlin source file which doesn't have required license header.
+ * This rule will report every Kotlin source file which doesn't have the required license header.
+ * Each Kotlin source file is checked, whether the header starts with the read text from the passed file in the
+ * `licenseTemplateFile` configuration option.
  *
  * @configuration licenseTemplateFile - path to file with license header template resolved relatively to config file
  * (default: `'license.template'`)

--- a/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/AbsentOrWrongFileLicense.kt
+++ b/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/AbsentOrWrongFileLicense.kt
@@ -11,7 +11,7 @@ import org.jetbrains.kotlin.psi.KtFile
 
 /**
  * This rule will report every Kotlin source file which doesn't have the required license header.
- * Each Kotlin source file is checked, whether the header starts with the read text from the passed file in the
+ * The rule checks each Kotlin source file whether the header starts with the read text from the passed file in the
  * `licenseTemplateFile` configuration option.
  *
  * @configuration licenseTemplateFile - path to file with license header template resolved relatively to config file

--- a/docs/pages/documentation/comments.md
+++ b/docs/pages/documentation/comments.md
@@ -12,7 +12,7 @@ of the code.
 ### AbsentOrWrongFileLicense
 
 This rule will report every Kotlin source file which doesn't have the required license header.
-Each Kotlin source file is checked, whether the header starts with the read text from the passed file in the
+The rule checks each Kotlin source file whether the header starts with the read text from the passed file in the
 `licenseTemplateFile` configuration option.
 
 **Severity**: Maintainability

--- a/docs/pages/documentation/comments.md
+++ b/docs/pages/documentation/comments.md
@@ -11,7 +11,9 @@ of the code.
 
 ### AbsentOrWrongFileLicense
 
-This rule will report every Kotlin source file which doesn't have required license header.
+This rule will report every Kotlin source file which doesn't have the required license header.
+Each Kotlin source file is checked, whether the header starts with the read text from the passed file in the
+`licenseTemplateFile` configuration option.
 
 **Severity**: Maintainability
 


### PR DESCRIPTION
The new description states how the rule checks Kotlin source files
against the given license header.
Closes #3100
