### PR TITLE
Fix SARIF validation failure

### DIFF
--- a/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/SarifOutputReport.kt
+++ b/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/SarifOutputReport.kt
@@ -36,7 +36,12 @@ class SarifOutputReport : OutputReport() {
     @OptIn(UnstableApi::class)
     override fun init(context: SetupContext) {
         this.config = context.config
-        this.basePath = context.getOrNull<Path>(DETEKT_OUTPUT_REPORT_BASE_PATH_KEY)?.toAbsolutePath()?.toUnifiedString()
+        this.basePath = context.getOrNull<Path>(DETEKT_OUTPUT_REPORT_BASE_PATH_KEY)
+            ?.toAbsolutePath()
+            ?.toUnifiedString()
+            ?.let {
+                if (!it.endsWith("/")) "$it/" else it
+            }
     }
 
     override fun render(detektion: Detektion): String {

--- a/detekt-report-sarif/src/test/resources/relative_path.sarif.json
+++ b/detekt-report-sarif/src/test/resources/relative_path.sarif.json
@@ -19,7 +19,7 @@
       },
       "originalUriBaseIds": {
         "%SRCROOT%": {
-          "uri": "file:///Users/tester/detekt"
+          "uri": "file:///Users/tester/detekt/"
         }
       },
       "results": [


### PR DESCRIPTION
When trying the relative output of SARIF report, [the official validation tool](https://sarifweb.azurewebsites.net/Validation) yields the following failure:
![WX20210228-232942](https://user-images.githubusercontent.com/1175468/109465497-234fba80-7a1d-11eb-8a12-e6b8dee35917.png)
