### PR TITLE
Remove exceptions of Library rules

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -553,7 +553,7 @@ style:
     active: false
     methods: ['kotlin.io.println', 'kotlin.io.print']
   ForbiddenPublicDataClass:
-    active: false
+    active: true
     excludes: ['**']
     ignorePackages: ['*.internal', '*.internal.*']
   ForbiddenVoid:
@@ -569,7 +569,7 @@ style:
     active: true
     excludes: ['**']
   LibraryEntitiesShouldNotBePublic:
-    active: false
+    active: true
     excludes: ['**']
   LoopWithTooManyJumpStatements:
     active: true

--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -554,6 +554,7 @@ style:
     methods: ['kotlin.io.println', 'kotlin.io.print']
   ForbiddenPublicDataClass:
     active: false
+    excludes: ['**']
     ignorePackages: ['*.internal', '*.internal.*']
   ForbiddenVoid:
     active: false
@@ -566,8 +567,10 @@ style:
     excludeAnnotatedFunction: ['dagger.Provides']
   LibraryCodeMustSpecifyReturnType:
     active: true
+    excludes: ['**']
   LibraryEntitiesShouldNotBePublic:
     active: false
+    excludes: ['**']
   LoopWithTooManyJumpStatements:
     active: true
     maxJumpCount: 1

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/rulesetpage/Exclusion.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/rulesetpage/Exclusion.kt
@@ -8,7 +8,7 @@ import io.gitlab.arturbosch.detekt.generator.collection.Rule
 val exclusions = arrayOf(TestExclusions, KotlinScriptExclusions)
 
 /**
- * Tracks rules and rule sets which needs an extra `exclusions: $pattern` property
+ * Tracks rules and rule sets which needs an extra `excludes: $pattern` property
  * when printing the default detekt config yaml file.
  */
 abstract class Exclusions {

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/rulesetpage/Exclusion.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/rulesetpage/Exclusion.kt
@@ -5,7 +5,7 @@ import io.gitlab.arturbosch.detekt.generator.collection.Rule
 /**
  * Holds a list of extra exclusions for rules and rule sets.
  */
-val exclusions = arrayOf(TestExclusions, KotlinScriptExclusions)
+val exclusions = arrayOf(TestExclusions, KotlinScriptExclusions, LibraryExclusions)
 
 /**
  * Tracks rules and rule sets which needs an extra `excludes: $pattern` property
@@ -45,4 +45,14 @@ private object KotlinScriptExclusions : Exclusions() {
 
     override val pattern = "['*.kts']"
     override val rules = setOf("InvalidPackageDeclaration")
+}
+
+private object LibraryExclusions : Exclusions() {
+
+    override val pattern = "['**']"
+    override val rules = setOf(
+        "ForbiddenPublicDataClass",
+        "LibraryCodeMustSpecifyReturnType",
+        "LibraryEntitiesShouldNotBePublic",
+    )
 }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenPublicDataClass.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenPublicDataClass.kt
@@ -11,7 +11,6 @@ import io.gitlab.arturbosch.detekt.api.internal.valueOrDefaultCommaSeparated
 import io.gitlab.arturbosch.detekt.api.simplePatternToRegex
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtClass
-import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.psiUtil.visibilityModifierTypeOrDefault
 
 /**
@@ -46,9 +45,6 @@ class ForbiddenPublicDataClass(config: Config = Config.empty) : Rule(config) {
         .distinct()
         .map { it.simplePatternToRegex() }
         .toList()
-
-    override fun visitCondition(root: KtFile): Boolean =
-        super.visitCondition(root) && filters != null
 
     override fun visitClass(klass: KtClass) {
         val packageName = klass.containingKtFile.packageDirective?.packageNameExpression?.text

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenPublicDataClass.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenPublicDataClass.kt
@@ -31,6 +31,7 @@ import org.jetbrains.kotlin.psi.psiUtil.visibilityModifierTypeOrDefault
  *
  * @configuration ignorePackages - ignores classes in the specified packages.
  * (default: `['*.internal', '*.internal.*']`)
+ * @active since v1.16.0
  */
 class ForbiddenPublicDataClass(config: Config = Config.empty) : Rule(config) {
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/LibraryCodeMustSpecifyReturnType.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/LibraryCodeMustSpecifyReturnType.kt
@@ -8,7 +8,6 @@ import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.psi.KtCallableDeclaration
-import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.KtProperty
 import org.jetbrains.kotlin.resolve.BindingContext
@@ -51,9 +50,6 @@ class LibraryCodeMustSpecifyReturnType(config: Config = Config.empty) : Rule(con
             "Inferred return type can easily be changed by mistake which may lead to breaking changes.",
         Debt.FIVE_MINS
     )
-
-    override fun visitCondition(root: KtFile): Boolean =
-        super.visitCondition(root) && filters != null
 
     override fun visitProperty(property: KtProperty) {
         if (bindingContext == BindingContext.EMPTY) {

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/LibraryEntitiesShouldNotBePublic.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/LibraryEntitiesShouldNotBePublic.kt
@@ -8,7 +8,6 @@ import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.psi.KtClass
-import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.KtTypeAlias
 import org.jetbrains.kotlin.psi.psiUtil.isPublic
@@ -36,8 +35,6 @@ class LibraryEntitiesShouldNotBePublic(ruleSetConfig: Config = Config.empty) : R
         "Library class should not be public",
         Debt.FIVE_MINS
     )
-
-    override fun visitCondition(root: KtFile): Boolean = super.visitCondition(root) && filters != null
 
     override fun visitClass(klass: KtClass) {
         if (klass.isInner()) {

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/LibraryEntitiesShouldNotBePublic.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/LibraryEntitiesShouldNotBePublic.kt
@@ -26,6 +26,7 @@ import org.jetbrains.kotlin.psi.psiUtil.isPublic
  * </compliant>
  *
  * @since 1.11.0
+ * @active since v1.16.0
  */
 class LibraryEntitiesShouldNotBePublic(ruleSetConfig: Config = Config.empty) : Rule(ruleSetConfig) {
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenPublicDataClassSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenPublicDataClassSpec.kt
@@ -14,11 +14,11 @@ class ForbiddenPublicDataClassSpec : Spek({
                 data class C(val a: String)                
             """
 
-            assertThat(ForbiddenPublicDataClass().compileAndLint(code)).isEmpty()
+            assertThat(ForbiddenPublicDataClass(TestConfig(Config.EXCLUDES_KEY to "**")).compileAndLint(code)).isEmpty()
         }
 
         val subject by memoized {
-            ForbiddenPublicDataClass(TestConfig(Config.INCLUDES_KEY to "*.kt"))
+            ForbiddenPublicDataClass()
         }
 
         it("public data class should fail") {
@@ -140,9 +140,7 @@ class ForbiddenPublicDataClassSpec : Spek({
                 data class C(val a: String)                
             """
 
-            val config = TestConfig(
-                "ignorePackages" to listOf("*.hello", "com.example"),
-                Config.INCLUDES_KEY to "*.kt")
+            val config = TestConfig("ignorePackages" to listOf("*.hello", "com.example"))
             assertThat(ForbiddenPublicDataClass(config).compileAndLint(code)).isEmpty()
         }
 
@@ -153,7 +151,7 @@ class ForbiddenPublicDataClassSpec : Spek({
                 data class C(val a: String)                
             """
 
-            val config = TestConfig("ignorePackages" to "*.hello,org.example", Config.INCLUDES_KEY to "*.kt")
+            val config = TestConfig("ignorePackages" to "*.hello,org.example")
             assertThat(ForbiddenPublicDataClass(config).compileAndLint(code)).isEmpty()
         }
     }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/LibraryCodeMustSpecifyReturnTypeSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/LibraryCodeMustSpecifyReturnTypeSpec.kt
@@ -18,7 +18,8 @@ internal class LibraryCodeMustSpecifyReturnTypeSpec : Spek({
     describe("library code must have explicit return types") {
 
         it("should not report without explicit filters set") {
-            assertThat(LibraryCodeMustSpecifyReturnType().compileAndLintWithContext(env, """
+            val subject = LibraryCodeMustSpecifyReturnType(TestConfig(Config.EXCLUDES_KEY to "**"))
+            assertThat(subject.compileAndLintWithContext(env, """
                 fun foo() = 5
                 val bar = 5
                 class A {
@@ -29,7 +30,7 @@ internal class LibraryCodeMustSpecifyReturnTypeSpec : Spek({
         }
 
         val subject by memoized {
-            LibraryCodeMustSpecifyReturnType(TestConfig(Config.INCLUDES_KEY to "*.kt"))
+            LibraryCodeMustSpecifyReturnType()
         }
 
         describe("positive cases") {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/LibraryEntitiesShouldNotBePublicTest.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/LibraryEntitiesShouldNotBePublicTest.kt
@@ -11,14 +11,15 @@ internal class LibraryEntitiesShouldNotBePublicTest : Spek({
 
     describe("Library class cannot be public") {
         it("should not report without explicit filters set") {
+            val subject = LibraryEntitiesShouldNotBePublic(TestConfig(Config.EXCLUDES_KEY to "**"))
             assertThat(
-                LibraryEntitiesShouldNotBePublic().compileAndLint("""
+                subject.compileAndLint("""
                     class A 
             """)).isEmpty()
         }
 
         val subject by memoized {
-            LibraryEntitiesShouldNotBePublic(TestConfig(Config.INCLUDES_KEY to "*.kt"))
+            LibraryEntitiesShouldNotBePublic()
         }
 
         describe("positive cases") {


### PR DESCRIPTION
We had this code to make our 3 library rules behave different. But our users don't understand that #3215.

With this PR I change those rules to behave as any other rule but changing their default configuration so the users can see what's going on.

This is an alternative implementation of #3279

I did disable the rule LibraryCodeMustSpecifyReturnType by default too.