### PR TITLE
Using lint- and compileWithContext is perfectly fine

### DIFF
--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/LibraryCodeMustSpecifyReturnTypeSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/LibraryCodeMustSpecifyReturnTypeSpec.kt
@@ -97,7 +97,6 @@ internal class LibraryCodeMustSpecifyReturnTypeSpec : Spek({
         describe("negative cases with no public scope") {
 
             it("should not report a private top level function") {
-                // Kotlin Script Engine reports wrongly local functions here
                 assertThat(subject.lintWithContext(env, """
                     internal fun bar() = 5
                     private fun foo() = 5

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/RuleExtensions.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/RuleExtensions.kt
@@ -38,11 +38,6 @@ fun BaseRule.lint(path: Path): List<Finding> {
     return findingsAfterVisit(ktFile)
 }
 
-/**
- * Compare with [compileAndLintWithContext], this does not use [KotlinScriptEngine]
- * to compile. Please use this sparingly: A typical usecase is when KotlinScript
- * failed to compile even when the Kotlin code in [content] is legal.
- */
 fun BaseRule.lintWithContext(
     environment: KotlinCoreEnvironment,
     @Language("kotlin") content: String,


### PR DESCRIPTION
Hence, I removed the comment.