### PR TITLE
Add DestructuringDeclarationWithTooManyEntries rule

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -524,6 +524,9 @@ style:
     conversionFunctionPrefix: 'to'
   DataClassShouldBeImmutable:
     active: false
+  DestructuringDeclarationWithTooManyEntries:
+    active: false
+    maxDestructuringEntries: 3
   EqualsNullCall:
     active: true
   EqualsOnSignatureLine:

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/DestructuringDeclarationWithTooManyEntries.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/DestructuringDeclarationWithTooManyEntries.kt
@@ -1,0 +1,49 @@
+package io.gitlab.arturbosch.detekt.rules.style
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import org.jetbrains.kotlin.psi.KtDestructuringDeclaration
+
+/**
+ * Destructuring declarations with too many entries are hard to read and understand.
+ * To increase readability they should be refactored to reduce the number of entries or avoid using a destructuring
+ * declaration.
+ *
+ * <noncompliant>
+ * data class TooManyElements(val a: Int, val b: Int, val c: Int, val d: Int)
+ * val (a, b, c, d) = TooManyElements(1, 2, 3, 4)
+ * </noncompliant>
+ * <compliant>
+ * data class FewerElements(val a: Int, val b: Int, val c: Int)
+ * val (a, b, c) = TooManyElements(1, 2, 3)
+ * </compliant>
+ *
+ * @configuration maxDestructuringEntries - maximum allowed elements in a destructuring declaration (default: `3`)
+ */
+class DestructuringDeclarationWithTooManyEntries(config: Config = Config.empty) : Rule(config) {
+    override val issue = Issue(
+        javaClass.simpleName,
+        Severity.Style,
+        "The destructuring declaration contains too many entries, making it difficult to read. Consider refactoring " +
+                "to avoid using a destructuring declaration for this case.",
+        Debt.TEN_MINS
+    )
+
+    private val maxDestructuringEntries = valueOrDefault(MAX_DESTRUCTURING_ENTRIES, 3)
+
+    override fun visitDestructuringDeclaration(destructuringDeclaration: KtDestructuringDeclaration) {
+        if (destructuringDeclaration.entries.size > maxDestructuringEntries) {
+            report(CodeSmell(issue, Entity.from(destructuringDeclaration), issue.description))
+        }
+        super.visitDestructuringDeclaration(destructuringDeclaration)
+    }
+
+    companion object {
+        const val MAX_DESTRUCTURING_ENTRIES = "maxDestructuringEntries"
+    }
+}

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/StyleGuideProvider.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/StyleGuideProvider.kt
@@ -25,6 +25,7 @@ class StyleGuideProvider : DefaultRuleSetProvider {
         listOf(
             ClassOrdering(config),
             CollapsibleIfStatements(config),
+            DestructuringDeclarationWithTooManyEntries(config),
             ReturnCount(config),
             ThrowsCount(config),
             NewLineAtEndOfFile(config),

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/DestructuringDeclarationWithTooManyEntriesSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/DestructuringDeclarationWithTooManyEntriesSpec.kt
@@ -1,0 +1,80 @@
+package io.gitlab.arturbosch.detekt.rules.style
+
+import io.gitlab.arturbosch.detekt.test.TestConfig
+import io.gitlab.arturbosch.detekt.test.lint
+import org.assertj.core.api.Assertions.assertThat
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+class DestructuringDeclarationWithTooManyEntriesSpec : Spek({
+    val subject by memoized { DestructuringDeclarationWithTooManyEntries() }
+
+    describe("DestructuringDeclarationWithTooManyEntries rule") {
+
+        context("default configuration") {
+
+            it("does not report destructuring declarations with 2 or 3 entries") {
+                val code = """
+                fun testFun() {
+                    val (x, y) = Pair(3, 4)
+                    println(x)
+                    println(y)
+                    
+                    val (a, b, c) = Triple(1, 2, 3)
+                    println(a)
+                    println(b)
+                    println(c)
+                }
+            """.trimIndent()
+                assertThat(subject.lint(code)).isEmpty()
+            }
+
+            it("reports destructuring declarations with more than 3 entries") {
+                val code = """
+                fun testFun() {
+                    data class ManyElements(val a: Int, val b: Int, val c: Int, val d: Int)
+
+                    val (a, b, c, d) = ManyElements(1, 2, 3, 4)
+                    println(a)
+                    println(b)
+                    println(c)
+                    println(d)
+                }
+            """.trimIndent()
+                assertThat(subject.lint(code)).hasSize(1)
+            }
+        }
+
+        context("maxDestructuringEntries = 2") {
+
+            val configuredRule by memoized {
+                DestructuringDeclarationWithTooManyEntries(
+                    TestConfig(mapOf(DestructuringDeclarationWithTooManyEntries.MAX_DESTRUCTURING_ENTRIES to "2"))
+                )
+            }
+
+            it("does not report destructuring declarations with 2 entries") {
+                val code = """
+                fun testFun() {
+                    val (x, y) = Pair(3, 4)
+                    println(x)
+                    println(y)
+                }
+            """.trimIndent()
+                assertThat(configuredRule.lint(code)).isEmpty()
+            }
+
+            it("reports destructuring declarations with more than 2 entries") {
+                val code = """
+                fun testFun() {
+                    val (a, b, c) = Triple(1, 2, 3)
+                    println(a)
+                    println(b)
+                    println(c)
+                }
+            """.trimIndent()
+                assertThat(configuredRule.lint(code)).hasSize(1)
+            }
+        }
+    }
+})

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/DestructuringDeclarationWithTooManyEntriesSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/DestructuringDeclarationWithTooManyEntriesSpec.kt
@@ -1,7 +1,7 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.test.TestConfig
-import io.gitlab.arturbosch.detekt.test.lint
+import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
@@ -26,7 +26,7 @@ class DestructuringDeclarationWithTooManyEntriesSpec : Spek({
                     println(c)
                 }
             """.trimIndent()
-                assertThat(subject.lint(code)).isEmpty()
+                assertThat(subject.compileAndLint(code)).isEmpty()
             }
 
             it("reports destructuring declarations with more than 3 entries") {
@@ -41,7 +41,38 @@ class DestructuringDeclarationWithTooManyEntriesSpec : Spek({
                     println(d)
                 }
             """.trimIndent()
-                assertThat(subject.lint(code)).hasSize(1)
+                assertThat(subject.compileAndLint(code)).hasSize(1)
+            }
+
+            it("does not report destructuring declarations in lambdas with 2 or 3 entries") {
+                val code = """
+                fun testFun() {
+                    val items = listOf(Pair(3, 4))
+
+                    items.forEach { (a, b) ->
+                        println(a)
+                        println(b)
+                    }
+                }
+            """.trimIndent()
+                assertThat(subject.compileAndLint(code)).isEmpty()
+            }
+
+            it("reports destructuring declarations in lambdas with more than 3 entries") {
+                val code = """
+                fun testFun() {
+                    data class ManyElements(val a: Int, val b: Int, val c: Int, val d: Int)
+
+                    val items = listOf(ManyElements(1, 2, 3, 4))
+                    items.forEach { (a, b, c, d) ->
+                        println(a)
+                        println(b)
+                        println(c)
+                        println(d)
+                    }
+                }
+            """.trimIndent()
+                assertThat(subject.compileAndLint(code)).hasSize(1)
             }
         }
 
@@ -61,7 +92,7 @@ class DestructuringDeclarationWithTooManyEntriesSpec : Spek({
                     println(y)
                 }
             """.trimIndent()
-                assertThat(configuredRule.lint(code)).isEmpty()
+                assertThat(configuredRule.compileAndLint(code)).isEmpty()
             }
 
             it("reports destructuring declarations with more than 2 entries") {
@@ -73,7 +104,7 @@ class DestructuringDeclarationWithTooManyEntriesSpec : Spek({
                     println(c)
                 }
             """.trimIndent()
-                assertThat(configuredRule.lint(code)).hasSize(1)
+                assertThat(configuredRule.compileAndLint(code)).hasSize(1)
             }
         }
     }


### PR DESCRIPTION
This rule checks for too many destructuring entries when using destructuring declarations. I've seen IntelliJ in the past recommend using destructuring on data classes with IMHO far too many fields, making the suggested code harder to understand. It's also [suggested by Kotlin's team](https://www.reddit.com/r/Kotlin/comments/ji9z19/kotlin_team_ama_2_ask_us_anything/ga5abq3/) that destructuring be used mostly for things like key/value pairs with only a very small number of elements.

The default maximum of 3 was chosen because it allows easy use of Kotlin stdlib `Pair` and `Triple`, and 4 seemed too many.

There weren't any violations in detekt's codebase when I was testing :)