### PR TITLE
Magic number extension functions

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -584,7 +584,7 @@ style:
     ignoreNamedArgument: true
     ignoreEnums: false
     ignoreRanges: false
-    ignoreExtensionFunctions: false
+    ignoreExtensionFunctions: true
   MandatoryBracesIfStatements:
     active: false
   MandatoryBracesLoops:

--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -584,6 +584,7 @@ style:
     ignoreNamedArgument: true
     ignoreEnums: false
     ignoreRanges: false
+    ignoreExtensionFunctions: false
   MandatoryBracesIfStatements:
     active: false
   MandatoryBracesLoops:

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumber.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumber.kt
@@ -198,9 +198,12 @@ class MagicNumber(config: Config = Config.empty) : Rule(config) {
     private fun KtConstantExpression.isPartOfRange(): Boolean {
         val theParent = parent
         val rangeOperators = setOf("downTo", "until", "step")
-        return if (theParent is KtBinaryExpression) theParent.operationToken == KtTokens.RANGE ||
-                theParent.operationReference.getReferencedName() in rangeOperators
-        else false
+        return if (theParent is KtBinaryExpression) {
+            theParent.operationToken == KtTokens.RANGE ||
+                    theParent.operationReference.getReferencedName() in rangeOperators
+        } else {
+            false
+        }
     }
 
     private fun KtConstantExpression.isPartOfHashCode(): Boolean {

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumber.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumber.kt
@@ -84,7 +84,7 @@ import java.util.Locale
  * @configuration ignoreEnums - whether magic numbers in enums should be ignored (default: `false`)
  * @configuration ignoreRanges - whether magic numbers in ranges should be ignored (default: `false`)
  * @configuration ignoreExtensionFunctions - whether magic numbers as subject of an extension function should be ignored
- * (default: `false`)
+ * (default: `true`)
  *
  * @active since v1.0.0
  */
@@ -111,7 +111,7 @@ class MagicNumber(config: Config = Config.empty) : Rule(config) {
     private val ignoreCompanionObjectPropertyDeclaration =
             valueOrDefault(IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION, true)
     private val ignoreRanges = valueOrDefault(IGNORE_RANGES, false)
-    private val ignoreExtensionFunctions = valueOrDefault(IGNORE_EXTENSION_FUNCTIONS, false)
+    private val ignoreExtensionFunctions = valueOrDefault(IGNORE_EXTENSION_FUNCTIONS, true)
 
     override fun visitConstantExpression(expression: KtConstantExpression) {
         val elementType = expression.elementType

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumberSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumberSpec.kt
@@ -779,5 +779,49 @@ class MagicNumberSpec : Spek({
                 assertThat(rule.compileAndLint("""fun bar() { val a = 3; foo(a) }; fun foo(n: Int) {}""")).isEmpty()
             }
         }
+
+        context("with extension function") {
+
+            val rule by memoized {
+                MagicNumber(
+                    TestConfig(
+                        mapOf(
+                            MagicNumber.IGNORE_EXTENSION_FUNCTIONS to "true"
+                        )
+                    )
+                )
+            }
+
+            it("should not report when function") {
+                val code = """
+                    fun Int.dp() = this + 1
+
+                    val a = 500.dp()
+                """
+
+                assertThat(rule.compileAndLint(code)).isEmpty()
+            }
+
+            it("should not report when property") {
+                val code = """
+                    val Int.dp: Int
+                      get() = this + 1
+
+                    val a = 500.dp
+                """
+
+                assertThat(rule.compileAndLint(code)).isEmpty()
+            }
+
+            it("should report the argument") {
+                val code = """
+                    fun Int.dp(a: Int) = this + a
+
+                    val a = 500.dp(400)
+                """
+
+                assertThat(rule.compileAndLint(code)).hasSize(1)
+            }
+        }
     }
 })


### PR DESCRIPTION
We should allow things like:
```kotlin
500.dp()
5.days
```
Because they are not magic numbers, they have units.

More about this in #3283

This PR adds a new flag to MagicNumber to allow this. Open questions:

- Should we enable this flag by default?
- Is `ignoreExtensionFunctions` a good name?