### PR TITLE
Add IntelliJ platform plugin template integration to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ Integrations:
 - [Codefactor](http://codefactor.io/)
 - [detekt-hint is a plugin to detekt that provides detection of design principle violations through integration with Danger](https://github.com/mkohm/detekt-hint)
 - [GitHub Action: Detekt All](https://github.com/marketplace/actions/detekt-all)
+- [IntelliJ Platform Plugin Template](https://github.com/JetBrains/intellij-platform-plugin-template)
 
 Custom rules from 3rd parties:
 


### PR DESCRIPTION
Detekt is part of the official JetBrains template for creating IntelliJ plugins.
