### PR TITLE
Fix deploy website on master

### DIFF
--- a/.github/workflows/deploy-website.yaml
+++ b/.github/workflows/deploy-website.yaml
@@ -45,6 +45,11 @@ jobs:
           name: detekt-kdoc
           path: docs/pages/kdoc/
 
+      - name: Upload generated CLI options documentation
+        uses: actions/upload-artifact@v2
+        with:
+          name: detekt-cli-options-docs
+          path: docs/pages/gettingstarted/cli-options.md
 
   build-website:
     needs: build-detekt-docs
@@ -71,6 +76,12 @@ jobs:
       with:
         name: detekt-kdoc
         path: docs/pages/kdoc/
+
+    - name: Unzipping generated CLI options documentation
+      uses: actions/download-artifact@v2
+      with:
+        name: detekt-cli-options-docs
+        path: docs/pages/gettingstarted/
 
     - name: Display structure of files
       run: ls -R


### PR DESCRIPTION
#3399 passed locally but failed on CI. The cause is the newly generated documentation not being uploaded in CI.

This PR is verified in https://github.com/chao2zhang/detekt/runs/1763974410
