### PR TITLE
Remove checkNotNull

### DIFF
--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/JCommander.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/JCommander.kt
@@ -32,15 +32,16 @@ private fun JCommander.usageAsString(): String {
 
 private fun CliArgs.validate(jCommander: JCommander) {
     val violations = StringBuilder()
+    val baseline = baseline
 
     if (createBaseline && baseline == null) {
         violations.appendLine("Creating a baseline.xml requires the --baseline parameter to specify a path.")
     }
 
     if (!createBaseline && baseline != null) {
-        if (Files.notExists(checkNotNull(baseline))) {
+        if (Files.notExists(baseline)) {
             violations.appendLine("The file specified by --baseline should exist '$baseline'.")
-        } else if (!Files.isRegularFile(checkNotNull(baseline))) {
+        } else if (!Files.isRegularFile(baseline)) {
             violations.appendLine("The path specified by --baseline should be a file '$baseline'.")
         }
     }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineResultMapping.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineResultMapping.kt
@@ -21,6 +21,7 @@ class BaselineResultMapping : ReportingExtension {
     }
 
     override fun transformFindings(findings: Map<RuleSetId, List<Finding>>): Map<RuleSetId, List<Finding>> {
+        val baselineFile = baselineFile
         require(
             !createBaseline ||
                 (createBaseline && baselineFile != null)
@@ -28,14 +29,13 @@ class BaselineResultMapping : ReportingExtension {
 
         if (baselineFile != null) {
             val facade = BaselineFacade()
-            val baselinePath = checkNotNull(baselineFile)
 
             if (createBaseline) {
                 val flatten = findings.flatMap { it.value }
-                facade.createOrUpdate(baselinePath, flatten)
+                facade.createOrUpdate(baselineFile, flatten)
             }
 
-            return facade.transformResult(baselinePath, DetektResult(findings)).findings
+            return facade.transformResult(baselineFile, DetektResult(findings)).findings
         }
 
         return findings


### PR DESCRIPTION
Avoid the use of `checkNotNull` when it's not necessary.