### PR TITLE
Fix false positive when `to` is used to create a pair within a function

### DIFF
--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/PreferToOverPairSyntaxSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/PreferToOverPairSyntaxSpec.kt
@@ -28,6 +28,16 @@ object PreferToOverPairSyntaxSpec : Spek({
             assertThat(findings[0].message).endsWith("`1 to 2`")
         }
 
+        it("reports if pair is created using a function that uses pair constructor") {
+            val code = """
+                val pair = createPair()
+                fun createPair() = Pair(1, 2)
+            """
+            val findings = subject.compileAndLintWithContext(env, code)
+            assertThat(findings).hasSize(1)
+            assertThat(findings[0].message).endsWith("`1 to 2`")
+        }
+
         it("does not report if it is created using the to syntax") {
             val code = "val pair = 1 to 2"
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
@@ -40,6 +50,14 @@ object PreferToOverPairSyntaxSpec : Spek({
                 val pair3 = Pair(Pair(1, 2), Pair(3, 4))
 
                 data class Pair<T, Z>(val int1: T, val int2: Z)
+            """
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        }
+
+        it("does not report if pair is created using a function that uses the to syntax") {
+            val code = """
+                val pair = createPair()
+                fun createPair() = 1 to 2
             """
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }


### PR DESCRIPTION
Fixes [#3177](https://github.com/detekt/detekt/issues/3177)

- Added check to ensure `Pair` is used within the callExpression before reporting
- Added test to create pair using `Pair` and `to` within a function