### PR TITLE
Dont generate baseline if empty

### DIFF
--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineFacade.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineFacade.kt
@@ -23,5 +23,5 @@ class BaselineFacade {
         BaselineFormat().write(baseline, baselineFile)
     }
 
-    fun baselineExists(baseline: Path) = baseline.exists() && baseline.isFile()
+    internal fun baselineExists(baseline: Path) = baseline.exists() && baseline.isFile()
 }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineFacade.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineFacade.kt
@@ -23,5 +23,5 @@ class BaselineFacade {
         BaselineFormat().write(baseline, baselineFile)
     }
 
-    private fun baselineExists(baseline: Path) = baseline.exists() && baseline.isFile()
+    fun baselineExists(baseline: Path) = baseline.exists() && baseline.isFile()
 }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineResultMapping.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineResultMapping.kt
@@ -36,13 +36,14 @@ class BaselineResultMapping : ReportingExtension {
         val facade = BaselineFacade()
         val flatten = this.flatMap { it.value }
 
+        if (flatten.isEmpty()) {
+            val action = if (facade.baselineExists(baselinePath)) "updated" else "created"
+            output?.appendLine("No issues found, baseline file will not be $action.")
+            return this
+        }
+
         if (createBaseline) {
-            if (flatten.isNotEmpty()) {
-                facade.createOrUpdate(baselinePath, flatten)
-            } else {
-                val action = if (facade.baselineExists(baselinePath)) "updated" else "created"
-                output?.appendLine("No issues found, baseline file will not be $action.")
-            }
+            facade.createOrUpdate(baselinePath, flatten)
         }
 
         return facade.transformResult(baselinePath, DetektResult(this)).findings

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineResultMapping.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineResultMapping.kt
@@ -40,12 +40,9 @@ class BaselineResultMapping : ReportingExtension {
             if (flatten.isNotEmpty()) {
                 facade.createOrUpdate(baselinePath, flatten)
             } else {
-                output?.appendLine("No issues found, baseline file will not be created / updated.")
+                val action = if (facade.baselineExists(baselinePath)) "updated" else "created"
+                output?.appendLine("No issues found, baseline file will not be $action.")
             }
-        }
-
-        if (flatten.isEmpty() && facade.baselineExists(baselinePath)) {
-            output?.appendLine("No issues found, you can safely delete the existing baseline file at $baselinePath.")
         }
 
         return facade.transformResult(baselinePath, DetektResult(this)).findings

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineResultMapping.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineResultMapping.kt
@@ -14,12 +14,10 @@ class BaselineResultMapping : ReportingExtension {
 
     private var baselineFile: Path? = null
     private var createBaseline: Boolean = false
-    private var output: Appendable? = null
 
     override fun init(context: SetupContext) {
         baselineFile = context.getOrNull(DETEKT_BASELINE_PATH_KEY)
         createBaseline = context.getOrNull(DETEKT_BASELINE_CREATION_KEY) ?: false
-        output = context.outputChannel
     }
 
     override fun transformFindings(findings: Map<RuleSetId, List<Finding>>): Map<RuleSetId, List<Finding>> {
@@ -37,8 +35,6 @@ class BaselineResultMapping : ReportingExtension {
         val flatten = this.flatMap { it.value }
 
         if (flatten.isEmpty()) {
-            val action = if (facade.baselineExists(baselinePath)) "updated" else "created"
-            output?.appendLine("No issues found, baseline file will not be $action.")
             return this
         }
 

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineResultMappingSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineResultMappingSpec.kt
@@ -1,0 +1,162 @@
+package io.gitlab.arturbosch.detekt.core.baseline
+
+import io.github.detekt.test.utils.NullPrintStream
+import io.github.detekt.test.utils.StringPrintStream
+import io.github.detekt.test.utils.createTempDirectoryForTest
+import io.github.detekt.test.utils.resourceAsPath
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Finding
+import io.gitlab.arturbosch.detekt.api.SetupContext
+import io.gitlab.arturbosch.detekt.api.UnstableApi
+import io.gitlab.arturbosch.detekt.core.exists
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import java.io.PrintStream
+import java.net.URI
+import java.nio.file.Path
+
+@OptIn(UnstableApi::class)
+class BaselineResultMappingSpec : Spek({
+
+    describe("a baseline result mapping") {
+
+        val dir by memoized { createTempDirectoryForTest("baseline_format") }
+        val baselineFile by memoized { dir.resolve("baseline.xml") }
+        val existingBaselineFile by memoized { resourceAsPath("/baseline_feature/valid-baseline.xml") }
+        val finding by memoized {
+            val issue = mockk<Finding>()
+            every { issue.id }.returns("SomeIssueId")
+            every { issue.signature }.returns("SomeSignature")
+            issue
+        }
+        val findings by memoized { mapOf("RuleSet" to listOf(finding)) }
+
+        it("should not create a new baseline file when no findings occurred") {
+            val output = StringPrintStream()
+            val mapping = resultMapping(
+                baselineFile = baselineFile,
+                createBaseline = true,
+                outputChannel = output
+            )
+
+            mapping.transformFindings(emptyMap())
+
+            assertThat(baselineFile.exists()).isFalse()
+            assertThat(output.toString()).isEqualTo("No issues found, baseline file will not be created.\n")
+        }
+
+        it("should not update an existing baseline file when no findings occurred") {
+            val output = StringPrintStream()
+            val existing = Baseline.load(existingBaselineFile)
+            val mapping = resultMapping(
+                baselineFile = existingBaselineFile,
+                createBaseline = true,
+                outputChannel = output
+            )
+
+            mapping.transformFindings(emptyMap())
+
+            val changed = Baseline.load(existingBaselineFile)
+            assertThat(existing).isEqualTo(changed)
+            assertThat(output.toString()).isEqualTo("No issues found, baseline file will not be updated.\n")
+        }
+
+        it("should not update an existing baseline file if option configured as false") {
+            val output = StringPrintStream()
+            val existing = Baseline.load(existingBaselineFile)
+            val mapping = resultMapping(
+                baselineFile = existingBaselineFile,
+                createBaseline = false,
+                outputChannel = output
+            )
+
+            mapping.transformFindings(findings)
+
+            val changed = Baseline.load(existingBaselineFile)
+            assertThat(existing).isEqualTo(changed)
+            assertThat(output.toString()).isEmpty()
+        }
+
+        it("should not update an existing baseline file if option is not configured") {
+            val output = StringPrintStream()
+            val existing = Baseline.load(existingBaselineFile)
+            val mapping = resultMapping(
+                baselineFile = existingBaselineFile,
+                createBaseline = null,
+                outputChannel = output
+            )
+
+            mapping.transformFindings(findings)
+
+            val changed = Baseline.load(existingBaselineFile)
+            assertThat(existing).isEqualTo(changed)
+            assertThat(output.toString()).isEmpty()
+        }
+
+        it("should not create a new baseline file if no file is configured") {
+            val output = StringPrintStream()
+            val mapping = resultMapping(
+                baselineFile = null,
+                createBaseline = false,
+                outputChannel = output
+            )
+
+            mapping.transformFindings(findings)
+
+            assertThat(baselineFile.exists()).isFalse()
+            assertThat(output.toString()).isEmpty()
+        }
+
+        it("should create a new baseline file if a file is configured") {
+            val output = StringPrintStream()
+            val mapping = resultMapping(
+                baselineFile = baselineFile,
+                createBaseline = true,
+                outputChannel = output
+            )
+
+            mapping.transformFindings(findings)
+
+            assertThat(baselineFile.exists()).isTrue()
+            assertThat(output.toString()).isEmpty()
+        }
+
+        it("should update an existing baseline file if a file is configured") {
+            val output = StringPrintStream()
+            val existing = Baseline.load(existingBaselineFile)
+            val mapping = resultMapping(
+                baselineFile = existingBaselineFile,
+                createBaseline = true,
+                outputChannel = output
+            )
+
+            mapping.transformFindings(findings)
+
+            val changed = Baseline.load(existingBaselineFile)
+            assertThat(existing).isNotEqualTo(changed)
+            assertThat(output.toString()).isEmpty()
+        }
+    }
+})
+
+@OptIn(UnstableApi::class)
+internal fun resultMapping(baselineFile: Path?, createBaseline: Boolean?, outputChannel: PrintStream) =
+    BaselineResultMapping().apply {
+        init(object : SetupContext {
+            override val configUris: Collection<URI> = mockk()
+            override val config: Config = mockk()
+            override val outputChannel: PrintStream = outputChannel
+            override val errorChannel: PrintStream = NullPrintStream()
+            override val properties: MutableMap<String, Any?> = mutableMapOf(
+                DETEKT_BASELINE_PATH_KEY to baselineFile,
+                DETEKT_BASELINE_CREATION_KEY to createBaseline
+            )
+
+            override fun register(key: String, value: Any) {
+                properties[key] = value
+            }
+        })
+    }

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineResultMappingSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineResultMappingSpec.kt
@@ -1,7 +1,6 @@
 package io.gitlab.arturbosch.detekt.core.baseline
 
 import io.github.detekt.test.utils.NullPrintStream
-import io.github.detekt.test.utils.StringPrintStream
 import io.github.detekt.test.utils.createTempDirectoryForTest
 import io.github.detekt.test.utils.resourceAsPath
 import io.gitlab.arturbosch.detekt.api.Config
@@ -35,120 +34,99 @@ class BaselineResultMappingSpec : Spek({
         val findings by memoized { mapOf("RuleSet" to listOf(finding)) }
 
         it("should not create a new baseline file when no findings occurred") {
-            val output = StringPrintStream()
             val mapping = resultMapping(
                 baselineFile = baselineFile,
                 createBaseline = true,
-                outputChannel = output
             )
 
             mapping.transformFindings(emptyMap())
 
             assertThat(baselineFile.exists()).isFalse()
-            assertThat(output.toString()).isEqualTo("No issues found, baseline file will not be created.\n")
         }
 
         it("should not update an existing baseline file when no findings occurred") {
-            val output = StringPrintStream()
             val existing = Baseline.load(existingBaselineFile)
             val mapping = resultMapping(
                 baselineFile = existingBaselineFile,
                 createBaseline = true,
-                outputChannel = output
             )
 
             mapping.transformFindings(emptyMap())
 
             val changed = Baseline.load(existingBaselineFile)
             assertThat(existing).isEqualTo(changed)
-            assertThat(output.toString()).isEqualTo("No issues found, baseline file will not be updated.\n")
         }
 
         it("should not update an existing baseline file if option configured as false") {
-            val output = StringPrintStream()
             val existing = Baseline.load(existingBaselineFile)
             val mapping = resultMapping(
                 baselineFile = existingBaselineFile,
                 createBaseline = false,
-                outputChannel = output
             )
 
             mapping.transformFindings(findings)
 
             val changed = Baseline.load(existingBaselineFile)
             assertThat(existing).isEqualTo(changed)
-            assertThat(output.toString()).isEmpty()
         }
 
         it("should not update an existing baseline file if option is not configured") {
-            val output = StringPrintStream()
             val existing = Baseline.load(existingBaselineFile)
             val mapping = resultMapping(
                 baselineFile = existingBaselineFile,
                 createBaseline = null,
-                outputChannel = output
             )
 
             mapping.transformFindings(findings)
 
             val changed = Baseline.load(existingBaselineFile)
             assertThat(existing).isEqualTo(changed)
-            assertThat(output.toString()).isEmpty()
         }
 
         it("should not create a new baseline file if no file is configured") {
-            val output = StringPrintStream()
             val mapping = resultMapping(
                 baselineFile = null,
                 createBaseline = false,
-                outputChannel = output
             )
 
             mapping.transformFindings(findings)
 
             assertThat(baselineFile.exists()).isFalse()
-            assertThat(output.toString()).isEmpty()
         }
 
         it("should create a new baseline file if a file is configured") {
-            val output = StringPrintStream()
             val mapping = resultMapping(
                 baselineFile = baselineFile,
                 createBaseline = true,
-                outputChannel = output
             )
 
             mapping.transformFindings(findings)
 
             assertThat(baselineFile.exists()).isTrue()
-            assertThat(output.toString()).isEmpty()
         }
 
         it("should update an existing baseline file if a file is configured") {
-            val output = StringPrintStream()
             val existing = Baseline.load(existingBaselineFile)
             val mapping = resultMapping(
                 baselineFile = existingBaselineFile,
                 createBaseline = true,
-                outputChannel = output
             )
 
             mapping.transformFindings(findings)
 
             val changed = Baseline.load(existingBaselineFile)
             assertThat(existing).isNotEqualTo(changed)
-            assertThat(output.toString()).isEmpty()
         }
     }
 })
 
 @OptIn(UnstableApi::class)
-internal fun resultMapping(baselineFile: Path?, createBaseline: Boolean?, outputChannel: PrintStream) =
+internal fun resultMapping(baselineFile: Path?, createBaseline: Boolean?) =
     BaselineResultMapping().apply {
         init(object : SetupContext {
             override val configUris: Collection<URI> = mockk()
             override val config: Config = mockk()
-            override val outputChannel: PrintStream = outputChannel
+            override val outputChannel: PrintStream = NullPrintStream()
             override val errorChannel: PrintStream = NullPrintStream()
             override val properties: MutableMap<String, Any?> = mutableMapOf(
                 DETEKT_BASELINE_PATH_KEY to baselineFile,


### PR DESCRIPTION
This PR is a rebase from #3027 full credit to @realdadfish

I added a new commit removing the output when the baseline is not generated. We had several PR already making detekt less noisy so I think that we should keep it like this. (Maybe for 2.0 we could implement a log system with different levels so this kind of output can be written at a verbose level).

Merge this PR is safe now. We already merged #3429