### PR TITLE
Filter existing files in classpath

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektJvm.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektJvm.kt
@@ -4,6 +4,7 @@ import io.gitlab.arturbosch.detekt.DetektPlugin
 import io.gitlab.arturbosch.detekt.extensions.DetektExtension
 import org.gradle.api.GradleException
 import org.gradle.api.Project
+import org.gradle.api.file.FileCollection
 import org.gradle.api.internal.HasConvention
 import org.gradle.api.plugins.JavaPluginConvention
 import org.gradle.api.tasks.SourceSet
@@ -25,7 +26,7 @@ internal class DetektJvm(private val project: Project) {
             ?: throw GradleException("Kotlin source set not found. Please report on detekt's issue tracker")
         registerDetektTask(DetektPlugin.DETEKT_TASK_NAME + sourceSet.name.capitalize(), extension) {
             setSource(kotlinSourceSet.kotlin.files)
-            classpath.setFrom(sourceSet.compileClasspath, sourceSet.output.classesDirs.filter { it.exists() })
+            classpath.setFrom(sourceSet.compileClasspath.existingFiles(), sourceSet.output.classesDirs.existingFiles())
             // If a baseline file is configured as input file, it must exist to be configured, otherwise the task fails.
             // We try to find the configured baseline or alternatively a specific variant matching this task.
             extension.baseline?.existingVariantOrBaseFile(sourceSet.name)?.let { baselineFile ->
@@ -45,10 +46,12 @@ internal class DetektJvm(private val project: Project) {
             ?: throw GradleException("Kotlin source set not found. Please report on detekt's issue tracker")
         registerCreateBaselineTask(DetektPlugin.BASELINE_TASK_NAME + sourceSet.name.capitalize(), extension) {
             setSource(kotlinSourceSet.kotlin.files)
-            classpath.setFrom(sourceSet.compileClasspath, sourceSet.output.classesDirs.filter { it.exists() })
+            classpath.setFrom(sourceSet.compileClasspath.existingFiles(), sourceSet.output.classesDirs.existingFiles())
             val variantBaselineFile = extension.baseline?.addVariantName(sourceSet.name)
             baseline.set(project.layout.file(project.provider { variantBaselineFile }))
             description = "EXPERIMENTAL: Creates detekt baseline for ${sourceSet.name} classes with type resolution"
         }
     }
+
+    private fun FileCollection.existingFiles() = filter { it.exists() }
 }


### PR DESCRIPTION
Resolves https://github.com/detekt/detekt/issues/3019#issuecomment-681075547

Test
====
Verified that `warning: classpath entry points to a non-existent location: /Users/cazhang/detekt/detekt-metrics/build/classes/java/main` is not shown in the log.