### PR TITLE
Suppress RedundantVisibilityModifierRule if explicit API mode enabled

### DIFF
--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantVisibilityModifierRule.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantVisibilityModifierRule.kt
@@ -68,7 +68,11 @@ class RedundantVisibilityModifierRule(config: Config = Config.empty) : Rule(conf
      * In this mode, the visibility modifier should be defined explicitly even if it is public.
      * See: https://kotlinlang.org/docs/reference/whatsnew14.html#explicit-api-mode-for-library-authors
      */
-    private fun isExplicitApiModeActive() = AnalysisFlags.explicitApiMode.defaultValue == ExplicitApiMode.STRICT
+    private fun isExplicitApiModeActive(): Boolean {
+        val resources = compilerResources ?: return false
+        val flag = resources.languageVersionSettings.getFlag(AnalysisFlags.explicitApiMode)
+        return flag == ExplicitApiMode.STRICT
+    }
 
     override fun visitKtFile(file: KtFile) {
         super.visitKtFile(file)

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantVisibilityModifierRuleSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantVisibilityModifierRuleSpec.kt
@@ -170,11 +170,14 @@ class RedundantVisibilityModifierRuleSpec : Spek({
 
         describe("Explicit API mode") {
 
-            val code = compileContentForTest("""
-                public class A() {
-                    fun f()
-                }""")
-            val rule = RedundantVisibilityModifierRule()
+            val code by memoized {
+                compileContentForTest("""
+                    public class A() {
+                        fun f()
+                    }"""
+                )
+            }
+            val rule by memoized { RedundantVisibilityModifierRule() }
 
             fun mockCompilerResources(mode: ExplicitApiMode): CompilerResources {
                 val languageVersionSettings = mockk<LanguageVersionSettings>()

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantVisibilityModifierRuleSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantVisibilityModifierRuleSpec.kt
@@ -1,7 +1,15 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.github.detekt.test.utils.compileContentForTest
+import io.gitlab.arturbosch.detekt.api.internal.CompilerResources
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.mockk.every
+import io.mockk.mockk
+import org.jetbrains.kotlin.config.AnalysisFlags
+import org.jetbrains.kotlin.config.ExplicitApiMode
+import org.jetbrains.kotlin.config.LanguageVersionSettings
+import org.jetbrains.kotlin.resolve.calls.smartcasts.DataFlowValueFactoryImpl
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
@@ -158,6 +166,37 @@ class RedundantVisibilityModifierRuleSpec : Spek({
                 }
             """
             assertThat(subject.compileAndLint(code)).hasSize(1)
+        }
+
+        describe("Explicit API mode") {
+
+            val code = compileContentForTest("""
+                public class A() {
+                    fun f()
+                }""")
+            val rule = RedundantVisibilityModifierRule()
+
+            fun mockCompilerResources(mode: ExplicitApiMode): CompilerResources {
+                val languageVersionSettings = mockk<LanguageVersionSettings>()
+                every { languageVersionSettings.getFlag(AnalysisFlags.explicitApiMode) } returns mode
+                @Suppress("DEPRECATION")
+                return CompilerResources(languageVersionSettings, DataFlowValueFactoryImpl(languageVersionSettings))
+            }
+
+            it("does not report public function in class if explicit API mode is set to strict") {
+                rule.visitFile(code, compilerResources = mockCompilerResources(ExplicitApiMode.STRICT))
+                assertThat(rule.findings).isEmpty()
+            }
+
+            it("reports public function in class if explicit API mode is disabled") {
+                rule.visitFile(code, compilerResources = mockCompilerResources(ExplicitApiMode.DISABLED))
+                assertThat(rule.findings).hasSize(1)
+            }
+
+            it("reports public function in class if compiler resources are not available") {
+                rule.visitFile(code, compilerResources = null)
+                assertThat(rule.findings).hasSize(1)
+            }
         }
     }
 })


### PR DESCRIPTION
This solution uses the languageVersionSettings of the compiler to fetch the API mode setting.

Explicit API mode was added in Kotlin 1.4
It prevents libraries' authors from making APIs public unintentionally.
In this mode, the visibility modifier should be defined explicitly even if it is public.
See: https://kotlinlang.org/docs/reference/whatsnew14.html#explicit-api-mode-for-library-authors

Closes #3125
