### PR TITLE
Fix false positive for `UnusedPrivateMember` with expect on objects

### DIFF
--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
@@ -22,6 +22,7 @@ import org.jetbrains.kotlin.lexer.KtSingleValueToken
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.psi.KtClass
+import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtFunction
 import org.jetbrains.kotlin.psi.KtNameReferenceExpression
@@ -199,10 +200,16 @@ private class UnusedParameterVisitor(allowedNames: Regex) : UnusedMemberVisitor(
         }
     }
 
-    override fun visitClass(klass: KtClass) {
-        if (klass.isInterface() || klass.isExpect()) return
+    override fun visitClassOrObject(klassOrObject: KtClassOrObject) {
+        if (klassOrObject.isExpect()) return
 
-        super.visitClassOrObject(klass)
+        super.visitClassOrObject(klassOrObject)
+    }
+
+    override fun visitClass(klass: KtClass) {
+        if (klass.isInterface()) return
+
+        super.visitClass(klass)
     }
 
     override fun visitNamedFunction(function: KtNamedFunction) {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMemberSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMemberSpec.kt
@@ -67,6 +67,16 @@ class UnusedPrivateMemberSpec : Spek({
             assertThat(subject.lint(code)).isEmpty()
         }
 
+        it("should not report parameters in expect object functions") {
+            val code = """
+                expect object Foo {
+                    fun bar(i: Int)
+                    fun baz(i: Int, s: String)
+                }
+            """
+            assertThat(subject.lint(code)).isEmpty()
+        }
+
         it("should not report parameters in expect functions") {
             val code = """
                 expect fun bar(i: Int)


### PR DESCRIPTION
We had a discrepancy on the `visitClass` and `visitClassOrObject` method (we were calling the wrong super method). I've fixed this, addressing the `expect object` scenarios.

Fixes #3415 
