### PR TITLE
Check for presence of null case in MissingWhenCase rule

### DIFF
--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingWhenCase.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingWhenCase.kt
@@ -86,31 +86,36 @@ class MissingWhenCase(config: Config = Config.empty) : Rule(config) {
         val subjectExpression = expression.subjectExpression ?: return
         val subjectType = subjectExpression.getType(bindingContext)
         val enumClassDescriptor = WhenChecker.getClassDescriptorOfTypeIfEnum(subjectType)
+        val containsMissingNullCase =
+            subjectType?.isMarkedNullable ?: false && !WhenChecker.containsNullCase(expression, bindingContext)
         if (enumClassDescriptor != null) {
             val enumMissingCases =
                 WhenChecker.getEnumMissingCases(expression, bindingContext, enumClassDescriptor)
-            reportMissingCases(enumMissingCases, expression)
+            reportMissingCases(enumMissingCases, containsMissingNullCase, expression)
         }
         val sealedClassDescriptor = WhenChecker.getClassDescriptorOfTypeIfSealed(subjectType)
         if (sealedClassDescriptor != null) {
             val sealedClassMissingCases =
                 WhenChecker.getSealedMissingCases(expression, bindingContext, sealedClassDescriptor)
-            reportMissingCases(sealedClassMissingCases, expression)
+            reportMissingCases(sealedClassMissingCases, containsMissingNullCase, expression)
         }
         super.visitWhenExpression(expression)
     }
 
     private fun reportMissingCases(
         missingCases: List<WhenMissingCase>,
+        containsMissingNullCase: Boolean,
         expression: KtWhenExpression
     ) {
-        if (missingCases.isNotEmpty()) {
-            var message = "When expression is missing cases: ${missingCases.joinToString()}."
+        if (missingCases.isNotEmpty() || containsMissingNullCase) {
+            val reportCases = returnMissingCases(missingCases, containsMissingNullCase)
+            var message = "When expression is missing cases: $reportCases."
             message = if (allowElseExpression) {
                 "$message Either add missing cases or a default `else` case."
             } else {
                 message
             }
+
             report(
                 CodeSmell(
                     issue, Entity.from(expression),
@@ -120,7 +125,21 @@ class MissingWhenCase(config: Config = Config.empty) : Rule(config) {
         }
     }
 
+    private fun returnMissingCases(
+        missingCases: List<WhenMissingCase>,
+        containsMissingNullCase: Boolean
+    ): String {
+        return if (missingCases.isNotEmpty() && containsMissingNullCase) {
+            "${missingCases.joinToString()}, $NULL_CASE"
+        } else if (missingCases.isEmpty()) {
+            NULL_CASE
+        } else {
+            missingCases.joinToString()
+        }
+    }
+
     companion object {
         const val ALLOW_ELSE_EXPRESSION = "allowElseExpression"
+        const val NULL_CASE = "null"
     }
 }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingWhenCaseSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingWhenCaseSpec.kt
@@ -81,6 +81,26 @@ object MissingWhenCaseSpec : Spek({
                 assertThat(actual.first().message).isEqualTo("When expression is missing cases: null. Either add missing cases or a default `else` case.")
             }
 
+            it("does not report missing null case in `when` expression when it is handled outside of `when`") {
+                val code = """
+                enum class Color {
+                    RED,
+                    GREEN,
+                    BLUE
+                }
+
+                fun whenNulLCheckEnum(c: Color?) {
+                    if(c == null) return
+                    when(c) {
+                        Color.BLUE -> {}
+                        Color.GREEN -> {}
+                        Color.RED -> {}
+                    }
+                }
+                """
+                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            }
+
             it("does not report when `when` expression used as statement and all cases are covered") {
                 val code = """
                 enum class Color {
@@ -171,6 +191,26 @@ object MissingWhenCaseSpec : Spek({
                 assertThat(actual).hasSize(1)
                 assertThat(actual.first().issue.id).isEqualTo("MissingWhenCase")
                 assertThat(actual.first().message).isEqualTo("When expression is missing cases: VariantC, null. Either add missing cases or a default `else` case.")
+            }
+
+            it("does not report missing null case in `when` expression when it is handled outside of `when`") {
+                val code = """
+                sealed class Variant {
+                        object VariantA : Variant()
+                        class VariantB : Variant()
+                        object VariantC : Variant()
+                    }
+
+                    fun whenOnEnumFail(v: Variant?) {
+                        if(v == null) return
+                        when(v) {
+                            is Variant.VariantA -> {}
+                            is Variant.VariantB -> {}
+                            is Variant.VariantC -> {}
+                        }
+                    }
+                """
+                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
             }
 
             it("does not report when `when` expression used as statement and all cases are covered") {

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingWhenCaseSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingWhenCaseSpec.kt
@@ -38,6 +38,49 @@ object MissingWhenCaseSpec : Spek({
                 assertThat(actual.first().message).isEqualTo("When expression is missing cases: RED. Either add missing cases or a default `else` case.")
             }
 
+            it("reports when `when` expression used as statement and not all cases including null are not covered") {
+                val code = """
+                enum class Color {
+                    RED,
+                    GREEN,
+                    BLUE
+                }
+
+                fun whenOnEnumFail(c: Color?) {
+                    when(c) {
+                        Color.BLUE -> {}
+                        Color.GREEN -> {}
+                    }
+                }
+                """
+                val actual = subject.compileAndLintWithContext(env, code)
+                assertThat(actual).hasSize(1)
+                assertThat(actual.first().issue.id).isEqualTo("MissingWhenCase")
+                assertThat(actual.first().message).isEqualTo("When expression is missing cases: RED, null. Either add missing cases or a default `else` case.")
+            }
+
+            it("reports when `when` expression used as statement and null case is not covered") {
+                val code = """
+                enum class Color {
+                    RED,
+                    GREEN,
+                    BLUE
+                }
+
+                fun whenOnEnumFail(c: Color?) {
+                    when(c) {
+                        Color.BLUE -> {}
+                        Color.GREEN -> {}
+                        Color.RED -> {}
+                    }
+                }
+                """
+                val actual = subject.compileAndLintWithContext(env, code)
+                assertThat(actual).hasSize(1)
+                assertThat(actual.first().issue.id).isEqualTo("MissingWhenCase")
+                assertThat(actual.first().message).isEqualTo("When expression is missing cases: null. Either add missing cases or a default `else` case.")
+            }
+
             it("does not report when `when` expression used as statement and all cases are covered") {
                 val code = """
                 enum class Color {
@@ -85,6 +128,49 @@ object MissingWhenCaseSpec : Spek({
                 assertThat(actual).hasSize(1)
                 assertThat(actual.first().issue.id).isEqualTo("MissingWhenCase")
                 assertThat(actual.first().message).isEqualTo("When expression is missing cases: VariantC. Either add missing cases or a default `else` case.")
+            }
+
+            it("reports when `when` expression used as statement and null case is not covered") {
+                val code = """
+                    sealed class Variant {
+                        object VariantA : Variant()
+                        class VariantB : Variant()
+                        object VariantC : Variant()
+                    }
+
+                    fun whenOnEnumFail(v: Variant?) {
+                        when(v) {
+                            is Variant.VariantA -> {}
+                            is Variant.VariantB -> {}
+                            is Variant.VariantC -> {}
+                        }
+                    }
+                """
+                val actual = subject.compileAndLintWithContext(env, code)
+                assertThat(actual).hasSize(1)
+                assertThat(actual.first().issue.id).isEqualTo("MissingWhenCase")
+                assertThat(actual.first().message).isEqualTo("When expression is missing cases: null. Either add missing cases or a default `else` case.")
+            }
+
+            it("reports when `when` expression used as statement and not all cases including null are not covered") {
+                val code = """
+                    sealed class Variant {
+                        object VariantA : Variant()
+                        class VariantB : Variant()
+                        object VariantC : Variant()
+                    }
+
+                    fun whenOnEnumFail(v: Variant?) {
+                        when(v) {
+                            is Variant.VariantA -> {}
+                            is Variant.VariantB -> {}
+                        }
+                    }
+                """
+                val actual = subject.compileAndLintWithContext(env, code)
+                assertThat(actual).hasSize(1)
+                assertThat(actual.first().issue.id).isEqualTo("MissingWhenCase")
+                assertThat(actual.first().message).isEqualTo("When expression is missing cases: VariantC, null. Either add missing cases or a default `else` case.")
             }
 
             it("does not report when `when` expression used as statement and all cases are covered") {
@@ -183,6 +269,29 @@ object MissingWhenCaseSpec : Spek({
                 assertThat(actual).hasSize(1)
                 assertThat(actual.first().issue.id).isEqualTo("MissingWhenCase")
                 assertThat(actual.first().message).isEqualTo("When expression is missing cases: RED.")
+            }
+
+            it("reports when `when` expression used as statement and null case is not covered") {
+                val code = """
+                enum class Color {
+                    RED,
+                    GREEN,
+                    BLUE
+                }
+
+                fun whenOnEnumFail(c: Color?) {
+                    when(c) {
+                        Color.BLUE -> {}
+                        Color.GREEN -> {}
+                        Color.RED -> {}
+                        else -> {}
+                    }
+                }
+                """
+                val actual = subject.compileAndLintWithContext(env, code)
+                assertThat(actual).hasSize(1)
+                assertThat(actual.first().issue.id).isEqualTo("MissingWhenCase")
+                assertThat(actual.first().message).isEqualTo("When expression is missing cases: null.")
             }
 
             it("does not reports when `when` expression used as statement and all cases are covered") {

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingWhenCaseSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingWhenCaseSpec.kt
@@ -38,7 +38,7 @@ object MissingWhenCaseSpec : Spek({
                 assertThat(actual.first().message).isEqualTo("When expression is missing cases: RED. Either add missing cases or a default `else` case.")
             }
 
-            it("reports when `when` expression used as statement and not all cases including null are not covered") {
+            it("reports when `when` expression used as statement and not all cases including null are covered") {
                 val code = """
                 enum class Color {
                     RED,
@@ -152,7 +152,7 @@ object MissingWhenCaseSpec : Spek({
                 assertThat(actual.first().message).isEqualTo("When expression is missing cases: null. Either add missing cases or a default `else` case.")
             }
 
-            it("reports when `when` expression used as statement and not all cases including null are not covered") {
+            it("reports when `when` expression used as statement and not all cases including null are covered") {
                 val code = """
                     sealed class Variant {
                         object VariantA : Variant()


### PR DESCRIPTION
Fixes: [#3189 ](https://github.com/detekt/detekt/issues/3189)

- `WhenChecker` does not return `null` while fetching missing cases.
- Used the method `containsNullCase` to verify if null was defined by user.