### PR TITLE
Introduce coroutines to handle parallelism

### DIFF
--- a/detekt-bom/build.gradle.kts
+++ b/detekt-bom/build.gradle.kts
@@ -2,13 +2,19 @@ plugins {
     `java-platform`
 }
 
+javaPlatform {
+    allowDependencies()
+}
+
 dependencies {
-    val version = object {
-        val spek = "2.0.15"
-        val ktlint = "0.40.0"
-    }
+    api(platform("org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.3.9"))
 
     constraints {
+        val version = object {
+            val spek = "2.0.15"
+            val ktlint = "0.40.0"
+        }
+
         api("org.assertj:assertj-core:3.17.2")
         api("org.spekframework.spek2:spek-dsl-jvm:${version.spek}")
         api("org.spekframework.spek2:spek-runner-junit5:${version.spek}")

--- a/detekt-core/build.gradle.kts
+++ b/detekt-core/build.gradle.kts
@@ -9,6 +9,8 @@ dependencies {
     implementation(project(":detekt-report-txt"))
     implementation(project(":detekt-report-xml"))
     implementation(project(":detekt-report-sarif"))
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-jdk8")
 
     testImplementation(project(":detekt-rules"))
     testImplementation(project(":detekt-test"))

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/KtTreeCompiler.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/KtTreeCompiler.kt
@@ -4,21 +4,24 @@ import io.github.detekt.parser.KtCompiler
 import io.github.detekt.tooling.api.spec.ProjectSpec
 import io.gitlab.arturbosch.detekt.api.internal.PathFilters
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.buffer
 import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull
-import kotlinx.coroutines.flow.toList
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.stream.consumeAsFlow
 import org.jetbrains.kotlin.psi.KtFile
 import java.nio.file.Files
 import java.nio.file.Path
+import kotlin.coroutines.coroutineContext
 
 class KtTreeCompiler(
     private val settings: ProcessingSettings,
@@ -30,45 +33,42 @@ class KtTreeCompiler(
     private val pathFilters: PathFilters? =
         PathFilters.of(spec.includes.toList(), spec.excludes.toList())
 
-    fun compile(path: Path): List<KtFile> {
+    suspend fun compile(path: Path): Flow<KtFile> {
         require(Files.exists(path)) { "Given path $path does not exist!" }
         return when {
-            path.isFile() && path.isKotlinFile() -> listOf(compiler.compile(basePath ?: path, path))
+            path.isFile() && path.isKotlinFile() -> flowOf(compiler.compile(basePath ?: path, path))
             path.isDirectory() -> compileProject(path)
             else -> {
                 settings.info("Ignoring a file detekt cannot handle: $path")
-                emptyList()
+                emptyFlow()
             }
         }
     }
 
-    private fun compileProject(project: Path): List<KtFile> {
-        return runBlocking {
-            val coroutineContext = if (settings.spec.executionSpec.parallelParsing) {
-                settings.taskPool.asCoroutineDispatcher()
-            } else {
-                coroutineContext
-            }
-            flow<Path> { emitAll(Files.walk(project).consumeAsFlow()) }
-                .filter { it.isFile() }
-                .flowOn(Dispatchers.IO)
-                .filter { it.isKotlinFile() }
-                .filter { !isIgnored(it) }
-                .map { path ->
-                    async(coroutineContext) {
-                        @Suppress("TooGenericExceptionCaught")
-                        try {
-                            compiler.compile(basePath ?: project, path)
-                        } catch (ex: Throwable) {
-                            settings.error("Could not compile '$path'.", ex)
-                            null
-                        }
+    private suspend fun compileProject(project: Path): Flow<KtFile> {
+        val coroutineContext = if (settings.spec.executionSpec.parallelParsing) {
+            settings.taskPool.asCoroutineDispatcher()
+        } else {
+            coroutineContext
+        }
+        return flow<Path> { emitAll(Files.walk(project).consumeAsFlow()) }
+            .filter { it.isFile() }
+            .flowOn(Dispatchers.IO)
+            .filter { it.isKotlinFile() }
+            .filter { !isIgnored(it) }
+            .map { path ->
+                GlobalScope.async(coroutineContext) {
+                    @Suppress("TooGenericExceptionCaught")
+                    try {
+                        compiler.compile(basePath ?: project, path)
+                    } catch (ex: Throwable) {
+                        settings.error("Could not compile '$path'.", ex)
+                        null
                     }
                 }
-                .buffer()
-                .mapNotNull { it.await() }
-                .toList()
-        }
+            }
+            .buffer()
+            .mapNotNull { it.await() }
     }
 
     private fun Path.isKotlinFile(): Boolean {

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/TaskPool.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/TaskPool.kt
@@ -1,20 +1,8 @@
 package io.gitlab.arturbosch.detekt.core
 
 import java.io.Closeable
-import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
-import java.util.function.Supplier
-
-typealias Task<T> = CompletableFuture<T>
-typealias TaskList<T> = List<CompletableFuture<T>>
-
-fun <T> TaskPool.task(block: () -> T): Task<T> =
-    CompletableFuture.supplyAsync(Supplier { block() }, this)
-
-fun <T> Task<T>.recover(block: (Throwable) -> T?): Task<T?> = this.exceptionally(block)
-
-fun <T> awaitAll(tasks: TaskList<T>) = tasks.map { it.join() }
 
 /**
  * An [ExecutorService] with auto close capabilities for non user managed thread pools.

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/AnalyzerSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/AnalyzerSpec.kt
@@ -16,7 +16,6 @@ import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.jetbrains.kotlin.psi.KtFile
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
-import java.util.concurrent.CompletionException
 
 class AnalyzerSpec : Spek({
 
@@ -55,9 +54,7 @@ class AnalyzerSpec : Spek({
             val analyzer = Analyzer(settings, listOf(StyleRuleSetProvider()), emptyList())
 
             assertThatThrownBy { settings.use { analyzer.run(listOf(compileForTest(testFile))) } }
-                .isInstanceOf(CompletionException::class.java)
-                .hasCauseInstanceOf(IllegalStateException::class.java)
-                .getCause()
+                .isInstanceOf(IllegalStateException::class.java)
                 .hasMessageContaining("please feel free to create an issue on our GitHub page")
         }
     }

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/AnalyzerSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/AnalyzerSpec.kt
@@ -35,9 +35,9 @@ class AnalyzerSpec : Spek({
             val settings = createProcessingSettings(testFile, yamlConfig("configs/config-value-type-wrong.yml"))
             val analyzer = Analyzer(settings, listOf(StyleRuleSetProvider()), emptyList())
 
-            assertThatThrownBy {
-                settings.use { analyzer.run(listOf(compileForTest(testFile))) }
-            }.isInstanceOf(IllegalStateException::class.java)
+            assertThatThrownBy { settings.use { analyzer.run(listOf(compileForTest(testFile))) } }
+                .isInstanceOf(IllegalStateException::class.java)
+                .hasMessageContaining("please feel free to create an issue on our GitHub page")
         }
 
         it("throw error explicitly in parallel when config has wrong value in config") {
@@ -57,6 +57,8 @@ class AnalyzerSpec : Spek({
             assertThatThrownBy { settings.use { analyzer.run(listOf(compileForTest(testFile))) } }
                 .isInstanceOf(CompletionException::class.java)
                 .hasCauseInstanceOf(IllegalStateException::class.java)
+                .getCause()
+                .hasMessageContaining("please feel free to create an issue on our GitHub page")
         }
     }
 })

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/KtTreeCompilerSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/KtTreeCompilerSpec.kt
@@ -15,9 +15,9 @@ class KtTreeCompilerSpec : Spek({
 
         it("should compile all files") {
             val ktFiles = fixture { compile(path) }
-            assertThat(ktFiles.size)
+            assertThat(ktFiles)
                 .describedAs("It should compile at least three files, but did ${ktFiles.size}")
-                .isGreaterThanOrEqualTo(3)
+                .hasSizeGreaterThanOrEqualTo(3)
         }
 
         it("should filter the file 'Default.kt'") {
@@ -37,7 +37,7 @@ class KtTreeCompilerSpec : Spek({
         }
 
         it("should also compile regular files") {
-            assertThat(fixture { compile(path.resolve("Default.kt")) }.size).isEqualTo(1)
+            assertThat(fixture { compile(path.resolve("Default.kt")) }).hasSize(1)
         }
 
         it("throws an exception if given file does not exist") {

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/KtTreeCompilerSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/KtTreeCompilerSpec.kt
@@ -3,69 +3,87 @@ package io.gitlab.arturbosch.detekt.core
 import io.github.detekt.test.utils.NullPrintStream
 import io.github.detekt.test.utils.resourceAsPath
 import io.gitlab.arturbosch.detekt.core.tooling.withSettings
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatIllegalArgumentException
+import org.jetbrains.kotlin.psi.KtFile
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 import java.nio.file.Paths
 
+@ExperimentalCoroutinesApi
 class KtTreeCompilerSpec : Spek({
 
     describe("tree compiler functionality") {
 
         it("should compile all files") {
-            val ktFiles = fixture { compile(path) }
-            assertThat(ktFiles)
-                .describedAs("It should compile at least three files, but did ${ktFiles.size}")
-                .hasSizeGreaterThanOrEqualTo(3)
+            runBlocking {
+                val ktFiles = fixture { compile(path) }
+                assertThat(ktFiles)
+                    .describedAs("It should compile at least three files, but did ${ktFiles.size}")
+                    .hasSizeGreaterThanOrEqualTo(3)
+            }
         }
 
         it("should filter the file 'Default.kt'") {
-            val ktFiles = fixture("**/Default.kt", assertIgnoreMessage = true) { compile(path) }
-            val ktFile = ktFiles.find { it.name == "Default.kt" }
-            assertThat(ktFile).describedAs("It should have no Default.kt file").isNull()
+            runBlocking {
+                val ktFiles = fixture("**/Default.kt", assertIgnoreMessage = true) { compile(path) }
+                val ktFile = ktFiles.find { it.name == "Default.kt" }
+                assertThat(ktFile).describedAs("It should have no Default.kt file").isNull()
+            }
         }
 
         it("should work with two or more filters") {
-            val ktFiles = fixture(
-                "**/Default.kt",
-                "**/*Test*",
-                "**/*Complex*",
-                "**/*KotlinScript*"
-            ) { compile(path) }
-            assertThat(ktFiles).isEmpty()
+            runBlocking {
+                val ktFiles = fixture(
+                    "**/Default.kt",
+                    "**/*Test*",
+                    "**/*Complex*",
+                    "**/*KotlinScript*"
+                ) { compile(path) }
+                assertThat(ktFiles).isEmpty()
+            }
         }
 
         it("should also compile regular files") {
-            assertThat(fixture { compile(path.resolve("Default.kt")) }).hasSize(1)
+            runBlocking {
+                assertThat(fixture { compile(path.resolve("Default.kt")) }).hasSize(1)
+            }
         }
 
         it("throws an exception if given file does not exist") {
             val invalidPath = "NOTHERE"
             assertThatIllegalArgumentException()
-                .isThrownBy { fixture { compile(Paths.get(invalidPath)) } }
+                .isThrownBy { runBlocking { fixture { compile(Paths.get(invalidPath)) } } }
                 .withMessage("Given path $invalidPath does not exist!")
         }
 
         it("does not compile a folder with a css file") {
-            val cssPath = resourceAsPath("css")
-            val ktFiles = fixture { compile(cssPath) }
-            assertThat(ktFiles).isEmpty()
+            runBlocking {
+                val cssPath = resourceAsPath("css")
+                val ktFiles = fixture { compile(cssPath) }
+                assertThat(ktFiles).isEmpty()
+            }
         }
 
         it("does not compile a css file") {
-            val cssPath = resourceAsPath("css").resolve("test.css")
-            val ktFiles = fixture { compile(cssPath) }
-            assertThat(ktFiles).isEmpty()
+            runBlocking {
+                val cssPath = resourceAsPath("css").resolve("test.css")
+                val ktFiles = fixture { compile(cssPath) }
+                assertThat(ktFiles).isEmpty()
+            }
         }
     }
 })
 
-internal inline fun <reified T> fixture(
+private fun fixture(
     vararg filters: String,
     assertIgnoreMessage: Boolean = false,
-    crossinline block: KtTreeCompiler.() -> T
-): T {
+    block: suspend KtTreeCompiler.() -> Flow<KtFile>
+): List<KtFile> {
     val channel = if (assertIgnoreMessage) StringBuilder() else NullPrintStream()
     val spec = createNullLoggingSpec {
         project {
@@ -77,7 +95,9 @@ internal inline fun <reified T> fixture(
             outputChannel = channel
         }
     }
-    val result = spec.withSettings { block(KtTreeCompiler(this, spec.projectSpec)) }
+    val result = spec.withSettings {
+        runBlocking { block(KtTreeCompiler(this@withSettings, spec.projectSpec)).toList() }
+    }
 
     if (assertIgnoreMessage) {
         assertThat(channel.toString()).contains("Ignoring file ")


### PR DESCRIPTION
I think that the API that Flow and the coroutines provide us fit really well with our needs of parallelism.

This is just the first step. We could make this even more parallel. For example, right now, we first create all the `KtFile`s and then we rune all the rules. We could do both at the same time (it's not that easy as I said it but you get the concept).

I'm not sure but maybe the new rule API could use suspend functions to run even more parallel.

This is the first time that I use coroutines "for real" so please tell me if you see any problem.