### PR TITLE
Adds a ForbiddenSingleExpressionSyntax rule

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -584,6 +584,8 @@ style:
     active: true
     excludes: ['**']
     ignorePackages: ['*.internal', '*.internal.*']
+  ForbiddenSingleExpressionFunction:
+    active: false
   ForbiddenVoid:
     active: false
     ignoreOverridden: false

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenSingleExpressionFunction.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenSingleExpressionFunction.kt
@@ -1,0 +1,78 @@
+package io.gitlab.arturbosch.detekt.rules.style
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.resolve.BindingContext
+import org.jetbrains.kotlin.resolve.calls.callUtil.getType
+import org.jetbrains.kotlin.types.typeUtil.isUnit
+import org.jetbrains.kotlin.types.typeUtil.makeNotNullable
+
+/**
+ * This rule detects single-expression functions with an inferred return type of `Unit` or `Unit?`.
+ * The single-expression functions allows for very concise function declarations but should be avoided
+ * for functions that only have side effects without returning anything meaningful because that fact may
+ * not immediately be clear to the reader.
+ *
+ * <noncompliant>
+ * fun printSomething() = println("something")
+ *
+ * fun maybePrintSomething(param: String?) = param?.let { println("something") }
+ * </noncompliant>
+ *
+ * <compliant>
+ * fun printSomething() {
+ *     println("something")
+ * }
+ *
+ * fun maybePrintSomething(param: String?) {
+ *     param?.let { println("something") }
+ * }
+ * </compliant>
+ *
+ * @requiresTypeResolution
+ */
+class ForbiddenSingleExpressionFunction(config: Config = Config.empty) : Rule(config) {
+    override val issue: Issue = Issue(
+        "ForbiddenSingleExpressionFunction",
+        Severity.Style,
+        "Avoid using single-expression syntax for functions that return `Unit` or `Unit?`.",
+        Debt.FIVE_MINS
+    )
+
+    override fun visitNamedFunction(function: KtNamedFunction) {
+
+        if (isBindingContextMissing()) return
+        if (function.hasBlockBody()) return
+        if (function.hasDeclaredReturnType()) return
+        if (function.bodyExpressionIsUnit()) return
+
+        function.bodyExpression
+            ?.getType(bindingContext)
+            ?.takeIf { it.makeNotNullable().isUnit() }
+            ?.also {
+                report(
+                    CodeSmell(
+                        issue = issue,
+                        entity = Entity.from(function),
+                        message = "Single expression syntax should be avoided " +
+                            "when the inferred return type is 'Unit' or 'Unit?'"
+                    )
+                )
+            }
+    }
+
+    private fun KtNamedFunction.bodyExpressionIsUnit() =
+        bodyExpression?.text == UNIT
+
+    private fun isBindingContextMissing() = bindingContext == BindingContext.EMPTY
+
+    companion object {
+        private const val UNIT = "Unit"
+    }
+}

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/StyleGuideProvider.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/StyleGuideProvider.kt
@@ -90,7 +90,8 @@ class StyleGuideProvider : DefaultRuleSetProvider {
             UseIfEmptyOrIfBlank(config),
             MultilineLambdaItParameter(config),
             UseIsNullOrEmpty(config),
-            UseOrEmpty(config)
+            UseOrEmpty(config),
+            ForbiddenSingleExpressionFunction(config),
         )
     )
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenSingleExpressionFunctionSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenSingleExpressionFunctionSpec.kt
@@ -1,0 +1,67 @@
+package io.gitlab.arturbosch.detekt.rules.style
+
+import io.gitlab.arturbosch.detekt.rules.setupKotlinEnvironment
+import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+object ForbiddenSingleExpressionFunctionSpec : Spek({
+    setupKotlinEnvironment()
+
+    val env: KotlinCoreEnvironment by memoized()
+    val subject by memoized { ForbiddenSingleExpressionFunction() }
+
+    describe("ForbiddenSingleExpressionFunction rule") {
+
+        it("flags a function using single expression syntax with inferred return type Unit") {
+            val code = """fun test() = println("something")"""
+            val findings = subject.compileAndLintWithContext(env, code)
+
+            assertThat(findings).hasSize(1)
+        }
+
+        it("flags a function using single expression syntax with inferred return type Unit?") {
+            val code = """fun test(param: String?) = param?.let { println("something") }"""
+            val findings = subject.compileAndLintWithContext(env, code)
+
+            assertThat(findings).hasSize(1)
+        }
+
+        it("does not flag a function using single expression syntax with inferred return type String") {
+            val code = """fun test() = "something" + "else""""
+            val findings = subject.compileAndLintWithContext(env, code)
+
+            assertThat(findings).isEmpty()
+        }
+
+        it("does not flag a function using single expression syntax with the return type Unit specified") {
+            val code = """fun test(): Unit = println("something")"""
+            val findings = subject.compileAndLintWithContext(env, code)
+
+            assertThat(findings).isEmpty()
+        }
+
+        it("does not flag a function using single expression syntax with the return type Unit? specified") {
+            val code = """fun test(param: String?): Unit? = param?.let { println("something") }"""
+            val findings = subject.compileAndLintWithContext(env, code)
+
+            assertThat(findings).isEmpty()
+        }
+
+        it("does not flag a function using single expression syntax returning the Unit object") {
+            val code = """fun test() = Unit"""
+            val findings = subject.compileAndLintWithContext(env, code)
+
+            assertThat(findings).isEmpty()
+        }
+
+        it("does not flag a function with an empty body") {
+            val code = """fun test() { }"""
+            val findings = subject.compileAndLintWithContext(env, code)
+
+            assertThat(findings).isEmpty()
+        }
+    }
+})


### PR DESCRIPTION
closes #1675 

While trying to find a reference for the rule documentation, I realized that there does not seem to be agreement about this in the community. I guess this will never become a rule that is turned on be default. 

While I personally like the rule, I am wondering if detekt should even be so opinionated about things that are not part of the official coding conventions or guidelines.

And then I may have formatting issues (again). Opening any other rule class causes the ktlint plugin to report an error such as `Unexpected indentation (20) (should be 12) (indent)`. Any help will be greatly appreciated.