### PR TITLE
Prompt bug reporters to attach gradle scan

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -25,5 +25,6 @@ about: Help make detekt better by reporting bugs, false positives and other issu
 <!-- Include as many relevant details about the environment you experienced the bug in -->
 * Version of detekt used:
 * Version of Gradle used (if applicable):
+* Gradle scan link (add `--scan` option when running the gradle task):
 * Operating System and version:
 * Link to your project (if it's a public repository):


### PR DESCRIPTION
There are recently quite a number of crash reports due to Kotlin versioning. I believe Gradle scan could help us find all relevant environment information and dependency versions. Hopefully, this will reduce turnaround time due to timezone difference.
