### PR TITLE
Bundle new sarif output format by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ detekt {
         html.enabled = true // observe findings in your browser with structure and code snippets
         xml.enabled = true // checkstyle like format mainly for integrations like Jenkins
         txt.enabled = true // similar to the console output, contains issue signature to manually edit baseline files
+        sarif.enabled = true // SARIF integration (https://sarifweb.azurewebsites.net/) for integrations with Github
     }
 }
 
@@ -211,7 +212,7 @@ If you contributed to detekt but your name is not in the list, please feel free 
 - [Zachary Moore](https://github.com/zsmoore) - Rule, cli, gradle plugin, and config improvements
 - [Veyndan Stuart](https://github.com/veyndan) - New rule: UseEmptyCounterpart; Rule improvement: UselessCallOnNotNull
 - [Parimatch Tech](https://github.com/parimatchtech) - New rule: LibraryEntitiesShouldNotBePublic
-- [Chao Zhang](https://github.com/chao2zhang) - Rule improvement: ImplicitDefaultLocale, ModifierOrder, and LibraryCodeMustReturnSpecifyReturnType
+- [Chao Zhang](https://github.com/chao2zhang) - SARIF report format; Rule improvements
 - [Marcelo Hernandez](https://github.com/mhernand40) - New rule: SuspendFunWithFlowReturnType
 - [Harold Martin](https://github.com/hbmartin) - Rule improvement: ClassOrdering
 - [Roman Ivanov](https://github.com/rwqwr) - Rule improvement: ReturnFromFinally

--- a/config/detekt/argsfile
+++ b/config/detekt/argsfile
@@ -13,5 +13,7 @@ html:./build/detekt-report.html
 xml:./build/detekt-report.xml
 -r
 txt:./build/detekt-report.txt
+-r
+sarif:./build/detekt-report.sarif
 -p
 ./build/detekt-formatting.jar

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt
@@ -79,7 +79,7 @@ class CliArgs {
         names = ["--report", "-r"],
         description = "Generates a report for given 'report-id' and stores it on given 'path'. " +
             "Entry should consist of: [report-id:path]. " +
-            "Available 'report-id' values: 'txt', 'xml', 'html'. " +
+            "Available 'report-id' values: 'txt', 'xml', 'html', 'sarif'. " +
             "These can also be used in combination with each other " +
             "e.g. '-r txt:reports/detekt.txt -r xml:reports/detekt.xml'"
     )

--- a/detekt-core/build.gradle.kts
+++ b/detekt-core/build.gradle.kts
@@ -8,6 +8,7 @@ dependencies {
     implementation(project(":detekt-report-html"))
     implementation(project(":detekt-report-txt"))
     implementation(project(":detekt-report-xml"))
+    implementation(project(":detekt-report-sarif"))
 
     testImplementation(project(":detekt-rules"))
     testImplementation(project(":detekt-test"))

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/Reporting.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/Reporting.kt
@@ -1,6 +1,7 @@
 package io.gitlab.arturbosch.detekt.core.reporting
 
 import io.github.detekt.report.html.HtmlOutputReport
+import io.github.detekt.report.sarif.SarifOutputReport
 import io.github.detekt.report.txt.TxtOutputReport
 import io.github.detekt.report.xml.XmlOutputReport
 import io.gitlab.arturbosch.detekt.api.Config
@@ -15,6 +16,7 @@ internal fun defaultReportMapping(reportId: String) = when (reportId) {
     TxtOutputReport::class.java.simpleName -> "txt"
     XmlOutputReport::class.java.simpleName -> "xml"
     HtmlOutputReport::class.java.simpleName -> "html"
+    SarifOutputReport::class.java.simpleName -> "sarif"
     else -> reportId
 }
 

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -159,7 +159,7 @@ open class Detekt @Inject constructor(
     internal val sarifReportFile: Provider<RegularFile>
         @OutputFile
         @Optional
-        get() = getTargetFileProvider(reports.sarif)
+        get() = getTargetFileProvider(report = reports.sarif, defaultEnabledValue = false)
 
     internal val customReportFiles: ConfigurableFileCollection
         @OutputFiles
@@ -233,8 +233,11 @@ open class Detekt @Inject constructor(
         CustomReportArgument(reportId, objects.fileProperty().getOrElse { destination })
     }
 
-    private fun getTargetFileProvider(report: DetektReport): RegularFileProperty {
-        val isEnabled = report.enabled ?: DetektExtension.DEFAULT_REPORT_ENABLED_VALUE
+    private fun getTargetFileProvider(
+        report: DetektReport,
+        defaultEnabledValue: Boolean = DetektExtension.DEFAULT_REPORT_ENABLED_VALUE
+    ): RegularFileProperty {
+        val isEnabled = report.enabled ?: defaultEnabledValue
         val provider = objects.fileProperty()
         if (isEnabled) {
             val destination = report.destination ?: reportsDir.getOrElse(defaultReportsDir.asFile)

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -156,6 +156,11 @@ open class Detekt @Inject constructor(
         @Optional
         get() = getTargetFileProvider(reports.txt)
 
+    internal val sarifReportFile: Provider<RegularFile>
+        @OutputFile
+        @Optional
+        get() = getTargetFileProvider(reports.sarif)
+
     internal val customReportFiles: ConfigurableFileCollection
         @OutputFiles
         @Optional
@@ -196,6 +201,7 @@ open class Detekt @Inject constructor(
             DefaultReportArgument(DetektReportType.XML, xmlReportFile.orNull),
             DefaultReportArgument(DetektReportType.HTML, htmlReportFile.orNull),
             DefaultReportArgument(DetektReportType.TXT, txtReportFile.orNull),
+            DefaultReportArgument(DetektReportType.SARIF, sarifReportFile.orNull),
             DebugArgument(debugProp.getOrElse(false)),
             ParallelArgument(parallelProp.getOrElse(false)),
             BuildUponDefaultConfigArgument(buildUponDefaultConfigProp.getOrElse(false)),

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektReportType.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektReportType.kt
@@ -4,7 +4,8 @@ enum class DetektReportType(val reportId: String, val extension: String) {
 
     XML("xml", "xml"),
     HTML("html", "html"),
-    TXT("txt", "txt");
+    TXT("txt", "txt"),
+    SARIF("sarif", "sarif");
 
     companion object {
         fun isWellKnownReportId(reportId: String) = reportId in values().map(DetektReportType::reportId)

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektReports.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektReports.kt
@@ -4,8 +4,10 @@ import groovy.lang.Closure
 import io.gitlab.arturbosch.detekt.extensions.DetektReportType.HTML
 import io.gitlab.arturbosch.detekt.extensions.DetektReportType.TXT
 import io.gitlab.arturbosch.detekt.extensions.DetektReportType.XML
+import io.gitlab.arturbosch.detekt.extensions.DetektReportType.SARIF
 import org.gradle.util.ConfigureUtil
 
+@Suppress("TooManyFunctions")
 class DetektReports {
 
     val xml = DetektReport(XML)
@@ -13,6 +15,8 @@ class DetektReports {
     val html = DetektReport(HTML)
 
     val txt = DetektReport(TXT)
+
+    val sarif = DetektReport(SARIF)
 
     val custom = mutableListOf<CustomDetektReport>()
 
@@ -24,6 +28,9 @@ class DetektReports {
 
     fun txt(configure: DetektReport.() -> Unit) = txt.configure()
     fun txt(closure: Closure<*>): DetektReport = ConfigureUtil.configure(closure, txt)
+
+    fun sarif(configure: DetektReport.() -> Unit) = sarif.configure()
+    fun sarif(closure: Closure<*>): DetektReport = ConfigureUtil.configure(closure, sarif)
 
     fun custom(configure: CustomDetektReport.() -> Unit) = createAndAddCustomReport().configure()
     fun custom(closure: Closure<*>): CustomDetektReport = ConfigureUtil.configure(closure, createAndAddCustomReport())

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektAndroid.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektAndroid.kt
@@ -119,6 +119,7 @@ internal class DetektAndroid(private val project: Project) {
             reports.xml.setDefaultIfUnset(File(extension.reportsDir, variant.name + ".xml"))
             reports.html.setDefaultIfUnset(File(extension.reportsDir, variant.name + ".html"))
             reports.txt.setDefaultIfUnset(File(extension.reportsDir, variant.name + ".txt"))
+            reports.sarif.setDefaultIfUnset(File(extension.reportsDir, variant.name + ".sarif"))
             description = "EXPERIMENTAL: Run detekt analysis for ${variant.name} classes with type resolution"
         }
 

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektJvm.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektJvm.kt
@@ -34,6 +34,7 @@ internal class DetektJvm(private val project: Project) {
             reports.xml.setDefaultIfUnset(File(extension.reportsDir, sourceSet.name + ".xml"))
             reports.html.setDefaultIfUnset(File(extension.reportsDir, sourceSet.name + ".html"))
             reports.txt.setDefaultIfUnset(File(extension.reportsDir, sourceSet.name + ".txt"))
+            reports.sarif.setDefaultIfUnset(File(extension.reportsDir, sourceSet.name + ".sarif"))
             description = "EXPERIMENTAL: Run detekt analysis for ${sourceSet.name} classes with type resolution"
         }
     }

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskDslTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskDslTest.kt
@@ -42,6 +42,11 @@ internal object DetektTaskDslTest : Spek({
                         val textReportFile = gradleRunner.projectFile("build/reports/detekt/detekt.txt")
                         assertThat(result.output).contains("--report txt:$textReportFile")
                     }
+
+                    it("enables sarif report to default location") {
+                        val sarifReportFile = gradleRunner.projectFile("build/reports/detekt/detekt.sarif")
+                        assertThat(result.output).contains("--report sarif:$sarifReportFile")
+                    }
                 }
 
                 describe("without multiple detekt configs") {
@@ -154,6 +159,11 @@ internal object DetektTaskDslTest : Spek({
                         val textReportFile = gradleRunner.projectFile("build/detekt-reports/detekt.txt")
                         assertThat(result.output).contains("--report txt:$textReportFile")
                     }
+
+                    it("configures sarif report to custom directory") {
+                        val sarifReportFile = gradleRunner.projectFile("build/detekt-reports/detekt.sarif")
+                        assertThat(result.output).contains("--report sarif:$sarifReportFile")
+                    }
                 }
 
                 describe("with custom reports dir and custom report filename") {
@@ -203,6 +213,9 @@ internal object DetektTaskDslTest : Spek({
                         |            enabled = false
                         |        }
                         |        txt {
+                        |            enabled = false
+                        |        }
+                        |        sarif {
                         |            enabled = false
                         |        }
                         |    }
@@ -329,9 +342,9 @@ internal object DetektTaskDslTest : Spek({
                                         |detekt {
                                         |    reports {
                                         |        custom {
-                                        |           reportId = "${wellKnownType.reportId}"
-                                        |           destination = file("build/reports/custom.xml")
-                                        |       }
+                                        |            reportId = "${wellKnownType.reportId}"
+                                        |            destination = file("build/reports/custom.xml")
+                                        |        }
                                         |    }
                                         |}
                                         """
@@ -472,6 +485,7 @@ internal object DetektTaskDslTest : Spek({
                         |        }
                         |        html.destination = file("build/reports/failfast.html")
                         |        txt.destination = file("build/reports/failfast.txt")
+                        |        sarif.destination = file("build/reports/failfast.sarif")
                         |    }
                         |}
                         """
@@ -501,6 +515,11 @@ internal object DetektTaskDslTest : Spek({
                 it("enables text report to specified location") {
                     val textReportFile = gradleRunner.projectFile("build/reports/failfast.txt")
                     assertThat(result.output).contains("--report txt:$textReportFile")
+                }
+
+                it("enables sarif report to specified location") {
+                    val sarifReportFile = gradleRunner.projectFile("build/reports/failfast.sarif")
+                    assertThat(result.output).contains("--report sarif:$sarifReportFile")
                 }
 
                 it("sets absolute filename of both config file to detekt cli") {
@@ -548,6 +567,7 @@ internal object DetektTaskDslTest : Spek({
                         |        }
                         |        html.destination = file("build/reports/failfast.html")
                         |        txt.destination = file("build/reports/failfast.txt")
+                        |        sarif.destination = file("build/reports/failfast.sarif")
                         |    }
                         |}
                         """
@@ -577,6 +597,11 @@ internal object DetektTaskDslTest : Spek({
                 it("enables text report to specified location") {
                     val textReportFile = gradleRunner.projectFile("build/reports/failfast.txt")
                     assertThat(result.output).contains("--report txt:$textReportFile")
+                }
+
+                it("enables sarif report to specified location") {
+                    val sarifReportFile = gradleRunner.projectFile("build/reports/failfast.sarif")
+                    assertThat(result.output).contains("--report sarif:$sarifReportFile")
                 }
 
                 it("sets absolute filename of both config file to detekt cli") {

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskDslTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskDslTest.kt
@@ -43,9 +43,9 @@ internal object DetektTaskDslTest : Spek({
                         assertThat(result.output).contains("--report txt:$textReportFile")
                     }
 
-                    it("enables sarif report to default location") {
+                    it("disables sarif report to default location") {
                         val sarifReportFile = gradleRunner.projectFile("build/reports/detekt/detekt.sarif")
-                        assertThat(result.output).contains("--report sarif:$sarifReportFile")
+                        assertThat(result.output).doesNotContain("--report sarif:$sarifReportFile")
                     }
                 }
 
@@ -136,6 +136,11 @@ internal object DetektTaskDslTest : Spek({
                         val config = """
                         |detekt {
                         |    reportsDir = file("build/detekt-reports")
+                        |    reports {
+                        |        sarif {
+                        |            enabled = true
+                        |        }
+                        |    }
                         |}
                         """
 
@@ -485,7 +490,10 @@ internal object DetektTaskDslTest : Spek({
                         |        }
                         |        html.destination = file("build/reports/failfast.html")
                         |        txt.destination = file("build/reports/failfast.txt")
-                        |        sarif.destination = file("build/reports/failfast.sarif")
+                        |        sarif {
+                        |            enabled = true
+                        |            destination = file("build/reports/failfast.sarif")
+                        |        }
                         |    }
                         |}
                         """
@@ -567,7 +575,10 @@ internal object DetektTaskDslTest : Spek({
                         |        }
                         |        html.destination = file("build/reports/failfast.html")
                         |        txt.destination = file("build/reports/failfast.txt")
-                        |        sarif.destination = file("build/reports/failfast.sarif")
+                        |        sarif {
+                        |            enabled = true
+                        |            destination = file("build/reports/failfast.sarif")
+                        |        }
                         |    }
                         |}
                         """

--- a/docs/pages/configurations.md
+++ b/docs/pages/configurations.md
@@ -87,6 +87,7 @@ output-reports:
   #  - 'HtmlOutputReport'
   #  - 'TxtOutputReport'
   #  - 'XmlOutputReport'
+  #  - 'SarifOutputReport'
 ```
 
 **HtmlOutputReport** contains rule violations and metrics formatted in a human friendly way, so that it can be inspected in a web browser.
@@ -94,6 +95,8 @@ output-reports:
 **TxtOutputReport** contains rule violations in a plain text report similar to a log file.
 
 **XmlOutputReport** contains rule violations in an XML format. The report follows the structure of a [Checkstyle report](https://checkstyle.sourceforge.io).
+
+**SarifOutputReport** contains rule violations in the SARIF format. Please check [SARIF](https://sarifweb.azurewebsites.net/).
 
 Rule violations show the name of the violated rule and in which file the issue happened.
 The mentioned metrics show detailed statistics concerning the analyzed code.

--- a/docs/pages/gettingstarted/gradle.md
+++ b/docs/pages/gettingstarted/gradle.md
@@ -211,7 +211,7 @@ detekt {
             destination = file("build/reports/detekt.txt") // Path where TXT report will be stored (default: `build/reports/detekt/detekt.txt`)
         }
         sarif {
-            enabled = true                                // Enable/Disable SARIF report (default: true)
+            enabled = true                                // Enable/Disable SARIF report (default: false)
             destination = file("build/reports/detekt.sarif") // Path where SARIF report will be stored (default: `build/reports/detekt/detekt.sarif`)
         }
         custom {

--- a/docs/pages/gettingstarted/gradle.md
+++ b/docs/pages/gettingstarted/gradle.md
@@ -18,8 +18,8 @@ The detekt Gradle plugin will generate multiple tasks:
 
 - `detekt` - Runs a detekt analysis and complexity report on your source files. Configure the analysis inside the 
 `detekt` closure. By default the standard rule set without any ignore list is executed on sources files located
- in `src/main/java` and `src/main/kotlin`. Reports are automatically generated in xml, html and txt format and can be 
- found in `build/reports/detekt/detekt.[xml|html|txt]` respectively. Please note that the `detekt` task is automatically 
+ in `src/main/java` and `src/main/kotlin`. Reports are automatically generated in xml, html, txt, and sarif format and can be 
+ found in `build/reports/detekt/detekt.[xml|html|txt|sarif]` respectively. Please note that the `detekt` task is automatically 
  run when executing `gradle check`.
 - `detektGenerateConfig` - Generates a default detekt configuration file into your project directory.
 - `detektBaseline` - Similar to `detekt`, but creates a code smell baseline. Further detekt runs will only feature new smells not in this list.
@@ -209,6 +209,10 @@ detekt {
         txt {
             enabled = true                                // Enable/Disable TXT report (default: true)
             destination = file("build/reports/detekt.txt") // Path where TXT report will be stored (default: `build/reports/detekt/detekt.txt`)
+        }
+        sarif {
+            enabled = true                                // Enable/Disable SARIF report (default: true)
+            destination = file("build/reports/detekt.sarif") // Path where SARIF report will be stored (default: `build/reports/detekt/detekt.sarif`)
         }
         custom {
             reportId = "CustomJsonReport"                   // The simple class name of your custom report.


### PR DESCRIPTION
It is great to see that Detekt is adding support for SARIF #3045. As I was testing sarif with [Github code scanning](https://github.com/detekt/detekt/issues/3045), I found that there is a decent amount of working code but we cannot generate SARIF output yet.

This PR should be the final step to fully integrate with SARIF. I tested locally in [this repo](https://github.com/chao2zhang/DetektSarifTest) and verified that the generated SARIF output passed [the validation](https://sarifweb.azurewebsites.net/Validation).

I tried my best to update all places where report types appear but I may still miss a few.
This PR can also wait if we are planning to roll out SARIF in future versions of Detekt.