### PR TITLE
Update documentations on snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ tasks {
 
 See [maven central](https://search.maven.org/artifact/io.gitlab.arturbosch.detekt/detekt-cli) for releases and [sonatype](https://oss.sonatype.org/#view-repositories;snapshots~browsestorage~io/gitlab/arturbosch/detekt) for snapshots.
 
+If you want to use a SNAPSHOT version, you can find more info on [this documentation page](https://detekt.github.io/detekt/snapshots.html).
+
 ### Adding more rule sets
 
 detekt itself provides a wrapper over [ktlint](https://github.com/pinterest/ktlint) as a `formatting` rule set

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ tasks {
 }
 ```
 
-See [maven central](https://search.maven.org/artifact/io.gitlab.arturbosch.detekt/detekt-cli) for releases and [sonatype](https://oss.sonatype.org/#view-repositories;snapshots~browsestorage~io.gitlab.arturbosch.detekt) for snapshots.
+See [maven central](https://search.maven.org/artifact/io.gitlab.arturbosch.detekt/detekt-cli) for releases and [sonatype](https://oss.sonatype.org/#view-repositories;snapshots~browsestorage~io/gitlab/arturbosch/detekt) for snapshots.
 
 ### Adding more rule sets
 

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,12 +1,13 @@
 object Versions {
 
     const val DETEKT: String = "1.15.0"
+    const val SNAPSHOT_NAME: String = "master"
     const val JVM_TARGET: String = "1.8"
     const val JACOCO: String = "0.8.6"
 
     fun currentOrSnapshot(): String {
         if (System.getProperty("snapshot")?.toBoolean() == true) {
-            return "$DETEKT-SNAPSHOT"
+            return "$SNAPSHOT_NAME-SNAPSHOT"
         }
         return DETEKT
     }

--- a/docs/_data/sidebars/home_sidebar.yml
+++ b/docs/_data/sidebars/home_sidebar.yml
@@ -29,6 +29,9 @@ entries:
     - title: Extending detekt
       url: /extensions.html
       output: web
+    - title: Using snapshots
+      url: /snapshots.html
+      output: web
   - title: Getting Started
     output: web
     folderitems:

--- a/docs/pages/snapshots.md
+++ b/docs/pages/snapshots.md
@@ -3,10 +3,10 @@ title: "Using Snapshots"
 keywords: snapshot releases 
 sidebar: 
 permalink: snapshots.html
-summary: This page explains you how you can setup snapshots for your Detekt build to test the latest unreleased features. 
+summary: This page explains how you can setup snapshots for your Detekt build to test the latest unreleased features. 
 ---
 
-This page explains you how you can use our **latest snapshots**, to test upcoming unreleased features.
+This page explains how you can use our **latest snapshots** to test upcoming unreleased features.
 
 ## Where to download snapshots
 

--- a/docs/pages/snapshots.md
+++ b/docs/pages/snapshots.md
@@ -1,0 +1,82 @@
+---
+title: "Using Snapshots"
+keywords: snapshot releases 
+sidebar: 
+permalink: snapshots.html
+summary: This page explains you how you can setup snapshots for your Detekt build to test the latest unreleased features. 
+---
+
+This page explains you how you can use our **latest snapshots**, to test upcoming unreleased features.
+
+## Where to download snapshots
+
+You can find the latest snapshot on [sonatype](https://oss.sonatype.org/#view-repositories;snapshots~browsestorage~io/gitlab/arturbosch/detekt). A new snapshot is published after every merge to `master` from the [Deploy Snapshot](https://github.com/detekt/detekt/actions?query=workflow%3A%22Deploy+Snapshot%22) Github Action workflow. 
+
+## Gradle setup with Buildscript
+
+If you're using Gradle with the `buildscript` block, you should update your top level `build.gradle` file with:
+
+```groovy
+buildscript {
+  repositories {
+    maven {
+      url "https://oss.sonatype.org/content/repositories/snapshots/"
+    }
+  }
+  dependencies {
+    classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:master-SNAPSHOT"
+  }
+}
+
+apply plugin: "io.gitlab.arturbosch.detekt"
+
+allprojects {
+  repositories {
+    maven {
+      url "https://oss.sonatype.org/content/repositories/snapshots/"
+    }
+  }
+}
+```
+
+Make sure that you're adding the sonatype maven repository to both the `repositories{}` block **inside** the `buildscript{}` block and outside it.
+
+## Gradle setup with Plugin block
+
+If you're using the `plugins{}` block to apply detekt, you should update your `build.gradle` file to:
+
+```groovy
+buildscript {
+  id("io.gitlab.arturbosch.detekt") version "master-SNAPSHOT"
+}
+
+allprojects {
+  repositories {
+    maven {
+      url "https://oss.sonatype.org/content/repositories/snapshots/"
+    }
+  }
+}
+```
+
+Plus you need to update the `settings.gradle` file as follows:
+
+```groovy
+pluginManagement {
+    resolutionStrategy {
+        eachPlugin {
+            if (requested.id.id == "io.gitlab.arturbosch.detekt") {
+                useModule("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:${requested.version}")
+            }
+        }
+    }
+    repositories {
+        // Your other repos here.
+        maven {
+            url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
+        }
+    }
+}
+```
+
+Please note that the extra `resolutionStrategy{}` block is needed as we don't publish a Gradle Plugin marker for our snapshots.


### PR DESCRIPTION
I'm updating the documentation around using SNAPSHOTS as it was lacking.

Moreover I'm updating the SNAPSHOT name to be `master-SNAPSHOT`. If we don't like it we could use the upcoming version (but that forces us to keep two versions number updated).