### PR TITLE
Fix failing website deployment on master

### DIFF
--- a/.github/workflows/deploy-website.yaml
+++ b/.github/workflows/deploy-website.yaml
@@ -82,6 +82,8 @@ jobs:
         mkdir -p vendor/bundle/
         chmod -R 777 _site/
         chmod -R 777 vendor/
+        touch Gemfile.lock
+        chmod a+w Gemfile.lock
       working-directory: docs/
 
     - name: Install Ruby Dependencies


### PR DESCRIPTION
The reason was the following:
"Gemfile.lock It is likely that you need to grant write permissions for that path."
Consequently, write permission is given for the Gemfile.lock file.

Fixes #3321
