### PR TITLE
Markdown: Reintroduce double-backticks for inline code rendering

### DIFF
--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/out/Markdown.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/out/Markdown.kt
@@ -39,7 +39,9 @@ inline fun MarkdownContent.orderedList(sectionList: () -> List<String>) {
     }
 }
 
-inline fun MarkdownContent.code(code: () -> String) = "`${code()}`"
+// Note: Use double-backticks here to be able to render code that itself contains backticks.
+inline fun MarkdownContent.code(code: () -> String) = "``${code()}``"
+
 inline fun MarkdownContent.codeBlock(syntax: String = "kotlin", code: () -> String) = "```$syntax\n${code()}\n```"
 
 fun MarkdownContent.emptyLine() = append("")

--- a/detekt-generator/src/test/resources/RuleSet.md
+++ b/detekt-generator/src/test/resources/RuleSet.md
@@ -12,11 +12,11 @@ a wildcard import
 
 #### Configuration options:
 
-* `conf1` (default: `foo`)
+* ``conf1`` (default: ``foo``)
 
    a config option
 
-* ~~`conf2`~~ (default: `false`)
+* ~~``conf2``~~ (default: ``false``)
 
    **Deprecated**: use conf1 instead
 


### PR DESCRIPTION
This partly reverts 9cf9f08 and add a code comment to explain why the
double-backticks were in fact intended, also see

https://github.com/detekt/detekt/issues/3523#issuecomment-793532727