### PR TITLE
Update rule doc for SwallowedException config

### DIFF
--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedException.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedException.kt
@@ -28,6 +28,11 @@ import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
  * Exceptions should not be swallowed. This rule reports all instances where exceptions are `caught` and not correctly
  * passed (e.g. as a cause) into a newly thrown exception.
  *
+ * The exception types configured in `ignoredExceptionTypes` indicate nonexceptional outcomes.
+ * These by default configured exception types are part of Java.
+ * Therefore, Kotlin developers have to handle them by using the catch clause.
+ * For that reason, this rule ignores that these configured exception types are caught.
+ *
  * <noncompliant>
  * fun foo() {
  *     try {


### PR DESCRIPTION
This update explains the reason behind the config defaults.

Related to #3524
