### PR TITLE
Silence IndexOutOfBoundsException in getLineAndColumnInPsiFile()

### DIFF
--- a/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/LinesOfCode.kt
+++ b/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/LinesOfCode.kt
@@ -45,6 +45,7 @@ fun KtElement.linesOfCode(inFile: KtFile = this.containingKtFile): Int =
         .distinct()
         .count()
 
+@Suppress("SwallowedException", "TooGenericExceptionCaught")
 fun ASTNode.line(inFile: KtFile): Int = try {
     DiagnosticUtils.getLineAndColumnInPsiFile(inFile, this.textRange).line
 } catch (e: IndexOutOfBoundsException) {


### PR DESCRIPTION
Rather than #3317, this is a short-term patch fix for #2693 and #3250.

This is verified by using the sample project https://github.com/andrey-bolduzev/detekt_issue_2693