### PR TITLE
Add allRules and deprecate failFast in gradle tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ plugins {
 }
 
 detekt {
-    failFast = true // fail build on any finding
     buildUponDefaultConfig = true // preconfigure defaults
+    allRules = false // activate all available (even unstable) rules.
     config = files("$projectDir/config/detekt.yml") // point to your custom config defining rules to run, overwriting default behavior
     baseline = file("$projectDir/config/baseline.xml") // a way of suppressing issues before introducing detekt
 

--- a/detekt-gradle-plugin/src/intTest/kotlin/io/gitlab/arturbosch/detekt/DetektTaskDslTest.kt
+++ b/detekt-gradle-plugin/src/intTest/kotlin/io/gitlab/arturbosch/detekt/DetektTaskDslTest.kt
@@ -397,7 +397,7 @@ internal object DetektTaskDslTest : Spek({
                         |    debug = true
                         |    parallel = true
                         |    disableDefaultRuleSets = true
-                        |    failFast = true
+                        |    allRules = true
                         |    autoCorrect = true
                         |    buildUponDefaultConfig = true
                         |    ignoreFailures = true
@@ -426,8 +426,8 @@ internal object DetektTaskDslTest : Spek({
                         assertThat(result.output).contains("Ignore failures: true")
                     }
 
-                    it("enables fail fast") {
-                        assertThat(result.output).contains("--fail-fast")
+                    it("enables all rules") {
+                        assertThat(result.output).contains("--all-rules")
                     }
 
                     it("enables auto correcting") {
@@ -493,8 +493,8 @@ internal object DetektTaskDslTest : Spek({
                 val builder = groovy().dryRun()
                 beforeGroup {
                     val config = """
-                        |task detektFailFast(type: io.gitlab.arturbosch.detekt.Detekt) {
-                        |    description = "Runs a failfast detekt build."
+                        |task myDetekt(type: io.gitlab.arturbosch.detekt.Detekt) {
+                        |    description = "Runs a custom detekt build."
                         |
                         |    setSource("${"$"}projectDir")
                         |    config.setFrom(files("config.yml"))
@@ -504,19 +504,19 @@ internal object DetektTaskDslTest : Spek({
                         |    parallel = true
                         |    disableDefaultRuleSets = true
                         |    buildUponDefaultConfig = true
-                        |    failFast = false
+                        |    allRules = false
                         |    ignoreFailures = false
                         |    autoCorrect = false
                         |    reports {
                         |        xml {
                         |            enabled = true
-                        |            destination = file("build/reports/failfast.xml")
+                        |            destination = file("build/reports/mydetekt.xml")
                         |        }
-                        |        html.destination = file("build/reports/failfast.html")
-                        |        txt.destination = file("build/reports/failfast.txt")
+                        |        html.destination = file("build/reports/mydetekt.html")
+                        |        txt.destination = file("build/reports/mydetekt.txt")
                         |        sarif {
                         |            enabled = true
-                        |            destination = file("build/reports/failfast.sarif")
+                        |            destination = file("build/reports/mydetekt.sarif")
                         |        }
                         |    }
                         |    basePath = projectDir
@@ -528,30 +528,30 @@ internal object DetektTaskDslTest : Spek({
                         .build()
                         .apply { writeProjectFile("config.yml", "") }
 
-                    result = gradleRunner.runTasks("detektFailFast")
+                    result = gradleRunner.runTasks("myDetekt")
                 }
 
                 it("completes successfully") {
-                    assertThat(result.task(":detektFailFast")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+                    assertThat(result.task(":myDetekt")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
                 }
 
                 it("enables xml report to specified location") {
-                    val xmlReportFile = gradleRunner.projectFile("build/reports/failfast.xml")
+                    val xmlReportFile = gradleRunner.projectFile("build/reports/mydetekt.xml")
                     assertThat(result.output).contains("--report xml:$xmlReportFile")
                 }
 
                 it("enables html report to specified location") {
-                    val htmlReportFile = gradleRunner.projectFile("build/reports/failfast.html")
+                    val htmlReportFile = gradleRunner.projectFile("build/reports/mydetekt.html")
                     assertThat(result.output).contains("--report html:$htmlReportFile")
                 }
 
                 it("enables text report to specified location") {
-                    val textReportFile = gradleRunner.projectFile("build/reports/failfast.txt")
+                    val textReportFile = gradleRunner.projectFile("build/reports/mydetekt.txt")
                     assertThat(result.output).contains("--report txt:$textReportFile")
                 }
 
                 it("enables sarif report to specified location") {
-                    val sarifReportFile = gradleRunner.projectFile("build/reports/failfast.sarif")
+                    val sarifReportFile = gradleRunner.projectFile("build/reports/mydetekt.sarif")
                     assertThat(result.output).contains("--report sarif:$sarifReportFile")
                 }
 
@@ -583,8 +583,8 @@ internal object DetektTaskDslTest : Spek({
                 val builder = kotlin().dryRun()
                 beforeGroup {
                     val config = """
-                        |task<io.gitlab.arturbosch.detekt.Detekt>("detektFailFast") {
-                        |    description = "Runs a failfast detekt build."
+                        |task<io.gitlab.arturbosch.detekt.Detekt>("myDetekt") {
+                        |    description = "Runs a custom detekt build."
                         |
                         |    setSource(files("${"$"}projectDir"))
                         |    setIncludes(listOf("**/*.kt", "**/*.kts"))
@@ -595,18 +595,19 @@ internal object DetektTaskDslTest : Spek({
                         |    disableDefaultRuleSets = true
                         |    buildUponDefaultConfig = true
                         |    failFast = false
+                        |    allRules = false
                         |    ignoreFailures = false
                         |    autoCorrect = false
                         |    reports {
                         |        xml {
                         |            enabled = true
-                        |            destination = file("build/reports/failfast.xml")
+                        |            destination = file("build/reports/mydetekt.xml")
                         |        }
-                        |        html.destination = file("build/reports/failfast.html")
-                        |        txt.destination = file("build/reports/failfast.txt")
+                        |        html.destination = file("build/reports/mydetekt.html")
+                        |        txt.destination = file("build/reports/mydetekt.txt")
                         |        sarif {
                         |            enabled = true
-                        |            destination = file("build/reports/failfast.sarif")
+                        |            destination = file("build/reports/mydetekt.sarif")
                         |        }
                         |    }
                         |    basePath = projectDir.toString()
@@ -618,30 +619,30 @@ internal object DetektTaskDslTest : Spek({
                         .build()
                         .apply { writeProjectFile("config.yml", "") }
 
-                    result = gradleRunner.runTasks("detektFailFast")
+                    result = gradleRunner.runTasks("myDetekt")
                 }
 
                 it("completes successfully") {
-                    assertThat(result.task(":detektFailFast")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+                    assertThat(result.task(":myDetekt")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
                 }
 
                 it("enables xml report to specified location") {
-                    val xmlReportFile = gradleRunner.projectFile("build/reports/failfast.xml")
+                    val xmlReportFile = gradleRunner.projectFile("build/reports/mydetekt.xml")
                     assertThat(result.output).contains("--report xml:$xmlReportFile")
                 }
 
                 it("enables html report to specified location") {
-                    val htmlReportFile = gradleRunner.projectFile("build/reports/failfast.html")
+                    val htmlReportFile = gradleRunner.projectFile("build/reports/mydetekt.html")
                     assertThat(result.output).contains("--report html:$htmlReportFile")
                 }
 
                 it("enables text report to specified location") {
-                    val textReportFile = gradleRunner.projectFile("build/reports/failfast.txt")
+                    val textReportFile = gradleRunner.projectFile("build/reports/mydetekt.txt")
                     assertThat(result.output).contains("--report txt:$textReportFile")
                 }
 
                 it("enables sarif report to specified location") {
-                    val sarifReportFile = gradleRunner.projectFile("build/reports/failfast.sarif")
+                    val sarifReportFile = gradleRunner.projectFile("build/reports/mydetekt.sarif")
                     assertThat(result.output).contains("--report sarif:$sarifReportFile")
                 }
 

--- a/detekt-gradle-plugin/src/intTest/kotlin/io/gitlab/arturbosch/detekt/DetektTaskDslTest.kt
+++ b/detekt-gradle-plugin/src/intTest/kotlin/io/gitlab/arturbosch/detekt/DetektTaskDslTest.kt
@@ -397,6 +397,10 @@ internal object DetektTaskDslTest : Spek({
                         |    debug = true
                         |    parallel = true
                         |    disableDefaultRuleSets = true
+<<<<<<< HEAD
+=======
+                        |    failFast = true
+>>>>>>> Add allRules and deprecate failFast in gradle tasks
                         |    allRules = true
                         |    autoCorrect = true
                         |    buildUponDefaultConfig = true
@@ -424,6 +428,10 @@ internal object DetektTaskDslTest : Spek({
 
                     it("ignores failures") {
                         assertThat(result.output).contains("Ignore failures: true")
+                    }
+
+                    it("enables all rules") {
+                        assertThat(result.output).contains("--all-rules")
                     }
 
                     it("enables all rules") {

--- a/detekt-gradle-plugin/src/intTest/kotlin/io/gitlab/arturbosch/detekt/DetektTaskDslTest.kt
+++ b/detekt-gradle-plugin/src/intTest/kotlin/io/gitlab/arturbosch/detekt/DetektTaskDslTest.kt
@@ -397,10 +397,7 @@ internal object DetektTaskDslTest : Spek({
                         |    debug = true
                         |    parallel = true
                         |    disableDefaultRuleSets = true
-<<<<<<< HEAD
-=======
                         |    failFast = true
->>>>>>> Add allRules and deprecate failFast in gradle tasks
                         |    allRules = true
                         |    autoCorrect = true
                         |    buildUponDefaultConfig = true
@@ -434,8 +431,8 @@ internal object DetektTaskDslTest : Spek({
                         assertThat(result.output).contains("--all-rules")
                     }
 
-                    it("enables all rules") {
-                        assertThat(result.output).contains("--all-rules")
+                    it("enables fail fast") {
+                        assertThat(result.output).contains("--fail-fast")
                     }
 
                     it("enables auto correcting") {

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -4,6 +4,7 @@ import io.gitlab.arturbosch.detekt.extensions.DetektExtension
 import io.gitlab.arturbosch.detekt.extensions.DetektReport
 import io.gitlab.arturbosch.detekt.extensions.DetektReportType
 import io.gitlab.arturbosch.detekt.extensions.DetektReports
+import io.gitlab.arturbosch.detekt.invoke.AllRulesArgument
 import io.gitlab.arturbosch.detekt.invoke.AutoCorrectArgument
 import io.gitlab.arturbosch.detekt.invoke.BasePathArgument
 import io.gitlab.arturbosch.detekt.invoke.BaselineArgument
@@ -127,6 +128,13 @@ open class Detekt @Inject constructor(
         set(value) = failFastProp.set(value)
 
     @get:Internal
+    internal val allRulesProp: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
+    var allRules: Boolean
+        @Input
+        get() = allRulesProp.getOrElse(false)
+        set(value) = allRulesProp.set(value)
+
+    @get:Internal
     internal val ignoreFailuresProp: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
 
     @get:Internal
@@ -202,6 +210,10 @@ open class Detekt @Inject constructor(
 
     @TaskAction
     fun check() {
+        if (failFastProp.getOrElse(false)) {
+            project.logger.warn("'failFast' is deprecated. Please use 'buildOnDefaultConfig' together with 'allRules'.")
+        }
+
         val arguments = mutableListOf(
             InputArgument(source),
             ClasspathArgument(classpath),
@@ -217,6 +229,7 @@ open class Detekt @Inject constructor(
             ParallelArgument(parallelProp.getOrElse(false)),
             BuildUponDefaultConfigArgument(buildUponDefaultConfigProp.getOrElse(false)),
             FailFastArgument(failFastProp.getOrElse(false)),
+            AllRulesArgument(allRulesProp.getOrElse(false)),
             AutoCorrectArgument(autoCorrectProp.getOrElse(false)),
             BasePathArgument(basePathProp.orNull),
             DisableDefaultRuleSetArgument(disableDefaultRuleSetsProp.getOrElse(false))

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt
 
+import io.gitlab.arturbosch.detekt.invoke.AllRulesArgument
 import io.gitlab.arturbosch.detekt.invoke.AutoCorrectArgument
 import io.gitlab.arturbosch.detekt.invoke.BasePathArgument
 import io.gitlab.arturbosch.detekt.invoke.BaselineArgument
@@ -81,6 +82,10 @@ open class DetektCreateBaselineTask : SourceTask() {
 
     @get:Input
     @get:Optional
+    val allRules: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
+
+    @get:Input
+    @get:Optional
     val autoCorrect: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
 
     /**
@@ -106,6 +111,10 @@ open class DetektCreateBaselineTask : SourceTask() {
 
     @TaskAction
     fun baseline() {
+        if (failFast.getOrElse(false)) {
+            project.logger.warn("'failFast' is deprecated. Please use 'buildOnDefaultConfig' together with 'allRules'.")
+        }
+
         val arguments = mutableListOf(
             CreateBaselineArgument,
             ClasspathArgument(classpath),
@@ -118,6 +127,7 @@ open class DetektCreateBaselineTask : SourceTask() {
             BuildUponDefaultConfigArgument(buildUponDefaultConfig.getOrElse(false)),
             FailFastArgument(failFast.getOrElse(false)),
             AutoCorrectArgument(autoCorrect.getOrElse(false)),
+            AllRulesArgument(allRules.getOrElse(false)),
             BasePathArgument(basePathProp.orNull),
             DisableDefaultRuleSetArgument(disableDefaultRuleSets.getOrElse(false))
         )

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
@@ -37,6 +37,8 @@ open class DetektExtension @Inject constructor(objects: ObjectFactory) : CodeQua
 
     var failFast: Boolean = DEFAULT_FAIL_FAST_VALUE
 
+    var allRules: Boolean = DEFAULT_ALL_RULES_VALUE
+
     var buildUponDefaultConfig: Boolean = DEFAULT_BUILD_UPON_DEFAULT_CONFIG_VALUE
 
     var disableDefaultRuleSets: Boolean = DEFAULT_DISABLE_RULESETS_VALUE
@@ -71,6 +73,7 @@ open class DetektExtension @Inject constructor(objects: ObjectFactory) : CodeQua
         const val DEFAULT_DISABLE_RULESETS_VALUE = false
         const val DEFAULT_REPORT_ENABLED_VALUE = true
         const val DEFAULT_FAIL_FAST_VALUE = false
+        const val DEFAULT_ALL_RULES_VALUE = false
         const val DEFAULT_BUILD_UPON_DEFAULT_CONFIG_VALUE = false
     }
 }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/SharedTasks.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/SharedTasks.kt
@@ -23,6 +23,7 @@ internal fun Project.registerDetektTask(
         it.config.setFrom(provider { extension.config })
         it.ignoreFailuresProp.set(project.provider { extension.ignoreFailures })
         it.basePathProp.set(extension.basePath)
+        it.allRulesProp.set(provider { extension.allRules })
         configuration(it)
     }
 
@@ -40,6 +41,7 @@ internal fun Project.registerCreateBaselineTask(
         it.failFast.set(project.provider { extension.failFast })
         it.autoCorrect.set(project.provider { extension.autoCorrect })
         it.basePathProp.set(extension.basePath)
+        it.allRules.set(provider { extension.allRules })
         configuration(it)
     }
 

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/CliArgument.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/CliArgument.kt
@@ -14,6 +14,7 @@ private const val DISABLE_DEFAULT_RULESETS_PARAMETER = "--disable-default-rulese
 private const val BUILD_UPON_DEFAULT_CONFIG_PARAMETER = "--build-upon-default-config"
 private const val AUTO_CORRECT_PARAMETER = "--auto-correct"
 private const val FAIL_FAST_PARAMETER = "--fail-fast"
+private const val ALL_RULES_PARAMETER = "--all-rules"
 private const val REPORT_PARAMETER = "--report"
 private const val GENERATE_CONFIG_PARAMETER = "--generate-config"
 private const val CREATE_BASELINE_PARAMETER = "--create-baseline"
@@ -95,5 +96,7 @@ internal data class BuildUponDefaultConfigArgument(override val value: Boolean) 
     BoolCliArgument(value, BUILD_UPON_DEFAULT_CONFIG_PARAMETER)
 
 internal data class FailFastArgument(override val value: Boolean) : BoolCliArgument(value, FAIL_FAST_PARAMETER)
+
+internal data class AllRulesArgument(override val value: Boolean) : BoolCliArgument(value, ALL_RULES_PARAMETER)
 
 internal data class AutoCorrectArgument(override val value: Boolean) : BoolCliArgument(value, AUTO_CORRECT_PARAMETER)

--- a/docs/pages/gettingstarted/gradle.md
+++ b/docs/pages/gettingstarted/gradle.md
@@ -330,16 +330,16 @@ uses the type `Detekt`.
 #### Groovy DSL
 
 ```groovy
-tasks.register(name: detektFailFast, type: io.gitlab.arturbosch.detekt.Detekt) {
-    description = "Runs a failfast detekt build."
+tasks.register(name: myDetekt, type: io.gitlab.arturbosch.detekt.Detekt) {
+    description = "Runs a custom detekt build."
     setSource(files("src/main/kotlin", "src/test/kotlin"))
     config.setFrom(files("$rootDir/config.yml"))
     debug = true
     reports {
         xml {
-            destination = file("build/reports/failfast.xml")
+            destination = file("build/reports/mydetekt.xml")
         }
-        html.destination = file("build/reports/failfast.html")
+        html.destination = file("build/reports/mydetekt.html")
     }
     include '**/*.kt'
     include '**/*.kts'
@@ -351,16 +351,16 @@ tasks.register(name: detektFailFast, type: io.gitlab.arturbosch.detekt.Detekt) {
 #### Kotlin DSL
 
 ```kotlin
-tasks.register<io.gitlab.arturbosch.detekt.Detekt>("detektFailFast") {
-    description = "Runs a failfast detekt build."
+tasks.register<io.gitlab.arturbosch.detekt.Detekt>("myDetekt") {
+    description = "Runs a custom detekt build."
     setSource(files("src/main/kotlin", "src/test/kotlin"))
     config.setFrom(files("$rootDir/config.yml"))
     debug = true
     reports {
         xml {
-            destination = file("build/reports/failfast.xml")
+            destination = file("build/reports/mydetekt.xml")
         }
-        html.destination = file("build/reports/failfast.html")
+        html.destination = file("build/reports/mydetekt.html")
     }
     include("**/*.kt")
     include("**/*.kts")


### PR DESCRIPTION
This is a follow-up of #3391 and should be merged as early as possible to ensure a smoother transition to the new Detekt 2.0 CLI #2692