### PR TITLE
Const naming

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -370,7 +370,7 @@ naming:
   EnumNaming:
     active: true
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
-    enumEntryPattern: '[A-Z][_a-zA-Z0-9]*'
+    enumEntryPattern: '[A-Z][A-Za-z0-9]*|[A-Z][_A-Z0-9]*'
   ForbiddenClassName:
     active: false
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
@@ -411,9 +411,9 @@ naming:
   ObjectPropertyNaming:
     active: true
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
-    constantPattern: '[A-Za-z][_A-Za-z0-9]*'
-    propertyPattern: '[A-Za-z][_A-Za-z0-9]*'
-    privatePropertyPattern: '(_)?[A-Za-z][_A-Za-z0-9]*'
+    constantPattern: '[a-z][A-Za-z0-9]*|[A-Z][_A-Z0-9]*'
+    propertyPattern: '[a-z][A-Za-z0-9]*|[A-Z][_A-Z0-9]*'
+    privatePropertyPattern: '_?[a-z][A-Za-z0-9]*|_?[A-Z][_A-Z0-9]*'
   PackageNaming:
     active: true
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
@@ -422,8 +422,8 @@ naming:
     active: true
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
     constantPattern: '[A-Z][_A-Z0-9]*'
-    propertyPattern: '[A-Za-z][_A-Za-z0-9]*'
-    privatePropertyPattern: '_?[A-Za-z][_A-Za-z0-9]*'
+    propertyPattern: '[a-z][A-Za-z0-9]*|[A-Z][_A-Z0-9]*'
+    privatePropertyPattern: '_?[a-z][A-Za-z0-9]*|_?[A-Z][_A-Z0-9]*'
   VariableMaxLength:
     active: false
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/EnumNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/EnumNaming.kt
@@ -14,7 +14,7 @@ import org.jetbrains.kotlin.psi.KtEnumEntry
 /**
  * Reports when enum names which do not follow the specified naming convention are used.
  *
- * @configuration enumEntryPattern - naming pattern (default: `'[A-Z][_a-zA-Z0-9]*'`)
+ * @configuration enumEntryPattern - naming pattern (default: `'[A-Z][A-Za-z0-9]*|[A-Z][_A-Z0-9]*'`)
  * @active since v1.0.0
  */
 class EnumNaming(config: Config = Config.empty) : Rule(config) {
@@ -24,7 +24,7 @@ class EnumNaming(config: Config = Config.empty) : Rule(config) {
             "Enum names should follow the naming convention set in the projects configuration.",
             debt = Debt.FIVE_MINS)
 
-    private val enumEntryPattern by LazyRegex(ENUM_PATTERN, "[A-Z][_a-zA-Z0-9]*")
+    private val enumEntryPattern by LazyRegex(ENUM_PATTERN, "[A-Z][A-Za-z0-9]*|[A-Z][_A-Z0-9]*")
 
     override fun visitEnumEntry(enumEntry: KtEnumEntry) {
         if (!enumEntry.identifierName().matches(enumEntryPattern)) {

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNaming.kt
@@ -16,9 +16,9 @@ import org.jetbrains.kotlin.psi.psiUtil.isPrivate
 /**
  * Reports when property names inside objects which do not follow the specified naming convention are used.
  *
- * @configuration constantPattern - naming pattern (default: `'[A-Za-z][_A-Za-z0-9]*'`)
- * @configuration propertyPattern - naming pattern (default: `'[A-Za-z][_A-Za-z0-9]*'`)
- * @configuration privatePropertyPattern - naming pattern (default: `'(_)?[A-Za-z][_A-Za-z0-9]*'`)
+ * @configuration constantPattern - naming pattern (default: `'[a-z][A-Za-z0-9]*|[A-Z][_A-Z0-9]*'`)
+ * @configuration propertyPattern - naming pattern (default: `'[a-z][A-Za-z0-9]*|[A-Z][_A-Z0-9]*'`)
+ * @configuration privatePropertyPattern - naming pattern (default: `'_?[a-z][A-Za-z0-9]*|_?[A-Z][_A-Z0-9]*'`)
  * @active since v1.0.0
  */
 class ObjectPropertyNaming(config: Config = Config.empty) : Rule(config) {
@@ -30,9 +30,9 @@ class ObjectPropertyNaming(config: Config = Config.empty) : Rule(config) {
         debt = Debt.FIVE_MINS
     )
 
-    private val constantPattern by LazyRegex(CONSTANT_PATTERN, "[A-Za-z][_A-Za-z0-9]*")
-    private val propertyPattern by LazyRegex(PROPERTY_PATTERN, "[A-Za-z][_A-Za-z0-9]*")
-    private val privatePropertyPattern by LazyRegex(PRIVATE_PROPERTY_PATTERN, "(_)?[A-Za-z][_A-Za-z0-9]*")
+    private val constantPattern by LazyRegex(CONSTANT_PATTERN, "[a-z][A-Za-z0-9]*|[A-Z][_A-Z0-9]*")
+    private val propertyPattern by LazyRegex(PROPERTY_PATTERN, "[a-z][A-Za-z0-9]*|[A-Z][_A-Z0-9]*")
+    private val privatePropertyPattern by LazyRegex(PRIVATE_PROPERTY_PATTERN, "_?[a-z][A-Za-z0-9]*|_?[A-Z][_A-Z0-9]*")
 
     override fun visitProperty(property: KtProperty) {
         if (property.isLocal) {

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/TopLevelPropertyNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/TopLevelPropertyNaming.kt
@@ -17,8 +17,8 @@ import org.jetbrains.kotlin.psi.psiUtil.isPrivate
  * Reports when top level constant names which do not follow the specified naming convention are used.
  *
  * @configuration constantPattern - naming pattern (default: `'[A-Z][_A-Z0-9]*'`)
- * @configuration propertyPattern - naming pattern (default: `'[A-Za-z][_A-Za-z0-9]*'`)
- * @configuration privatePropertyPattern - naming pattern (default: `'_?[A-Za-z][_A-Za-z0-9]*'`)
+ * @configuration propertyPattern - naming pattern (default: `'[a-z][A-Za-z0-9]*|[A-Z][_A-Z0-9]*'`)
+ * @configuration privatePropertyPattern - naming pattern (default: `'_?[a-z][A-Za-z0-9]*|_?[A-Z][_A-Z0-9]*'`)
  *
  * @active since v1.0.0
  */
@@ -30,8 +30,8 @@ class TopLevelPropertyNaming(config: Config = Config.empty) : Rule(config) {
             debt = Debt.FIVE_MINS)
 
     private val constantPattern by LazyRegex(CONSTANT_PATTERN, "[A-Z][_A-Z0-9]*")
-    private val propertyPattern by LazyRegex(PROPERTY_PATTERN, "[A-Za-z][_A-Za-z0-9]*")
-    private val privatePropertyPattern by LazyRegex(PRIVATE_PROPERTY_PATTERN, "_?[A-Za-z][_A-Za-z0-9]*")
+    private val propertyPattern by LazyRegex(PROPERTY_PATTERN, "[a-z][A-Za-z0-9]*|[A-Z][_A-Z0-9]*")
+    private val privatePropertyPattern by LazyRegex(PRIVATE_PROPERTY_PATTERN, "_?[a-z][A-Za-z0-9]*|_?[A-Z][_A-Z0-9]*")
 
     override fun visitProperty(property: KtProperty) {
         if (property.isConstant()) {

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/EnumNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/EnumNamingSpec.kt
@@ -20,6 +20,14 @@ class EnumNamingSpec : Spek({
             assertThat(findings).isEmpty()
         }
 
+        it("enum name that uses lowercases and undescores") {
+            val code = """
+                enum class WorkFlow {
+                    Def_AULT
+                }"""
+            assertThat(NamingRules().compileAndLint(code)).hasSize(1)
+        }
+
         it("enum name that start with lowercase") {
             val code = """
                 enum class WorkFlow {

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNamingSpec.kt
@@ -149,13 +149,26 @@ class ObjectPropertyNamingSpec : Spek({
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
-        it("should detect private variables not complying to the naming rules") {
+        it("should detect constants not complying to the naming rules") {
+            val code = """
+                object O {
+                    val MyNAME = "Artur"
+                    val n_a_m_e = "Artur"
+                }
+            """
+            assertThat(subject.compileAndLint(code)).hasSize(2)
+        }
+
+        it("should detect private constants not complying to the naming rules") {
             val code = """
                 object O {
                     private val __NAME = "Artur"
+                    private val MyNAME = "Artur"
+                    private val n_a_m_e = "Artur"
+                    private val _MY_NAME = "Artur"
                 }
             """
-            assertThat(subject.compileAndLint(code)).hasSize(1)
+            assertThat(subject.compileAndLint(code)).hasSize(3)
         }
     }
 
@@ -216,7 +229,6 @@ abstract class NamingSnippet(private val isPrivate: Boolean, private val isConst
     val negative = """
                     ${visibility()}${const()}val MY_NAME_8 = "Artur"
                     ${visibility()}${const()}val MYNAME = "Artur"
-                    ${visibility()}${const()}val MyNAME = "Artur"
                     ${visibility()}${const()}val name = "Artur"
                     ${visibility()}${const()}val nAme = "Artur"
                     ${visibility()}${const()}val serialVersionUID = 42L"""

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/TopLevelPropertyNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/TopLevelPropertyNamingSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.naming
 
+import io.gitlab.arturbosch.detekt.test.compileAndLint
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
@@ -41,10 +42,9 @@ class TopLevelPropertyNamingSpec : Spek({
                 val serialVersionUID = 42L
                 val MY_NAME = "Artur"
                 val MYNAME = "Artur"
-                val MyNAME = "Artur"
                 private val NAME = "Artur"
-                val s_d_d_1 = listOf("")
                 private val INTERNAL_VERSION = "1.0.0"
+                private val _INTERNAL_VERSION = "1.0.0"
             """
             assertThat(subject.lint(code)).isEmpty()
         }
@@ -61,6 +61,33 @@ class TopLevelPropertyNamingSpec : Spek({
                 private val __NAME = "Artur"
             """
             io.gitlab.arturbosch.detekt.test.assertThat(subject.lint(code)).hasSize(1)
+        }
+        it("should report top level property using lowercases and underscores") {
+            val code = """
+                val s_d_d_1 = listOf("")
+            """
+            assertThat(subject.compileAndLint(code)).hasSize(1)
+        }
+
+        it("should report private top level property using lowercases and underscores") {
+            val code = """
+                private val s_d_d_1 = listOf("")
+            """
+            assertThat(subject.compileAndLint(code)).hasSize(1)
+        }
+
+        it("should report top level property starting with upercase and then using lowercases") {
+            val code = """
+                val MyNAME = "Artur"
+            """
+            assertThat(subject.compileAndLint(code)).hasSize(1)
+        }
+
+        it("should report private top level property starting with upercase and then using lowercases") {
+            val code = """
+                private val MyNAME = "Artur"
+            """
+            assertThat(subject.compileAndLint(code)).hasSize(1)
         }
     }
 })


### PR DESCRIPTION
This is just a reopen for #2017 (I don't know why I can't reopen it). Extracted from there: 

> There are places where we allow to use: thisFormat or THIS_FORMAT but we should never allow to use This_Format. This PR fix this issue in the 3 places where we allow the use of _ in the naming: enums, object properties and top level properties.

Why am I reopening this?

After @arturbosch closed that PR I opened this issue to IntelliJ: https://youtrack.jetbrains.com/issue/KT-34508 It was accepted as a valid issue but after one year it's not fixed.

I think that we should rethink about merging this.

~We have another related issue: `private val _HELLO` should not be valid and we are allowing it. I'm going to create another PR fixing it.~ 