### PR TITLE
Gradle Plugin tests should access also Maven Local

### DIFF
--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektAndroidTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektAndroidTest.kt
@@ -334,6 +334,7 @@ private fun createGradleRunnerAndSetupProject(projectLayout: ProjectLayout) = Ds
                 mavenCentral()
                 google()
                 jcenter()
+                mavenLocal()
             }
         }
     """.trimIndent(),

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektJvmTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektJvmTest.kt
@@ -22,6 +22,7 @@ object DetektJvmTest : Spek({
                     repositories {
                         mavenCentral()
                         jcenter()
+                        mavenLocal()
                     }
                     
                     detekt {
@@ -48,6 +49,7 @@ object DetektJvmTest : Spek({
                     repositories {
                         mavenCentral()
                         jcenter()
+                        mavenLocal()
                     }
 
                     detekt {

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektMultiplatformTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektMultiplatformTest.kt
@@ -263,6 +263,7 @@ private fun setupProject(projectLayoutAction: ProjectLayout.() -> Unit): DslGrad
                     mavenCentral()
                     google()
                     jcenter()
+                    mavenLocal()
                 }
             }
         """.trimIndent(),


### PR DESCRIPTION
While preparing RC3, I noticed that Gradle plugin tests are failing once you bump version, even if you have the artifact on Maven Local.

Steps to reproduce:
- Bump `buildSrc/src/main/kotlin/Versions.kt`
- Run `gradle publishToMavenLocal`
- Run `gradle build`

Tests are failing with:

```
    Caused by: org.gradle.internal.resolve.ModuleVersionNotFoundException: Could not find io.gitlab.arturbosch.detekt:detekt-cli:1.16.0-RC3.
    Searched in the following locations:
      - https://repo.maven.apache.org/maven2/io/gitlab/arturbosch/detekt/detekt-cli/1.16.0-RC3/detekt-cli-1.16.0-RC3.pom
      - https://jcenter.bintray.com/io/gitlab/arturbosch/detekt/detekt-cli/1.16.0-RC3/detekt-cli-1.16.0-RC3.pom
    Required by:
        project :

    * Get more help at https://help.gradle.org
    BUILD FAILED in 1s
```