### PR TITLE
[RFC] Register Detekt tasks based on source set for Android

### DIFF
--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -8,13 +8,13 @@ repositories {
 }
 
 dependencies {
-    val androidGradlePlugin = "com.android.tools.build:gradle:4.1.1"
+    val agpVersion = "4.1.1"
     implementation(kotlin("gradle-plugin-api"))
-    compileOnly(androidGradlePlugin)
+    compileOnly("com.android.tools.build:gradle-api:$agpVersion")
 
     testImplementation(project(":detekt-test-utils"))
     testImplementation(kotlin("gradle-plugin"))
-    testImplementation(androidGradlePlugin)
+    testImplementation("com.android.tools.build:gradle:$agpVersion")
 
     constraints {
         implementation("org.jetbrains.kotlin:kotlin-reflect:1.4.0") {

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
@@ -5,6 +5,7 @@ import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.plugins.quality.CodeQualityExtension
 import java.io.File
+import java.util.function.Predicate
 import javax.inject.Inject
 
 open class DetektExtension @Inject constructor(objects: ObjectFactory) : CodeQualityExtension() {
@@ -42,21 +43,10 @@ open class DetektExtension @Inject constructor(objects: ObjectFactory) : CodeQua
     var autoCorrect: Boolean = DEFAULT_AUTO_CORRECT_VALUE
 
     /**
-     * List of Android build variants for which no detekt task should be created.
-     *
-     * This is a combination of build types and flavors, such as fooDebug or barRelease.
+     * A filter to specify if the detekt task of any [org.gradle.api.tasks.SourceSet] or
+     * [com.android.build.api.dsl.AndroidSourceSet] should be configured and executed given its name.
      */
-    var ignoredVariants: List<String> = emptyList()
-
-    /**
-     * List of Android build types for which no detekt task should be created.
-     */
-    var ignoredBuildTypes: List<String> = emptyList()
-
-    /**
-     * List of Android build flavors for which no detekt task should be created
-     */
-    var ignoredFlavors: List<String> = emptyList()
+    var sourceSetFilter: Predicate<String> = Predicate { true }
 
     fun reports(configure: Action<DetektReports>) = configure.execute(reports)
 

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektAndroid.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektAndroid.kt
@@ -1,139 +1,89 @@
 package io.gitlab.arturbosch.detekt.internal
 
-import com.android.build.gradle.AppExtension
-import com.android.build.gradle.BaseExtension
-import com.android.build.gradle.LibraryExtension
-import com.android.build.gradle.TestExtension
-import com.android.build.gradle.api.BaseVariant
-import com.android.build.gradle.internal.api.TestedVariant
-import com.android.build.gradle.internal.tasks.factory.dependsOn
+import com.android.build.api.dsl.AndroidSourceSet
+import com.android.build.api.dsl.CommonExtension
 import io.gitlab.arturbosch.detekt.Detekt
 import io.gitlab.arturbosch.detekt.DetektCreateBaselineTask
 import io.gitlab.arturbosch.detekt.DetektPlugin
 import io.gitlab.arturbosch.detekt.extensions.DetektExtension
-import org.gradle.api.DomainObjectSet
 import org.gradle.api.Project
 import org.gradle.api.Task
-import org.gradle.api.file.FileCollection
 import org.gradle.api.tasks.TaskProvider
 import java.io.File
 
 internal class DetektAndroid(private val project: Project) {
 
-    private val mainTaskProvider: TaskProvider<Task> by lazy {
-        project.tasks.register("${DetektPlugin.DETEKT_TASK_NAME}Main") {
+    private val allTasksProvider: TaskProvider<Task> by lazy {
+        project.tasks.register("${DetektPlugin.DETEKT_TASK_NAME}All") {
             it.group = "verification"
-            it.description = "EXPERIMENTAL: Run detekt analysis for production classes across " +
-                    "all variants with type resolution"
+            it.description = "EXPERIMENTAL: Creates detekt baseline files for all classes across " +
+                "all variants with type resolution"
         }
     }
 
-    private val testTaskProvider: TaskProvider<Task> by lazy {
-        project.tasks.register("${DetektPlugin.DETEKT_TASK_NAME}Test") {
+    private val baselineTasksProvider: TaskProvider<Task> by lazy {
+        project.tasks.register("${DetektPlugin.BASELINE_TASK_NAME}All") {
             it.group = "verification"
-            it.description = "EXPERIMENTAL: Run detekt analysis for test classes across " +
-                    "all variants with type resolution"
+            it.description = "EXPERIMENTAL: Creates detekt baseline files for all classes across " +
+                "all variants with type resolution"
         }
     }
-
-    private val mainBaselineTaskProvider: TaskProvider<Task> by lazy {
-        project.tasks.register("${DetektPlugin.BASELINE_TASK_NAME}Main") {
-            it.group = "verification"
-            it.description = "EXPERIMENTAL: Creates detekt baseline files for production classes across " +
-                    "all variants with type resolution"
-        }
-    }
-
-    private val testBaselineTaskProvider: TaskProvider<Task> by lazy {
-        project.tasks.register("${DetektPlugin.BASELINE_TASK_NAME}Test") {
-            it.group = "verification"
-            it.description = "EXPERIMENTAL: Creates detekt baseline files for test classes across " +
-                    "all variants with type resolution"
-        }
-    }
-
-    private val BaseExtension.variants: DomainObjectSet<out BaseVariant>?
-        get() = when (this) {
-            is AppExtension -> applicationVariants
-            is LibraryExtension -> libraryVariants
-            is TestExtension -> applicationVariants
-            else -> null
-        }
-
-    private val BaseVariant.testVariants: List<BaseVariant>
-        get() = if (this is TestedVariant) listOfNotNull(testVariant, unitTestVariant)
-        else emptyList()
 
     fun registerDetektAndroidTasks(extension: DetektExtension) {
-        // There is not a single Android plugin, but each registers an extension based on BaseExtension,
-        // so we catch them all by looking for this one
+        // Ideally we don't need this, but if the user configures Android CommonExtension before Detekt Extension,
+        // sourceSetFilter will not work.
         project.afterEvaluate {
-            val baseExtension = project.extensions.findByType(BaseExtension::class.java)
-            baseExtension?.let {
-                val bootClasspath = project.files(baseExtension.bootClasspath)
-                baseExtension.variants
-                    ?.matching { !extension.matchesIgnoredConfiguration(it) }
-                    ?.all { variant ->
-                        project.registerAndroidDetektTask(bootClasspath, extension, variant).also { provider ->
-                            mainTaskProvider.dependsOn(provider)
-                        }
-                        project.registerAndroidCreateBaselineTask(bootClasspath, extension, variant)
-                            .also { provider ->
-                                mainBaselineTaskProvider.dependsOn(provider)
-                            }
-                        variant.testVariants
-                            .filter { !extension.matchesIgnoredConfiguration(it) }
-                            .forEach { testVariant ->
-                                project.registerAndroidDetektTask(bootClasspath, extension, testVariant)
-                                    .also { provider ->
-                                        testTaskProvider.dependsOn(provider)
-                                    }
-                                project.registerAndroidCreateBaselineTask(bootClasspath, extension, testVariant)
-                                    .also { provider ->
-                                        testBaselineTaskProvider.dependsOn(provider)
-                                    }
-                            }
+            // All Android plugins consume their extension extending on CommonExtension.
+            project.extensions.configure(CommonExtension::class.java) { androidExtension ->
+                androidExtension.sourceSets.all { sourceSet ->
+                    if (extension.sourceSetFilter.test(sourceSet.name)) {
+                        val detektTask = project.registerAndroidDetektTask(sourceSet, extension)
+                        allTasksProvider.configure { it.dependsOn(detektTask) }
+                        val baselineTask = project.registerAndroidCreateBaselineTask(sourceSet, extension)
+                        baselineTasksProvider.configure { it.dependsOn(baselineTask) }
                     }
+                }
             }
         }
     }
 
-    private fun DetektExtension.matchesIgnoredConfiguration(variant: BaseVariant): Boolean =
-        ignoredVariants.contains(variant.name) ||
-                ignoredBuildTypes.contains(variant.buildType.name) ||
-                ignoredFlavors.contains(variant.flavorName)
-
     private fun Project.registerAndroidDetektTask(
-        bootClasspath: FileCollection,
+        sourceSet: AndroidSourceSet,
         extension: DetektExtension,
-        variant: BaseVariant
     ): TaskProvider<Detekt> =
-        registerDetektTask(DetektPlugin.DETEKT_TASK_NAME + variant.name.capitalize(), extension) {
-            setSource(variant.sourceSets.map { it.javaDirectories })
-            classpath.setFrom(variant.getCompileClasspath(null).filter { it.exists() } + bootClasspath)
+        registerDetektTask(DetektPlugin.DETEKT_TASK_NAME + sourceSet.name.capitalize(), extension) {
+            source = project.files().asFileTree.matching(sourceSet.java)
+            classpath.setFrom(
+                configurations.getByName(sourceSet.apiConfigurationName),
+                configurations.getByName(sourceSet.implementationConfigurationName),
+                configurations.getByName(sourceSet.compileOnlyConfigurationName)
+            )
             // If a baseline file is configured as input file, it must exist to be configured, otherwise the task fails.
             // We try to find the configured baseline or alternatively a specific variant matching this task.
-            extension.baseline?.existingVariantOrBaseFile(variant.name)?.let { baselineFile ->
+            extension.baseline?.existingVariantOrBaseFile(sourceSet.name)?.let { baselineFile ->
                 baseline.set(layout.file(project.provider { baselineFile }))
             }
             reports = extension.reports
-            reports.xml.setDefaultIfUnset(File(extension.reportsDir, variant.name + ".xml"))
-            reports.html.setDefaultIfUnset(File(extension.reportsDir, variant.name + ".html"))
-            reports.txt.setDefaultIfUnset(File(extension.reportsDir, variant.name + ".txt"))
-            reports.sarif.setDefaultIfUnset(File(extension.reportsDir, variant.name + ".sarif"))
-            description = "EXPERIMENTAL: Run detekt analysis for ${variant.name} classes with type resolution"
+            reports.xml.setDefaultIfUnset(File(extension.reportsDir, sourceSet.name + ".xml"))
+            reports.html.setDefaultIfUnset(File(extension.reportsDir, sourceSet.name + ".html"))
+            reports.txt.setDefaultIfUnset(File(extension.reportsDir, sourceSet.name + ".txt"))
+            reports.sarif.setDefaultIfUnset(File(extension.reportsDir, sourceSet.name + ".sarif"))
+            description = "EXPERIMENTAL: Run detekt analysis for ${sourceSet.name} classes with type resolution"
         }
 
     private fun Project.registerAndroidCreateBaselineTask(
-        bootClasspath: FileCollection,
-        extension: DetektExtension,
-        variant: BaseVariant
+        sourceSet: AndroidSourceSet,
+        extension: DetektExtension
     ): TaskProvider<DetektCreateBaselineTask> =
-        registerCreateBaselineTask(DetektPlugin.BASELINE_TASK_NAME + variant.name.capitalize(), extension) {
-            setSource(variant.sourceSets.map { it.javaDirectories })
-            classpath.setFrom(variant.getCompileClasspath(null).filter { it.exists() } + bootClasspath)
-            val variantBaselineFile = extension.baseline?.addVariantName(variant.name)
+        registerCreateBaselineTask(DetektPlugin.BASELINE_TASK_NAME + sourceSet.name.capitalize(), extension) {
+            source = project.files().asFileTree.matching(sourceSet.java)
+            classpath.setFrom(
+                configurations.getByName(sourceSet.apiConfigurationName),
+                configurations.getByName(sourceSet.implementationConfigurationName),
+                configurations.getByName(sourceSet.compileOnlyConfigurationName)
+            )
+            val variantBaselineFile = extension.baseline?.addVariantName(sourceSet.name)
             baseline.set(project.layout.file(project.provider { variantBaselineFile }))
-            description = "EXPERIMENTAL: Creates detekt baseline for ${variant.name} classes with type resolution"
+            description = "EXPERIMENTAL: Creates detekt baseline for ${sourceSet.name} classes with type resolution"
         }
 }


### PR DESCRIPTION
Changes:
- This addressed #3327 by registering Detekt tasks based on source set for Android. This brings the implementation of `DetektAndroid` closer to `DetektJvm` (Although, `AndroidSourceSet` is different from Gradle's `SourceSet`, see [Documentation](https://developer.android.com/reference/tools/gradle-api/4.1/com/android/build/api/dsl/AndroidSourceSet).
- Now detekt-gradle-plugin only depends on `gradle-api`.  Although `AndroidSourceSet` and `CommonExtension` are @Incubating, they are not changed in AGP 4.2/7.0.
- Removed `detektMain` and `detektTest` and replaced with `detektAll`, because Main/Test does not really fit the standard source set groups: `main`, `test` and `androidTest`.
- Removed `sally` from `flavorSetup()` to limit the LoC of test code.

Missing items in this PR:
- [ ] Testing Groovy DSL on `sourceSetFilter`
- [ ] Testing in real Android projects