### PR TITLE
Update dangling URLs pointing to the old website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # __detekt__
 
 [![Join the chat at https://kotlinlang.slack.com/messages/C88E12QH4/convo/C0BQ5GZ0S-1511956674.000289/](https://img.shields.io/badge/chat-on_slack-red.svg?style=flat-square)](https://kotlinlang.slack.com/messages/C88E12QH4/convo/C0BQ5GZ0S-1511956674.000289/)
-[![Visit the website at https://arturbosch.github.io/detekt/](https://img.shields.io/badge/visit-website-red.svg?style=flat-square)](https://arturbosch.github.io/detekt/)
+[![Visit the website at https://detekt.github.io/detekt/](https://img.shields.io/badge/visit-website-red.svg?style=flat-square)](https://detekt.github.io/detekt/)
 [![Maven Central](https://img.shields.io/maven-central/v/io.gitlab.arturbosch.detekt/detekt-cli)](https://search.maven.org/artifact/io.gitlab.arturbosch.detekt/detekt-cli)
 [![gradle plugin](https://img.shields.io/maven-metadata/v/https/plugins.gradle.org/m2/io/gitlab/arturbosch/detekt/io.gitlab.arturbosch.detekt.gradle.plugin/maven-metadata.xml.svg?label=Gradle&style=flat-square)](https://plugins.gradle.org/plugin/io.gitlab.arturbosch.detekt)
 

--- a/docs/_posts/2019-08-14-custom-console-reports.md
+++ b/docs/_posts/2019-08-14-custom-console-reports.md
@@ -6,7 +6,7 @@ summary: "This guide shows how to silence detekt and write a custom report forma
 tags: [guides]
 ---
 
-detekt's reporting mechanism relies on implementations of [ConsoleReport](https://arturbosch.github.io/detekt/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-console-report/index.html)'s.
+detekt's reporting mechanism relies on implementations of [ConsoleReport](https://detekt.github.io/detekt/pages/kdoc/detekt-api/io.gitlab.arturbosch.detekt.api/-console-report/index.html)'s.
 The cli module and therefore the Gradle plugin implement a bunch of this reports.
 
 A typical detekt report will look like following:
@@ -60,4 +60,4 @@ Combined with our silent configuration only messages are printed when findings a
 
 ![report](images/howto-silent-run/compact_report.png)
 
-See the [extension](https://arturbosch.github.io/detekt/extensions.html) documention on how to let detekt know about your custom report.
+See the [extension](https://detekt.github.io/detekt/extensions.html) documention on how to let detekt know about your custom report.

--- a/docs/index.md
+++ b/docs/index.md
@@ -95,6 +95,6 @@ dependencies {
 }
 ```
 
-Likewise custom [extensions](https://arturbosch.github.io/detekt/extensions.html) can be added to detekt.
+Likewise custom [extensions](https://detekt.github.io/detekt/extensions.html) can be added to detekt.
 
 {% include links.html %}

--- a/docs/pages/changelog 1.x.x.md
+++ b/docs/pages/changelog 1.x.x.md
@@ -1403,7 +1403,7 @@ See all issues at: [1.1.0](https://github.com/detekt/detekt/milestone/19)
 
 ##### Notable changes
 
-- [detekt runs can be completely silent on absence of findings](https://arturbosch.github.io/detekt/howto-silent-reports.html)
+- [detekt runs can be completely silent on absence of findings](https://detekt.github.io/detekt/howto-silent-reports.html)
 - All detekt's dependencies are now on MavenCentral. Bogus "*could not find JCommander dependency*" should be gone.
 
 ##### Changelog

--- a/docs/pages/changelog.md
+++ b/docs/pages/changelog.md
@@ -63,7 +63,7 @@ See all issues at: [RC16](https://github.com/detekt/detekt/milestone/45)
   For example `--filters .*/resources/.*` becomes `--excludes **/resources/**`. `includes` also accepts *globing patterns*.
   *Globing patterns* allow us to reuse some common logic of the `java.nio.file` package which for example handle Windows specific paths for us.
   This change also allows to be more fine granular with analyzing files: `--excludes **/generated/** --includes **/generated/this-needs-to-be-checked`.
-  The following [how-to guide](https://arturbosch.github.io/detekt/howto-migratetestpattern.html) describes the migration process from the **test-pattern** functionality.
+  The following [how-to guide](https://detekt.github.io/detekt/howto-migratetestpattern.html) describes the migration process from the **test-pattern** functionality.
 - **Gradle Plugin**: Including or excluding paths and files from detekt scanning is now done by setting `include` & `exclude` on the
   detekt task which aligns with how other static analysis tools handle filters. Any use of `filters` will be ignored. See custom task examples for [Groovy][1] and [Kotlin][2].
   For details of syntax see https://docs.gradle.org/current/javadoc/org/gradle/api/tasks/util/PatternFilterable.html
@@ -572,7 +572,7 @@ detekt {
 can be applied to the root build file.
 
 A full `detekt` configuration for multi-module gradle project could look like `detekt`'s own build file.
-Attention(!) this must be translated to [groovy](https://arturbosch.github.io/detekt/groovydsl.html) if you do not use the [kotlin-dsl](https://arturbosch.github.io/detekt/kotlindsl.html).
+Attention(!) this must be translated to [groovy](https://detekt.github.io/detekt/groovydsl.html) if you do not use the [kotlin-dsl](https://detekt.github.io/detekt/kotlindsl.html).
 ```gradle
 plugins {
 	id("io.gitlab.arturbosch.detekt") version "[1.0.0.RC9]"
@@ -621,7 +621,7 @@ The `config` property now explicitly tells the user that `detekt` can consume mu
 There is also a breaking change for the `detekt-cli` module which will attack custom gradle task and cli users.
 The `output` and `reports` options are no longer. There is the new `--report` option which can be used multiple times to generate specific reports.
 The report pattern now is `--report [report-id:path-to-store-report]`.
-There are three provided output reports named: `plain`, `xml` and `html`. Custom reports can be added to leveraging the detekt extension mechanism as described on the [website](https://arturbosch.github.io/detekt/extensions.html).
+There are three provided output reports named: `plain`, `xml` and `html`. Custom reports can be added to leveraging the detekt extension mechanism as described on the [website](https://detekt.github.io/detekt/extensions.html).
 
 ##### Changes
 
@@ -1768,5 +1768,5 @@ More issues: https://gitlab.com/arturbosch/detekt/milestones/2
 
 More issues: https://gitlab.com/arturbosch/detekt/milestones/1
 
-[1]: https://arturbosch.github.io/detekt/groovydsl.html#defining-custom-detekt-task
-[2]: https://arturbosch.github.io/detekt/kotlindsl.html#defining-custom-detekt-task
+[1]: https://detekt.github.io/detekt/groovydsl.html#defining-custom-detekt-task
+[2]: https://detekt.github.io/detekt/kotlindsl.html#defining-custom-detekt-task


### PR DESCRIPTION
After we deleted the old documentation in #2805, there are broken links on the website + Github repo README.
This PR only searches for `arturbosch.github.io` and updated them, so it may not be perfectly exhaustive.

I am open to revert the changes in changelog if we want to keep the origin of changelogs.