### PR TITLE
Remove unnecessary .trimIndent() - housekeeping

### DIFF
--- a/custom-checks/src/test/kotlin/io/github/detekt/custom/SpekTestDiscoverySpec.kt
+++ b/custom-checks/src/test/kotlin/io/github/detekt/custom/SpekTestDiscoverySpec.kt
@@ -22,7 +22,7 @@ class SpekTestDiscoverySpec : Spek({
                     val s = "simple"
                     val p = Paths.get("")
                     val f = File("")
-                """.trimIndent())
+                """)
 
                 assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
             }
@@ -51,7 +51,7 @@ class SpekTestDiscoverySpec : Spek({
                             val f = File("")
                             val m by memoized { Any() }
                         }
-                    """.trimIndent())
+                    """)
 
                     assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
                 }
@@ -63,7 +63,7 @@ class SpekTestDiscoverySpec : Spek({
                         $name("group") {
                             val complex = Any()
                         }
-                    """.trimIndent())
+                    """)
 
                     assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
                 }
@@ -83,4 +83,4 @@ class Test : Spek({
         $content
     }
 })
-""".trimIndent()
+"""

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/FinalNewlineSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/FinalNewlineSpec.kt
@@ -14,7 +14,7 @@ class FinalNewlineSpec : Spek({
 
         it("should report missing new line by default") {
             val findings = FinalNewline(Config.empty)
-                .lint("fun main() = Unit".trimIndent())
+                .lint("fun main() = Unit")
 
             assertThat(findings).hasSize(1)
         }
@@ -23,7 +23,7 @@ class FinalNewlineSpec : Spek({
             val findings = FinalNewline(Config.empty).lint("""
                     fun main() = Unit
 
-            """.trimIndent())
+            """)
 
             assertThat(findings).isEmpty()
         }
@@ -33,14 +33,14 @@ class FinalNewlineSpec : Spek({
                 .lint("""
                 fun main() = Unit
 
-            """.trimIndent())
+            """)
 
             assertThat(findings).hasSize(1)
         }
 
         it("should not report when no new line is configured and not present") {
             val findings = FinalNewline(TestConfig(INSERT_FINAL_NEWLINE to "false"))
-                .lint("fun main() = Unit".trimIndent())
+                .lint("fun main() = Unit")
 
             assertThat(findings).isEmpty()
         }

--- a/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/CyclomaticComplexitySpec.kt
+++ b/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/CyclomaticComplexitySpec.kt
@@ -15,7 +15,7 @@ class CyclomaticComplexitySpec : Spek({
         it("counts for safe navigation") {
             val code = compileContentForTest("""
                     fun test() = null as? String ?: ""
-                """.trimIndent())
+                """)
 
             val actual = CyclomaticComplexity.calculate(code)
 
@@ -25,7 +25,7 @@ class CyclomaticComplexitySpec : Spek({
         it("counts if and && and || expressions") {
             val code = compileContentForTest("""
                     fun test() = if (true || true && false) 1 else 0
-                """.trimIndent())
+                """)
 
             val actual = CyclomaticComplexity.calculate(code)
 
@@ -47,7 +47,7 @@ class CyclomaticComplexitySpec : Spek({
                         }
                         println("finished")
                     }
-                """.trimIndent())
+                """)
 
             val actual = CyclomaticComplexity.calculate(code)
 
@@ -62,7 +62,7 @@ class CyclomaticComplexitySpec : Spek({
                     fun test(i: Int) {
                         (1..10).forEach { println(it) }
                     }
-                """.trimIndent()
+                """
             )
         }
 

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexMethodSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexMethodSpec.kt
@@ -26,7 +26,7 @@ class ComplexMethodSpec : Spek({
                         do {} while(true)
                         (1..10).forEach {}
                     }
-                """.trimIndent())
+                """)
 
                 assertThat(findings.first()).isThresholded().withValue(defaultComplexity + 4)
             }
@@ -36,7 +36,7 @@ class ComplexMethodSpec : Spek({
                     fun test() {
                         try {} catch(e: IllegalArgumentException) {} catch(e: Exception) {} finally {}
                     }
-                """.trimIndent())
+                """)
 
                 assertThat(findings.first()).isThresholded().withValue(defaultComplexity + 2)
             }
@@ -57,7 +57,7 @@ class ComplexMethodSpec : Spek({
                             // only catches count
                         }
                     }
-                """.trimIndent())
+                """)
 
                 assertThat(findings.first()).isThresholded().withValue(defaultComplexity + 4)
             }
@@ -70,7 +70,7 @@ class ComplexMethodSpec : Spek({
                         for (i in 1..10) {}
                         (1..10).forEach {}
                     }
-                """.trimIndent()
+                """
 
             it("counts three with nesting function 'forEach'") {
                 val config = TestConfig(mapOf(ComplexMethod.IGNORE_NESTING_FUNCTIONS to "false"))

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/AbsentOrWrongFileLicenseSpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/AbsentOrWrongFileLicenseSpec.kt
@@ -26,7 +26,7 @@ internal class AbsentOrWrongFileLicenseSpec : Spek({
                 val findings = checkLicence("""
                     /* LICENSE */
                     package cases
-                """.trimIndent())
+                """)
 
                 assertThat(findings).isEmpty()
             }
@@ -38,7 +38,7 @@ internal class AbsentOrWrongFileLicenseSpec : Spek({
                 val findings = checkLicence("""
                     /* WRONG LICENSE */
                     package cases
-                """.trimIndent())
+                """)
 
                 assertThat(findings).hasSize(1)
             }
@@ -49,7 +49,7 @@ internal class AbsentOrWrongFileLicenseSpec : Spek({
             it("reports missed license header") {
                 val findings = checkLicence("""
                     package cases
-                """.trimIndent())
+                """)
 
                 assertThat(findings).hasSize(1)
             }
@@ -59,7 +59,7 @@ internal class AbsentOrWrongFileLicenseSpec : Spek({
 
 @OptIn(UnstableApi::class)
 private fun checkLicence(content: String): List<Finding> {
-    val file = compileContentForTest(content)
+    val file = compileContentForTest(content.trimIndent())
 
     val resource = resourceAsPath("license-config.yml")
     val config = yamlConfig("license-config.yml")

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/InvalidPackageDeclarationSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/InvalidPackageDeclarationSpec.kt
@@ -36,11 +36,7 @@ internal class InvalidPackageDeclarationSpec : Spek({
         }
 
         it("should report if package declaration does not match source location") {
-            val source = """
-                package foo
-
-                class C
-            """.trimIndent()
+            val source = "package foo\n\nclass C"
 
             val ktFile = compileContentForTest(source, createPath("project/src/bar/File.kt"))
             val findings = InvalidPackageDeclaration().lint(ktFile)

--- a/detekt-rules-performance/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/SpreadOperatorSpec.kt
+++ b/detekt-rules-performance/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/SpreadOperatorSpec.kt
@@ -101,7 +101,7 @@ class SpreadOperatorSpec : Spek({
                     fun a(vararg bla: Int) { 
                         b(*bla) 
                     }
-                """.trimIndent()
+                """
                 assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
             }
 
@@ -113,7 +113,7 @@ class SpreadOperatorSpec : Spek({
                         val bla = arrayOf("")
                         b(*bla)
                     }
-                """.trimIndent()
+                """
                 assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
             }
         }
@@ -203,7 +203,7 @@ class SpreadOperatorSpec : Spek({
                     fun a(vararg bla: Int) { 
                         b(*bla)
                     }
-                """.trimIndent()
+                """
                 assertThat(subject.compileAndLint(code)).isEmpty()
             }
 
@@ -215,7 +215,7 @@ class SpreadOperatorSpec : Spek({
                         val bla = arrayOf("")
                         b(*bla)
                     }
-                """.trimIndent()
+                """
                 assertThat(subject.compileAndLint(code)).isEmpty()
             }
         }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ClassOrderingSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ClassOrderingSpec.kt
@@ -28,7 +28,7 @@ class ClassOrderingSpec : Spek({
                         const val IMPORTANT_VALUE = 3
                     }
                 }
-            """.trimIndent()
+            """
 
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
@@ -50,7 +50,7 @@ class ClassOrderingSpec : Spek({
                         const val IMPORTANT_VALUE = 3
                     }
                 }
-            """.trimIndent()
+            """
 
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
@@ -72,7 +72,7 @@ class ClassOrderingSpec : Spek({
                         const val IMPORTANT_VALUE = 3
                     }
                 }
-            """.trimIndent()
+            """
 
             val findings = subject.compileAndLint(code)
             assertThat(findings).hasSize(1)
@@ -97,7 +97,7 @@ class ClassOrderingSpec : Spek({
                         const val IMPORTANT_VALUE = 3
                     }
                 }
-            """.trimIndent()
+            """
 
             val findings = subject.compileAndLint(code)
             assertThat(findings).hasSize(1)
@@ -122,7 +122,7 @@ class ClassOrderingSpec : Spek({
                         const val IMPORTANT_VALUE = 3
                     }
                 }
-            """.trimIndent()
+            """
 
             val findings = subject.compileAndLint(code)
             assertThat(findings).hasSize(1)
@@ -146,7 +146,7 @@ class ClassOrderingSpec : Spek({
 
                     fun returnX() = x
                 }
-            """.trimIndent()
+            """
 
             val findings = subject.compileAndLint(code)
             assertThat(findings).hasSize(1)
@@ -170,7 +170,7 @@ class ClassOrderingSpec : Spek({
 
                     fun returnX() = x
                 }
-            """.trimIndent()
+            """
 
             assertThat(subject.compileAndLint(code)).hasSize(0)
         }
@@ -192,7 +192,7 @@ class ClassOrderingSpec : Spek({
 
                     fun returnX() = x
                 }
-            """.trimIndent()
+            """
 
             assertThat(subject.compileAndLint(code)).hasSize(0)
         }
@@ -210,7 +210,7 @@ class ClassOrderingSpec : Spek({
                     
                     val y = x
                 }
-            """.trimIndent()
+            """
 
             val findings = subject.compileAndLint(code)
             assertThat(findings).hasSize(3)

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/FunctionOnlyReturningConstantSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/FunctionOnlyReturningConstantSpec.kt
@@ -40,7 +40,7 @@ class FunctionOnlyReturningConstantSpec : Spek({
                     return "I am a constant"
                 }
             }
-        """.trimIndent()
+        """
 
         listOf(
             TestConfig(mapOf(FunctionOnlyReturningConstant.EXCLUDE_ANNOTATED_FUNCTION to "kotlin.SinceKotlin")),

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ModifierOrderSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ModifierOrderSpec.kt
@@ -117,7 +117,7 @@ class ModifierOrderSpec : Spek({
                     private fun interface LoadMoreCallback {
                         fun loadMore(): Boolean
                     }
-                """.trimIndent()
+                """
                 assertThat(subject.compileAndLint(code)).isEmpty()
             }
         }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCountSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCountSpec.kt
@@ -175,7 +175,7 @@ class ReturnCountSpec : Spek({
 
                     return
                 }
-            """.trimIndent()
+            """
 
             it("should not count all four guard clauses") {
                 val findings = ReturnCount(TestConfig(

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseArrayLiteralsInAnnotationsSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseArrayLiteralsInAnnotationsSpec.kt
@@ -16,7 +16,7 @@ class UseArrayLiteralsInAnnotationsSpec : Spek({
             annotation class Test(val values: Array<String>)
             @Test(arrayOf("value"))
             fun test() = Unit
-        """.trimIndent())
+        """)
 
             assertThat(findings).hasSize(1)
         }
@@ -26,7 +26,7 @@ class UseArrayLiteralsInAnnotationsSpec : Spek({
             annotation class Test(val values: Array<String>)
             @Test(["value"])
             fun test() = Unit
-        """.trimIndent())
+        """)
 
             assertThat(findings).isEmpty()
         }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseDataClassSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseDataClassSpec.kt
@@ -96,7 +96,7 @@ class UseDataClassSpec : Spek({
                     class NotDataClassBecauseItsImplementingInterfaceWithMethods(val i : Int): SomeInterface {
                         override fun foo() = i
                     }
-                """.trimIndent()
+                """
 
                 assertThat(subject.compileAndLint(code)).isEmpty()
             }
@@ -108,7 +108,7 @@ class UseDataClassSpec : Spek({
                     }
                     
                     data class DataClass(override val i: Int): SimpleInterface
-                """.trimIndent()
+                """
 
                 assertThat(subject.compileAndLint(code)).isEmpty()
             }
@@ -122,7 +122,7 @@ class UseDataClassSpec : Spek({
                     open class BaseClass(open val j: Int)
                     
                     class DataClass(override val i: Int, override val j: Int): SimpleInterface, BaseClass(j)
-                """.trimIndent()
+                """
 
                 assertThat(subject.compileAndLint(code)).isEmpty()
             }
@@ -132,7 +132,7 @@ class UseDataClassSpec : Spek({
                     interface I
                     class B() : I
                     class A(val b: B) : I by b
-                """.trimIndent()
+                """
 
                 assertThat(subject.compileAndLint(code)).isEmpty()
             }
@@ -195,7 +195,7 @@ class UseDataClassSpec : Spek({
                 val code = """
                     interface SimpleInterface
                     class DataClass(val i: Int): SimpleInterface
-                """.trimIndent()
+                """
 
                 assertThat(subject.compileAndLint(code)).hasSize(1)
             }
@@ -207,7 +207,7 @@ class UseDataClassSpec : Spek({
                     }
                     
                     class DataClass(override val i: Int): SimpleInterface
-                """.trimIndent()
+                """
 
                 assertThat(subject.compileAndLint(code)).hasSize(1)
             }


### PR DESCRIPTION
This statement only added noise to the test specification.
