### PR TITLE
Fix maven publish

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,7 @@ buildScan {
     termsOfServiceAgree = "yes"
 }
 
-subprojects {
+allprojects {
     group = "io.gitlab.arturbosch.detekt"
     version = Versions.currentOrSnapshot()
 }

--- a/buildSrc/src/main/kotlin/packaging.gradle.kts
+++ b/buildSrc/src/main/kotlin/packaging.gradle.kts
@@ -46,9 +46,9 @@ subprojects {
             }
         }
         publications.register<MavenPublication>(DETEKT_PUBLICATION) {
-            groupId = project.group as? String
+            groupId = "io.gitlab.arturbosch.detekt"
             artifactId = project.name
-            version = project.version as? String
+            version = Versions.currentOrSnapshot()
             pom {
                 description.set("Static code analysis for Kotlin")
                 name.set("detekt")


### PR DESCRIPTION
Issue
=====
The deployment task failed: https://github.com/detekt/detekt/runs/1730645753
This issue is also observed locally that after `./gradlew publishToMavenLocal`, we should see a directory structure like `.m2/repository/io/gitlab/arturbosch/detekt/detekt-*`. However, `.m2/repository/detekt/detekt-*` was observed.

Root cause
=====
#3389 implicitly changed the order of 
- project.group and project.version (from `commons.gradle.kts` to root `build.gradle`)
- publications.groupId and publications.version (in `packaging.gradle.kts`)

Switching the order resulted in incorrect publications.groupId and version (groupId becomes detekt and version becomes unspecified)

Fix
=====
There does not seem to be a clean fix in the short-term. In the long term, we may consider moving non-shareable build logic outside `buildSrc`.