### PR TITLE
Add support to Kotlin Multiplatform Projects

### DIFF
--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -39,6 +39,7 @@ dependencies {
     val androidGradlePlugin = "com.android.tools.build:gradle:4.1.2"
     implementation(kotlin("gradle-plugin-api"))
     compileOnly(androidGradlePlugin)
+    compileOnly(kotlin("gradle-plugin"))
 
     testImplementation(project(":detekt-test-utils"))
     testImplementation(kotlin("gradle-plugin"))

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
@@ -3,6 +3,7 @@ package io.gitlab.arturbosch.detekt
 import io.gitlab.arturbosch.detekt.extensions.DetektExtension
 import io.gitlab.arturbosch.detekt.internal.DetektAndroid
 import io.gitlab.arturbosch.detekt.internal.DetektJvm
+import io.gitlab.arturbosch.detekt.internal.DetektMultiplatform
 import io.gitlab.arturbosch.detekt.internal.DetektPlain
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -28,12 +29,19 @@ class DetektPlugin : Plugin<Project> {
         project.registerDetektPlainTask(extension)
         project.registerDetektJvmTasks(extension)
         project.registerDetektAndroidTasks(extension)
+        project.registerDetektMultiplatformTasks(extension)
         project.registerGenerateConfigTask(extension)
     }
 
     private fun Project.registerDetektJvmTasks(extension: DetektExtension) {
         plugins.withId("org.jetbrains.kotlin.jvm") {
             DetektJvm(this).registerTasks(extension)
+        }
+    }
+
+    private fun Project.registerDetektMultiplatformTasks(extension: DetektExtension) {
+        plugins.withId("org.jetbrains.kotlin.multiplatform") {
+            DetektMultiplatform(this).registerTasks(extension)
         }
     }
 

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektMultiplatform.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektMultiplatform.kt
@@ -20,10 +20,12 @@ internal class DetektMultiplatform(private val project: Project) {
     }
 
     private fun Project.registerMultiplatformTasks(extension: DetektExtension) {
+        // We need another project.afterEvaluate as the Android target is attached on
+        // a project.afterEvaluate inside AGP. We should further investigate and potentially remove this.
         project.afterEvaluate {
             val kmpExtension = project.extensions.getByType(KotlinMultiplatformExtension::class.java)
 
-            kmpExtension.targets.filter { it.platformType != common }.forEach { target ->
+            kmpExtension.targets.all { target ->
                 target.compilations.forEach { compilation ->
                     val taskSuffix = target.name.capitalize() + compilation.name.capitalize()
 
@@ -35,7 +37,7 @@ internal class DetektMultiplatform(private val project: Project) {
                         else -> false
                     }
 
-                    val inputSource = compilation.allKotlinSourceSets.map {
+                    val inputSource = compilation.kotlinSourceSets.map {
                         it.kotlin.sourceDirectories
                     }.fold(project.files() as FileCollection) { collection, next ->
                         collection.plus(next)

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektMultiplatform.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektMultiplatform.kt
@@ -1,0 +1,89 @@
+package io.gitlab.arturbosch.detekt.internal
+
+import io.gitlab.arturbosch.detekt.DetektPlugin
+import io.gitlab.arturbosch.detekt.extensions.DetektExtension
+import org.gradle.api.Project
+import org.gradle.api.file.FileCollection
+import org.gradle.language.base.plugins.LifecycleBasePlugin
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType.androidJvm
+import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType.common
+import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType.jvm
+import java.io.File
+
+internal class DetektMultiplatform(private val project: Project) {
+
+    fun registerTasks(extension: DetektExtension) {
+        project.afterEvaluate {
+            project.registerMultiplatformTasks(extension)
+        }
+    }
+
+    private fun Project.registerMultiplatformTasks(extension: DetektExtension) {
+        project.afterEvaluate {
+            val kmpExtension = project.extensions.getByType(KotlinMultiplatformExtension::class.java)
+
+            kmpExtension.targets.filter { it.platformType != common }.forEach { target ->
+                target.compilations.forEach { compilation ->
+                    val taskSuffix = target.name.capitalize() + compilation.name.capitalize()
+
+                    // We currently run type resolution only for Jvm & Android targets as
+                    // native/js targets needs a different compiler classpath.
+                    val runWithTypeResolution = when (target.platformType) {
+                        jvm -> true
+                        androidJvm -> true
+                        else -> false
+                    }
+
+                    val inputSource = compilation.allKotlinSourceSets.map {
+                        it.kotlin.sourceDirectories
+                    }.fold(project.files() as FileCollection) { collection, next ->
+                        collection.plus(next)
+                    }
+
+                    val detektTaskProvider = project.registerDetektTask(
+                        DetektPlugin.DETEKT_TASK_NAME + taskSuffix,
+                        extension
+                    ) {
+                        setSource(inputSource)
+                        if (runWithTypeResolution) {
+                            classpath.setFrom(inputSource, compilation.compileDependencyFiles)
+                        }
+                        // If a baseline file is configured as input file, it must exist to be configured, otherwise the task fails.
+                        // We try to find the configured baseline or alternatively a specific variant matching this task.
+                        extension.baseline?.existingVariantOrBaseFile(taskSuffix)?.let { baselineFile ->
+                            baseline.set(layout.file(project.provider { baselineFile }))
+                        }
+                        reports = extension.reports
+                        reports.xml.setDefaultIfUnset(File(extension.reportsDir, compilation.name + ".xml"))
+                        reports.html.setDefaultIfUnset(File(extension.reportsDir, compilation.name + ".html"))
+                        reports.txt.setDefaultIfUnset(File(extension.reportsDir, compilation.name + ".txt"))
+                        reports.sarif.setDefaultIfUnset(File(extension.reportsDir, compilation.name + ".sarif"))
+                        description = "Run detekt analysis for target ${target.name} and source set ${compilation.name}"
+                        if (runWithTypeResolution) {
+                            description = "EXPERIMENTAL: $description with type resolution."
+                        }
+                    }
+
+                    tasks.matching { it.name == LifecycleBasePlugin.CHECK_TASK_NAME }.configureEach {
+                        it.dependsOn(detektTaskProvider)
+                    }
+
+                    project.registerCreateBaselineTask(DetektPlugin.BASELINE_TASK_NAME + taskSuffix, extension) {
+                        setSource(inputSource)
+                        if (runWithTypeResolution) {
+                            classpath.setFrom(inputSource, compilation.compileDependencyFiles)
+                        }
+                        val variantBaselineFile = extension.baseline?.addVariantName(taskSuffix)
+                        baseline.set(project.layout.file(project.provider { variantBaselineFile }))
+
+                        description = "Creates detekt baseline for ${target.name} and source set ${compilation.name}"
+                        if (runWithTypeResolution) {
+                            description = "EXPERIMENTAL: $description with type resolution."
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektMultiplatform.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektMultiplatform.kt
@@ -7,7 +7,6 @@ import org.gradle.api.file.FileCollection
 import org.gradle.language.base.plugins.LifecycleBasePlugin
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType.androidJvm
-import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType.common
 import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType.jvm
 import java.io.File
 

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektPluginOnMultiplatformTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektPluginOnMultiplatformTest.kt
@@ -75,7 +75,6 @@ object DetektPluginOnMultiplatformTest : Spek({
         }
     }
 
-
     describe("multiplatform projects - JVM target") {
 
         it("creates detekt tasks for the JVM target") {

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektPluginOnMultiplatformTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektPluginOnMultiplatformTest.kt
@@ -10,6 +10,72 @@ import org.spekframework.spek2.dsl.Skip
 import org.spekframework.spek2.style.specification.describe
 
 object DetektPluginOnMultiplatformTest : Spek({
+
+    describe("multiplatform projects - Common target") {
+
+        it("creates detekt tasks for the Common target") {
+            with(ProjectBuilder.builder().build()) {
+                with(pluginManager) {
+                    apply(DetektPlugin::class.java)
+                    apply("kotlin-multiplatform")
+                }
+
+                configureExtension<KotlinMultiplatformExtension> {
+                    // We need to provide at least one target
+                    jvm()
+                }
+
+                evaluate()
+
+                assertThat(getTask("check").dependencies())
+                    .contains("detektMetadataMain")
+
+                getTask("detektBaselineMetadataMain")
+            }
+        }
+
+        it("configures detekt correctly") {
+            with(ProjectBuilder.builder().build()) {
+                with(pluginManager) {
+                    apply(DetektPlugin::class.java)
+                    apply("kotlin-multiplatform")
+                }
+
+                configureExtension<KotlinMultiplatformExtension> {
+                    // We need to provide at least one target
+                    jvm()
+                }
+
+                configureExtension<DetektExtension> {
+                    reports.sarif.enabled = true
+                }
+
+                evaluate()
+
+                assertThat((getTask("detektMetadataMain") as Detekt).reports.sarif.enabled).isTrue
+            }
+        }
+
+        it("configures detekt without type resolution") {
+            with(ProjectBuilder.builder().build()) {
+                with(pluginManager) {
+                    apply(DetektPlugin::class.java)
+                    apply("kotlin-multiplatform")
+                }
+
+                configureExtension<KotlinMultiplatformExtension> {
+                    // We need to provide at least one target
+                    jvm()
+                }
+
+                evaluate()
+
+                assertThat((getTask("detektMetadataMain") as Detekt).classpath).isEmpty()
+            }
+        }
+    }
+
+
     describe("multiplatform projects - JVM target") {
 
         it("creates detekt tasks for the JVM target") {

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektPluginOnMultiplatformTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektPluginOnMultiplatformTest.kt
@@ -1,0 +1,353 @@
+package io.gitlab.arturbosch.detekt
+
+import com.android.build.gradle.AppExtension
+import io.gitlab.arturbosch.detekt.extensions.DetektExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.testfixtures.ProjectBuilder
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.dsl.Skip
+import org.spekframework.spek2.style.specification.describe
+
+object DetektPluginOnMultiplatformTest : Spek({
+    describe("multiplatform projects - JVM target") {
+
+        it("creates detekt tasks for the JVM target") {
+            with(ProjectBuilder.builder().build()) {
+                with(pluginManager) {
+                    apply(DetektPlugin::class.java)
+                    apply("kotlin-multiplatform")
+                }
+
+                configureExtension<KotlinMultiplatformExtension> {
+                    jvm()
+                }
+
+                evaluate()
+
+                assertThat(getTask("check").dependencies())
+                    .contains("detektJvmMain", "detektJvmTest")
+
+                getTask("detektBaselineJvmMain")
+                getTask("detektBaselineJvmTest")
+            }
+        }
+
+        it("creates detekt tasks for multiple JVM target") {
+            with(ProjectBuilder.builder().build()) {
+                with(pluginManager) {
+                    apply(DetektPlugin::class.java)
+                    apply("kotlin-multiplatform")
+                }
+
+                configureExtension<KotlinMultiplatformExtension> {
+                    jvm("jvmBackend")
+                    jvm("jvmEmbedded")
+                }
+
+                evaluate()
+
+                assertThat(getTask("check").dependencies()).contains(
+                    "detektJvmBackendMain",
+                    "detektJvmBackendTest",
+                    "detektJvmEmbeddedMain",
+                    "detektJvmEmbeddedTest",
+                )
+
+                getTask("detektBaselineJvmBackendMain")
+                getTask("detektBaselineJvmBackendTest")
+                getTask("detektBaselineJvmEmbeddedMain")
+                getTask("detektBaselineJvmEmbeddedTest")
+            }
+        }
+
+        it("configures detekt correctly") {
+            with(ProjectBuilder.builder().build()) {
+                with(pluginManager) {
+                    apply(DetektPlugin::class.java)
+                    apply("kotlin-multiplatform")
+                }
+
+                configureExtension<KotlinMultiplatformExtension> {
+                    jvm()
+                }
+
+                configureExtension<DetektExtension> {
+                    reports.sarif.enabled = true
+                }
+
+                evaluate()
+
+                assertThat((getTask("detektJvmMain") as Detekt).reports.sarif.enabled).isTrue
+                assertThat((getTask("detektJvmTest") as Detekt).reports.sarif.enabled).isTrue
+            }
+        }
+
+        it("configures detekt with type resolution") {
+            with(ProjectBuilder.builder().build()) {
+                with(pluginManager) {
+                    apply(DetektPlugin::class.java)
+                    apply("kotlin-multiplatform")
+                }
+
+                configureExtension<KotlinMultiplatformExtension> {
+                    jvm()
+                }
+
+                // A repository is necessary otherwise Gradle will fail
+                // to resolve the `classpath` property
+                project.repositories.mavenCentral()
+
+                evaluate()
+
+                assertThat((getTask("detektJvmMain") as Detekt).classpath).isNotEmpty
+                assertThat((getTask("detektJvmTest") as Detekt).classpath).isNotEmpty
+            }
+        }
+    }
+
+    describe(
+        "multiplatform projects - Android target",
+        skip = if (isAndroidSdkInstalled()) Skip.No else Skip.Yes("No android sdk.")) {
+
+        it("creates detekt tasks for Android") {
+            with(ProjectBuilder.builder().build()) {
+                with(pluginManager) {
+                    apply(DetektPlugin::class.java)
+                    apply("kotlin-multiplatform")
+                    apply("com.android.application")
+                }
+
+                configureExtension<AppExtension> {
+                    compileSdkVersion(ANDROID_COMPILE_SDK_VERSION)
+                }
+
+                configureExtension<KotlinMultiplatformExtension> {
+                    android()
+                }
+
+                evaluate()
+
+                assertThat(getTask("check").dependencies())
+                    .contains(
+                        "detektAndroidDebug",
+                        "detektAndroidDebugUnitTest",
+                        "detektAndroidDebugAndroidTest",
+                        "detektAndroidRelease",
+                        "detektAndroidReleaseUnitTest",
+                    )
+
+                getTask("detektBaselineAndroidDebug")
+                getTask("detektBaselineAndroidDebugUnitTest")
+                getTask("detektBaselineAndroidDebugAndroidTest")
+                getTask("detektBaselineAndroidRelease")
+                getTask("detektBaselineAndroidReleaseUnitTest")
+            }
+        }
+
+        it("configures detekt correctly") {
+            with(ProjectBuilder.builder().build()) {
+                with(pluginManager) {
+                    apply(DetektPlugin::class.java)
+                    apply("kotlin-multiplatform")
+                    apply("com.android.application")
+                }
+
+                configureExtension<AppExtension> {
+                    compileSdkVersion(ANDROID_COMPILE_SDK_VERSION)
+                }
+
+                configureExtension<KotlinMultiplatformExtension> {
+                    android()
+                }
+
+                configureExtension<DetektExtension> {
+                    reports.sarif.enabled = true
+                }
+
+                evaluate()
+
+                assertThat((getTask("detektAndroidDebug") as Detekt).reports.sarif.enabled).isTrue
+                assertThat((getTask("detektAndroidDebugUnitTest") as Detekt).reports.sarif.enabled).isTrue
+                assertThat((getTask("detektAndroidDebugAndroidTest") as Detekt).reports.sarif.enabled).isTrue
+                assertThat((getTask("detektAndroidRelease") as Detekt).reports.sarif.enabled).isTrue
+                assertThat((getTask("detektAndroidReleaseUnitTest") as Detekt).reports.sarif.enabled).isTrue
+            }
+        }
+
+        it("configures detekt with type resolution") {
+            with(ProjectBuilder.builder().build()) {
+                with(pluginManager) {
+                    apply(DetektPlugin::class.java)
+                    apply("kotlin-multiplatform")
+                    apply("com.android.application")
+                }
+
+                configureExtension<AppExtension> {
+                    compileSdkVersion(ANDROID_COMPILE_SDK_VERSION)
+                }
+
+                configureExtension<KotlinMultiplatformExtension> {
+                    android()
+                }
+
+                // A repository is necessary otherwise Gradle will fail
+                // to resolve the `classpath` property
+                project.repositories.mavenCentral()
+
+                evaluate()
+
+                assertThat((getTask("detektAndroidDebug") as Detekt).classpath).isNotEmpty
+                assertThat((getTask("detektAndroidRelease") as Detekt).classpath).isNotEmpty
+            }
+        }
+    }
+
+    describe("multiplatform projects - JS target") {
+
+        it("creates detekt tasks for JS") {
+            with(ProjectBuilder.builder().build()) {
+                with(pluginManager) {
+                    apply(DetektPlugin::class.java)
+                    apply("kotlin-multiplatform")
+                }
+
+                configureExtension<KotlinMultiplatformExtension> {
+                    js {
+                        browser()
+                    }
+                }
+
+                evaluate()
+
+                assertThat(getTask("check").dependencies())
+                    .contains(
+                        "detektJsMain",
+                        "detektJsTest",
+                    )
+
+                getTask("detektBaselineJsMain")
+                getTask("detektBaselineJsTest")
+            }
+        }
+
+        it("configures detekt correctly") {
+            with(ProjectBuilder.builder().build()) {
+                with(pluginManager) {
+                    apply(DetektPlugin::class.java)
+                    apply("kotlin-multiplatform")
+                }
+
+                configureExtension<DetektExtension> {
+                    reports.sarif.enabled = true
+                }
+
+                configureExtension<KotlinMultiplatformExtension> {
+                    js {
+                        browser()
+                    }
+                }
+
+                evaluate()
+
+                assertThat((getTask("detektJsMain") as Detekt).reports.sarif.enabled).isTrue
+                assertThat((getTask("detektJsTest") as Detekt).reports.sarif.enabled).isTrue
+            }
+        }
+
+        it("configures detekt without type resolution") {
+            with(ProjectBuilder.builder().build()) {
+                with(pluginManager) {
+                    apply(DetektPlugin::class.java)
+                    apply("kotlin-multiplatform")
+                }
+
+                configureExtension<KotlinMultiplatformExtension> {
+                    js {
+                        browser()
+                    }
+                }
+
+                evaluate()
+
+                assertThat((getTask("detektJsMain") as Detekt).classpath).isEmpty()
+                assertThat((getTask("detektJsTest") as Detekt).classpath).isEmpty()
+            }
+        }
+    }
+
+    describe("multiplatform projects - iOS target") {
+
+        it("creates detekt tasks for iOS") {
+            with(ProjectBuilder.builder().build()) {
+                with(pluginManager) {
+                    apply(DetektPlugin::class.java)
+                    apply("kotlin-multiplatform")
+                }
+
+                configureExtension<KotlinMultiplatformExtension> {
+                    ios()
+                }
+
+                evaluate()
+
+                assertThat(getTask("check").dependencies())
+                    .contains(
+                        "detektIosArm64Main",
+                        "detektIosArm64Test",
+                        "detektIosX64Main",
+                        "detektIosX64Test",
+                    )
+
+                getTask("detektBaselineIosArm64Main")
+                getTask("detektBaselineIosArm64Test")
+                getTask("detektBaselineIosX64Main")
+                getTask("detektBaselineIosX64Test")
+            }
+        }
+
+        it("configures detekt correctly") {
+            with(ProjectBuilder.builder().build()) {
+                with(pluginManager) {
+                    apply(DetektPlugin::class.java)
+                    apply("kotlin-multiplatform")
+                }
+
+                configureExtension<DetektExtension> {
+                    reports.sarif.enabled = true
+                }
+
+                configureExtension<KotlinMultiplatformExtension> {
+                    ios()
+                }
+
+                evaluate()
+
+                assertThat((getTask("detektIosArm64Main") as Detekt).reports.sarif.enabled).isTrue
+                assertThat((getTask("detektIosArm64Test") as Detekt).reports.sarif.enabled).isTrue
+                assertThat((getTask("detektIosX64Main") as Detekt).reports.sarif.enabled).isTrue
+                assertThat((getTask("detektIosX64Test") as Detekt).reports.sarif.enabled).isTrue
+            }
+        }
+
+        it("configures detekt without type resolution") {
+            with(ProjectBuilder.builder().build()) {
+                with(pluginManager) {
+                    apply(DetektPlugin::class.java)
+                    apply("kotlin-multiplatform")
+                }
+
+                configureExtension<KotlinMultiplatformExtension> {
+                    ios()
+                }
+
+                evaluate()
+
+                assertThat((getTask("detektIosArm64Main") as Detekt).classpath).isEmpty()
+                assertThat((getTask("detektIosArm64Test") as Detekt).classpath).isEmpty()
+                assertThat((getTask("detektIosX64Main") as Detekt).classpath).isEmpty()
+                assertThat((getTask("detektIosX64Test") as Detekt).classpath).isEmpty()
+            }
+        }
+    }
+})

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektPluginTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektPluginTest.kt
@@ -413,5 +413,5 @@ internal inline fun <reified T : Any> Project.configureExtension(configuration: 
  * ANDROID_SDK_ROOT is preferred over ANDROID_HOME, but the check here is more lenient.
  * See [Android CLI Environment Variables](https://developer.android.com/studio/command-line/variables.html)
  */
-private fun isAndroidSdkInstalled() =
+internal fun isAndroidSdkInstalled() =
     System.getenv("ANDROID_SDK_ROOT") != null || System.getenv("ANDROID_HOME") != null


### PR DESCRIPTION
This PR adds support to generate detekt tasks for Kotlin Multiplatform projects. Specifically, tasks for `jvm` and `android` targets have Type Resolution enabled, while `js` and `native` don't (as I still haven't found a way to properly invoke the compiler with the correct classpath/dependency).

For a KMM project like this one:
```
kotlin {
    android()
    ios()
    jvm("jvmDesktop")
    jvm("jvmBackend")
    js()
}
```

The following tasks will be added to the graph:

```
detektAndroidDebug - EXPERIMENTAL: Run detekt analysis for target android and source set debug with type resolution.
detektAndroidDebugAndroidTest - EXPERIMENTAL: Run detekt analysis for target android and source set debugAndroidTest with type resolution.
detektAndroidDebugUnitTest - EXPERIMENTAL: Run detekt analysis for target android and source set debugUnitTest with type resolution.
detektAndroidRelease - EXPERIMENTAL: Run detekt analysis for target android and source set release with type resolution.
detektAndroidReleaseUnitTest - EXPERIMENTAL: Run detekt analysis for target android and source set releaseUnitTest with type resolution.
detektIosArm64Main - Run detekt analysis for target iosArm64 and source set main
detektIosArm64Test - Run detekt analysis for target iosArm64 and source set test
detektIosX64Main - Run detekt analysis for target iosX64 and source set main
detektIosX64Test - Run detekt analysis for target iosX64 and source set test
detektJsMain - Run detekt analysis for target js and source set main
detektJsTest - Run detekt analysis for target js and source set test
detektJvmBackendMain - EXPERIMENTAL: Run detekt analysis for target jvmBackend and source set main with type resolution.
detektJvmBackendTest - EXPERIMENTAL: Run detekt analysis for target jvmBackend and source set test with type resolution.
detektJvmDesktopMain - EXPERIMENTAL: Run detekt analysis for target jvmDesktop and source set main with type resolution.
detektJvmDesktopTest - EXPERIMENTAL: Run detekt analysis for target jvmDesktop and source set test with type resolution.
```

Alongside `detektBaseline*` tasks for each of them.

I still haven't managed to write documentation for this, since I'd like to kickoff the discussion to understand if this is going in the right direction.

Also with the KMM ecosystem growing quickly, I believe this could be a great addition to the ecosystem.

Related to #3414 
Closes #3385