### PR TITLE
Fix MaxLineLengthSuppressed ignoring @Suppress annotation on class

### DIFF
--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/Junk.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/Junk.kt
@@ -13,6 +13,7 @@ import org.jetbrains.kotlin.psi.psiUtil.getNonStrictParentOfType
  */
 internal fun findFirstKtElementInParents(file: KtFile, offset: Int, line: String): PsiElement? {
     return file.elementsInRange(TextRange.create(offset - line.length, offset))
-            .mapNotNull { it.getNonStrictParentOfType<KtElement>() }
+            .plus(file.findElementAt(offset))
+            .mapNotNull { it?.getNonStrictParentOfType() }
             .firstOrNull()
 }

--- a/detekt-rules-style/src/test/resources/MaxLineLengthSuppressed.kt
+++ b/detekt-rules-style/src/test/resources/MaxLineLengthSuppressed.kt
@@ -55,3 +55,14 @@ class MaxLineLengthSuppressed {
 
 @Suppress("MaxLineLength")
 class AClassWithSuperLongNameItIsSooooLongThatIHaveTroubleThinkingAboutAVeryLongNameManThisIsReallyHardToFillAllTheNecessaryCharacters
+
+@Suppress("MaxLineLength")
+class AClassWithReallyLongCommentsInside {
+    /*
+     a really long line that is inside a normal comment ------------------------------------------------------------------------------------------------>
+     */
+
+    /**
+     a really long line that is inside a KDoc comment   ------------------------------------------------------------------------------------------------>
+     */
+}


### PR DESCRIPTION
Fixes #3136 

The `MaxLineLength` rule was failing to pickup the parent `KtElement` when reporting a line from a long comment. This caused the `@Suppress` annotation on the class to be ignored. 
