### PR TITLE
Suppress RedundantVisibilityModifierRule if explicit API mode enabled

### DIFF
--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantVisibilityModifierRule.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantVisibilityModifierRule.kt
@@ -24,6 +24,11 @@ import org.jetbrains.kotlin.psi.psiUtil.isPrivate
 
 /**
  * This rule checks for redundant visibility modifiers.
+
+ * One exemption is the
+ * [explicit API mode](https://kotlinlang.org/docs/reference/whatsnew14.html#explicit-api-mode-for-library-authors)
+ * In this mode, the visibility modifier should be defined explicitly even if it is public.
+ * Hence, the rule ignores the visibility modifiers in explicit API mode.
  *
  * <noncompliant>
  * public interface Foo { // public per default

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantVisibilityModifierRule.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantVisibilityModifierRule.kt
@@ -10,6 +10,8 @@ import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.rules.isInternal
 import io.gitlab.arturbosch.detekt.rules.isOverride
+import org.jetbrains.kotlin.config.AnalysisFlags
+import org.jetbrains.kotlin.config.ExplicitApiMode
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtDeclaration
@@ -53,11 +55,21 @@ class RedundantVisibilityModifierRule(config: Config = Config.empty) : Rule(conf
 
     private fun KtModifierListOwner.isExplicitlyPublic() = this.hasModifier(KtTokens.PUBLIC_KEYWORD)
 
+    /**
+     * Explicit API mode was added in Kotlin 1.4
+     * It prevents libraries' authors from making APIs public unintentionally.
+     * In this mode, the visibility modifier should be defined explicitly even if it is public.
+     * See: https://kotlinlang.org/docs/reference/whatsnew14.html#explicit-api-mode-for-library-authors
+     */
+    private fun isExplicitApiModeActive() = AnalysisFlags.explicitApiMode.defaultValue == ExplicitApiMode.STRICT
+
     override fun visitKtFile(file: KtFile) {
         super.visitKtFile(file)
-        file.declarations.forEach {
-            it.accept(classVisitor)
-            it.acceptChildren(childrenVisitor)
+        if (!isExplicitApiModeActive()) {
+            file.declarations.forEach {
+                it.accept(classVisitor)
+                it.acceptChildren(childrenVisitor)
+            }
         }
     }
 

--- a/docs/pages/documentation/style.md
+++ b/docs/pages/documentation/style.md
@@ -1002,6 +1002,11 @@ val x = "string"
 
 This rule checks for redundant visibility modifiers.
 
+One exemption is the
+[explicit API mode](https://kotlinlang.org/docs/reference/whatsnew14.html#explicit-api-mode-for-library-authors)
+In this mode, the visibility modifier should be defined explicitly even if it is public.
+Hence, the rule ignores the visibility modifiers in explicit API mode.
+
 **Severity**: Style
 
 **Debt**: 5min


### PR DESCRIPTION
Explicit API mode was added in Kotlin 1.4
It prevents libraries' authors from making APIs public unintentionally.
In this mode, the visibility modifier should be defined explicitly even if it is public.
See: https://kotlinlang.org/docs/reference/whatsnew14.html#explicit-api-mode-for-library-authors

Closes #3125
