### PR TITLE
Move KtFileContent to FileParsingRule

### DIFF
--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/FileParsingRule.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/FileParsingRule.kt
@@ -20,3 +20,5 @@ class FileParsingRule(val config: Config = Config.empty) : MultiRule() {
         noTabs.runIfActive { findTabs(file) }
     }
 }
+
+data class KtFileContent(val file: KtFile, val content: Sequence<String>)

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLength.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLength.kt
@@ -8,9 +8,6 @@ import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.rules.lastArgumentMatchesUrl
-import org.jetbrains.kotlin.psi.KtFile
-
-data class KtFileContent(val file: KtFile, val content: Sequence<String>)
 
 /**
  * This rule reports lines of code which exceed a defined maximum line length.


### PR DESCRIPTION
`KtFileContent` is used for more rules than `MaxLineLength` so it should not be declared in that file. `FileParsingRule.kt` is a better place because is where the constructor of that class is called.