### PR TITLE
Simplify documentation

### DIFF
--- a/docs/pages/extensions.md
+++ b/docs/pages/extensions.md
@@ -214,14 +214,7 @@ For example `detekt` itself provides a wrapper over [ktlint](https://github.com/
 custom `formatting` rule set.
 To enable it, we add the published dependency to `detekt` via the `detektPlugins` configuration:
 
-###### Groovy DSL
-```groovy
-dependencies {
-    detektPlugins "io.gitlab.arturbosch.detekt:detekt-formatting:{{ site.detekt_version }}"
-}
-```
-
-###### Kotlin DSL
+###### Gradle (Kotlin/Groovy DSL)
 ```kotlin
 dependencies {
     detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:{{ site.detekt_version }}")


### PR DESCRIPTION
Simplify documentation since Kotlin and Groovy code can be 100% the same here.