### PR TITLE
Allow opt-out configuring detekt android and multiplatform

### DIFF
--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
     compileOnly(kotlin("gradle-plugin"))
 
     testImplementation(project(":detekt-test-utils"))
+    testImplementation(kotlin("gradle-plugin"))
     intTest(kotlin("gradle-plugin"))
     intTest(androidGradlePlugin)
 

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
@@ -29,8 +29,12 @@ class DetektPlugin : Plugin<Project> {
 
         project.registerDetektPlainTask(extension)
         project.registerDetektJvmTasks(extension)
-        project.registerDetektAndroidTasks(extension)
-        project.registerDetektMultiplatformTasks(extension)
+        if (project.findProperty(DETEKT_ANDROID_DISABLED_PROPERTY) != "true") {
+            project.registerDetektAndroidTasks(extension)
+        }
+        if (project.findProperty(DETEKT_MULTIPLATFORM_DISABLED_PROPERTY) != "true") {
+            project.registerDetektMultiplatformTasks(extension)
+        }
         project.registerGenerateConfigTask(extension)
     }
 
@@ -106,6 +110,9 @@ class DetektPlugin : Plugin<Project> {
         internal val defaultIncludes = listOf("**/*.kt", "**/*.kts")
         internal const val CONFIG_DIR_NAME = "config/detekt"
         internal const val CONFIG_FILE = "detekt.yml"
+
+        internal const val DETEKT_ANDROID_DISABLED_PROPERTY = "detekt.android.disabled"
+        internal const val DETEKT_MULTIPLATFORM_DISABLED_PROPERTY = "detekt.multiplatform.disabled"
     }
 }
 

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektMultiplatformTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektMultiplatformTest.kt
@@ -42,6 +42,35 @@ class DetektMultiplatformTest : Spek({
         }
     }
 
+    describe("multiplatform projects - detekt plain only if user opts out") {
+
+        val gradleRunner = setupProject {
+            addSubmodule("shared", 1, 1,
+                buildFileContent = """
+                    $KMM_PLUGIN_BLOCK
+                    kotlin {
+                        jvm()
+                    }
+                    $DETEKT_BLOCK
+                """.trimIndent(),
+                srcDirs = listOf("src/commonMain/kotlin", "src/commonTest/kotlin")
+            )
+        }
+        gradleRunner.writeProjectFile("gradle.properties", "detekt.multiplatform.disabled=true")
+
+        it("does not configure baseline task") {
+            gradleRunner.runTasksAndExpectFailure(":shared:detektBaselineMetadataMain") { result ->
+                assertThat(result.output).contains("Task 'detektBaselineMetadataMain' not found in project")
+            }
+        }
+
+        it("does not configure detekt task") {
+            gradleRunner.runTasksAndExpectFailure(":shared:detektMetadataMain") { result ->
+                assertThat(result.output).contains("Task 'detektMetadataMain' not found in project")
+            }
+        }
+    }
+
     describe("multiplatform projects - JVM target") {
         val gradleRunner = setupProject {
             addSubmodule("shared", 1, 1,

--- a/docs/pages/gettingstarted/type-resolution.md
+++ b/docs/pages/gettingstarted/type-resolution.md
@@ -73,7 +73,12 @@ Other than the aforementioned tasks for JVM projects, you can use the following 
 - `detekt<Variant>` - Runs detekt with type resolution on the specific build variant
 - `detektBaseline<Variant>` - Creates a detekt baselines starting from a run of Detekt with type resolution enabled on the specific build variant.
 
-Alternatively, you can create a **custom detekt task**, making sure to specify the `classpath` and `jvmTarget` properties correctly. Doing this on Android is more complicated due to build types/flavors (see [#2259](https://github.com/detekt/detekt/issues/2259) for further context). Therefore, we recommend using the `detekt<Variant>` tasks offered by the Gradle plugins.
+Alternatively, you can create a **custom detekt task**, making sure to specify the `classpath` and `jvmTarget` properties correctly.
+Doing this on Android is more complicated due to build types/flavors (see [#2259](https://github.com/detekt/detekt/issues/2259) for further context).
+Therefore, we recommend using the `detekt<Variant>` tasks offered by the Gradle plugins.
+
+In case of build related issues, you may try `detekt.android.disabled=true` in `gradle.properties` to prevent detekt
+Gradle plugins from configuring Android-specific gradle tasks.
 
 ## Enabling on Detekt CLI
 


### PR DESCRIPTION
Detekt Android can worsen the user experience in case of
- Mismatched android gradle plugin versions: #3476
- Apply script plugins: #3490

For those "experimental" gradle plugin setups, we should provide a way to allow users to opt-out to unblock users from upgrading.