### PR TITLE
Add a test for UndocumentedPublicClass and fun interfaces

### DIFF
--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicClassSpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicClassSpec.kt
@@ -185,5 +185,20 @@ class UndocumentedPublicClassSpec : Spek({
         """
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
+
+        it("should not report for fun interfaces") {
+            val code = """
+            /**
+             * This interface is an example
+             */
+            fun interface Example {
+                /**
+                 * Trigger when done
+                 */
+                fun onComplete()
+            }
+            """
+            assertThat(subject.compileAndLint(code)).isEmpty()
+        }
     }
 })


### PR DESCRIPTION
Adding a test case to validate `UndocumentedPublicClass` against `fun interfaces`.

See #3372 for reference.
