### PR TITLE
Fix reports not propagated to detekt task with type resolution

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektAndroid.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektAndroid.kt
@@ -116,6 +116,7 @@ internal class DetektAndroid(private val project: Project) {
             extension.baseline?.existingVariantOrBaseFile(variant.name)?.let { baselineFile ->
                 baseline.set(layout.file(project.provider { baselineFile }))
             }
+            reports = extension.reports
             reports.xml.setDefaultIfUnset(File(extension.reportsDir, variant.name + ".xml"))
             reports.html.setDefaultIfUnset(File(extension.reportsDir, variant.name + ".html"))
             reports.txt.setDefaultIfUnset(File(extension.reportsDir, variant.name + ".txt"))

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektJvm.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektJvm.kt
@@ -31,6 +31,7 @@ internal class DetektJvm(private val project: Project) {
             extension.baseline?.existingVariantOrBaseFile(sourceSet.name)?.let { baselineFile ->
                 baseline.set(layout.file(project.provider { baselineFile }))
             }
+            reports = extension.reports
             reports.xml.setDefaultIfUnset(File(extension.reportsDir, sourceSet.name + ".xml"))
             reports.html.setDefaultIfUnset(File(extension.reportsDir, sourceSet.name + ".html"))
             reports.txt.setDefaultIfUnset(File(extension.reportsDir, sourceSet.name + ".txt"))


### PR DESCRIPTION
Configuring detekt gradle extension as below does not actually generate SARIF reports when running `detekt<SourceSet>` like `:detektMain`. The problem here is that we are merely not passing the `reports` in `DetektExtension` to `reports` of `Detekt` as a gradle task.

```
detekt {
    reports {
        sarif.enabled = true
    }
}
```

In addition to integration testing, I also manually verified through a sample project that the above is working.
