### PR TITLE
Add allowElseExpression configuration for MissingWhenCase rule

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -491,6 +491,7 @@ potential-bugs:
     active: false
   MissingWhenCase:
     active: true
+    allowElseExpression: true
   NullableToStringCall:
     active: false
   RedundantElseInWhen:

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingWhenCase.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingWhenCase.kt
@@ -58,7 +58,8 @@ import org.jetbrains.kotlin.resolve.calls.callUtil.getType
  *     }
  * }
  * </compliant>
- * @configuration allowElseExpression - whether else can be treated as a valid case (default: `true`)
+ * @configuration allowElseExpression - whether else can be treated as a valid case for enums and sealed classes (default: `true`)
+ *
  * Based on code from Kotlin compiler:
  * https://github.com/JetBrains/kotlin/blob/v1.3.30/compiler/frontend/src/org/jetbrains/kotlin/cfg/ControlFlowInformationProvider.kt
  *

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingWhenCase.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingWhenCase.kt
@@ -8,6 +8,7 @@ import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.cfg.WhenChecker
+import org.jetbrains.kotlin.cfg.WhenMissingCase
 import org.jetbrains.kotlin.psi.KtWhenExpression
 import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.bindingContextUtil.isUsedAsExpression
@@ -57,7 +58,7 @@ import org.jetbrains.kotlin.resolve.calls.callUtil.getType
  *     }
  * }
  * </compliant>
- *
+ * @configuration allowElseExpression - whether else can be treated as a valid case (default: `true`)
  * Based on code from Kotlin compiler:
  * https://github.com/JetBrains/kotlin/blob/v1.3.30/compiler/frontend/src/org/jetbrains/kotlin/cfg/ControlFlowInformationProvider.kt
  *
@@ -74,40 +75,51 @@ class MissingWhenCase(config: Config = Config.empty) : Rule(config) {
         Debt.TWENTY_MINS
     )
 
+    private val allowElseExpression = valueOrDefault(ALLOW_ELSE_EXPRESSION, true)
+
     @Suppress("ReturnCount")
     override fun visitWhenExpression(expression: KtWhenExpression) {
         if (bindingContext == BindingContext.EMPTY) return
-        if (expression.elseExpression != null) return
+        if (allowElseExpression && expression.elseExpression != null) return
         if (expression.isUsedAsExpression(bindingContext)) return
         val subjectExpression = expression.subjectExpression ?: return
         val subjectType = subjectExpression.getType(bindingContext)
         val enumClassDescriptor = WhenChecker.getClassDescriptorOfTypeIfEnum(subjectType)
         if (enumClassDescriptor != null) {
-            val enumMissingCases = WhenChecker.getEnumMissingCases(expression, bindingContext, enumClassDescriptor)
-            if (enumMissingCases.isNotEmpty()) {
-                report(
-                    CodeSmell(
-                        issue, Entity.from(expression),
-                        "When expression is missing cases: ${enumMissingCases.joinToString()}. Either add missing " +
-                                "cases or a default `else` case."
-                    )
-                )
-            }
+            val enumMissingCases =
+                WhenChecker.getEnumMissingCases(expression, bindingContext, enumClassDescriptor)
+            getReport(enumMissingCases, expression)
         }
         val sealedClassDescriptor = WhenChecker.getClassDescriptorOfTypeIfSealed(subjectType)
         if (sealedClassDescriptor != null) {
             val sealedClassMissingCases =
                 WhenChecker.getSealedMissingCases(expression, bindingContext, sealedClassDescriptor)
-            if (sealedClassMissingCases.isNotEmpty()) {
-                report(
-                    CodeSmell(
-                        issue, Entity.from(expression),
-                        "When expression is missing cases: ${sealedClassMissingCases.joinToString()}. Either add " +
-                                "missing cases or a default `else` case."
-                    )
-                )
-            }
+            getReport(sealedClassMissingCases, expression)
         }
         super.visitWhenExpression(expression)
+    }
+
+    private fun getReport(
+        missingCases: List<WhenMissingCase>,
+        expression: KtWhenExpression
+    ) {
+        if (missingCases.isNotEmpty()) {
+            val defaultMessage = "When expression is missing cases: ${missingCases.joinToString()}."
+            val message = if (allowElseExpression) {
+                "$defaultMessage Either add missing cases or a default `else` case."
+            } else {
+                defaultMessage
+            }
+            report(
+                CodeSmell(
+                    issue, Entity.from(expression),
+                    message
+                )
+            )
+        }
+    }
+
+    companion object {
+        const val ALLOW_ELSE_EXPRESSION = "allowElseExpression"
     }
 }

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingWhenCase.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingWhenCase.kt
@@ -100,7 +100,7 @@ class MissingWhenCase(config: Config = Config.empty) : Rule(config) {
         super.visitWhenExpression(expression)
     }
 
-    private fun getReport(
+    private fun reportMissingCases(
         missingCases: List<WhenMissingCase>,
         expression: KtWhenExpression
     ) {

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingWhenCase.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingWhenCase.kt
@@ -58,7 +58,7 @@ import org.jetbrains.kotlin.resolve.calls.callUtil.getType
  *     }
  * }
  * </compliant>
- * @configuration allowElseExpression - whether else can be treated as a valid case for enums and sealed classes (default: `true`)
+ * @configuration allowElseExpression - whether `else` can be treated as a valid case for enums and sealed classes (default: `true`)
  *
  * Based on code from Kotlin compiler:
  * https://github.com/JetBrains/kotlin/blob/v1.3.30/compiler/frontend/src/org/jetbrains/kotlin/cfg/ControlFlowInformationProvider.kt
@@ -105,11 +105,11 @@ class MissingWhenCase(config: Config = Config.empty) : Rule(config) {
         expression: KtWhenExpression
     ) {
         if (missingCases.isNotEmpty()) {
-            val defaultMessage = "When expression is missing cases: ${missingCases.joinToString()}."
-            val message = if (allowElseExpression) {
-                "$defaultMessage Either add missing cases or a default `else` case."
+            var message = "When expression is missing cases: ${missingCases.joinToString()}."
+            message = if (allowElseExpression) {
+                "$message Either add missing cases or a default `else` case."
             } else {
-                defaultMessage
+                message
             }
             report(
                 CodeSmell(

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingWhenCase.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingWhenCase.kt
@@ -89,13 +89,13 @@ class MissingWhenCase(config: Config = Config.empty) : Rule(config) {
         if (enumClassDescriptor != null) {
             val enumMissingCases =
                 WhenChecker.getEnumMissingCases(expression, bindingContext, enumClassDescriptor)
-            getReport(enumMissingCases, expression)
+            reportMissingCases(enumMissingCases, expression)
         }
         val sealedClassDescriptor = WhenChecker.getClassDescriptorOfTypeIfSealed(subjectType)
         if (sealedClassDescriptor != null) {
             val sealedClassMissingCases =
                 WhenChecker.getSealedMissingCases(expression, bindingContext, sealedClassDescriptor)
-            getReport(sealedClassMissingCases, expression)
+            reportMissingCases(sealedClassMissingCases, expression)
         }
         super.visitWhenExpression(expression)
     }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingWhenCaseSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingWhenCaseSpec.kt
@@ -242,6 +242,20 @@ object MissingWhenCaseSpec : Spek({
                 """
                 assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
             }
+
+            it("does not report when else is used for non enum or sealed `when` expression") {
+                val code = """
+                     fun whenChecks() {
+                        val x = 3
+
+                        when (x) {
+                            0, 1 -> print("x == 0 or x == 1")
+                            else -> print("otherwise")
+                        }
+                    }
+                """
+                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            }
         }
     }
 })

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingWhenCaseSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingWhenCaseSpec.kt
@@ -1,6 +1,7 @@
 package io.gitlab.arturbosch.detekt.rules.bugs
 
 import io.gitlab.arturbosch.detekt.rules.setupKotlinEnvironment
+import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
@@ -11,9 +12,9 @@ object MissingWhenCaseSpec : Spek({
     setupKotlinEnvironment()
 
     val env: KotlinCoreEnvironment by memoized()
-    val subject by memoized { MissingWhenCase() }
 
     describe("MissingWhenCase rule") {
+        val subject by memoized { MissingWhenCase() }
         context("enum") {
             it("reports when `when` expression used as statement and not all cases covered") {
                 val code = """
@@ -143,6 +144,99 @@ object MissingWhenCaseSpec : Spek({
                             x.equals(s) -> print("x equals s")
                             x.plus(3) == 4 -> print("x is 1")
                             else -> print("x is funny")
+                        }
+                    }
+                """
+                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            }
+        }
+    }
+    describe("MissingWhenCase rule when else expression is not considered") {
+        val subject by memoized {
+            MissingWhenCase(
+                TestConfig(mapOf(MissingWhenCase.ALLOW_ELSE_EXPRESSION to false))
+            )
+        }
+
+        context("enum") {
+            it("reports when `when` expression used as statement and not all cases covered") {
+                val code = """
+                enum class Color {
+                    RED,
+                    GREEN,
+                    BLUE
+                }
+
+                fun whenOnEnumFail(c: Color) {
+                    when(c) {
+                        Color.BLUE -> {}
+                        Color.GREEN -> {}
+                        else -> {}
+                    }
+                }
+                """
+                val actual = subject.compileAndLintWithContext(env, code)
+                assertThat(actual).hasSize(1)
+                assertThat(actual.first().issue.id).isEqualTo("MissingWhenCase")
+                assertThat(actual.first().message).isEqualTo("When expression is missing cases: RED.")
+            }
+
+            it("does not reports when `when` expression used as statement and all cases are covered") {
+                val code = """
+                enum class Color {
+                    RED,
+                    GREEN,
+                    BLUE
+                }
+
+                fun whenOnEnumFail(c: Color) {
+                    when(c) {
+                        Color.BLUE -> {}
+                        Color.GREEN -> {}
+                        Color.RED -> {}
+                    }
+                }
+                """
+                val actual = subject.compileAndLintWithContext(env, code)
+                assertThat(actual).isEmpty()
+            }
+        }
+        context("sealed classes") {
+            it("reports when `when` expression used as statement and not all cases covered") {
+                val code = """
+                    sealed class Variant {
+                        object VariantA : Variant()
+                        class VariantB : Variant()
+                        object VariantC : Variant()
+                    }
+
+                    fun whenOnEnumFail(v: Variant) {
+                        when(v) {
+                            is Variant.VariantA -> {}
+                            is Variant.VariantB -> {}
+                            else -> {}
+                        }
+                    }
+                """
+                val actual = subject.compileAndLintWithContext(env, code)
+                assertThat(actual).hasSize(1)
+                assertThat(actual.first().issue.id).isEqualTo("MissingWhenCase")
+                assertThat(actual.first().message).isEqualTo("When expression is missing cases: VariantC.")
+            }
+
+            it("does not report when `when` expression used as statement and all cases covered") {
+                val code = """
+                    sealed class Variant {
+                        object VariantA : Variant()
+                        class VariantB : Variant()
+                        object VariantC : Variant()
+                    }
+
+                    fun whenOnEnumPassA(v: Variant) {
+                        when(v) {
+                            is Variant.VariantA -> {}
+                            is Variant.VariantB -> {}
+                            is Variant.VariantC -> {}
                         }
                     }
                 """

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingWhenCaseSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingWhenCaseSpec.kt
@@ -15,8 +15,9 @@ object MissingWhenCaseSpec : Spek({
 
     describe("MissingWhenCase rule") {
         val subject by memoized { MissingWhenCase() }
+
         context("enum") {
-            it("reports when `when` expression used as statement and not all cases covered") {
+            it("reports when `when` expression used as statement and not all cases are covered") {
                 val code = """
                 enum class Color {
                     RED,
@@ -37,7 +38,7 @@ object MissingWhenCaseSpec : Spek({
                 assertThat(actual.first().message).isEqualTo("When expression is missing cases: RED. Either add missing cases or a default `else` case.")
             }
 
-            it("does not report when `when` expression used as statement and all cases covered") {
+            it("does not report when `when` expression used as statement and all cases are covered") {
                 val code = """
                 enum class Color {
                     RED,
@@ -63,8 +64,9 @@ object MissingWhenCaseSpec : Spek({
                 assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
             }
         }
+
         context("sealed classes") {
-            it("reports when `when` expression used as statement and not all cases covered") {
+            it("reports when `when` expression used as statement and not all cases are covered") {
                 val code = """
                     sealed class Variant {
                         object VariantA : Variant()
@@ -85,7 +87,7 @@ object MissingWhenCaseSpec : Spek({
                 assertThat(actual.first().message).isEqualTo("When expression is missing cases: VariantC. Either add missing cases or a default `else` case.")
             }
 
-            it("does not report when `when` expression used as statement and all cases covered") {
+            it("does not report when `when` expression used as statement and all cases are covered") {
                 val code = """
                     sealed class Variant {
                         object VariantA : Variant()
@@ -112,6 +114,7 @@ object MissingWhenCaseSpec : Spek({
                 assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
             }
         }
+
         context("standard when") {
             it("does not report when `when` not checking for missing cases") {
                 val code = """
@@ -151,6 +154,7 @@ object MissingWhenCaseSpec : Spek({
             }
         }
     }
+
     describe("MissingWhenCase rule when else expression is not considered") {
         val subject by memoized {
             MissingWhenCase(
@@ -159,7 +163,7 @@ object MissingWhenCaseSpec : Spek({
         }
 
         context("enum") {
-            it("reports when `when` expression used as statement and not all cases covered") {
+            it("reports when `when` expression used as statement and not all cases are covered") {
                 val code = """
                 enum class Color {
                     RED,
@@ -201,6 +205,7 @@ object MissingWhenCaseSpec : Spek({
                 assertThat(actual).isEmpty()
             }
         }
+
         context("sealed classes") {
             it("reports when `when` expression used as statement and not all cases covered") {
                 val code = """
@@ -224,7 +229,7 @@ object MissingWhenCaseSpec : Spek({
                 assertThat(actual.first().message).isEqualTo("When expression is missing cases: VariantC.")
             }
 
-            it("does not report when `when` expression used as statement and all cases covered") {
+            it("does not report when `when` expression used as statement and all cases are covered") {
                 val code = """
                     sealed class Variant {
                         object VariantA : Variant()
@@ -242,7 +247,9 @@ object MissingWhenCaseSpec : Spek({
                 """
                 assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
             }
+        }
 
+        context("standard when") {
             it("does not report when else is used for non enum or sealed `when` expression") {
                 val code = """
                      fun whenChecks() {

--- a/docs/pages/documentation/potential-bugs.md
+++ b/docs/pages/documentation/potential-bugs.md
@@ -444,7 +444,7 @@ either handle all cases or use a default `else` statement to cover the unhandled
 
 * ``allowElseExpression`` (default: ``true``)
 
-   whether else can be treated as a valid case for enums and sealed classes 
+   whether `else` can be treated as a valid case for enums and sealed classes 
 
 Based on code from Kotlin compiler:
 https://github.com/JetBrains/kotlin/blob/v1.3.30/compiler/frontend/src/org/jetbrains/kotlin/cfg/ControlFlowInformationProvider.kt

--- a/docs/pages/documentation/potential-bugs.md
+++ b/docs/pages/documentation/potential-bugs.md
@@ -440,6 +440,14 @@ either handle all cases or use a default `else` statement to cover the unhandled
 
 **Debt**: 20min
 
+#### Configuration options:
+
+* ``allowElseExpression`` (default: ``true``)
+
+   whether else can be treated as a valid case 
+Based on code from Kotlin compiler:
+https://github.com/JetBrains/kotlin/blob/v1.3.30/compiler/frontend/src/org/jetbrains/kotlin/cfg/ControlFlowInformationProvider.kt
+
 #### Noncompliant Code:
 
 ```kotlin

--- a/docs/pages/documentation/potential-bugs.md
+++ b/docs/pages/documentation/potential-bugs.md
@@ -444,7 +444,8 @@ either handle all cases or use a default `else` statement to cover the unhandled
 
 * ``allowElseExpression`` (default: ``true``)
 
-   whether else can be treated as a valid case 
+   whether else can be treated as a valid case for enums and sealed classes 
+
 Based on code from Kotlin compiler:
 https://github.com/JetBrains/kotlin/blob/v1.3.30/compiler/frontend/src/org/jetbrains/kotlin/cfg/ControlFlowInformationProvider.kt
 


### PR DESCRIPTION
Fixes [#3176 ](https://github.com/detekt/detekt/issues/3176)

- Add `allowElseExpression` and default it to true.
- Refactor report generation
- Added tests