### PR TITLE
Generate API validation for  `detekt-psi-utils`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,10 +16,10 @@ buildScan {
 }
 
 apiValidation {
-    // We only need to perform api validation for :detekt-api.
-    //
     // rootProject.name is a temporary workaround to exclude api validation of rootProject.
     // We should refactoring our gradle setup to not apply `JavaBasePlugin`
-    ignoredProjects.addAll(subprojects.filter { it.name != "detekt-api" }.map { it.name } + rootProject.name)
+    ignoredProjects.add(rootProject.name)
+    // We need to perform api validations for external APIs, for :detekt-api and :detekt-psi-utils
+    ignoredProjects.addAll(subprojects.filter { it.name !in listOf("detekt-api", "detekt-psi-utils") }.map { it.name })
     ignoredPackages.add("io.gitlab.arturbosch.detekt.api.internal")
 }

--- a/detekt-psi-utils/api/detekt-psi-utils.api
+++ b/detekt-psi-utils/api/detekt-psi-utils.api
@@ -1,0 +1,100 @@
+public final class io/github/detekt/psi/KeysKt {
+	public static final fun getLINE_SEPARATOR ()Lorg/jetbrains/kotlin/com/intellij/openapi/util/Key;
+	public static final fun getRELATIVE_PATH ()Lorg/jetbrains/kotlin/com/intellij/openapi/util/Key;
+}
+
+public final class io/github/detekt/psi/KtFilesKt {
+	public static final field KOTLIN_SCRIPT_SUFFIX Ljava/lang/String;
+	public static final field KOTLIN_SUFFIX Ljava/lang/String;
+	public static final fun absolutePath (Lorg/jetbrains/kotlin/com/intellij/psi/PsiFile;)Ljava/nio/file/Path;
+	public static final fun fileNameWithoutSuffix (Lorg/jetbrains/kotlin/com/intellij/psi/PsiFile;)Ljava/lang/String;
+	public static final fun getFileName (Lorg/jetbrains/kotlin/com/intellij/psi/PsiFile;)Ljava/lang/String;
+	public static final fun relativePath (Lorg/jetbrains/kotlin/com/intellij/psi/PsiFile;)Ljava/nio/file/Path;
+}
+
+public final class io/gitlab/arturbosch/detekt/rules/AllowedExceptionNamePatternKt {
+	public static final field ALLOWED_EXCEPTION_NAME Ljava/lang/String;
+	public static final fun isAllowedExceptionName (Lorg/jetbrains/kotlin/psi/KtCatchClause;Lkotlin/text/Regex;)Z
+}
+
+public final class io/gitlab/arturbosch/detekt/rules/GuardClausesKt {
+	public static final fun isElvisOperatorGuardClause (Lorg/jetbrains/kotlin/psi/KtExpression;)Z
+	public static final fun isIfConditionGuardClause (Lorg/jetbrains/kotlin/psi/KtExpression;Lorg/jetbrains/kotlin/psi/KtExpression;)Z
+}
+
+public final class io/gitlab/arturbosch/detekt/rules/IdentifierNameKt {
+	public static final fun identifierName (Lorg/jetbrains/kotlin/psi/KtNamedDeclaration;)Ljava/lang/String;
+}
+
+public final class io/gitlab/arturbosch/detekt/rules/IsPartOfUtilsKt {
+	public static final fun isPartOfString (Lorg/jetbrains/kotlin/com/intellij/psi/PsiElement;)Z
+}
+
+public final class io/gitlab/arturbosch/detekt/rules/JunkKt {
+	public static final fun companionObject (Lorg/jetbrains/kotlin/psi/KtClass;)Lorg/jetbrains/kotlin/psi/KtObjectDeclaration;
+	public static final fun getIntValueForPsiElement (Lorg/jetbrains/kotlin/com/intellij/psi/PsiElement;)Ljava/lang/Integer;
+	public static final fun hasCommentInside (Lorg/jetbrains/kotlin/com/intellij/psi/PsiElement;)Z
+	public static final fun hasCommentInside (Lorg/jetbrains/kotlin/psi/KtClassOrObject;)Z
+	public static final fun isUsedForNesting (Lorg/jetbrains/kotlin/psi/KtCallExpression;)Z
+	public static final fun receiverIsUsed (Lorg/jetbrains/kotlin/psi/KtCallExpression;Lorg/jetbrains/kotlin/resolve/BindingContext;)Z
+}
+
+public final class io/gitlab/arturbosch/detekt/rules/KeywordsKt {
+	public static final field IT_LITERAL Ljava/lang/String;
+	public static final field LET_LITERAL Ljava/lang/String;
+}
+
+public final class io/gitlab/arturbosch/detekt/rules/KtAnnotatedExtensionsKt {
+	public static final fun hasAnnotation (Lorg/jetbrains/kotlin/psi/KtAnnotated;[Ljava/lang/String;)Z
+}
+
+public final class io/gitlab/arturbosch/detekt/rules/KtBinaryExpressionKt {
+	public static final fun isNonNullCheck (Lorg/jetbrains/kotlin/psi/KtBinaryExpression;)Z
+}
+
+public final class io/gitlab/arturbosch/detekt/rules/KtCallExpressionKt {
+	public static final fun isCalling (Lorg/jetbrains/kotlin/psi/KtCallExpression;Lorg/jetbrains/kotlin/name/FqName;Lorg/jetbrains/kotlin/resolve/BindingContext;)Z
+	public static final fun isCallingWithNonNullCheckArgument (Lorg/jetbrains/kotlin/psi/KtCallExpression;Lorg/jetbrains/kotlin/name/FqName;Lorg/jetbrains/kotlin/resolve/BindingContext;)Z
+}
+
+public final class io/gitlab/arturbosch/detekt/rules/KtModifierListKt {
+	public static final fun isAbstract (Lorg/jetbrains/kotlin/psi/KtModifierListOwner;)Z
+	public static final fun isConstant (Lorg/jetbrains/kotlin/psi/KtModifierListOwner;)Z
+	public static final fun isExpect (Lorg/jetbrains/kotlin/psi/KtModifierListOwner;)Z
+	public static final fun isExternal (Lorg/jetbrains/kotlin/psi/KtModifierListOwner;)Z
+	public static final fun isInline (Lorg/jetbrains/kotlin/psi/KtModifierListOwner;)Z
+	public static final fun isInternal (Lorg/jetbrains/kotlin/psi/KtModifierListOwner;)Z
+	public static final fun isLateinit (Lorg/jetbrains/kotlin/psi/KtModifierListOwner;)Z
+	public static final fun isOpen (Lorg/jetbrains/kotlin/psi/KtModifierListOwner;)Z
+	public static final fun isOperator (Lorg/jetbrains/kotlin/psi/KtModifierListOwner;)Z
+	public static final fun isOverride (Lorg/jetbrains/kotlin/psi/KtModifierListOwner;)Z
+	public static final fun isPublicNotOverridden (Lorg/jetbrains/kotlin/psi/KtModifierListOwner;)Z
+}
+
+public final class io/gitlab/arturbosch/detekt/rules/KtValueArgumentKt {
+	public static final fun isEmptyOrSingleStringArgument (Ljava/util/List;Lorg/jetbrains/kotlin/resolve/BindingContext;)Z
+	public static final fun isString (Lorg/jetbrains/kotlin/psi/KtValueArgument;Lorg/jetbrains/kotlin/resolve/BindingContext;)Z
+}
+
+public final class io/gitlab/arturbosch/detekt/rules/MethodSignatureKt {
+	public static final fun hasCorrectEqualsParameter (Lorg/jetbrains/kotlin/psi/KtFunction;)Z
+	public static final fun isEqualsFunction (Lorg/jetbrains/kotlin/psi/KtFunction;)Z
+	public static final fun isHashCodeFunction (Lorg/jetbrains/kotlin/psi/KtFunction;)Z
+	public static final fun isMainFunction (Lorg/jetbrains/kotlin/psi/KtNamedFunction;)Z
+}
+
+public final class io/gitlab/arturbosch/detekt/rules/StringExtensionsKt {
+	public static final fun lastArgumentMatchesUrl (Ljava/lang/String;)Z
+}
+
+public final class io/gitlab/arturbosch/detekt/rules/ThrowExtensionsKt {
+	public static final fun getArguments (Lorg/jetbrains/kotlin/psi/KtThrowExpression;)Ljava/util/List;
+	public static final fun isEnclosedByConditionalStatement (Lorg/jetbrains/kotlin/psi/KtThrowExpression;)Z
+	public static final fun isIllegalArgumentException (Lorg/jetbrains/kotlin/psi/KtThrowExpression;)Z
+	public static final fun isIllegalStateException (Lorg/jetbrains/kotlin/psi/KtThrowExpression;)Z
+}
+
+public final class io/gitlab/arturbosch/detekt/rules/TraversingKt {
+	public static final fun isPublicInherited (Lorg/jetbrains/kotlin/psi/KtNamedDeclaration;)Z
+}
+


### PR DESCRIPTION
`detekt-api` depends on `detekt-psi-utils`, so we should generate api documentation as well.
