### PR TITLE
Simplify ReturnFromFinally check for finally expressions

### DIFF
--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ReturnFromFinally.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ReturnFromFinally.kt
@@ -47,17 +47,6 @@ class ReturnFromFinally(config: Config = Config.empty) : Rule(config) {
 
     private val ignoreLabeled = valueOrDefault(IGNORE_LABELED, false)
 
-    override fun visitFinallySection(finallySection: KtFinallySection) {
-        if (bindingContext == BindingContext.EMPTY) return
-
-        finallySection.finalExpression
-            .collectDescendantsOfType<KtReturnExpression> { expression ->
-                isReturnFromTargetFunction(finallySection.finalExpression, expression) &&
-                        canFilterLabeledExpression(expression)
-            }
-            .forEach { report(CodeSmell(issue, Entity.from(it), issue.description)) }
-    }
-
     override fun visitTryExpression(expression: KtTryExpression) {
         super.visitTryExpression(expression)
         if (bindingContext == BindingContext.EMPTY) return
@@ -75,6 +64,13 @@ class ReturnFromFinally(config: Config = Config.empty) : Rule(config) {
                 )
             )
         }
+
+        finallyBlock.finalExpression
+            .collectDescendantsOfType<KtReturnExpression> { returnExpression ->
+                isReturnFromTargetFunction(finallyBlock.finalExpression, returnExpression) &&
+                        canFilterLabeledExpression(returnExpression)
+            }
+            .forEach { report(CodeSmell(issue, Entity.from(it), issue.description)) }
     }
 
     private fun isReturnFromTargetFunction(


### PR DESCRIPTION
The BindingContext does not need to be checked twice whether it is empty.
Visiting both the try block and corresponding finally block is unnecessary,
because the try block can navigate to the finally block.
