### PR TITLE
Refactor XmlOutputFormatSpec

### DIFF
--- a/detekt-report-xml/src/test/kotlin/io/github/detekt/report/xml/XmlOutputFormatSpec.kt
+++ b/detekt-report-xml/src/test/kotlin/io/github/detekt/report/xml/XmlOutputFormatSpec.kt
@@ -15,6 +15,8 @@ import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
+private const val TAB = "\t"
+
 class XmlOutputFormatSpec : Spek({
 
     val entity1 by memoized {
@@ -32,39 +34,64 @@ class XmlOutputFormatSpec : Spek({
 
     describe("XML output format") {
 
-        it("renderEmpty") {
+        it("renders empty report") {
             val result = outputFormat.render(TestDetektion())
 
-            assertThat(result).isEqualTo("<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<checkstyle version=\"4.3\">\n</checkstyle>")
+            assertThat(result).isEqualTo("""
+                <?xml version="1.0" encoding="utf-8"?>
+                <checkstyle version="4.3">
+                </checkstyle>""".trimIndent())
         }
 
-        it("renderOneForSingleFile") {
+        it("renders one reported issue in single file") {
             val smell = CodeSmell(Issue("id_a", Severity.CodeSmell, "", Debt.TWENTY_MINS), entity1, message = "")
 
             val result = outputFormat.render(TestDetektion(smell))
 
-            assertThat(result).isEqualTo("<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<checkstyle version=\"4.3\">\n<file name=\"src/main/com/sample/Sample1.kt\">\n\t<error line=\"11\" column=\"1\" severity=\"warning\" message=\"\" source=\"detekt.id_a\" />\n</file>\n</checkstyle>")
+            assertThat(result).isEqualTo("""
+                <?xml version="1.0" encoding="utf-8"?>
+                <checkstyle version="4.3">
+                <file name="src/main/com/sample/Sample1.kt">
+                $TAB<error line="11" column="1" severity="warning" message="" source="detekt.id_a" />
+                </file>
+                </checkstyle>""".trimIndent())
         }
 
-        it("renderTwoForSingleFile") {
+        it("renders two reported issues in single file") {
             val smell1 = CodeSmell(Issue("id_a", Severity.CodeSmell, "", Debt.TWENTY_MINS), entity1, message = "")
             val smell2 = CodeSmell(Issue("id_b", Severity.CodeSmell, "", Debt.TWENTY_MINS), entity1, message = "")
 
             val result = outputFormat.render(TestDetektion(smell1, smell2))
 
-            assertThat(result).isEqualTo("<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<checkstyle version=\"4.3\">\n<file name=\"src/main/com/sample/Sample1.kt\">\n\t<error line=\"11\" column=\"1\" severity=\"warning\" message=\"\" source=\"detekt.id_a\" />\n\t<error line=\"11\" column=\"1\" severity=\"warning\" message=\"\" source=\"detekt.id_b\" />\n</file>\n</checkstyle>")
+            assertThat(result).isEqualTo("""
+                <?xml version="1.0" encoding="utf-8"?>
+                <checkstyle version="4.3">
+                <file name="src/main/com/sample/Sample1.kt">
+                $TAB<error line="11" column="1" severity="warning" message="" source="detekt.id_a" />
+                $TAB<error line="11" column="1" severity="warning" message="" source="detekt.id_b" />
+                </file>
+                </checkstyle>""".trimIndent())
         }
 
-        it("renderOneForMultipleFiles") {
+        it("renders one reported issue across multiple files") {
             val smell1 = CodeSmell(Issue("id_a", Severity.CodeSmell, "", Debt.TWENTY_MINS), entity1, message = "")
             val smell2 = CodeSmell(Issue("id_a", Severity.CodeSmell, "", Debt.TWENTY_MINS), entity2, message = "")
 
             val result = outputFormat.render(TestDetektion(smell1, smell2))
 
-            assertThat(result).isEqualTo("<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<checkstyle version=\"4.3\">\n<file name=\"src/main/com/sample/Sample1.kt\">\n\t<error line=\"11\" column=\"1\" severity=\"warning\" message=\"\" source=\"detekt.id_a\" />\n</file>\n<file name=\"src/main/com/sample/Sample2.kt\">\n\t<error line=\"22\" column=\"2\" severity=\"warning\" message=\"\" source=\"detekt.id_a\" />\n</file>\n</checkstyle>")
+            assertThat(result).isEqualTo("""
+                <?xml version="1.0" encoding="utf-8"?>
+                <checkstyle version="4.3">
+                <file name="src/main/com/sample/Sample1.kt">
+                $TAB<error line="11" column="1" severity="warning" message="" source="detekt.id_a" />
+                </file>
+                <file name="src/main/com/sample/Sample2.kt">
+                $TAB<error line="22" column="2" severity="warning" message="" source="detekt.id_a" />
+                </file>
+                </checkstyle>""".trimIndent())
         }
 
-        it("renderTwoForMultipleFiles") {
+        it("renders two reported issues across multiple files") {
             val smell1 = CodeSmell(Issue("id_a", Severity.CodeSmell, "", Debt.TWENTY_MINS), entity1, message = "")
             val smell2 = CodeSmell(Issue("id_b", Severity.CodeSmell, "", Debt.TWENTY_MINS), entity1, message = "")
             val smell3 = CodeSmell(Issue("id_a", Severity.CodeSmell, "", Debt.TWENTY_MINS), entity2, message = "")
@@ -79,7 +106,18 @@ class XmlOutputFormatSpec : Spek({
                 )
             )
 
-            assertThat(result).isEqualTo("<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<checkstyle version=\"4.3\">\n<file name=\"src/main/com/sample/Sample1.kt\">\n\t<error line=\"11\" column=\"1\" severity=\"warning\" message=\"\" source=\"detekt.id_a\" />\n\t<error line=\"11\" column=\"1\" severity=\"warning\" message=\"\" source=\"detekt.id_b\" />\n</file>\n<file name=\"src/main/com/sample/Sample2.kt\">\n\t<error line=\"22\" column=\"2\" severity=\"warning\" message=\"\" source=\"detekt.id_a\" />\n\t<error line=\"22\" column=\"2\" severity=\"warning\" message=\"\" source=\"detekt.id_b\" />\n</file>\n</checkstyle>")
+            assertThat(result).isEqualTo("""
+                <?xml version="1.0" encoding="utf-8"?>
+                <checkstyle version="4.3">
+                <file name="src/main/com/sample/Sample1.kt">
+                $TAB<error line="11" column="1" severity="warning" message="" source="detekt.id_a" />
+                $TAB<error line="11" column="1" severity="warning" message="" source="detekt.id_b" />
+                </file>
+                <file name="src/main/com/sample/Sample2.kt">
+                $TAB<error line="22" column="2" severity="warning" message="" source="detekt.id_a" />
+                $TAB<error line="22" column="2" severity="warning" message="" source="detekt.id_b" />
+                </file>
+                </checkstyle>""".trimIndent())
         }
 
         describe("severities conversion") {


### PR DESCRIPTION
Test content is crowded into a single line, making it difficult to read and update.
