### PR TITLE
Allow camelCase for top level constant names

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -418,7 +418,7 @@ naming:
   TopLevelPropertyNaming:
     active: true
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
-    constantPattern: '[A-Z][_A-Z0-9]*'
+    constantPattern: '[A-Za-z][_A-Za-z0-9]*'
     propertyPattern: '[A-Za-z][_A-Za-z0-9]*'
     privatePropertyPattern: '_?[A-Za-z][_A-Za-z0-9]*'
   VariableMaxLength:

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/TopLevelPropertyNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/TopLevelPropertyNaming.kt
@@ -16,7 +16,7 @@ import org.jetbrains.kotlin.psi.psiUtil.isPrivate
 /**
  * Reports when top level constant names which do not follow the specified naming convention are used.
  *
- * @configuration constantPattern - naming pattern (default: `'[A-Z][_A-Z0-9]*'`)
+ * @configuration constantPattern - naming pattern (default: `'[A-Za-z][_A-Za-z0-9]*'`)
  * @configuration propertyPattern - naming pattern (default: `'[A-Za-z][_A-Za-z0-9]*'`)
  * @configuration privatePropertyPattern - naming pattern (default: `'_?[A-Za-z][_A-Za-z0-9]*'`)
  *
@@ -29,7 +29,7 @@ class TopLevelPropertyNaming(config: Config = Config.empty) : Rule(config) {
             "Top level property names should follow the naming convention set in the projects configuration.",
             debt = Debt.FIVE_MINS)
 
-    private val constantPattern by LazyRegex(CONSTANT_PATTERN, "[A-Z][_A-Z0-9]*")
+    private val constantPattern by LazyRegex(CONSTANT_PATTERN, "[A-Za-z][_A-Za-z0-9]*")
     private val propertyPattern by LazyRegex(PROPERTY_PATTERN, "[A-Za-z][_A-Za-z0-9]*")
     private val privatePropertyPattern by LazyRegex(PRIVATE_PROPERTY_PATTERN, "_?[A-Za-z][_A-Za-z0-9]*")
 

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/TopLevelPropertyNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/TopLevelPropertyNamingSpec.kt
@@ -15,19 +15,19 @@ class TopLevelPropertyNamingSpec : Spek({
             val code = """
                 const val MY_NAME_8 = "Artur"
                 const val MYNAME = "Artur"
+                const val MyNAME = "Artur"
+                const val name = "Artur"
+                const val nAme = "Artur"
+                const val serialVersionUID = 42L
             """
             assertThat(subject.lint(code)).isEmpty()
         }
 
-        it("should detect five constants not complying to the naming rules") {
+        it("should detect one constants not complying to the naming rules") {
             val code = """
-                const val MyNAME = "Artur"
-                const val name = "Artur"
-                const val nAme = "Artur"
                 private const val _nAme = "Artur"
-                const val serialVersionUID = 42L
             """
-            assertThat(subject.lint(code)).hasSize(5)
+            assertThat(subject.lint(code)).hasSize(1)
         }
     }
 

--- a/docs/pages/documentation/naming.md
+++ b/docs/pages/documentation/naming.md
@@ -341,7 +341,7 @@ Reports when top level constant names which do not follow the specified naming c
 
 #### Configuration options:
 
-* ``constantPattern`` (default: ``'[A-Z][_A-Z0-9]*'``)
+* ``constantPattern`` (default: ``'[A-Za-z][_A-Za-z0-9]*'``)
 
    naming pattern
 


### PR DESCRIPTION
Fix #3147