### PR TITLE
Add ExitOutsideMain rule

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -463,6 +463,8 @@ potential-bugs:
     active: true
   EqualsWithHashCodeExist:
     active: true
+  ExitOutsideMain:
+    active: false
   ExplicitGarbageCollectionCall:
     active: true
   HasPlatformType:

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ExitOutsideMain.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ExitOutsideMain.kt
@@ -1,0 +1,70 @@
+package io.gitlab.arturbosch.detekt.rules.bugs
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.rules.isMainFunction
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
+import org.jetbrains.kotlin.resolve.BindingContext
+import org.jetbrains.kotlin.resolve.calls.callUtil.getResolvedCall
+import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameOrNull
+
+/**
+ * Flags use of System.exit() and Kotlin's exitProcess() when used outside of the `main` function. This makes code more
+ * difficult to test, causes unexpected behaviour on Android, and is a poor way to signal a failure in the program. In
+ * almost all cases it is more appropriate to throw an exception.
+ *
+ * <noncompliant>
+ * fun randomFunction() {
+ *   val result = doWork()
+ *   if (result == FAILURE) {
+ *     exitProcess(2)
+ *   } else {
+ *     exitProcess(0)
+ *   }
+ * }
+ * </noncompliant>
+ *
+ * <compliant>
+ * fun main() {
+ *   val result = doWork()
+ *   if (result == FAILURE) {
+ *     exitProcess(2)
+ *   } else {
+ *     exitProcess(0)
+ *   }
+ * }
+ * </compliant>
+ *
+ * @requiresTypeResolution
+ */
+
+class ExitOutsideMain(config: Config = Config.empty) : Rule(config) {
+
+    override val issue = Issue(
+        javaClass.simpleName,
+        Severity.Warning,
+        "Do not directly exit the process outside the `main` function. Throw an exception instead.",
+        Debt.TEN_MINS
+    )
+
+    override fun visitCallExpression(expression: KtCallExpression) {
+        if (context == BindingContext.EMPTY) return
+
+        if (expression.getStrictParentOfType<KtNamedFunction>()?.isMainFunction() == true) return
+        val fqName = expression.getResolvedCall(bindingContext)?.resultingDescriptor?.fqNameOrNull() ?: return
+
+        when (fqName.asString()) {
+            "kotlin.system.exitProcess" -> { report(CodeSmell(issue, Entity.from(expression), issue.description)) }
+            "java.lang.System.exit" -> { report(CodeSmell(issue, Entity.from(expression), issue.description)) }
+        }
+
+        super.visitCallExpression(expression)
+    }
+}

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ExitOutsideMain.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ExitOutsideMain.kt
@@ -44,7 +44,6 @@ import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameOrNull
  *
  * @requiresTypeResolution
  */
-
 class ExitOutsideMain(config: Config = Config.empty) : Rule(config) {
 
     override val issue = Issue(
@@ -54,17 +53,17 @@ class ExitOutsideMain(config: Config = Config.empty) : Rule(config) {
         Debt.TEN_MINS
     )
 
+    @Suppress("ReturnCount")
     override fun visitCallExpression(expression: KtCallExpression) {
+        super.visitCallExpression(expression)
+
         if (context == BindingContext.EMPTY) return
 
         if (expression.getStrictParentOfType<KtNamedFunction>()?.isMainFunction() == true) return
         val fqName = expression.getResolvedCall(bindingContext)?.resultingDescriptor?.fqNameOrNull() ?: return
 
-        when (fqName.asString()) {
-            "kotlin.system.exitProcess" -> { report(CodeSmell(issue, Entity.from(expression), issue.description)) }
-            "java.lang.System.exit" -> { report(CodeSmell(issue, Entity.from(expression), issue.description)) }
+        if (fqName.asString() in setOf("kotlin.system.exitProcess", "java.lang.System.exit")) {
+            report(CodeSmell(issue, Entity.from(expression), issue.description))
         }
-
-        super.visitCallExpression(expression)
     }
 }

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/PotentialBugProvider.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/PotentialBugProvider.kt
@@ -20,6 +20,7 @@ class PotentialBugProvider : DefaultRuleSetProvider {
             DuplicateCaseInWhenExpression(config),
             EqualsAlwaysReturnsTrueOrFalse(config),
             EqualsWithHashCodeExist(config),
+            ExitOutsideMain(config),
             ExplicitGarbageCollectionCall(config),
             HasPlatformType(config),
             ImplicitDefaultLocale(config),

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ExitOutsideMainSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ExitOutsideMainSpec.kt
@@ -1,0 +1,73 @@
+package io.gitlab.arturbosch.detekt.rules.bugs
+
+import io.gitlab.arturbosch.detekt.rules.setupKotlinEnvironment
+import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+object ExitOutsideMainSpec : Spek({
+    setupKotlinEnvironment()
+
+    val env: KotlinCoreEnvironment by memoized()
+    val subject by memoized { ExitOutsideMain() }
+
+    describe("ExitOutsideMainSpec rule") {
+
+        it("reports exitProcess used outside main()") {
+            val code = """
+                import kotlin.system.exitProcess
+                fun f() {
+                    exitProcess(0)
+                }"""
+            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        }
+
+        it("reports System.exit used outside main()") {
+            val code = """
+                fun f() {
+                    System.exit(0)
+                }"""
+            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        }
+
+        it("does not report exitProcess used in main()") {
+            val code = """
+                import kotlin.system.exitProcess
+                fun main() {
+                    exitProcess(0)
+                }"""
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        }
+
+        it("does not report System.exit used in main()") {
+            val code = """
+                fun main() {
+                    System.exit(0)
+                }"""
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        }
+
+        it("reports exitProcess used in nested function in main()") {
+            val code = """
+                import kotlin.system.exitProcess
+                fun main() {
+                    fun exit() {
+                        exitProcess(0)
+                    }
+                }"""
+            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        }
+
+        it("reports System.exit used in nested function in main()") {
+            val code = """
+                fun main() {
+                    fun exit() {
+                        System.exit(0)
+                    }
+                }"""
+            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        }
+    }
+})


### PR DESCRIPTION
A port of [Error Prone's SystemExitOutsideMain rule](http://errorprone.info/bugpattern/SystemExitOutsideMain).

The rule also flags usage of `System.exit` or `exitProcess` that are in `main` but in a nested function. It's debatable whether it makes sense to flag usage in the nested function since it's technically in the `main` function and maybe not really an issue. I'm looking for feedback on that. If the logic stays as originally submitted then I'll try and come up with a better name for the rule.