### PR TITLE
Fix hyperlink for elements of the type 'KtFile'

### DIFF
--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/Signatures.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/Signatures.kt
@@ -18,6 +18,16 @@ internal fun PsiElement.searchName(): String {
     return this.namedUnwrappedElement?.name?.formatElementName() ?: "<UnknownName>"
 }
 
+/*
+ * PsiElements of type KtFile use the absolute path as their names. This resulted in
+ * having two absolute paths being printed along with the output: one for the name
+ * and one for the location. Consequently, IntelliJ was not hyperlinking them because
+ * it only hyperlinks one path file per line.
+ *
+ * This gets the file name only, instead of the entire absolute path, and takes it as the element name.
+ *
+ * Example: KtFile with name /full/path/to/Test.kt will have its name formatted to be simply Test.kt
+ */
 private fun String.formatElementName(): String =
     if (contains(File.separatorChar)) substringAfterLast(File.separatorChar)
     else this

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/Signatures.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/Signatures.kt
@@ -10,12 +10,17 @@ import org.jetbrains.kotlin.psi.psiUtil.endOffset
 import org.jetbrains.kotlin.psi.psiUtil.getNonStrictParentOfType
 import org.jetbrains.kotlin.psi.psiUtil.parents
 import org.jetbrains.kotlin.psi.psiUtil.startOffset
+import java.io.File
 
 private val multipleWhitespaces = Regex("\\s{2,}")
 
 internal fun PsiElement.searchName(): String {
-    return this.namedUnwrappedElement?.name ?: "<UnknownName>"
+    return this.namedUnwrappedElement?.name?.formatElementName() ?: "<UnknownName>"
 }
+
+private fun String.formatElementName(): String =
+    if (contains(File.separatorChar)) substringAfterLast(File.separatorChar)
+    else this
 
 /*
  * KtCompiler wrongly used Path.filename as the name for a KtFile instead of the whole path.

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/EntitySpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/EntitySpec.kt
@@ -16,8 +16,7 @@ class EntitySpec : Spek({
     describe("entity signatures") {
         val path = Paths.get("/full/path/to/Test.kt")
         val code by memoized(CachingMode.SCOPE) {
-            compileContentForTest(
-                """
+            compileContentForTest("""
             package test
 
             class C : Any() {


### PR DESCRIPTION
Issue: https://github.com/detekt/detekt/issues/2340

**Description:**

IntelliJ (and consequently Android Studio), considers the following implementation when enabling hyperlink in its terminal emulator: [AbstractFileHyperlinkFilter](https://github.com/JetBrains/intellij-community/blob/master/platform/execution-impl/src/com/intellij/execution/filters/AbstractFileHyperlinkFilter.java)

I noticed that there were two issues happening related to hyperlinks not being enabled in the output of detect:
1. Files outside the considered project scope by IntelliJ (/build, etc) were not hyperlinking because IntelliJ uses the Filter above, and consequently, the file must be inside the considered project scope by IntelliJ in order to be Highlighted. 
2. And output with two file paths in the same line -- this usually happens for elements of type KtFile, classes and functions seem to hyperlink just fine. I didn’t find a reason as to why this happens, but I think it’s out of the scope of Detekt to fix it -- other tools have the same problem. 

Example of the point 2 before the changes I applied in this PR:
<img width="1348" alt="Screenshot 2021-01-17 at 21 42 43" src="https://user-images.githubusercontent.com/48203644/104908098-3f742c80-5986-11eb-8963-54da1b392b62.png">

------

**Fix:**
A fix for point 2 is to simplify the Entity name in the case of Files by getting the file name without the absolute path since the path is also written along with the output. 

Regarding other terminal emulators, it really depends on the terminal emulator you're using to specify the way of hyperlinking: https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda. 
This only tackles the IntelliJ Terminal Emulator. 
