### PR TITLE
Fix `githubRelease` skipping assets

### DIFF
--- a/buildSrc/src/main/kotlin/releasing.gradle.kts
+++ b/buildSrc/src/main/kotlin/releasing.gradle.kts
@@ -4,28 +4,30 @@ plugins {
     id("com.github.breadmoirai.github-release")
 }
 
-githubRelease {
-    token(project.findProperty("github.token") as? String ?: "")
-    owner.set("detekt")
-    repo.set("detekt")
-    overwrite.set(true)
-    dryRun.set(false)
-    body {
-        var changelog = project.file("docs/pages/changelog 1.x.x.md").readText()
-        val nextNonBetaVersion = project.version.toString().substringBeforeLast("-")
-        val sectionStart = "#### $nextNonBetaVersion"
-        changelog = changelog.substring(changelog.indexOf(sectionStart) + sectionStart.length)
-        changelog = changelog.substring(0, changelog.indexOf("#### 1."))
-        changelog.trim()
-    }
-    val cliBuildDir = project(":detekt-cli").buildDir
-    releaseAssets.setFrom(
-        files(
-            cliBuildDir.resolve("libs/detekt-cli-${project.version}-all.jar"),
-            cliBuildDir.resolve("distributions/detekt-cli-${project.version}.zip"),
-            project(":detekt-formatting").buildDir.resolve("libs/detekt-formatting-${project.version}.jar")
+project.afterEvaluate {
+    githubRelease {
+        token(project.findProperty("github.token") as? String ?: "")
+        owner.set("detekt")
+        repo.set("detekt")
+        overwrite.set(true)
+        dryRun.set(false)
+        body {
+            var changelog = project.file("docs/pages/changelog 1.x.x.md").readText()
+            val nextNonBetaVersion = project.version.toString().substringBeforeLast("-")
+            val sectionStart = "#### $nextNonBetaVersion"
+            changelog = changelog.substring(changelog.indexOf(sectionStart) + sectionStart.length)
+            changelog = changelog.substring(0, changelog.indexOf("#### 1."))
+            changelog.trim()
+        }
+        val cliBuildDir = project(":detekt-cli").buildDir
+        releaseAssets.setFrom(
+            files(
+                cliBuildDir.resolve("libs/detekt-cli-${project.version}-all.jar"),
+                cliBuildDir.resolve("distributions/detekt-cli-${project.version}.zip"),
+                project(":detekt-formatting").buildDir.resolve("libs/detekt-formatting-${project.version}.jar")
+            )
         )
-    )
+    }
 }
 
 fun updateVersion(increment: (Semver) -> Semver) {


### PR DESCRIPTION
Currently we fail to resolve `project.version` inside the `githubRelease {}` block. This is causing release artifacts to not be included in the release on Github.

This happens as the version is set after the precompiled plugin is applied. 

Fixes https://github.com/detekt/detekt/discussions/3425