### PR TITLE
Fix detektBaseline task filtering .java files

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/SharedTasks.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/SharedTasks.kt
@@ -39,8 +39,6 @@ internal fun Project.registerCreateBaselineTask(
         it.buildUponDefaultConfig.set(project.provider { extension.buildUponDefaultConfig })
         it.failFast.set(project.provider { extension.failFast })
         it.autoCorrect.set(project.provider { extension.autoCorrect })
-        it.setIncludes(DetektPlugin.defaultIncludes)
-        it.setExcludes(DetektPlugin.defaultExcludes)
         configuration(it)
     }
 

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/SharedTasks.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/SharedTasks.kt
@@ -2,7 +2,6 @@ package io.gitlab.arturbosch.detekt.internal
 
 import io.gitlab.arturbosch.detekt.Detekt
 import io.gitlab.arturbosch.detekt.DetektCreateBaselineTask
-import io.gitlab.arturbosch.detekt.DetektPlugin
 import io.gitlab.arturbosch.detekt.extensions.DetektExtension
 import io.gitlab.arturbosch.detekt.extensions.DetektReport
 import org.gradle.api.Project


### PR DESCRIPTION
The util functions `Project.registerDetektTask` and `Project.registerCreateBaselineTask` are used to register `detekt` and `detektBaseline` tasks on the applied Gradle project.

Due to (I suppose) legacy reason, the `registerCreateBaselineTask` was still declaring `excludes` and `includes` while the `registerDetektTask` function was updated.

This caused the input source for the `detektBaseline` to have all the `.java` files filtered out (resulting in issues like #3130) and generally a different inspection from the one performed by the plain `detekt` task.

Fixes #3130 