### PR TITLE
New rule: DontDowncastCollectionTypes

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -467,6 +467,8 @@ potential-bugs:
   active: true
   Deprecation:
     active: false
+  DontDowncastCollectionTypes:
+    active: false
   DuplicateCaseInWhenExpression:
     active: true
   EqualsAlwaysReturnsTrueOrFalse:

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DontDowncastCollectionTypes.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DontDowncastCollectionTypes.kt
@@ -1,0 +1,91 @@
+package io.gitlab.arturbosch.detekt.rules.bugs
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.rules.safeAs
+import org.jetbrains.kotlin.js.descriptorUtils.nameIfStandardType
+import org.jetbrains.kotlin.psi.KtBinaryExpressionWithTypeRHS
+import org.jetbrains.kotlin.psi.KtExpression
+import org.jetbrains.kotlin.psi.KtIsExpression
+import org.jetbrains.kotlin.psi.KtTypeReference
+import org.jetbrains.kotlin.psi.KtUserType
+import org.jetbrains.kotlin.resolve.BindingContext
+import org.jetbrains.kotlin.resolve.calls.callUtil.getType
+
+/**
+ * Down-casting immutable types from kotlin.collections should be discouraged.
+ * The result of the downcast is platform specific and can lead to unexpected crashes.
+ * Prefer to use instead the `toMutable<Type>()` functions.
+ *
+ * <noncompliant>
+ * val list : List<Int> = getAList()
+ * if (list is MutableList) {
+ *     list.add(42)
+ * }
+ *
+ * (list as MutableList).add(42)
+ * </noncompliant>
+ *
+ * <compliant>
+ * val list : List<Int> = getAList()
+ * list.toMutableList().add(42)
+ * </compliant>
+ *
+ * @requiresTypeResolution
+ */
+class DontDowncastCollectionTypes(config: Config) : Rule(config) {
+
+    override val issue = Issue(
+        "DontDowncastCollectionTypes",
+        Severity.Warning,
+        "Down-casting immutable collection types is breaking the collection contract",
+        Debt.TEN_MINS
+    )
+
+    override fun visitIsExpression(expression: KtIsExpression) {
+        super.visitIsExpression(expression)
+        if (bindingContext == BindingContext.EMPTY) return
+
+        checkForDowncast(expression, expression.leftHandSide, expression.typeReference)
+    }
+
+    override fun visitBinaryWithTypeRHSExpression(expression: KtBinaryExpressionWithTypeRHS) {
+        super.visitBinaryWithTypeRHSExpression(expression)
+
+        if (bindingContext == BindingContext.EMPTY) return
+
+        checkForDowncast(expression, expression.left, expression.right)
+    }
+
+    private fun checkForDowncast(parent: KtExpression, left: KtExpression, right: KtTypeReference?) {
+        val lhsType = left
+            .getType(bindingContext)
+            ?.nameIfStandardType
+            ?.identifier
+
+        val rhsType = right
+            ?.typeElement
+            ?.safeAs<KtUserType>()
+            ?.referencedName
+
+        if (lhsType in immutableTypes && rhsType in mutableTypes) {
+            report(
+                CodeSmell(
+                    issue,
+                    Entity.from(parent),
+                    "Down-casting from type $lhsType to $rhsType is risky. Use `to$rhsType()` instead."
+                )
+            )
+        }
+    }
+
+    companion object {
+        val immutableTypes = listOf("List", "Map", "Set")
+        val mutableTypes = listOf("MutableList", "MutableMap", "MutableSet")
+    }
+}

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DontDowncastCollectionTypes.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DontDowncastCollectionTypes.kt
@@ -74,18 +74,28 @@ class DontDowncastCollectionTypes(config: Config) : Rule(config) {
             ?.referencedName
 
         if (lhsType in immutableTypes && rhsType in mutableTypes) {
-            report(
-                CodeSmell(
-                    issue,
-                    Entity.from(parent),
-                    "Down-casting from type $lhsType to $rhsType is risky. Use `to$rhsType()` instead."
-                )
-            )
+            var message = "Down-casting from type $lhsType to $rhsType is risky."
+            if (rhsType != null && rhsType.startsWith("Mutable")) {
+                message += " Use `to$rhsType()` instead."
+            }
+            report(CodeSmell(issue, Entity.from(parent), message))
         }
     }
 
     companion object {
         val immutableTypes = listOf("List", "Map", "Set")
-        val mutableTypes = listOf("MutableList", "MutableMap", "MutableSet")
+
+        // Kotlin Stdlib Mutable types plus Type-aliases from:
+        // https://github.com/JetBrains/kotlin/blob/46b7a774b558001c136be225cf4367fa09ba1aee/libraries/stdlib/jvm/src/kotlin/collections/TypeAliases.kt#L13-L17
+        val mutableTypes = listOf(
+            "MutableList",
+            "MutableMap",
+            "MutableSet",
+            "ArrayList",
+            "LinkedHashSet",
+            "HashSet",
+            "LinkedHashMap",
+            "HashMap",
+        )
     }
 }

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/PotentialBugProvider.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/PotentialBugProvider.kt
@@ -17,6 +17,7 @@ class PotentialBugProvider : DefaultRuleSetProvider {
         ruleSetId,
         listOf(
             Deprecation(config),
+            DontDowncastCollectionTypes(config),
             DuplicateCaseInWhenExpression(config),
             EqualsAlwaysReturnsTrueOrFalse(config),
             EqualsWithHashCodeExist(config),

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DontDowncastCollectionTypesSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DontDowncastCollectionTypesSpec.kt
@@ -138,7 +138,7 @@ class DontDowncastCollectionTypesSpec : Spek({
                 fun main() {
                     val myMap = mapOf(1 to 2)
                     if (myMap is MutableMap<Int, Int>) {
-                        myMap.add(3 to 4)
+                        myMap[3] = 4
                     }
                 }
                 """

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DontDowncastCollectionTypesSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DontDowncastCollectionTypesSpec.kt
@@ -185,5 +185,228 @@ class DontDowncastCollectionTypesSpec : Spek({
                 assertThat(result).isEmpty()
             }
         }
+
+        describe("type-aliases") {
+
+            it("detects ArrayList type casts") {
+                val code = """
+                fun main() {
+                    val myList = listOf(1,2,3)
+                    val mutList = myList as ArrayList<Int>
+                }
+                """
+                val result = subject.compileAndLintWithContext(env, code)
+                assertThat(result).hasSize(1)
+                assertThat(result.first().message).isEqualTo(
+                    "Down-casting from type List to ArrayList is risky."
+                )
+            }
+
+            it("detects ArrayList type safe casts") {
+                val code = """
+                fun main() {
+                    val myList : List<Int>? = null
+                    val mutList = myList as? ArrayList<Int>
+                }
+                """
+                val result = subject.compileAndLintWithContext(env, code)
+                assertThat(result).hasSize(1)
+                assertThat(result.first().message).isEqualTo(
+                    "Down-casting from type List to ArrayList is risky."
+                )
+            }
+
+            it("detects ArrayList type checks") {
+                val code = """
+                fun main() {
+                    val myList = listOf(1,2,3)
+                    if (myList is ArrayList<Int>) {
+                        myList.add(4)
+                    }
+                }
+                """
+                val result = subject.compileAndLintWithContext(env, code)
+                assertThat(result).hasSize(1)
+                assertThat(result.first().message).isEqualTo(
+                    "Down-casting from type List to ArrayList is risky."
+                )
+            }
+
+            it("detects LinkedHashSet type casts") {
+                val code = """
+                fun main() {
+                    val mySet = setOf(1,2,3)
+                    val mutSet = mySet as LinkedHashSet<Int>
+                }
+                """
+                val result = subject.compileAndLintWithContext(env, code)
+                assertThat(result).hasSize(1)
+                assertThat(result.first().message).isEqualTo(
+                    "Down-casting from type Set to LinkedHashSet is risky."
+                )
+            }
+
+            it("detects LinkedHashSet type safe casts") {
+                val code = """
+                fun main() {
+                    val mySet : Set<Int>? = null
+                    val mutSet = mySet as? LinkedHashSet<Int>
+                }
+                """
+                val result = subject.compileAndLintWithContext(env, code)
+                assertThat(result).hasSize(1)
+                assertThat(result.first().message).isEqualTo(
+                    "Down-casting from type Set to LinkedHashSet is risky."
+                )
+            }
+
+            it("detects LinkedHashSet type checks") {
+                val code = """
+                fun main() {
+                    val mySet = setOf(1,2,3)
+                    if (mySet is LinkedHashSet<Int>) {
+                        mySet.add(4)
+                    }
+                }
+                """
+                val result = subject.compileAndLintWithContext(env, code)
+                assertThat(result).hasSize(1)
+                assertThat(result.first().message).isEqualTo(
+                    "Down-casting from type Set to LinkedHashSet is risky."
+                )
+            }
+
+            it("detects HashSet type casts") {
+                val code = """
+                fun main() {
+                    val mySet = setOf(1,2,3)
+                    val mutSet = mySet as HashSet<Int>
+                }
+                """
+                val result = subject.compileAndLintWithContext(env, code)
+                assertThat(result).hasSize(1)
+                assertThat(result.first().message).isEqualTo(
+                    "Down-casting from type Set to HashSet is risky."
+                )
+            }
+
+            it("detects HashSet type safe casts") {
+                val code = """
+                fun main() {
+                    val mySet : Set<Int>? = null
+                    val mutSet = mySet as? HashSet<Int>
+                }
+                """
+                val result = subject.compileAndLintWithContext(env, code)
+                assertThat(result).hasSize(1)
+                assertThat(result.first().message).isEqualTo(
+                    "Down-casting from type Set to HashSet is risky."
+                )
+            }
+
+            it("detects HashSet type checks") {
+                val code = """
+                fun main() {
+                    val mySet = setOf(1,2,3)
+                    if (mySet is HashSet<Int>) {
+                        mySet.add(4)
+                    }
+                }
+                """
+                val result = subject.compileAndLintWithContext(env, code)
+                assertThat(result).hasSize(1)
+                assertThat(result.first().message).isEqualTo(
+                    "Down-casting from type Set to HashSet is risky."
+                )
+            }
+
+            it("detects HashMap type casts") {
+                val code = """
+                fun main() {
+                    val myMap = mapOf(1 to 2)
+                    val mutMap = myMap as HashMap<Int, Int>
+                }
+                """
+                val result = subject.compileAndLintWithContext(env, code)
+                assertThat(result).hasSize(1)
+                assertThat(result.first().message).isEqualTo(
+                    "Down-casting from type Map to HashMap is risky."
+                )
+            }
+
+            it("detects HashMap type safe casts") {
+                val code = """
+                fun main() {
+                    val myMap : Map<Int, Int>? = null
+                    val mutMap = myMap as? HashMap<Int, Int>
+                }
+                """
+                val result = subject.compileAndLintWithContext(env, code)
+                assertThat(result).hasSize(1)
+                assertThat(result.first().message).isEqualTo(
+                    "Down-casting from type Map to HashMap is risky."
+                )
+            }
+
+            it("detects HashMap type checks") {
+                val code = """
+                fun main() {
+                    val myMap = mapOf(1 to 2)
+                    if (myMap is HashMap<Int, Int>) {
+                        myMap[3] = 4
+                    }
+                }
+                """
+                val result = subject.compileAndLintWithContext(env, code)
+                assertThat(result).hasSize(1)
+                assertThat(result.first().message).isEqualTo(
+                    "Down-casting from type Map to HashMap is risky."
+                )
+            }
+
+            it("detects LinkedHashMap type casts") {
+                val code = """
+                fun main() {
+                    val myMap = mapOf(1 to 2)
+                    val mutMap = myMap as LinkedHashMap<Int, Int>
+                }
+                """
+                val result = subject.compileAndLintWithContext(env, code)
+                assertThat(result).hasSize(1)
+                assertThat(result.first().message).isEqualTo(
+                    "Down-casting from type Map to LinkedHashMap is risky."
+                )
+            }
+
+            it("detects LinkedHashMap type safe casts") {
+                val code = """
+                fun main() {
+                    val myMap : Map<Int, Int>? = null
+                    val mutMap = myMap as? LinkedHashMap<Int, Int>
+                }
+                """
+                val result = subject.compileAndLintWithContext(env, code)
+                assertThat(result).hasSize(1)
+                assertThat(result.first().message).isEqualTo(
+                    "Down-casting from type Map to LinkedHashMap is risky."
+                )
+            }
+
+            it("detects LinkedHashMap type checks") {
+                val code = """
+                fun main() {
+                    val myMap = mapOf(1 to 2)
+                    if (myMap is LinkedHashMap<Int, Int>) {
+                        myMap[3] = 4
+                    }
+                }
+                """
+                val result = subject.compileAndLintWithContext(env, code)
+                assertThat(result).hasSize(1)
+                assertThat(result.first().message).isEqualTo(
+                    "Down-casting from type Map to LinkedHashMap is risky."
+                )
+            }
+        }
     }
 })

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DontDowncastCollectionTypesSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DontDowncastCollectionTypesSpec.kt
@@ -1,0 +1,189 @@
+package io.gitlab.arturbosch.detekt.rules.bugs
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.rules.setupKotlinEnvironment
+import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+class DontDowncastCollectionTypesSpec : Spek({
+    setupKotlinEnvironment()
+
+    val env: KotlinCoreEnvironment by memoized()
+    val subject by memoized { DontDowncastCollectionTypes(Config.empty) }
+
+    describe("DontDowncastCollectionTypes rule") {
+
+        describe("valid cases") {
+            it("detects List type casts") {
+                val code = """
+                fun main() {
+                    val myList = listOf(1,2,3)
+                    val mutList = myList as MutableList<Int>
+                }
+                """
+                val result = subject.compileAndLintWithContext(env, code)
+                assertThat(result).hasSize(1)
+                assertThat(result.first().message).isEqualTo(
+                    "Down-casting from type List to MutableList is risky. Use `toMutableList()` instead."
+                )
+            }
+
+            it("detects List type safe casts") {
+                val code = """
+                fun main() {
+                    val myList : List<Int>? = null
+                    val mutList = myList as? MutableList<Int>
+                }
+                """
+                val result = subject.compileAndLintWithContext(env, code)
+                assertThat(result).hasSize(1)
+                assertThat(result.first().message).isEqualTo(
+                    "Down-casting from type List to MutableList is risky. Use `toMutableList()` instead."
+                )
+            }
+
+            it("detects List type checks") {
+                val code = """
+                fun main() {
+                    val myList = listOf(1,2,3)
+                    if (myList is MutableList<Int>) {
+                        myList.add(4)
+                    }
+                }
+                """
+                val result = subject.compileAndLintWithContext(env, code)
+                assertThat(result).hasSize(1)
+                assertThat(result.first().message).isEqualTo(
+                    "Down-casting from type List to MutableList is risky. Use `toMutableList()` instead."
+                )
+            }
+
+            it("detects Set type casts") {
+                val code = """
+                fun main() {
+                    val mySet = setOf(1,2,3)
+                    val mutSet = mySet as MutableSet<Int>
+                }
+                """
+                val result = subject.compileAndLintWithContext(env, code)
+                assertThat(result).hasSize(1)
+                assertThat(result.first().message).isEqualTo(
+                    "Down-casting from type Set to MutableSet is risky. Use `toMutableSet()` instead."
+                )
+            }
+
+            it("detects Set type safe casts") {
+                val code = """
+                fun main() {
+                    val mySet : Set<Int>? = null
+                    val mutSet = mySet as? MutableSet<Int>
+                }
+                """
+                val result = subject.compileAndLintWithContext(env, code)
+                assertThat(result).hasSize(1)
+                assertThat(result.first().message).isEqualTo(
+                    "Down-casting from type Set to MutableSet is risky. Use `toMutableSet()` instead."
+                )
+            }
+
+            it("detects Set type checks") {
+                val code = """
+                fun main() {
+                    val mySet = setOf(1,2,3)
+                    if (mySet is MutableSet<Int>) {
+                        mySet.add(4)
+                    }
+                }
+                """
+                val result = subject.compileAndLintWithContext(env, code)
+                assertThat(result).hasSize(1)
+                assertThat(result.first().message).isEqualTo(
+                    "Down-casting from type Set to MutableSet is risky. Use `toMutableSet()` instead."
+                )
+            }
+
+            it("detects Map type casts") {
+                val code = """
+                fun main() {
+                    val myMap = mapOf(1 to 2)
+                    val mutMap = myMap as MutableMap<Int, Int>
+                }
+                """
+                val result = subject.compileAndLintWithContext(env, code)
+                assertThat(result).hasSize(1)
+                assertThat(result.first().message).isEqualTo(
+                    "Down-casting from type Map to MutableMap is risky. Use `toMutableMap()` instead."
+                )
+            }
+
+            it("detects Map type safe casts") {
+                val code = """
+                fun main() {
+                    val myMap : Map<Int, Int>? = null
+                    val mutMap = myMap as? MutableMap<Int, Int>
+                }
+                """
+                val result = subject.compileAndLintWithContext(env, code)
+                assertThat(result).hasSize(1)
+                assertThat(result.first().message).isEqualTo(
+                    "Down-casting from type Map to MutableMap is risky. Use `toMutableMap()` instead."
+                )
+            }
+
+            it("detects Map type checks") {
+                val code = """
+                fun main() {
+                    val myMap = mapOf(1 to 2)
+                    if (myMap is MutableMap<Int, Int>) {
+                        myMap.add(3 to 4)
+                    }
+                }
+                """
+                val result = subject.compileAndLintWithContext(env, code)
+                assertThat(result).hasSize(1)
+                assertThat(result.first().message).isEqualTo(
+                    "Down-casting from type Map to MutableMap is risky. Use `toMutableMap()` instead."
+                )
+            }
+        }
+
+        describe("ignores valid casts") {
+
+            it("ignores MutableList casts") {
+                val code = """
+                fun main() {
+                    val myList = mutableListOf(1,2,3)
+                    val mutList = myList as MutableList<Int>
+                }
+                """
+                val result = subject.compileAndLintWithContext(env, code)
+                assertThat(result).isEmpty()
+            }
+
+            it("ignores MutableSet casts") {
+                val code = """
+                fun main() {
+                    val mySet = mutableSetOf(1,2,3)
+                    val mutSet = mySet as MutableSet<Int>
+                }
+                """
+                val result = subject.compileAndLintWithContext(env, code)
+                assertThat(result).isEmpty()
+            }
+
+            it("detects Map type casts") {
+                val code = """
+                fun main() {
+                    val myMap = mutableMapOf(1 to 2)
+                    val mutMap = myMap as MutableMap<Int, Int>
+                }
+                """
+                val result = subject.compileAndLintWithContext(env, code)
+                assertThat(result).isEmpty()
+            }
+        }
+    }
+})


### PR DESCRIPTION
I'm proposing a new rule: `DontDowncastCollectionTypes`

Down-casting immutable types from kotlin.collections should be discouraged.
The result of the downcast is platform specific and can lead to unexpected crashes.
Prefer to use instead the `toMutable<Type>()` functions.

### Non-compliant
```kotlin
val list : List<Int> = getAList()
if (list is MutableList) {
    list.add(42)
}

(list as MutableList).add(42)
```

### Compliant 
```kotlin
val list : List<Int> = getAList()
list.toMutableList().add(42)
```

Happy to discuss if we want to adapt it to check casts against Java concrete collection types (e.g. `ArrayList`, etc.).