### PR TITLE
ClassOrdering rule reports a list of errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ If you contributed to detekt but your name is not in the list, please feel free 
 - [Parimatch Tech](https://github.com/parimatchtech) - New rule: LibraryEntitiesShouldNotBePublic
 - [Chao Zhang](https://github.com/chao2zhang) - Rule improvement: ImplicitDefaultLocale, ModifierOrder.
 - [Marcelo Hernandez](https://github.com/mhernand40) - New rule: SuspendFunWithFlowReturnType
+- [Harold Martin](https://github.com/hbmartin) - Rule improvement: ClassOrdering
 
 ### Mentions
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ClassOrdering.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ClassOrdering.kt
@@ -68,7 +68,8 @@ class ClassOrdering(config: Config = Config.empty) : Rule(config) {
     override fun visitClassBody(classBody: KtClassBody) {
         super.visitClassBody(classBody)
 
-        comparator.findOutOfOrder(classBody.declarations).letNotEmpty { misorders ->
+        val misorders = comparator.findOutOfOrder(classBody.declarations)
+        if (misorders.isNotEmpty()) {
             report(
                 misorders.map {
                     CodeSmell(
@@ -115,5 +116,3 @@ private val KtDeclaration.priority: Int?
         is KtObjectDeclaration -> if (isCompanion()) 3 else null
         else -> null
     }
-private fun <T, R> Collection<T>.letNotEmpty(block: (Collection<T>) -> R?): R? =
-    if (isEmpty()) null else block(this)

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ClassOrderingSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ClassOrderingSpec.kt
@@ -199,7 +199,7 @@ class ClassOrderingSpec : Spek({
 
         it("does report all issues in a class with multiple misorderings") {
             val code = """
-                class MultipleOutOfOrder(private val x: String) {
+                class MultipleMisorders(private val x: String) {
                     companion object {
                         const val IMPORTANT_VALUE = 3
                     }
@@ -212,7 +212,14 @@ class ClassOrderingSpec : Spek({
                 }
             """.trimIndent()
 
-            assertThat(subject.compileAndLint(code)).hasSize(3)
+            val findings = subject.compileAndLint(code)
+            assertThat(findings).hasSize(3)
+            assertThat(findings[0].message)
+                .isEqualTo("Companion object should not come before returnX (function)")
+            assertThat(findings[1].message)
+                .isEqualTo("returnX (function) should not come before MultipleMisorders (secondary constructor)")
+            assertThat(findings[2].message)
+                .isEqualTo("MultipleMisorders (secondary constructor) should not come before y (property)")
         }
     }
 })

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ClassOrderingSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ClassOrderingSpec.kt
@@ -196,5 +196,23 @@ class ClassOrderingSpec : Spek({
 
             assertThat(subject.compileAndLint(code)).hasSize(0)
         }
+
+        it("does report all issues in a class with multiple misorderings") {
+            val code = """
+                class MultipleOutOfOrder(private val x: String) {
+                    companion object {
+                        const val IMPORTANT_VALUE = 3
+                    }
+
+                    fun returnX() = x
+
+                    constructor(z: Int): this(z.toString())
+                    
+                    val y = x
+                }
+            """.trimIndent()
+
+            assertThat(subject.compileAndLint(code)).hasSize(3)
+        }
     }
 })


### PR DESCRIPTION
* Addresses https://github.com/detekt/detekt/issues/3141 where only the first misorder in a class is reported
* Also report entity where error occurred, not just parent class
* Both of these changes might break existing baselines? - not sure how to address this
* Follow up to https://github.com/detekt/detekt/pull/3138
