### PR TITLE
[RFC] New Rule API

### DIFF
--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/DetektVisitor.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/DetektVisitor.kt
@@ -6,4 +6,4 @@ import org.jetbrains.kotlin.psi.KtTreeVisitorVoid
  * Basic visitor which is used inside detekt.
  * Guarantees a better looking name as the extended base class :).
  */
-open class DetektVisitor : KtTreeVisitorVoid()
+open class DetektVisitor : KtTreeVisitorVoid() // This should be an alias in 2.0

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/v2/FileProcessListener.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/v2/FileProcessListener.kt
@@ -1,7 +1,5 @@
 package io.gitlab.arturbosch.detekt.api.v2
 
-import io.gitlab.arturbosch.detekt.api.Detektion
-import io.gitlab.arturbosch.detekt.api.Finding
 import org.jetbrains.kotlin.psi.KtFile
 
 // This will be a sealed interface in 1.5
@@ -14,9 +12,9 @@ interface PlainFileProcessListener : FileProcessListener {
 
     fun onProcess(file: KtFile) = Unit
 
-    fun onProcessComplete(file: KtFile, findings: Map<String, List<Finding>>) = Unit
+    fun onProcessComplete(file: KtFile, findings: List<Finding>) = Unit
 
-    fun onFinish(files: List<KtFile>, result: Detektion) = Unit
+    fun onFinish(files: List<KtFile>, findings: List<Finding>) = Unit
 }
 
 interface TypeSolvingFileProcessListener : FileProcessListener {
@@ -25,7 +23,7 @@ interface TypeSolvingFileProcessListener : FileProcessListener {
 
     fun onProcess(file: KtFile, resolvedContext: ResolvedContext) = Unit
 
-    fun onProcessComplete(file: KtFile, findings: Map<String, List<Finding>>, resolvedContext: ResolvedContext) = Unit
+    fun onProcessComplete(file: KtFile, findings: List<Finding>, resolvedContext: ResolvedContext) = Unit
 
-    fun onFinish(files: List<KtFile>, result: Detektion, resolvedContext: ResolvedContext) = Unit
+    fun onFinish(files: List<KtFile>, findings: List<Finding>, resolvedContext: ResolvedContext) = Unit
 }

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/v2/FileProcessListener.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/v2/FileProcessListener.kt
@@ -2,9 +2,7 @@ package io.gitlab.arturbosch.detekt.api.v2
 
 import io.gitlab.arturbosch.detekt.api.Detektion
 import io.gitlab.arturbosch.detekt.api.Finding
-import io.gitlab.arturbosch.detekt.api.internal.CompilerResources
 import org.jetbrains.kotlin.psi.KtFile
-import org.jetbrains.kotlin.resolve.BindingContext
 
 // This will be a sealed interface in 1.5
 interface FileProcessListener {
@@ -23,16 +21,11 @@ interface PlainFileProcessListener : FileProcessListener {
 
 interface TypeSolvingFileProcessListener : FileProcessListener {
 
-    fun onStart(files: List<KtFile>, binding: BindingContext, resources: CompilerResources) = Unit
+    fun onStart(files: List<KtFile>, resolvedContext: ResolvedContext) = Unit
 
-    fun onProcess(file: KtFile, binding: BindingContext, resources: CompilerResources) = Unit
+    fun onProcess(file: KtFile, resolvedContext: ResolvedContext) = Unit
 
-    fun onProcessComplete(
-        file: KtFile,
-        findings: Map<String, List<Finding>>,
-        binding: BindingContext,
-        resources: CompilerResources
-    ) = Unit
+    fun onProcessComplete(file: KtFile, findings: Map<String, List<Finding>>, resolvedContext: ResolvedContext) = Unit
 
-    fun onFinish(files: List<KtFile>, result: Detektion, binding: BindingContext, resources: CompilerResources) = Unit
+    fun onFinish(files: List<KtFile>, result: Detektion, resolvedContext: ResolvedContext) = Unit
 }

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/v2/FileProcessListener.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/v2/FileProcessListener.kt
@@ -1,0 +1,38 @@
+package io.gitlab.arturbosch.detekt.api.v2
+
+import io.gitlab.arturbosch.detekt.api.Detektion
+import io.gitlab.arturbosch.detekt.api.Finding
+import io.gitlab.arturbosch.detekt.api.internal.CompilerResources
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.resolve.BindingContext
+
+// This will be a sealed interface in 1.5
+interface FileProcessListener {
+}
+
+interface PlainFileProcessListener : FileProcessListener {
+
+    fun onStart(files: List<KtFile>) = Unit
+
+    fun onProcess(file: KtFile) = Unit
+
+    fun onProcessComplete(file: KtFile, findings: Map<String, List<Finding>>) = Unit
+
+    fun onFinish(files: List<KtFile>, result: Detektion) = Unit
+}
+
+interface TypeSolvingFileProcessListener : FileProcessListener {
+
+    fun onStart(files: List<KtFile>, binding: BindingContext, resources: CompilerResources) = Unit
+
+    fun onProcess(file: KtFile, binding: BindingContext, resources: CompilerResources) = Unit
+
+    fun onProcessComplete(
+        file: KtFile,
+        findings: Map<String, List<Finding>>,
+        binding: BindingContext,
+        resources: CompilerResources
+    ) = Unit
+
+    fun onFinish(files: List<KtFile>, result: Detektion, binding: BindingContext, resources: CompilerResources) = Unit
+}

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/v2/Finding.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/v2/Finding.kt
@@ -1,0 +1,77 @@
+package io.gitlab.arturbosch.detekt.api.v2
+
+import io.github.detekt.psi.FilePath
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.SeverityLevel
+import org.jetbrains.kotlin.psi.KtElement
+import java.nio.file.Path
+
+interface Finding {
+    val id: String
+    val message: String
+    val location: Location
+    val severityLevel: SeverityLevel
+    val debt: Debt
+    val entity: Entity
+    val correctable: Boolean
+    val rule: RuleInfo
+}
+
+interface Entity {
+    val id: String
+    val ktElement: KtElement
+}
+
+interface RuleInfo {
+    val id: String
+    val ruleSetId: String
+    val description: String
+}
+
+interface Location {
+    val source: SourceLocation
+    val text: TextLocation
+    val filePath: FilePath
+}
+
+interface FilePath {
+    val absolute: Path
+    val relative: Path?
+    val base: Path?
+}
+
+interface SourceLocation {
+    val line: Int
+    val column: Int
+
+    companion object {
+        operator fun invoke(line: Int, column: Int): SourceLocation {
+            return Impl(line, column)
+        }
+    }
+
+    private data class Impl(
+        override val line: Int,
+        override val column: Int
+    ) : SourceLocation {
+        override fun toString(): String = "$line:$column"
+    }
+}
+
+interface TextLocation {
+    val start: Int
+    val end: Int
+
+    companion object {
+        operator fun invoke(start: Int, end: Int): TextLocation {
+            return Impl(start, end)
+        }
+    }
+
+    private data class Impl(
+        override val start: Int,
+        override val end: Int
+    ) : TextLocation {
+        override fun toString(): String = "$start:$end"
+    }
+}

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/v2/Finding.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/v2/Finding.kt
@@ -32,6 +32,9 @@ interface SourceLocation {
     val line: Int
     val column: Int
 
+    operator fun component1(): Int = line
+    operator fun component2(): Int = column
+
     companion object {
         operator fun invoke(line: Int, column: Int): SourceLocation {
             return Impl(line, column)
@@ -49,6 +52,9 @@ interface SourceLocation {
 interface TextLocation {
     val start: Int
     val end: Int
+
+    operator fun component1(): Int = start
+    operator fun component2(): Int = end
 
     companion object {
         operator fun invoke(start: Int, end: Int): TextLocation {

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/v2/Finding.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/v2/Finding.kt
@@ -4,7 +4,6 @@ import io.github.detekt.psi.FilePath
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.SeverityLevel
 import org.jetbrains.kotlin.psi.KtElement
-import java.nio.file.Path
 
 interface Finding {
     val id: String
@@ -12,14 +11,9 @@ interface Finding {
     val location: Location
     val severityLevel: SeverityLevel
     val debt: Debt
-    val entity: Entity
-    val correctable: Boolean
-    val rule: RuleInfo
-}
-
-interface Entity {
-    val id: String
     val ktElement: KtElement
+    val autoCorrectable: Boolean
+    val rule: RuleInfo
 }
 
 interface RuleInfo {
@@ -31,13 +25,7 @@ interface RuleInfo {
 interface Location {
     val source: SourceLocation
     val text: TextLocation
-    val filePath: FilePath
-}
-
-interface FilePath {
-    val absolute: Path
-    val relative: Path?
-    val base: Path?
+    val filePath: FilePath // TODO The api should not depend on io.github.detekt.psi.FilePath
 }
 
 interface SourceLocation {

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/v2/ResolvedContext.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/v2/ResolvedContext.kt
@@ -1,0 +1,9 @@
+package io.gitlab.arturbosch.detekt.api.v2
+
+import io.gitlab.arturbosch.detekt.api.internal.CompilerResources
+import org.jetbrains.kotlin.resolve.BindingContext
+
+interface ResolvedContext {
+    val binding: BindingContext
+    val resources: CompilerResources
+}

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/v2/Rule.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/v2/Rule.kt
@@ -1,7 +1,9 @@
 package io.gitlab.arturbosch.detekt.api.v2
 
+import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.SeverityLevel
 import org.jetbrains.kotlin.psi.KtFile
 
 // This will be a sealed interface in 1.5
@@ -23,7 +25,7 @@ interface TypeSolvingRule : Rule, (KtFile, ResolvedContext) -> List<NewIssue> {
 interface NewIssue {
     val entity: Entity
     val message: String
-    // This should be here but the code is not ready yet
-    //val severity: SeverityLevel
-    //val debt: Debt
+    val severity: SeverityLevel
+    val debt: Debt
+    val autoCorrectable: Boolean
 }

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/v2/Rule.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/v2/Rule.kt
@@ -1,0 +1,31 @@
+package io.gitlab.arturbosch.detekt.api.v2
+
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.internal.CompilerResources
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.resolve.BindingContext
+
+// This will be a sealed interface in 1.5
+interface Rule {
+    // This should not be here but the code is not ready yet to remove it
+    val issue: Issue
+}
+
+interface PlainRule : Rule, (KtFile) -> List<NewIssue> {
+
+    override fun invoke(file: KtFile): List<NewIssue>
+}
+
+interface TypeSolvingRule : Rule, (KtFile, BindingContext, CompilerResources) -> List<NewIssue> {
+
+    override fun invoke(file: KtFile, binding: BindingContext, resources: CompilerResources): List<NewIssue>
+}
+
+interface NewIssue {
+    val entity: Entity
+    val message: String
+    // This should be here but the code is not ready yet
+    //val severity: SeverityLevel
+    //val debt: Debt
+}

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/v2/Rule.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/v2/Rule.kt
@@ -22,7 +22,7 @@ interface TypeSolvingRule : Rule, (KtFile, ResolvedContext) -> List<Issue> {
 }
 
 interface Issue {
-    val entity: Entity
+    val entity: Entity // TODO We should rethink this class. I'm using the old because I don't want to address this yet
     val message: String
     val severity: SeverityLevel
     val debt: Debt

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/v2/Rule.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/v2/Rule.kt
@@ -11,17 +11,17 @@ interface Rule {
     val description: String
 }
 
-interface PlainRule : Rule, (KtFile) -> List<NewIssue> {
+interface PlainRule : Rule, (KtFile) -> List<Issue> {
 
-    override fun invoke(file: KtFile): List<NewIssue>
+    override fun invoke(file: KtFile): List<Issue>
 }
 
-interface TypeSolvingRule : Rule, (KtFile, ResolvedContext) -> List<NewIssue> {
+interface TypeSolvingRule : Rule, (KtFile, ResolvedContext) -> List<Issue> {
 
-    override fun invoke(file: KtFile, resolvedContext: ResolvedContext): List<NewIssue>
+    override fun invoke(file: KtFile, resolvedContext: ResolvedContext): List<Issue>
 }
 
-interface NewIssue {
+interface Issue {
     val entity: Entity
     val message: String
     val severity: SeverityLevel

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/v2/Rule.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/v2/Rule.kt
@@ -2,9 +2,7 @@ package io.gitlab.arturbosch.detekt.api.v2
 
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.internal.CompilerResources
 import org.jetbrains.kotlin.psi.KtFile
-import org.jetbrains.kotlin.resolve.BindingContext
 
 // This will be a sealed interface in 1.5
 interface Rule {
@@ -17,9 +15,9 @@ interface PlainRule : Rule, (KtFile) -> List<NewIssue> {
     override fun invoke(file: KtFile): List<NewIssue>
 }
 
-interface TypeSolvingRule : Rule, (KtFile, BindingContext, CompilerResources) -> List<NewIssue> {
+interface TypeSolvingRule : Rule, (KtFile, ResolvedContext) -> List<NewIssue> {
 
-    override fun invoke(file: KtFile, binding: BindingContext, resources: CompilerResources): List<NewIssue>
+    override fun invoke(file: KtFile, resolvedContext: ResolvedContext): List<NewIssue>
 }
 
 interface NewIssue {

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/v2/Rule.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/v2/Rule.kt
@@ -2,14 +2,13 @@ package io.gitlab.arturbosch.detekt.api.v2
 
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
-import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.SeverityLevel
 import org.jetbrains.kotlin.psi.KtFile
 
 // This will be a sealed interface in 1.5
 interface Rule {
-    // This should not be here but the code is not ready yet to remove it
-    val issue: Issue
+    val id: String
+    val description: String
 }
 
 interface PlainRule : Rule, (KtFile) -> List<NewIssue> {

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/v2/RuleCollectionProvider.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/v2/RuleCollectionProvider.kt
@@ -10,7 +10,6 @@ import io.gitlab.arturbosch.detekt.api.Config
  */
 interface RuleCollectionProvider {
 
-    // TODO Can we remove this?
     val ruleSetId: String
 
     /**

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/v2/RuleCollectionProvider.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/v2/RuleCollectionProvider.kt
@@ -1,0 +1,22 @@
+package io.gitlab.arturbosch.detekt.api.v2
+
+import io.gitlab.arturbosch.detekt.api.Config
+
+/**
+ * A rule collection provider, as the name states, is responsible for creating rule collection.
+ *
+ * When writing own rule set providers make sure to register them according the ServiceLoader documentation.
+ * http://docs.oracle.com/javase/8/docs/api/java/util/ServiceLoader.html
+ */
+interface RuleCollectionProvider {
+
+    // TODO Can we remove this?
+    val ruleSetId: String
+
+    /**
+     * This function must be implemented to provide custom rule sets.
+     * Make sure to pass the configuration to each rule to allow rules
+     * to be self configurable.
+     */
+    fun instance(config: Config): List<Rule>
+}

--- a/detekt-bom/build.gradle.kts
+++ b/detekt-bom/build.gradle.kts
@@ -2,13 +2,18 @@ plugins {
     `java-platform`
 }
 
+javaPlatform {
+    allowDependencies()
+}
+
 dependencies {
-    val version = object {
-        val spek = "2.0.15"
-        val ktlint = "0.40.0"
-    }
+    api("org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.4.1")
 
     constraints {
+        val version = object {
+            val spek = "2.0.15"
+            val ktlint = "0.40.0"
+        }
         api("org.assertj:assertj-core:3.19.0")
         api("org.spekframework.spek2:spek-dsl-jvm:${version.spek}")
         api("org.spekframework.spek2:spek-runner-junit5:${version.spek}")

--- a/detekt-core/build.gradle.kts
+++ b/detekt-core/build.gradle.kts
@@ -13,6 +13,7 @@ dependencies {
     implementation(project(":detekt-report-txt"))
     implementation(project(":detekt-report-xml"))
     implementation(project(":detekt-report-sarif"))
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core")
 
     testImplementation(project(":detekt-rules"))
     testImplementation(project(":detekt-test"))

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/v2/Analyzer.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/v2/Analyzer.kt
@@ -1,0 +1,184 @@
+package io.gitlab.arturbosch.detekt.core.v2
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Finding
+import io.gitlab.arturbosch.detekt.api.internal.CompilerResources
+import io.gitlab.arturbosch.detekt.api.v2.FileProcessListener
+import io.gitlab.arturbosch.detekt.api.v2.NewIssue
+import io.gitlab.arturbosch.detekt.api.v2.PlainFileProcessListener
+import io.gitlab.arturbosch.detekt.api.v2.PlainRule
+import io.gitlab.arturbosch.detekt.api.v2.Rule
+import io.gitlab.arturbosch.detekt.api.v2.TypeSolvingFileProcessListener
+import io.gitlab.arturbosch.detekt.api.v2.TypeSolvingRule
+import io.gitlab.arturbosch.detekt.core.DetektResult
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.async
+import kotlinx.coroutines.channels.Channel.Factory.UNLIMITED
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flatMapMerge
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.toList
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.resolve.BindingContext
+
+@FlowPreview
+fun analyze(
+    rules: Flow<Rule>,
+    files: Flow<KtFile>,
+    fileProcessListeners: Flow<FileProcessListener>,
+    bindingContextProvider: suspend (files: Flow<KtFile>) -> BindingContext,
+    compilerResourcesProvider: suspend () -> CompilerResources,
+): Flow<Finding> {
+    return flow {
+        coroutineScope {
+            emitAll(
+                myAnalyze(
+                    rules.reusable(UNLIMITED),
+                    files.reusable(UNLIMITED),
+                    fileProcessListeners.reusable(UNLIMITED),
+                    async(start = CoroutineStart.LAZY) { bindingContextProvider(files) },
+                    async(start = CoroutineStart.LAZY) { compilerResourcesProvider() },
+                )
+            )
+        }
+    }
+}
+
+@FlowPreview
+private fun myAnalyze(
+    rules: Flow<Rule>,
+    files: Flow<KtFile>,
+    fileProcessListeners: Flow<FileProcessListener>,
+    bindingContext: Deferred<BindingContext>,
+    compilerResources: Deferred<CompilerResources>,
+): Flow<Finding> {
+    return flow {
+        fileProcessListeners.collect { listener -> listener.onStart(files, bindingContext, compilerResources) }
+
+        val findings = files
+            .onEach { file ->
+                fileProcessListeners.collect { listener ->
+                    listener.onProcess(file, bindingContext, compilerResources)
+                }
+            }
+            .flatMapMerge { file ->
+                flow {
+                    val findings = rules
+                        // TODO check if we should filter this rule on this file
+                        .flatMapMerge { rule ->
+                            rule.invoke(file, bindingContext, compilerResources)
+                                .map<NewIssue, Finding> { CodeSmell(rule.issue, it.entity, it.message) }
+                                // TODO check if we should filter this issue (Suppress, ignore...)
+                                .asFlow()
+                        }
+                        .toList()
+
+                    emit(file to findings)
+                }
+            }
+            .onEach { (file, findings) ->
+                fileProcessListeners.collect { listener ->
+                    listener.onProcessComplete(file, findings, bindingContext, compilerResources)
+                }
+            }
+            .flatMapMerge { (_, findings) -> findings.asFlow() }
+            .reusable(UNLIMITED)
+
+
+        fileProcessListeners.collect { listener ->
+            listener.onFinish(files, DetektResult(mapOf("a" to findings.toList())), bindingContext, compilerResources)
+        }
+
+        emitAll(findings)
+    }
+}
+
+private suspend fun Rule.invoke(
+    file: KtFile,
+    bindingContext: Deferred<BindingContext>,
+    compilerResources: Deferred<CompilerResources>
+): List<NewIssue> {
+    return when (this) {
+        is TypeSolvingRule -> invoke(file, bindingContext.await(), compilerResources.await())
+        is PlainRule -> invoke(file)
+        else -> error("")
+    }
+}
+
+private suspend fun FileProcessListener.onStart(
+    files: Flow<KtFile>,
+    bindingContext: Deferred<BindingContext>,
+    compilerResources: Deferred<CompilerResources>
+) {
+    when (this) {
+        is PlainFileProcessListener -> onStart(files.toList())
+        is TypeSolvingFileProcessListener -> onStart(
+            files.toList(),
+            bindingContext.await(),
+            compilerResources.await()
+        )
+        else -> error("")
+    }
+}
+
+private suspend fun FileProcessListener.onProcess(
+    file: KtFile,
+    bindingContext: Deferred<BindingContext>,
+    compilerResources: Deferred<CompilerResources>
+) {
+    when (this) {
+        is PlainFileProcessListener -> onProcess(file)
+        is TypeSolvingFileProcessListener -> onProcess(
+            file,
+            bindingContext.await(),
+            compilerResources.await()
+        )
+        else -> error("")
+    }
+}
+
+private suspend fun FileProcessListener.onProcessComplete(
+    file: KtFile,
+    findings: List<Finding>,
+    bindingContext: Deferred<BindingContext>,
+    compilerResources: Deferred<CompilerResources>
+) {
+    when (this) {
+        is PlainFileProcessListener -> onProcessComplete(file, mapOf("a" to findings))
+        is TypeSolvingFileProcessListener -> onProcessComplete(
+            file,
+            mapOf("a" to findings),
+            bindingContext.await(),
+            compilerResources.await()
+        )
+        else -> error("")
+    }
+}
+
+private suspend fun FileProcessListener.onFinish(
+    files: Flow<KtFile>,
+    findings: DetektResult,
+    bindingContext: Deferred<BindingContext>,
+    compilerResources: Deferred<CompilerResources>
+) {
+    when (this) {
+        is PlainFileProcessListener -> onFinish(
+            files.toList(),
+            findings
+        )
+        is TypeSolvingFileProcessListener -> onFinish(
+            files.toList(),
+            findings,
+            bindingContext.await(),
+            compilerResources.await()
+        )
+        else -> error("")
+    }
+}

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/v2/Analyzer.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/v2/Analyzer.kt
@@ -4,7 +4,7 @@ import io.github.detekt.psi.absolutePath
 import io.gitlab.arturbosch.detekt.api.internal.CompilerResources
 import io.gitlab.arturbosch.detekt.api.v2.FileProcessListener
 import io.gitlab.arturbosch.detekt.api.v2.Finding
-import io.gitlab.arturbosch.detekt.api.v2.NewIssue
+import io.gitlab.arturbosch.detekt.api.v2.Issue
 import io.gitlab.arturbosch.detekt.api.v2.PlainFileProcessListener
 import io.gitlab.arturbosch.detekt.api.v2.PlainRule
 import io.gitlab.arturbosch.detekt.api.v2.ResolvedContext
@@ -127,7 +127,7 @@ private suspend fun buildResolvedContextAsync(
 private suspend fun Rule.invoke(
     file: KtFile,
     resolvedContext: Deferred<ResolvedContext>
-): List<NewIssue> {
+): List<Issue> {
     return when (this) {
         is TypeSolvingRule -> invoke(file, resolvedContext.await())
         is PlainRule -> invoke(file)

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/v2/Filter.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/v2/Filter.kt
@@ -1,0 +1,10 @@
+package io.gitlab.arturbosch.detekt.core.v2
+
+import io.gitlab.arturbosch.detekt.api.v2.NewIssue
+import java.nio.file.Path
+
+interface Filter {
+    fun filter(path: Path): Boolean
+
+    fun filter(issue: NewIssue): Boolean
+}

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/v2/Filter.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/v2/Filter.kt
@@ -1,10 +1,10 @@
 package io.gitlab.arturbosch.detekt.core.v2
 
-import io.gitlab.arturbosch.detekt.api.v2.NewIssue
+import io.gitlab.arturbosch.detekt.api.v2.Issue
 import java.nio.file.Path
 
 interface Filter {
     fun filter(path: Path): Boolean
 
-    fun filter(issue: NewIssue): Boolean
+    fun filter(issue: Issue): Boolean
 }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/v2/Finding.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/v2/Finding.kt
@@ -5,14 +5,14 @@ import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.SeverityLevel
 import io.gitlab.arturbosch.detekt.api.v2.Finding
 import io.gitlab.arturbosch.detekt.api.v2.Location
-import io.gitlab.arturbosch.detekt.api.v2.NewIssue
+import io.gitlab.arturbosch.detekt.api.v2.Issue
 import io.gitlab.arturbosch.detekt.api.v2.Rule
 import io.gitlab.arturbosch.detekt.api.v2.RuleInfo
 import io.gitlab.arturbosch.detekt.api.v2.SourceLocation
 import io.gitlab.arturbosch.detekt.api.v2.TextLocation
 import org.jetbrains.kotlin.psi.KtElement
 
-internal fun NewIssue.toFinding(rule: Rule): Finding {
+internal fun Issue.toFinding(rule: Rule): Finding {
     return CodeSmell(
         id = entity.signature,
         message = this.message,

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/v2/Finding.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/v2/Finding.kt
@@ -1,0 +1,61 @@
+package io.gitlab.arturbosch.detekt.core.v2
+
+import io.github.detekt.psi.FilePath
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.SeverityLevel
+import io.gitlab.arturbosch.detekt.api.v2.Finding
+import io.gitlab.arturbosch.detekt.api.v2.Location
+import io.gitlab.arturbosch.detekt.api.v2.NewIssue
+import io.gitlab.arturbosch.detekt.api.v2.Rule
+import io.gitlab.arturbosch.detekt.api.v2.RuleInfo
+import io.gitlab.arturbosch.detekt.api.v2.SourceLocation
+import io.gitlab.arturbosch.detekt.api.v2.TextLocation
+import org.jetbrains.kotlin.psi.KtElement
+
+internal fun NewIssue.toFinding(rule: Rule): Finding {
+    return CodeSmell(
+        id = entity.signature,
+        message = this.message,
+        location = entity.location.toV2(),
+        severityLevel = this.severity,
+        debt = this.debt,
+        ktElement = entity.ktElement!!,
+        autoCorrectable = this.autoCorrectable,
+        rule = RuleInformation(
+            id = rule.issue.id,
+            ruleSetId = "TODO", // TODO I need to figure out how to use this or if we need it at all
+            description = rule.issue.id,
+        )
+    )
+}
+
+private fun io.gitlab.arturbosch.detekt.api.Location.toV2(): Location {
+    return LocationImpl(
+        source = SourceLocation(source.line, source.column),
+        text = TextLocation(text.start, text.end),
+        filePath = filePath
+    )
+}
+
+private data class LocationImpl(
+    override val source: SourceLocation,
+    override val text: TextLocation,
+    override val filePath: FilePath
+) : Location
+
+private data class CodeSmell(
+    override val id: String,
+    override val message: String,
+    override val location: Location,
+    override val severityLevel: SeverityLevel,
+    override val debt: Debt,
+    override val ktElement: KtElement,
+    override val autoCorrectable: Boolean,
+    override val rule: RuleInfo
+) : Finding
+
+private data class RuleInformation(
+    override val id: String,
+    override val ruleSetId: String,
+    override val description: String
+) : RuleInfo

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/v2/Finding.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/v2/Finding.kt
@@ -22,9 +22,9 @@ internal fun NewIssue.toFinding(rule: Rule): Finding {
         ktElement = entity.ktElement!!,
         autoCorrectable = this.autoCorrectable,
         rule = RuleInformation(
-            id = rule.issue.id,
+            id = rule.id,
             ruleSetId = "TODO", // TODO I need to figure out how to use this or if we need it at all
-            description = rule.issue.id,
+            description = rule.id,
         )
     )
 }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/v2/Utils.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/v2/Utils.kt
@@ -1,0 +1,26 @@
+package io.gitlab.arturbosch.detekt.core.v2
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.flow.shareIn
+import kotlinx.coroutines.flow.takeWhile
+
+suspend fun <T> Flow<T>.reusable(
+    scope: CoroutineScope,
+    replay: Int = 0
+): Flow<T> {
+    return this
+        .map { Result.success(it) }
+        .onCompletion { e -> if (e == null) emit(Result.failure(Throwable())) }
+        .shareIn(scope, SharingStarted.Lazily, replay)
+        .takeWhile { it.isSuccess }
+        .map { it.getOrThrow() }
+}
+
+suspend fun <T> Flow<T>.reusable(replay: Int): Flow<T> {
+    return coroutineScope { reusable(this, replay) }
+}


### PR DESCRIPTION
This is a prove of concept for a new API for our rules.

The base idea is that a rule is just this:

```
interface NewRule : (KtFile, BindingContext, CompilerResources) -> List<Finding> {

    override fun invoke(file: KtFile, binding: BindingContext, resources: CompilerResources): List<Finding>
}
```

You don't even need to implement `KtTreeVisitor` if you don't need it for your rule.

This interface is really abstract so it force a lot of boilerplate for nearly all the use-cases. For this reason I implemented `BaseNewRule` that provides (more less) the same functionality as `BaseRule` without the boilerplate.

The core code isn't production ready. It don't even work. I know it, I just want to show the api and prove that it's possible to mix both apis in core.

In the last commit you can see another idea to simplify the rules a bit more. They expose it's information just once. And then, in core, we melt that information with the issues to create the `Finding`. This way we can remove `CodeSmell` from our public API and just expose the simplier `data class Asdf(Entity, message: String)` (name pending)

Notes:

- I only moved the coroutines rules because is our smallest rule set. But as you can see the BaseRule doesn't know about configuration so all the configurations should be injected to the rule. Probably those rules will need a factory to reduce the code inside the `RuleCollectionProvider`. Later, those Factories will be removed/refactored by #3002.
- I think that we can publish this API in detekt 1.0. We can support both APIs for a while. The new API should be used with an opt-in annotation. Once we like our new API we can deprecate the old and remove it in 2.0.
- I don't like the names that I'm using. Any idea in this regard is more than welcome.
- I know that I have #3002 open. But I don't see how to continue with it after we address this.