### PR TITLE
Allow using regular expressions when defining license header templates

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -52,6 +52,7 @@ comments:
   AbsentOrWrongFileLicense:
     active: false
     licenseTemplateFile: 'license.template'
+    licenseTemplateIsRegex: false
   CommentOverPrivateFunction:
     active: false
   CommentOverPrivateProperty:

--- a/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/LicenceHeaderLoaderExtension.kt
+++ b/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/LicenceHeaderLoaderExtension.kt
@@ -6,7 +6,9 @@ import io.gitlab.arturbosch.detekt.api.SetupContext
 import io.gitlab.arturbosch.detekt.api.SingleAssign
 import io.gitlab.arturbosch.detekt.api.UnstableApi
 import io.gitlab.arturbosch.detekt.rules.documentation.AbsentOrWrongFileLicense.Companion.DEFAULT_LICENSE_TEMPLATE_FILE
+import io.gitlab.arturbosch.detekt.rules.documentation.AbsentOrWrongFileLicense.Companion.DEFAULT_LICENSE_TEMPLATE_IS_REGEX
 import io.gitlab.arturbosch.detekt.rules.documentation.AbsentOrWrongFileLicense.Companion.PARAM_LICENSE_TEMPLATE_FILE
+import io.gitlab.arturbosch.detekt.rules.documentation.AbsentOrWrongFileLicense.Companion.PARAM_LICENSE_TEMPLATE_IS_REGEX
 import io.gitlab.arturbosch.detekt.rules.documentation.AbsentOrWrongFileLicense.Companion.RULE_NAME
 import org.jetbrains.kotlin.com.intellij.openapi.util.Key
 import org.jetbrains.kotlin.com.intellij.openapi.util.text.StringUtilRt
@@ -41,6 +43,10 @@ class LicenceHeaderLoaderExtension : FileProcessListener {
             .subConfig(RULE_NAME)
             .valueOrDefault(PARAM_LICENSE_TEMPLATE_FILE, DEFAULT_LICENSE_TEMPLATE_FILE)
 
+        fun isRegexTemplate(): Boolean = config.subConfig("comments")
+            .subConfig(RULE_NAME)
+            .valueOrDefault(PARAM_LICENSE_TEMPLATE_IS_REGEX, DEFAULT_LICENSE_TEMPLATE_IS_REGEX)
+
         fun loadLicence(dir: Path): String {
             val templateFile = dir.resolve(getPathToTemplate())
 
@@ -56,24 +62,35 @@ class LicenceHeaderLoaderExtension : FileProcessListener {
                 .let(StringUtilRt::convertLineSeparators)
         }
 
-        fun cacheLicence(dir: Path) {
+        fun cacheLicence(dir: Path, isRegexTemplate: Boolean) {
             val licenceHeader = loadLicence(dir)
+            if (!isRegexTemplate) {
+                for (file in files) {
+                    file.putUserData(LICENCE_KEY, licenceHeader)
+                }
+                return
+            }
+            val licenseHeaderRegex = licenceHeader.toRegex(RegexOption.MULTILINE)
             for (file in files) {
-                file.putUserData(LICENCE_KEY, licenceHeader)
+                file.putUserData(LICENCE_REGEX_KEY, licenseHeaderRegex)
             }
         }
 
         if (configPath != null && shouldRuleRun()) {
-            val configDir = configPath?.parent
-            if (configDir != null) {
-                cacheLicence(configDir)
-            }
+            val configDir = configPath?.parent ?: return
+            cacheLicence(configDir, isRegexTemplate())
         }
     }
 }
 
 internal val LICENCE_KEY = Key.create<String>("LICENCE_HEADER")
+internal val LICENCE_REGEX_KEY = Key.create<Regex>("LICENCE_HEADER_REGEX")
 
 internal fun KtFile.hasLicenseHeader(): Boolean = this.getUserData(LICENCE_KEY) != null
 
 internal fun KtFile.getLicenseHeader(): String = this.getUserData(LICENCE_KEY) ?: error("License header expected")
+
+internal fun KtFile.hasLicenseHeaderRegex(): Boolean = this.getUserData(LICENCE_REGEX_KEY) != null
+
+internal fun KtFile.getLicenseHeaderRegex(): Regex =
+    this.getUserData(LICENCE_REGEX_KEY) ?: error("License header regex expected")

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/AbsentOrWrongFileLicenseSpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/AbsentOrWrongFileLicenseSpec.kt
@@ -54,15 +54,112 @@ internal class AbsentOrWrongFileLicenseSpec : Spek({
                 assertThat(findings).hasSize(1)
             }
         }
+
+        context("file with correct license header using regex matching") {
+
+            it("reports nothing for 2016") {
+                val findings = checkLicence("""
+                    //
+                    // Copyright 2016 Artur Bosch & Contributors
+                    //     http://www.apache.org/licenses/LICENSE-2.0
+                    // See the License for the specific language governing permissions and
+                    // limitations under the License.
+                    //
+                    package cases
+                """.trimIndent(), isRegexLicense = true)
+
+                assertThat(findings).isEmpty()
+            }
+
+            it("reports nothing for 2021") {
+                val findings = checkLicence("""
+                    //
+                    // Copyright 2021 Artur Bosch & Contributors
+                    //     http://www.apache.org/licenses/LICENSE-2.0
+                    // See the License for the specific language governing permissions and
+                    // limitations under the License.
+                    //
+                    package cases
+                """.trimIndent(), isRegexLicense = true)
+
+                assertThat(findings).isEmpty()
+            }
+        }
+
+        context("file with incorrect license header using regex matching") {
+
+            it("file with missing license header") {
+                val findings = checkLicence("""
+                    package cases
+                """.trimIndent(), isRegexLicense = true)
+
+                assertThat(findings).hasSize(1)
+            }
+
+            it("file with license header not on the first line") {
+                val findings = checkLicence("""
+                    package cases
+                    //
+                    // Copyright 2021 Artur Bosch & Contributors
+                    //     http://www.apache.org/licenses/LICENSE-2.0
+                    // See the License for the specific language governing permissions and
+                    // limitations under the License.
+                    //
+                """.trimIndent(), isRegexLicense = true)
+
+                assertThat(findings).hasSize(1)
+            }
+
+            it("file with incomplete license header") {
+                val findings = checkLicence("""
+                    //
+                    // Copyright 2021 Artur Bosch & Contributors
+                    //
+                    package cases
+                """.trimIndent(), isRegexLicense = true)
+
+                assertThat(findings).hasSize(1)
+            }
+
+            it("file with too many empty likes in license header") {
+                val findings = checkLicence("""
+                    //
+                    //
+                    // Copyright 2021 Artur Bosch & Contributors
+                    //     http://www.apache.org/licenses/LICENSE-2.0
+                    // See the License for the specific language governing permissions and
+                    // limitations under the License.
+                    //
+                    package cases
+                """.trimIndent(), isRegexLicense = true)
+
+                assertThat(findings).hasSize(1)
+            }
+
+            it("file with incorrect year in license header") {
+                val findings = checkLicence("""
+                    //
+                    // Copyright 202 Artur Bosch & Contributors
+                    //     http://www.apache.org/licenses/LICENSE-2.0
+                    // See the License for the specific language governing permissions and
+                    // limitations under the License.
+                    //
+                    package cases
+                """.trimIndent(), isRegexLicense = true)
+
+                assertThat(findings).hasSize(1)
+            }
+        }
     }
 })
 
 @OptIn(UnstableApi::class)
-private fun checkLicence(content: String): List<Finding> {
+private fun checkLicence(content: String, isRegexLicense: Boolean = false): List<Finding> {
     val file = compileContentForTest(content.trimIndent())
 
-    val resource = resourceAsPath("license-config.yml")
-    val config = yamlConfig("license-config.yml")
+    val configFileName = if (isRegexLicense) "license-config-regex.yml" else "license-config.yml"
+    val resource = resourceAsPath(configFileName)
+    val config = yamlConfig(configFileName)
 
     LicenceHeaderLoaderExtension().apply {
         init(object : SetupContext {

--- a/detekt-rules-documentation/src/test/resources/license-config-regex.yml
+++ b/detekt-rules-documentation/src/test/resources/license-config-regex.yml
@@ -1,0 +1,6 @@
+comments:
+  active: true
+  AbsentOrWrongFileLicense:
+    active: true
+    licenseTemplateFile: 'license-regex.template'
+    licenseTemplateIsRegex: true

--- a/detekt-rules-documentation/src/test/resources/license-regex.template
+++ b/detekt-rules-documentation/src/test/resources/license-regex.template
@@ -1,0 +1,6 @@
+^\/\/
+\/\/ Copyright 20[0-9]{2} Artur Bosch & Contributors
+\/\/     http:\/\/www\.apache\.org\/licenses\/LICENSE-2\.0
+\/\/ See the License for the specific language governing permissions and
+\/\/ limitations under the License\.
+\/\/$


### PR DESCRIPTION
Problem: different projects might impose different rules on license headers.
It's not uncommon, for example, that a year in the license header is the year when the source
file was created. This leads to a situation when different source files have different license
headers (at least some parts of them differ) making it impossible to use a single static
license header template to match against.

This change makes it possible to define license header templates as regexps.
An example of such template is:
  \/\/ Copyright 20[0-9]{2} Artur Bosch & Contributors
which would match both
  \\ Copyright 2020 Artur Bosch & Contributors
and
  \\ Copyright 2021 Artur Bosch & Contributors

The way `AbsentOrWrongFileLicense` works now is controlled
by the new configuration option `licenseTemplateIsRegex`:
when `licenseTemplateIsRegex` is false the template is considered to be static
and the old matching rules apply.
If `licenseTemplateIsRegex` is set to true the new regexp based logic kicks in.

To avoid breakage of existing projects, the added configuration option
`licenseTemplateIsRegex` is disabled by default.

This commit implements a feature requested here #3100.

A similar PR may already be submitted!
Please search among the [Pull requests](https://github.com/detekt/detekt/pulls) before creating one.

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Link to relevant issues if possible.

For more information, see the [CONTRIBUTING guide](https://github.com/detekt/detekt/blob/master/.github/CONTRIBUTING.md).
