### PR TITLE
Make gradle plugin defaults consider multiplatform sourcesets

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ If you contributed to detekt but your name is not in the list, please feel free 
 - [Roman Ivanov](https://github.com/rwqwr) - Rule improvement: ReturnFromFinally
 - [Severn Everett](https://github.com/severn-everett) - New rule: SleepInsteadOfDelay
 - [Adam Kobor](https://github.com/adamkobor) - New rule: MultilineLambdaItParameter
+- [Gustav Karlsson](https://github.com/gustavkarlsson) - Improvement: Make gradle plugin defaults consider multiplatform sourcesets
 
 ### Mentions
 

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
@@ -23,11 +23,11 @@ open class DetektExtension @Inject constructor(objects: ObjectFactory) : CodeQua
     val reports = DetektReports()
 
     var input: ConfigurableFileCollection =
-        objects.fileCollection().from(DEFAULT_SRC_DIR_JAVA, DEFAULT_SRC_DIR_KOTLIN)
+        objects.fileCollection().from(
+            objects.fileTree().from("src").include("main/kotlin/", "*Main/kotlin/", "main/java/", "*Main/java/")
+        )
 
     var baseline: File? = null
-
-    var basePath: String? = null
 
     var config: ConfigurableFileCollection = objects.fileCollection()
 
@@ -63,8 +63,6 @@ open class DetektExtension @Inject constructor(objects: ObjectFactory) : CodeQua
     fun reports(configure: Action<DetektReports>) = configure.execute(reports)
 
     companion object {
-        const val DEFAULT_SRC_DIR_JAVA = "src/main/java"
-        const val DEFAULT_SRC_DIR_KOTLIN = "src/main/kotlin"
         const val DEFAULT_DEBUG_VALUE = false
         const val DEFAULT_PARALLEL_VALUE = false
         const val DEFAULT_AUTO_CORRECT_VALUE = false

--- a/docs/pages/gettingstarted/gradle.md
+++ b/docs/pages/gettingstarted/gradle.md
@@ -18,7 +18,7 @@ The detekt Gradle plugin will generate multiple tasks:
 
 - `detekt` - Runs a detekt analysis and complexity report on your source files. Configure the analysis inside the 
 `detekt` closure. By default the standard rule set without any ignore list is executed on sources files located
- in `src/main/java` and `src/main/kotlin`. Reports are automatically generated in xml, html, txt, and sarif format and can be 
+ in `src/main/java`, `src/main/kotlin`, `src/*Main/java` and `src/*Main/kotlin`. Reports are automatically generated in xml, html, txt, and sarif format and can be 
  found in `build/reports/detekt/detekt.[xml|html|txt|sarif]` respectively. Please note that the `detekt` task is automatically 
  run when executing `gradle check`.
 - `detektGenerateConfig` - Generates a default detekt configuration file into your project directory.
@@ -190,7 +190,7 @@ For more information about how to configure the repositories read [about the rep
 ```groovy
 detekt {
     toolVersion = "{{ site.detekt_version }}"                                 // Version of Detekt that will be used. When unspecified the latest detekt version found will be used. Override to stay on the same version.
-    input = files(                                        // The directories where detekt looks for source files. Defaults to `files("src/main/java", "src/main/kotlin")`.
+    input = files(                                        // The directories where detekt looks for source files. Defaults to `files(fileTree("src").include("main/kotlin/", "*Main/kotlin/", "main/java/", "*Main/java/"))`.
         "src/main/kotlin",
         "gensrc/main/kotlin"
     )
@@ -235,7 +235,7 @@ detekt {
 ```kotlin
 detekt {
     toolVersion = "{{ site.detekt_version }}"                                 // Version of Detekt that will be used. When unspecified the latest detekt version found will be used. Override to stay on the same version.
-    input = files("src/main/java", "src/main/kotlin")     // The directories where detekt looks for source files. Defaults to `files("src/main/java", "src/main/kotlin")`.
+    input = files("src/main/java", "src/main/kotlin")     // The directories where detekt looks for source files. Defaults to `files(fileTree("src").include("main/kotlin/", "*Main/kotlin/", "main/java/", "*Main/java/"))`.
     parallel = false                                      // Builds the AST in parallel. Rules are always executed in parallel. Can lead to speedups in larger projects. `false` by default.
     config = files("path/to/config.yml")                  // Define the detekt configuration(s) you want to use. Defaults to the default detekt configuration.
     buildUponDefaultConfig = false                        // Interpret config files as updates to the default config. `false` by default.


### PR DESCRIPTION
By default, the gradle plugin only considers `src/main/java` and `src/main/kotlin` when looking for source directories. This means multiplatform projects must add custom configuration to work.

This PR adds multiplatform directories by using a `FileTree` with patterns to find all applicable directories