### PR TITLE
Enabled publishing of sha256 and sha512 signatures

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,5 +6,3 @@ org.gradle.workers.max=4
 org.gradle.caching=true
 # increase max heap for dokka on Java 11
 org.gradle.jvmargs=-Xmx1024m
-# Needed for https://github.com/gradle/gradle/issues/11412
-systemProp.org.gradle.internal.publish.checksums.insecure=true


### PR DESCRIPTION
Seems like the issue on Bintray side was resolved:
https://github.com/gradle/gradle/issues/11412#issuecomment-733655244

It is now safe to publish sha256 and sha512 of our artifacts. 