### PR TITLE
Adding support for full method signatures in ForbiddenMethodCall

### DIFF
--- a/detekt-psi-utils/api/detekt-psi-utils.api
+++ b/detekt-psi-utils/api/detekt-psi-utils.api
@@ -104,6 +104,7 @@ public final class io/gitlab/arturbosch/detekt/rules/KtValueArgumentKt {
 }
 
 public final class io/gitlab/arturbosch/detekt/rules/MethodSignatureKt {
+	public static final fun extractMethodNameAndParams (Ljava/lang/String;)Lkotlin/Pair;
 	public static final fun hasCorrectEqualsParameter (Lorg/jetbrains/kotlin/psi/KtFunction;)Z
 	public static final fun isEqualsFunction (Lorg/jetbrains/kotlin/psi/KtFunction;)Z
 	public static final fun isHashCodeFunction (Lorg/jetbrains/kotlin/psi/KtFunction;)Z

--- a/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/MethodSignature.kt
+++ b/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/MethodSignature.kt
@@ -16,6 +16,20 @@ fun KtFunction.hasCorrectEqualsParameter() =
 
 fun KtNamedFunction.isMainFunction() = hasMainSignature() && (this.isTopLevel || isMainInsideObject())
 
+fun extractMethodNameAndParams(methodSignature: String): Pair<String, List<String>?> {
+    val tokens = methodSignature.split("(", ")")
+        .map { it.trim() }
+
+    val methodName = tokens.first().replace("`", "")
+    val params = if (tokens.size > 1) {
+        tokens[1].split(",").map { it.trim() }.filter { it.isNotBlank() }
+    } else {
+        null
+    }
+
+    return methodName to params
+}
+
 private fun KtNamedFunction.hasMainSignature() =
     this.name == "main" && this.isPublicNotOverridden() && this.hasMainParameter()
 

--- a/detekt-psi-utils/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/MethodSignatureSpec.kt
+++ b/detekt-psi-utils/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/MethodSignatureSpec.kt
@@ -1,0 +1,57 @@
+package io.gitlab.arturbosch.detekt.rules
+
+import org.assertj.core.api.Assertions.assertThat
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+class MethodSignatureSpec : Spek({
+    describe("extractMethodNameAndParams") {
+        listOf(
+            TestCase(
+                testDescription = "should return method name and null params list in case of simplifies signature",
+                methodSignature = "java.time.LocalDate.now",
+                expectedMethodName = "java.time.LocalDate.now",
+                expectedParams = null
+            ),
+            TestCase(
+                testDescription = "should return method name and empty params list for full signature parameterless method",
+                methodSignature = "java.time.LocalDate.now()",
+                expectedMethodName = "java.time.LocalDate.now",
+                expectedParams = emptyList()
+            ),
+            TestCase(
+                testDescription = "should return method name and params list for full signature method with single param",
+                methodSignature = "java.time.LocalDate.now(java.time.Clock)",
+                expectedMethodName = "java.time.LocalDate.now",
+                expectedParams = listOf("java.time.Clock")
+            ),
+            TestCase(
+                testDescription = "should return method name and params list for full signature method with multiple params",
+                methodSignature = "java.time.LocalDate.of(kotlin.Int, kotlin.Int, kotlin.Int)",
+                expectedMethodName = "java.time.LocalDate.of",
+                expectedParams = listOf("kotlin.Int", "kotlin.Int", "kotlin.Int")
+            ),
+            TestCase(
+                testDescription = "should return method name and params list for full signature method with multiple params " +
+                        "where method name has spaces and special characters",
+                methodSignature = "io.gitlab.arturbosch.detekt.SomeClass.`some , method`(kotlin.String)",
+                expectedMethodName = "io.gitlab.arturbosch.detekt.SomeClass.some , method",
+                expectedParams = listOf("kotlin.String")
+            )
+        ).forEach { testCase ->
+            it(testCase.testDescription) {
+                val (methodName, params) = extractMethodNameAndParams(testCase.methodSignature)
+
+                assertThat(methodName).isEqualTo(testCase.expectedMethodName)
+                assertThat(params).isEqualTo(testCase.expectedParams)
+            }
+        }
+    }
+})
+
+private class TestCase(
+    val testDescription: String,
+    val methodSignature: String,
+    val expectedMethodName: String,
+    val expectedParams: List<String>?
+)


### PR DESCRIPTION
This PR is for now a proof of concept for [#3498](https://github.com/detekt/detekt/issues/3498).

Namely it's adding support for full method signatures (like `java.time.LocalDate.now(java.time.Clock)` in ForbiddenMethodCall rule.