### PR TITLE
Fix false positives for MultilineLambdaItParameter.kt

### DIFF
--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MultilineLambdaItParameter.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MultilineLambdaItParameter.kt
@@ -70,10 +70,9 @@ class MultilineLambdaItParameter(val config: Config) : Rule(config) {
 
     override fun visitLambdaExpression(lambdaExpression: KtLambdaExpression) {
         super.visitLambdaExpression(lambdaExpression)
+        if (bindingContext == BindingContext.EMPTY) return
         // If the lambda expression has <= 1 statements, skip check.
-        if (lambdaExpression.bodyExpression?.statements?.size ?: 0 <= 1) {
-            return
-        }
+        if (lambdaExpression.bodyExpression?.statements?.size ?: 0 <= 1) return
 
         val parameterNames = lambdaExpression.valueParameters.map { it.name }
         when {
@@ -88,7 +87,7 @@ class MultilineLambdaItParameter(val config: Config) : Rule(config) {
                 )
             // Implicit `it`
             parameterNames.isEmpty() -> {
-                if (bindingContext != BindingContext.EMPTY && lambdaExpression.hasImplicitParameter(bindingContext)) {
+                if (lambdaExpression.hasImplicitParameter(bindingContext)) {
                     report(
                         CodeSmell(
                             issue, Entity.from(lambdaExpression),

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MultilineLambdaItParameterSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MultilineLambdaItParameterSpec.kt
@@ -2,7 +2,6 @@ package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.setupKotlinEnvironment
-import io.gitlab.arturbosch.detekt.test.compileAndLint
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
@@ -16,28 +15,16 @@ class MultilineLambdaItParameterSpec : Spek({
 
     describe("MultilineLambdaItParameter rule") {
         context("single parameter, multiline lambda with multiple statements") {
-            it("reports when parameter name is implicit `it` with type resolution") {
+            it("reports when parameter name is implicit `it`") {
                 val code = """
                 fun f() {
-                    val digits = 1234.let { 
+                    val digits = 1234.let {
                         listOf(it)
                         println(it)
                     }
                 }"""
                 val findings = subject.compileAndLintWithContext(env, code)
                 assertThat(findings).hasSize(1)
-            }
-
-            it("does not report implicit `it`") {
-                val code = """
-                fun f() {
-                    val digits = 1234.let { 
-                        listOf(it)
-                        println(it)
-                    }
-                }"""
-                val findings = subject.compileAndLint(code)
-                assertThat(findings).isEmpty()
             }
 
             it("reports when parameter name is explicit `it`") {
@@ -48,7 +35,7 @@ class MultilineLambdaItParameterSpec : Spek({
                         println(it)
                     }
                 }"""
-                val findings = subject.compileAndLint(code)
+                val findings = subject.compileAndLintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }
 
@@ -60,13 +47,13 @@ class MultilineLambdaItParameterSpec : Spek({
                         println(param)
                     }
                 }"""
-                val findings = subject.compileAndLint(code)
+                val findings = subject.compileAndLintWithContext(env, code)
                 assertThat(findings).isEmpty()
             }
         }
 
         context("single parameter, multiline lambda with a single statement") {
-            it("does not report when parameter name is an implicit `it` with type resolution") {
+            it("does not report when parameter name is an implicit `it`") {
                 val code = """
                 fun f() {
                     val digits = 1234.let { 
@@ -77,17 +64,6 @@ class MultilineLambdaItParameterSpec : Spek({
                 assertThat(findings).isEmpty()
             }
 
-            it("does not report when parameter name is an implicit `it`") {
-                val code = """
-                fun f() {
-                    val digits = 1234.let { 
-                        listOf(it)
-                    }
-                }"""
-                val findings = subject.compileAndLint(code)
-                assertThat(findings).isEmpty()
-            }
-
             it("does not report when parameter name is an explicit `it`") {
                 val code = """
                 fun f() {
@@ -95,7 +71,7 @@ class MultilineLambdaItParameterSpec : Spek({
                         listOf(it)
                     }
                 }"""
-                val findings = subject.compileAndLint(code)
+                val findings = subject.compileAndLintWithContext(env, code)
                 assertThat(findings).isEmpty()
             }
             it("does not report when parameter name is explicit and not `it`") {
@@ -105,7 +81,7 @@ class MultilineLambdaItParameterSpec : Spek({
                         listOf(param)
                     }
                 }"""
-                val findings = subject.compileAndLint(code)
+                val findings = subject.compileAndLintWithContext(env, code)
                 assertThat(findings).isEmpty()
             }
         }
@@ -125,7 +101,7 @@ class MultilineLambdaItParameterSpec : Spek({
                 fun f() {
                     val digits = 1234.let { listOf(it) }
                 }"""
-                val findings = subject.compileAndLint(code)
+                val findings = subject.compileAndLintWithContext(env, code)
                 assertThat(findings).isEmpty()
             }
 
@@ -134,7 +110,7 @@ class MultilineLambdaItParameterSpec : Spek({
                 fun f() {
                     val digits = 1234.let { it -> listOf(it) }
                 }"""
-                val findings = subject.compileAndLint(code)
+                val findings = subject.compileAndLintWithContext(env, code)
                 assertThat(findings).isEmpty()
             }
 
@@ -143,7 +119,7 @@ class MultilineLambdaItParameterSpec : Spek({
                 fun f() {
                     val digits = 1234.let { param -> listOf(param) }
                 }"""
-                val findings = subject.compileAndLint(code)
+                val findings = subject.compileAndLintWithContext(env, code)
                 assertThat(findings).isEmpty()
             }
         }
@@ -157,7 +133,7 @@ class MultilineLambdaItParameterSpec : Spek({
                         it + index 
                     }
                 }"""
-                val findings = subject.compileAndLint(code)
+                val findings = subject.compileAndLintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }
 
@@ -169,7 +145,7 @@ class MultilineLambdaItParameterSpec : Spek({
                         item.toString() + that 
                     }
                 }"""
-                val findings = subject.compileAndLint(code)
+                val findings = subject.compileAndLintWithContext(env, code)
                 assertThat(findings).isEmpty()
             }
         }


### PR DESCRIPTION
This addresses #3449.

Notes:
- This rule now requires type-resolution to run in full mode. Without type-resolution, this rule would check only if `it` is used as explicit parameters.
- I have updated the tests to cover the scenario with type-resolution and without type-resolution.