### PR TITLE
Fix rule LibraryCodeMustSpecifyReturnType

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ If you contributed to detekt but your name is not in the list, please feel free 
 - [Zachary Moore](https://github.com/zsmoore) - Rule, cli, gradle plugin, and config improvements
 - [Veyndan Stuart](https://github.com/veyndan) - New rule: UseEmptyCounterpart; Rule improvement: UselessCallOnNotNull
 - [Parimatch Tech](https://github.com/parimatchtech) - New rule: LibraryEntitiesShouldNotBePublic
-- [Chao Zhang](https://github.com/chao2zhang) - Rule improvement: ImplicitDefaultLocale, ModifierOrder.
+- [Chao Zhang](https://github.com/chao2zhang) - Rule improvement: ImplicitDefaultLocale, ModifierOrder, and LibraryCodeMustReturnSpecifyReturnType
 - [Marcelo Hernandez](https://github.com/mhernand40) - New rule: SuspendFunWithFlowReturnType
 - [Harold Martin](https://github.com/hbmartin) - Rule improvement: ClassOrdering
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/LibraryCodeMustSpecifyReturnType.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/LibraryCodeMustSpecifyReturnType.kt
@@ -39,6 +39,7 @@ import org.jetbrains.kotlin.resolve.checkers.ExplicitApiDeclarationChecker
  * }
  * </compliant>
  *
+ * @requiresTypeResolution
  * @active since v1.2.0
  */
 class LibraryCodeMustSpecifyReturnType(config: Config = Config.empty) : Rule(config) {
@@ -55,6 +56,9 @@ class LibraryCodeMustSpecifyReturnType(config: Config = Config.empty) : Rule(con
         super.visitCondition(root) && filters != null
 
     override fun visitProperty(property: KtProperty) {
+        if (bindingContext == BindingContext.EMPTY) {
+            return
+        }
         if (property.explicitReturnTypeRequired()) {
             report(CodeSmell(
                 issue,
@@ -66,6 +70,9 @@ class LibraryCodeMustSpecifyReturnType(config: Config = Config.empty) : Rule(con
     }
 
     override fun visitNamedFunction(function: KtNamedFunction) {
+        if (bindingContext == BindingContext.EMPTY) {
+            return
+        }
         if (function.explicitReturnTypeRequired()) {
             report(
                 CodeSmell(

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/LibraryCodeMustSpecifyReturnType.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/LibraryCodeMustSpecifyReturnType.kt
@@ -7,14 +7,18 @@ import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import org.jetbrains.kotlin.psi.KtCallableDeclaration
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.KtProperty
-import org.jetbrains.kotlin.psi.psiUtil.isPublic
+import org.jetbrains.kotlin.resolve.BindingContext
+import org.jetbrains.kotlin.resolve.checkers.ExplicitApiDeclarationChecker
 
 /**
- * Library functions/properties should have an explicit return type.
+ * Functions/properties exposed as public APIs of a library should have an explicit return type.
  * Inferred return type can easily be changed by mistake which may lead to breaking changes.
+ *
+ * See also: [Kotlin 1.4 Explicit API](https://kotlinlang.org/docs/reference/whatsnew14.html#explicit-api-mode-for-library-authors)
  *
  * <noncompliant>
  * // code from a library
@@ -51,7 +55,7 @@ class LibraryCodeMustSpecifyReturnType(config: Config = Config.empty) : Rule(con
         super.visitCondition(root) && filters != null
 
     override fun visitProperty(property: KtProperty) {
-        if (!property.isLocal && property.isPublic && property.typeReference == null) {
+        if (property.explicitReturnTypeRequired()) {
             report(CodeSmell(
                 issue,
                 Entity.atName(property),
@@ -62,9 +66,7 @@ class LibraryCodeMustSpecifyReturnType(config: Config = Config.empty) : Rule(con
     }
 
     override fun visitNamedFunction(function: KtNamedFunction) {
-        if (!function.isLocal &&
-            function.isPublic &&
-            function.hasExpressionBodyWithoutExplicitReturnType()) {
+        if (function.explicitReturnTypeRequired()) {
             report(
                 CodeSmell(
                     issue,
@@ -76,6 +78,13 @@ class LibraryCodeMustSpecifyReturnType(config: Config = Config.empty) : Rule(con
         super.visitNamedFunction(function)
     }
 
-    private fun KtNamedFunction.hasExpressionBodyWithoutExplicitReturnType(): Boolean =
-        equalsToken != null && !hasDeclaredReturnType()
+    private fun KtCallableDeclaration.explicitReturnTypeRequired(): Boolean =
+        ExplicitApiDeclarationChecker.returnTypeCheckIsApplicable(this) &&
+            ExplicitApiDeclarationChecker.returnTypeRequired(
+                element = this,
+                descriptor = bindingContext[BindingContext.DECLARATION_TO_DESCRIPTOR, this],
+                checkForPublicApi = true,
+                checkForInternal = false,
+                checkForPrivate = false
+            )
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/LibraryCodeMustSpecifyReturnTypeSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/LibraryCodeMustSpecifyReturnTypeSpec.kt
@@ -97,6 +97,7 @@ internal class LibraryCodeMustSpecifyReturnTypeSpec : Spek({
         describe("negative cases with no public scope") {
 
             it("should not report a private top level function") {
+                // Kotlin Script Engine reports wrongly local functions here
                 assertThat(subject.lintWithContext(env, """
                     internal fun bar() = 5
                     private fun foo() = 5

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/LibraryCodeMustSpecifyReturnTypeSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/LibraryCodeMustSpecifyReturnTypeSpec.kt
@@ -1,19 +1,23 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.rules.setupKotlinEnvironment
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLint
-import io.gitlab.arturbosch.detekt.test.lint
+import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
 internal class LibraryCodeMustSpecifyReturnTypeSpec : Spek({
 
+    setupKotlinEnvironment()
+    val env: KotlinCoreEnvironment by memoized()
+
     describe("library code must have explicit return types") {
 
         it("should not report without explicit filters set") {
-            assertThat(LibraryCodeMustSpecifyReturnType().compileAndLint("""
+            assertThat(LibraryCodeMustSpecifyReturnType().compileAndLintWithContext(env, """
                 fun foo() = 5
                 val bar = 5
                 class A {
@@ -30,22 +34,31 @@ internal class LibraryCodeMustSpecifyReturnTypeSpec : Spek({
         describe("positive cases") {
 
             it("should report a top level function") {
-                assertThat(subject.compileAndLint("""
+                assertThat(subject.compileAndLintWithContext(env, """
                     fun foo() = 5
                 """)).hasSize(1)
             }
 
             it("should report a top level property") {
-                assertThat(subject.compileAndLint("""
+                assertThat(subject.compileAndLintWithContext(env, """
                     val foo = 5
                 """)).hasSize(1)
             }
 
             it("should report a public class with public members") {
-                assertThat(subject.compileAndLint("""
+                assertThat(subject.compileAndLintWithContext(env, """
                     class A {
                         val foo = 5
                         fun bar() = 5
+                    }
+                """)).hasSize(2)
+            }
+
+            it("should report a public class with protected members") {
+                assertThat(subject.compileAndLintWithContext(env, """
+                    open class A {
+                        protected val foo = 5
+                        protected fun bar() = 5
                     }
                 """)).hasSize(2)
             }
@@ -54,25 +67,25 @@ internal class LibraryCodeMustSpecifyReturnTypeSpec : Spek({
         describe("negative cases with public scope") {
 
             it("should not report a top level function") {
-                assertThat(subject.compileAndLint("""
+                assertThat(subject.compileAndLintWithContext(env, """
                     fun foo(): Int = 5
                 """)).isEmpty()
             }
 
             it("should not report a non expression function") {
-                assertThat(subject.compileAndLint("""
+                assertThat(subject.compileAndLintWithContext(env, """
                     fun foo() {}
                 """)).isEmpty()
             }
 
             it("should not report a top level property") {
-                assertThat(subject.compileAndLint("""
+                assertThat(subject.compileAndLintWithContext(env, """
                     val foo: Int = 5
                 """)).isEmpty()
             }
 
             it("should not report a public class with public members") {
-                assertThat(subject.compileAndLint("""
+                assertThat(subject.compileAndLintWithContext(env, """
                     class A {
                         val foo: Int = 5
                         fun bar(): Int = 5
@@ -84,26 +97,35 @@ internal class LibraryCodeMustSpecifyReturnTypeSpec : Spek({
 
             it("should not report a private top level function") {
                 // Kotlin Script Engine reports wrongly local functions here
-                assertThat(subject.lint("""
+                assertThat(subject.compileAndLintWithContext(env, """
                     internal fun bar() = 5
                     private fun foo() = 5
                 """)).isEmpty()
             }
 
             it("should not report a internal top level property") {
-                assertThat(subject.compileAndLint("""
+                assertThat(subject.compileAndLintWithContext(env, """
                     internal val foo = 5
                 """)).isEmpty()
             }
 
             it("should not report members and local variables") {
-                assertThat(subject.compileAndLint("""
+                assertThat(subject.compileAndLintWithContext(env, """
                     internal class A {
                         internal val foo = 5
                         private fun bar() {
                             fun stuff() = Unit
                             val a = 5
                         }
+                    }
+                """)).isEmpty()
+            }
+
+            it("should not report effectively private properties and functions") {
+                assertThat(subject.compileAndLintWithContext(env, """
+                    internal class A {
+                        fun baz() = 5
+                        val qux = 5
                     }
                 """)).isEmpty()
             }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/LibraryCodeMustSpecifyReturnTypeSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/LibraryCodeMustSpecifyReturnTypeSpec.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.rules.setupKotlinEnvironment
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
@@ -96,8 +97,7 @@ internal class LibraryCodeMustSpecifyReturnTypeSpec : Spek({
         describe("negative cases with no public scope") {
 
             it("should not report a private top level function") {
-                // Kotlin Script Engine reports wrongly local functions here
-                assertThat(subject.compileAndLintWithContext(env, """
+                assertThat(subject.lintWithContext(env, """
                     internal fun bar() = 5
                     private fun foo() = 5
                 """)).isEmpty()

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/RuleExtensions.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/RuleExtensions.kt
@@ -41,6 +41,7 @@ fun BaseRule.lint(path: Path): List<Finding> {
 /**
  * Compare with [compileAndLintWithContext], this does not use [KotlinScriptEngine]
  * to compile. Please use this sparingly: A typical usecase is when KotlinScript
+ * failed to compile even when the Kotlin code in [content] is legal.
  */
 fun BaseRule.lintWithContext(
     environment: KotlinCoreEnvironment,

--- a/docs/pages/documentation/style.md
+++ b/docs/pages/documentation/style.md
@@ -486,6 +486,8 @@ Inferred return type can easily be changed by mistake which may lead to breaking
 
 See also: [Kotlin 1.4 Explicit API](https://kotlinlang.org/docs/reference/whatsnew14.html#explicit-api-mode-for-library-authors)
 
+**Requires Type Resolution**
+
 **Severity**: Style
 
 **Debt**: 5min

--- a/docs/pages/documentation/style.md
+++ b/docs/pages/documentation/style.md
@@ -481,8 +481,10 @@ const val constantString = "1"
 
 ### LibraryCodeMustSpecifyReturnType
 
-Library functions/properties should have an explicit return type.
+Functions/properties exposed as public APIs of a library should have an explicit return type.
 Inferred return type can easily be changed by mistake which may lead to breaking changes.
+
+See also: [Kotlin 1.4 Explicit API](https://kotlinlang.org/docs/reference/whatsnew14.html#explicit-api-mode-for-library-authors)
 
 **Severity**: Style
 


### PR DESCRIPTION
False-positive: Members without visibility modifiers in an internal class should not be reported.
False-negative: Members with protected modifiers in a public class should be reported.

This PR changes the underlying implementation of LibraryCodeMustSpecifyReturnType to Kotlin Compiler's explicit API mode, which was introduced in Kotlin 1.4
See https://kotlinlang.org/docs/reference/whatsnew14.html#explicit-api-mode-for-library-authors

This is actually blocking my company's repositories to enable `LibraryCodeMustSpecifyReturnType` rule because of tons of false positives.