### PR TITLE
Change spek and assertj to compile only dependencies for detekt-test consumers

### DIFF
--- a/detekt-test-utils/build.gradle.kts
+++ b/detekt-test-utils/build.gradle.kts
@@ -1,7 +1,6 @@
 dependencies {
     api(kotlin("stdlib-jdk8"))
-    api("org.assertj:assertj-core")
-    api("org.spekframework.spek2:spek-dsl-jvm")
+    compileOnly("org.spekframework.spek2:spek-dsl-jvm")
     implementation(project(":detekt-parser"))
     implementation(project(":detekt-psi-utils"))
     implementation(kotlin("script-runtime"))

--- a/detekt-test/build.gradle.kts
+++ b/detekt-test/build.gradle.kts
@@ -1,5 +1,6 @@
 dependencies {
     api(project(":detekt-api"))
     api(project(":detekt-test-utils"))
+    compileOnly("org.assertj:assertj-core")
     implementation(project(":detekt-parser"))
 }


### PR DESCRIPTION
Closes #3082

Tested with the intellij plugin.
No need to exclude these dependencies anymore:
 ```kt
    testImplementation("io.gitlab.arturbosch.detekt:detekt-test-utils:$detektVersion") {
        exclude(group = "org.assertj")
        exclude(group = "org.spekframework.spek2")
    }
```