### PR TITLE
Compile test snippets if context is passed

### DIFF
--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValueSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValueSpec.kt
@@ -19,93 +19,81 @@ object IgnoredReturnValueSpec : Spek({
 
         it("does not report when a function which returns a value is called and the return is ignored") {
             val code = """
-                package test
-
                 fun foo() {
                     listOf("hello")
                 }
             """
-            val findings = subject.compileAndLintWithContext(env, code, checkReturnValueAnnotationCode)
+            val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
         it("does not report when a function which returns a value is called before a valid return") {
             val code = """
-                package test
-
                 fun foo() : Int {
                     listOf("hello")
                     return 42
                 }
             """
-            val findings = subject.compileAndLintWithContext(env, code, checkReturnValueAnnotationCode)
+            val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
         it("does not report when a function which returns a value is called in chain and the return is ignored") {
             val code = """
-                package test
-
                 fun foo() {
                     listOf("hello").isEmpty().not()
                 }
             """
-            val findings = subject.compileAndLintWithContext(env, code, checkReturnValueAnnotationCode)
+            val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
         it("does not report when a function which returns a value is called before a semicolon") {
             val code = """
-                package test
-
                 fun foo() {
                     listOf("hello");println("foo")
                 }
             """
-            val findings = subject.compileAndLintWithContext(env, code, checkReturnValueAnnotationCode)
+            val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
         it("does not report when a function which returns a value is called after a semicolon") {
             val code = """
-                package test
-
                 fun foo() {
                     println("foo");listOf("hello")
                 }
             """
-            val findings = subject.compileAndLintWithContext(env, code, checkReturnValueAnnotationCode)
+            val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
         it("does not report when a function which returns a value is called between comments") {
             val code = """
-                package test
-
                 fun foo() {
                     listOf("hello")//foo
                 }
             """
-            val findings = subject.compileAndLintWithContext(env, code, checkReturnValueAnnotationCode)
+            val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
         it("does not report when an extension function which returns a value is called and the return is ignored") {
             val code = """
-                package test
-
                 fun Int.isTheAnswer(): Boolean = this == 42
                 fun foo(input: Int) {
                     input.isTheAnswer()
                 }
             """
-            val findings = subject.compileAndLintWithContext(env, code, checkReturnValueAnnotationCode)
+            val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
         it("does not report when the return value is assigned to a pre-existing variable") {
             val code = """
                 package test
+                
+                annotation class CheckReturnValue
                 
                 @CheckReturnValue
                 @Deprecated("Yes")
@@ -116,73 +104,67 @@ object IgnoredReturnValueSpec : Spek({
                     x = listA()
                 }
             """
-            val findings = subject.compileAndLintWithContext(env, code, checkReturnValueAnnotationCode)
+            val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
         it("does not report when a function which doesn't return a value is called") {
             val code = """
-                package test
-
                 fun noReturnValue() {}
 
                 fun foo() {
                     noReturnValue()
                 }
             """
-            val findings = subject.compileAndLintWithContext(env, code, checkReturnValueAnnotationCode)
+            val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
         it("does not report when a function's return value is used in a test statement") {
             val code = """
-                package test
-
                 fun returnsBoolean() = true
                 
-                if (returnsBoolean()) {
-                    // no-op
+                fun f() {
+                    if (returnsBoolean()) {}
                 }
             """
-            val findings = subject.compileAndLintWithContext(env, code, checkReturnValueAnnotationCode)
+            val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
         it("does not report when a function's return value is used in a comparison") {
             val code = """
-                package test
-
                 fun returnsInt() = 42
                 
-                if (42 == returnsInt()) {
-                    // no-op
+                fun f() {
+                    if (42 == returnsInt()) {}
                 }
             """
-            val findings = subject.compileAndLintWithContext(env, code, checkReturnValueAnnotationCode)
+            val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
         it("does not report when a function's return value is used as parameter for another call") {
             val code = """
-                package test
-
                 fun returnsInt() = 42
                 
-                println(returnsInt())
+                fun f() {
+                    println(returnsInt())
+                }
             """
-            val findings = subject.compileAndLintWithContext(env, code, checkReturnValueAnnotationCode)
+            val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
         it("does not report when a function's return value is used with named parameters") {
             val code = """
-                package test
-
                 fun returnsInt() = 42
                 
-                println(message = returnsInt())
+                fun f() {
+                    println(message = returnsInt())
+                }
             """
-            val findings = subject.compileAndLintWithContext(env, code, checkReturnValueAnnotationCode)
+            val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
     }
@@ -192,7 +174,9 @@ object IgnoredReturnValueSpec : Spek({
 
         it("reports when a function which returns a value is called and the return is ignored") {
             val code = """
-                package test
+                package noreturn
+                
+                annotation class CheckReturnValue
                 
                 @CheckReturnValue
                 fun listOfChecked(value: String) = listOf(value)
@@ -202,15 +186,17 @@ object IgnoredReturnValueSpec : Spek({
                     println("foo")
                 }
             """
-            val findings = subject.compileAndLintWithContext(env, code, checkReturnValueAnnotationCode)
+            val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
-            assertThat(findings).hasSourceLocation(7, 5)
+            assertThat(findings).hasSourceLocation(9, 5)
             assertThat(findings[0]).hasMessage("The call listOfChecked is returning a value that is ignored.")
         }
 
         it("reports when a function which returns a value is called before a valid return") {
             val code = """
-                package test
+                package noreturn
+                
+                annotation class CheckReturnValue
                 
                 @CheckReturnValue
                 fun listOfChecked(value: String) = listOf(value)
@@ -220,15 +206,17 @@ object IgnoredReturnValueSpec : Spek({
                     return 42
                 }
             """
-            val findings = subject.compileAndLintWithContext(env, code, checkReturnValueAnnotationCode)
+            val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
-            assertThat(findings).hasSourceLocation(7, 5)
+            assertThat(findings).hasSourceLocation(9, 5)
             assertThat(findings[0]).hasMessage("The call listOfChecked is returning a value that is ignored.")
         }
 
         it("reports when a function which returns a value is called in chain as first statement and the return is ignored") {
             val code = """
-                package test
+                package noreturn
+                
+                annotation class CheckReturnValue
                 
                 @CheckReturnValue
                 fun listOfChecked(value: String) = listOf(value)
@@ -238,13 +226,15 @@ object IgnoredReturnValueSpec : Spek({
                     return 42
                 }
             """
-            val findings = subject.compileAndLintWithContext(env, code, checkReturnValueAnnotationCode)
+            val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
         it("does not report when a function which returns a value is called in the middle of a chain and the return is ignored") {
             val code = """
-                package test
+                package noreturn
+                
+                annotation class CheckReturnValue
                 
                 @CheckReturnValue
                 fun String.listOfChecked() = listOf(this)
@@ -259,13 +249,15 @@ object IgnoredReturnValueSpec : Spek({
                     return 42
                 }
             """
-            val findings = subject.compileAndLintWithContext(env, code, checkReturnValueAnnotationCode)
+            val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
         it("reports when a function which returns a value is called in the end of a chain and the return is ignored") {
             val code = """
-                package test
+                package noreturn
+                
+                annotation class CheckReturnValue
 
                 @CheckReturnValue
                 fun String.listOfChecked() = listOf(this)
@@ -278,15 +270,17 @@ object IgnoredReturnValueSpec : Spek({
                     return 42
                 }
             """
-            val findings = subject.compileAndLintWithContext(env, code, checkReturnValueAnnotationCode)
+            val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
-            assertThat(findings).hasSourceLocation(10, 10)
+            assertThat(findings).hasSourceLocation(12, 10)
             assertThat(findings[0]).hasMessage("The call listOfChecked is returning a value that is ignored.")
         }
 
         it("reports when a function which returns a value is called before a semicolon") {
             val code = """
-                package test
+                package special
+                
+                annotation class CheckReturnValue
                 
                 @CheckReturnValue
                 fun listOfChecked(value: String) = listOf(value)
@@ -295,15 +289,17 @@ object IgnoredReturnValueSpec : Spek({
                     listOfChecked("hello");println("foo")
                 }
             """
-            val findings = subject.compileAndLintWithContext(env, code, checkReturnValueAnnotationCode)
+            val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
-            assertThat(findings).hasSourceLocation(7, 5)
+            assertThat(findings).hasSourceLocation(9, 5)
             assertThat(findings[0]).hasMessage("The call listOfChecked is returning a value that is ignored.")
         }
 
         it("reports when a function which returns a value is called after a semicolon") {
             val code = """
-                package test
+                package special
+                
+                annotation class CheckReturnValue
                 
                 @CheckReturnValue
                 fun listOfChecked(value: String) = listOf(value)
@@ -313,15 +309,17 @@ object IgnoredReturnValueSpec : Spek({
                     return 42
                 }
             """
-            val findings = subject.compileAndLintWithContext(env, code, checkReturnValueAnnotationCode)
+            val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
-            assertThat(findings).hasSourceLocation(7, 20)
+            assertThat(findings).hasSourceLocation(9, 20)
             assertThat(findings[0]).hasMessage("The call listOfChecked is returning a value that is ignored.")
         }
 
         it("reports when a function which returns a value is called between comments") {
             val code = """
-                package test
+                package special
+                
+                annotation class CheckReturnValue
                 
                 @CheckReturnValue
                 fun listOfChecked(value: String) = listOf(value)
@@ -331,15 +329,17 @@ object IgnoredReturnValueSpec : Spek({
                     return 42
                 }
             """
-            val findings = subject.compileAndLintWithContext(env, code, checkReturnValueAnnotationCode)
+            val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
-            assertThat(findings).hasSourceLocation(7, 14)
+            assertThat(findings).hasSourceLocation(9, 14)
             assertThat(findings[0]).hasMessage("The call listOfChecked is returning a value that is ignored.")
         }
 
         it("reports when an extension function which returns a value is called and the return is ignored") {
             val code = """
-                package test
+                package specialize
+                
+                annotation class CheckReturnValue
                 
                 @CheckReturnValue
                 fun Int.isTheAnswer(): Boolean = this == 42
@@ -348,15 +348,17 @@ object IgnoredReturnValueSpec : Spek({
                     return 42
                 }
             """
-            val findings = subject.compileAndLintWithContext(env, code, checkReturnValueAnnotationCode)
+            val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
-            assertThat(findings).hasSourceLocation(6, 11)
+            assertThat(findings).hasSourceLocation(8, 11)
             assertThat(findings[0]).hasMessage("The call isTheAnswer is returning a value that is ignored.")
         }
 
         it("does not report when the return value is assigned to a pre-existing variable") {
             val code = """
-                package test
+                package specialize
+                
+                annotation class CheckReturnValue
 
                 @CheckReturnValue
                 fun listOfChecked(value: String) = listOf(value)
@@ -367,13 +369,15 @@ object IgnoredReturnValueSpec : Spek({
                     return 42
                 }
             """
-            val findings = subject.compileAndLintWithContext(env, code, checkReturnValueAnnotationCode)
+            val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
         it("does not report when a function which doesn't return a value is called") {
             val code = """
-                package test
+                package specialize
+                
+                annotation class CheckReturnValue
 
                 @CheckReturnValue
                 fun noReturnValue() {}
@@ -383,137 +387,149 @@ object IgnoredReturnValueSpec : Spek({
                     return 42
                 }
             """
-            val findings = subject.compileAndLintWithContext(env, code, checkReturnValueAnnotationCode)
+            val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
         it("does not report when a function's return value is used in a test statement") {
             val code = """
-                package test
+                package comparison
+                
+                annotation class CheckReturnValue
 
                 @CheckReturnValue
                 fun returnsBoolean() = true
                 
-                if (returnsBoolean()) {
-                    // no-op
+                fun f() {
+                    if (returnsBoolean()) {}
                 }
             """
-            val findings = subject.compileAndLintWithContext(env, code, checkReturnValueAnnotationCode)
+            val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
         it("does not report when a function's return value is used in a comparison") {
             val code = """
-                package test
+                package comparison
+                
+                annotation class CheckReturnValue
 
                 @CheckReturnValue
                 fun returnsInt() = 42
                 
-                if (42 == returnsInt()) {
-                    // no-op
+                fun f() {
+                    if (42 == returnsInt()) {}
                 }
             """
-            val findings = subject.compileAndLintWithContext(env, code, checkReturnValueAnnotationCode)
+            val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
         it("does not report when a function's return value is used as parameter for another call") {
             val code = """
-                package test
+                package parameter
+                
+                annotation class CheckReturnValue
 
                 @CheckReturnValue
                 fun returnsInt() = 42
                 
-                println(returnsInt())
+                fun f() {
+                    println(returnsInt())
+                }
             """
-            val findings = subject.compileAndLintWithContext(env, code, checkReturnValueAnnotationCode)
+            val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
         it("does not report when a function's return value is used with named parameters") {
             val code = """
-                package test
+                package parameter
+                
+                annotation class CheckReturnValue
 
                 @CheckReturnValue
                 fun returnsInt() = 42
                 
-                println(message = returnsInt())
+                fun f() {
+                    println(message = returnsInt())
+                }
             """
-            val findings = subject.compileAndLintWithContext(env, code, checkReturnValueAnnotationCode)
+            val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
         it("does not report when a function is the last statement in a block and it's used") {
             val code = """
-                package test
-
-                import kotlin.random.Random
+                package block
+                
+                annotation class CheckReturnValue
 
                 @CheckReturnValue
                 fun returnsInt() = 42
 
-                val result = if (Random.nextBoolean()) {
+                val result = if (true) {
                     1
                 } else {
                     returnsInt()
                 }
             """
-            val findings = subject.compileAndLintWithContext(env, code, checkReturnValueAnnotationCode)
+            val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
         it("report when a function is not the last statement in a 'if' block and 'if' block is used") {
             val code = """
-                package test
-
-                import kotlin.random.Random
+                package block
+                
+                annotation class CheckReturnValue
 
                 @CheckReturnValue
                 fun returnsInt() = 42
 
-                val result = if (Random.nextBoolean()) {
+                val result = if (true) {
                     1
                 } else {
                     returnsInt()
                     2
                 }
             """
-            val findings = subject.compileAndLintWithContext(env, code, checkReturnValueAnnotationCode)
+            val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
 
         it("does not report when a function is the last statement in a block and it's in a chain") {
             val code = """
-                package test
+                package block
 
-                import kotlin.random.Random
+                annotation class CheckReturnValue
 
                 @CheckReturnValue
                 fun returnsInt() = 42
 
                 fun test() {
-                    if (Random.nextBoolean()) {
+                    if (true) {
                         1
                     } else {
                         returnsInt()
                     }.plus(1)
                 }
             """
-            val findings = subject.compileAndLintWithContext(env, code, checkReturnValueAnnotationCode)
+            val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
         it("report when a function is not the last statement in a block and it's in a chain") {
             val code = """
-                package test
+                package block
 
-                import kotlin.random.Random
+                annotation class CheckReturnValue
 
                 @CheckReturnValue
                 fun returnsInt() = 42
 
                 fun test() {
-                    if (Random.nextBoolean()) {
+                    if (true) {
                         1
                     } else {
                         returnsInt()
@@ -521,34 +537,36 @@ object IgnoredReturnValueSpec : Spek({
                     }.plus(1)
                 }
             """
-            val findings = subject.compileAndLintWithContext(env, code, checkReturnValueAnnotationCode)
+            val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
 
         it("report when a function is the last statement in a block") {
             val code = """
-                package test
+                package block
 
-                import kotlin.random.Random
+                annotation class CheckReturnValue
 
                 @CheckReturnValue
                 fun returnsInt() = 42
 
                 fun test() {
-                    if (Random.nextBoolean()) {
+                    if (true) {
                         println("hello")
                     } else {
                         returnsInt()
                     }
                 }
             """
-            val findings = subject.compileAndLintWithContext(env, code, checkReturnValueAnnotationCode)
+            val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
 
         it("does not report when a function return value is consumed in a chain that returns a Unit") {
             val code = """
-                package test
+                package callchain
+                
+                annotation class CheckReturnValue
 
                 @CheckReturnValue
                 fun String.listOfChecked() = listOf(this)
@@ -563,7 +581,7 @@ object IgnoredReturnValueSpec : Spek({
                     return 42
                 }
             """
-            val findings = subject.compileAndLintWithContext(env, code, checkReturnValueAnnotationCode)
+            val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
     }
@@ -577,7 +595,7 @@ object IgnoredReturnValueSpec : Spek({
 
         it("reports when a function is annotated with the custom annotation") {
             val code = """
-                package test
+                package config
                 annotation class CustomReturn
                 
                 @CustomReturn
@@ -588,7 +606,7 @@ object IgnoredReturnValueSpec : Spek({
                     return 42
                 }
             """
-            val findings = subject.compileAndLintWithContext(env, code, checkReturnValueAnnotationCode)
+            val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasSourceLocation(8, 5)
             assertThat(findings[0]).hasMessage("The call listOfChecked is returning a value that is ignored.")
@@ -596,7 +614,9 @@ object IgnoredReturnValueSpec : Spek({
 
         it("does not report when a function is annotated with the not included annotation") {
             val code = """
-                package test
+                package config
+                
+                annotation class CheckReturnValue
                 
                 @CheckReturnValue
                 fun listOfChecked(value: String) = listOf(value)
@@ -606,13 +626,13 @@ object IgnoredReturnValueSpec : Spek({
                     return 42
                 }
             """
-            val findings = subject.compileAndLintWithContext(env, code, checkReturnValueAnnotationCode)
+            val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
         it("does not report when a function is not annotated") {
             val code = """
-                package test
+                package config
 
                 fun listOfChecked(value: String) = listOf(value)
                 
@@ -621,7 +641,7 @@ object IgnoredReturnValueSpec : Spek({
                     return 42
                 }
             """
-            val findings = subject.compileAndLintWithContext(env, code, checkReturnValueAnnotationCode)
+            val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
     }
@@ -633,7 +653,9 @@ object IgnoredReturnValueSpec : Spek({
 
         it("reports when a function is annotated with a custom annotation") {
             val code = """
-                package test
+                package config
+                
+                annotation class CheckReturnValue
                 
                 @CheckReturnValue
                 fun listOfChecked(value: String) = listOf(value)
@@ -643,16 +665,14 @@ object IgnoredReturnValueSpec : Spek({
                     return 42
                 }
             """
-            val findings = subject.compileAndLintWithContext(env, code, checkReturnValueAnnotationCode)
+            val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
-            assertThat(findings).hasSourceLocation(7, 5)
+            assertThat(findings).hasSourceLocation(9, 5)
             assertThat(findings[0]).hasMessage("The call listOfChecked is returning a value that is ignored.")
         }
 
         it("reports when a function is not annotated") {
             val code = """
-                package test
-
                 fun listOfChecked(value: String) = listOf(value)
                 
                 fun foo() : Int {
@@ -660,16 +680,10 @@ object IgnoredReturnValueSpec : Spek({
                     return 42
                 }
             """
-            val findings = subject.compileAndLintWithContext(env, code, checkReturnValueAnnotationCode)
+            val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
-            assertThat(findings).hasSourceLocation(6, 5)
+            assertThat(findings).hasSourceLocation(4, 5)
             assertThat(findings[0]).hasMessage("The call listOfChecked is returning a value that is ignored.")
         }
     }
 })
-
-private const val checkReturnValueAnnotationCode = """
-package test
-
-annotation class CheckReturnValue
-"""

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValueSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValueSpec.kt
@@ -4,6 +4,7 @@ import io.gitlab.arturbosch.detekt.rules.setupKotlinEnvironment
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
@@ -174,9 +175,7 @@ object IgnoredReturnValueSpec : Spek({
 
         it("reports when a function which returns a value is called and the return is ignored") {
             val code = """
-                package noreturn
-                
-                annotation class CheckReturnValue
+                package annotation
                 
                 @CheckReturnValue
                 fun listOfChecked(value: String) = listOf(value)
@@ -186,9 +185,15 @@ object IgnoredReturnValueSpec : Spek({
                     println("foo")
                 }
             """
-            val findings = subject.compileAndLintWithContext(env, code)
+            val annotationClass = """
+                package annotation
+
+                annotation class CheckReturnValue
+            """
+
+            val findings = subject.lintWithContext(env, code, annotationClass)
             assertThat(findings).hasSize(1)
-            assertThat(findings).hasSourceLocation(9, 5)
+            assertThat(findings).hasSourceLocation(7, 5)
             assertThat(findings[0]).hasMessage("The call listOfChecked is returning a value that is ignored.")
         }
 
@@ -206,7 +211,7 @@ object IgnoredReturnValueSpec : Spek({
                     return 42
                 }
             """
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasSourceLocation(9, 5)
             assertThat(findings[0]).hasMessage("The call listOfChecked is returning a value that is ignored.")

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedImportsSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedImportsSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.setupKotlinEnvironment
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.spekframework.spek2.Spek
@@ -33,7 +33,7 @@ class UnusedImportsSpec : Spek({
 
                 infix fun Int.success(f: () -> Unit) {}
             """
-            assertThat(subject.compileAndLintWithContext(env, main, additional)).isEmpty()
+            assertThat(subject.lintWithContext(env, main, additional)).isEmpty()
         }
 
         it("does not report imports in documentation") {
@@ -63,7 +63,7 @@ class UnusedImportsSpec : Spek({
                 infix fun Int.failure(f: () -> Unit) {}
                 infix fun Int.undefined(f: () -> Unit) {}
             """
-            assertThat(subject.compileAndLintWithContext(env, main, additional)).isEmpty()
+            assertThat(subject.lintWithContext(env, main, additional)).isEmpty()
         }
 
         it("should ignore import for link") {
@@ -90,7 +90,7 @@ class UnusedImportsSpec : Spek({
                 infix fun Int.failure(f: () -> Unit) {}
                 infix fun Int.undefined(f: () -> Unit) {}
             """
-            val lint = subject.compileAndLintWithContext(env, main, additional)
+            val lint = subject.lintWithContext(env, main, additional)
             with(lint) {
                 assertThat(this).hasSize(1)
                 assertThat(this[0].entity.signature).endsWith("import tasks.undefined")
@@ -109,7 +109,7 @@ class UnusedImportsSpec : Spek({
 
                 class SomeClass
             """
-            val lint = subject.compileAndLintWithContext(env, main, additional)
+            val lint = subject.lintWithContext(env, main, additional)
             with(lint) {
                 assertThat(this).hasSize(1)
                 assertThat(this[0].entity.signature).endsWith("import test.SomeClass")
@@ -138,7 +138,7 @@ class UnusedImportsSpec : Spek({
                     fun beforeTextChanged() {}
                 }                
             """
-            assertThat(subject.compileAndLintWithContext(env, main, additional)).isEmpty()
+            assertThat(subject.lintWithContext(env, main, additional)).isEmpty()
         }
 
         it("reports imports with different cases") {
@@ -186,7 +186,7 @@ class UnusedImportsSpec : Spek({
                 fun `when`() {}
                 fun `foo`() {}
             """
-            val lint = subject.compileAndLintWithContext(env, main, p, p2, escaped)
+            val lint = subject.lintWithContext(env, main, p, p2, escaped)
             with(lint) {
                 assertThat(this).hasSize(3)
                 assertThat(this[0].entity.signature).contains("import p.B6")
@@ -212,7 +212,7 @@ class UnusedImportsSpec : Spek({
                     class Inner
                 }
             """
-            val lint = subject.compileAndLintWithContext(env, main, additional)
+            val lint = subject.lintWithContext(env, main, additional)
             with(lint) {
                 assertThat(this).isEmpty()
             }
@@ -233,7 +233,7 @@ class UnusedImportsSpec : Spek({
 
                 fun success() {}
             """
-            assertThat(subject.compileAndLintWithContext(env, main, additional)).isEmpty()
+            assertThat(subject.lintWithContext(env, main, additional)).isEmpty()
         }
 
         it("does not report KDoc @see annotation linking to class with description") {
@@ -251,7 +251,7 @@ class UnusedImportsSpec : Spek({
 
                 fun success() {}
             """
-            assertThat(subject.compileAndLintWithContext(env, main, additional)).isEmpty()
+            assertThat(subject.lintWithContext(env, main, additional)).isEmpty()
         }
 
         it("reports KDoc @see annotation that does not link to class") {
@@ -269,7 +269,7 @@ class UnusedImportsSpec : Spek({
 
                 fun success() {}
             """
-            assertThat(subject.compileAndLintWithContext(env, main, additional)).hasSize(1)
+            assertThat(subject.lintWithContext(env, main, additional)).hasSize(1)
         }
 
         it("reports KDoc @see annotation that links after description") {
@@ -287,7 +287,7 @@ class UnusedImportsSpec : Spek({
 
                 fun success() {}
             """
-            assertThat(subject.compileAndLintWithContext(env, main, additional)).hasSize(1)
+            assertThat(subject.lintWithContext(env, main, additional)).hasSize(1)
         }
 
         it("does not report imports in KDoc") {
@@ -310,7 +310,7 @@ class UnusedImportsSpec : Spek({
                 fun success() {}
                 fun undefined() {}
             """
-            assertThat(subject.compileAndLintWithContext(env, main, additional)).isEmpty()
+            assertThat(subject.lintWithContext(env, main, additional)).isEmpty()
         }
 
         it("should not report import alias as unused when the alias is used") {
@@ -322,7 +322,7 @@ class UnusedImportsSpec : Spek({
                 package test
                 fun Iterator<Int>.forEach(f: () -> Unit) {}
             """
-            assertThat(subject.compileAndLintWithContext(env, main, additional)).isEmpty()
+            assertThat(subject.lintWithContext(env, main, additional)).isEmpty()
         }
 
         it("should not report used alias even when import is from same package") {
@@ -344,7 +344,7 @@ class UnusedImportsSpec : Spek({
                 package com.example.other
                 fun foo() = 1                
             """
-            assertThat(subject.compileAndLintWithContext(env, main, additional1, additional2)).isEmpty()
+            assertThat(subject.lintWithContext(env, main, additional1, additional2)).isEmpty()
         }
 
         it("should not report import of provideDelegate operator overload - #1608") {
@@ -368,7 +368,7 @@ class UnusedImportsSpec : Spek({
                     prop: KProperty<*>
                 ) = lazy { "" }                
             """
-            assertThat(subject.compileAndLintWithContext(env, main, additional)).isEmpty()
+            assertThat(subject.lintWithContext(env, main, additional)).isEmpty()
         }
 
         it("should not report import of componentN operator") {
@@ -386,7 +386,7 @@ class UnusedImportsSpec : Spek({
                 data class MyClass(val a: Int, val b: Int)                
             """
 
-            assertThat(subject.compileAndLintWithContext(env, main, additional)).isEmpty()
+            assertThat(subject.lintWithContext(env, main, additional)).isEmpty()
         }
 
         it("should report import of identifiers with component in the name") {
@@ -410,7 +410,7 @@ class UnusedImportsSpec : Spek({
                 package com.example.component1
                 class Unused
             """
-            val lint = subject.compileAndLintWithContext(env, main, additional1, additional2)
+            val lint = subject.lintWithContext(env, main, additional1, additional2)
 
             with(lint) {
                 assertThat(this).hasSize(4)
@@ -437,7 +437,7 @@ class UnusedImportsSpec : Spek({
                 package bar
                 fun test(s: String) {}
             """
-            val findings = subject.compileAndLintWithContext(env, mainFile, additionalFile1, additionalFile2)
+            val findings = subject.lintWithContext(env, mainFile, additionalFile1, additionalFile2)
             assertThat(findings).hasSize(1)
             assertThat(findings[0].entity.signature).endsWith("import bar.test")
         }
@@ -449,7 +449,7 @@ class UnusedImportsSpec : Spek({
                 fun doesNothing(thing: HashMap<String, String>) {
                 }
             """
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -463,7 +463,7 @@ class UnusedImportsSpec : Spek({
                 @Ann(HashMap::class)
                 fun foo() {}
             """
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -478,7 +478,7 @@ class UnusedImportsSpec : Spek({
                 
                 class Foo
             """
-            val findings = subject.compileAndLintWithContext(env, mainFile, additionalFile)
+            val findings = subject.lintWithContext(env, mainFile, additionalFile)
             assertThat(findings).isEmpty()
         }
 
@@ -494,7 +494,7 @@ class UnusedImportsSpec : Spek({
                 
                 annotation class Ann
             """
-            val findings = subject.compileAndLintWithContext(env, mainFile, additionalFile)
+            val findings = subject.lintWithContext(env, mainFile, additionalFile)
             assertThat(findings).isEmpty()
         }
 
@@ -511,7 +511,7 @@ class UnusedImportsSpec : Spek({
                     companion object
                 }
             """
-            val findings = subject.compileAndLintWithContext(env, mainFile, additionalFile)
+            val findings = subject.lintWithContext(env, mainFile, additionalFile)
             assertThat(findings).isEmpty()
         }
 
@@ -530,7 +530,7 @@ class UnusedImportsSpec : Spek({
                     }
                 }
             """
-            val findings = subject.compileAndLintWithContext(env, mainFile, additionalFile)
+            val findings = subject.lintWithContext(env, mainFile, additionalFile)
             assertThat(findings).isEmpty()
         }
 
@@ -549,7 +549,7 @@ class UnusedImportsSpec : Spek({
                     }
                 }
             """
-            val findings = subject.compileAndLintWithContext(env, mainFile, additionalFile)
+            val findings = subject.lintWithContext(env, mainFile, additionalFile)
             assertThat(findings).isEmpty()
         }
 
@@ -566,7 +566,7 @@ class UnusedImportsSpec : Spek({
                     LAZY
                 }
             """
-            assertThat(subject.compileAndLintWithContext(env, mainFile, additionalFile)).isEmpty()
+            assertThat(subject.lintWithContext(env, mainFile, additionalFile)).isEmpty()
         }
     }
 })

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/RuleExtensions.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/RuleExtensions.kt
@@ -60,14 +60,13 @@ fun BaseRule.lintWithContext(
 }
 
 fun BaseRule.compileAndLintWithContext(
-    environment: KotlinCoreEnvironment,
-    @Language("kotlin") content: String,
-    @Language("kotlin") vararg additionalContents: String,
+        environment: KotlinCoreEnvironment,
+        @Language("kotlin") content: String
 ): List<Finding> {
-    if (shouldCompileTestSnippets && additionalContents.isEmpty()) {
+    if (shouldCompileTestSnippets) {
         KotlinScriptEngine.compile(content)
     }
-    return lintWithContext(environment, content, *additionalContents)
+    return lintWithContext(environment, content)
 }
 
 private fun getContextForPaths(environment: KotlinCoreEnvironment, paths: List<KtFile>) =


### PR DESCRIPTION
The compileAndLint() function in test code does not work correctly,
if additionalContents are passed.
The code should be compiled no matter if additionalContents are present.

The fix changes the following in RuleExtensions.kt:
  * Only 1 content can be passed to compileAndLintWithContext()
  * Only 1 content is compiled
  * lintWithContext() stays as it is

Test snippets in UnusedImportsSpec.kt are not compiled,
since the Kotlin script engine can't resolve user declared imports.

Test snippets were adapted in IgnoredReturnValueSpec.kt accordingly:
* Compile all test snippets
* Declare the annotation class only at necessary places
* Don't use conflicting package names to satisfy the Kotlin script engine
* Refactor and simplify test snippets

Fixes #3191

