### PR TITLE
Support configurable severity per ruleset/rule in XML and Sarif output

### DIFF
--- a/detekt-api/api/detekt-api.api
+++ b/detekt-api/api/detekt-api.api
@@ -18,6 +18,7 @@ public class io/gitlab/arturbosch/detekt/api/CodeSmell : io/gitlab/arturbosch/de
 	public fun getMessage ()Ljava/lang/String;
 	public fun getMetrics ()Ljava/util/List;
 	public fun getReferences ()Ljava/util/List;
+	public fun getSeverity ()Lio/gitlab/arturbosch/detekt/api/SeverityLevel;
 	public fun getSignature ()Ljava/lang/String;
 	public fun getStartPosition ()Lio/gitlab/arturbosch/detekt/api/SourceLocation;
 	public fun messageOrDescription ()Ljava/lang/String;
@@ -41,6 +42,7 @@ public abstract interface class io/gitlab/arturbosch/detekt/api/Config {
 	public static final field Companion Lio/gitlab/arturbosch/detekt/api/Config$Companion;
 	public static final field EXCLUDES_KEY Ljava/lang/String;
 	public static final field INCLUDES_KEY Ljava/lang/String;
+	public static final field SEVERITY_KEY Ljava/lang/String;
 	public abstract fun getParentPath ()Ljava/lang/String;
 	public abstract fun subConfig (Ljava/lang/String;)Lio/gitlab/arturbosch/detekt/api/Config;
 	public abstract fun valueOrDefault (Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/Object;
@@ -53,6 +55,7 @@ public final class io/gitlab/arturbosch/detekt/api/Config$Companion {
 	public static final field CONFIG_SEPARATOR Ljava/lang/String;
 	public static final field EXCLUDES_KEY Ljava/lang/String;
 	public static final field INCLUDES_KEY Ljava/lang/String;
+	public static final field SEVERITY_KEY Ljava/lang/String;
 	public final fun getEmpty ()Lio/gitlab/arturbosch/detekt/api/Config;
 	public final fun getPRIMITIVES ()Ljava/util/Set;
 }
@@ -251,6 +254,7 @@ public abstract interface class io/gitlab/arturbosch/detekt/api/Finding : io/git
 	public abstract fun getIssue ()Lio/gitlab/arturbosch/detekt/api/Issue;
 	public abstract fun getMessage ()Ljava/lang/String;
 	public abstract fun getReferences ()Ljava/util/List;
+	public abstract fun getSeverity ()Lio/gitlab/arturbosch/detekt/api/SeverityLevel;
 	public abstract fun messageOrDescription ()Ljava/lang/String;
 }
 
@@ -259,6 +263,7 @@ public final class io/gitlab/arturbosch/detekt/api/Finding$DefaultImpls {
 	public static fun getCharPosition (Lio/gitlab/arturbosch/detekt/api/Finding;)Lio/gitlab/arturbosch/detekt/api/TextLocation;
 	public static fun getFile (Lio/gitlab/arturbosch/detekt/api/Finding;)Ljava/lang/String;
 	public static fun getLocation (Lio/gitlab/arturbosch/detekt/api/Finding;)Lio/gitlab/arturbosch/detekt/api/Location;
+	public static fun getSeverity (Lio/gitlab/arturbosch/detekt/api/Finding;)Lio/gitlab/arturbosch/detekt/api/SeverityLevel;
 	public static fun getSignature (Lio/gitlab/arturbosch/detekt/api/Finding;)Ljava/lang/String;
 	public static fun getStartPosition (Lio/gitlab/arturbosch/detekt/api/Finding;)Lio/gitlab/arturbosch/detekt/api/SourceLocation;
 	public static fun metricByType (Lio/gitlab/arturbosch/detekt/api/Finding;Ljava/lang/String;)Lio/gitlab/arturbosch/detekt/api/Metric;
@@ -495,6 +500,14 @@ public final class io/gitlab/arturbosch/detekt/api/Severity : java/lang/Enum {
 	public static final field Warning Lio/gitlab/arturbosch/detekt/api/Severity;
 	public static fun valueOf (Ljava/lang/String;)Lio/gitlab/arturbosch/detekt/api/Severity;
 	public static fun values ()[Lio/gitlab/arturbosch/detekt/api/Severity;
+}
+
+public final class io/gitlab/arturbosch/detekt/api/SeverityLevel : java/lang/Enum {
+	public static final field ERROR Lio/gitlab/arturbosch/detekt/api/SeverityLevel;
+	public static final field INFO Lio/gitlab/arturbosch/detekt/api/SeverityLevel;
+	public static final field WARNING Lio/gitlab/arturbosch/detekt/api/SeverityLevel;
+	public static fun valueOf (Ljava/lang/String;)Lio/gitlab/arturbosch/detekt/api/SeverityLevel;
+	public static fun values ()[Lio/gitlab/arturbosch/detekt/api/SeverityLevel;
 }
 
 public final class io/gitlab/arturbosch/detekt/api/SingleAssign {

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/CodeSmell.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/CodeSmell.kt
@@ -15,17 +15,12 @@ open class CodeSmell(
     override val entity: Entity,
     override val message: String,
     override val metrics: List<Metric> = listOf(),
-    override val references: List<Entity> = listOf(),
-    override val severity: SeverityLevel = SeverityLevel.WARNING
+    override val references: List<Entity> = listOf()
 ) : Finding {
 
-    constructor(
-        issue: Issue,
-        entity: Entity,
-        message: String,
-        metrics: List<Metric> = listOf(),
-        references: List<Entity> = listOf()
-    ) : this(issue, entity, message, metrics, references, SeverityLevel.WARNING)
+    internal var internalSeverity: SeverityLevel = SeverityLevel.WARNING
+    override val severity
+        get() = internalSeverity
 
     override val id: String = issue.id
 
@@ -44,20 +39,6 @@ open class CodeSmell(
     }
 
     override fun messageOrDescription(): String = if (message.isEmpty()) issue.description else message
-
-    /**
-     * Create a new copy of [CodeSmell] with specified [severity].
-     */
-    override fun copyWithSeverity(severity: SeverityLevel): Finding {
-        return CodeSmell(
-            issue = this.issue,
-            entity = this.entity,
-            message = this.message,
-            metrics = this.metrics,
-            references = this.references,
-            severity = severity
-        )
-    }
 }
 
 /**
@@ -65,32 +46,20 @@ open class CodeSmell(
  *
  * @see CodeSmell
  */
-@Suppress("LongParameterList")
 open class CorrectableCodeSmell(
     issue: Issue,
     entity: Entity,
     message: String,
     metrics: List<Metric> = listOf(),
     references: List<Entity> = listOf(),
-    val autoCorrectEnabled: Boolean,
-    severity: SeverityLevel = SeverityLevel.WARNING
+    val autoCorrectEnabled: Boolean
 ) : CodeSmell(
     issue = issue,
     entity = entity,
     message = message,
     metrics = metrics,
-    references = references,
-    severity = severity
+    references = references
 ) {
-
-    constructor(
-        issue: Issue,
-        entity: Entity,
-        message: String,
-        metrics: List<Metric> = listOf(),
-        references: List<Entity> = listOf(),
-        autoCorrectEnabled: Boolean
-    ) : this(issue, entity, message, metrics, references, autoCorrectEnabled, SeverityLevel.WARNING)
 
     override fun toString(): String {
         return "CorrectableCodeSmell(" +
@@ -102,18 +71,6 @@ open class CorrectableCodeSmell(
             "references=$references, " +
             "severity=$severity, " +
             "id='$id')"
-    }
-
-    override fun copyWithSeverity(severity: SeverityLevel): Finding {
-        return CorrectableCodeSmell(
-            issue = this.issue,
-            entity = this.entity,
-            message = this.message,
-            metrics = this.metrics,
-            references = this.references,
-            autoCorrectEnabled = this.autoCorrectEnabled,
-            severity = severity
-        )
     }
 }
 
@@ -129,23 +86,13 @@ open class ThresholdedCodeSmell(
     val metric: Metric,
     message: String,
     references: List<Entity> = emptyList(),
-    severity: SeverityLevel = SeverityLevel.WARNING
 ) : CodeSmell(
     issue = issue,
     entity = entity,
     message = message,
     metrics = listOf(metric),
     references = references,
-    severity = severity
 ) {
-
-    constructor(
-        issue: Issue,
-        entity: Entity,
-        metric: Metric,
-        message: String,
-        references: List<Entity> = listOf()
-    ) : this(issue, entity, metric, message, references, SeverityLevel.WARNING)
 
     val value: Int
         get() = metric.value
@@ -155,15 +102,4 @@ open class ThresholdedCodeSmell(
     override fun compact(): String = "$id - $metric - ${entity.compact()}"
 
     override fun messageOrDescription(): String = if (message.isEmpty()) issue.description else message
-
-    override fun copyWithSeverity(severity: SeverityLevel): Finding {
-        return ThresholdedCodeSmell(
-            issue = this.issue,
-            entity = this.entity,
-            metric = this.metric,
-            message = this.message,
-            references = this.references,
-            severity = severity
-        )
-    }
 }

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/CodeSmell.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/CodeSmell.kt
@@ -54,13 +54,12 @@ open class CorrectableCodeSmell(
     references: List<Entity> = listOf(),
     val autoCorrectEnabled: Boolean
 ) : CodeSmell(
-    issue = issue,
-    entity = entity,
-    message = message,
-    metrics = metrics,
-    references = references
+    issue,
+    entity,
+    message,
+    metrics,
+    references
 ) {
-
     override fun toString(): String {
         return "CorrectableCodeSmell(" +
             "autoCorrectEnabled=$autoCorrectEnabled," +
@@ -85,13 +84,9 @@ open class ThresholdedCodeSmell(
     entity: Entity,
     val metric: Metric,
     message: String,
-    references: List<Entity> = emptyList(),
+    references: List<Entity> = emptyList()
 ) : CodeSmell(
-    issue = issue,
-    entity = entity,
-    message = message,
-    metrics = listOf(metric),
-    references = references,
+    issue, entity, message, metrics = listOf(metric), references = references
 ) {
 
     val value: Int

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/CodeSmell.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/CodeSmell.kt
@@ -15,7 +15,8 @@ open class CodeSmell(
     override val entity: Entity,
     override val message: String,
     override val metrics: List<Metric> = listOf(),
-    override val references: List<Entity> = listOf()
+    override val references: List<Entity> = listOf(),
+    override val severity: SeverityLevel = SeverityLevel.WARNING
 ) : Finding {
 
     override val id: String = issue.id
@@ -30,10 +31,25 @@ open class CodeSmell(
             "message=$message, " +
             "metrics=$metrics, " +
             "references=$references, " +
+            "severity=$severity, " +
             "id='$id')"
     }
 
     override fun messageOrDescription(): String = if (message.isEmpty()) issue.description else message
+
+    /**
+     * Create a new copy of [CodeSmell] with specified [severity].
+     */
+    open override fun copyWithSeverity(severity: SeverityLevel): Finding {
+        return CodeSmell(
+            issue = this.issue,
+            entity = this.entity,
+            message = this.message,
+            metrics = this.metrics,
+            references = this.references,
+            severity = severity
+        )
+    }
 }
 
 /**
@@ -41,19 +57,22 @@ open class CodeSmell(
  *
  * @see CodeSmell
  */
+@Suppress("LongParameterList")
 open class CorrectableCodeSmell(
     issue: Issue,
     entity: Entity,
     message: String,
     metrics: List<Metric> = listOf(),
     references: List<Entity> = listOf(),
-    val autoCorrectEnabled: Boolean
+    val autoCorrectEnabled: Boolean,
+    severity: SeverityLevel = SeverityLevel.WARNING
 ) : CodeSmell(
-    issue,
-    entity,
-    message,
-    metrics,
-    references
+    issue = issue,
+    entity = entity,
+    message = message,
+    metrics = metrics,
+    references = references,
+    severity = severity
 ) {
     override fun toString(): String {
         return "CorrectableCodeSmell(" +
@@ -63,7 +82,20 @@ open class CorrectableCodeSmell(
             "message=$message, " +
             "metrics=$metrics, " +
             "references=$references, " +
+            "severity=$severity, " +
             "id='$id')"
+    }
+
+    override fun copyWithSeverity(severity: SeverityLevel): Finding {
+        return CorrectableCodeSmell(
+            issue = this.issue,
+            entity = this.entity,
+            message = this.message,
+            metrics = this.metrics,
+            references = this.references,
+            autoCorrectEnabled = this.autoCorrectEnabled,
+            severity = severity
+        )
     }
 }
 
@@ -78,9 +110,15 @@ open class ThresholdedCodeSmell(
     entity: Entity,
     val metric: Metric,
     message: String,
-    references: List<Entity> = emptyList()
+    references: List<Entity> = emptyList(),
+    severity: SeverityLevel = SeverityLevel.WARNING
 ) : CodeSmell(
-    issue, entity, message, metrics = listOf(metric), references = references
+    issue = issue,
+    entity = entity,
+    message = message,
+    metrics = listOf(metric),
+    references = references,
+    severity = severity
 ) {
 
     val value: Int
@@ -91,4 +129,15 @@ open class ThresholdedCodeSmell(
     override fun compact(): String = "$id - $metric - ${entity.compact()}"
 
     override fun messageOrDescription(): String = if (message.isEmpty()) issue.description else message
+
+    override fun copyWithSeverity(severity: SeverityLevel): Finding {
+        return ThresholdedCodeSmell(
+            issue = this.issue,
+            entity = this.entity,
+            metric = this.metric,
+            message = this.message,
+            references = this.references,
+            severity = severity
+        )
+    }
 }

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/CodeSmell.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/CodeSmell.kt
@@ -19,7 +19,7 @@ open class CodeSmell(
 ) : Finding {
 
     internal var internalSeverity: SeverityLevel = SeverityLevel.WARNING
-    override val severity
+    override val severity: SeverityLevel
         get() = internalSeverity
 
     override val id: String = issue.id

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/CodeSmell.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/CodeSmell.kt
@@ -19,6 +19,14 @@ open class CodeSmell(
     override val severity: SeverityLevel = SeverityLevel.WARNING
 ) : Finding {
 
+    constructor(
+        issue: Issue,
+        entity: Entity,
+        message: String,
+        metrics: List<Metric> = listOf(),
+        references: List<Entity> = listOf()
+    ) : this(issue, entity, message, metrics, references, SeverityLevel.WARNING)
+
     override val id: String = issue.id
 
     override fun compact(): String = "$id - ${entity.compact()}"
@@ -40,7 +48,7 @@ open class CodeSmell(
     /**
      * Create a new copy of [CodeSmell] with specified [severity].
      */
-    open override fun copyWithSeverity(severity: SeverityLevel): Finding {
+    override fun copyWithSeverity(severity: SeverityLevel): Finding {
         return CodeSmell(
             issue = this.issue,
             entity = this.entity,
@@ -74,6 +82,16 @@ open class CorrectableCodeSmell(
     references = references,
     severity = severity
 ) {
+
+    constructor(
+        issue: Issue,
+        entity: Entity,
+        message: String,
+        metrics: List<Metric> = listOf(),
+        references: List<Entity> = listOf(),
+        autoCorrectEnabled: Boolean
+    ) : this(issue, entity, message, metrics, references, autoCorrectEnabled, SeverityLevel.WARNING)
+
     override fun toString(): String {
         return "CorrectableCodeSmell(" +
             "autoCorrectEnabled=$autoCorrectEnabled," +
@@ -120,6 +138,14 @@ open class ThresholdedCodeSmell(
     references = references,
     severity = severity
 ) {
+
+    constructor(
+        issue: Issue,
+        entity: Entity,
+        metric: Metric,
+        message: String,
+        references: List<Entity> = listOf()
+    ) : this(issue, entity, metric, message, references, SeverityLevel.WARNING)
 
     val value: Int
         get() = metric.value

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Config.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Config.kt
@@ -56,6 +56,7 @@ interface Config {
 
         const val ACTIVE_KEY: String = "active"
         const val AUTO_CORRECT_KEY: String = "autoCorrect"
+        const val SEVERITY_KEY: String = "severity"
         const val EXCLUDES_KEY: String = "excludes"
         const val INCLUDES_KEY: String = "includes"
         const val CONFIG_SEPARATOR: String = ">"

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/ConfigAware.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/ConfigAware.kt
@@ -43,7 +43,7 @@ interface ConfigAware : Config {
 
     /**
      * Is this rule specified as active in configuration?
-     * If an rule is not specified in the underlying configuration, we assume it should not be run.
+     * If a rule is not specified in the underlying configuration, we assume it should not be run.
      */
     val active: Boolean get() = valueOrDefault(Config.ACTIVE_KEY, false)
 

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Findings.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Findings.kt
@@ -12,11 +12,17 @@ interface Finding : Compactable, HasEntity, HasMetrics {
     val issue: Issue
     val references: List<Entity>
     val message: String
+    val severity: SeverityLevel
 
     /**
      * Explanation why this finding was raised.
      */
     fun messageOrDescription(): String
+
+    /**
+     * Copy function to assign a new severity.
+     */
+    fun copyWithSeverity(severity: SeverityLevel): Finding
 }
 
 /**

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Findings.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Findings.kt
@@ -13,6 +13,7 @@ interface Finding : Compactable, HasEntity, HasMetrics {
     val references: List<Entity>
     val message: String
     val severity: SeverityLevel
+        get() = SeverityLevel.WARNING
 
     /**
      * Explanation why this finding was raised.

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Findings.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Findings.kt
@@ -19,11 +19,6 @@ interface Finding : Compactable, HasEntity, HasMetrics {
      * Explanation why this finding was raised.
      */
     fun messageOrDescription(): String
-
-    /**
-     * Copy function to assign a new severity.
-     */
-    fun copyWithSeverity(severity: SeverityLevel): Finding = this
 }
 
 /**

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Findings.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Findings.kt
@@ -22,7 +22,7 @@ interface Finding : Compactable, HasEntity, HasMetrics {
     /**
      * Copy function to assign a new severity.
      */
-    fun copyWithSeverity(severity: SeverityLevel): Finding
+    fun copyWithSeverity(severity: SeverityLevel): Finding = this
 }
 
 /**

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Rule.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Rule.kt
@@ -69,11 +69,11 @@ abstract class Rule(
      * Compute severity in the priority order:
      * - Severity of the rule
      * - Severity of the parent ruleset
-     * - Default severity: Error
+     * - Default severity: warning
      */
     private fun computeSeverity(): SeverityLevel {
         val configValue: String = valueOrNull(SEVERITY_KEY)
-            ?: ruleSetConfig.valueOrDefault(SEVERITY_KEY, "error")
+            ?: ruleSetConfig.valueOrDefault(SEVERITY_KEY, "warning")
         return enumValueOf(configValue.toUpperCase())
     }
 

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Rule.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Rule.kt
@@ -81,15 +81,19 @@ abstract class Rule(
      * Simplified version of [Context.report] with rule defaults.
      */
     fun report(finding: Finding) {
-        report(finding.copyWithSeverity(computeSeverity()), aliases, ruleSetId)
+        (finding as? CodeSmell)?.internalSeverity = computeSeverity()
+        report(finding, aliases, ruleSetId)
     }
 
     /**
      * Simplified version of [Context.report] with rule defaults.
      */
     fun report(findings: List<Finding>) {
+        findings.forEach {
+            (it as? CodeSmell)?.internalSeverity = computeSeverity()
+        }
         report(
-            findings.map { it.copyWithSeverity(computeSeverity()) },
+            findings,
             aliases,
             ruleSetId
         )

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Severity.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Severity.kt
@@ -1,6 +1,8 @@
 package io.gitlab.arturbosch.detekt.api
 
 /**
+ * Note: This will be replaced by [SeverityLevel] in future versions of Detekt.
+ *
  * Rules can classified into different severity grades. Maintainer can choose
  * a grade which is most harmful to their projects.
  */

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/SeverityLevel.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/SeverityLevel.kt
@@ -20,10 +20,5 @@ enum class SeverityLevel {
     /**
      * Report issue, does not contribute to the count.
      */
-    INFO,
-
-    /**
-     * Do not report issue.
-     */
-    IGNORE
+    INFO
 }

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/SeverityLevel.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/SeverityLevel.kt
@@ -1,0 +1,29 @@
+package io.gitlab.arturbosch.detekt.api
+
+/**
+ * The severity level for each [Issue]. This will be printed to the output, such as XML or Sarif.
+ *
+ * In the future, this will be used to determine the process result and reports.
+ */
+enum class SeverityLevel {
+
+    /**
+     * Fail the cli process or gradle task.
+     */
+    ERROR,
+
+    /**
+     * Report issue and contribute to the total count, but does not fail cli process or gradle task.
+     */
+    WARNING,
+
+    /**
+     * Report issue, does not contribute to the count.
+     */
+    INFO,
+
+    /**
+     * Do not report issue.
+     */
+    IGNORE
+}

--- a/detekt-api/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/test/TestFactory.kt
+++ b/detekt-api/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/test/TestFactory.kt
@@ -7,7 +7,6 @@ import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Location
 import io.gitlab.arturbosch.detekt.api.Severity
-import io.gitlab.arturbosch.detekt.api.SeverityLevel
 import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.api.TextLocation
 import org.jetbrains.kotlin.psi.KtElement

--- a/detekt-api/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/test/TestFactory.kt
+++ b/detekt-api/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/test/TestFactory.kt
@@ -7,12 +7,16 @@ import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Location
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.SeverityLevel
 import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.api.TextLocation
 import org.jetbrains.kotlin.psi.KtElement
 
-fun createFinding(ruleName: String = "TestSmell", fileName: String = "TestFile.kt") =
-    CodeSmell(createIssue(ruleName), createEntity(fileName), "TestMessage")
+fun createFinding(
+    ruleName: String = "TestSmell",
+    fileName: String = "TestFile.kt",
+    severity: SeverityLevel = SeverityLevel.WARNING
+) = CodeSmell(createIssue(ruleName), createEntity(fileName), "TestMessage", severity = severity)
 
 fun createCorrectableFinding(ruleName: String = "TestSmell", fileName: String = "TestFile.kt") =
     CorrectableCodeSmell(createIssue(ruleName), createEntity(fileName), "TestMessage", autoCorrectEnabled = true)
@@ -20,7 +24,7 @@ fun createCorrectableFinding(ruleName: String = "TestSmell", fileName: String = 
 fun createFinding(
     issue: Issue,
     entity: Entity,
-    message: String = entity.signature
+    message: String = entity.signature,
 ) = CodeSmell(
     issue = issue,
     entity = entity,

--- a/detekt-api/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/test/TestFactory.kt
+++ b/detekt-api/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/test/TestFactory.kt
@@ -12,11 +12,8 @@ import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.api.TextLocation
 import org.jetbrains.kotlin.psi.KtElement
 
-fun createFinding(
-    ruleName: String = "TestSmell",
-    fileName: String = "TestFile.kt",
-    severity: SeverityLevel = SeverityLevel.WARNING
-) = CodeSmell(createIssue(ruleName), createEntity(fileName), "TestMessage", severity = severity)
+fun createFinding(ruleName: String = "TestSmell", fileName: String = "TestFile.kt") =
+    CodeSmell(createIssue(ruleName), createEntity(fileName), "TestMessage")
 
 fun createCorrectableFinding(ruleName: String = "TestSmell", fileName: String = "TestFile.kt") =
     CorrectableCodeSmell(createIssue(ruleName), createEntity(fileName), "TestMessage", autoCorrectEnabled = true)

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/ValidatableConfiguration.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/ValidatableConfiguration.kt
@@ -21,6 +21,8 @@ val DEFAULT_PROPERTY_EXCLUDES = setOf(
     ".*>.*>includes",
     ".*>.*>active",
     ".*>.*>autoCorrect",
+    ".*>severity",
+    ".*>.*>severity",
     "build>weights.*"
 ).joinToString(",")
 

--- a/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/SarifOutputReport.kt
+++ b/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/SarifOutputReport.kt
@@ -49,7 +49,6 @@ private fun SeverityLevel.toResultLevel() = when (this) {
     SeverityLevel.ERROR -> Result.Level.ERROR
     SeverityLevel.WARNING -> Result.Level.WARNING
     SeverityLevel.INFO -> Result.Level.NOTE
-    SeverityLevel.IGNORE -> Result.Level.NONE
 }
 
 private fun Finding.toIssue(ruleSetId: RuleSetId): SarifIssue = result {

--- a/detekt-report-sarif/src/test/kotlin/io/github/detekt/report/sarif/SarifOutputReportSpec.kt
+++ b/detekt-report-sarif/src/test/kotlin/io/github/detekt/report/sarif/SarifOutputReportSpec.kt
@@ -2,10 +2,14 @@ package io.github.detekt.report.sarif
 
 import io.github.detekt.test.utils.readResourceContent
 import io.github.detekt.tooling.api.VersionProvider
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.api.SeverityLevel
 import io.gitlab.arturbosch.detekt.test.EmptySetupContext
 import io.gitlab.arturbosch.detekt.test.TestDetektion
+import io.gitlab.arturbosch.detekt.test.createEntity
 import io.gitlab.arturbosch.detekt.test.createFinding
+import io.gitlab.arturbosch.detekt.test.createIssue
 import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
@@ -34,6 +38,13 @@ class SarifOutputReportSpec : Spek({
         }
     }
 })
+
+private fun createFinding(ruleName: String, severity: SeverityLevel): Finding {
+    return object : CodeSmell(createIssue(ruleName), createEntity("TestFile.kt"), "TestMessage") {
+        override val severity: SeverityLevel
+            get() = severity
+    }
+}
 
 internal fun String.stripWhitespace() = replace(Regex("\\s"), "")
 

--- a/detekt-report-sarif/src/test/kotlin/io/github/detekt/report/sarif/SarifOutputReportSpec.kt
+++ b/detekt-report-sarif/src/test/kotlin/io/github/detekt/report/sarif/SarifOutputReportSpec.kt
@@ -26,8 +26,7 @@ class SarifOutputReportSpec : Spek({
             val result = TestDetektion(
                 createFinding(ruleName = "TestSmellA", severity = SeverityLevel.ERROR),
                 createFinding(ruleName = "TestSmellB", severity = SeverityLevel.WARNING),
-                createFinding(ruleName = "TestSmellC", severity = SeverityLevel.INFO),
-                createFinding(ruleName = "TestSmellD", severity = SeverityLevel.IGNORE)
+                createFinding(ruleName = "TestSmellC", severity = SeverityLevel.INFO)
             )
 
             val report = SarifOutputReport().apply { init(EmptySetupContext()) }

--- a/detekt-report-sarif/src/test/kotlin/io/github/detekt/report/sarif/SarifOutputReportSpec.kt
+++ b/detekt-report-sarif/src/test/kotlin/io/github/detekt/report/sarif/SarifOutputReportSpec.kt
@@ -2,6 +2,7 @@ package io.github.detekt.report.sarif
 
 import io.github.detekt.test.utils.readResourceContent
 import io.github.detekt.tooling.api.VersionProvider
+import io.gitlab.arturbosch.detekt.api.SeverityLevel
 import io.gitlab.arturbosch.detekt.test.EmptySetupContext
 import io.gitlab.arturbosch.detekt.test.TestDetektion
 import io.gitlab.arturbosch.detekt.test.createFinding
@@ -19,9 +20,10 @@ class SarifOutputReportSpec : Spek({
 
         it("renders multiple issues") {
             val result = TestDetektion(
-                createFinding(ruleName = "TestSmellA"),
-                createFinding(ruleName = "TestSmellB"),
-                createFinding(ruleName = "TestSmellC")
+                createFinding(ruleName = "TestSmellA", severity = SeverityLevel.ERROR),
+                createFinding(ruleName = "TestSmellB", severity = SeverityLevel.WARNING),
+                createFinding(ruleName = "TestSmellC", severity = SeverityLevel.INFO),
+                createFinding(ruleName = "TestSmellD", severity = SeverityLevel.IGNORE)
             )
 
             val report = SarifOutputReport().apply { init(EmptySetupContext()) }

--- a/detekt-report-sarif/src/test/resources/expected.sarif.json
+++ b/detekt-report-sarif/src/test/resources/expected.sarif.json
@@ -76,26 +76,6 @@
               }
             }
           ]
-        },
-        {
-          "ruleId": "detekt.TestSmellD.TestSmellD",
-          "level": "none",
-          "message": {
-            "text": "TestMessage"
-          },
-          "locations": [
-            {
-              "physicalLocation": {
-                "artifactLocation": {
-                  "uri": "TestFile.kt"
-                },
-                "region": {
-                  "startLine": 1,
-                  "startColumn": 1
-                }
-              }
-            }
-          ]
         }
       ]
     }

--- a/detekt-report-sarif/src/test/resources/expected.sarif.json
+++ b/detekt-report-sarif/src/test/resources/expected.sarif.json
@@ -20,6 +20,7 @@
       "results": [
         {
           "ruleId": "detekt.TestSmellA.TestSmellA",
+          "level": "error",
           "message": {
             "text": "TestMessage"
           },
@@ -58,6 +59,27 @@
         },
         {
           "ruleId": "detekt.TestSmellC.TestSmellC",
+          "level": "note",
+          "message": {
+            "text": "TestMessage"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "TestFile.kt"
+                },
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 1
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "detekt.TestSmellD.TestSmellD",
+          "level": "none",
           "message": {
             "text": "TestMessage"
           },

--- a/detekt-report-xml/src/main/kotlin/io/github/detekt/report/xml/XmlOutputReport.kt
+++ b/detekt-report-xml/src/main/kotlin/io/github/detekt/report/xml/XmlOutputReport.kt
@@ -3,7 +3,6 @@ package io.github.detekt.report.xml
 import io.gitlab.arturbosch.detekt.api.Detektion
 import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.api.OutputReport
-import io.gitlab.arturbosch.detekt.api.Severity
 
 /**
  * Contains rule violations in an XML format. The report follows the structure of a Checkstyle report.
@@ -16,16 +15,7 @@ class XmlOutputReport : OutputReport() {
     override val name = "Checkstyle XML report"
 
     private val Finding.severityLabel: String
-        get() = when (issue.severity) {
-            Severity.CodeSmell,
-            Severity.Style,
-            Severity.Warning,
-            Severity.Maintainability,
-            Severity.Performance -> "warning"
-            Severity.Defect -> "error"
-            Severity.Minor -> "info"
-            Severity.Security -> "fatal"
-        }
+        get() = severity.name.toLowerCase()
 
     override fun render(detektion: Detektion): String {
         val smells = detektion.findings.flatMap { it.value }

--- a/detekt-report-xml/src/test/kotlin/io/github/detekt/report/xml/XmlOutputFormatSpec.kt
+++ b/detekt-report-xml/src/test/kotlin/io/github/detekt/report/xml/XmlOutputFormatSpec.kt
@@ -8,6 +8,7 @@ import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Location
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.SeverityLevel
 import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.api.TextLocation
 import io.gitlab.arturbosch.detekt.test.TestDetektion

--- a/detekt-report-xml/src/test/kotlin/io/github/detekt/report/xml/XmlOutputFormatSpec.kt
+++ b/detekt-report-xml/src/test/kotlin/io/github/detekt/report/xml/XmlOutputFormatSpec.kt
@@ -127,12 +127,14 @@ class XmlOutputFormatSpec : Spek({
                 val xmlSeverity = severity.name.toLowerCase()
 
                 it("renders detektion with severity [$severity] as XML with severity [$xmlSeverity]") {
-                    val finding = CodeSmell(
+                    val finding = object : CodeSmell(
                         issue = Issue("issue_id", Severity.CodeSmell, "issue description", Debt.FIVE_MINS),
-                        message = "message",
                         entity = entity1,
-                        severity = severity
-                    )
+                        message = "message"
+                    ) {
+                        override val severity: SeverityLevel
+                            get() = severity
+                    }
 
                     val expected = """
                     <?xml version="1.0" encoding="utf-8"?>

--- a/detekt-report-xml/src/test/kotlin/io/github/detekt/report/xml/XmlOutputFormatSpec.kt
+++ b/detekt-report-xml/src/test/kotlin/io/github/detekt/report/xml/XmlOutputFormatSpec.kt
@@ -120,33 +120,25 @@ class XmlOutputFormatSpec : Spek({
                 </checkstyle>""".trimIndent())
         }
 
-        describe("severities conversion") {
+        describe("severity level conversion") {
 
-            Severity.values().forEach { severity ->
+            SeverityLevel.values().forEach { severity ->
 
-                val severityLabel = when (severity) {
-                    Severity.CodeSmell,
-                    Severity.Style,
-                    Severity.Warning,
-                    Severity.Maintainability,
-                    Severity.Performance -> "warning"
-                    Severity.Defect -> "error"
-                    Severity.Minor -> "info"
-                    Severity.Security -> "fatal"
-                }
+                val xmlSeverity = severity.name.toLowerCase()
 
-                it("renders detektion with severity [${severity.name}] as XML with severity [$severityLabel]") {
+                it("renders detektion with severity [$severity] as XML with severity [$xmlSeverity]") {
                     val finding = CodeSmell(
-                        issue = Issue("issue_id", severity, "issue description", Debt.FIVE_MINS),
+                        issue = Issue("issue_id", Severity.CodeSmell, "issue description", Debt.FIVE_MINS),
                         message = "message",
-                        entity = entity1
+                        entity = entity1,
+                        severity = severity
                     )
 
                     val expected = """
                     <?xml version="1.0" encoding="utf-8"?>
                     <checkstyle version="4.3">
                     <file name="${finding.location.file}">
-                    ${"\t"}<error line="${finding.location.source.line}" column="${finding.location.source.column}" severity="$severityLabel" message="${finding.messageOrDescription()}" source="detekt.${finding.id}" />
+                    $TAB<error line="${finding.location.source.line}" column="${finding.location.source.column}" severity="$xmlSeverity" message="${finding.messageOrDescription()}" source="detekt.${finding.id}" />
                     </file>
                     </checkstyle>
                     """


### PR DESCRIPTION
Summary
=======
This PR implements configuring the severity in the XML and Sarif output, which is the first step to implement #3274. The implementation is also different from #3306, because the severity in the configuration can only be a simplified version and does not allow custom strings.

Implementation
===========
Adding the `severity` as a property of `Issue` does not work: Each rule initializes the `issue` first then uses the `issue.id` to initialize `ruleConfig`. If we want to use `ruleConfig` to parse `severity`, it has to be done after `issue` is created.
We can break such cycling dependency by refactoring, but I would prefer doing so in the next PR where we can remove the existing `Severity` and replace it with the new `SeverityLevel`.

The choice here is to add the `severity` as a property of `Finding`, which is appended at the end to mitigate incompatibility. However, since `Finding` and its children are not data class, I need to create `copyWithSeverity` to override the given severity.

Followup
===========
I did not deprecate or remove `Severity`, `maxIssues`, `warningsAsErrors` in this PR. If this is a good time to do so, I would be happy to do those in a follow-up PR.

Test
====
In addition to the unit test, I also performed an integration test in a different repo. Users can configure severity at ruleset level and rule level.
```
style:
  severity: error
  MagicNumber:
    severity: ignore
```