### PR TITLE
Revert Update Kotlin to version 1.4.31

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -14,7 +14,7 @@ repositories {
 }
 
 object Plugins {
-    const val KOTLIN = "1.4.31"
+    const val KOTLIN = "1.4.21"
     const val DETEKT = "1.16.0-RC3"
     const val GITHUB_RELEASE = "2.2.12"
     const val SHADOW = "5.2.0"


### PR DESCRIPTION
The bump to Kotlin v1.4.31 caused problems with race conditions described in #3509 

The problem seems to be related with:
https://youtrack.jetbrains.com/issue/IDEA-261782

As a more general solution, Kotlin 1.4.32 should fix this:
https://youtrack.jetbrains.com/issue/KT-45007
