### PR TITLE
Support sarif as a report type - #3045

### DIFF
--- a/detekt-api/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/test/EmptySetupContext.kt
+++ b/detekt-api/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/test/EmptySetupContext.kt
@@ -1,0 +1,18 @@
+package io.gitlab.arturbosch.detekt.test
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.SetupContext
+import io.gitlab.arturbosch.detekt.api.UnstableApi
+import java.net.URI
+
+@OptIn(UnstableApi::class)
+class EmptySetupContext : SetupContext {
+    override val configUris: Collection<URI> = emptyList()
+    override val config: Config = Config.empty
+    override val outputChannel: Appendable = StringBuilder()
+    override val errorChannel: Appendable = StringBuilder()
+    override val properties: MutableMap<String, Any?> = HashMap()
+    override fun register(key: String, value: Any) {
+        properties[key] = value
+    }
+}

--- a/detekt-report-sarif/build.gradle.kts
+++ b/detekt-report-sarif/build.gradle.kts
@@ -1,0 +1,24 @@
+repositories {
+    mavenLocal()
+}
+
+dependencies {
+    compileOnly(project(":detekt-api"))
+    compileOnly(project(":detekt-tooling"))
+    implementation("io.github.detekt.sarif4j:sarif4j:1.0.0")
+    testImplementation(project(":detekt-tooling"))
+    testImplementation(testFixtures(project(":detekt-api")))
+    testImplementation("io.rest-assured:json-path:4.3.1")
+}
+
+tasks.withType<Jar>().configureEach {
+    dependsOn(configurations.runtimeClasspath)
+    from({
+        configurations.runtimeClasspath.get()
+            .asSequence()
+            .filterNot { "org.jetbrains" in it.toString() }
+            .filterNot { "org.intellij" in it.toString() }
+            .map { if (it.isDirectory) it else zipTree(it) }
+            .toList()
+    })
+}

--- a/detekt-report-sarif/build.gradle.kts
+++ b/detekt-report-sarif/build.gradle.kts
@@ -7,8 +7,8 @@ dependencies {
     compileOnly(project(":detekt-tooling"))
     implementation("io.github.detekt.sarif4j:sarif4j:1.0.0")
     testImplementation(project(":detekt-tooling"))
+    testImplementation(project(":detekt-test-utils"))
     testImplementation(testFixtures(project(":detekt-api")))
-    testImplementation("io.rest-assured:json-path:4.3.1")
 }
 
 tasks.withType<Jar>().configureEach {

--- a/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/RuleDescriptors.kt
+++ b/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/RuleDescriptors.kt
@@ -36,9 +36,6 @@ fun MultiRule.toDescriptors(ruleSetId: RuleSetId): List<ReportingDescriptor> =
 fun Rule.toDescriptor(ruleSetId: RuleSetId): ReportingDescriptor = descriptor {
     id = "detekt.$ruleSetId.$ruleId"
     name = "$ruleSetId>$ruleId"
-    shortDescription = MultiformatMessageString().apply {
-        text = issue.description.substringBefore(System.lineSeparator())
-    }
-    fullDescription = MultiformatMessageString().apply { text = issue.description }
+    shortDescription = MultiformatMessageString().apply { text = issue.description }
     helpUri = URI.create("https://detekt.github.io/detekt/${ruleSetId.toLowerCase()}.html#${ruleId.toLowerCase()}")
 }

--- a/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/RuleDescriptors.kt
+++ b/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/RuleDescriptors.kt
@@ -1,0 +1,44 @@
+package io.github.detekt.report.sarif
+
+import io.github.detekt.sarif4j.MultiformatMessageString
+import io.github.detekt.sarif4j.ReportingDescriptor
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.MultiRule
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.RuleSetId
+import io.gitlab.arturbosch.detekt.api.RuleSetProvider
+import java.net.URI
+import java.util.ServiceLoader
+
+fun ruleDescriptors(config: Config): HashMap<String, ReportingDescriptor> {
+    val sets = ServiceLoader.load(RuleSetProvider::class.java)
+        .map { it.instance(config.subConfig(it.ruleSetId)) }
+    val descriptors = HashMap<String, ReportingDescriptor>()
+    for (ruleSet in sets) {
+        for (rule in ruleSet.rules) {
+            if (rule is MultiRule) {
+                descriptors.putAll(rule.toDescriptors(ruleSet.id).associateBy { it.name })
+            } else {
+                assert(rule is Rule)
+                val descriptor = (rule as Rule).toDescriptor(ruleSet.id)
+                descriptors[descriptor.name] = descriptor
+            }
+        }
+    }
+    return descriptors
+}
+
+fun descriptor(init: ReportingDescriptor.() -> Unit) = ReportingDescriptor().apply(init)
+
+fun MultiRule.toDescriptors(ruleSetId: RuleSetId): List<ReportingDescriptor> =
+    this.rules.map { it.toDescriptor(ruleSetId) }
+
+fun Rule.toDescriptor(ruleSetId: RuleSetId): ReportingDescriptor = descriptor {
+    id = "detekt.$ruleSetId.$ruleId"
+    name = "$ruleSetId>$ruleId"
+    shortDescription = MultiformatMessageString().apply {
+        text = issue.description.substringBefore(System.lineSeparator())
+    }
+    fullDescription = MultiformatMessageString().apply { text = issue.description }
+    helpUri = URI.create("https://detekt.github.io/detekt/${ruleSetId.toLowerCase()}.html#${ruleId.toLowerCase()}")
+}

--- a/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/RuleDescriptors.kt
+++ b/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/RuleDescriptors.kt
@@ -16,12 +16,14 @@ fun ruleDescriptors(config: Config): HashMap<String, ReportingDescriptor> {
     val descriptors = HashMap<String, ReportingDescriptor>()
     for (ruleSet in sets) {
         for (rule in ruleSet.rules) {
-            if (rule is MultiRule) {
-                descriptors.putAll(rule.toDescriptors(ruleSet.id).associateBy { it.name })
-            } else {
-                assert(rule is Rule)
-                val descriptor = (rule as Rule).toDescriptor(ruleSet.id)
-                descriptors[descriptor.name] = descriptor
+            when (rule) {
+                is MultiRule -> {
+                    descriptors.putAll(rule.toDescriptors(ruleSet.id).associateBy { it.name })
+                }
+                is Rule -> {
+                    val descriptor = rule.toDescriptor(ruleSet.id)
+                    descriptors[descriptor.name] = descriptor
+                }
             }
         }
     }

--- a/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/RuleDescriptors.kt
+++ b/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/RuleDescriptors.kt
@@ -35,7 +35,7 @@ fun MultiRule.toDescriptors(ruleSetId: RuleSetId): List<ReportingDescriptor> =
 
 fun Rule.toDescriptor(ruleSetId: RuleSetId): ReportingDescriptor = descriptor {
     id = "detekt.$ruleSetId.$ruleId"
-    name = "$ruleSetId>$ruleId"
+    name = ruleId
     shortDescription = MultiformatMessageString().apply { text = issue.description }
     helpUri = URI.create("https://detekt.github.io/detekt/${ruleSetId.toLowerCase()}.html#${ruleId.toLowerCase()}")
 }

--- a/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/SarifDsl.kt
+++ b/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/SarifDsl.kt
@@ -10,17 +10,15 @@ import java.net.URI
 
 const val SCHEMA_URL = "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json"
 
-fun sarif(init: SarifSchema210.() -> Unit): SarifSchema210 {
-    val sarif = SarifSchema210().apply {
-        version = SarifSchema210.Version._2_1_0
-        `$schema` = URI.create(SCHEMA_URL)
-    }
-    return sarif.apply(init)
-}
+fun sarif(init: SarifSchema210.() -> Unit): SarifSchema210 = SarifSchema210()
+    .`with$schema`(URI.create(SCHEMA_URL))
+    .withVersion(SarifSchema210.Version._2_1_0)
+    .withRuns(ArrayList())
+    .apply(init)
 
 typealias SarifIssue = io.github.detekt.sarif4j.Result
 
-fun result(init: SarifIssue.() -> Unit): SarifIssue = SarifIssue().apply(init)
+fun result(init: SarifIssue.() -> Unit): SarifIssue = SarifIssue().withLocations(ArrayList()).apply(init)
 
 fun tool(init: Tool.() -> Unit): Tool = Tool().apply(init)
 
@@ -28,8 +26,9 @@ fun component(init: ToolComponent.() -> Unit): ToolComponent = ToolComponent().a
 
 fun SarifSchema210.withDetektRun(config: Config, init: Run.() -> Unit) {
     runs.add(
-        Run().apply {
-            tool = tool {
+        Run()
+            .withResults(ArrayList())
+            .withTool(tool {
                 driver = component {
                     guid = "022ca8c2-f6a2-4c95-b107-bb72c43263f3"
                     name = "detekt"
@@ -42,8 +41,7 @@ fun SarifSchema210.withDetektRun(config: Config, init: Run.() -> Unit) {
                     informationUri = URI.create("https://detekt.github.io/detekt")
                     rules = ruleDescriptors(config).values.toSet()
                 }
-            }
-            apply(init)
-        }
+            })
+            .apply(init)
     )
 }

--- a/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/SarifDsl.kt
+++ b/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/SarifDsl.kt
@@ -1,0 +1,49 @@
+package io.github.detekt.report.sarif
+
+import io.github.detekt.sarif4j.Run
+import io.github.detekt.sarif4j.SarifSchema210
+import io.github.detekt.sarif4j.Tool
+import io.github.detekt.sarif4j.ToolComponent
+import io.github.detekt.tooling.api.VersionProvider
+import io.gitlab.arturbosch.detekt.api.Config
+import java.net.URI
+
+const val SCHEMA_URL = "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json"
+
+fun sarif(init: SarifSchema210.() -> Unit): SarifSchema210 {
+    val sarif = SarifSchema210().apply {
+        version = SarifSchema210.Version._2_1_0
+        `$schema` = URI.create(SCHEMA_URL)
+    }
+    return sarif.apply(init)
+}
+
+typealias SarifIssue = io.github.detekt.sarif4j.Result
+
+fun result(init: SarifIssue.() -> Unit): SarifIssue = SarifIssue().apply(init)
+
+fun tool(init: Tool.() -> Unit): Tool = Tool().apply(init)
+
+fun component(init: ToolComponent.() -> Unit): ToolComponent = ToolComponent().apply(init)
+
+fun SarifSchema210.withDetektRun(config: Config, init: Run.() -> Unit) {
+    runs.add(
+        Run().apply {
+            tool = tool {
+                driver = component {
+                    guid = "022ca8c2-f6a2-4c95-b107-bb72c43263f3"
+                    name = "detekt"
+                    fullName = name
+                    organization = name
+                    language = "en"
+                    version = VersionProvider.load().current()
+                    semanticVersion = version
+                    downloadUri = URI.create("https://github.com/detekt/detekt/releases/download/v$version/detekt")
+                    informationUri = URI.create("https://detekt.github.io/detekt")
+                    rules = ruleDescriptors(config).values.toSet()
+                }
+            }
+            apply(init)
+        }
+    )
+}

--- a/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/SarifOutputReport.kt
+++ b/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/SarifOutputReport.kt
@@ -1,0 +1,65 @@
+package io.github.detekt.report.sarif
+
+import io.github.detekt.sarif4j.ArtifactLocation
+import io.github.detekt.sarif4j.Location
+import io.github.detekt.sarif4j.Message
+import io.github.detekt.sarif4j.MoshiSarifJsonWriter
+import io.github.detekt.sarif4j.PhysicalLocation
+import io.github.detekt.sarif4j.Region
+import io.github.detekt.sarif4j.Result
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Detektion
+import io.gitlab.arturbosch.detekt.api.Finding
+import io.gitlab.arturbosch.detekt.api.OutputReport
+import io.gitlab.arturbosch.detekt.api.RuleSetId
+import io.gitlab.arturbosch.detekt.api.SetupContext
+import io.gitlab.arturbosch.detekt.api.SingleAssign
+import io.gitlab.arturbosch.detekt.api.UnstableApi
+import java.net.URI
+
+class SarifOutputReport : OutputReport() {
+
+    override val ending: String = "sarif"
+    override val id: String = "sarif"
+    override val name = "SARIF: a standard format for the output of static analysis tools"
+
+    private var config: Config by SingleAssign()
+
+    @OptIn(UnstableApi::class)
+    override fun init(context: SetupContext) {
+        this.config = context.config
+    }
+
+    override fun render(detektion: Detektion): String {
+        val report = sarif {
+            withDetektRun(config) {
+                for ((ruleSetId, issues) in detektion.findings) {
+                    for (issue in issues) {
+                        results.add(issue.toIssue(ruleSetId))
+                    }
+                }
+            }
+        }
+        return MoshiSarifJsonWriter().toJson(report)
+    }
+}
+
+fun Finding.toIssue(ruleSetId: RuleSetId): SarifIssue = result {
+    ruleId = "detekt.$ruleSetId.$id"
+    level = Result.Level.WARNING
+    hostedViewerUri = URI.create(entity.location.file)
+    for (location in listOf(location) + references.map { it.location }) {
+        locations.add(Location().apply {
+            physicalLocation = PhysicalLocation().apply {
+                region = Region().apply {
+                    startLine = location.source.line
+                    startColumn = location.source.column
+                }
+                artifactLocation = ArtifactLocation().apply {
+                    uri = URI.create(location.file).toString()
+                }
+            }
+        })
+    }
+    message = Message().apply { text = messageOrDescription() }
+}

--- a/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/SarifOutputReport.kt
+++ b/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/SarifOutputReport.kt
@@ -1,9 +1,9 @@
 package io.github.detekt.report.sarif
 
 import io.github.detekt.sarif4j.ArtifactLocation
+import io.github.detekt.sarif4j.JacksonSarifWriter
 import io.github.detekt.sarif4j.Location
 import io.github.detekt.sarif4j.Message
-import io.github.detekt.sarif4j.MoshiSarifJsonWriter
 import io.github.detekt.sarif4j.PhysicalLocation
 import io.github.detekt.sarif4j.Region
 import io.github.detekt.sarif4j.Result
@@ -40,14 +40,13 @@ class SarifOutputReport : OutputReport() {
                 }
             }
         }
-        return MoshiSarifJsonWriter().toJson(report)
+        return JacksonSarifWriter().toJson(report)
     }
 }
 
 fun Finding.toIssue(ruleSetId: RuleSetId): SarifIssue = result {
     ruleId = "detekt.$ruleSetId.$id"
     level = Result.Level.WARNING
-    hostedViewerUri = URI.create(entity.location.file)
     for (location in listOf(location) + references.map { it.location }) {
         locations.add(Location().apply {
             physicalLocation = PhysicalLocation().apply {

--- a/detekt-report-sarif/src/main/resources/META-INF/services/io.gitlab.arturbosch.detekt.api.OutputReport
+++ b/detekt-report-sarif/src/main/resources/META-INF/services/io.gitlab.arturbosch.detekt.api.OutputReport
@@ -1,0 +1,1 @@
+io.github.detekt.report.sarif.SarifOutputReport

--- a/detekt-report-sarif/src/test/kotlin/io/github/detekt/report/sarif/SarifOutputReportSpec.kt
+++ b/detekt-report-sarif/src/test/kotlin/io/github/detekt/report/sarif/SarifOutputReportSpec.kt
@@ -1,0 +1,38 @@
+package io.github.detekt.report.sarif
+
+import io.github.detekt.tooling.api.VersionProvider
+import io.gitlab.arturbosch.detekt.test.EmptySetupContext
+import io.gitlab.arturbosch.detekt.test.TestDetektion
+import io.gitlab.arturbosch.detekt.test.createFinding
+import io.restassured.path.json.JsonPath
+import org.assertj.core.api.Assertions.assertThat
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+class SarifOutputReportSpec : Spek({
+
+    describe("sarif output report") {
+
+        it("renders multiple issues") {
+            val result = TestDetektion(
+                createFinding(ruleName = "TestSmellA"),
+                createFinding(ruleName = "TestSmellB"),
+                createFinding(ruleName = "TestSmellC")
+            )
+
+            val report = SarifOutputReport().apply { init(EmptySetupContext()) }
+            val json = JsonPath.from(report.render(result))
+
+            assertThat(json.getString("runs[0].tool.driver.name")).isEqualTo("detekt")
+            assertThat(json.getString("runs[0].tool.driver.informationUri"))
+                .isEqualTo("https://detekt.github.io/detekt")
+            assertThat(json.getString("runs[0].results[0].hostedViewerUri")).isEqualTo("TestFile.kt")
+            assertThat(json.getList<Any>("runs[0].results")).hasSize(3)
+        }
+    }
+})
+
+internal class TestVersionProvider : VersionProvider {
+
+    override fun current(): String = "1.0.0"
+}

--- a/detekt-report-sarif/src/test/kotlin/io/github/detekt/report/sarif/SarifOutputReportSpec.kt
+++ b/detekt-report-sarif/src/test/kotlin/io/github/detekt/report/sarif/SarifOutputReportSpec.kt
@@ -21,12 +21,12 @@ class SarifOutputReportSpec : Spek({
             )
 
             val report = SarifOutputReport().apply { init(EmptySetupContext()) }
-            val json = JsonPath.from(report.render(result))
+            val jsonResult = report.render(result)
+            val json = JsonPath.from(jsonResult)
 
             assertThat(json.getString("runs[0].tool.driver.name")).isEqualTo("detekt")
             assertThat(json.getString("runs[0].tool.driver.informationUri"))
                 .isEqualTo("https://detekt.github.io/detekt")
-            assertThat(json.getString("runs[0].results[0].hostedViewerUri")).isEqualTo("TestFile.kt")
             assertThat(json.getList<Any>("runs[0].results")).hasSize(3)
         }
     }

--- a/detekt-report-sarif/src/test/kotlin/io/github/detekt/report/sarif/SarifOutputReportSpec.kt
+++ b/detekt-report-sarif/src/test/kotlin/io/github/detekt/report/sarif/SarifOutputReportSpec.kt
@@ -1,10 +1,10 @@
 package io.github.detekt.report.sarif
 
+import io.github.detekt.test.utils.readResourceContent
 import io.github.detekt.tooling.api.VersionProvider
 import io.gitlab.arturbosch.detekt.test.EmptySetupContext
 import io.gitlab.arturbosch.detekt.test.TestDetektion
 import io.gitlab.arturbosch.detekt.test.createFinding
-import io.restassured.path.json.JsonPath
 import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
@@ -12,6 +12,10 @@ import org.spekframework.spek2.style.specification.describe
 class SarifOutputReportSpec : Spek({
 
     describe("sarif output report") {
+
+        val expectedReport by memoized {
+            readResourceContent("expected.sarif.json").stripWhitespace()
+        }
 
         it("renders multiple issues") {
             val result = TestDetektion(
@@ -21,16 +25,15 @@ class SarifOutputReportSpec : Spek({
             )
 
             val report = SarifOutputReport().apply { init(EmptySetupContext()) }
-            val jsonResult = report.render(result)
-            val json = JsonPath.from(jsonResult)
+                .render(result)
+                .stripWhitespace()
 
-            assertThat(json.getString("runs[0].tool.driver.name")).isEqualTo("detekt")
-            assertThat(json.getString("runs[0].tool.driver.informationUri"))
-                .isEqualTo("https://detekt.github.io/detekt")
-            assertThat(json.getList<Any>("runs[0].results")).hasSize(3)
+            assertThat(report).isEqualTo(expectedReport)
         }
     }
 })
+
+internal fun String.stripWhitespace() = replace(Regex("\\s"), "")
 
 internal class TestVersionProvider : VersionProvider {
 

--- a/detekt-report-sarif/src/test/resources/META-INF/services/io.github.detekt.tooling.api.VersionProvider
+++ b/detekt-report-sarif/src/test/resources/META-INF/services/io.github.detekt.tooling.api.VersionProvider
@@ -1,0 +1,1 @@
+io.github.detekt.report.sarif.TestVersionProvider

--- a/detekt-report-sarif/src/test/resources/expected.sarif.json
+++ b/detekt-report-sarif/src/test/resources/expected.sarif.json
@@ -1,0 +1,81 @@
+{
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "guid": "022ca8c2-f6a2-4c95-b107-bb72c43263f3",
+          "name": "detekt",
+          "organization": "detekt",
+          "fullName": "detekt",
+          "version": "1.0.0",
+          "semanticVersion": "1.0.0",
+          "downloadUri": "https://github.com/detekt/detekt/releases/download/v1.0.0/detekt",
+          "informationUri": "https://detekt.github.io/detekt",
+          "rules": [],
+          "language": "en"
+        }
+      },
+      "results": [
+        {
+          "ruleId": "detekt.TestSmellA.TestSmellA",
+          "message": {
+            "text": "TestMessage"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "TestFile.kt"
+                },
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 1
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "detekt.TestSmellB.TestSmellB",
+          "message": {
+            "text": "TestMessage"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "TestFile.kt"
+                },
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 1
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "detekt.TestSmellC.TestSmellC",
+          "message": {
+            "text": "TestMessage"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "TestFile.kt"
+                },
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 1
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,6 +12,7 @@ include(
     "detekt-parser",
     "detekt-psi-utils",
     "detekt-report-html",
+    "detekt-report-sarif",
     "detekt-report-txt",
     "detekt-report-xml",
     "detekt-rules",


### PR DESCRIPTION
New optional report format which can be plugged via `--plugins detekt-report-sarif.jar`:

Output preview via the VSCode extension:
![2020-10-06-153635_927x499_scrot](https://user-images.githubusercontent.com/20924106/95211268-a5c8ab00-07ec-11eb-956d-e49bc9dcf236.png)
![2020-10-06-153629_932x514_scrot](https://user-images.githubusercontent.com/20924106/95211270-a6614180-07ec-11eb-8002-a6cdf24eccc8.png)

CI will fail due to not a published version of sarif4j. We need to wait until #3045 gets an answer from the sarif authors.