### PR TITLE
Introduce NamedArguments rule

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -99,6 +99,9 @@ complexity:
   MethodOverloading:
     active: false
     threshold: 6
+  NamedArguments:
+    active: false
+    threshold: 3
   NestedBlockDepth:
     active: true
     threshold: 4

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexityProvider.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexityProvider.kt
@@ -28,6 +28,7 @@ class ComplexityProvider : DefaultRuleSetProvider {
             ComplexCondition(config),
             LabeledExpression(config),
             ReplaceSafeCallChainWithRun(config),
+            NamedArguments(config)
         )
     )
 }

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NamedArguments.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NamedArguments.kt
@@ -10,9 +10,9 @@ import io.gitlab.arturbosch.detekt.api.ThresholdRule
 import org.jetbrains.kotlin.psi.KtCallExpression
 
 /**
- * Reports functions invocations which have more parameters than a certain threshold and are not named.
+ * Reports function invocations which have more parameters than a certain threshold and are all not named.
  *
- * @configuration threshold - number of non-named parameters allowed in function invocation (default: `3`)
+ * @configuration threshold - number of parameters that triggers this inspection (default: `3`)
  */
 class NamedArguments(
     config: Config = Config.empty,
@@ -21,18 +21,13 @@ class NamedArguments(
 
     override val issue = Issue(
         "NamedArguments", Severity.Maintainability,
-        "Function invocation with more number of parameters must be named.",
+        "Function invocation with more than $threshold parameters must all be named",
         Debt.FIVE_MINS
     )
 
-    private val functionInvocationThreshold: Int =
-        valueOrDefault(
-            THRESHOLD, valueOrDefault(THRESHOLD, DEFAULT_FUNCTION_THRESHOLD)
-        )
-
     override fun visitCallExpression(expression: KtCallExpression) {
         val valueArguments = expression.valueArguments
-        if (valueArguments.size > functionInvocationThreshold && valueArguments.any { !it.isNamed() }) {
+        if (valueArguments.size > threshold && valueArguments.any { !it.isNamed() }) {
             report(CodeSmell(issue, Entity.from(expression), issue.description))
         } else {
             super.visitCallExpression(expression)
@@ -40,7 +35,6 @@ class NamedArguments(
     }
 
     companion object {
-        const val THRESHOLD = "threshold"
         const val DEFAULT_FUNCTION_THRESHOLD = 3
     }
 }

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NamedArguments.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NamedArguments.kt
@@ -1,0 +1,46 @@
+package io.gitlab.arturbosch.detekt.rules.complexity
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.ThresholdRule
+import org.jetbrains.kotlin.psi.KtCallExpression
+
+/**
+ * Reports functions invocations which have more parameters than a certain threshold and are not named.
+ *
+ * @configuration threshold - number of non-named parameters allowed in function invocation (default: `3`)
+ */
+class NamedArguments(
+    config: Config = Config.empty,
+    threshold: Int = DEFAULT_FUNCTION_THRESHOLD
+) : ThresholdRule(config, threshold) {
+
+    override val issue = Issue(
+        "NamedArguments", Severity.Maintainability,
+        "Function invocation with more number of parameters must be named.",
+        Debt.FIVE_MINS
+    )
+
+    private val functionInvocationThreshold: Int =
+        valueOrDefault(
+            THRESHOLD, valueOrDefault(THRESHOLD, DEFAULT_FUNCTION_THRESHOLD)
+        )
+
+    override fun visitCallExpression(expression: KtCallExpression) {
+        val valueArguments = expression.valueArguments
+        if (valueArguments.size > functionInvocationThreshold && valueArguments.any { !it.isNamed() }) {
+            report(CodeSmell(issue, Entity.from(expression), issue.description))
+        } else {
+            super.visitCallExpression(expression)
+        }
+    }
+
+    companion object {
+        const val THRESHOLD = "threshold"
+        const val DEFAULT_FUNCTION_THRESHOLD = 3
+    }
+}

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NamedArguments.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NamedArguments.kt
@@ -12,6 +12,18 @@ import org.jetbrains.kotlin.psi.KtCallExpression
 /**
  * Reports function invocations which have more parameters than a certain threshold and are all not named.
  *
+ * <noncompliant>
+ * fun sum(a: Int, b: Int, c: Int, d: Int) {
+ * }
+ * sum(1, 2, 3, 4)
+ * </noncompliant>
+ *
+ * <compliant>
+ * fun sum(a: Int, b: Int, c: Int, d: Int) {
+ * }
+ * sum(a = 1, b = 2, c = 3, d = 4)
+ * </compliant>
+ *
  * @configuration threshold - number of parameters that triggers this inspection (default: `3`)
  */
 class NamedArguments(

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NamedArgumentsSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NamedArgumentsSpec.kt
@@ -1,6 +1,5 @@
 package io.gitlab.arturbosch.detekt.rules.complexity
 
-import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
@@ -9,19 +8,11 @@ import org.spekframework.spek2.style.specification.describe
 class NamedArgumentsSpec : Spek({
 
     val defaultThreshold = 2
-    val defaultConfig by memoized {
-        TestConfig(
-            mapOf(
-                NamedArguments.THRESHOLD to defaultThreshold,
-            )
-        )
-    }
-
-    val subject by memoized { NamedArguments(defaultConfig) }
+    val namedArguments by memoized { NamedArguments(threshold = defaultThreshold) }
 
     describe("NameArguments rule") {
 
-        val errorMessage = "Function invocation with more number of parameters must be named."
+        val errorMessage = "Function invocation with more than $defaultThreshold parameters must all be named"
         it("invocation with more than 2 parameters should throw error") {
             val code = """
                 fun sum(a: Int, b:Int, c:Int) {
@@ -31,7 +22,7 @@ class NamedArgumentsSpec : Spek({
                     sum(1, 2, 3)
                 }
                 """
-            val findings = subject.compileAndLint(code)
+            val findings = namedArguments.compileAndLint(code)
             assertThat(findings).hasSize(1)
             assertThat(findings.first().message).isEqualTo(errorMessage)
         }
@@ -45,7 +36,7 @@ class NamedArgumentsSpec : Spek({
                     sum(a = 1, b = 2, c = 3)
                 }
                 """
-            val findings = subject.compileAndLint(code)
+            val findings = namedArguments.compileAndLint(code)
             assertThat(findings).hasSize(0)
         }
 
@@ -58,7 +49,7 @@ class NamedArgumentsSpec : Spek({
                     sum(1, b = 2, c = 3)
                 }
                 """
-            val findings = subject.compileAndLint(code)
+            val findings = namedArguments.compileAndLint(code)
             assertThat(findings).hasSize(1)
             assertThat(findings.first().message).isEqualTo(errorMessage)
         }
@@ -72,7 +63,7 @@ class NamedArgumentsSpec : Spek({
                     sum(1, 2)
                 }
                 """
-            val findings = subject.compileAndLint(code)
+            val findings = namedArguments.compileAndLint(code)
             assertThat(findings).hasSize(0)
         }
 
@@ -85,7 +76,7 @@ class NamedArgumentsSpec : Spek({
                     sum(a = 1, b = 2)
                 }
                 """
-            val findings = subject.compileAndLint(code)
+            val findings = namedArguments.compileAndLint(code)
             assertThat(findings).hasSize(0)
         }
     }

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NamedArgumentsSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NamedArgumentsSpec.kt
@@ -1,0 +1,92 @@
+package io.gitlab.arturbosch.detekt.rules.complexity
+
+import io.gitlab.arturbosch.detekt.test.TestConfig
+import io.gitlab.arturbosch.detekt.test.compileAndLint
+import org.assertj.core.api.Assertions.assertThat
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+class NamedArgumentsSpec : Spek({
+
+    val defaultThreshold = 2
+    val defaultConfig by memoized {
+        TestConfig(
+            mapOf(
+                NamedArguments.THRESHOLD to defaultThreshold,
+            )
+        )
+    }
+
+    val subject by memoized { NamedArguments(defaultConfig) }
+
+    describe("NameArguments rule") {
+
+        val errorMessage = "Function invocation with more number of parameters must be named."
+        it("invocation with more than 2 parameters should throw error") {
+            val code = """
+                fun sum(a: Int, b:Int, c:Int) {
+                    println(a + b + c)
+                }
+                fun call() {
+                    sum(1, 2, 3)
+                }
+                """
+            val findings = subject.compileAndLint(code)
+            assertThat(findings).hasSize(1)
+            assertThat(findings.first().message).isEqualTo(errorMessage)
+        }
+
+        it("Function invocation with more than 2 parameters should not throw error if named") {
+            val code = """
+                fun sum(a: Int, b:Int, c:Int) {
+                    println(a + b + c)
+                }
+                fun call() {
+                    sum(a = 1, b = 2, c = 3)
+                }
+                """
+            val findings = subject.compileAndLint(code)
+            assertThat(findings).hasSize(0)
+        }
+
+        it("invocation with more than 2 parameters should throw error if even one is not named") {
+            val code = """
+                fun sum(a: Int, b:Int, c:Int) {
+                    println(a + b + c)
+                }
+                fun call() {
+                    sum(1, b = 2, c = 3)
+                }
+                """
+            val findings = subject.compileAndLint(code)
+            assertThat(findings).hasSize(1)
+            assertThat(findings.first().message).isEqualTo(errorMessage)
+        }
+
+        it("invocation with less than 3 parameters should not throw error") {
+            val code = """
+                fun sum(a: Int, b:Int) {
+                    println(a + b)
+                }
+                fun call() {
+                    sum(1, 2)
+                }
+                """
+            val findings = subject.compileAndLint(code)
+            assertThat(findings).hasSize(0)
+        }
+
+        it("invocation with less than 3 named parameters should not throw error") {
+            val code = """
+                fun sum(a: Int, b:Int) {
+                    println(a + b)
+                }
+                fun call() {
+                    sum(a = 1, b = 2)
+                }
+                """
+            val findings = subject.compileAndLint(code)
+            assertThat(findings).hasSize(0)
+        }
+    }
+})

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NamedArgumentsSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NamedArgumentsSpec.kt
@@ -79,5 +79,36 @@ class NamedArgumentsSpec : Spek({
             val findings = namedArguments.compileAndLint(code)
             assertThat(findings).hasSize(0)
         }
+
+        it("constructor invocation with more than 3 non-named parameters should throw error") {
+            val code = """
+                class C(val a: Int, val b:Int, val c:Int)
+                
+                val obj = C(1, 2, 3)
+            """
+            val findings = namedArguments.compileAndLint(code)
+            assertThat(findings).hasSize(1)
+            assertThat(findings.first().message).isEqualTo(errorMessage)
+        }
+
+        it("constructor invocation with more than 3 named parameters should not throw error") {
+            val code = """
+                class C(val a: Int, val b:Int, val c:Int)
+                
+                val obj = C(a = 1, b = 2, c= 3)
+            """
+            val findings = namedArguments.compileAndLint(code)
+            assertThat(findings).hasSize(0)
+        }
+
+        it("constructor invocation with less than 3 non-named parameters should not throw error") {
+            val code = """
+                class C(val a: Int, val b:Int)
+                
+                val obj = C(1, 2)
+            """
+            val findings = namedArguments.compileAndLint(code)
+            assertThat(findings).hasSize(0)
+        }
     }
 })

--- a/docs/pages/documentation/complexity.md
+++ b/docs/pages/documentation/complexity.md
@@ -263,6 +263,20 @@ Refactor these methods and try to use optional parameters instead to prevent som
 
    number of overloads which will trigger the rule
 
+### NamedArguments
+
+Reports functions invocations which have more parameters than a certain threshold and are not named.
+
+**Severity**: Maintainability
+
+**Debt**: 5min
+
+#### Configuration options:
+
+* ``threshold`` (default: ``3``)
+
+   number of non-named parameters allowed in function invocation
+
 ### NestedBlockDepth
 
 This rule reports excessive nesting depth in functions. Excessively nested code becomes harder to read and increases

--- a/docs/pages/documentation/complexity.md
+++ b/docs/pages/documentation/complexity.md
@@ -277,6 +277,22 @@ Reports function invocations which have more parameters than a certain threshold
 
    number of parameters that triggers this inspection
 
+#### Noncompliant Code:
+
+```kotlin
+fun sum(a: Int, b: Int, c: Int, d: Int) {
+}
+sum(1, 2, 3, 4)
+```
+
+#### Compliant Code:
+
+```kotlin
+fun sum(a: Int, b: Int, c: Int, d: Int) {
+}
+sum(a = 1, b = 2, c = 3, d = 4)
+```
+
 ### NestedBlockDepth
 
 This rule reports excessive nesting depth in functions. Excessively nested code becomes harder to read and increases

--- a/docs/pages/documentation/complexity.md
+++ b/docs/pages/documentation/complexity.md
@@ -265,7 +265,7 @@ Refactor these methods and try to use optional parameters instead to prevent som
 
 ### NamedArguments
 
-Reports functions invocations which have more parameters than a certain threshold and are not named.
+Reports function invocations which have more parameters than a certain threshold and are all not named.
 
 **Severity**: Maintainability
 
@@ -275,7 +275,7 @@ Reports functions invocations which have more parameters than a certain threshol
 
 * ``threshold`` (default: ``3``)
 
-   number of non-named parameters allowed in function invocation
+   number of parameters that triggers this inspection
 
 ### NestedBlockDepth
 


### PR DESCRIPTION
Fixes [#1007](https://github.com/detekt/detekt/issues/1007)

Changes done:

- Introduce `NamedArguments` rule which enforces function invocation to have named parameters when they cross the threshold of number of non-named parameters.
- Currently, the default is set to `3`.

