### PR TITLE
Correct `maxIssues` documentation

### DIFF
--- a/docs/pages/configurations.md
+++ b/docs/pages/configurations.md
@@ -54,7 +54,7 @@ For this the following code must be inside the detekt config:
 
 ```yaml
 build:
-  maxIssues: 10 # break the build if ten weighted issues are found
+  maxIssues: 10 # break the build if more than ten weighted issues are found
   weights:
     complexity: 2 # every rule of the complexity rule set should count as if two issues were found...
     LongParameterList: 1 # ...with the exception of the LongParameterList rule.


### PR DESCRIPTION
This repo's [own config](https://github.com/detekt/detekt/blob/b120ffb058c706bd94ba8c60afb28fc2a65c5e1e/detekt-core/src/main/resources/default-detekt-config.yml#L2) contains `maxIssues: 0`, which only makes sense under this PR's new wording since it'd be impossible for the build to ever pass with `maxIssues: 0` if the current wording were true.

The current wording led to an issue in Duolingo's codebase where we were declaring `maxIssues: 1` to mean "break if at least one issue is found" and unknowingly allowing our repo to always contain exactly 1 unfixed violation. This confused contributors because two new PRs each introducing one violation would often be merged around the same time into master, adding up to two violations and breaking master.