### PR TITLE
Fix `runLastOnRoot` being empty in KtLintMultiRule

### DIFF
--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/KtLintMultiRule.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/KtLintMultiRule.kt
@@ -1,5 +1,8 @@
 package io.gitlab.arturbosch.detekt.formatting
 
+import com.pinterest.ktlint.core.Rule.Modifier.Last
+import com.pinterest.ktlint.core.Rule.Modifier.RestrictToRoot
+import com.pinterest.ktlint.core.Rule.Modifier.RestrictToRootLast
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.MultiRule
 import io.gitlab.arturbosch.detekt.api.Rule
@@ -103,7 +106,7 @@ class KtLintMultiRule(config: Config = Config.empty) : MultiRule() {
         }
     }
 
-    private fun getSortedRules(): List<FormattingRule> {
+    internal fun getSortedRules(): List<FormattingRule> {
         val runFirstOnRoot = mutableListOf<FormattingRule>()
         val other = mutableListOf<FormattingRule>()
         val runLastOnRoot = mutableListOf<FormattingRule>()
@@ -111,8 +114,9 @@ class KtLintMultiRule(config: Config = Config.empty) : MultiRule() {
         for (rule in activeRules.filterIsInstance<FormattingRule>()) {
             when (rule.wrapping) {
                 is Last -> runLast.add(rule)
-                is RestrictToRoot -> runFirstOnRoot.add(rule)
+                // RestrictToRootLast implements RestrictToRoot, so we have to perform this check first
                 is RestrictToRootLast -> runLastOnRoot.add(rule)
+                is RestrictToRoot -> runFirstOnRoot.add(rule)
                 else -> other.add(rule)
             }
         }
@@ -136,7 +140,3 @@ class KtLintMultiRule(config: Config = Config.empty) : MultiRule() {
         return parent !is JavaDummyHolder && parent !is JavaDummyElement
     }
 }
-
-typealias RestrictToRoot = com.pinterest.ktlint.core.Rule.Modifier.RestrictToRoot
-typealias RestrictToRootLast = com.pinterest.ktlint.core.Rule.Modifier.RestrictToRootLast
-typealias Last = com.pinterest.ktlint.core.Rule.Modifier.Last

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/KtLintMultiRuleSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/KtLintMultiRuleSpec.kt
@@ -1,0 +1,32 @@
+package io.gitlab.arturbosch.detekt.formatting
+
+import com.pinterest.ktlint.core.Rule.Modifier.Last
+import com.pinterest.ktlint.core.Rule.Modifier.RestrictToRoot
+import com.pinterest.ktlint.core.Rule.Modifier.RestrictToRootLast
+import io.github.detekt.test.utils.compileContentForTest
+import io.gitlab.arturbosch.detekt.api.Config
+import org.assertj.core.api.Assertions.assertThat
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+class KtLintMultiRuleSpec : Spek({
+
+    describe("KtLintMultiRule rule") {
+
+        it("sort rules correctly") {
+            val ktlintRule = KtLintMultiRule(Config.empty)
+            ktlintRule.visitFile(compileContentForTest(""))
+            val sortedRules = ktlintRule.getSortedRules()
+            assertThat(sortedRules).isNotEmpty
+            assertThat(sortedRules.indexOfFirst { it.wrapping is RestrictToRoot })
+                .isGreaterThan(-1)
+                .isLessThan(sortedRules.indexOfFirst { it.wrapping !is RestrictToRoot })
+            assertThat(sortedRules.indexOfFirst { it.wrapping !is RestrictToRoot })
+                .isGreaterThan(-1)
+                .isLessThan(sortedRules.indexOfFirst { it.wrapping is RestrictToRootLast })
+            assertThat(sortedRules.indexOfFirst { it.wrapping is RestrictToRootLast })
+                .isGreaterThan(-1)
+                .isLessThan(sortedRules.indexOfFirst { it.wrapping is Last })
+        }
+    }
+})

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/KtLintMultiRuleSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/KtLintMultiRuleSpec.kt
@@ -13,7 +13,7 @@ class KtLintMultiRuleSpec : Spek({
 
     describe("KtLintMultiRule rule") {
 
-        it("sort rules correctly") {
+        it("sorts rules correctly") {
             val ktlintRule = KtLintMultiRule(Config.empty)
             ktlintRule.visitFile(compileContentForTest(""))
             val sortedRules = ktlintRule.getSortedRules()


### PR DESCRIPTION
`RestrictToRootLast` implements `RestrictToRoot`, so we need to check is `RestrictToRootLast` first.

Before
![Before](https://user-images.githubusercontent.com/1175468/103069241-d3afc700-4573-11eb-9a06-117508ef05c9.png)

After
![After](https://user-images.githubusercontent.com/1175468/103069252-dad6d500-4573-11eb-8488-5f1820ec899d.png)
