### PR TITLE
Upgrade ktlint to 0.40.0

### DIFF
--- a/detekt-bom/build.gradle.kts
+++ b/detekt-bom/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 dependencies {
     val version = object {
         val spek = "2.0.15"
-        val ktlint = "0.39.0"
+        val ktlint = "0.40.0"
     }
 
     constraints {

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/EditorConfigMerge.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/EditorConfigMerge.kt
@@ -3,13 +3,11 @@ package io.gitlab.arturbosch.detekt.formatting
 import com.pinterest.ktlint.core.EditorConfig
 
 /**
- * Creates new EditorConfig by copying the existing EditorConfig with properties values passed by parameters.
- * Values of properties passed by parameters are more important than properties in sourceEditorConfig.
+ * Creates a new [EditorConfig] by copying the existing [EditorConfig] and replacing or adding entries by [overrides].
  */
-fun EditorConfig?.copy(vararg overrides: Pair<String, Any>): EditorConfig {
-    val valuesToOverride = overrides.toMap()
+fun EditorConfig?.copy(overrides: Map<String, Any>): EditorConfig {
     val newValues = HashMap<String, String>()
-    knownEditorConfigProps.forEach { copyProperty(newValues, it, valuesToOverride[it], this) }
+    knownEditorConfigProps.forEach { copyProperty(newValues, it, overrides[it], this) }
     return EditorConfig.fromMap(newValues)
 }
 

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingRule.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingRule.kt
@@ -1,6 +1,5 @@
 package io.gitlab.arturbosch.detekt.formatting
 
-import com.pinterest.ktlint.core.EditorConfig
 import com.pinterest.ktlint.core.KtLint
 import io.github.detekt.psi.absolutePath
 import io.github.detekt.psi.fileName
@@ -15,6 +14,7 @@ import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.SingleAssign
 import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.api.TextLocation
+import org.ec4j.core.model.Property
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.lang.FileASTNode
 import org.jetbrains.kotlin.psi.KtFile
@@ -45,14 +45,25 @@ abstract class FormattingRule(config: Config) : Rule(config) {
         root.node.putUserData(KtLint.ANDROID_USER_DATA_KEY, isAndroid)
         positionByOffset = KtLintLineColCalculator
             .calculateLineColByOffset(KtLintLineColCalculator.normalizeText(root.text))
-        editorConfigUpdater()?.let { updateFunc ->
+        overrideEditorConfig()?.let { overrides ->
             val oldEditorConfig = root.node.getUserData(KtLint.EDITOR_CONFIG_USER_DATA_KEY)
-            root.node.putUserData(KtLint.EDITOR_CONFIG_USER_DATA_KEY, updateFunc(oldEditorConfig))
+            root.node.putUserData(KtLint.EDITOR_CONFIG_USER_DATA_KEY, oldEditorConfig.copy(overrides))
+        }
+        overrideEditorConfigProperties()?.let { overrides ->
+            val oldUserData = root.node.getUserData(KtLint.EDITOR_CONFIG_PROPERTIES_USER_DATA_KEY)
+            val newUserData = if (oldUserData != null) {
+                oldUserData + overrides
+            } else {
+                overrides
+            }
+            root.node.putUserData(KtLint.EDITOR_CONFIG_PROPERTIES_USER_DATA_KEY, newUserData)
         }
         root.node.putUserData(KtLint.FILE_PATH_USER_DATA_KEY, root.name)
     }
 
-    open fun editorConfigUpdater(): ((oldEditorConfig: EditorConfig?) -> EditorConfig)? = null
+    open fun overrideEditorConfig(): Map<String, Any>? = null
+
+    open fun overrideEditorConfigProperties(): Map<String, Property>? = null
 
     fun apply(node: ASTNode) {
         if (ruleShouldOnlyRunOnFileNode(node)) {

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/FinalNewline.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/FinalNewline.kt
@@ -1,11 +1,12 @@
 package io.gitlab.arturbosch.detekt.formatting.wrappers
 
-import com.pinterest.ktlint.core.EditorConfig
+import com.pinterest.ktlint.core.api.FeatureInAlphaState
 import com.pinterest.ktlint.ruleset.standard.FinalNewlineRule
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 import io.gitlab.arturbosch.detekt.formatting.INSERT_FINAL_NEWLINE_KEY
-import io.gitlab.arturbosch.detekt.formatting.copy
+import org.ec4j.core.model.Property
+import org.ec4j.core.model.PropertyType
 
 /**
  * See <a href="https://ktlint.github.io">ktlint-website</a> for documentation.
@@ -16,6 +17,7 @@ import io.gitlab.arturbosch.detekt.formatting.copy
  * @autoCorrect since v1.0.0
  *
  */
+@OptIn(FeatureInAlphaState::class)
 class FinalNewline(config: Config) : FormattingRule(config) {
 
     override val wrapping = FinalNewlineRule()
@@ -23,9 +25,13 @@ class FinalNewline(config: Config) : FormattingRule(config) {
 
     private val insertFinalNewline = valueOrDefault(INSERT_FINAL_NEWLINE, true)
 
-    override fun editorConfigUpdater(): ((oldEditorConfig: EditorConfig?) -> EditorConfig)? = {
-        it.copy(INSERT_FINAL_NEWLINE_KEY to insertFinalNewline)
-    }
+    // HACK! FinalNewlineRule.insertNewLineProperty is internal. Therefore we are building
+    // our custom Property to override the editor config properties.
+    // When FinalNewlineRule exits the alpha/beta state, hopefully we could remove this hack.
+    override fun overrideEditorConfigProperties() = mapOf(
+        INSERT_FINAL_NEWLINE_KEY to
+            Property.builder().type(PropertyType.insert_final_newline).value(insertFinalNewline.toString()).build()
+    )
 }
 
 const val INSERT_FINAL_NEWLINE = "insertFinalNewline"

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/ImportOrdering.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/ImportOrdering.kt
@@ -1,11 +1,11 @@
 package io.gitlab.arturbosch.detekt.formatting.wrappers
 
-import com.pinterest.ktlint.core.EditorConfig
+import com.pinterest.ktlint.core.api.FeatureInAlphaState
 import com.pinterest.ktlint.ruleset.standard.ImportOrderingRule
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 import io.gitlab.arturbosch.detekt.formatting.KOTLIN_IMPORTS_LAYOUT_KEY
-import io.gitlab.arturbosch.detekt.formatting.copy
+import org.ec4j.core.model.Property
 
 /**
  * See <a href="https://ktlint.github.io">ktlint-website</a> for documentation.
@@ -16,6 +16,7 @@ import io.gitlab.arturbosch.detekt.formatting.copy
  *
  * @autoCorrect since v1.0.0
  */
+@OptIn(FeatureInAlphaState::class)
 class ImportOrdering(config: Config) : FormattingRule(config) {
 
     override val wrapping = ImportOrderingRule()
@@ -25,8 +26,13 @@ class ImportOrdering(config: Config) : FormattingRule(config) {
 
     private fun chooseDefaultLayout() = if (isAndroid) ASCII else IDEA
 
-    override fun editorConfigUpdater(): ((oldEditorConfig: EditorConfig?) -> EditorConfig)? =
-        { it.copy(KOTLIN_IMPORTS_LAYOUT_KEY to layout) }
+    // HACK! ImportOrderingRule.ktlintCustomImportsLayoutProperty is internal. Therefore we are using
+    // ImportOrderingRule.editorConfigProperties.first() to access it.
+    // When FinalNewlineRule exits the alpha/beta state, hopefully we could remove this hack.
+    override fun overrideEditorConfigProperties() = mapOf(
+        KOTLIN_IMPORTS_LAYOUT_KEY to
+            Property.builder().type(wrapping.editorConfigProperties.first().type).value(layout).build()
+    )
 
     companion object {
         const val LAYOUT_PATTERN = "layout"

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/ImportOrdering.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/ImportOrdering.kt
@@ -28,7 +28,7 @@ class ImportOrdering(config: Config) : FormattingRule(config) {
 
     // HACK! ImportOrderingRule.ktlintCustomImportsLayoutProperty is internal. Therefore we are using
     // ImportOrderingRule.editorConfigProperties.first() to access it.
-    // When FinalNewlineRule exits the alpha/beta state, hopefully we could remove this hack.
+    // When ImportOrderingRule exits the alpha/beta state, hopefully we could remove this hack.
     override fun overrideEditorConfigProperties() = mapOf(
         KOTLIN_IMPORTS_LAYOUT_KEY to
             Property.builder().type(wrapping.editorConfigProperties.first().type).value(layout).build()

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/Indentation.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/Indentation.kt
@@ -1,6 +1,5 @@
 package io.gitlab.arturbosch.detekt.formatting.wrappers
 
-import com.pinterest.ktlint.core.EditorConfig
 import com.pinterest.ktlint.ruleset.standard.IndentationRule
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.formatting.CONTINUATION_INDENT_SIZE_KEY
@@ -8,7 +7,6 @@ import io.gitlab.arturbosch.detekt.formatting.DEFAULT_CONTINUATION_INDENT
 import io.gitlab.arturbosch.detekt.formatting.DEFAULT_INDENT
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 import io.gitlab.arturbosch.detekt.formatting.INDENT_SIZE_KEY
-import io.gitlab.arturbosch.detekt.formatting.copy
 
 /**
  * See <a href="https://ktlint.github.io/#rule-indentation">ktlint-website</a> for documentation.
@@ -26,11 +24,10 @@ class Indentation(config: Config) : FormattingRule(config) {
     private val indentSize = valueOrDefault(INDENT_SIZE, DEFAULT_INDENT)
     private val continuationIndentSize = valueOrDefault(CONTINUATION_INDENT_SIZE, DEFAULT_CONTINUATION_INDENT)
 
-    override fun editorConfigUpdater(): ((oldEditorConfig: EditorConfig?) -> EditorConfig)? = {
-        it.copy(
-            INDENT_SIZE_KEY to indentSize,
-            CONTINUATION_INDENT_SIZE_KEY to continuationIndentSize)
-    }
+    override fun overrideEditorConfig() = mapOf(
+        INDENT_SIZE_KEY to indentSize,
+        CONTINUATION_INDENT_SIZE_KEY to continuationIndentSize
+    )
 
     companion object {
         const val INDENT_SIZE = "indentSize"

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/MaximumLineLength.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/MaximumLineLength.kt
@@ -1,13 +1,11 @@
 package io.gitlab.arturbosch.detekt.formatting.wrappers
 
-import com.pinterest.ktlint.core.EditorConfig
 import com.pinterest.ktlint.ruleset.standard.MaxLineLengthRule
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.formatting.ANDROID_MAX_LINE_LENGTH
 import io.gitlab.arturbosch.detekt.formatting.DEFAULT_IDEA_LINE_LENGTH
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 import io.gitlab.arturbosch.detekt.formatting.MAX_LINE_LENGTH_KEY
-import io.gitlab.arturbosch.detekt.formatting.copy
 
 /**
  * See <a href="https://ktlint.github.io">ktlint-website</a> for documentation.
@@ -30,9 +28,7 @@ class MaximumLineLength(config: Config) : FormattingRule(config) {
 
     private val maxLineLength: Int = valueOrDefault(MAX_LINE_LENGTH, defaultMaxLineLength)
 
-    override fun editorConfigUpdater(): ((oldEditorConfig: EditorConfig?) -> EditorConfig)? = {
-        it.copy(MAX_LINE_LENGTH_KEY to maxLineLength)
-    }
+    override fun overrideEditorConfig() = mapOf(MAX_LINE_LENGTH_KEY to maxLineLength)
 
     companion object {
         const val MAX_LINE_LENGTH = "maxLineLength"

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/ParameterListWrapping.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/ParameterListWrapping.kt
@@ -1,12 +1,10 @@
 package io.gitlab.arturbosch.detekt.formatting.wrappers
 
-import com.pinterest.ktlint.core.EditorConfig
 import com.pinterest.ktlint.ruleset.standard.ParameterListWrappingRule
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.formatting.DEFAULT_INDENT
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 import io.gitlab.arturbosch.detekt.formatting.INDENT_SIZE_KEY
-import io.gitlab.arturbosch.detekt.formatting.copy
 
 /**
  * See <a href="https://ktlint.github.io">ktlint-website</a> for documentation.
@@ -23,9 +21,7 @@ class ParameterListWrapping(config: Config) : FormattingRule(config) {
 
     private val indentSize = valueOrDefault(INDENT_SIZE, DEFAULT_INDENT)
 
-    override fun editorConfigUpdater(): ((oldEditorConfig: EditorConfig?) -> EditorConfig)? = {
-        it.copy(INDENT_SIZE_KEY to indentSize)
-    }
+    override fun overrideEditorConfig() = mapOf(INDENT_SIZE_KEY to indentSize)
 
     companion object {
         const val INDENT_SIZE = "indentSize"


### PR DESCRIPTION
Motivation
=======
`Indentation` and `ParameterListWrapping` have had a regression since ktlint 0.37.0.  ParameterListWrapping was fixed in 0.39.0 and Indentation was fixed in 0.40.0. Therefore, bumping the versions will benefit the users who have either of these rules active.

Issue
====
https://github.com/pinterest/ktlint/pull/874 and https://github.com/pinterest/ktlint/pull/935 changed the implementation of `ImportOrdering` and `FinalNewLine` to use the new `EDITOR_CONFIG_PROPERTIES_USER_DATA_KEY`.

Some of the data structures are qualified with internal, but since those rules are set back to alpha state, I put comments next to the hack so that we can reevaluate detekt code when those ktlint rules become stable.

In addition, I refactored `overrideEditorConfig()` and `overrideEditorConfigProperties()` to simplify the code

Testing
====
Most of the testing is done by running detekt task in detekt repo itself.
- If there are detekt issues reported for Indentation or `ImportOrdering` which are not active in default-detekt-config.yml, the code is working.
- If there is any exception printed with stack trace, the code is breaking.

`ImportOrdering` and `FinalNewLine` also have sufficient test coverage, so no new tests are added.