### PR TITLE
Don't use deprecated functions

### DIFF
--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/DetektProgressListener.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/DetektProgressListener.kt
@@ -6,6 +6,7 @@ import io.gitlab.arturbosch.detekt.api.SetupContext
 import io.gitlab.arturbosch.detekt.api.SingleAssign
 import io.gitlab.arturbosch.detekt.api.UnstableApi
 import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.resolve.BindingContext
 
 class DetektProgressListener : FileProcessListener {
 
@@ -16,11 +17,11 @@ class DetektProgressListener : FileProcessListener {
         this.outPrinter = context.outputChannel
     }
 
-    override fun onProcess(file: KtFile) {
+    override fun onProcess(file: KtFile, bindingContext: BindingContext) {
         outPrinter.append('.')
     }
 
-    override fun onFinish(files: List<KtFile>, result: Detektion) {
+    override fun onFinish(files: List<KtFile>, result: Detektion, bindingContext: BindingContext) {
         val middlePart = if (files.size == 1) "file was" else "files were"
         outPrinter.appendLine("\n\n${files.size} kotlin $middlePart analyzed.")
     }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/KtFileModifier.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/KtFileModifier.kt
@@ -8,12 +8,13 @@ import io.gitlab.arturbosch.detekt.api.Notification
 import org.jetbrains.kotlin.com.intellij.openapi.util.text.StringUtilRt
 import org.jetbrains.kotlin.fileClasses.javaFileFacadeFqName
 import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.resolve.BindingContext
 import java.nio.file.Files
 import java.nio.file.Path
 
 class KtFileModifier : FileProcessListener {
 
-    override fun onFinish(files: List<KtFile>, result: Detektion) {
+    override fun onFinish(files: List<KtFile>, result: Detektion, bindingContext: BindingContext) {
         files.filter { it.modificationStamp > 0 }
             .map { it.absolutePath() to it.unnormalizeContent() }
             .forEach {

--- a/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/processors/AbstractProcessor.kt
+++ b/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/processors/AbstractProcessor.kt
@@ -5,17 +5,18 @@ import io.gitlab.arturbosch.detekt.api.Detektion
 import io.gitlab.arturbosch.detekt.api.FileProcessListener
 import org.jetbrains.kotlin.com.intellij.openapi.util.Key
 import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.resolve.BindingContext
 
 abstract class AbstractProcessor : FileProcessListener {
 
     protected abstract val visitor: DetektVisitor
     protected abstract val key: Key<Int>
 
-    override fun onProcess(file: KtFile) {
+    override fun onProcess(file: KtFile, bindingContext: BindingContext) {
         file.accept(visitor)
     }
 
-    override fun onFinish(files: List<KtFile>, result: Detektion) {
+    override fun onFinish(files: List<KtFile>, result: Detektion, bindingContext: BindingContext) {
         val count = files
                 .mapNotNull { it.getUserData(key) }
                 .sum()

--- a/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/processors/AbstractProjectMetricProcessor.kt
+++ b/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/processors/AbstractProjectMetricProcessor.kt
@@ -3,12 +3,13 @@ package io.github.detekt.metrics.processors
 import io.gitlab.arturbosch.detekt.api.Detektion
 import io.gitlab.arturbosch.detekt.api.ProjectMetric
 import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.resolve.BindingContext
 
 abstract class AbstractProjectMetricProcessor : AbstractProcessor() {
 
     val type: String get() = key.toString()
 
-    override fun onFinish(files: List<KtFile>, result: Detektion) {
+    override fun onFinish(files: List<KtFile>, result: Detektion, bindingContext: BindingContext) {
         val count = files
                 .mapNotNull { it.getUserData(key) }
                 .sum()

--- a/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/processors/PackageCountProcessor.kt
+++ b/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/processors/PackageCountProcessor.kt
@@ -6,17 +6,18 @@ import io.gitlab.arturbosch.detekt.api.FileProcessListener
 import io.gitlab.arturbosch.detekt.api.ProjectMetric
 import org.jetbrains.kotlin.com.intellij.openapi.util.Key
 import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.resolve.BindingContext
 
 class PackageCountProcessor : FileProcessListener {
 
     private val visitor = PackageCountVisitor()
     private val key = numberOfPackagesKey
 
-    override fun onProcess(file: KtFile) {
+    override fun onProcess(file: KtFile, bindingContext: BindingContext) {
         file.accept(visitor)
     }
 
-    override fun onFinish(files: List<KtFile>, result: Detektion) {
+    override fun onFinish(files: List<KtFile>, result: Detektion, bindingContext: BindingContext) {
         val count = files
                 .mapNotNull { it.getUserData(key) }
                 .distinct()

--- a/detekt-sample-extensions/src/main/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/processors/NumberOfLoopsProcessor.kt
+++ b/detekt-sample-extensions/src/main/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/processors/NumberOfLoopsProcessor.kt
@@ -5,10 +5,11 @@ import io.gitlab.arturbosch.detekt.api.FileProcessListener
 import org.jetbrains.kotlin.com.intellij.openapi.util.Key
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtLoopExpression
+import org.jetbrains.kotlin.resolve.BindingContext
 
 class NumberOfLoopsProcessor : FileProcessListener {
 
-    override fun onProcess(file: KtFile) {
+    override fun onProcess(file: KtFile, bindingContext: BindingContext) {
         val visitor = LoopVisitor()
         file.accept(visitor)
         file.putUserData(numberOfLoopsKey, visitor.numberOfLoops)

--- a/detekt-sample-extensions/src/main/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/processors/QualifiedNameProcessor.kt
+++ b/detekt-sample-extensions/src/main/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/processors/QualifiedNameProcessor.kt
@@ -6,10 +6,11 @@ import io.gitlab.arturbosch.detekt.api.FileProcessListener
 import org.jetbrains.kotlin.com.intellij.openapi.util.Key
 import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.resolve.BindingContext
 
 class QualifiedNameProcessor : FileProcessListener {
 
-    override fun onProcess(file: KtFile) {
+    override fun onProcess(file: KtFile, bindingContext: BindingContext) {
         val packageName = file.packageFqName.asString()
         val nameVisitor = ClassNameVisitor()
         file.accept(nameVisitor)
@@ -18,7 +19,7 @@ class QualifiedNameProcessor : FileProcessListener {
         file.putUserData(fqNamesKey, fqNames)
     }
 
-    override fun onFinish(files: List<KtFile>, result: Detektion) {
+    override fun onFinish(files: List<KtFile>, result: Detektion, bindingContext: BindingContext) {
         val fqNames = files
             .mapNotNull { it.getUserData(fqNamesKey) }
             .flatMapTo(HashSet()) { it }


### PR DESCRIPTION
We deprecated those functions some time ago so we should not using them.