### PR TITLE
Add KDoc for convoluted PathFilters.isIgnored

### DIFF
--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/PathFilters.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/PathFilters.kt
@@ -10,6 +10,16 @@ class PathFilters internal constructor(
     private val excludes: Set<PathMatcher>?
 ) {
 
+    /**
+     * - If [includes] and [excludes] are not specified,
+     *   always return true.
+     * - If [includes] is specified but [excludes] is not,
+     *   return false iff [path] matches any [includes].
+     * - If [includes] is not specified but [excludes] is,
+     *   return true iff [path] matches any [excludes].
+     * - If [includes] and [excludes] are both specified,
+     *   return false iff [path] matches any [includes] and [path] does not match any [excludes].
+     */
     fun isIgnored(path: Path): Boolean {
 
         fun isIncluded() = includes?.any { it.matches(path) }

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/PathFiltersSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/PathFiltersSpec.kt
@@ -17,6 +17,38 @@ class PathFiltersSpec : Spek({
             assertThat(filters?.isIgnored(Paths.get("/two/path"))).isFalse()
         }
 
+        describe("parsing with different nullability combinations of path filters") {
+            it("returns an empty path filter when includes are empty and excludes are empty") {
+                val pathFilter = PathFilters.of(emptyList(), emptyList())
+                assertThat(pathFilter).isNull()
+            }
+
+            it("parse includes correctly") {
+                val pathFilter = PathFilters.of(listOf("**/one/**", "**/two/**"), emptyList())
+                assertThat(pathFilter).isNotNull
+                assertThat(pathFilter?.isIgnored(Paths.get("/one/path"))).isFalse
+                assertThat(pathFilter?.isIgnored(Paths.get("/two/path"))).isFalse
+                assertThat(pathFilter?.isIgnored(Paths.get("/three/path"))).isTrue
+            }
+
+            it("parse excludes correctly") {
+                val pathFilter = PathFilters.of(emptyList(), listOf("**/one/**", "**/two/**"))
+                assertThat(pathFilter).isNotNull
+                assertThat(pathFilter?.isIgnored(Paths.get("/one/path"))).isTrue
+                assertThat(pathFilter?.isIgnored(Paths.get("/two/path"))).isTrue
+                assertThat(pathFilter?.isIgnored(Paths.get("/three/path"))).isFalse
+            }
+
+            it("parse both includes and excludes correctly") {
+                val pathFilter = PathFilters.of(listOf("**/one/**"), listOf("**/two/**"))
+                assertThat(pathFilter).isNotNull
+                assertThat(pathFilter?.isIgnored(Paths.get("/one/path"))).isFalse
+                assertThat(pathFilter?.isIgnored(Paths.get("/two/path"))).isTrue
+                assertThat(pathFilter?.isIgnored(Paths.get("/three/path"))).isTrue
+            }
+        }
+
+
         describe("parsing with different separators") {
 
             it("should load multiple comma-separated filters with no spaces around commas") {

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/PathFiltersSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/PathFiltersSpec.kt
@@ -48,7 +48,6 @@ class PathFiltersSpec : Spek({
             }
         }
 
-
         describe("parsing with different separators") {
 
             it("should load multiple comma-separated filters with no spaces around commas") {

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/PathFiltersSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/PathFiltersSpec.kt
@@ -23,7 +23,7 @@ class PathFiltersSpec : Spek({
                 assertThat(pathFilter).isNull()
             }
 
-            it("parse includes correctly") {
+            it("parses includes correctly") {
                 val pathFilter = PathFilters.of(listOf("**/one/**", "**/two/**"), emptyList())
                 assertThat(pathFilter).isNotNull
                 assertThat(pathFilter?.isIgnored(Paths.get("/one/path"))).isFalse
@@ -31,7 +31,7 @@ class PathFiltersSpec : Spek({
                 assertThat(pathFilter?.isIgnored(Paths.get("/three/path"))).isTrue
             }
 
-            it("parse excludes correctly") {
+            it("parses excludes correctly") {
                 val pathFilter = PathFilters.of(emptyList(), listOf("**/one/**", "**/two/**"))
                 assertThat(pathFilter).isNotNull
                 assertThat(pathFilter?.isIgnored(Paths.get("/one/path"))).isTrue
@@ -39,7 +39,7 @@ class PathFiltersSpec : Spek({
                 assertThat(pathFilter?.isIgnored(Paths.get("/three/path"))).isFalse
             }
 
-            it("parse both includes and excludes correctly") {
+            it("parses both includes and excludes correctly") {
                 val pathFilter = PathFilters.of(listOf("**/one/**"), listOf("**/two/**"))
                 assertThat(pathFilter).isNotNull
                 assertThat(pathFilter?.isIgnored(Paths.get("/one/path"))).isFalse


### PR DESCRIPTION
#3279 describes the scenario that rules are not doing anything if neither `includes` or `excludes` are specified.

When reading the code, it comes to me that `PathFilters.isIgnored()` is a bit convoluted and probably the implementation is not working as expected. Therefore I publish this PR to describe the current behavior. And in case we update the behavior later, we should be able to correct the doc and help the reviewers to understand the status quo.