### PR TITLE
Fix broken website redirects

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -111,7 +111,7 @@ description: "Meet detekt, a static code analysis tool for Kotlin."
 # the description is used in the feed.xml file
 
 # needed for sitemap.xml file only
-url: https://detekt.github.io/detekt/
-baseurl: /detekt/
+url: https://detekt.github.io
+baseurl: /detekt
 
 detekt_version: 1.14.2


### PR DESCRIPTION
It seems like after #3199 (or even before?) we broke redirects.

https://detekt.github.io/detekt/kotlindsl.html should redirect to https://detekt.github.io/detekt/gradle.html. See: 

https://github.com/detekt/detekt/blob/cd659ce8737fb177caf140f46f73a1a86b22be56/docs/pages/gettingstarted/gradle.md#L7-L9

This is broken right now, I'm fixing it.