### PR TITLE
Specify type explicitly in DetektCreateBaselineTask

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
@@ -54,7 +54,7 @@ open class DetektCreateBaselineTask : SourceTask() {
 
     @get:Classpath
     @get:Optional
-    val classpath = project.objects.fileCollection()
+    val classpath: ConfigurableFileCollection = project.objects.fileCollection()
 
     @get:Console
     val debug: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)


### PR DESCRIPTION
In order to prevent unexpected errors, the type should be declared explicitly.