### PR TITLE
Swallow exception fixes

### DIFF
--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedException.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedException.kt
@@ -78,12 +78,6 @@ class SwallowedException(config: Config = Config.empty) : Rule(config) {
         "The caught exception is swallowed. The original exception could be lost.",
         Debt.TWENTY_MINS)
 
-    private val defaultIgnoredExceptions = listOf(
-            "NumberFormatException",
-            "InterruptedException",
-            "ParseException",
-            "MalformedURLException"
-    )
     private val ignoredExceptionTypes = valueOrDefaultCommaSeparated(IGNORED_EXCEPTION_TYPES, defaultIgnoredExceptions)
             .map { it.removePrefix("*").removeSuffix("*") }
 
@@ -166,5 +160,12 @@ class SwallowedException(config: Config = Config.empty) : Rule(config) {
     companion object {
         const val IGNORED_EXCEPTION_TYPES = "ignoredExceptionTypes"
         const val ALLOWED_EXCEPTION_NAME_REGEX = "allowedExceptionNameRegex"
+
+        internal val defaultIgnoredExceptions = listOf(
+            "NumberFormatException",
+            "InterruptedException",
+            "ParseException",
+            "MalformedURLException"
+        )
     }
 }

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedException.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedException.kt
@@ -98,7 +98,9 @@ class SwallowedException(config: Config = Config.empty) : Rule(config) {
     private fun isExceptionUnused(catchClause: KtCatchClause): Boolean {
         val parameterName = catchClause.catchParameter?.name
         val catchBody = catchClause.catchBody ?: return true
-        return !catchBody.anyDescendantOfType<KtNameReferenceExpression> { it.text == parameterName }
+        return !catchBody.anyDescendantOfType<KtNameReferenceExpression> {
+            it.text in ignoredExceptionTypes || it.text == parameterName
+        }
     }
 
     private fun isExceptionSwallowed(catchClause: KtCatchClause): Boolean {

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedExceptionSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedExceptionSpec.kt
@@ -5,8 +5,6 @@ import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
-import java.net.MalformedURLException
-import java.text.ParseException
 
 class SwallowedExceptionSpec : Spek({
     val subject by memoized { SwallowedException() }
@@ -207,12 +205,7 @@ class SwallowedExceptionSpec : Spek({
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
-        listOf(
-            InterruptedException::class.java.simpleName,
-            MalformedURLException::class.java.simpleName,
-            NumberFormatException::class.java.simpleName,
-            ParseException::class.java.simpleName
-        ).forEach { exceptionName ->
+        SwallowedException.defaultIgnoredExceptions.forEach { exceptionName ->
             it("ignores $exceptionName by default") {
                 val code = """
                 import java.net.MalformedURLException

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedExceptionSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedExceptionSpec.kt
@@ -206,7 +206,7 @@ class SwallowedExceptionSpec : Spek({
         }
 
         SwallowedException.defaultIgnoredExceptions.forEach { exceptionName ->
-            it("ignores $exceptionName by default") {
+            it("ignores $exceptionName in the catch clause by default") {
                 val code = """
                 import java.net.MalformedURLException
                 import java.text.ParseException
@@ -215,6 +215,27 @@ class SwallowedExceptionSpec : Spek({
                     try {
                     } catch (e: $exceptionName) {
                         throw Exception()
+                    }
+                }
+            """
+                assertThat(subject.compileAndLint(code)).isEmpty()
+            }
+
+            it("ignores $exceptionName in the catch body by default") {
+                val exceptionInstantiation = if (exceptionName == "ParseException") {
+                    "$exceptionName(\"\", 0)"
+                } else {
+                    "$exceptionName(\"\")"
+                }
+
+                val code = """
+                import java.net.MalformedURLException
+                import java.text.ParseException
+
+                fun f() {
+                    try {
+                    } catch (e: Exception) {
+                        throw $exceptionInstantiation
                     }
                 }
             """


### PR DESCRIPTION
What all by default ignored exceptions have in common is that none of
their constructors allows to pass an exception as the cause. Thus, it
does not make sense to complain when these are used in the catch body to
replace the original exception.
    
Fixes #3524.