### PR TITLE
Switch order of correctable rules and other rules

### DIFF
--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Analyzer.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Analyzer.kt
@@ -124,8 +124,8 @@ internal class Analyzer(
             }
         }
 
-        executeRules(correctableRules)
         executeRules(otherRules)
+        executeRules(correctableRules)
 
         return result
     }


### PR DESCRIPTION
Interestingly, the previous code caused a crash in (#2693). The problem is that we run Ktlint/CommentSpacing before running LongMethod. Because CommentSpacing mutates the `ktfile.text`, but does not update
`Ktfile.viewerProvider.document`, resulting in an inconsistent state and eventually crash (https://github.com/detekt/detekt/issues/2693#issuecomment-750395108)

Note that this commit is merely a short-term fix. In the long term, we should be more careful in rule running order, while leveraging parallelism to optimize the runtime.

Test
====
I verified that the correct violations `CommentSpacing` are reported in the sample project (https://github.com/andrey-bolduzev/detekt_issue_2693) after the change. Before this change, it will crash with `java.lang.IndexOutOfBoundsException: Wrong offset: 834. Should be in range: [0, 833]`
