### PR TITLE
Remove unused format function in RuleExtensions

### DIFF
--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/ChainWrappingSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/ChainWrappingSpec.kt
@@ -2,7 +2,6 @@ package io.gitlab.arturbosch.detekt.formatting
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.formatting.wrappers.ChainWrapping
-import io.gitlab.arturbosch.detekt.test.format
 import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
@@ -15,9 +14,9 @@ class ChainWrappingSpec : Spek({
             val subject = loadFile("configTests/chain-wrapping-before.kt")
             val expected = loadFileContent("configTests/chain-wrapping-after.kt")
 
-            val findings = ChainWrapping(Config.empty).format(subject.text)
+            val findings = ChainWrapping(Config.empty).lint(subject.text)
 
-            assertThat(findings).isNotEmpty()
+            assertThat(findings).isNotEmpty
             assertThat(subject.text).isEqualTo(expected)
         }
     }

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/RuleExtensions.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/RuleExtensions.kt
@@ -4,7 +4,6 @@ import io.github.detekt.test.utils.KotlinScriptEngine
 import io.github.detekt.test.utils.compileContentForTest
 import io.github.detekt.test.utils.compileForTest
 import io.gitlab.arturbosch.detekt.api.Finding
-import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.internal.BaseRule
 import io.gitlab.arturbosch.detekt.api.internal.CompilerResources
 import org.intellij.lang.annotations.Language

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/RuleExtensions.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/RuleExtensions.kt
@@ -88,11 +88,6 @@ private fun BaseRule.findingsAfterVisit(
     return this.findings
 }
 
-fun Rule.format(@Language("kotlin") content: String): String {
-    val ktFile = compileContentForTest(content.trimIndent())
-    return contentAfterVisit(ktFile)
-}
-
 fun Rule.format(path: Path): String {
     val ktFile = compileForTest(path)
     return contentAfterVisit(ktFile)


### PR DESCRIPTION
The single use of this function was refactored to use lint(),
which also trims the indent of the given code.
