### PR TITLE
Refactor orders of repositories

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -7,9 +7,9 @@ kotlinDslPluginOptions {
 }
 
 repositories {
+    mavenLocal() // used to publish and test local gradle plugin changes
     gradlePluginPortal()
     jcenter()
-    mavenLocal() // used to publish and test local gradle plugin changes
 }
 
 object Plugins {

--- a/detekt-report-sarif/build.gradle.kts
+++ b/detekt-report-sarif/build.gradle.kts
@@ -2,10 +2,6 @@ plugins {
     module
 }
 
-repositories {
-    mavenLocal()
-}
-
 dependencies {
     compileOnly(project(":detekt-api"))
     compileOnly(project(":detekt-tooling"))


### PR DESCRIPTION
One pain point of testing the detekt-gradle-plugin against local changes in detekt-cli is that I have to swap order as done in this PR. I am publishing this PR to make it easier for contributors.

This also upholds the truth of [Contributing.md#when working on the gradle plugin](https://github.com/detekt/detekt/blob/master/.github/CONTRIBUTING.md#when-working-on-the-gradle-plugin-).