### PR TITLE
Update Android Gradle Plugin to 4.1.1

### DIFF
--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -8,7 +8,7 @@ repositories {
 }
 
 dependencies {
-    val androidGradlePlugin = "com.android.tools.build:gradle:4.0.1"
+    val androidGradlePlugin = "com.android.tools.build:gradle:4.1.1"
     implementation(kotlin("gradle-plugin-api"))
     compileOnly(androidGradlePlugin)
 


### PR DESCRIPTION
This is a prerequisite for https://github.com/detekt/detekt/issues/3327.