### PR TITLE
Simplify our buildSrc

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,6 +10,10 @@ plugins {
     id("binary-compatibility-validator")
 }
 
+repositories {
+    jcenter()
+}
+
 buildScan {
     termsOfServiceUrl = "https://gradle.com/terms-of-service"
     termsOfServiceAgree = "yes"

--- a/buildSrc/src/main/kotlin/commons.gradle.kts
+++ b/buildSrc/src/main/kotlin/commons.gradle.kts
@@ -1,97 +1,11 @@
-import org.gradle.api.tasks.testing.logging.TestExceptionFormat
-import org.gradle.api.tasks.testing.logging.TestLogEvent
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-
 plugins {
-    kotlin("jvm")
-    jacoco
+    kotlin("jvm") apply false
+    jacoco apply false
 }
 
-allprojects {
+subprojects {
     group = "io.gitlab.arturbosch.detekt"
     version = Versions.currentOrSnapshot()
-
-    repositories {
-        jcenter()
-    }
-}
-
-configure(subprojects.filter { it.name != "detekt-bom" }) {
-
-    val project = this
-
-    apply {
-        plugin("java-library")
-        plugin("kotlin")
-        plugin("jacoco")
-    }
-
-    java {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
-    }
-
-    // bundle detekt's version for all jars to use it at runtime
-    tasks.withType<Jar>().configureEach {
-        manifest {
-            attributes(mapOf("DetektVersion" to Versions.DETEKT))
-        }
-    }
-
-    jacoco.toolVersion = Versions.JACOCO
-
-    tasks.withType<Test>().configureEach {
-        useJUnitPlatform()
-        systemProperty("spek2.jvm.cg.scan.concurrency", 1) // use one thread for classpath scanning
-        systemProperty("spek2.execution.test.timeout", 0) // disable test timeout
-        systemProperty("spek2.discovery.parallel.enabled", 1) // enable parallel test discovery
-        val compileSnippetText: Boolean = if (project.hasProperty("compile-test-snippets")) {
-            (project.property("compile-test-snippets") as String).toBoolean()
-        } else {
-            false
-        }
-        systemProperty("compile-snippet-tests", compileSnippetText)
-        testLogging {
-            // set options for log level LIFECYCLE
-            events = setOf(
-                TestLogEvent.FAILED,
-                TestLogEvent.STANDARD_ERROR,
-                TestLogEvent.STANDARD_OUT,
-                TestLogEvent.SKIPPED
-            )
-            exceptionFormat = TestExceptionFormat.FULL
-            showExceptions = true
-            showCauses = true
-            showStackTraces = true
-        }
-    }
-
-    tasks.withType<KotlinCompile>().configureEach {
-        kotlinOptions.jvmTarget = Versions.JVM_TARGET
-        kotlinOptions.freeCompilerArgs = listOf(
-            "-progressive",
-            "-Xopt-in=kotlin.RequiresOptIn"
-        )
-        // Usage: <code>./gradlew build -PwarningsAsErrors=true</code>.
-        kotlinOptions.allWarningsAsErrors = project.findProperty("warningsAsErrors") == "true"
-    }
-
-    dependencies {
-        implementation(platform(project(":detekt-bom")))
-        compileOnly(kotlin("stdlib-jdk8"))
-
-        testImplementation("org.assertj:assertj-core")
-        testImplementation("org.spekframework.spek2:spek-dsl-jvm")
-        testImplementation("org.reflections:reflections")
-        testImplementation("io.mockk:mockk")
-
-        testRuntimeOnly("org.junit.platform:junit-platform-launcher")
-        testRuntimeOnly("org.spekframework.spek2:spek-runner-junit5")
-    }
-}
-
-configure(listOf(project(":detekt-rules"), project(":detekt-formatting"))) {
-    tasks.build { finalizedBy(":detekt-generator:generateDocumentation") }
 }
 
 jacoco.toolVersion = Versions.JACOCO

--- a/buildSrc/src/main/kotlin/module.gradle.kts
+++ b/buildSrc/src/main/kotlin/module.gradle.kts
@@ -1,0 +1,103 @@
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+import org.gradle.api.tasks.testing.logging.TestLogEvent
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+plugins {
+    kotlin("jvm")
+    `maven-publish`
+    jacoco
+}
+
+repositories {
+    jcenter()
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
+// bundle detekt's version for all jars to use it at runtime
+tasks.withType<Jar>().configureEach {
+    manifest {
+        attributes(mapOf("DetektVersion" to Versions.DETEKT))
+    }
+}
+
+jacoco.toolVersion = Versions.JACOCO
+
+tasks.withType<Test>().configureEach {
+    useJUnitPlatform()
+    systemProperty("spek2.jvm.cg.scan.concurrency", 1) // use one thread for classpath scanning
+    systemProperty("spek2.execution.test.timeout", 0) // disable test timeout
+    systemProperty("spek2.discovery.parallel.enabled", 1) // enable parallel test discovery
+    val compileSnippetText: Boolean = if (project.hasProperty("compile-test-snippets")) {
+        (project.property("compile-test-snippets") as String).toBoolean()
+    } else {
+        false
+    }
+    systemProperty("compile-snippet-tests", compileSnippetText)
+    testLogging {
+        // set options for log level LIFECYCLE
+        events = setOf(
+            TestLogEvent.FAILED,
+            TestLogEvent.STANDARD_ERROR,
+            TestLogEvent.STANDARD_OUT,
+            TestLogEvent.SKIPPED
+        )
+        exceptionFormat = TestExceptionFormat.FULL
+        showExceptions = true
+        showCauses = true
+        showStackTraces = true
+    }
+}
+
+tasks.withType<KotlinCompile>().configureEach {
+    kotlinOptions.jvmTarget = Versions.JVM_TARGET
+    kotlinOptions.freeCompilerArgs = listOf(
+        "-progressive",
+        "-Xopt-in=kotlin.RequiresOptIn"
+    )
+    // Usage: <code>./gradlew build -PwarningsAsErrors=true</code>.
+    kotlinOptions.allWarningsAsErrors = project.findProperty("warningsAsErrors") == "true"
+}
+
+dependencies {
+    implementation(platform(project(":detekt-bom")))
+    compileOnly(kotlin("stdlib-jdk8"))
+
+    testImplementation("org.assertj:assertj-core")
+    testImplementation("org.spekframework.spek2:spek-dsl-jvm")
+    testImplementation("org.reflections:reflections")
+    testImplementation("io.mockk:mockk")
+
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    testRuntimeOnly("org.spekframework.spek2:spek-runner-junit5")
+}
+
+val sourcesJar by tasks.registering(Jar::class) {
+    dependsOn(tasks.classes)
+    archiveClassifier.set("sources")
+    from(sourceSets.main.get().allSource)
+}
+
+val javadocJar by tasks.registering(Jar::class) {
+    from(tasks.javadoc)
+    archiveClassifier.set("javadoc")
+}
+
+artifacts {
+    archives(sourcesJar)
+    archives(javadocJar)
+}
+
+publishing {
+    publications.named<MavenPublication>(DETEKT_PUBLICATION) {
+        from(components["java"])
+        artifact(sourcesJar.get())
+        artifact(javadocJar.get())
+        if (project.name == "detekt-cli") {
+            artifact(tasks.getByName("shadowJar"))
+        }
+    }
+}

--- a/buildSrc/src/main/kotlin/packaging.gradle.kts
+++ b/buildSrc/src/main/kotlin/packaging.gradle.kts
@@ -1,5 +1,3 @@
-import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
-
 plugins {
     `java-library` apply false // is applied in commons; make configurations available in this script
     `maven-publish` apply false
@@ -19,17 +17,6 @@ nexusStaging {
     stagingProfileId = "1d8efc8232c5c"
     username = sonatypeUsername
     password = sonatypePassword
-}
-
-project(":detekt-cli") {
-    apply {
-        plugin("application")
-        plugin("com.github.johnrengelman.shadow")
-    }
-
-    tasks.withType<ShadowJar>().configureEach {
-        mergeServiceFiles()
-    }
 }
 
 subprojects {

--- a/buildSrc/src/main/kotlin/packaging.gradle.kts
+++ b/buildSrc/src/main/kotlin/packaging.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    `java-library` apply false // is applied in commons; make configurations available in this script
+    `java-library` apply false
     `maven-publish` apply false
     signing apply false
     id("io.codearte.nexus-staging")
@@ -80,34 +80,5 @@ subprojects {
         }
     } else {
         logger.info("Signing Disabled as the PGP key was not found")
-    }
-}
-
-configure(subprojects.filter { it.name != "detekt-bom" }) {
-    val sourcesJar by tasks.registering(Jar::class) {
-        dependsOn(tasks.classes)
-        archiveClassifier.set("sources")
-        from(sourceSets.main.get().allSource)
-    }
-
-    val javadocJar by tasks.registering(Jar::class) {
-        from(tasks.javadoc)
-        archiveClassifier.set("javadoc")
-    }
-
-    artifacts {
-        archives(sourcesJar)
-        archives(javadocJar)
-    }
-
-    publishing {
-        publications.named<MavenPublication>(DETEKT_PUBLICATION) {
-            from(components["java"])
-            artifact(sourcesJar.get())
-            artifact(javadocJar.get())
-            if (project.name == "detekt-cli") {
-                artifact(tasks.getByName("shadowJar"))
-            }
-        }
     }
 }

--- a/custom-checks/build.gradle.kts
+++ b/custom-checks/build.gradle.kts
@@ -1,3 +1,7 @@
+plugins {
+    module
+}
+
 dependencies {
     implementation(project(":detekt-api"))
     testImplementation(project(":detekt-test"))

--- a/detekt-api/build.gradle.kts
+++ b/detekt-api/build.gradle.kts
@@ -1,6 +1,7 @@
 import org.jetbrains.dokka.gradle.DokkaTask
 
 plugins {
+    module
     id("org.jetbrains.dokka")
     `java-test-fixtures`
 }

--- a/detekt-cli/build.gradle.kts
+++ b/detekt-cli/build.gradle.kts
@@ -1,5 +1,16 @@
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+
+plugins {
+    application
+    id("com.github.johnrengelman.shadow")
+}
+
 application {
     mainClassName = "io.gitlab.arturbosch.detekt.cli.Main"
+}
+
+tasks.withType<ShadowJar>().configureEach {
+    mergeServiceFiles()
 }
 
 dependencies {

--- a/detekt-cli/build.gradle.kts
+++ b/detekt-cli/build.gradle.kts
@@ -1,8 +1,9 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
 plugins {
-    application
     id("com.github.johnrengelman.shadow")
+    module
+    application
 }
 
 application {

--- a/detekt-core/build.gradle.kts
+++ b/detekt-core/build.gradle.kts
@@ -1,3 +1,7 @@
+plugins {
+    module
+}
+
 dependencies {
     implementation("org.yaml:snakeyaml")
     implementation(project(":detekt-api"))

--- a/detekt-formatting/build.gradle.kts
+++ b/detekt-formatting/build.gradle.kts
@@ -1,3 +1,7 @@
+plugins {
+    module
+}
+
 dependencies {
     implementation(project(":detekt-api"))
     implementation("com.pinterest.ktlint:ktlint-ruleset-standard") {
@@ -12,6 +16,8 @@ dependencies {
 
     testImplementation(project(":detekt-test"))
 }
+
+tasks.build { finalizedBy(":detekt-generator:generateDocumentation") }
 
 val depsToPackage = setOf(
     "org.ec4j.core",

--- a/detekt-generator/build.gradle.kts
+++ b/detekt-generator/build.gradle.kts
@@ -1,5 +1,9 @@
 import java.io.ByteArrayOutputStream
 
+plugins {
+    module
+}
+
 dependencies {
     implementation(project(":detekt-parser"))
     implementation(project(":detekt-api"))

--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
+    module
     `java-gradle-plugin`
     id("com.gradle.plugin-publish") version "0.12.0"
 }

--- a/detekt-metrics/build.gradle.kts
+++ b/detekt-metrics/build.gradle.kts
@@ -1,3 +1,7 @@
+plugins {
+    module
+}
+
 dependencies {
     api(project(":detekt-api"))
     testImplementation(project(":detekt-test-utils"))

--- a/detekt-parser/build.gradle.kts
+++ b/detekt-parser/build.gradle.kts
@@ -1,5 +1,9 @@
 import org.jetbrains.kotlin.gradle.plugin.getKotlinPluginVersion
 
+plugins {
+    module
+}
+
 dependencies {
     api(kotlin("compiler-embeddable"))
     implementation(project(":detekt-psi-utils"))

--- a/detekt-psi-utils/build.gradle.kts
+++ b/detekt-psi-utils/build.gradle.kts
@@ -1,3 +1,7 @@
+plugins {
+    module
+}
+
 dependencies {
     implementation(kotlin("compiler-embeddable"))
 }

--- a/detekt-report-html/build.gradle.kts
+++ b/detekt-report-html/build.gradle.kts
@@ -1,3 +1,7 @@
+plugins {
+    module
+}
+
 dependencies {
     compileOnly(project(":detekt-api"))
     compileOnly(project(":detekt-metrics"))

--- a/detekt-report-sarif/build.gradle.kts
+++ b/detekt-report-sarif/build.gradle.kts
@@ -1,3 +1,7 @@
+plugins {
+    module
+}
+
 repositories {
     mavenLocal()
 }

--- a/detekt-report-txt/build.gradle.kts
+++ b/detekt-report-txt/build.gradle.kts
@@ -1,3 +1,7 @@
+plugins {
+    module
+}
+
 dependencies {
     implementation(project(":detekt-api"))
     testImplementation(testFixtures(project(":detekt-api")))

--- a/detekt-report-xml/build.gradle.kts
+++ b/detekt-report-xml/build.gradle.kts
@@ -1,3 +1,7 @@
+plugins {
+    module
+}
+
 dependencies {
     implementation(project(":detekt-api"))
     testImplementation(testFixtures(project(":detekt-api")))

--- a/detekt-rules-complexity/build.gradle.kts
+++ b/detekt-rules-complexity/build.gradle.kts
@@ -1,3 +1,7 @@
+plugins {
+    module
+}
+
 dependencies {
     compileOnly(project(":detekt-api"))
     compileOnly(project(":detekt-metrics"))

--- a/detekt-rules-coroutines/build.gradle.kts
+++ b/detekt-rules-coroutines/build.gradle.kts
@@ -1,3 +1,7 @@
+plugins {
+    module
+}
+
 dependencies {
     compileOnly(project(":detekt-api"))
     testImplementation(project(":detekt-test"))

--- a/detekt-rules-documentation/build.gradle.kts
+++ b/detekt-rules-documentation/build.gradle.kts
@@ -1,3 +1,7 @@
+plugins {
+    module
+}
+
 dependencies {
     compileOnly(project(":detekt-api"))
     testImplementation(project(":detekt-test"))

--- a/detekt-rules-empty/build.gradle.kts
+++ b/detekt-rules-empty/build.gradle.kts
@@ -1,3 +1,7 @@
+plugins {
+    module
+}
+
 dependencies {
     compileOnly(project(":detekt-api"))
     testImplementation(project(":detekt-test"))

--- a/detekt-rules-errorprone/build.gradle.kts
+++ b/detekt-rules-errorprone/build.gradle.kts
@@ -1,3 +1,7 @@
+plugins {
+    module
+}
+
 dependencies {
     compileOnly(project(":detekt-api"))
     testImplementation(project(":detekt-test"))

--- a/detekt-rules-exceptions/build.gradle.kts
+++ b/detekt-rules-exceptions/build.gradle.kts
@@ -1,3 +1,7 @@
+plugins {
+    module
+}
+
 dependencies {
     compileOnly(project(":detekt-api"))
     testImplementation(project(":detekt-test"))

--- a/detekt-rules-naming/build.gradle.kts
+++ b/detekt-rules-naming/build.gradle.kts
@@ -1,3 +1,7 @@
+plugins {
+    module
+}
+
 dependencies {
     compileOnly(project(":detekt-api"))
     testImplementation(project(":detekt-test"))

--- a/detekt-rules-performance/build.gradle.kts
+++ b/detekt-rules-performance/build.gradle.kts
@@ -1,3 +1,7 @@
+plugins {
+    module
+}
+
 dependencies {
     compileOnly(project(":detekt-api"))
     testImplementation(project(":detekt-test"))

--- a/detekt-rules-style/build.gradle.kts
+++ b/detekt-rules-style/build.gradle.kts
@@ -1,3 +1,7 @@
+plugins {
+    module
+}
+
 dependencies {
     compileOnly(project(":detekt-api"))
     compileOnly(project(":detekt-metrics"))

--- a/detekt-rules/build.gradle.kts
+++ b/detekt-rules/build.gradle.kts
@@ -1,3 +1,7 @@
+plugins {
+    module
+}
+
 dependencies {
     compileOnly(project(":detekt-api"))
     implementation(project(":detekt-rules-complexity"))
@@ -14,3 +18,5 @@ dependencies {
     testImplementation(project(":detekt-parser"))
     testImplementation(project(":detekt-test"))
 }
+
+tasks.build { finalizedBy(":detekt-generator:generateDocumentation") }

--- a/detekt-sample-extensions/build.gradle.kts
+++ b/detekt-sample-extensions/build.gradle.kts
@@ -1,3 +1,7 @@
+plugins {
+    module
+}
+
 dependencies {
     // When creating a sample extension, change this dependency to the detekt-api version you build against
     // e.g. io.gitlab.arturbosch.detekt:detekt-api:1.x.x

--- a/detekt-test-utils/build.gradle.kts
+++ b/detekt-test-utils/build.gradle.kts
@@ -1,3 +1,7 @@
+plugins {
+    module
+}
+
 dependencies {
     api(kotlin("stdlib-jdk8"))
     compileOnly("org.spekframework.spek2:spek-dsl-jvm")

--- a/detekt-test/build.gradle.kts
+++ b/detekt-test/build.gradle.kts
@@ -1,3 +1,7 @@
+plugins {
+    module
+}
+
 dependencies {
     api(project(":detekt-api"))
     api(project(":detekt-test-utils"))

--- a/detekt-tooling/build.gradle.kts
+++ b/detekt-tooling/build.gradle.kts
@@ -1,3 +1,7 @@
+plugins {
+    module
+}
+
 dependencies {
     api(project(":detekt-api"))
     testImplementation(project(":detekt-test-utils"))


### PR DESCRIPTION
The idea is to simplify how we configure our own gradle.

Right now we force that all our modules have a specific configuration and with this new approuch we provide a plugin that configures the module as we want and is the module that opts-in this configuration.

An advantage is that we don't need to add exceptions for `:detekt-bom`. It just don't use this module.

The idea is that this is just the first step. Once we do this I'll like to use the plugin https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin to improve how we manage our dependencies because we add a lot by default and we probably don't need that much. And, probably, we could remove all the code in `commons.gradle.kts` at some point.

This will help with the integration with the plugin `binary-compatibility-validator` too. This last one was the trigger to start this refactor.