### PR TITLE
Fix False Positive on `UnnecessarySafeCall`

### DIFF
--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessarySafeCall.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessarySafeCall.kt
@@ -61,6 +61,11 @@ class UnnecessarySafeCall(config: Config = Config.empty) : Rule(config) {
             // For external types, if they're not included in the classpath, we still get an Errors.UNNECESSARY_SAFE_CALL.
             // This causes false positives if our users are misconfiguring detekt with Type Resolution.
             // Here we try to check if the compiler reports failed to resolve the nullable type.
+
+            // More reference on where the compiler is attaching this information is here:
+            // https://github.com/JetBrains/kotlin/blob/29b23e79f32791e456a5b4a453277f0f0b3e984d/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/CallExpressionResolver.kt#L543
+            // Specifically the Kotlin Compiler is not checking if the receiver type is of type `ErrorType`
+            // so we circumvent it here.
             if (compilerReport is DiagnosticWithParameters1<*, *> && compilerReport.a is ErrorType) {
                 return
             }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessarySafeCallSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessarySafeCallSpec.kt
@@ -3,6 +3,7 @@ package io.gitlab.arturbosch.detekt.rules.bugs
 import io.gitlab.arturbosch.detekt.rules.setupKotlinEnvironment
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
@@ -59,6 +60,46 @@ class UnnecessarySafeCallSpec : Spek({
                 }"""
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
+        }
+    }
+
+    describe("check safe operator with non included types") {
+
+        it("does not report safe calls with non specified types") {
+            val code = """
+                import com.sample.function.from.outside
+
+                fun test(s: String) {
+                    val a = outside()
+                    val b = a?.plus(42)
+                }"""
+            val findings = subject.lintWithContext(env, code)
+            assertThat(findings).isEmpty()
+        }
+
+        it("does not report safe calls if nullable type is specified") {
+            val code = """
+                import com.sample.function.from.outside
+
+                fun test(s: String) {
+                    val a : Int? = outside()
+                    val b = a?.plus(42)
+                }"""
+            val findings = subject.lintWithContext(env, code)
+            assertThat(findings).isEmpty()
+        }
+
+        it("reports safe calls if non nullable type is specified") {
+            val code = """
+                import com.sample.function.from.outside
+
+                fun test(s: String) {
+                    val a : Int = outside()
+                    val b = a?.plus(42)
+                }"""
+            val findings = subject.lintWithContext(env, code)
+            assertThat(findings).hasSize(1)
+            assertThat(findings).hasTextLocations(103 to 114)
         }
     }
 })


### PR DESCRIPTION
This is a fix for the various false positives on `UnnecessarySafeCall`.

After some debugging the problems seems to be with misconfigured class-paths (e.g. https://github.com/cph-cachet/carp.core-kotlin/pull/223). If the classpath doesn't contain a third-party types, but still has a safe call operator, the Kotlin Compiler raises an `Errors.UNNECESSARY_SAFE_CALL` detection.

Inside the detection the compiler adds information on the non-nullable type that is the receiver of the safe call (in the `.a` field). In this patch I'm try to see if the compiler failed to resolve the type => If so, we can skip the report.

Fixes #3409 
Fixes #3414 