### PR TITLE
Integrate SARIF report with Github code scanning

### DIFF
--- a/.github/workflows/detekt-with-type-resolution.yaml
+++ b/.github/workflows/detekt-with-type-resolution.yaml
@@ -33,11 +33,11 @@ jobs:
         with:
           java-version: 11
 
-      - name: Build detekt and skip checks
-        run: ./gradlew build moveJarForIntegrationTest shadowJarExecutable -x check
+      - name: Package executable jar
+        run: ./gradlew jar moveJarForIntegrationTest shadowJarExecutable
 
       - name: Run detekt-cli with argsfile, override the exit code
-        run: java -jar ./detekt-cli/build/run/detekt "@./config/detekt/argsfile" || true
+        run: ./detekt-cli/build/run/detekt "@./config/detekt/argsfile" || true
 
       - name: Upload SARIF to Github using the upload-sarif action
         uses: github/codeql-action/upload-sarif@v1

--- a/.github/workflows/detekt-with-type-resolution.yaml
+++ b/.github/workflows/detekt-with-type-resolution.yaml
@@ -9,6 +9,42 @@ on:
       - '*'
 
 jobs:
+  without-type-resolution:
+    runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.head_commit.message, 'ci skip') }}
+    env:
+      GRADLE_OPTS: -Dorg.gradle.daemon=false
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+
+      - name: Cache Gradle Folders
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches/
+            ~/.gradle/wrapper/
+          key: cache-gradle-${{ hashFiles('detekt-bom/build.gradle.kts') }}
+          restore-keys: |
+            cache-gradle-
+
+      - name: Setup Java
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
+      - name: Build detekt and skip checks
+        run: ./gradlew build moveJarForIntegrationTest shadowJarExecutable -x check
+
+      - name: Run detekt-cli with argsfile, override the exit code
+        run: java -jar ./detekt-cli/build/run/detekt "@./config/detekt/argsfile" || true
+
+      - name: Upload SARIF to Github using the upload-sarif action
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: build/detekt-report.sarif
+
+
   gradle:
     runs-on: ubuntu-latest
     if: ${{ !contains(github.event.head_commit.message, 'ci skip') }}

--- a/config/detekt/argsfile
+++ b/config/detekt/argsfile
@@ -17,3 +17,5 @@ txt:./build/detekt-report.txt
 sarif:./build/detekt-report.sarif
 -p
 ./build/detekt-formatting.jar
+-bp
+.

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/Reporting.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/Reporting.kt
@@ -45,6 +45,7 @@ const val BUILD = "build"
 const val EXCLUDE_CORRECTABLE = "excludeCorrectable"
 
 const val DETEKT_OUTPUT_REPORT_PATHS_KEY = "detekt.output.report.paths.key"
+const val DETEKT_OUTPUT_REPORT_BASE_PATH_KEY = "detekt.output.report.base.path"
 
 fun Config.excludeCorrectable(): Boolean = subConfig(BUILD).valueOrDefault(EXCLUDE_CORRECTABLE, false)
 

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/tooling/ProcessingSpecSettingsBridge.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/tooling/ProcessingSpecSettingsBridge.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.core.ProcessingSettings
 import io.gitlab.arturbosch.detekt.core.baseline.DETEKT_BASELINE_CREATION_KEY
 import io.gitlab.arturbosch.detekt.core.baseline.DETEKT_BASELINE_PATH_KEY
 import io.gitlab.arturbosch.detekt.core.config.loadConfiguration
+import io.gitlab.arturbosch.detekt.core.reporting.DETEKT_OUTPUT_REPORT_BASE_PATH_KEY
 import io.gitlab.arturbosch.detekt.core.reporting.DETEKT_OUTPUT_REPORT_PATHS_KEY
 import io.gitlab.arturbosch.detekt.core.util.MONITOR_PROPERTY_KEY
 import io.gitlab.arturbosch.detekt.core.util.PerformanceMonitor
@@ -17,8 +18,9 @@ internal fun <R> ProcessingSpec.withSettings(execute: ProcessingSettings.() -> R
         ProcessingSettings(this, configuration).apply {
             baselineSpec.path?.let { register(DETEKT_BASELINE_PATH_KEY, it) }
             register(DETEKT_BASELINE_CREATION_KEY, baselineSpec.shouldCreateDuringAnalysis)
-            register(DETEKT_OUTPUT_REPORT_PATHS_KEY, reportsSpec.reports)
             register(MONITOR_PROPERTY_KEY, monitor)
+            register(DETEKT_OUTPUT_REPORT_PATHS_KEY, reportsSpec.reports)
+            projectSpec.basePath?.let { register(DETEKT_OUTPUT_REPORT_BASE_PATH_KEY, it) }
         }
     }
     val result = settings.use { execute(it) }

--- a/detekt-parser/src/main/kotlin/io/github/detekt/parser/KtCompiler.kt
+++ b/detekt-parser/src/main/kotlin/io/github/detekt/parser/KtCompiler.kt
@@ -35,7 +35,7 @@ open class KtCompiler(
 
         return psiFile.apply {
             putUserData(LINE_SEPARATOR, lineSeparator)
-            val normalizedBasePath = basePath?.normalize()
+            val normalizedBasePath = basePath?.toAbsolutePath()?.normalize()
             normalizedBasePath?.relativize(normalizedAbsolutePath)?.let { relativePath ->
                 putUserData(BASE_PATH, normalizedBasePath.toAbsolutePath().toString())
                 putUserData(RELATIVE_PATH, relativePath.toString())

--- a/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/SarifDsl.kt
+++ b/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/SarifDsl.kt
@@ -1,5 +1,6 @@
 package io.github.detekt.report.sarif
 
+import io.github.detekt.sarif4j.Result
 import io.github.detekt.sarif4j.Run
 import io.github.detekt.sarif4j.SarifSchema210
 import io.github.detekt.sarif4j.Tool
@@ -16,9 +17,7 @@ fun sarif(init: SarifSchema210.() -> Unit): SarifSchema210 = SarifSchema210()
     .withRuns(ArrayList())
     .apply(init)
 
-typealias SarifIssue = io.github.detekt.sarif4j.Result
-
-fun result(init: SarifIssue.() -> Unit): SarifIssue = SarifIssue().withLocations(ArrayList()).apply(init)
+fun result(init: Result.() -> Unit): Result = Result().withLocations(ArrayList()).apply(init)
 
 fun tool(init: Tool.() -> Unit): Tool = Tool().apply(init)
 

--- a/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/SarifOutputReport.kt
+++ b/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/SarifOutputReport.kt
@@ -5,6 +5,7 @@ import io.github.detekt.sarif4j.ArtifactLocation
 import io.github.detekt.sarif4j.JacksonSarifWriter
 import io.github.detekt.sarif4j.Location
 import io.github.detekt.sarif4j.Message
+import io.github.detekt.sarif4j.OriginalUriBaseIds
 import io.github.detekt.sarif4j.PhysicalLocation
 import io.github.detekt.sarif4j.Region
 import io.github.detekt.sarif4j.Result
@@ -17,6 +18,11 @@ import io.gitlab.arturbosch.detekt.api.SetupContext
 import io.gitlab.arturbosch.detekt.api.SeverityLevel
 import io.gitlab.arturbosch.detekt.api.SingleAssign
 import io.gitlab.arturbosch.detekt.api.UnstableApi
+import io.gitlab.arturbosch.detekt.api.getOrNull
+import java.nio.file.Path
+
+const val DETEKT_OUTPUT_REPORT_BASE_PATH_KEY = "detekt.output.report.base.path"
+const val SARIF_SRCROOT_PROPERTY = "%SRCROOT%"
 
 class SarifOutputReport : OutputReport() {
 
@@ -25,18 +31,27 @@ class SarifOutputReport : OutputReport() {
     override val name = "SARIF: a standard format for the output of static analysis tools"
 
     private var config: Config by SingleAssign()
+    private var basePath: String? = null
 
     @OptIn(UnstableApi::class)
     override fun init(context: SetupContext) {
         this.config = context.config
+        this.basePath = context.getOrNull<Path>(DETEKT_OUTPUT_REPORT_BASE_PATH_KEY)?.toAbsolutePath()?.toUnifiedString()
     }
 
     override fun render(detektion: Detektion): String {
         val report = sarif {
             withDetektRun(config) {
+                basePath?.let {
+                    originalUriBaseIds = OriginalUriBaseIds()
+                        .withAdditionalProperty(
+                            SARIF_SRCROOT_PROPERTY,
+                            ArtifactLocation().withUri("file://$basePath")
+                        )
+                }
                 for ((ruleSetId, findings) in detektion.findings) {
                     for (finding in findings) {
-                        results.add(finding.toIssue(ruleSetId))
+                        results.add(finding.toResult(ruleSetId))
                     }
                 }
             }
@@ -51,7 +66,7 @@ private fun SeverityLevel.toResultLevel() = when (this) {
     SeverityLevel.INFO -> Result.Level.NOTE
 }
 
-private fun Finding.toIssue(ruleSetId: RuleSetId): SarifIssue = result {
+private fun Finding.toResult(ruleSetId: RuleSetId): Result = result {
     ruleId = "detekt.$ruleSetId.$id"
     level = severity.toResultLevel()
     for (location in listOf(location) + references.map { it.location }) {
@@ -62,9 +77,9 @@ private fun Finding.toIssue(ruleSetId: RuleSetId): SarifIssue = result {
                     startColumn = location.source.column
                 }
                 artifactLocation = ArtifactLocation().apply {
-                    if (location.filePath.basePath != null && location.filePath.relativePath != null) {
+                    if (location.filePath.relativePath != null) {
                         uri = location.filePath.relativePath?.toUnifiedString()
-                        uriBaseId = "%SRCROOT%"
+                        uriBaseId = SARIF_SRCROOT_PROPERTY
                     } else {
                         uri = location.filePath.absolutePath.toUnifiedString()
                     }

--- a/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/SarifOutputReport.kt
+++ b/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/SarifOutputReport.kt
@@ -64,7 +64,7 @@ private fun Finding.toIssue(ruleSetId: RuleSetId): SarifIssue = result {
                 artifactLocation = ArtifactLocation().apply {
                     if (location.filePath.basePath != null && location.filePath.relativePath != null) {
                         uri = location.filePath.relativePath?.toUnifiedString()
-                        uriBaseId = location.filePath.basePath?.toFile()?.toURI()?.toString()
+                        uriBaseId = "%SRCROOT%"
                     } else {
                         uri = location.filePath.absolutePath.toUnifiedString()
                     }

--- a/detekt-report-sarif/src/test/kotlin/io/github/detekt/report/sarif/SarifOutputReportSpec.kt
+++ b/detekt-report-sarif/src/test/kotlin/io/github/detekt/report/sarif/SarifOutputReportSpec.kt
@@ -5,12 +5,11 @@ import io.github.detekt.tooling.api.VersionProvider
 import io.gitlab.arturbosch.detekt.api.CodeSmell
 import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.api.SeverityLevel
-import io.gitlab.arturbosch.detekt.api.internal.whichOS
 import io.gitlab.arturbosch.detekt.test.EmptySetupContext
 import io.gitlab.arturbosch.detekt.test.TestDetektion
 import io.gitlab.arturbosch.detekt.test.createEntity
-import io.gitlab.arturbosch.detekt.test.createIssue
 import io.gitlab.arturbosch.detekt.test.createFindingForRelativePath
+import io.gitlab.arturbosch.detekt.test.createIssue
 import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
@@ -48,13 +47,7 @@ class SarifOutputReportSpec : Spek({
             val expectedReport = readResourceContent("relative_path.sarif.json")
                 .stripWhitespace()
 
-            // Note: On Github actions, windows file URI is on D: drive
-            val systemAwareExpectedReport = if (whichOS().startsWith("windows", ignoreCase = true)) {
-                expectedReport.replace("file:/", "file:/D:/")
-            } else {
-                expectedReport
-            }
-            assertThat(report).isEqualTo(systemAwareExpectedReport)
+            assertThat(report).isEqualTo(expectedReport)
         }
     }
 })

--- a/detekt-report-sarif/src/test/resources/relative_path.sarif.json
+++ b/detekt-report-sarif/src/test/resources/relative_path.sarif.json
@@ -17,6 +17,11 @@
           "language": "en"
         }
       },
+      "originalUriBaseIds": {
+        "%SRCROOT%": {
+          "uri": "file:///Users/tester/detekt"
+        }
+      },
       "results": [
         {
           "ruleId": "detekt.TestSmellA.TestSmellA",

--- a/detekt-report-sarif/src/test/resources/relative_path.sarif.json
+++ b/detekt-report-sarif/src/test/resources/relative_path.sarif.json
@@ -28,7 +28,7 @@
               "physicalLocation": {
                 "artifactLocation": {
                   "uri": "TestFile.kt",
-                  "uriBaseId": "file:/Users/tester/detekt"
+                  "uriBaseId": "%SRCROOT%"
                 },
                 "region": {
                   "startLine": 1,
@@ -48,7 +48,7 @@
               "physicalLocation": {
                 "artifactLocation": {
                   "uri": "TestFile.kt",
-                  "uriBaseId": "file:/Users/tester/detekt"
+                  "uriBaseId": "%SRCROOT%"
                 },
                 "region": {
                   "startLine": 1,
@@ -68,7 +68,7 @@
               "physicalLocation": {
                 "artifactLocation": {
                   "uri": "TestFile.kt",
-                  "uriBaseId": "file:/Users/tester/detekt"
+                  "uriBaseId": "%SRCROOT%"
                 },
                 "region": {
                   "startLine": 1,


### PR DESCRIPTION
This should wrap up basic support for #3045. This PR integrates SARIF output with Github code scanning by adding a new GitHub workflow using detekt without type resolution.
- Fix a bug in KtCompiler.kt that we need to yield the absolute path of the base path.
- Use `%SRCROOT%` as uriBaseId. In [SARIF support for coding scanning](https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/sarif-support-for-code-scanning), `%SRCROOT%` was used as an example, which seems to be the only way that works with Github Action. If we pass the base path based on the local directory, like `"uriBaseId": "/Users/chaozhang/detekt"`, it will not be consumed by Github.
- In the screenshot, we are showing duplicate messages. This is because not each `CodeSmell` defines its own message. It will fallback to issue description if no message is specified, which is exactly the case in the manual test.

Follow up
=====
- Once this PR is merged, I will add a specific page in doc on integrating with Github actions.
- Type resolution is still experimental that I see errors in the log. Running detekt **with** type resolution will also generate one SARIF per source set and require Github work flow to upload multiple SARIF files, instead of one file. Given these complications, I am only using the SARIF output for detekt run **without** type resolution in this PR.
- Once there is a new detekt version released, I can change the option to enable the SARIF output by default + to enable relative path by default given the project root. (If we resolve #3324, we no longer need to wait for new detekt versions to be released).

Test
=====
See [the PR on my own fork of detekt](https://github.com/chao2zhang/detekt/pull/4), you can find GitHub codescanning like the following:
![image](https://user-images.githubusercontent.com/1175468/103974874-8ca30380-5127-11eb-80cf-51a92b4cf929.png)
