### PR TITLE
Remove UnnecessarySafeCall safeguard against ErrorType

### DIFF
--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessarySafeCall.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessarySafeCall.kt
@@ -10,13 +10,11 @@ import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
 import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
-import org.jetbrains.kotlin.diagnostics.DiagnosticWithParameters1
 import org.jetbrains.kotlin.diagnostics.Errors
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtSafeQualifiedExpression
 import org.jetbrains.kotlin.psi.psiUtil.getChildOfType
 import org.jetbrains.kotlin.resolve.BindingContext
-import org.jetbrains.kotlin.types.ErrorType
 
 /**
  * Reports unnecessary safe call operators (`?.`) that can be removed by the user.
@@ -59,17 +57,6 @@ class UnnecessarySafeCall(config: Config = Config.empty) : Rule(config) {
             .firstOrNull { it.factory == Errors.UNNECESSARY_SAFE_CALL }
 
         if (compilerReport != null) {
-            // For external types, if they're not included in the classpath, we still get an Errors.UNNECESSARY_SAFE_CALL.
-            // This causes false positives if our users are misconfiguring detekt with Type Resolution.
-            // Here we try to check if the compiler reports failed to resolve the nullable type.
-
-            // More reference on where the compiler is attaching this information is here:
-            // https://github.com/JetBrains/kotlin/blob/29b23e79f32791e456a5b4a453277f0f0b3e984d/compiler/frontend/src/org/jetbrains/kotlin/resolve/calls/CallExpressionResolver.kt#L543
-            // Specifically the Kotlin Compiler is not checking if the receiver type is of type `ErrorType`
-            // so we circumvent it here.
-            if (compilerReport is DiagnosticWithParameters1<*, *> && compilerReport.a is ErrorType) {
-                return
-            }
             report(
                 CodeSmell(
                     issue,


### PR DESCRIPTION
Opening this to recall to remove this extra patch introduced in #3419
A fix was pushed upstream in the Kotlin compiler and should land in Kotlin 1.5

As soon as we bump the `compiler-embeddable` version we can also merge this PR (as the tests should be green)