### PR TITLE
Ignore actual functions in FunctionOnlyReturningConstant (#3388)

### DIFF
--- a/.github/workflows/codecoverage.yaml
+++ b/.github/workflows/codecoverage.yaml
@@ -6,7 +6,7 @@ on:
       - master
   pull_request:
     branches:
-      - '*'
+      - '**'
 
 jobs:
   publish-code-coverage:

--- a/.github/workflows/detekt-with-type-resolution.yaml
+++ b/.github/workflows/detekt-with-type-resolution.yaml
@@ -6,7 +6,7 @@ on:
       - master
   pull_request:
     branches:
-      - '*'
+      - '**'
 
 jobs:
   without-type-resolution:

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -5,7 +5,7 @@ on:
       - master
   pull_request:
     branches:
-      - '*'
+      - '**'
 
 jobs:
   validation:

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -6,7 +6,7 @@ on:
       - master
   pull_request:
     branches:
-      - '*'
+      - '**'
 
 jobs:
   gradle:

--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ If you contributed to detekt but your name is not in the list, please feel free 
 - [Roman Ivanov](https://github.com/rwqwr) - Rule improvement: ReturnFromFinally
 - [Severn Everett](https://github.com/severn-everett) - New rule: SleepInsteadOfDelay
 - [Adam Kobor](https://github.com/adamkobor) - New rule: MultilineLambdaItParameter
+- [Slawomir Czerwinski](https://github.com/sczerwinski) - Rule improvement: FunctionOnlyReturningConstant
 
 ### Mentions
 

--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -572,6 +572,7 @@ style:
   FunctionOnlyReturningConstant:
     active: true
     ignoreOverridableFunction: true
+    ignoreActualFunction: true
     excludedFunctions: 'describeContents'
     excludeAnnotatedFunction: ['dagger.Provides']
   LibraryCodeMustSpecifyReturnType:

--- a/detekt-psi-utils/api/detekt-psi-utils.api
+++ b/detekt-psi-utils/api/detekt-psi-utils.api
@@ -85,6 +85,7 @@ public final class io/gitlab/arturbosch/detekt/rules/KtCallExpressionKt {
 
 public final class io/gitlab/arturbosch/detekt/rules/KtModifierListKt {
 	public static final fun isAbstract (Lorg/jetbrains/kotlin/psi/KtModifierListOwner;)Z
+	public static final fun isActual (Lorg/jetbrains/kotlin/psi/KtModifierListOwner;)Z
 	public static final fun isConstant (Lorg/jetbrains/kotlin/psi/KtModifierListOwner;)Z
 	public static final fun isExpect (Lorg/jetbrains/kotlin/psi/KtModifierListOwner;)Z
 	public static final fun isExternal (Lorg/jetbrains/kotlin/psi/KtModifierListOwner;)Z

--- a/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/KtModifierList.kt
+++ b/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/KtModifierList.kt
@@ -28,3 +28,5 @@ fun KtModifierListOwner.isLateinit() = hasModifier(KtTokens.LATEINIT_KEYWORD)
 fun KtModifierListOwner.isInline() = hasModifier(KtTokens.INLINE_KEYWORD)
 
 fun KtModifierListOwner.isExpect() = hasModifier(KtTokens.EXPECT_KEYWORD)
+
+fun KtModifierListOwner.isActual() = hasModifier(KtTokens.ACTUAL_KEYWORD)

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/FunctionOnlyReturningConstantSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/FunctionOnlyReturningConstantSpec.kt
@@ -29,7 +29,7 @@ class FunctionOnlyReturningConstantSpec : Spek({
             actual class ActualFunctionReturningConstant {
                 actual fun f() = 1
             }
-        """.trimIndent()
+        """
 
         it("does not report actual functions which return constants") {
             assertThat(subject.lint(actualFunctionCode)).isEmpty()

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/FunctionOnlyReturningConstantSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/FunctionOnlyReturningConstantSpec.kt
@@ -25,6 +25,22 @@ class FunctionOnlyReturningConstantSpec : Spek({
             assertThat(rule.lint(path)).hasSize(9)
         }
 
+        val actualFunctionCode = """
+            actual class ActualFunctionReturningConstant {
+                actual fun f() = 1
+            }
+        """.trimIndent()
+
+        it("does not report actual functions which return constants") {
+            assertThat(subject.lint(actualFunctionCode)).isEmpty()
+        }
+
+        it("reports actual functions which return constants") {
+            val config = TestConfig(mapOf(FunctionOnlyReturningConstant.IGNORE_ACTUAL_FUNCTION to "false"))
+            val rule = FunctionOnlyReturningConstant(config)
+            assertThat(rule.lint(actualFunctionCode)).hasSize(1)
+        }
+
         it("does not report excluded function which returns a constant") {
             val code = "fun f() = 1"
             val config = TestConfig(mapOf(FunctionOnlyReturningConstant.EXCLUDED_FUNCTIONS to "f"))


### PR DESCRIPTION
Closes #3388

## Expected Behavior of the rule
By default, `actual` functions in multiplatform projects should be ignored when evaluating `FunctionOnlyReturningConstant`.

There should be a configuration option `ignoreActualFunction`, which would allow changing this behaviour.

### Example
#### commonMain
```kotlin
expect class Foo {
    fun foo(param: Any): Boolean
}
```
#### jvmMain
```kotlin
actual class Foo {
    actual fun foo(param: Any): Boolean = checkSomeCondition(param)
}
```
#### jsMain
```kotlin
actual class Foo {
    actual fun foo(param: Any): Boolean = false    // <-- FunctionOnlyReturningConstant should be ignored
}
```

## Context
Similar to `ignoreOverridableFunction`.

Implementing an `actual` function, is conceptually similar to overriding a function from an interface/abstract class.
It makes sense for such a function to provide complex logic on some platforms, and only return a constant value on others.
