### PR TITLE
recover binary compatibility with 1.15.0

### DIFF
--- a/detekt-api/api/detekt-api.api
+++ b/detekt-api/api/detekt-api.api
@@ -121,6 +121,7 @@ public abstract interface class io/gitlab/arturbosch/detekt/api/Context {
 }
 
 public final class io/gitlab/arturbosch/detekt/api/Context$DefaultImpls {
+	public static fun report (Lio/gitlab/arturbosch/detekt/api/Context;Lio/gitlab/arturbosch/detekt/api/Finding;Ljava/util/Set;Ljava/lang/String;)V
 	public static fun report (Lio/gitlab/arturbosch/detekt/api/Context;Ljava/util/List;Ljava/util/Set;Ljava/lang/String;)V
 	public static synthetic fun report$default (Lio/gitlab/arturbosch/detekt/api/Context;Lio/gitlab/arturbosch/detekt/api/Finding;Ljava/util/Set;Ljava/lang/String;ILjava/lang/Object;)V
 	public static synthetic fun report$default (Lio/gitlab/arturbosch/detekt/api/Context;Ljava/util/List;Ljava/util/Set;Ljava/lang/String;ILjava/lang/Object;)V

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Context.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Context.kt
@@ -22,7 +22,7 @@ interface Context {
      * Additionally suppression by rule set id is supported.
      */
     fun report(finding: Finding, aliases: Set<String> = emptySet(), ruleSetId: RuleSetId? = null) {
-        report(finding, aliases, null)
+        // no-op
     }
 
     /**

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Context.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Context.kt
@@ -21,15 +21,14 @@ interface Context {
      * An alias set can be given to additionally check if an alias was used when suppressing.
      * Additionally suppression by rule set id is supported.
      */
-    fun report(finding: Finding, aliases: Set<String> = emptySet(), ruleSetId: RuleSetId? = null)
+    fun report(finding: Finding, aliases: Set<String> = emptySet(), ruleSetId: RuleSetId? = null) {
+        report(finding, aliases, null)
+    }
 
     /**
      * Same as [report] but reports a list of [findings].
      */
-    fun report(findings: List<Finding>,
-               aliases: Set<String> = emptySet(),
-               ruleSetId: RuleSetId? = null
-    ) {
+    fun report(findings: List<Finding>, aliases: Set<String> = emptySet(), ruleSetId: RuleSetId? = null) {
         findings.forEach { report(it, aliases, ruleSetId) }
     }
 


### PR DESCRIPTION
I move the project to 1.15.0 and runned the task `apiDump` and I found that we already had a binary compatibility problem. This code just restores that compatibility so 1.16.0 will be binary compatible with 1.15.0