### PR TITLE
Don't fail if baseline doesn't exist in PlainDetekt

### DIFF
--- a/detekt-gradle-plugin/src/intTest/kotlin/io/gitlab/arturbosch/detekt/DetektTaskDslTest.kt
+++ b/detekt-gradle-plugin/src/intTest/kotlin/io/gitlab/arturbosch/detekt/DetektTaskDslTest.kt
@@ -99,6 +99,28 @@ internal object DetektTaskDslTest : Spek({
                     }
                 }
 
+                describe("with custom baseline file that doesn't exist") {
+                    val baselineFilename = "detekt-baseline-no-exist.xml"
+
+                    beforeGroup {
+
+                        val config = """
+                        |detekt {
+                        |   baseline = file("$baselineFilename")
+                        |}
+                        """
+
+                        gradleRunner = builder
+                            .withDetektConfig(config)
+                            .build()
+                        result = gradleRunner.runDetektTask()
+                    }
+
+                    it("doesn't set the baseline parameter") {
+                        assertThat(result.output).doesNotContain("--baseline")
+                    }
+                }
+
                 describe("with custom input directories") {
                     val customSrc1 = "gensrc/kotlin"
                     val customSrc2 = "src/main/kotlin"

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektPlain.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektPlain.kt
@@ -16,7 +16,9 @@ internal class DetektPlain(private val project: Project) {
 
     private fun Project.registerDetektTask(extension: DetektExtension) {
         val detektTaskProvider = registerDetektTask(DetektPlugin.DETEKT_TASK_NAME, extension) {
-            baseline.set(project.layout.file(project.provider { extension.baseline }))
+            extension.baseline?.takeIf { it.exists() }?.let { baselineFile ->
+                baseline.set(project.layout.file(project.provider { baselineFile }))
+            }
             setSource(existingInputDirectoriesProvider(project, extension))
             setIncludes(DetektPlugin.defaultIncludes)
             setExcludes(DetektPlugin.defaultExcludes)

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/FileMangling.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/FileMangling.kt
@@ -2,12 +2,12 @@ package io.gitlab.arturbosch.detekt.internal
 
 import java.io.File
 
-internal fun File?.existingVariantOrBaseFile(variant: String): File? {
-    val variantFile = this?.addVariantName(variant)
+internal fun File.existingVariantOrBaseFile(variant: String): File? {
+    val variantFile = this.addVariantName(variant)
     // if there is a file with the variant name, it has precedence
     return when {
-        variantFile?.exists() == true -> variantFile
-        this?.exists() == true -> this
+        variantFile.exists() -> variantFile
+        this.exists() -> this
         else -> null
     }
 }


### PR DESCRIPTION
Fixes #3355

At work I realised that we had some modules without it's baseline and they were working as expected. I just figured out why: we have this code https://github.com/detekt/detekt/blob/a26038388f8fed5351870532dcdf090c79af1f6e/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektJvm.kt#L30-L34
for jvm and android but we don't for plain detekt. In this PR I just add that code in detekt too.