### PR TITLE
Fix EmptyConfig making all rules active in production

### DIFF
--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Config.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Config.kt
@@ -50,7 +50,7 @@ interface Config {
         /**
          * An empty configuration with no properties.
          * This config should only be used in test cases.
-         * Always returns the default value except when 'active' is queried, it returns true .
+         * Always returns the default value except when 'active' is queried, it returns true.
          */
         val empty: Config = EmptyConfig
 

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/YamlConfig.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/YamlConfig.kt
@@ -72,7 +72,7 @@ class YamlConfig internal constructor(
                 Yaml().loadAs(it, Map::class.java) as Map<*, *>?
             }.getOrElse { throw Config.InvalidConfigurationError(it) }
             if (map == null) {
-                Config.empty
+                YamlConfig(emptyMap())
             } else {
                 YamlConfig(map as Map<String, Any>)
             }

--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -17,11 +17,18 @@ processors:
   active: true
   exclude:
     - 'DetektProgressListener'
+  # - 'KtFileCountProcessor'
+  # - 'PackageCountProcessor'
+  # - 'ClassCountProcessor'
   # - 'FunctionCountProcessor'
   # - 'PropertyCountProcessor'
-  # - 'ClassCountProcessor'
-  # - 'PackageCountProcessor'
-  # - 'KtFileCountProcessor'
+  # - 'ProjectComplexityProcessor'
+  # - 'ProjectCognitiveComplexityProcessor'
+  # - 'ProjectLLOCProcessor'
+  # - 'ProjectCLOCProcessor'
+  # - 'ProjectLOCProcessor'
+  # - 'ProjectSLOCProcessor'
+  # - 'LicenseHeaderLoaderExtension'
 
 console-reports:
   active: true

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/rulesetpage/ConfigPrinter.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/rulesetpage/ConfigPrinter.kt
@@ -94,11 +94,18 @@ object ConfigPrinter : DocumentationPrinter<List<RuleSetPage>> {
         active: true
         exclude:
           - 'DetektProgressListener'
+        # - 'KtFileCountProcessor'
+        # - 'PackageCountProcessor'
+        # - 'ClassCountProcessor'
         # - 'FunctionCountProcessor'
         # - 'PropertyCountProcessor'
-        # - 'ClassCountProcessor'
-        # - 'PackageCountProcessor'
-        # - 'KtFileCountProcessor'
+        # - 'ProjectComplexityProcessor'
+        # - 'ProjectCognitiveComplexityProcessor'
+        # - 'ProjectLLOCProcessor'
+        # - 'ProjectCLOCProcessor'
+        # - 'ProjectLOCProcessor'
+        # - 'ProjectSLOCProcessor'
+        # - 'LicenseHeaderLoaderExtension'
     """.trimIndent()
 
     private fun defaultConsoleReportsConfiguration(): String = """

--- a/docs/pages/configurations.md
+++ b/docs/pages/configurations.md
@@ -140,11 +140,18 @@ processors:
     active: true
     exclude:
         - 'DetektProgressListener'
+        # - 'KtFileCountProcessor'
+        # - 'PackageCountProcessor'
+        # - 'ClassCountProcessor'
         # - 'FunctionCountProcessor'
         # - 'PropertyCountProcessor'
-        # - 'ClassCountProcessor'
-        # - 'PackageCountProcessor'
-        # - 'KtFileCountProcessor'
+        # - 'ProjectComplexityProcessor'
+        # - 'ProjectCognitiveComplexityProcessor'
+        # - 'ProjectLLOCProcessor'
+        # - 'ProjectCLOCProcessor'
+        # - 'ProjectLOCProcessor'
+        # - 'ProjectSLOCProcessor'
+        # - 'LicenseHeaderLoaderExtension'
 ```
 
 ## Config JSON Schema


### PR DESCRIPTION
Fixes #3379

The root cause is that we are returning `Config.empty` when the custom config file is an empty yaml. This is problematic because the `Config.empty` by default enables all rules.
We fixes this by returning a `Config(emptyMap)` instead of an `EmptyConfig`. This conforms to the comment "An empty configuration with no properties. This config should only be used in **test** cases. Always returns the default value except when 'active' is queried, it returns true."

I also updated the default-detekt-config.yml to list all FileProcessorListeners, as discovered when debugging #3379. 