### PR TITLE
Improve gradle plugin

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -200,7 +200,6 @@ open class Detekt @Inject constructor(
 
     fun reports(configure: Action<DetektReports>) = configure.execute(reports)
 
-    @Suppress("DEPRECATION")
     @TaskAction
     fun check() {
         val arguments = mutableListOf(

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
@@ -31,7 +31,6 @@ class DetektPlugin : Plugin<Project> {
         project.registerOldDetektTask(extension)
         project.registerDetektJvmTasks(extension)
         project.registerDetektAndroidTasks(extension)
-        project.registerOldCreateBaselineTask(extension)
         project.registerGenerateConfigTask(extension)
     }
 
@@ -69,13 +68,12 @@ class DetektPlugin : Plugin<Project> {
         tasks.matching { it.name == LifecycleBasePlugin.CHECK_TASK_NAME }.configureEach {
             it.dependsOn(detektTaskProvider)
         }
-    }
 
-    private fun Project.registerOldCreateBaselineTask(extension: DetektExtension) =
         registerCreateBaselineTask(BASELINE_TASK_NAME, extension) {
             setSource(existingInputDirectoriesProvider(project, extension))
             baseline.set(project.layout.file(project.provider { extension.baseline }))
         }
+    }
 
     private fun Project.registerGenerateConfigTask(extension: DetektExtension) {
         tasks.register(GENERATE_CONFIG, DetektGenerateConfigTask::class.java) {

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
@@ -28,7 +28,7 @@ class DetektPlugin : Plugin<Project> {
         configurePluginDependencies(project, extension)
         setTaskDefaults(project)
 
-        project.registerOldDetektTask(extension)
+        project.registerDetektVanillaTask(extension)
         project.registerDetektJvmTasks(extension)
         project.registerDetektAndroidTasks(extension)
         project.registerGenerateConfigTask(extension)
@@ -46,7 +46,7 @@ class DetektPlugin : Plugin<Project> {
         }
     }
 
-    private fun Project.registerOldDetektTask(extension: DetektExtension) {
+    private fun Project.registerDetektVanillaTask(extension: DetektExtension) {
         val detektTaskProvider = tasks.register(DETEKT_TASK_NAME, Detekt::class.java) {
             it.debugProp.set(project.provider { extension.debug })
             it.parallelProp.set(project.provider { extension.parallel })

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
@@ -3,7 +3,7 @@ package io.gitlab.arturbosch.detekt
 import io.gitlab.arturbosch.detekt.extensions.DetektExtension
 import io.gitlab.arturbosch.detekt.internal.DetektAndroid
 import io.gitlab.arturbosch.detekt.internal.DetektJvm
-import io.gitlab.arturbosch.detekt.internal.DetektVanilla
+import io.gitlab.arturbosch.detekt.internal.DetektPlain
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.plugins.ReportingBasePlugin
@@ -25,7 +25,7 @@ class DetektPlugin : Plugin<Project> {
         configurePluginDependencies(project, extension)
         setTaskDefaults(project)
 
-        project.registerDetektVanillaTask(extension)
+        project.registerDetektPlainTask(extension)
         project.registerDetektJvmTasks(extension)
         project.registerDetektAndroidTasks(extension)
         project.registerGenerateConfigTask(extension)
@@ -43,8 +43,8 @@ class DetektPlugin : Plugin<Project> {
         }
     }
 
-    private fun Project.registerDetektVanillaTask(extension: DetektExtension) {
-        DetektVanilla(this).registerTasks(extension)
+    private fun Project.registerDetektPlainTask(extension: DetektExtension) {
+        DetektPlain(this).registerTasks(extension)
     }
 
     private fun Project.registerGenerateConfigTask(extension: DetektExtension) {

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
@@ -4,6 +4,7 @@ import io.gitlab.arturbosch.detekt.extensions.DetektExtension
 import io.gitlab.arturbosch.detekt.internal.DetektAndroid
 import io.gitlab.arturbosch.detekt.internal.DetektJvm
 import io.gitlab.arturbosch.detekt.internal.registerCreateBaselineTask
+import io.gitlab.arturbosch.detekt.internal.registerDetektTask
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.file.FileCollection
@@ -47,22 +48,13 @@ class DetektPlugin : Plugin<Project> {
     }
 
     private fun Project.registerDetektVanillaTask(extension: DetektExtension) {
-        val detektTaskProvider = tasks.register(DETEKT_TASK_NAME, Detekt::class.java) {
-            it.debugProp.set(project.provider { extension.debug })
-            it.parallelProp.set(project.provider { extension.parallel })
-            it.disableDefaultRuleSetsProp.set(project.provider { extension.disableDefaultRuleSets })
-            it.buildUponDefaultConfigProp.set(project.provider { extension.buildUponDefaultConfig })
-            it.failFastProp.set(project.provider { extension.failFast })
-            it.autoCorrectProp.set(project.provider { extension.autoCorrect })
-            it.config.setFrom(project.provider { extension.config })
-            it.baseline.set(project.layout.file(project.provider { extension.baseline }))
-            it.setSource(existingInputDirectoriesProvider(project, extension))
-            it.setIncludes(defaultIncludes)
-            it.setExcludes(defaultExcludes)
-            it.reportsDir.set(project.provider { extension.customReportsDir })
-            it.reports = extension.reports
-            it.ignoreFailuresProp.set(project.provider { extension.ignoreFailures })
-            it.basePathProp.set(extension.basePath)
+        val detektTaskProvider = registerDetektTask(DETEKT_TASK_NAME, extension) {
+            baseline.set(project.layout.file(project.provider { extension.baseline }))
+            setSource(existingInputDirectoriesProvider(project, extension))
+            setIncludes(defaultIncludes)
+            setExcludes(defaultExcludes)
+            reportsDir.set(project.provider { extension.customReportsDir })
+            reports = extension.reports
         }
 
         tasks.matching { it.name == LifecycleBasePlugin.CHECK_TASK_NAME }.configureEach {

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
@@ -37,13 +37,13 @@ class DetektPlugin : Plugin<Project> {
 
     private fun Project.registerDetektJvmTasks(extension: DetektExtension) {
         plugins.withId("org.jetbrains.kotlin.jvm") {
-            DetektJvm(this).registerDetektJvmTasks(extension)
+            DetektJvm(this).registerTasks(extension)
         }
     }
 
     private fun Project.registerDetektAndroidTasks(extension: DetektExtension) {
         plugins.withId("kotlin-android") {
-            DetektAndroid(this).registerDetektAndroidTasks(extension)
+            DetektAndroid(this).registerTasks(extension)
         }
     }
 

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektAndroid.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektAndroid.kt
@@ -64,7 +64,7 @@ internal class DetektAndroid(private val project: Project) {
         get() = if (this is TestedVariant) listOfNotNull(testVariant, unitTestVariant)
         else emptyList()
 
-    fun registerDetektAndroidTasks(extension: DetektExtension) {
+    fun registerTasks(extension: DetektExtension) {
         // There is not a single Android plugin, but each registers an extension based on BaseExtension,
         // so we catch them all by looking for this one
         project.afterEvaluate {

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektJvm.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektJvm.kt
@@ -12,7 +12,7 @@ import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
 import java.io.File
 
 internal class DetektJvm(private val project: Project) {
-    fun registerDetektJvmTasks(extension: DetektExtension) {
+    fun registerTasks(extension: DetektExtension) {
         project.afterEvaluate {
             project.convention.getPlugin(JavaPluginConvention::class.java).sourceSets.all { sourceSet ->
                 project.registerJvmDetektTask(extension, sourceSet)

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektPlain.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektPlain.kt
@@ -7,7 +7,7 @@ import org.gradle.api.file.FileCollection
 import org.gradle.api.provider.Provider
 import org.gradle.language.base.plugins.LifecycleBasePlugin
 
-internal class DetektVanilla(private val project: Project) {
+internal class DetektPlain(private val project: Project) {
 
     fun registerTasks(extension: DetektExtension) {
         project.registerDetektTask(extension)

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektVanilla.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektVanilla.kt
@@ -1,0 +1,43 @@
+package io.gitlab.arturbosch.detekt.internal
+
+import io.gitlab.arturbosch.detekt.DetektPlugin
+import io.gitlab.arturbosch.detekt.extensions.DetektExtension
+import org.gradle.api.Project
+import org.gradle.api.file.FileCollection
+import org.gradle.api.provider.Provider
+import org.gradle.language.base.plugins.LifecycleBasePlugin
+
+internal class DetektVanilla(private val project: Project) {
+
+    fun registerTasks(extension: DetektExtension) {
+        project.registerDetektTask(extension)
+        project.registerCreateBaselineTask(extension)
+    }
+
+    private fun Project.registerDetektTask(extension: DetektExtension) {
+        val detektTaskProvider = registerDetektTask(DetektPlugin.DETEKT_TASK_NAME, extension) {
+            baseline.set(project.layout.file(project.provider { extension.baseline }))
+            setSource(existingInputDirectoriesProvider(project, extension))
+            setIncludes(DetektPlugin.defaultIncludes)
+            setExcludes(DetektPlugin.defaultExcludes)
+            reportsDir.set(project.provider { extension.customReportsDir })
+            reports = extension.reports
+        }
+
+        tasks.matching { it.name == LifecycleBasePlugin.CHECK_TASK_NAME }.configureEach {
+            it.dependsOn(detektTaskProvider)
+        }
+    }
+
+    private fun Project.registerCreateBaselineTask(extension: DetektExtension) {
+        registerCreateBaselineTask(DetektPlugin.BASELINE_TASK_NAME, extension) {
+            baseline.set(project.layout.file(project.provider { extension.baseline }))
+            setSource(existingInputDirectoriesProvider(project, extension))
+        }
+    }
+
+    private fun existingInputDirectoriesProvider(
+        project: Project,
+        extension: DetektExtension
+    ): Provider<FileCollection> = project.provider { extension.input.filter { it.exists() } }
+}


### PR DESCRIPTION
Align how we register all our tasks in our plugin.

And I renamed "oldDetekt" to "vanillaDetekt". The old is kind of missleading because is the only non-experimental way that we expose. 