### PR TITLE
Allow to overwrite in the task moveJarForIntegrationTest

### DIFF
--- a/detekt-formatting/build.gradle.kts
+++ b/detekt-formatting/build.gradle.kts
@@ -36,6 +36,6 @@ val moveJarForIntegrationTest by tasks.registering {
     outputs.file(rootProject.buildDir.resolve("detekt-formatting.jar"))
 
     doLast {
-        inputs.files.singleFile.copyTo(outputs.files.singleFile)
+        inputs.files.singleFile.copyTo(outputs.files.singleFile, overwrite = true)
     }
 }


### PR DESCRIPTION
Right now we can't run the task `moveJarForIntegrationTest` multiple times. Usually this is not a problem because you will not change the input so it only runs once.