### PR TITLE
Add two missing ktlint rules

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -326,6 +326,9 @@ formatting:
     active: true
     autoCorrect: true
     indentSize: 4
+  SpacingAroundAngleBrackets:
+    active: false
+    autoCorrect: true
   SpacingAroundColon:
     active: true
     autoCorrect: true
@@ -352,6 +355,9 @@ formatting:
     autoCorrect: true
   SpacingAroundRangeOperator:
     active: true
+    autoCorrect: true
+  SpacingAroundUnaryOperator:
+    active: false
     autoCorrect: true
   SpacingBetweenDeclarationsWithAnnotations:
     active: false

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/KtLintMultiRule.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/KtLintMultiRule.kt
@@ -33,6 +33,7 @@ import io.gitlab.arturbosch.detekt.formatting.wrappers.NoUnusedImports
 import io.gitlab.arturbosch.detekt.formatting.wrappers.NoWildcardImports
 import io.gitlab.arturbosch.detekt.formatting.wrappers.PackageName
 import io.gitlab.arturbosch.detekt.formatting.wrappers.ParameterListWrapping
+import io.gitlab.arturbosch.detekt.formatting.wrappers.SpacingAroundAngleBrackets
 import io.gitlab.arturbosch.detekt.formatting.wrappers.SpacingAroundColon
 import io.gitlab.arturbosch.detekt.formatting.wrappers.SpacingAroundComma
 import io.gitlab.arturbosch.detekt.formatting.wrappers.SpacingAroundCurly
@@ -42,6 +43,7 @@ import io.gitlab.arturbosch.detekt.formatting.wrappers.SpacingAroundKeyword
 import io.gitlab.arturbosch.detekt.formatting.wrappers.SpacingAroundOperators
 import io.gitlab.arturbosch.detekt.formatting.wrappers.SpacingAroundParens
 import io.gitlab.arturbosch.detekt.formatting.wrappers.SpacingAroundRangeOperator
+import io.gitlab.arturbosch.detekt.formatting.wrappers.SpacingAroundUnaryOperator
 import io.gitlab.arturbosch.detekt.formatting.wrappers.SpacingBetweenDeclarationsWithAnnotations
 import io.gitlab.arturbosch.detekt.formatting.wrappers.SpacingBetweenDeclarationsWithComments
 import io.gitlab.arturbosch.detekt.formatting.wrappers.StringTemplate
@@ -84,6 +86,7 @@ class KtLintMultiRule(config: Config = Config.empty) : MultiRule() {
         NoWildcardImports(config),
         PackageName(config),
         ParameterListWrapping(config),
+        SpacingAroundAngleBrackets(config),
         SpacingAroundColon(config),
         SpacingAroundComma(config),
         SpacingAroundCurly(config),
@@ -93,6 +96,7 @@ class KtLintMultiRule(config: Config = Config.empty) : MultiRule() {
         SpacingAroundOperators(config),
         SpacingAroundParens(config),
         SpacingAroundRangeOperator(config),
+        SpacingAroundUnaryOperator(config),
         SpacingBetweenDeclarationsWithAnnotations(config),
         SpacingBetweenDeclarationsWithComments(config),
         StringTemplate(config)

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingAroundAngleBrackets.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingAroundAngleBrackets.kt
@@ -1,0 +1,16 @@
+package io.gitlab.arturbosch.detekt.formatting.wrappers
+
+import com.pinterest.ktlint.ruleset.experimental.SpacingAroundAngleBracketsRule
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.formatting.FormattingRule
+
+/**
+ * See <a href="https://ktlint.github.io/#rule-spacing">ktlint-website</a> for documentation.
+ *
+ * @autoCorrect since v1.16.0
+ */
+class SpacingAroundAngleBrackets(config: Config) : FormattingRule(config) {
+
+    override val wrapping = SpacingAroundAngleBracketsRule()
+    override val issue = issueFor("Reports spaces around angle brackets")
+}

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingAroundUnaryOperator.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingAroundUnaryOperator.kt
@@ -1,0 +1,16 @@
+package io.gitlab.arturbosch.detekt.formatting.wrappers
+
+import com.pinterest.ktlint.ruleset.experimental.SpacingAroundUnaryOperatorRule
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.formatting.FormattingRule
+
+/**
+ * See <a href="https://ktlint.github.io/#rule-spacing">ktlint-website</a> for documentation.
+ *
+ * @autoCorrect since v1.16.0
+ */
+class SpacingAroundUnaryOperator(config: Config) : FormattingRule(config) {
+
+    override val wrapping = SpacingAroundUnaryOperatorRule()
+    override val issue = issueFor("Reports spaces around unary operator")
+}


### PR DESCRIPTION
These two rules may be missing from the recent ktlint version upgrades. I am adding them with `active: false` by default.