### PR TITLE
Fix not being able to override `insertFinalNewLine`

### DIFF
--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/FinalNewline.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/FinalNewline.kt
@@ -34,4 +34,4 @@ class FinalNewline(config: Config) : FormattingRule(config) {
     )
 }
 
-const val INSERT_FINAL_NEWLINE = "insertFinalNewline"
+const val INSERT_FINAL_NEWLINE = "insertFinalNewLine"


### PR DESCRIPTION
This fixes the type in the constant to match `@configuration`

Resolve #3513