### PR TITLE
Merge XML outputs into a consolidated report

### DIFF
--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -43,6 +43,7 @@ dependencies {
     testImplementation(project(":detekt-test-utils"))
     testImplementation(kotlin("gradle-plugin"))
     testImplementation(androidGradlePlugin)
+    testImplementation("org.assertj:assertj-core")
 
     constraints {
         implementation("org.jetbrains.kotlin:kotlin-reflect:1.4.0") {
@@ -63,6 +64,10 @@ gradlePlugin {
             id = "io.gitlab.arturbosch.detekt"
             implementationClass = "io.gitlab.arturbosch.detekt.DetektPlugin"
         }
+        register("detektProjectPlugin") {
+            id = "io.gitlab.arturbosch.detekt.project"
+            implementationClass = "io.gitlab.arturbosch.detekt.DetektProjectPlugin"
+        }
     }
     testSourceSets(intTest)
 }
@@ -81,6 +86,10 @@ pluginBundle {
         "detektPlugin" {
             id = "io.gitlab.arturbosch.detekt"
             displayName = "Static code analysis for Kotlin"
+        }
+        "detektProjectPlugin" {
+            id = "io.gitlab.arturbosch.detekt.project"
+            displayName = "Root project plugin for detekt"
         }
     }
 }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektProjectPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektProjectPlugin.kt
@@ -1,10 +1,5 @@
 package io.gitlab.arturbosch.detekt
 
-import com.android.build.gradle.internal.tasks.factory.dependsOn
-import io.gitlab.arturbosch.detekt.report.XmlOutputMergeTask
-import org.gradle.api.Plugin
-import org.gradle.api.Project
-import org.gradle.api.file.ConfigurableFileCollection
 import io.gitlab.arturbosch.detekt.report.XmlOutputMergeTask
 import org.gradle.api.Plugin
 import org.gradle.api.Project

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektProjectPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektProjectPlugin.kt
@@ -1,0 +1,45 @@
+package io.gitlab.arturbosch.detekt
+
+import com.android.build.gradle.internal.tasks.factory.dependsOn
+import io.gitlab.arturbosch.detekt.report.XmlOutputMergeTask
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.plugins.ReportingBasePlugin
+import org.gradle.api.reporting.ReportingExtension
+
+class DetektProjectPlugin : Plugin<Project> {
+
+    override fun apply(project: Project) {
+        require(project.isRootProject()) {
+            "DetektProjectPlugin should be applied to rootProject only."
+        }
+        project.pluginManager.apply(ReportingBasePlugin::class.java)
+        project.registerMergeReportTask()
+    }
+
+    private fun Project.registerMergeReportTask() {
+        val xmlOutputMergeTask = tasks.register(MERGE_XML_REPORT, XmlOutputMergeTask::class.java) { task ->
+            task.description = "Merge XML report for all individual detekt tasks in this project"
+            task.output.set(
+                project.extensions.getByType(ReportingExtension::class.java).file(MERGE_XML_FILE_RELATIVE_PATH)
+            )
+        }
+        // Delay the configuration so that detektTask.reports.xml.destination is always set
+        // when configuring the input of merge task.
+        project.afterEvaluate { project ->
+            project.subprojects { subproject ->
+                subproject.tasks.withType(Detekt::class.java).configureEach { detektTask ->
+                    xmlOutputMergeTask.configure { it.input.from(detektTask.reports.xml.destination) }
+                }
+            }
+        }
+    }
+
+    private fun Project.isRootProject() = path == ":"
+
+    companion object {
+        private const val MERGE_XML_REPORT = "mergeXmlReport"
+        private const val MERGE_XML_FILE_RELATIVE_PATH = "detekt/merged.xml"
+    }
+}

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektProjectPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektProjectPlugin.kt
@@ -5,6 +5,9 @@ import io.gitlab.arturbosch.detekt.report.XmlOutputMergeTask
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.file.ConfigurableFileCollection
+import io.gitlab.arturbosch.detekt.report.XmlOutputMergeTask
+import org.gradle.api.Plugin
+import org.gradle.api.Project
 import org.gradle.api.plugins.ReportingBasePlugin
 import org.gradle.api.reporting.ReportingExtension
 

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/report/XmlOutputMergeTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/report/XmlOutputMergeTask.kt
@@ -1,0 +1,29 @@
+package io.gitlab.arturbosch.detekt.report
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+
+@CacheableTask
+abstract class XmlOutputMergeTask : DefaultTask() {
+
+    @get:InputFiles
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val input: ConfigurableFileCollection
+
+    @get:OutputFile
+    abstract val output: RegularFileProperty
+
+    @TaskAction
+    fun merge() {
+        logger.info(input.files.joinToString(separator = "\n") { it.absolutePath })
+        XmlOutputMerger.merge(input.files, output.get().asFile)
+        logger.lifecycle("Merged XML output to ${output.get().asFile.absolutePath}")
+    }
+}

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/report/XmlOutputMerger.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/report/XmlOutputMerger.kt
@@ -1,0 +1,40 @@
+package io.gitlab.arturbosch.detekt.report
+
+import java.io.File
+
+/**
+ * A naive implementation to merge xml assuming all input xml are written by the standard xml format.
+ */
+internal object XmlOutputMerger {
+
+    private const val XML_PROLOG = "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
+    private const val CHECKSTYLE_OPEN_TAG = "<checkstyle version=\"4.3\">"
+    private const val CHECKSTYLE_CLOSE_TAG = "</checkstyle>"
+    private const val MIN_LINES = 3
+
+    fun merge(inputs: Collection<File>, output: File) {
+        output.printWriter().use { printWriter ->
+            printWriter.println(XML_PROLOG)
+            printWriter.println(CHECKSTYLE_OPEN_TAG)
+            inputs.forEach {
+                extractInputContent(it)?.let(printWriter::println)
+            }
+            printWriter.println(CHECKSTYLE_CLOSE_TAG)
+        }
+    }
+
+    private fun extractInputContent(input: File): String? {
+        if (!input.exists()) {
+            return null
+        }
+        val lines = input.readLines()
+        if (lines.size < MIN_LINES) return null
+        return if (lines.first().trim() == XML_PROLOG &&
+            lines[1].trim() == CHECKSTYLE_OPEN_TAG &&
+            lines.last().trim() == CHECKSTYLE_CLOSE_TAG) {
+            lines.subList(2, lines.size - 1).joinToString(separator = System.lineSeparator())
+        } else {
+            null
+        }
+    }
+}

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/report/XmlOutputMerger.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/report/XmlOutputMerger.kt
@@ -26,7 +26,7 @@ internal object XmlOutputMerger {
         }
         TransformerFactory.newInstance().newTransformer().run {
             setOutputProperty(OutputKeys.INDENT, "yes")
-            setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2");
+            setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2")
 
             val streamResult = StreamResult(output.writer())
             transform(DOMSource(document), streamResult)

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/report/XmlOutputMerger.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/report/XmlOutputMerger.kt
@@ -1,40 +1,59 @@
 package io.gitlab.arturbosch.detekt.report
 
+import com.android.utils.forEach
+import org.w3c.dom.Document
+import org.w3c.dom.Node
 import java.io.File
+import javax.xml.parsers.DocumentBuilderFactory
+import javax.xml.transform.OutputKeys
+import javax.xml.transform.TransformerFactory
+import javax.xml.transform.dom.DOMSource
+import javax.xml.transform.stream.StreamResult
 
 /**
  * A naive implementation to merge xml assuming all input xml are written by the standard xml format.
  */
 internal object XmlOutputMerger {
 
-    private const val XML_PROLOG = "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
-    private const val CHECKSTYLE_OPEN_TAG = "<checkstyle version=\"4.3\">"
-    private const val CHECKSTYLE_CLOSE_TAG = "</checkstyle>"
-    private const val MIN_LINES = 3
+    private val documentBuilder by lazy { DocumentBuilderFactory.newInstance().newDocumentBuilder() }
 
     fun merge(inputs: Collection<File>, output: File) {
-        output.printWriter().use { printWriter ->
-            printWriter.println(XML_PROLOG)
-            printWriter.println(CHECKSTYLE_OPEN_TAG)
-            inputs.forEach {
-                extractInputContent(it)?.let(printWriter::println)
-            }
-            printWriter.println(CHECKSTYLE_CLOSE_TAG)
+        val document = documentBuilder.newDocument()
+        document.appendChild(document.createElement("checkstyle"))
+        document.xmlStandalone = true
+        inputs.forEach {
+            importNodesFromInput(it, document)
+        }
+        TransformerFactory.newInstance().newTransformer().run {
+            setOutputProperty(OutputKeys.INDENT, "yes")
+            setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2");
+
+            val streamResult = StreamResult(output.writer())
+            transform(DOMSource(document), streamResult)
         }
     }
 
-    private fun extractInputContent(input: File): String? {
+    private fun importNodesFromInput(input: File, document: Document) {
         if (!input.exists()) {
-            return null
+            return
         }
-        val lines = input.readLines()
-        if (lines.size < MIN_LINES) return null
-        return if (lines.first().trim() == XML_PROLOG &&
-            lines[1].trim() == CHECKSTYLE_OPEN_TAG &&
-            lines.last().trim() == CHECKSTYLE_CLOSE_TAG) {
-            lines.subList(2, lines.size - 1).joinToString(separator = System.lineSeparator())
-        } else {
-            null
+        removeWhitespaces(documentBuilder.parse(input).documentElement).childNodes.forEach { node ->
+            document.documentElement.appendChild(document.importNode(node, true))
         }
+    }
+
+    // Checkstyle does not provide XSD schema https://github.com/checkstyle/checkstyle/issues/7517.
+    // Therefore we have to exclude whitespaces ourselves.
+    private fun removeWhitespaces(node: Node): Node {
+        val childNodes = node.childNodes
+        (childNodes.length - 1 downTo 0).forEach { idx ->
+            val childNode = childNodes.item(idx)
+            if (childNode.nodeType == Node.TEXT_NODE && childNode.textContent.isBlank()) {
+                node.removeChild(childNode)
+            } else {
+                removeWhitespaces(childNode)
+            }
+        }
+        return node
     }
 }

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/report/XmlOutputMergerSpec.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/report/XmlOutputMergerSpec.kt
@@ -1,0 +1,51 @@
+package io.gitlab.arturbosch.detekt.report
+
+import org.assertj.core.api.Assertions.assertThat
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import java.io.File
+
+private const val TAB = "\t"
+
+internal class XmlOutputMergerSpec : Spek({
+
+    describe("classpath changes") {
+
+        it("passes for same files") {
+            val file1 = File.createTempFile("detekt1", "xml").apply {
+                writeText("""
+                    <?xml version="1.0" encoding="utf-8"?>
+                    <checkstyle version="4.3">
+                    <file name="Sample1.kt">
+                    $TAB<error line="1" column="1" severity="warning" message="TestMessage" source="detekt.id_a" />
+                    </file>
+                    </checkstyle>
+                """.trimIndent())
+            }
+            val file2 = File.createTempFile("detekt2", "xml").apply {
+                writeText("""
+                    <?xml version="1.0" encoding="utf-8"?>
+                    <checkstyle version="4.3">
+                    <file name="Sample2.kt">
+                    $TAB<error line="1" column="1" severity="warning" message="TestMessage" source="detekt.id_b" />
+                    </file>
+                    </checkstyle>
+                """.trimIndent())
+            }
+            val output = File.createTempFile("output", "xml")
+            XmlOutputMerger.merge(setOf(file1, file2), output)
+
+            assertThat(output.readText()).isEqualTo("""
+                <?xml version="1.0" encoding="utf-8"?>
+                <checkstyle version="4.3">
+                <file name="Sample1.kt">
+                $TAB<error line="1" column="1" severity="warning" message="TestMessage" source="detekt.id_a" />
+                </file>
+                <file name="Sample2.kt">
+                $TAB<error line="1" column="1" severity="warning" message="TestMessage" source="detekt.id_b" />
+                </file>
+                </checkstyle>
+            """.trimIndent() + System.lineSeparator())
+        }
+    }
+})

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/report/XmlOutputMergerSpec.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/report/XmlOutputMergerSpec.kt
@@ -9,9 +9,9 @@ private const val TAB = "\t"
 
 internal class XmlOutputMergerSpec : Spek({
 
-    describe("classpath changes") {
+    describe("merge xml output") {
 
-        it("passes for same files") {
+        it("merges two inputs") {
             val file1 = File.createTempFile("detekt1", "xml").apply {
                 writeText("""
                     <?xml version="1.0" encoding="utf-8"?>
@@ -36,14 +36,13 @@ internal class XmlOutputMergerSpec : Spek({
             XmlOutputMerger.merge(setOf(file1, file2), output)
 
             assertThat(output.readText()).isEqualTo("""
-                <?xml version="1.0" encoding="utf-8"?>
-                <checkstyle version="4.3">
-                <file name="Sample1.kt">
-                $TAB<error line="1" column="1" severity="warning" message="TestMessage" source="detekt.id_a" />
-                </file>
-                <file name="Sample2.kt">
-                $TAB<error line="1" column="1" severity="warning" message="TestMessage" source="detekt.id_b" />
-                </file>
+                <?xml version="1.0" encoding="UTF-8"?><checkstyle>
+                  <file name="Sample1.kt">
+                    <error column="1" line="1" message="TestMessage" severity="warning" source="detekt.id_a"/>
+                  </file>
+                  <file name="Sample2.kt">
+                    <error column="1" line="1" message="TestMessage" severity="warning" source="detekt.id_b"/>
+                  </file>
                 </checkstyle>
             """.trimIndent() + System.lineSeparator())
         }

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/report/XmlOutputMergerSpec.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/report/XmlOutputMergerSpec.kt
@@ -35,7 +35,8 @@ internal class XmlOutputMergerSpec : Spek({
             val output = File.createTempFile("output", "xml")
             XmlOutputMerger.merge(setOf(file1, file2), output)
 
-            assertThat(output.readText()).isEqualTo("""
+            // On Windows, the XML output uses the carriage return
+            assertThat(output.readText().replace(System.lineSeparator(), "\n")).isEqualTo("""
                 <?xml version="1.0" encoding="UTF-8"?><checkstyle>
                   <file name="Sample1.kt">
                     <error column="1" line="1" message="TestMessage" severity="warning" source="detekt.id_a"/>
@@ -44,7 +45,7 @@ internal class XmlOutputMergerSpec : Spek({
                     <error column="1" line="1" message="TestMessage" severity="warning" source="detekt.id_b"/>
                   </file>
                 </checkstyle>
-            """.trimIndent() + System.lineSeparator())
+            """.trimIndent() + "\n")
         }
     }
 })

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/report/XmlOutputMergerSpec.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/report/XmlOutputMergerSpec.kt
@@ -9,9 +9,9 @@ private const val TAB = "\t"
 
 internal class XmlOutputMergerSpec : Spek({
 
-    describe("merge xml output") {
+    describe("classpath changes") {
 
-        it("merges two inputs") {
+        it("passes for same files") {
             val file1 = File.createTempFile("detekt1", "xml").apply {
                 writeText("""
                     <?xml version="1.0" encoding="utf-8"?>
@@ -35,17 +35,17 @@ internal class XmlOutputMergerSpec : Spek({
             val output = File.createTempFile("output", "xml")
             XmlOutputMerger.merge(setOf(file1, file2), output)
 
-            // On Windows, the XML output uses the carriage return
-            assertThat(output.readText().replace(System.lineSeparator(), "\n")).isEqualTo("""
-                <?xml version="1.0" encoding="UTF-8"?><checkstyle>
-                  <file name="Sample1.kt">
-                    <error column="1" line="1" message="TestMessage" severity="warning" source="detekt.id_a"/>
-                  </file>
-                  <file name="Sample2.kt">
-                    <error column="1" line="1" message="TestMessage" severity="warning" source="detekt.id_b"/>
-                  </file>
+            assertThat(output.readText()).isEqualTo("""
+                <?xml version="1.0" encoding="utf-8"?>
+                <checkstyle version="4.3">
+                <file name="Sample1.kt">
+                $TAB<error line="1" column="1" severity="warning" message="TestMessage" source="detekt.id_a" />
+                </file>
+                <file name="Sample2.kt">
+                $TAB<error line="1" column="1" severity="warning" message="TestMessage" source="detekt.id_b" />
+                </file>
                 </checkstyle>
-            """.trimIndent() + "\n")
+            """.trimIndent() + System.lineSeparator())
         }
     }
 })

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/report/XmlOutputMergerSpec.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/report/XmlOutputMergerSpec.kt
@@ -35,7 +35,8 @@ internal class XmlOutputMergerSpec : Spek({
             val output = File.createTempFile("output", "xml")
             XmlOutputMerger.merge(setOf(file1, file2), output)
 
-            assertThat(output.readText()).isEqualTo("""
+            val text = output.readText()
+            val expectedText = """
                 <?xml version="1.0" encoding="utf-8"?>
                 <checkstyle version="4.3">
                 <file name="Sample1.kt">
@@ -45,7 +46,9 @@ internal class XmlOutputMergerSpec : Spek({
                 $TAB<error line="1" column="1" severity="warning" message="TestMessage" source="detekt.id_b" />
                 </file>
                 </checkstyle>
-            """.trimIndent() + System.lineSeparator())
+            """.trimIndent() + System.lineSeparator()
+            assertThat(text.length).isEqualTo(expectedText.length)
+            assertThat(text).isEqualTo(expectedText)
         }
     }
 })


### PR DESCRIPTION
Addresses #1295

Here are my own judgment calls that needs review:
- Create a new gradle plugin for the root project. Because merging only makes sense for a multi-project setup. Configuring in any subproject will create dependencies across subprojects, which is not a good gradle practise.
- Not depending on XML parsing library because we can safely assume that all the generated output is managed by detekt.
- Not automatically apply the merge when running `./gradlew detekt` or `./gradlew detektMain`, this is because of incremental cacheability of gradle that does not guarantee each detekt task will be actually run / and or each individual gradle task may fail due to detected issues. The expectation for our users is to run `./gradlew detekt mergeXmlReport --continue` or `./gradlew detekt --continue; ./gradlew mergeXmlReport`