### PR TITLE
Disable parallel test discovery; we already use Grade workers for max parallelism

### DIFF
--- a/buildSrc/src/main/kotlin/module.gradle.kts
+++ b/buildSrc/src/main/kotlin/module.gradle.kts
@@ -30,7 +30,7 @@ tasks.withType<Test>().configureEach {
     useJUnitPlatform()
     systemProperty("spek2.jvm.cg.scan.concurrency", 1) // use one thread for classpath scanning
     systemProperty("spek2.execution.test.timeout", 0) // disable test timeout
-    systemProperty("spek2.discovery.parallel.enabled", 1) // enable parallel test discovery
+    systemProperty("spek2.discovery.parallel.enabled", 0) // disable parallel test discovery
     val compileSnippetText: Boolean = if (project.hasProperty("compile-test-snippets")) {
         (project.property("compile-test-snippets") as String).toBoolean()
     } else {


### PR DESCRIPTION
Additional thread parallelism in a Gradle worker does not increase the test throughput:

with spek2.discovery.parallel.enabled=1
https://scans.gradle.com/s/wf5ehygo374ck/tests?toggled=WyI6ZGV0ZWt0LWdyYWRsZS1wbHVnaW4iLCI6ZGV0ZWt0LXJ1bGVzLWVycm9ycHJvbmUiLCI6ZGV0ZWt0LXJ1bGVzLXN0eWxlIiwiOmRldGVrdC1ydWxlcy1jb21wbGV4aXR5Il0

spek2.discovery.parallel.enabled=0
https://scans.gradle.com/s/kpvph5aoudc5c/tests?toggled=WyI6ZGV0ZWt0LWdyYWRsZS1wbHVnaW4iLCI6ZGV0ZWt0LXJ1bGVzLXN0eWxlIiwiOmRldGVrdC1ydWxlcy1lcnJvcnByb25lIl0