### PR TITLE
Fix ForbiddenComment rule not checking for KDoc

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -84,6 +84,7 @@ style:
   ForbiddenComment:
     active: true
     values: ['TODO:', 'FIXME:', 'STOPSHIP:', '@author']
+    excludes: ['**/detekt-rules-style/**/ForbiddenComment.kt']
   LibraryCodeMustSpecifyReturnType:
     active: true
     excludes: ['**/*.kt']

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenComment.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenComment.kt
@@ -1,6 +1,13 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
-import io.gitlab.arturbosch.detekt.api.*
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.LazyRegex
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.internal.valueOrDefaultCommaSeparated
 import org.jetbrains.kotlin.com.intellij.psi.PsiComment
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenComment.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenComment.kt
@@ -61,12 +61,8 @@ class ForbiddenComment(config: Config = Config.empty) : Rule(config) {
 
         values.forEach {
             if (text.contains(it, ignoreCase = true)) {
-                report(
-                    CodeSmell(
-                        issue, Entity.from(comment), "This comment contains text that has been " +
-                                "defined as forbidden in detekt."
-                    )
-                )
+                report(CodeSmell(issue, Entity.from(comment), "This comment contains text that has been " +
+                    "defined as forbidden in detekt."))
             }
         }
     }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenComment.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenComment.kt
@@ -61,7 +61,7 @@ class ForbiddenComment(config: Config = Config.empty) : Rule(config) {
 
         values.forEach {
             if (text.contains(it, ignoreCase = true)) {
-                report(CodeSmell(issue, Entity.from(comment), "This comment contains text that has been " +
+                report(CodeSmell(issue, Entity.from(comment), "This comment contains '$it' that has been " +
                     "defined as forbidden in detekt."))
             }
         }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenCommentSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenCommentSpec.kt
@@ -63,13 +63,17 @@ class ForbiddenCommentSpec : Spek({
 
             it("should report violation in KDoc") {
                 val code = """
-                    /*
+                    /**
                      * TODO: I need to fix this.
                      */
-                    class A
+                    class A {
+                        /**
+                         * TODO: I need to fix this.
+                         */
+                    }
                 """
                 val findings = ForbiddenComment().compileAndLint(code)
-                assertThat(findings).hasSize(1)
+                assertThat(findings).hasSize(2)
             }
         }
 


### PR DESCRIPTION
ForbiddenComment now analyzes KDoc elements for forbidden comments.
KDoc sections don't inherit from the PsiComment type.
Hence, this rule needs to also gather and analyze KDocSection types.

Fixes #3273
