### PR TITLE
Add new ObjectExtendsThrowable rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ If you contributed to detekt but your name is not in the list, please feel free 
 - [Veyndan Stuart](https://github.com/veyndan) - New rule: UseEmptyCounterpart; Rule improvement: UselessCallOnNotNull
 - [Parimatch Tech](https://github.com/parimatch-tech) - New rule: LibraryEntitiesShouldNotBePublic, UnnecessaryFilter
 - [Chao Zhang](https://github.com/chao2zhang) - SARIF report format; Rule improvements
-- [Marcelo Hernandez](https://github.com/mhernand40) - New rule: SuspendFunWithFlowReturnType
+- [Marcelo Hernandez](https://github.com/mhernand40) - New rule: SuspendFunWithFlowReturnType, ObjectExtendsThrowable
 - [Harold Martin](https://github.com/hbmartin) - Rule improvement: ClassOrdering
 - [Roman Ivanov](https://github.com/rwqwr) - Rule improvement: ReturnFromFinally
 - [Severn Everett](https://github.com/severn-everett) - New rule: SleepInsteadOfDelay

--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -189,6 +189,8 @@ exceptions:
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
   NotImplementedDeclaration:
     active: false
+  ObjectExtendsThrowable:
+    active: false
   PrintStackTrace:
     active: true
   RethrowCaughtException:

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ExceptionsProvider.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ExceptionsProvider.kt
@@ -28,7 +28,8 @@ class ExceptionsProvider : DefaultRuleSetProvider {
             ThrowingExceptionInMain(config),
             RethrowCaughtException(config),
             ThrowingNewInstanceOfSameException(config),
-            SwallowedException(config)
+            SwallowedException(config),
+            ObjectExtendsThrowable(config)
         )
     )
 }

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ObjectExtendsThrowable.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ObjectExtendsThrowable.kt
@@ -53,20 +53,17 @@ class ObjectExtendsThrowable(config: Config = Config.empty) : Rule(config) {
     )
 
     override fun visitObjectDeclaration(declaration: KtObjectDeclaration) {
-        declaration
-            .takeUnless { bindingContext == BindingContext.EMPTY }
-            ?.takeUnless { it.isObjectLiteral() }
-            ?.takeIf { it.isSubtypeOfThrowable() }
-            ?.also {
-                report(
-                    CodeSmell(
-                        issue = issue,
-                        entity = Entity.from(element = it),
-                        message = issue.description
-                    )
-                )
-            }
         super.visitObjectDeclaration(declaration)
+        if (bindingContext == BindingContext.EMPTY) return
+        if (!declaration.isObjectLiteral() && declaration.isSubtypeOfThrowable()) {
+            report(
+                CodeSmell(
+                    issue = issue,
+                    entity = Entity.from(element = declaration),
+                    message = issue.description
+                )
+            )
+        }
     }
 
     private fun KtObjectDeclaration.isSubtypeOfThrowable(): Boolean {

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ObjectExtendsThrowable.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ObjectExtendsThrowable.kt
@@ -1,0 +1,79 @@
+package io.gitlab.arturbosch.detekt.rules.exceptions
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import org.jetbrains.kotlin.psi.KtObjectDeclaration
+import org.jetbrains.kotlin.resolve.BindingContext
+import org.jetbrains.kotlin.types.typeUtil.isNotNullThrowable
+import org.jetbrains.kotlin.types.typeUtil.supertypes
+
+/**
+ * This rule reports all `objects` including `companion objects` that extend any type of
+ * `Throwable`. Throwable instances are not intended for reuse as they are stateful and contain
+ * mutable information about a specific exception or error. Hence, global singleton `Throwables`
+ * should be avoided.
+ *
+ * See https://kotlinlang.org/docs/reference/object-declarations.html#object-declarations
+ * See https://kotlinlang.org/docs/reference/object-declarations.html#companion-objects
+ *
+ * <noncompliant>
+ * object InvalidCredentialsException : Throwable()
+ *
+ * object BanException : Exception()
+ *
+ * object AuthException : RuntimeException()
+ * </noncompliant>
+ *
+ * <compliant>
+ * class InvalidCredentialsException : Throwable()
+ *
+ * class BanException : Exception()
+ *
+ * class AuthException : RuntimeException()
+ * </compliant>
+ *
+ * @requiresTypeResolution
+ */
+class ObjectExtendsThrowable(config: Config = Config.empty) : Rule(config) {
+    override val issue = Issue(
+        id = "ObjectExtendsThrowable",
+        severity = Severity.CodeSmell,
+        description = "An `object` should not extend and type of Throwable. Throwables are " +
+                "stateful and should be instantiated only when needed for when a specific error " +
+                "occurs. An `object`, being a singleton, that extends any type of Throwable " +
+                "consequently introduces a global singleton exception whose instance may be " +
+                "inadvertently reused from multiple places, thus introducing shared mutable " +
+                "state.",
+        debt = Debt.TEN_MINS
+    )
+
+    override fun visitObjectDeclaration(declaration: KtObjectDeclaration) {
+        declaration
+            .takeUnless { bindingContext == BindingContext.EMPTY }
+            ?.takeUnless { it.isObjectLiteral() }
+            ?.takeIf { it.isSubtypeOfThrowable() }
+            ?.also {
+                report(
+                    CodeSmell(
+                        issue = issue,
+                        entity = Entity.from(element = it),
+                        message = issue.description
+                    )
+                )
+            }
+        super.visitObjectDeclaration(declaration)
+    }
+
+    private fun KtObjectDeclaration.isSubtypeOfThrowable(): Boolean {
+        return bindingContext[BindingContext.CLASS, this]
+            ?.defaultType
+            ?.supertypes()
+            .orEmpty()
+            .any { it.isNotNullThrowable() }
+    }
+}

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ObjectExtendsThrowable.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ObjectExtendsThrowable.kt
@@ -60,7 +60,8 @@ class ObjectExtendsThrowable(config: Config = Config.empty) : Rule(config) {
                 CodeSmell(
                     issue = issue,
                     entity = Entity.from(element = declaration),
-                    message = issue.description
+                    message = "${declaration.nameAsSafeName} should be a class instead of an " +
+                        "object because it is a subtype of Throwable."
                 )
             )
         }

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ObjectExtendsThrowableSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ObjectExtendsThrowableSpec.kt
@@ -15,23 +15,34 @@ class ObjectExtendsThrowableSpec : Spek({
 
     describe("ObjectExtendsThrowable rule") {
 
-        it("reports objects that extend Throwable") {
+        it("reports top-level objects that extend Throwable") {
             val code = """
             object BanException : Throwable()
             object AuthException : RuntimeException()
             object ReportedException : Exception()
             object FatalException : Error()
-            object ObjectCustomException : CustomException("singleton custom exception")
+            """
+            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(4)
+        }
 
+        it("reports object subtype of sealed class that extends Throwable") {
+            val code = """
             sealed class DomainException : RuntimeException() {
                 data class Exception1(val prop1: String, val prop2: Boolean) : DomainException()
                 class Exception2 : DomainException()
                 object Exception3 : DomainException()
             }
+            """
+            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        }
+
+        it("reports object that extends custom exception") {
+            val code = """
+            object ObjectCustomException : CustomException("singleton custom exception")
 
             open class CustomException(message: String) : RuntimeException(message)
             """
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(6)
+            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
         it("reports companion objects that extend Throwable") {

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ObjectExtendsThrowableSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ObjectExtendsThrowableSpec.kt
@@ -1,0 +1,127 @@
+package io.gitlab.arturbosch.detekt.rules.exceptions
+
+import io.gitlab.arturbosch.detekt.rules.setupKotlinEnvironment
+import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+class ObjectExtendsThrowableSpec : Spek({
+    setupKotlinEnvironment()
+
+    val subject by memoized { ObjectExtendsThrowable() }
+    val env: KotlinCoreEnvironment by memoized()
+
+    describe("ObjectExtendsThrowable rule") {
+
+        it("reports objects that extend Throwable") {
+            val code = """
+            object BanException : Throwable()
+            object AuthException : RuntimeException()
+            object ReportedException : Exception()
+            object FatalException : Error()
+            object ObjectCustomException : CustomException("singleton custom exception")
+
+            sealed class DomainException : RuntimeException() {
+                data class Exception1(val prop1: String, val prop2: Boolean) : DomainException()
+                class Exception2 : DomainException()
+                object Exception3 : DomainException()
+            }
+
+            open class CustomException(message: String) : RuntimeException(message)
+            """
+            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(6)
+        }
+
+        it("reports companion objects that extend Throwable") {
+            val code = """
+            class Test1 {
+                companion object : Throwable() {
+                    const val NAME = "Test 1"
+                }
+            }
+
+            class Test2 {
+                companion object : Exception() {
+                    const val NAME = "Test 2"
+                }
+            }
+
+            class Test3 {
+                companion object Named : Error() {
+                    const val NAME = "Test 3"
+                }
+            }
+
+            class Test4 {
+                companion object Named : RuntimeException() {
+                    const val NAME = "Test 4"
+                }
+            }
+            """
+            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(4)
+        }
+
+        it("does not report objects that do not extend Throwable") {
+            val code = """
+            object BanException
+            object AuthException : CustomException(message = "Authentication failed!")
+
+            sealed class DomainException {
+                object Exception1 : DomainException()
+                object Exception2 : DomainException()
+                object Exception3 : DomainException()
+            }
+
+            open class CustomException(message: String) 
+            """
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        }
+
+        it("does not report companion objects that do not extend Throwable") {
+            val code = """
+            class Test1 {
+                companion object {
+                    const val NAME = "Test 1"
+                }
+            }
+
+            class Test2 {
+                companion object Named {
+                    const val NAME = "Test 3"
+                }
+            }
+            """
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        }
+
+        it("does not report non-objects that do extend Throwable") {
+            val code = """
+            class BanException : Throwable()
+            data class AuthException(val code: Int) : RuntimeException()
+            class ReportedException : Exception()
+            class FatalException : Error()
+            class ObjectCustomException : CustomException("singleton custom exception")
+
+            sealed class DomainException : RuntimeException() {
+                data class Exception1(val prop1: String, val prop2: Boolean) : DomainException()
+                class Exception2 : DomainException()
+                class Exception3 : DomainException()
+            }
+
+            open class CustomException(message: String) 
+            """
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        }
+
+        it("does not report an anonymous object that extends Throwable") {
+            val code = """
+            val exception = object : AbstractCustomException() {}
+
+            abstract class AbstractCustomException : RuntimeException()
+            """
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        }
+    }
+})


### PR DESCRIPTION
An Exceptions rule that reports when an `object` extend any type of `Throwable`. Although using `object` may look innocent at times, having one that extends a `Throwable`/`Exception` inadvertently introduces a global singleton exception instance. Any custom exception should be made instantiable by being defined as a regular `class`.

Addresses https://github.com/detekt/detekt/issues/3436.