### PR TITLE
Introduce --all-rules flag

### DIFF
--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt
@@ -116,6 +116,12 @@ class CliArgs {
     var failFast: Boolean = false
 
     @Parameter(
+        names = ["--all-rules"],
+        description = "Activates all available (even unstable) rules."
+    )
+    var allRules: Boolean = false
+
+    @Parameter(
         names = ["--auto-correct", "-ac"],
         description = "Allow rules to auto correct code if they support it. " +
             "The default rule sets do NOT support auto correcting and won't change any line in the users code base. " +

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt
@@ -109,10 +109,12 @@ class CliArgs {
 
     @Parameter(
         names = ["--fail-fast"],
-        description = "Same as 'build-upon-default-config' but explicitly running all available rules. " +
+        description = "DEPRECATED: please use '--build-upon-default-config' together with '--all-rules'. " +
+            "Same as 'build-upon-default-config' but explicitly running all available rules. " +
             "With this setting only exit code 0 is returned when the analysis does not find a single code smell. " +
             "Additional configuration files can override rule properties which includes turning off specific rules."
     )
+    @Deprecated("Please use the buildUponDefaultConfig and allRules flags instead.", ReplaceWith("allRules"))
     var failFast: Boolean = false
 
     @Parameter(

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Spec.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Spec.kt
@@ -23,7 +23,7 @@ internal fun CliArgs.createSpec(output: Appendable, error: Appendable): Processi
 
         rules {
             autoCorrect = args.autoCorrect
-            activateExperimentalRules = args.failFast
+            activateExperimentalRules = args.failFast || args.allRules
             maxIssuePolicy = RulesSpec.MaxIssuePolicy.NonSpecified // not yet supported; prefer to read from config
             excludeCorrectable = false // not yet supported; loaded from config
             runPolicy = args.toRunPolicy()

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Spec.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Spec.kt
@@ -23,6 +23,7 @@ internal fun CliArgs.createSpec(output: Appendable, error: Appendable): Processi
 
         rules {
             autoCorrect = args.autoCorrect
+            @Suppress("DEPRECATION")
             activateAllRules = args.failFast || args.allRules
             maxIssuePolicy = RulesSpec.MaxIssuePolicy.NonSpecified // not yet supported; prefer to read from config
             excludeCorrectable = false // not yet supported; loaded from config

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Spec.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Spec.kt
@@ -23,7 +23,7 @@ internal fun CliArgs.createSpec(output: Appendable, error: Appendable): Processi
 
         rules {
             autoCorrect = args.autoCorrect
-            activateExperimentalRules = args.failFast || args.allRules
+            activateAllRules = args.failFast || args.allRules
             maxIssuePolicy = RulesSpec.MaxIssuePolicy.NonSpecified // not yet supported; prefer to read from config
             excludeCorrectable = false // not yet supported; loaded from config
             runPolicy = args.toRunPolicy()

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgsSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgsSpec.kt
@@ -94,4 +94,14 @@ internal class CliArgsSpec : Spek({
                 .isThrownBy { parseArguments(arrayOf("--unknown-to-us-all")) }
         }
     }
+
+    describe("--all-rules and --fail-fast lead to all rules being activated") {
+
+        arrayOf("--all-rules", "--fail-fast").forEach { flag ->
+            it("is true for flag $flag") {
+                val spec = parseArguments(arrayOf(flag)).toSpec()
+                assertThat(spec.rulesSpec.activateAllRules).isTrue()
+            }
+        }
+    }
 })

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Analyzer.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Analyzer.kt
@@ -159,7 +159,7 @@ internal fun ProcessingSpec.workaroundConfiguration(config: Config): Config = wi
         else -> null
     }
 
-    if (rulesSpec.activateExperimentalRules) {
+    if (rulesSpec.activateAllRules) {
         val defaultConfig = DefaultConfig.newInstance()
         declaredConfig = FailFastConfig(declaredConfig ?: defaultConfig, defaultConfig)
     }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Analyzer.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Analyzer.kt
@@ -16,7 +16,7 @@ import io.gitlab.arturbosch.detekt.api.internal.whichJava
 import io.gitlab.arturbosch.detekt.api.internal.whichOS
 import io.gitlab.arturbosch.detekt.core.config.DefaultConfig
 import io.gitlab.arturbosch.detekt.core.config.DisabledAutoCorrectConfig
-import io.gitlab.arturbosch.detekt.core.config.FailFastConfig
+import io.gitlab.arturbosch.detekt.core.config.AllRulesConfig
 import io.gitlab.arturbosch.detekt.core.rules.IdMapping
 import io.gitlab.arturbosch.detekt.core.rules.associateRuleIdsToRuleSetIds
 import io.gitlab.arturbosch.detekt.core.rules.isActive
@@ -161,7 +161,7 @@ internal fun ProcessingSpec.workaroundConfiguration(config: Config): Config = wi
 
     if (rulesSpec.activateAllRules) {
         val defaultConfig = DefaultConfig.newInstance()
-        declaredConfig = FailFastConfig(declaredConfig ?: defaultConfig, defaultConfig)
+        declaredConfig = AllRulesConfig(declaredConfig ?: defaultConfig, defaultConfig)
     }
 
     if (!rulesSpec.autoCorrect) {

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/AllRulesConfig.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/AllRulesConfig.kt
@@ -14,7 +14,6 @@ internal data class AllRulesConfig(
     override fun <T : Any> valueOrDefault(key: String, default: T): T {
         return when (key) {
             Config.ACTIVE_KEY -> originalConfig.valueOrDefault(key, true) as T
-            MAX_ISSUES_KEY -> originalConfig.valueOrDefault(key, 0) as T
             else -> originalConfig.valueOrDefault(key, defaultConfig.valueOrDefault(key, default))
         }
     }
@@ -22,7 +21,6 @@ internal data class AllRulesConfig(
     override fun <T : Any> valueOrNull(key: String): T? {
         return when (key) {
             Config.ACTIVE_KEY -> originalConfig.valueOrNull(key) ?: true as? T
-            MAX_ISSUES_KEY -> originalConfig.valueOrNull(key) ?: 0 as? T
             else -> originalConfig.valueOrNull(key) ?: defaultConfig.valueOrNull(key)
         }
     }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/AllRulesConfig.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/AllRulesConfig.kt
@@ -3,11 +3,13 @@ package io.gitlab.arturbosch.detekt.core.config
 import io.gitlab.arturbosch.detekt.api.Config
 
 @Suppress("UNCHECKED_CAST")
-data class FailFastConfig(private val originalConfig: Config, private val defaultConfig: Config) :
-    Config, ValidatableConfiguration {
+internal data class AllRulesConfig(
+    private val originalConfig: Config,
+    private val defaultConfig: Config
+) : Config, ValidatableConfiguration {
 
     override fun subConfig(key: String) =
-        FailFastConfig(originalConfig.subConfig(key), defaultConfig.subConfig(key))
+        AllRulesConfig(originalConfig.subConfig(key), defaultConfig.subConfig(key))
 
     override fun <T : Any> valueOrDefault(key: String, default: T): T {
         return when (key) {

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/WorkaroundConfigurationKtSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/WorkaroundConfigurationKtSpec.kt
@@ -14,7 +14,7 @@ internal class WorkaroundConfigurationKtSpec : Spek({
         val config by memoized {
             ProcessingSpec {
                 config { resources = listOf(resourceUrl("/configs/empty.yml")) }
-                rules { activateExperimentalRules = true }
+                rules { activateAllRules = true }
             }.let { spec ->
                 spec.workaroundConfiguration(spec.loadConfiguration())
             }
@@ -44,7 +44,7 @@ internal class WorkaroundConfigurationKtSpec : Spek({
         val config by memoized {
             ProcessingSpec {
                 config { resources = listOf(resourceUrl("/configs/fail-fast-will-override-here.yml")) }
-                rules { activateExperimentalRules = true }
+                rules { activateAllRules = true }
             }.let { spec ->
                 spec.workaroundConfiguration(spec.loadConfiguration())
             }
@@ -117,7 +117,7 @@ internal class WorkaroundConfigurationKtSpec : Spek({
                 }
                 rules {
                     autoCorrect = false
-                    activateExperimentalRules = true
+                    activateAllRules = true
                 }
             }.let { spec ->
                 spec.workaroundConfiguration(spec.loadConfiguration())

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/ConfigurationsSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/ConfigurationsSpec.kt
@@ -76,7 +76,7 @@ internal class ConfigurationsSpec : Spek({
                     resources = listOf(resourceUrl("/configs/fail-fast-wont-override-here.yml"))
                     useDefaultConfig = true
                 }
-                rules { activateExperimentalRules = true }
+                rules { activateAllRules = true }
             }.loadConfiguration()
         }
 

--- a/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/api/spec/RulesSpec.kt
+++ b/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/api/spec/RulesSpec.kt
@@ -7,10 +7,8 @@ interface RulesSpec {
 
     /**
      * Activates all rules which do not have the active property set to 'true' by default.
-     *
-     * Also known as 'failFast' flag.
      */
-    val activateExperimentalRules: Boolean
+    val activateAllRules: Boolean
 
     /**
      * Sets the policy for allowed max issues found during the analysis.

--- a/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/dsl/RulesSpecBuilder.kt
+++ b/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/dsl/RulesSpecBuilder.kt
@@ -4,14 +4,14 @@ import io.github.detekt.tooling.api.spec.RulesSpec
 
 class RulesSpecBuilder : Builder<RulesSpec> {
 
-    var activateExperimentalRules: Boolean = false
+    var activateAllRules: Boolean = false
     var maxIssuePolicy: RulesSpec.MaxIssuePolicy = RulesSpec.MaxIssuePolicy.NoneAllowed
     var excludeCorrectable: Boolean = false
     var autoCorrect: Boolean = false
     var runPolicy: RulesSpec.RunPolicy = RulesSpec.RunPolicy.NoRestrictions
 
     override fun build(): RulesSpec = RulesModel(
-        activateExperimentalRules,
+        activateAllRules,
         maxIssuePolicy,
         excludeCorrectable,
         autoCorrect,
@@ -20,7 +20,7 @@ class RulesSpecBuilder : Builder<RulesSpec> {
 }
 
 private data class RulesModel(
-    override val activateExperimentalRules: Boolean,
+    override val activateAllRules: Boolean,
     override val maxIssuePolicy: RulesSpec.MaxIssuePolicy,
     override val excludeCorrectable: Boolean,
     override val autoCorrect: Boolean,


### PR DESCRIPTION
Part one to replace and deprecate `--fail-fast` in the long run - #2267

@BraisGabin @cortinico  I accidentally merged #3247 and needed to revert it. So this is the same as #3247.
Now really for 1.16.0.