### PR TITLE
Remove trailing newline after ending IndentingXMLStreamWriter

### DIFF
--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/IndentingXMLStreamWriter.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/IndentingXMLStreamWriter.kt
@@ -64,10 +64,6 @@ internal class IndentingXMLStreamWriter(
         super.writeCharacters("\n")
     }
 
-    override fun writeEndDocument() {
-        super.writeEndDocument()
-    }
-
     override fun writeStartElement(localName: String) {
         onStartTag()
         super.writeStartElement(localName)

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/IndentingXMLStreamWriter.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/IndentingXMLStreamWriter.kt
@@ -66,7 +66,6 @@ internal class IndentingXMLStreamWriter(
 
     override fun writeEndDocument() {
         super.writeEndDocument()
-        super.writeCharacters("\n")
     }
 
     override fun writeStartElement(localName: String) {

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineFormatSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineFormatSpec.kt
@@ -7,7 +7,6 @@ import org.assertj.core.api.Assertions.assertThatIllegalStateException
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
-import java.nio.file.Files
 
 class BaselineFormatSpec : Spek({
 
@@ -54,17 +53,6 @@ class BaselineFormatSpec : Spek({
         context("writes a baseline file") {
 
             val savedBaseline by memoized { Baseline(setOf("4", "2", "2"), setOf("1", "2", "3")) }
-
-            it("has a new line at the end of the written baseline file") {
-                val tempFile = createTempFileForTest("baseline1", ".xml")
-
-                val format = BaselineFormat()
-                format.write(savedBaseline, tempFile)
-                val bytes = Files.readAllBytes(tempFile)
-                val content = String(bytes, Charsets.UTF_8)
-
-                assertThat(content).endsWith(">\n")
-            }
 
             it("asserts that the saved and loaded baseline files are equal") {
                 val tempFile = createTempFileForTest("baseline-saved", ".xml")


### PR DESCRIPTION
Resolves #2655. I know the trailing newline may seem to be stylistically nice, it's not how the underlying writer views a document ending
