### PR TITLE
Add MultilineLambdaItParameter rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ If you contributed to detekt but your name is not in the list, please feel free 
 - [Marcelo Hernandez](https://github.com/mhernand40) - New rule: SuspendFunWithFlowReturnType
 - [Harold Martin](https://github.com/hbmartin) - Rule improvement: ClassOrdering
 - [Roman Ivanov](https://github.com/rwqwr) - Rule improvement: ReturnFromFinally
+- [Adam Kobor](https://github.com/adamkobor) - New rule: MultilineLambdaItParameter
 
 ### Mentions
 

--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -599,6 +599,8 @@ style:
     active: true
   ModifierOrder:
     active: true
+  MultilineLambdaItParameter:
+    active: false
   NestedClassesVisibility:
     active: false
   NewLineAtEndOfFile:

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MultilineLambdaItParameter.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MultilineLambdaItParameter.kt
@@ -13,34 +13,49 @@ import org.jetbrains.kotlin.psi.KtLambdaExpression
 /**
  * Lambda expressions are are very useful in a lot of cases and they often include very small chunks of
  * code using only one parameter. In this cases Kotlin can supply the implicit `it` parameter
- * to make code more concise. However, when you are dealing with multiline lambdas, you might end up with a code
- * that is hard to read if you don't specify the parameter name explicitly.
+ * to make code more concise. However, when you are dealing with lambdas that contain multiple statements,
+ * you might end up with a code that is hard to read if you don't specify the parameter name explicitly.
  *
  * <noncompliant>
  * val digits = 1234.let {
+ *   println(it)
  *   listOf(it)
  * }
  *
  * val digits = 1234.let { it ->
+ *   println(it)
  *   listOf(it)
  * }
  *
  * val flat = listOf(listOf(1), listOf(2)).mapIndexed { index, it ->
+ *   println(it)
  *   it + index
  * }
  * </noncompliant>
  *
  * <compliant>
  * val digits = 1234.let { explicitParameterName ->
+ *   println(explicitParameterName)
  *   listOf(explicitParameterName)
  * }
+ *
  * val lambda = { item: Int, that: String ->
+ *   println(item)
  *   item.toString() + that
  * }
  *
  * val digits = 1234.let { listOf(it) }
+ * val digits = 1234.let {
+ *   listOf(it)
+ * }
  * val digits = 1234.let { it -> listOf(it) }
+ * val digits = 1234.let { it ->
+ *   listOf(it)
+ * }
  * val digits = 1234.let { explicit -> listOf(explicit) }
+ * val digits = 1234.let { explicit ->
+ *   listOf(explicit)
+ * }
  * </compliant>
  */
 class MultilineLambdaItParameter(val config: Config) : Rule(config) {
@@ -52,12 +67,13 @@ class MultilineLambdaItParameter(val config: Config) : Rule(config) {
     override fun visitLambdaExpression(lambdaExpression: KtLambdaExpression) {
         super.visitLambdaExpression(lambdaExpression)
         val parameterNames = lambdaExpression.valueParameters.map { it.name }
-        val isMultiline = lambdaExpression.text.contains("\n")
-        if (isMultiline && (parameterNames.isEmpty() || IT_LITERAL in parameterNames)) {
+        val statementCount = lambdaExpression.bodyExpression?.statements?.size ?: 0
+        if (statementCount > 1 && (parameterNames.isEmpty() || IT_LITERAL in parameterNames)) {
             report(
                 CodeSmell(
                     issue, Entity.from(lambdaExpression),
-                    "The parameter name in a multiline lambda should not be an implicit/explicit `it`. Consider giving your parameter a name"
+                    "The parameter name in a multiline lambda should not be an implicit/explicit `it`. " +
+                            "Consider giving your parameter a name"
                 )
             )
         }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MultilineLambdaItParameter.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MultilineLambdaItParameter.kt
@@ -57,7 +57,7 @@ class MultilineLambdaItParameter(val config: Config) : Rule(config) {
             report(
                 CodeSmell(
                     issue, Entity.from(lambdaExpression),
-                    "The parameter name in a multiline lambda should not be an implicit/explicit `it`"
+                    "The parameter name in a multiline lambda should not be an implicit/explicit `it`. Consider giving your parameter a name"
                 )
             )
         }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MultilineLambdaItParameter.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MultilineLambdaItParameter.kt
@@ -1,0 +1,65 @@
+package io.gitlab.arturbosch.detekt.rules.style
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.rules.IT_LITERAL
+import org.jetbrains.kotlin.psi.KtLambdaExpression
+
+/**
+ * Lambda expressions are are very useful in a lot of cases and they often include very small chunks of
+ * code using only one parameter. In this cases Kotlin can supply the implicit `it` parameter
+ * to make code more concise. However, when you are dealing with multiline lambdas, you might end up with a code
+ * that is hard to read if you don't specify the parameter name explicitly.
+ *
+ * <noncompliant>
+ * val digits = 1234.let {
+ *   listOf(it)
+ * }
+ *
+ * val digits = 1234.let { it ->
+ *   listOf(it)
+ * }
+ *
+ * val flat = listOf(listOf(1), listOf(2)).mapIndexed { index, it ->
+ *   it + index
+ * }
+ * </noncompliant>
+ *
+ * <compliant>
+ * val digits = 1234.let { explicitParameterName ->
+ *   listOf(explicitParameterName)
+ * }
+ * val lambda = { item: Int, that: String ->
+ *   item.toString() + that
+ * }
+ *
+ * val digits = 1234.let { listOf(it) }
+ * val digits = 1234.let { it -> listOf(it) }
+ * val digits = 1234.let { explicit -> listOf(explicit) }
+ * </compliant>
+ */
+class MultilineLambdaItParameter(val config: Config) : Rule(config) {
+    override val issue = Issue(
+        javaClass.simpleName, Severity.Style,
+        "Multiline lambdas should not use `it` as a parameter name", Debt.FIVE_MINS
+    )
+
+    override fun visitLambdaExpression(lambdaExpression: KtLambdaExpression) {
+        super.visitLambdaExpression(lambdaExpression)
+        val parameterNames = lambdaExpression.valueParameters.map { it.name }
+        val isMultiline = lambdaExpression.text.contains("\n")
+        if (isMultiline && (parameterNames.isEmpty() || IT_LITERAL in parameterNames)) {
+            report(
+                CodeSmell(
+                    issue, Entity.from(lambdaExpression),
+                    "The parameter name in a multiline lambda should not be an implicit/explicit `it`"
+                )
+            )
+        }
+    }
+}

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MultilineLambdaItParameter.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MultilineLambdaItParameter.kt
@@ -11,10 +11,11 @@ import io.gitlab.arturbosch.detekt.rules.IT_LITERAL
 import org.jetbrains.kotlin.psi.KtLambdaExpression
 
 /**
- * Lambda expressions are are very useful in a lot of cases and they often include very small chunks of
+ * Lambda expressions are very useful in a lot of cases and they often include very small chunks of
  * code using only one parameter. In this cases Kotlin can supply the implicit `it` parameter
  * to make code more concise. However, when you are dealing with lambdas that contain multiple statements,
- * you might end up with a code that is hard to read if you don't specify the parameter name explicitly.
+ * you might end up with a code that is hard to read if you don't specify a readable, descriptive parameter name
+ * explicitly.
  *
  * <noncompliant>
  * val digits = 1234.let {
@@ -73,7 +74,7 @@ class MultilineLambdaItParameter(val config: Config) : Rule(config) {
                 CodeSmell(
                     issue, Entity.from(lambdaExpression),
                     "The parameter name in a multiline lambda should not be an implicit/explicit `it`. " +
-                            "Consider giving your parameter a name"
+                            "Consider giving your parameter a readable, descriptive name"
                 )
             )
         }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/StyleGuideProvider.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/StyleGuideProvider.kt
@@ -86,7 +86,8 @@ class StyleGuideProvider : DefaultRuleSetProvider {
             UseCheckNotNull(config),
             UseRequireNotNull(config),
             RedundantHigherOrderMapUsage(config),
-            UseIfEmptyOrIfBlank(config)
+            UseIfEmptyOrIfBlank(config),
+            MultilineLambdaItParameter(config)
         )
     )
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MultilineLambdaItParameterSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MultilineLambdaItParameterSpec.kt
@@ -1,0 +1,91 @@
+package io.gitlab.arturbosch.detekt.rules.style
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.test.compileAndLint
+import org.assertj.core.api.Assertions.assertThat
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+class MultilineLambdaItParameterSpec : Spek({
+    val subject by memoized { MultilineLambdaItParameter(Config.empty) }
+
+    describe("MultilineLambdaItParameter rule") {
+        context("single parameter, multiline lambda") {
+            it("reports when parameter name is implicit `it`") {
+                val findings = subject.compileAndLint(
+                    """
+                fun f() {
+                    val digits = 1234.let { 
+                        listOf(it)
+                    }
+                }""")
+                assertThat(findings).hasSize(1)
+            }
+            it("reports when parameter name is explicit `it`") {
+                val findings = subject.compileAndLint(
+                    """
+                fun f() {
+                    val digits = 1234.let { it ->
+                        listOf(it)
+                    }
+                }""")
+                assertThat(findings).hasSize(1)
+            }
+            it("does not report when parameter name is explicit and not `it`") {
+                val findings = subject.compileAndLint("""
+                fun f() {
+                    val digits = 1234.let { explicitParameterName ->
+                        listOf(explicitParameterName)
+                    }
+                }""")
+                assertThat(findings).hasSize(0)
+            }
+        }
+
+        context("single parameter, single-line lambda") {
+            it("does not report when parameter name is an implicit `it`") {
+                val findings = subject.compileAndLint(
+                    """
+                fun f() {
+                    val digits = 1234.let { listOf(it) }
+                }""")
+                assertThat(findings).hasSize(0)
+            }
+            it("does not report when parameter name is an explicit `it`") {
+                val findings = subject.compileAndLint("""
+                fun f() {
+                    val digits = 1234.let { it -> listOf(it) }
+                }""")
+                assertThat(findings).hasSize(0)
+            }
+            it("does not report when parameter name is explicit and not `it`") {
+                val findings = subject.compileAndLint("""
+                fun f() {
+                    val digits = 1234.let { explicit -> listOf(explicit) }
+                }""")
+                assertThat(findings).hasSize(0)
+            }
+        }
+
+        context("multiple parameters, multiline lambda") {
+            it("reports when one of the explicit parameters is an `it`") {
+                val findings = subject.compileAndLint("""
+                fun f() {
+                    val flat = listOf(listOf(1), listOf(2)).mapIndexed { index, it -> 
+                        it + index 
+                    }
+                }""")
+                assertThat(findings).hasSize(1)
+            }
+            it("does not report when none of the explicit parameters is an `it`") {
+                val findings = subject.compileAndLint("""
+                fun f() {
+                    val lambda = { item: Int, that: String -> 
+                        item.toString() + that 
+                    }
+                }""")
+                assertThat(findings).hasSize(0)
+            }
+        }
+    }
+})

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MultilineLambdaItParameterSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MultilineLambdaItParameterSpec.kt
@@ -42,7 +42,7 @@ class MultilineLambdaItParameterSpec : Spek({
                     }
                 }"""
                 val findings = subject.compileAndLint(code)
-                assertThat(findings).hasSize(0)
+                assertThat(findings).isEmpty()
             }
         }
 
@@ -55,7 +55,7 @@ class MultilineLambdaItParameterSpec : Spek({
                     }
                 }"""
                 val findings = subject.compileAndLint(code)
-                assertThat(findings).hasSize(0)
+                assertThat(findings).isEmpty()
             }
             it("does not report when parameter name is an explicit `it`") {
                 val code = """
@@ -65,7 +65,7 @@ class MultilineLambdaItParameterSpec : Spek({
                     }
                 }"""
                 val findings = subject.compileAndLint(code)
-                assertThat(findings).hasSize(0)
+                assertThat(findings).isEmpty()
             }
             it("does not report when parameter name is explicit and not `it`") {
                 val code = """
@@ -75,7 +75,7 @@ class MultilineLambdaItParameterSpec : Spek({
                     }
                 }"""
                 val findings = subject.compileAndLint(code)
-                assertThat(findings).hasSize(0)
+                assertThat(findings).isEmpty()
             }
         }
 
@@ -86,7 +86,7 @@ class MultilineLambdaItParameterSpec : Spek({
                     val digits = 1234.let { listOf(it) }
                 }"""
                 val findings = subject.compileAndLint(code)
-                assertThat(findings).hasSize(0)
+                assertThat(findings).isEmpty()
             }
             it("does not report when parameter name is an explicit `it`") {
                 val code = """
@@ -94,7 +94,7 @@ class MultilineLambdaItParameterSpec : Spek({
                     val digits = 1234.let { it -> listOf(it) }
                 }"""
                 val findings = subject.compileAndLint(code)
-                assertThat(findings).hasSize(0)
+                assertThat(findings).isEmpty()
             }
             it("does not report when parameter name is explicit and not `it`") {
                 val code = """
@@ -102,7 +102,7 @@ class MultilineLambdaItParameterSpec : Spek({
                     val digits = 1234.let { param -> listOf(param) }
                 }"""
                 val findings = subject.compileAndLint(code)
-                assertThat(findings).hasSize(0)
+                assertThat(findings).isEmpty()
             }
         }
 
@@ -127,7 +127,7 @@ class MultilineLambdaItParameterSpec : Spek({
                     }
                 }"""
                 val findings = subject.compileAndLint(code)
-                assertThat(findings).hasSize(0)
+                assertThat(findings).isEmpty()
             }
         }
     }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MultilineLambdaItParameterSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MultilineLambdaItParameterSpec.kt
@@ -10,80 +10,123 @@ class MultilineLambdaItParameterSpec : Spek({
     val subject by memoized { MultilineLambdaItParameter(Config.empty) }
 
     describe("MultilineLambdaItParameter rule") {
-        context("single parameter, multiline lambda") {
+        context("single parameter, multiline lambda with multiple statements") {
             it("reports when parameter name is implicit `it`") {
-                val findings = subject.compileAndLint(
-                    """
+                val code = """
+                fun f() {
+                    val digits = 1234.let { 
+                        listOf(it)
+                        println(it)
+                    }
+                }"""
+                val findings = subject.compileAndLint(code)
+                assertThat(findings).hasSize(1)
+            }
+            it("reports when parameter name is explicit `it`") {
+                val code = """
+                fun f() {
+                    val digits = 1234.let { it ->
+                        listOf(it)
+                        println(it)
+                    }
+                }"""
+                val findings = subject.compileAndLint(code)
+                assertThat(findings).hasSize(1)
+            }
+            it("does not report when parameter name is explicit and not `it`") {
+                val code = """
+                fun f() {
+                    val digits = 1234.let { param ->
+                        listOf(param)
+                        println(param)
+                    }
+                }"""
+                val findings = subject.compileAndLint(code)
+                assertThat(findings).hasSize(0)
+            }
+        }
+
+        context("single parameter, multiline lambda with a single statement") {
+            it("does not report when parameter name is an implicit `it`") {
+                val code = """
                 fun f() {
                     val digits = 1234.let { 
                         listOf(it)
                     }
-                }""")
-                assertThat(findings).hasSize(1)
+                }"""
+                val findings = subject.compileAndLint(code)
+                assertThat(findings).hasSize(0)
             }
-            it("reports when parameter name is explicit `it`") {
-                val findings = subject.compileAndLint(
-                    """
+            it("does not report when parameter name is an explicit `it`") {
+                val code = """
                 fun f() {
                     val digits = 1234.let { it ->
                         listOf(it)
                     }
-                }""")
-                assertThat(findings).hasSize(1)
+                }"""
+                val findings = subject.compileAndLint(code)
+                assertThat(findings).hasSize(0)
             }
             it("does not report when parameter name is explicit and not `it`") {
-                val findings = subject.compileAndLint("""
+                val code = """
                 fun f() {
-                    val digits = 1234.let { explicitParameterName ->
-                        listOf(explicitParameterName)
+                    val digits = 1234.let { param ->
+                        listOf(param)
                     }
-                }""")
+                }"""
+                val findings = subject.compileAndLint(code)
                 assertThat(findings).hasSize(0)
             }
         }
 
         context("single parameter, single-line lambda") {
             it("does not report when parameter name is an implicit `it`") {
-                val findings = subject.compileAndLint(
-                    """
+                val code = """
                 fun f() {
                     val digits = 1234.let { listOf(it) }
-                }""")
+                }"""
+                val findings = subject.compileAndLint(code)
                 assertThat(findings).hasSize(0)
             }
             it("does not report when parameter name is an explicit `it`") {
-                val findings = subject.compileAndLint("""
+                val code = """
                 fun f() {
                     val digits = 1234.let { it -> listOf(it) }
-                }""")
+                }"""
+                val findings = subject.compileAndLint(code)
                 assertThat(findings).hasSize(0)
             }
             it("does not report when parameter name is explicit and not `it`") {
-                val findings = subject.compileAndLint("""
+                val code = """
                 fun f() {
-                    val digits = 1234.let { explicit -> listOf(explicit) }
-                }""")
+                    val digits = 1234.let { param -> listOf(param) }
+                }"""
+                val findings = subject.compileAndLint(code)
                 assertThat(findings).hasSize(0)
             }
         }
 
         context("multiple parameters, multiline lambda") {
             it("reports when one of the explicit parameters is an `it`") {
-                val findings = subject.compileAndLint("""
+                val code = """
                 fun f() {
-                    val flat = listOf(listOf(1), listOf(2)).mapIndexed { index, it -> 
+                    val flat = listOf(listOf(1), listOf(2)).mapIndexed { index, it ->
+                        println(it)
                         it + index 
                     }
-                }""")
+                }"""
+                val findings = subject.compileAndLint(code)
                 assertThat(findings).hasSize(1)
             }
             it("does not report when none of the explicit parameters is an `it`") {
-                val findings = subject.compileAndLint("""
+                val code = """
                 fun f() {
                     val lambda = { item: Int, that: String -> 
+                        println(item)
                         item.toString() + that 
                     }
-                }""")
+                }"""
+                val findings = subject.compileAndLint(code)
                 assertThat(findings).hasSize(0)
             }
         }


### PR DESCRIPTION
This new rule checks if there is any multiline lambda with a parameter called `it` (whether it's an implicit or an explicit one, it doesn't matter).