### PR TITLE
Remove already activated rules from detekt.yml

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -143,18 +143,8 @@ style:
     excludeGuardClauses: true
   SpacingBetweenPackageAndImports:
     active: true
-  UnnecessaryAbstractClass:
-    active: true
-  UnnecessaryInheritance:
-    active: true
-  UnusedPrivateClass:
-    active: true
   UnusedPrivateMember:
     active: true
     allowedNames: '(_|ignored|expected)'
   UseCheckOrError:
-    active: true
-  UselessCallOnNotNull:
-    active: true
-  UtilityClassWithPublicConstructor:
     active: true


### PR DESCRIPTION
Those rules are already activated in the default-detekt-config.yml.
