### PR TITLE
Prepare Detekt 1.16.0-RC3

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -14,7 +14,7 @@ repositories {
 
 object Plugins {
     const val KOTLIN = "1.4.31"
-    const val DETEKT = "1.16.0-RC2"
+    const val DETEKT = "1.16.0-RC3"
     const val GITHUB_RELEASE = "2.2.12"
     const val SHADOW = "5.2.0"
     const val VERSIONS = "0.28.0"

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -9,6 +9,7 @@ kotlinDslPluginOptions {
 repositories {
     mavenLocal() // used to publish and test local gradle plugin changes
     gradlePluginPortal()
+    mavenCentral()
     jcenter()
 }
 

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,6 +1,6 @@
 object Versions {
 
-    const val DETEKT: String = "1.16.0-RC2"
+    const val DETEKT: String = "1.16.0-RC3"
     const val SNAPSHOT_NAME: String = "master"
     const val JVM_TARGET: String = "1.8"
     const val JACOCO: String = "0.8.6"

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -117,4 +117,4 @@ description: "Meet detekt, a static code analysis tool for Kotlin."
 url: https://detekt.github.io
 baseurl: /detekt
 
-detekt_version: 1.16.0-RC2
+detekt_version: 1.16.0-RC3

--- a/docs/pages/changelog 1.x.x.md
+++ b/docs/pages/changelog 1.x.x.md
@@ -5,7 +5,7 @@ keywords: changelog, release-notes, migration
 permalink: changelog.html
 toc: true
 ---
-#### 1.16.0 - 2021-02-19
+#### 1.16.0 - 2021-03-04
 
 ##### Notable Changes
 
@@ -13,10 +13,20 @@ toc: true
 
 ##### Changelog
 
+- Gradle Plugin tests should access also Maven Local - [#3510](https://github.com/detekt/detekt/pull/3510)
+- Update Kotlin to version 1.4.31 - [#3509](https://github.com/detekt/detekt/pull/3509)
+- Fix SARIF validation failure - [#3507](https://github.com/detekt/detekt/pull/3507)
+- Remove off importing android util - [#3506](https://github.com/detekt/detekt/pull/3506)
+- Adding support for full method signatures in ForbiddenMethodCall - [#3505](https://github.com/detekt/detekt/pull/3505)
+- New rule: disallow to cast to nullable type - [#3497](https://github.com/detekt/detekt/pull/3497)
+- Merge XML report output - [#3491](https://github.com/detekt/detekt/pull/3491)
+- Allow using regular expressions when defining license header templates - [#3486](https://github.com/detekt/detekt/pull/3486)
 - Add UnreachableCatchBlock rule - [#3478](https://github.com/detekt/detekt/pull/3478)
+- Add NoNameShadowing rule - [#3477](https://github.com/detekt/detekt/pull/3477)
 - Fix false negative "UselessCallOnNotNull" with `list.isNullOrEmpty()` - [#3475](https://github.com/detekt/detekt/pull/3475)
 - Add UseOrEmpty rule - [#3470](https://github.com/detekt/detekt/pull/3470)
 - Add UseIsNullOrEmpty rule - [#3469](https://github.com/detekt/detekt/pull/3469)
+- Add support to Kotlin Multiplatform Projects - [#3453](https://github.com/detekt/detekt/pull/3453)
 - Fix false positives for MultilineLambdaItParameter.kt - [#3451](https://github.com/detekt/detekt/pull/3451)
 - Dont generate baseline if empty - [#3450](https://github.com/detekt/detekt/pull/3450)
 - Silence IndexOutOfBoundsException in getLineAndColumnInPsiFile() - [#3446](https://github.com/detekt/detekt/pull/3446)
@@ -77,6 +87,13 @@ toc: true
 
 ##### Housekeeping & Refactorings
 
+- Move gradle testkit test back to test/ - [#3504](https://github.com/detekt/detekt/pull/3504)
+- Add documentation on suppressing formatting rules - [#3503](https://github.com/detekt/detekt/pull/3503)
+- Change DetektMultiplatform from unit test to gradle testkit integrati… - [#3500](https://github.com/detekt/detekt/pull/3500)
+- Bump com.gradle.plugin-publish from 0.12.0 to 0.13.0 - [#3494](https://github.com/detekt/detekt/pull/3494)
+- Refactor Gradle integration tests - [#3489](https://github.com/detekt/detekt/pull/3489)
+- Refactor gradle integration test - [#3487](https://github.com/detekt/detekt/pull/3487)
+- Prepare Detekt 1.16.0-RC2 - [#3485](https://github.com/detekt/detekt/pull/3485)
 - Bump mockk from 1.10.5 to 1.10.6 - [#3473](https://github.com/detekt/detekt/pull/3473)
 - Upgrade to Gradle 6.8.2 - [#3468](https://github.com/detekt/detekt/pull/3468)
 - Correct `maxIssues` documentation - [#3456](https://github.com/detekt/detekt/pull/3456)


### PR DESCRIPTION
Giving another try before releasing `1.16.0`.
We had to do a couple of fine tuning before crafting a fully stable release.
