### PR TITLE
Merge XML report output

### DIFF
--- a/detekt-gradle-plugin/src/intTest/kotlin/io/gitlab/arturbosch/detekt/DetektXmlReportMergeTest.kt
+++ b/detekt-gradle-plugin/src/intTest/kotlin/io/gitlab/arturbosch/detekt/DetektXmlReportMergeTest.kt
@@ -13,10 +13,10 @@ internal class DetektXmlReportMergeTest : Spek({
 
         val groovy = DslTestBuilder.groovy()
         val groovyBuildFileContent = """
-            |${groovy.gradlePluginsSection}
+            |${groovy.gradlePlugins}
             |
             |allprojects {
-            |  ${groovy.gradleRepositoriesSection}
+            |  ${groovy.gradleRepositories}
             |}
             |
             |task xmlReportMerge(type: io.gitlab.arturbosch.detekt.report.XmlReportMergeTask) {
@@ -24,7 +24,7 @@ internal class DetektXmlReportMergeTest : Spek({
             |}
             |
             |subprojects {
-            |  ${groovy.gradleApplyPlugins}
+            |  ${groovy.gradleSubprojectsApplyPlugins}
             |  
             |  detekt {
             |    reports.xml.enabled = true
@@ -42,10 +42,10 @@ internal class DetektXmlReportMergeTest : Spek({
             |""".trimMargin()
         val kotlin = DslTestBuilder.kotlin()
         val kotlinBuildFileContent = """
-            |${kotlin.gradlePluginsSection}
+            |${kotlin.gradlePlugins}
             |
             |allprojects {
-            |  ${kotlin.gradleRepositoriesSection}
+            |  ${kotlin.gradleRepositories}
             |}
             |
             |val xmlReportMerge by tasks.registering(io.gitlab.arturbosch.detekt.report.XmlReportMergeTask::class) {
@@ -53,7 +53,7 @@ internal class DetektXmlReportMergeTest : Spek({
             |}
             |
             |subprojects {
-            |  ${kotlin.gradleApplyPlugins}
+            |  ${kotlin.gradleSubprojectsApplyPlugins}
             |  
             |  detekt {
             |    reports.xml.enabled = true
@@ -75,17 +75,18 @@ internal class DetektXmlReportMergeTest : Spek({
             kotlin to kotlinBuildFileContent
         ).forEach { (builder, mainBuildFileContent) ->
             it("using ${builder.gradleBuildName}") {
-                val projectLayout = ProjectLayout(numberOfSourceFilesInRootPerSourceDir = 0)
-                    .withSubmodule(
+                val projectLayout = ProjectLayout(numberOfSourceFilesInRootPerSourceDir = 0).apply {
+                    addSubmodule(
                         name = "child1",
                         numberOfSourceFilesPerSourceDir = 2,
                         numberOfCodeSmells = 2
                     )
-                    .withSubmodule(
+                    addSubmodule(
                         name = "child2",
                         numberOfSourceFilesPerSourceDir = 4,
                         numberOfCodeSmells = 4
                     )
+                }
 
                 val gradleRunner = DslGradleRunner(projectLayout, builder.gradleBuildName, mainBuildFileContent)
                 gradleRunner.setupProject()

--- a/detekt-gradle-plugin/src/intTest/kotlin/io/gitlab/arturbosch/detekt/DetektXmlReportMergeTest.kt
+++ b/detekt-gradle-plugin/src/intTest/kotlin/io/gitlab/arturbosch/detekt/DetektXmlReportMergeTest.kt
@@ -1,0 +1,105 @@
+package io.gitlab.arturbosch.detekt
+
+import io.gitlab.arturbosch.detekt.testkit.DslGradleRunner
+import io.gitlab.arturbosch.detekt.testkit.DslTestBuilder
+import io.gitlab.arturbosch.detekt.testkit.ProjectLayout
+import org.assertj.core.api.Assertions.assertThat
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+internal class DetektXmlReportMergeTest : Spek({
+
+    describe("XML merge is configured correctly for multi module project") {
+
+        val groovy = DslTestBuilder.groovy()
+        val groovyBuildFileContent = """
+            |${groovy.gradlePluginsSection}
+            |
+            |allprojects {
+            |  ${groovy.gradleRepositoriesSection}
+            |}
+            |
+            |task xmlReportMerge(type: io.gitlab.arturbosch.detekt.report.XmlReportMergeTask) {
+            |  output = project.layout.buildDirectory.file("reports/detekt/merge.xml")
+            |}
+            |
+            |subprojects {
+            |  ${groovy.gradleApplyPlugins}
+            |  
+            |  detekt {
+            |    reports.xml.enabled = true
+            |  }
+            |  
+            |  plugins.withType(io.gitlab.arturbosch.detekt.DetektPlugin) {
+            |    tasks.withType(io.gitlab.arturbosch.detekt.Detekt) { detektTask ->
+            |       xmlReportMerge.configure { mergeTask ->
+            |         mergeTask.mustRunAfter(detektTask)
+            |         mergeTask.input.from(detektTask.xmlReportFile)
+            |       }
+            |    }
+            |  }
+            |}
+            |""".trimMargin()
+        val kotlin = DslTestBuilder.kotlin()
+        val kotlinBuildFileContent = """
+            |${kotlin.gradlePluginsSection}
+            |
+            |allprojects {
+            |  ${kotlin.gradleRepositoriesSection}
+            |}
+            |
+            |val xmlReportMerge by tasks.registering(io.gitlab.arturbosch.detekt.report.XmlReportMergeTask::class) {
+            |  output.set(project.layout.buildDirectory.file("reports/detekt/merge.xml"))
+            |}
+            |
+            |subprojects {
+            |  ${kotlin.gradleApplyPlugins}
+            |  
+            |  detekt {
+            |    reports.xml.enabled = true
+            |  }
+            |  
+            |  plugins.withType(io.gitlab.arturbosch.detekt.DetektPlugin::class) {
+            |    tasks.withType(io.gitlab.arturbosch.detekt.Detekt::class) detekt@{
+            |       xmlReportMerge.configure {
+            |         this.mustRunAfter(this@detekt)
+            |         input.from(this@detekt.xmlReportFile)
+            |       }
+            |    }
+            |  }
+            |}
+            |""".trimMargin()
+
+        listOf(
+            groovy to groovyBuildFileContent,
+            kotlin to kotlinBuildFileContent
+        ).forEach { (builder, mainBuildFileContent) ->
+            it("using ${builder.gradleBuildName}") {
+                val projectLayout = ProjectLayout(numberOfSourceFilesInRootPerSourceDir = 0)
+                    .withSubmodule(
+                        name = "child1",
+                        numberOfSourceFilesPerSourceDir = 2,
+                        numberOfCodeSmells = 2
+                    )
+                    .withSubmodule(
+                        name = "child2",
+                        numberOfSourceFilesPerSourceDir = 4,
+                        numberOfCodeSmells = 4
+                    )
+
+                val gradleRunner = DslGradleRunner(projectLayout, builder.gradleBuildName, mainBuildFileContent)
+                gradleRunner.setupProject()
+                gradleRunner.runTasksAndExpectFailure("detekt", "xmlReportMerge", "--continue") { result ->
+                    println(result.output)
+                    assertThat(projectFile("build/reports/detekt/detekt.xml")).doesNotExist()
+                    assertThat(projectFile("build/reports/detekt/merge.xml")).exists()
+                    assertThat(projectFile("build/reports/detekt/merge.xml").readText())
+                        .contains("<error column=\"30\" line=\"4\"")
+                    projectLayout.submodules.forEach {
+                        assertThat(projectFile("${it.name}/build/reports/detekt/detekt.xml")).exists()
+                    }
+                }
+            }
+        }
+    }
+})

--- a/detekt-gradle-plugin/src/intTest/kotlin/io/gitlab/arturbosch/detekt/testkit/DslGradleRunner.kt
+++ b/detekt-gradle-plugin/src/intTest/kotlin/io/gitlab/arturbosch/detekt/testkit/DslGradleRunner.kt
@@ -115,6 +115,11 @@ class DslGradleRunner @Suppress("LongParameterList") constructor(
 
     fun runTasks(vararg tasks: String): BuildResult = buildGradleRunner(tasks.toList()).build()
 
+    fun runTasksAndExpectFailure(vararg tasks: String, doAssert: DslGradleRunner.(BuildResult) -> Unit) {
+        val result: BuildResult = buildGradleRunner(tasks.toList()).buildAndFail()
+        this.doAssert(result)
+    }
+
     fun runDetektTaskAndCheckResult(doAssert: DslGradleRunner.(BuildResult) -> Unit) {
         runTasksAndCheckResult(DETEKT_TASK) { this.doAssert(it) }
     }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -161,22 +161,22 @@ open class Detekt @Inject constructor(
     @get:Internal
     val reportsDir: Property<File> = project.objects.property(File::class.java)
 
-    internal val xmlReportFile: Provider<RegularFile>
+    val xmlReportFile: Provider<RegularFile>
         @OutputFile
         @Optional
         get() = getTargetFileProvider(reports.xml)
 
-    internal val htmlReportFile: Provider<RegularFile>
+    val htmlReportFile: Provider<RegularFile>
         @OutputFile
         @Optional
         get() = getTargetFileProvider(reports.html)
 
-    internal val txtReportFile: Provider<RegularFile>
+    val txtReportFile: Provider<RegularFile>
         @OutputFile
         @Optional
         get() = getTargetFileProvider(reports.txt)
 
-    internal val sarifReportFile: Provider<RegularFile>
+    val sarifReportFile: Provider<RegularFile>
         @OutputFile
         @Optional
         get() = getTargetFileProvider(report = reports.sarif, defaultEnabledValue = false)

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/report/XmlReportMergeTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/report/XmlReportMergeTask.kt
@@ -1,0 +1,29 @@
+package io.gitlab.arturbosch.detekt.report
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+
+@CacheableTask
+abstract class XmlReportMergeTask : DefaultTask() {
+
+    @get:InputFiles
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val input: ConfigurableFileCollection
+
+    @get:OutputFile
+    abstract val output: RegularFileProperty
+
+    @TaskAction
+    fun merge() {
+        logger.lifecycle(input.files.joinToString(separator = "\n") { it.absolutePath })
+        XmlReportMerger.merge(input.files, output.get().asFile)
+        logger.lifecycle("Merged XML output to ${output.get().asFile.absolutePath}")
+    }
+}

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/report/XmlReportMergeTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/report/XmlReportMergeTask.kt
@@ -22,7 +22,7 @@ abstract class XmlReportMergeTask : DefaultTask() {
 
     @TaskAction
     fun merge() {
-        logger.lifecycle(input.files.joinToString(separator = "\n") { it.absolutePath })
+        logger.info(input.files.joinToString(separator = "\n") { it.absolutePath })
         XmlReportMerger.merge(input.files, output.get().asFile)
         logger.lifecycle("Merged XML output to ${output.get().asFile.absolutePath}")
     }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/report/XmlReportMerger.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/report/XmlReportMerger.kt
@@ -1,0 +1,57 @@
+package io.gitlab.arturbosch.detekt.report
+
+import com.android.utils.forEach
+import org.w3c.dom.Document
+import org.w3c.dom.Node
+import java.io.File
+import javax.xml.parsers.DocumentBuilderFactory
+import javax.xml.transform.OutputKeys
+import javax.xml.transform.TransformerFactory
+import javax.xml.transform.dom.DOMSource
+import javax.xml.transform.stream.StreamResult
+
+/**
+ * A naive implementation to merge xml assuming all input xml are written by detekt.
+ */
+object XmlReportMerger {
+
+    private val documentBuilder by lazy { DocumentBuilderFactory.newInstance().newDocumentBuilder() }
+
+    fun merge(inputs: Collection<File>, output: File) {
+        val document = documentBuilder.newDocument().apply {
+            xmlStandalone = true
+            val checkstyleNode = createElement("checkstyle")
+            checkstyleNode.setAttribute("version", "4.3")
+            appendChild(checkstyleNode)
+        }
+        inputs.filter { it.exists() }.forEach {
+            importNodesFromInput(it, document)
+        }
+        TransformerFactory.newInstance().newTransformer().run {
+            setOutputProperty(OutputKeys.INDENT, "yes")
+            setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2")
+            transform(DOMSource(document), StreamResult(output.writer()))
+        }
+    }
+
+    private fun importNodesFromInput(input: File, document: Document) {
+        val checkstyleNode = documentBuilder.parse(input.inputStream()).documentElement.also { removeWhitespaces(it) }
+        checkstyleNode.childNodes.forEach { node ->
+            document.documentElement.appendChild(document.importNode(node, true))
+        }
+    }
+
+    /**
+     * Use code instead of XSLT to exclude whitespaces.
+     */
+    private fun removeWhitespaces(node: Node) {
+        (node.childNodes.length - 1 downTo 0).forEach { idx ->
+            val childNode = node.childNodes.item(idx)
+            if (childNode.nodeType == Node.TEXT_NODE && childNode.textContent.isBlank()) {
+                node.removeChild(childNode)
+            } else {
+                removeWhitespaces(childNode)
+            }
+        }
+    }
+}

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/report/XmlOutputMergerSpec.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/report/XmlOutputMergerSpec.kt
@@ -1,0 +1,53 @@
+package io.gitlab.arturbosch.detekt.report
+
+import org.assertj.core.api.Assertions.assertThat
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import java.io.File
+
+private const val TAB = "\t"
+
+internal class XmlOutputMergerSpec : Spek({
+
+    describe("classpath changes") {
+
+        it("passes for same files") {
+            val file1 = File.createTempFile("detekt1", "xml").apply {
+                writeText("""
+                    <?xml version="1.0" encoding="utf-8"?>
+                    <checkstyle version="4.3">
+                    <file name="Sample1.kt">
+                    $TAB<error line="1" column="1" severity="warning" message="TestMessage" source="detekt.id_a" />
+                    </file>
+                    </checkstyle>
+                """.trimIndent())
+            }
+            val file2 = File.createTempFile("detekt2", "xml").apply {
+                writeText("""
+                    <?xml version="1.0" encoding="utf-8"?>
+                    <checkstyle version="4.3">
+                    <file name="Sample2.kt">
+                    $TAB<error line="1" column="1" severity="warning" message="TestMessage" source="detekt.id_b" />
+                    </file>
+                    </checkstyle>
+                """.trimIndent())
+            }
+            val output = File.createTempFile("output", "xml")
+            XmlReportMerger.merge(setOf(file1, file2), output)
+
+            val text = output.readText()
+            val expectedText = """
+                <?xml version="1.0" encoding="UTF-8"?><checkstyle version="4.3">
+                  <file name="Sample1.kt">
+                    <error column="1" line="1" message="TestMessage" severity="warning" source="detekt.id_a"/>
+                  </file>
+                  <file name="Sample2.kt">
+                    <error column="1" line="1" message="TestMessage" severity="warning" source="detekt.id_b"/>
+                  </file>
+                </checkstyle>
+            """.trimIndent() + System.lineSeparator()
+            assertThat(text.length).isEqualTo(expectedText.length)
+            assertThat(text).isEqualTo(expectedText)
+        }
+    }
+})

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/report/XmlReportMergerSpec.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/report/XmlReportMergerSpec.kt
@@ -7,7 +7,7 @@ import java.io.File
 
 private const val TAB = "\t"
 
-internal class XmlOutputMergerSpec : Spek({
+internal class XmlReportMergerSpec : Spek({
 
     describe("classpath changes") {
 
@@ -35,7 +35,7 @@ internal class XmlOutputMergerSpec : Spek({
             val output = File.createTempFile("output", "xml")
             XmlReportMerger.merge(setOf(file1, file2), output)
 
-            val text = output.readText()
+            val text = output.readLines()
             val expectedText = """
                 <?xml version="1.0" encoding="UTF-8"?><checkstyle version="4.3">
                   <file name="Sample1.kt">
@@ -45,8 +45,7 @@ internal class XmlOutputMergerSpec : Spek({
                     <error column="1" line="1" message="TestMessage" severity="warning" source="detekt.id_b"/>
                   </file>
                 </checkstyle>
-            """.trimIndent() + System.lineSeparator()
-            assertThat(text.length).isEqualTo(expectedText.length)
+            """.trimIndent().split("\n")
             assertThat(text).isEqualTo(expectedText)
         }
     }

--- a/detekt-report-xml/src/main/kotlin/io/github/detekt/report/xml/XmlOutputReport.kt
+++ b/detekt-report-xml/src/main/kotlin/io/github/detekt/report/xml/XmlOutputReport.kt
@@ -23,7 +23,7 @@ class XmlOutputReport : OutputReport() {
         val smells = detektion.findings.flatMap { it.value }
 
         val lines = ArrayList<String>()
-        lines += "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
+        lines += "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
         lines += "<checkstyle version=\"4.3\">"
 
         smells.groupBy { it.location.filePath.relativePath ?: it.location.filePath.absolutePath }

--- a/detekt-report-xml/src/test/kotlin/io/github/detekt/report/xml/XmlOutputFormatSpec.kt
+++ b/detekt-report-xml/src/test/kotlin/io/github/detekt/report/xml/XmlOutputFormatSpec.kt
@@ -41,7 +41,7 @@ class XmlOutputFormatSpec : Spek({
             val result = outputFormat.render(TestDetektion())
 
             assertThat(result).isEqualTo("""
-                <?xml version="1.0" encoding="utf-8"?>
+                <?xml version="1.0" encoding="UTF-8"?>
                 <checkstyle version="4.3">
                 </checkstyle>""".trimIndent())
         }
@@ -52,7 +52,7 @@ class XmlOutputFormatSpec : Spek({
             val result = outputFormat.render(TestDetektion(smell))
 
             assertThat(result).isEqualTo("""
-                <?xml version="1.0" encoding="utf-8"?>
+                <?xml version="1.0" encoding="UTF-8"?>
                 <checkstyle version="4.3">
                 <file name="src/main/com/sample/Sample1.kt">
                 $TAB<error line="11" column="1" severity="warning" message="" source="detekt.id_a" />
@@ -67,7 +67,7 @@ class XmlOutputFormatSpec : Spek({
             val result = outputFormat.render(TestDetektion(smell1, smell2))
 
             assertThat(result).isEqualTo("""
-                <?xml version="1.0" encoding="utf-8"?>
+                <?xml version="1.0" encoding="UTF-8"?>
                 <checkstyle version="4.3">
                 <file name="src/main/com/sample/Sample1.kt">
                 $TAB<error line="11" column="1" severity="warning" message="" source="detekt.id_a" />
@@ -83,7 +83,7 @@ class XmlOutputFormatSpec : Spek({
             val result = outputFormat.render(TestDetektion(smell1, smell2))
 
             assertThat(result).isEqualTo("""
-                <?xml version="1.0" encoding="utf-8"?>
+                <?xml version="1.0" encoding="UTF-8"?>
                 <checkstyle version="4.3">
                 <file name="src/main/com/sample/Sample1.kt">
                 $TAB<error line="11" column="1" severity="warning" message="" source="detekt.id_a" />
@@ -109,7 +109,7 @@ class XmlOutputFormatSpec : Spek({
             val result = outputFormat.render(TestDetektion(findingA, findingB))
 
             assertThat(result).isEqualTo("""
-                <?xml version="1.0" encoding="utf-8"?>
+                <?xml version="1.0" encoding="UTF-8"?>
                 <checkstyle version="4.3">
                 <file name="Sample1.kt">
                 $TAB<error line="1" column="1" severity="warning" message="TestMessage" source="detekt.id_a" />
@@ -136,7 +136,7 @@ class XmlOutputFormatSpec : Spek({
             )
 
             assertThat(result).isEqualTo("""
-                <?xml version="1.0" encoding="utf-8"?>
+                <?xml version="1.0" encoding="UTF-8"?>
                 <checkstyle version="4.3">
                 <file name="src/main/com/sample/Sample1.kt">
                 $TAB<error line="11" column="1" severity="warning" message="" source="detekt.id_a" />
@@ -166,7 +166,7 @@ class XmlOutputFormatSpec : Spek({
                     }
 
                     val expected = """
-                    <?xml version="1.0" encoding="utf-8"?>
+                    <?xml version="1.0" encoding="UTF-8"?>
                     <checkstyle version="4.3">
                     <file name="${finding.location.file}">
                     $TAB<error line="${finding.location.source.line}" column="${finding.location.source.column}" severity="$xmlSeverity" message="${finding.messageOrDescription()}" source="detekt.${finding.id}" />

--- a/docs/pages/reporting.md
+++ b/docs/pages/reporting.md
@@ -111,18 +111,18 @@ val xmlReportMerge by tasks.registering(io.gitlab.arturbosch.detekt.report.XmlRe
 }
 
 subprojects {
-    detekt {
-      reports.xml.enabled = true
-    }
-    
-    plugins.withType(io.gitlab.arturbosch.detekt.DetektPlugin::class) {
-      tasks.withType(io.gitlab.arturbosch.detekt.Detekt::class) detekt@{
-         xmlReportMerge.configure {
-           this.mustRunAfter(this@detekt)
-           input.from(this@detekt.xmlReportFile)
-         }
+  detekt {
+    reports.xml.enabled = true
+  }
+  
+  plugins.withType(io.gitlab.arturbosch.detekt.DetektPlugin::class) {
+    tasks.withType(io.gitlab.arturbosch.detekt.Detekt::class) detekt@{
+      xmlReportMerge.configure {
+        this.mustRunAfter(this@detekt)
+        input.from(this@detekt.xmlReportFile)
       }
     }
+  }
 }
 ```
 

--- a/docs/pages/reporting.md
+++ b/docs/pages/reporting.md
@@ -94,10 +94,10 @@ subprojects {
   
   plugins.withType(io.gitlab.arturbosch.detekt.DetektPlugin) {
     tasks.withType(io.gitlab.arturbosch.detekt.Detekt) { detektTask ->
-       xmlReportMerge.configure { mergeTask ->
-         mergeTask.mustRunAfter(detektTask)
-         mergeTask.input.from(detektTask.xmlReportFile)
-       }
+      xmlReportMerge.configure { mergeTask ->
+        mergeTask.mustRunAfter(detektTask)
+        mergeTask.input.from(detektTask.xmlReportFile)
+      }
     }
   }
 }
@@ -107,7 +107,7 @@ subprojects {
 
 ```kotlin
 val xmlReportMerge by tasks.registering(io.gitlab.arturbosch.detekt.report.XmlReportMergeTask::class) { 
-    output.set(project.layout.buildDirectory.file("reports/detekt/merge.xml"))
+  output.set(project.layout.buildDirectory.file("reports/detekt/merge.xml"))
 }
 
 subprojects {

--- a/docs/pages/reporting.md
+++ b/docs/pages/reporting.md
@@ -73,7 +73,7 @@ namely XML and SARIF.
 
 ## Merging reports
 
-The machine-readable report formats supports report merging.
+The machine-readable report formats support report merging.
 Detekt Gradle plugin is not opinionated in how merging is set up and respects each project's build logic, especially 
 the merging makes most sense in a multi-module project. In this spirit, only Gradle tasks are provided.
 


### PR DESCRIPTION
This is a rewrite of #3394 and addresses one item in #3360.

- Only the gradle tasks are exposed: No opinionated way to configure the tasks.
- Documentation is added.
- Fix: `utf-8` to `UTF-8`, because the latter is the [standard](https://www.w3schools.com/xml/xml_syntax.asp).