### PR TITLE
Standardize "active" constant

### DIFF
--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/ConfigAware.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/ConfigAware.kt
@@ -45,7 +45,7 @@ interface ConfigAware : Config {
      * Is this rule specified as active in configuration?
      * If an rule is not specified in the underlying configuration, we assume it should not be run.
      */
-    val active: Boolean get() = valueOrDefault("active", false)
+    val active: Boolean get() = valueOrDefault(Config.ACTIVE_KEY, false)
 
     /**
      * If your rule supports to automatically correct the misbehaviour of underlying smell,

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/EmptyConfig.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/EmptyConfig.kt
@@ -11,7 +11,7 @@ internal object EmptyConfig : Config {
 
     @Suppress("UNCHECKED_CAST")
     override fun <T : Any> valueOrNull(key: String): T? = when (key) {
-        "active" -> true as? T
+        Config.ACTIVE_KEY -> true as? T
         else -> null
     }
 }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/FileProcessorLocator.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/FileProcessorLocator.kt
@@ -3,12 +3,13 @@ package io.gitlab.arturbosch.detekt.core
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.FileProcessListener
 import io.gitlab.arturbosch.detekt.core.extensions.loadExtensions
+import io.gitlab.arturbosch.detekt.core.rules.isActive
 
 class FileProcessorLocator(private val settings: ProcessingSettings) {
 
     private val config: Config = settings.config
     private val subConfig = config.subConfig("processors")
-    private val processorsActive = subConfig.valueOrDefault("active", true)
+    private val processorsActive = subConfig.isActive()
     private val excludes = subConfig.valueOrDefault("exclude", emptyList<String>())
 
     fun load(): List<FileProcessListener> {

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/FailFastConfig.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/FailFastConfig.kt
@@ -11,7 +11,7 @@ data class FailFastConfig(private val originalConfig: Config, private val defaul
 
     override fun <T : Any> valueOrDefault(key: String, default: T): T {
         return when (key) {
-            "active" -> originalConfig.valueOrDefault(key, true) as T
+            Config.ACTIVE_KEY -> originalConfig.valueOrDefault(key, true) as T
             "maxIssues" -> originalConfig.valueOrDefault(key, 0) as T
             else -> originalConfig.valueOrDefault(key, defaultConfig.valueOrDefault(key, default))
         }
@@ -19,7 +19,7 @@ data class FailFastConfig(private val originalConfig: Config, private val defaul
 
     override fun <T : Any> valueOrNull(key: String): T? {
         return when (key) {
-            "active" -> originalConfig.valueOrNull(key) ?: true as? T
+            Config.ACTIVE_KEY -> originalConfig.valueOrNull(key) ?: true as? T
             "maxIssues" -> originalConfig.valueOrNull(key) ?: 0 as? T
             else -> originalConfig.valueOrNull(key) ?: defaultConfig.valueOrNull(key)
         }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/ReportLocator.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/ReportLocator.kt
@@ -5,11 +5,12 @@ import io.gitlab.arturbosch.detekt.api.Extension
 import io.gitlab.arturbosch.detekt.api.OutputReport
 import io.gitlab.arturbosch.detekt.core.ProcessingSettings
 import io.gitlab.arturbosch.detekt.core.extensions.loadExtensions
+import io.gitlab.arturbosch.detekt.core.rules.isActive
 
 internal sealed class ReportLocator<T : Extension>(configKey: String, protected val settings: ProcessingSettings) {
 
     private val config = settings.config.subConfig(configKey)
-    private val isActive = config.valueOrDefault("active", true)
+    private val isActive = config.isActive()
     protected val excludes = config.valueOrDefault("exclude", emptyList<String>()).toSet()
 
     fun load(): List<T> {

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/rules/RuleSets.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/rules/RuleSets.kt
@@ -17,7 +17,7 @@ import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.resolve.BindingContext
 
 fun Config.isActive(): Boolean =
-    valueOrDefault("active", true)
+    valueOrDefault(Config.ACTIVE_KEY, true)
 
 fun Config.shouldAnalyzeFile(file: KtFile): Boolean {
     val filters = createPathFilters()

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/TestConfig.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/TestConfig.kt
@@ -12,14 +12,14 @@ open class TestConfig(
     override fun subConfig(key: String) = this
 
     override fun <T : Any> valueOrDefault(key: String, default: T) =
-        if (key == "active") {
+        if (key == Config.ACTIVE_KEY) {
             getActiveValue(default) as T
         } else {
             valueOrDefaultInternal(key, values[key], default, ::tryParseBasedOnDefaultRespectingCollections) as T
         }
 
     private fun <T : Any> getActiveValue(default: T): Any {
-        val active = values["active"]
+        val active = values[Config.ACTIVE_KEY]
         return if (active != null) {
             valueOrDefaultInternal("active", active, default, ::tryParseBasedOnDefaultRespectingCollections)
         } else {
@@ -28,7 +28,7 @@ open class TestConfig(
     }
 
     override fun <T : Any> valueOrNull(key: String): T? =
-        if (key == "active") (values["active"] ?: true) as T?
+        if (key == Config.ACTIVE_KEY) (values[Config.ACTIVE_KEY] ?: true) as T?
         else values[key] as? T
 
     private fun tryParseBasedOnDefaultRespectingCollections(result: String, defaultResult: Any): Any =


### PR DESCRIPTION
While working on #3274, I noticed that I cannot find the scope where I need to add `severity` as a universal config key.
So I created this PR to use Config.ACTIVE_KEY as the root. Please keep in mind that there are still "active" as the string literals not touched in this PR. Those appearances are primarily test code and website generation code.