### PR TITLE
Throw error instead of logging as error in analysis phase

### DIFF
--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Junk.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Junk.kt
@@ -1,31 +1,10 @@
 package io.gitlab.arturbosch.detekt.core
 
-import io.github.detekt.psi.absolutePath
-import io.gitlab.arturbosch.detekt.api.Finding
-import io.gitlab.arturbosch.detekt.api.RuleSetId
-import io.gitlab.arturbosch.detekt.api.internal.whichDetekt
-import io.gitlab.arturbosch.detekt.api.internal.whichJava
-import io.gitlab.arturbosch.detekt.api.internal.whichOS
-import org.jetbrains.kotlin.psi.KtFile
 import java.nio.file.Files
 import java.nio.file.Path
 
 fun Path.exists(): Boolean = Files.exists(this)
 fun Path.isFile(): Boolean = Files.isRegularFile(this)
 fun Path.isDirectory(): Boolean = Files.isDirectory(this)
-
-fun MutableMap<String, List<Finding>>.mergeSmells(other: Map<String, List<Finding>>) {
-    for ((key, findings) in other.entries) {
-        merge(key, findings) { f1, f2 -> f1.plus(f2) }
-    }
-}
-
-typealias FindingsResult = List<Map<RuleSetId, List<Finding>>>
-
-fun createErrorMessage(file: KtFile, error: Throwable): String =
-    "Analyzing '${file.absolutePath()}' led to an exception.\n" +
-        "The original exception message was: ${error.localizedMessage}\n" +
-        "Running detekt '${whichDetekt() ?: "unknown"}' on Java '${whichJava()}' on OS '${whichOS()}'.\n" +
-        "If the exception message does not help, please feel free to create an issue on our GitHub page."
 
 val NL: String = System.lineSeparator()

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/tooling/Lifecycle.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/tooling/Lifecycle.kt
@@ -38,9 +38,9 @@ internal interface Lifecycle {
         }
 
         val result = measure(Phase.Analyzer) {
-            val detektor = Analyzer(settings, ruleSets, processors)
+            val analyzer = Analyzer(settings, ruleSets, processors)
             processors.forEach { it.onStart(filesToAnalyze, bindingContext) }
-            val findings: Map<RuleSetId, List<Finding>> = detektor.run(filesToAnalyze, bindingContext)
+            val findings: Map<RuleSetId, List<Finding>> = analyzer.run(filesToAnalyze, bindingContext)
             val result: Detektion = DetektResult(findings.toSortedMap())
             processors.forEach { it.onFinish(filesToAnalyze, result, bindingContext) }
             result

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/AnalyzerSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/AnalyzerSpec.kt
@@ -1,7 +1,6 @@
 package io.gitlab.arturbosch.detekt.core
 
 import io.github.detekt.test.utils.compileForTest
-import io.github.detekt.tooling.api.UnexpectedError
 import io.gitlab.arturbosch.detekt.api.CodeSmell
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
@@ -38,7 +37,7 @@ class AnalyzerSpec : Spek({
 
             assertThatThrownBy {
                 settings.use { analyzer.run(listOf(compileForTest(testFile))) }
-            }.isInstanceOf(UnexpectedError::class.java)
+            }.isInstanceOf(IllegalStateException::class.java)
         }
 
         it("throw error explicitly in parallel when config has wrong value in config") {
@@ -57,7 +56,7 @@ class AnalyzerSpec : Spek({
 
             assertThatThrownBy { settings.use { analyzer.run(listOf(compileForTest(testFile))) } }
                 .isInstanceOf(CompletionException::class.java)
-                .hasCauseInstanceOf(UnexpectedError::class.java)
+                .hasCauseInstanceOf(IllegalStateException::class.java)
         }
     }
 })

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/AnalyzerSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/AnalyzerSpec.kt
@@ -1,0 +1,81 @@
+package io.gitlab.arturbosch.detekt.core
+
+import io.github.detekt.test.utils.compileForTest
+import io.github.detekt.tooling.api.UnexpectedError
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.RuleSet
+import io.gitlab.arturbosch.detekt.api.RuleSetProvider
+import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.test.yamlConfig
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.jetbrains.kotlin.psi.KtFile
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import java.util.concurrent.CompletionException
+
+class AnalyzerSpec : Spek({
+
+    describe("exceptions during analyze()") {
+
+        it("analyze successfully when config has correct value type in config") {
+            val testFile = path.resolve("Test.kt")
+            val settings = createProcessingSettings(testFile, yamlConfig("configs/config-value-type-correct.yml"))
+            val analyzer = Analyzer(settings, listOf(StyleRuleSetProvider()), emptyList())
+
+            assertThat(settings.use { analyzer.run(listOf(compileForTest(testFile))) }).isEmpty()
+        }
+
+        it("throw error explicitly when config has wrong value type in config") {
+            val testFile = path.resolve("Test.kt")
+            val settings = createProcessingSettings(testFile, yamlConfig("configs/config-value-type-wrong.yml"))
+            val analyzer = Analyzer(settings, listOf(StyleRuleSetProvider()), emptyList())
+
+            assertThatThrownBy {
+                settings.use { analyzer.run(listOf(compileForTest(testFile))) }
+            }.isInstanceOf(UnexpectedError::class.java)
+        }
+
+        it("throw error explicitly in parallel when config has wrong value in config") {
+            val testFile = path.resolve("Test.kt")
+            val settings = createProcessingSettings(
+                inputPath = testFile,
+                config = yamlConfig("configs/config-value-type-wrong.yml"),
+                spec = createNullLoggingSpec {
+                    execution {
+                        parallelParsing = true
+                        parallelAnalysis = true
+                    }
+                }
+            )
+            val analyzer = Analyzer(settings, listOf(StyleRuleSetProvider()), emptyList())
+
+            assertThatThrownBy { settings.use { analyzer.run(listOf(compileForTest(testFile))) } }
+                .isInstanceOf(CompletionException::class.java)
+                .hasCauseInstanceOf(UnexpectedError::class.java)
+        }
+    }
+})
+
+private class StyleRuleSetProvider : RuleSetProvider {
+    override val ruleSetId: String = "style"
+    override fun instance(config: Config) = RuleSet(ruleSetId, listOf(MaxLineLength(config)))
+}
+
+private class MaxLineLength(config: Config) : Rule(config) {
+    override val issue = Issue(this::class.java.simpleName, Severity.Style, "", Debt.FIVE_MINS)
+    private val lengthThreshold: Int = valueOrDefault("maxLineLength", 100)
+    override fun visitKtFile(file: KtFile) {
+        super.visitKtFile(file)
+        for (line in file.text.splitToSequence(NL)) {
+            if (line.length > lengthThreshold) {
+                report(CodeSmell(issue, Entity.atPackageOrFirstDecl(file), issue.description))
+            }
+        }
+    }
+}

--- a/detekt-core/src/test/resources/configs/config-value-type-correct.yml
+++ b/detekt-core/src/test/resources/configs/config-value-type-correct.yml
@@ -1,0 +1,4 @@
+style:
+  MaxLineLength:
+    active: true
+    maxLineLength: 120

--- a/detekt-core/src/test/resources/configs/config-value-type-wrong.yml
+++ b/detekt-core/src/test/resources/configs/config-value-type-wrong.yml
@@ -1,0 +1,4 @@
+style:
+  MaxLineLength:
+    active: true
+    maxLineLength: 'abc'

--- a/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/api/DetektError.kt
+++ b/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/api/DetektError.kt
@@ -9,4 +9,6 @@ class MaxIssuesReached(message: String) : DetektError(message)
 
 class InvalidConfig(message: String) : DetektError(message)
 
-class UnexpectedError(override val cause: Throwable) : DetektError(null, cause)
+class UnexpectedError(message: String?, override val cause: Throwable) : DetektError(message, cause) {
+    constructor(cause: Throwable) : this(null, cause)
+}

--- a/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/api/DetektError.kt
+++ b/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/api/DetektError.kt
@@ -9,6 +9,4 @@ class MaxIssuesReached(message: String) : DetektError(message)
 
 class InvalidConfig(message: String) : DetektError(message)
 
-class UnexpectedError(message: String?, override val cause: Throwable) : DetektError(message, cause) {
-    constructor(cause: Throwable) : this(null, cause)
-}
+class UnexpectedError(override val cause: Throwable) : DetektError(null, cause)


### PR DESCRIPTION
This PR addresses #3183

A few changes worth calling out:
- Move a few public elements from `Junk.kt` to private elements `Analyzer.kt`
- Add a new primary constructor for UnexpectedError which accepts the message
- Rename a few places where the name `Detektor` appears to `Analyzer`.  #2861 renamed the class from `Detektor` to `Analyzer` but did not update all references like variable names.

With this PR, users will see the following output in the console:
```
~/DetektSilentError(main*) » ./gradlew detekt                                                                                                                                     1 ↵ cazhang@cazhang-mn4
> Task :detekt FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':detekt'.
> io.github.detekt.tooling.api.AnalysisError: Analyzing /Users/cazhang/DetektSilentError/src/main/kotlin/A.kt led to an exception. 
  The original exception message was: java.lang.ClassCastException: java.lang.String cannot be cast to java.lang.Number
  Running detekt '1.14.2' on Java '1.8.0_212-b10' on OS 'Mac OS X'
  If the exception message does not help, please feel free to create an issue on our GitHub page.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 749ms
1 actionable task: 1 executed
---------------------------------
```

There is one more usage of `LoggingAware.error()`, although tangential to this PR, it would be great to remove `LoggingAware.error()` because logging as an error is not treating the severity correctly. When an exception happens, we should surface the error back to the user rather than logging and telling the user that the command completed successfully.