### PR TITLE
`jcenter()` -> `mavenCentral()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,25 +67,12 @@ You can find [other ways to install detekt here](https://detekt.github.io/detekt
 Gradle 5.4+ is required:
 
 ```kotlin
-buildscript {
-    repositories {
-        jcenter()
-    }
-
-    // or
-
-    mavenCentral()
-    jcenter {
-        content {
-            // Only download the 'kotlinx-html-jvm' module from JCenter, but nothing else.
-            // detekt needs 'kotlinx-html-jvm' for the HTML report.
-            includeModule("org.jetbrains.kotlinx", "kotlinx-html-jvm")
-        }
-    }
-}
-
 plugins {
     id("io.gitlab.arturbosch.detekt").version("[version]")
+}
+
+repositories {
+    mavenCentral()
 }
 
 detekt {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -19,7 +19,7 @@ object Plugins {
     const val SHADOW = "6.1.0"
     const val VERSIONS = "0.28.0"
     const val SONAR = "2.8"
-    const val DOKKA = "1.4.10"
+    const val DOKKA = "1.4.32"
     const val SEMVER4J = "3.1.0"
     const val NEXUS = "0.22.0"
     const val KOTLIN_API_VALIDATOR = "0.4.0"

--- a/detekt-bom/build.gradle.kts
+++ b/detekt-bom/build.gradle.kts
@@ -20,7 +20,7 @@ dependencies {
         api("com.pinterest.ktlint:ktlint-ruleset-standard:${version.ktlint}")
         api("com.pinterest.ktlint:ktlint-core:${version.ktlint}")
         api("com.pinterest.ktlint:ktlint-ruleset-experimental:${version.ktlint}")
-        api("org.jetbrains.kotlinx:kotlinx-html-jvm:0.7.2")
+        api("org.jetbrains.kotlinx:kotlinx-html-jvm:0.7.3")
         api("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.1")
         api("io.github.detekt.sarif4k:sarif4k:0.0.1")
     }

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektAndroidTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektAndroidTest.kt
@@ -461,6 +461,7 @@ private fun createGradleRunnerAndSetupProject(projectLayout: ProjectLayout) = Ds
                 mavenCentral()
                 google()
                 mavenLocal()
+                jcenter()
             }
         }
     """.trimIndent(),

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektAndroidTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektAndroidTest.kt
@@ -460,7 +460,6 @@ private fun createGradleRunnerAndSetupProject(projectLayout: ProjectLayout) = Ds
             repositories {
                 mavenCentral()
                 google()
-                jcenter()
                 mavenLocal()
             }
         }

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektJvmTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektJvmTest.kt
@@ -22,7 +22,6 @@ object DetektJvmTest : Spek({
 
                 repositories {
                     mavenCentral()
-                    jcenter()
                     mavenLocal()
                 }
 

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektJvmTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektJvmTest.kt
@@ -23,6 +23,7 @@ object DetektJvmTest : Spek({
                 repositories {
                     mavenCentral()
                     mavenLocal()
+                    jcenter()
                 }
 
                 detekt {

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektMultiplatformTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektMultiplatformTest.kt
@@ -330,7 +330,6 @@ private fun setupProject(projectLayoutAction: ProjectLayout.() -> Unit): DslGrad
                 repositories {
                     mavenCentral()
                     google()
-                    jcenter()
                     mavenLocal()
                 }
             }

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektMultiplatformTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektMultiplatformTest.kt
@@ -331,6 +331,7 @@ private fun setupProject(projectLayoutAction: ProjectLayout.() -> Unit): DslGrad
                     mavenCentral()
                     google()
                     mavenLocal()
+                    jcenter()
                 }
             }
         """.trimIndent(),

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/testkit/DslTestBuilder.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/testkit/DslTestBuilder.kt
@@ -10,7 +10,6 @@ abstract class DslTestBuilder {
         repositories {
             mavenLocal()
             mavenCentral()
-            jcenter()
         }
     """.trimIndent()
 

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/testkit/DslTestBuilder.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/testkit/DslTestBuilder.kt
@@ -10,6 +10,7 @@ abstract class DslTestBuilder {
         repositories {
             mavenLocal()
             mavenCentral()
+            jcenter()
         }
     """.trimIndent()
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,18 +27,12 @@ summary:
 Apply the following configuration to your Gradle project build file:
 
 ```kotlin
-buildscript {
-    repositories {
-        jcenter()
-    }
-}
-
 plugins {
     id("io.gitlab.arturbosch.detekt").version("{{ site.detekt_version }}")
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 ```
 

--- a/docs/pages/gettingstarted/gradle.md
+++ b/docs/pages/gettingstarted/gradle.md
@@ -67,7 +67,7 @@ plugins {
 }
 
 repositories {
-    jcenter() // jcenter is needed https://github.com/Kotlin/kotlinx.html/issues/81
+    mavenCentral()
 }
 ```
 
@@ -79,7 +79,7 @@ plugins {
 }
 
 repositories {
-    jcenter() // jcenter is needed https://github.com/Kotlin/kotlinx.html/issues/81
+    mavenCentral()
 }
 ```
 
@@ -100,7 +100,7 @@ buildscript {
 apply plugin: "io.gitlab.arturbosch.detekt"
 
 repositories {
-    jcenter() // jcenter is needed https://github.com/Kotlin/kotlinx.html/issues/81
+    mavenCentral()
 }
 ```
 
@@ -119,7 +119,7 @@ buildscript {
 apply(plugin = "io.gitlab.arturbosch.detekt")
 
 repositories {
-    jcenter() // jcenter is needed https://github.com/Kotlin/kotlinx.html/issues/81
+    mavenCentral()
 }
 ```
 
@@ -135,7 +135,7 @@ You can configure the plugin in the same way as indicated above.
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
         gradlePluginPortal()
     }
     dependencies {
@@ -150,7 +150,7 @@ plugins {
 }
 
 repositories {
-    jcenter() // jcenter is needed https://github.com/Kotlin/kotlinx.html/issues/81
+    mavenCentral()
 }
 ```
 
@@ -160,7 +160,7 @@ repositories {
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
         gradlePluginPortal()
     }
     dependencies {
@@ -175,7 +175,7 @@ plugins {
 }
 
 repositories {
-    jcenter() // jcenter is needed https://github.com/Kotlin/kotlinx.html/issues/81
+    mavenCentral()
 }
 ```
 

--- a/docs/pages/gettingstarted/gradletask.md
+++ b/docs/pages/gettingstarted/gradletask.md
@@ -14,18 +14,7 @@ summary:
 ###### Groovy DSL
 ```groovy
 repositories {
-    jcenter()
-
-    // or
-
     mavenCentral()
-    jcenter {
-        content {
-            // just allow to include kotlinx projects
-            // detekt needs 'kotlinx-html' for the html report
-            includeGroup "org.jetbrains.kotlinx"
-        }
-    }
 }
 
 configurations {


### PR DESCRIPTION
This is a tentative PR to remove our dependency on `jcenter()`.

The impact on our project is:
- We're currently depending on kotlix-html that hasn't been migrated to JCenter yet (see https://github.com/Kotlin/kotlinx.html/issues/81 & https://github.com/Kotlin/kotlinx.html/issues/173)
- We have several older versions of Detekt on JCenter that haven't been migrated to Central yet.

I'll keep this PR updated as things evolve.

Fixes #3461