### PR TITLE
Don't mix kotlin 1.3 and 1.4

### DIFF
--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -15,6 +15,12 @@ dependencies {
     testImplementation(project(":detekt-test-utils"))
     testImplementation(kotlin("gradle-plugin"))
     testImplementation(androidGradlePlugin)
+
+    constraints {
+        implementation("org.jetbrains.kotlin:kotlin-reflect:1.4.0") {
+            because("com.android.tools.build:gradle:4.0.1 depends on Kotlin 1.3.72 and we should not mix 1.3 and 1.4")
+        }
+    }
 }
 
 gradlePlugin {


### PR DESCRIPTION
`com.android.tools.build:gradle:4.0.1` uses kotlin-reflect. And it uses the version 1.3.72. We should not mix kotlin-reflect 1.3 and kotlin-reflect 1.4.

With this constraint we force kotlin-reflect to update.

We should remove this constraint as soon as we update to a version of `com.android.tools.build:gradle` that uses kotlin 1.4

This change does little change until we update to gradle 6.8 because we still have the warning but it's a step in the right direction.