### PR TITLE
Remove unused format function in RuleExtensions

### DIFF
--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/RuleExtensions.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/RuleExtensions.kt
@@ -93,11 +93,6 @@ fun Rule.format(@Language("kotlin") content: String): String {
     return contentAfterVisit(ktFile)
 }
 
-fun Rule.format(path: Path): String {
-    val ktFile = compileForTest(path)
-    return contentAfterVisit(ktFile)
-}
-
 private fun Rule.contentAfterVisit(ktFile: KtFile): String {
     this.visit(ktFile)
     return ktFile.text


### PR DESCRIPTION
* This function is unused throughout detekt's codebase
* The function name is misleading, since no code formatting is done.