### PR TITLE
Reduce visibility

### DIFF
--- a/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/dsl/BaselineSpecBuilder.kt
+++ b/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/dsl/BaselineSpecBuilder.kt
@@ -4,10 +4,10 @@ import io.github.detekt.tooling.api.spec.BaselineSpec
 import java.nio.file.Path
 
 @ProcessingModelDsl
-class BaselineSpecBuilder : Builder<BaselineSpec>, BaselineSpec {
+class BaselineSpecBuilder : Builder<BaselineSpec> {
 
-    override var path: Path? = null
-    override var shouldCreateDuringAnalysis: Boolean = false
+    var path: Path? = null
+    var shouldCreateDuringAnalysis: Boolean = false
 
     override fun build(): BaselineSpec = BaselineModel(path, shouldCreateDuringAnalysis)
 }

--- a/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/dsl/BaselineSpecBuilder.kt
+++ b/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/dsl/BaselineSpecBuilder.kt
@@ -12,7 +12,7 @@ class BaselineSpecBuilder : Builder<BaselineSpec>, BaselineSpec {
     override fun build(): BaselineSpec = BaselineModel(path, shouldCreateDuringAnalysis)
 }
 
-internal data class BaselineModel(
+private data class BaselineModel(
     override val path: Path?,
     override val shouldCreateDuringAnalysis: Boolean
 ) : BaselineSpec

--- a/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/dsl/CompilerSpecBuilder.kt
+++ b/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/dsl/CompilerSpecBuilder.kt
@@ -3,16 +3,16 @@ package io.github.detekt.tooling.dsl
 import io.github.detekt.tooling.api.spec.CompilerSpec
 
 @ProcessingModelDsl
-class CompilerSpecBuilder : Builder<CompilerSpec>, CompilerSpec {
+class CompilerSpecBuilder : Builder<CompilerSpec> {
 
-    override var jvmTarget: String = "1.8"
-    override var languageVersion: String? = null
-    override var classpath: String? = null
+    var jvmTarget: String = "1.8"
+    var languageVersion: String? = null
+    var classpath: String? = null
 
     override fun build(): CompilerSpec = CompilerModel(jvmTarget, languageVersion, classpath)
 }
 
-internal data class CompilerModel(
+private data class CompilerModel(
     override val jvmTarget: String?,
     override val languageVersion: String?,
     override val classpath: String?

--- a/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/dsl/ConfigSpecBuilder.kt
+++ b/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/dsl/ConfigSpecBuilder.kt
@@ -5,13 +5,13 @@ import java.net.URL
 import java.nio.file.Path
 
 @ProcessingModelDsl
-class ConfigSpecBuilder : Builder<ConfigSpec>, ConfigSpec {
+class ConfigSpecBuilder : Builder<ConfigSpec> {
 
-    override var shouldValidateBeforeAnalysis: Boolean = true
-    override var knownPatterns: Collection<String> = emptyList()
-    override var useDefaultConfig: Boolean = false // false to be backwards compatible in 1.X
-    override var resources: Collection<URL> = emptyList()
-    override var configPaths: Collection<Path> = emptyList()
+    var shouldValidateBeforeAnalysis: Boolean = true
+    var knownPatterns: Collection<String> = emptyList()
+    var useDefaultConfig: Boolean = false // false to be backwards compatible in 1.X
+    var resources: Collection<URL> = emptyList()
+    var configPaths: Collection<Path> = emptyList()
 
     override fun build(): ConfigSpec = ConfigModel(
         shouldValidateBeforeAnalysis,

--- a/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/dsl/ConfigSpecBuilder.kt
+++ b/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/dsl/ConfigSpecBuilder.kt
@@ -22,7 +22,7 @@ class ConfigSpecBuilder : Builder<ConfigSpec>, ConfigSpec {
     )
 }
 
-internal data class ConfigModel(
+private data class ConfigModel(
     override val shouldValidateBeforeAnalysis: Boolean,
     override val knownPatterns: Collection<String>,
     override val useDefaultConfig: Boolean,

--- a/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/dsl/ExecutionSpecBuilder.kt
+++ b/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/dsl/ExecutionSpecBuilder.kt
@@ -12,7 +12,7 @@ class ExecutionSpecBuilder : Builder<ExecutionSpec>, ExecutionSpec {
     override fun build(): ExecutionSpec = ExecutionModel(executorService, parallelParsing, parallelAnalysis)
 }
 
-internal data class ExecutionModel(
+private data class ExecutionModel(
     override val executorService: ExecutorService?,
     override val parallelParsing: Boolean,
     override val parallelAnalysis: Boolean

--- a/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/dsl/ExecutionSpecBuilder.kt
+++ b/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/dsl/ExecutionSpecBuilder.kt
@@ -4,11 +4,11 @@ import io.github.detekt.tooling.api.spec.ExecutionSpec
 import java.util.concurrent.ExecutorService
 
 @ProcessingModelDsl
-class ExecutionSpecBuilder : Builder<ExecutionSpec>, ExecutionSpec {
+class ExecutionSpecBuilder : Builder<ExecutionSpec> {
 
-    override var executorService: ExecutorService? = null
-    override var parallelParsing: Boolean = false
-    override var parallelAnalysis: Boolean = false
+    var executorService: ExecutorService? = null
+    var parallelParsing: Boolean = false
+    var parallelAnalysis: Boolean = false
     override fun build(): ExecutionSpec = ExecutionModel(executorService, parallelParsing, parallelAnalysis)
 }
 

--- a/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/dsl/ExtensionsSpecBuilder.kt
+++ b/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/dsl/ExtensionsSpecBuilder.kt
@@ -33,7 +33,7 @@ class ExtensionsSpecBuilder : Builder<ExtensionsSpec>, ExtensionsSpec {
     }
 }
 
-internal data class ExtensionsModel(
+private data class ExtensionsModel(
     override val disableDefaultRuleSets: Boolean,
     override val plugins: ExtensionsSpec.Plugins?,
     override val disabledExtensions: Set<ExtensionId>

--- a/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/dsl/ExtensionsSpecBuilder.kt
+++ b/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/dsl/ExtensionsSpecBuilder.kt
@@ -6,11 +6,11 @@ import io.github.detekt.tooling.internal.PluginsHolder
 import java.nio.file.Path
 
 @ProcessingModelDsl
-class ExtensionsSpecBuilder : Builder<ExtensionsSpec>, ExtensionsSpec {
+class ExtensionsSpecBuilder : Builder<ExtensionsSpec> {
 
-    override var disableDefaultRuleSets: Boolean = false
-    override var plugins: ExtensionsSpec.Plugins? = null
-    override var disabledExtensions: MutableSet<ExtensionId> = mutableSetOf()
+    var disableDefaultRuleSets: Boolean = false
+    var plugins: ExtensionsSpec.Plugins? = null
+    var disabledExtensions: MutableSet<ExtensionId> = mutableSetOf()
 
     override fun build(): ExtensionsSpec = ExtensionsModel(
         disableDefaultRuleSets,

--- a/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/dsl/LoggingSpecBuilder.kt
+++ b/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/dsl/LoggingSpecBuilder.kt
@@ -11,7 +11,7 @@ class LoggingSpecBuilder : Builder<LoggingSpec> {
     override fun build(): LoggingSpec = LoggingModel(debug, outputChannel, errorChannel)
 }
 
-internal data class LoggingModel(
+private data class LoggingModel(
     override val debug: Boolean,
     override val outputChannel: Appendable,
     override val errorChannel: Appendable

--- a/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/dsl/ProcessingSpecBuilder.kt
+++ b/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/dsl/ProcessingSpecBuilder.kt
@@ -50,7 +50,7 @@ class ProcessingSpecBuilder : Builder<ProcessingSpec> {
     )
 }
 
-internal data class ProcessingModel(
+private data class ProcessingModel(
     override val baselineSpec: BaselineSpec,
     override val compilerSpec: CompilerSpec,
     override val configSpec: ConfigSpec,

--- a/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/dsl/ProjectSpecBuilder.kt
+++ b/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/dsl/ProjectSpecBuilder.kt
@@ -14,7 +14,7 @@ class ProjectSpecBuilder : Builder<ProjectSpec>, ProjectSpec {
     override fun build(): ProjectSpec = ProjectModel(basePath, inputPaths, excludes, includes)
 }
 
-internal data class ProjectModel(
+private data class ProjectModel(
     override val basePath: Path?,
     override val inputPaths: Collection<Path>,
     override val excludes: Collection<String>,

--- a/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/dsl/ProjectSpecBuilder.kt
+++ b/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/dsl/ProjectSpecBuilder.kt
@@ -4,12 +4,12 @@ import io.github.detekt.tooling.api.spec.ProjectSpec
 import java.nio.file.Path
 
 @ProcessingModelDsl
-class ProjectSpecBuilder : Builder<ProjectSpec>, ProjectSpec {
+class ProjectSpecBuilder : Builder<ProjectSpec> {
 
-    override var basePath: Path? = null
-    override var inputPaths: Collection<Path> = emptyList()
-    override var excludes: Collection<String> = emptyList()
-    override var includes: Collection<String> = emptyList()
+    var basePath: Path? = null
+    var inputPaths: Collection<Path> = emptyList()
+    var excludes: Collection<String> = emptyList()
+    var includes: Collection<String> = emptyList()
 
     override fun build(): ProjectSpec = ProjectModel(basePath, inputPaths, excludes, includes)
 }

--- a/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/dsl/ReportsSpecBuilder.kt
+++ b/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/dsl/ReportsSpecBuilder.kt
@@ -15,8 +15,8 @@ class ReportsSpecBuilder : Builder<ReportsSpec>, ReportsSpec {
     override fun build(): ReportsSpec = ReportsModel(reports)
 }
 
-internal data class ReportsModel(override val reports: Collection<ReportsSpec.Report>) : ReportsSpec
+private data class ReportsModel(override val reports: Collection<ReportsSpec.Report>) : ReportsSpec
 
-internal data class Report(override val type: String, override val path: Path) : ReportsSpec.Report {
+private data class Report(override val type: String, override val path: Path) : ReportsSpec.Report {
     constructor(values: Pair<String, Path>) : this(values.first, values.second)
 }

--- a/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/dsl/ReportsSpecBuilder.kt
+++ b/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/dsl/ReportsSpecBuilder.kt
@@ -4,9 +4,9 @@ import io.github.detekt.tooling.api.spec.ReportsSpec
 import java.nio.file.Path
 
 @ProcessingModelDsl
-class ReportsSpecBuilder : Builder<ReportsSpec>, ReportsSpec {
+class ReportsSpecBuilder : Builder<ReportsSpec> {
 
-    override var reports: MutableCollection<ReportsSpec.Report> = mutableListOf()
+    var reports: MutableCollection<ReportsSpec.Report> = mutableListOf()
 
     fun report(init: () -> Pair<String, Path>) {
         reports.add(Report(init()))

--- a/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/dsl/RulesSpecBuilder.kt
+++ b/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/dsl/RulesSpecBuilder.kt
@@ -19,7 +19,7 @@ class RulesSpecBuilder : Builder<RulesSpec> {
     )
 }
 
-internal data class RulesModel(
+private data class RulesModel(
     override val activateExperimentalRules: Boolean,
     override val maxIssuePolicy: RulesSpec.MaxIssuePolicy,
     override val excludeCorrectable: Boolean,


### PR DESCRIPTION
We don't need to expose the implementations outside the file. And we don't want to mix builders and actual implementations so we should not make the builders implement the interfaces.