### PR TITLE
New Rule: DoubleMutabilityForCollection

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -482,6 +482,8 @@ potential-bugs:
     active: false
   DontDowncastCollectionTypes:
     active: false
+  DoubleMutabilityForCollection:
+    active: false
   DuplicateCaseInWhenExpression:
     active: true
   EqualsAlwaysReturnsTrueOrFalse:

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DoubleMutabilityForCollection.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DoubleMutabilityForCollection.kt
@@ -1,0 +1,79 @@
+package io.gitlab.arturbosch.detekt.rules.bugs
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import org.jetbrains.kotlin.descriptors.VariableDescriptor
+import org.jetbrains.kotlin.js.descriptorUtils.getJetTypeFqName
+import org.jetbrains.kotlin.psi.KtProperty
+import org.jetbrains.kotlin.resolve.BindingContext
+
+/**
+ * Using `var` when declaring a mutable collection leads to double mutability. Consider instead
+ * declaring your variable with `val` or switching your declaration to use an immutable type.
+ *
+ * <noncompliant>
+ * var myList = mutableListOf(1,2,3)
+ * var mySet = mutableSetOf(1,2,3)
+ * var myMap = mutableMapOf("answer" to 42)
+ * </noncompliant>
+ *
+ * <compliant>
+ * // Use val
+ * val myList = mutableListOf(1,2,3)
+ * val mySet = mutableSetOf(1,2,3)
+ * val myMap = mutableMapOf("answer" to 42)
+ *
+ * // Use immutable types
+ * var myList = listOf(1,2,3)
+ * var mySet = setOf(1,2,3)
+ * var myMap = mapOf("answer" to 42)
+ * </compliant>
+ *
+ * @requiresTypeResolution
+ */
+class DoubleMutabilityForCollection(config: Config = Config.empty) : Rule(config) {
+
+    override val issue: Issue = Issue(
+        "DoubleMutabilityInCollection",
+        Severity.CodeSmell,
+        "Using var with mutable collections leads to double mutability. " +
+                "Consider using val or immutable collection types.",
+        Debt.FIVE_MINS
+    )
+
+    override fun visitProperty(property: KtProperty) {
+        super.visitProperty(property)
+
+        if (bindingContext == BindingContext.EMPTY) return
+
+        val type =
+            (bindingContext[BindingContext.DECLARATION_TO_DESCRIPTOR, property] as? VariableDescriptor)?.type ?: return
+        val standardType = type.getJetTypeFqName(false)
+        if (property.isVar && standardType in mutableTypes) {
+            report(CodeSmell(
+                issue,
+                Entity.from(property),
+                "Property ${property.name} is declared as `var` with a mutable type $standardType. " +
+                        "Consider using `val` or an immutable collection type"
+            ))
+        }
+    }
+
+    companion object {
+        val mutableTypes = setOf(
+            "kotlin.collections.MutableList",
+            "kotlin.collections.MutableMap",
+            "kotlin.collections.MutableSet",
+            "java.util.ArrayList",
+            "java.util.LinkedHashSet",
+            "java.util.HashSet",
+            "java.util.LinkedHashMap",
+            "java.util.HashMap",
+        )
+    }
+}

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DoubleMutabilityForCollection.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DoubleMutabilityForCollection.kt
@@ -58,7 +58,7 @@ class DoubleMutabilityForCollection(config: Config = Config.empty) : Rule(config
             report(CodeSmell(
                 issue,
                 Entity.from(property),
-                "Property ${property.name} is declared as `var` with a mutable type $standardType. " +
+                "Variable ${property.name} is declared as `var` with a mutable type $standardType. " +
                         "Consider using `val` or an immutable collection type"
             ))
         }

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/PotentialBugProvider.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/PotentialBugProvider.kt
@@ -18,6 +18,7 @@ class PotentialBugProvider : DefaultRuleSetProvider {
         listOf(
             Deprecation(config),
             DontDowncastCollectionTypes(config),
+            DoubleMutabilityForCollection(config),
             DuplicateCaseInWhenExpression(config),
             EqualsAlwaysReturnsTrueOrFalse(config),
             EqualsWithHashCodeExist(config),

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DoubleMutabilityInCollectionSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DoubleMutabilityInCollectionSpec.kt
@@ -1,0 +1,226 @@
+package io.gitlab.arturbosch.detekt.rules.bugs
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.rules.setupKotlinEnvironment
+import io.gitlab.arturbosch.detekt.test.assertThat
+import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+class DoubleMutabilityInCollectionSpec : Spek({
+    setupKotlinEnvironment()
+
+    val env: KotlinCoreEnvironment by memoized()
+    val subject by memoized { DoubleMutabilityForCollection(Config.empty) }
+
+    describe("DoubleMutabilityInCollection rule") {
+
+        describe("valid cases") {
+
+            it("detects var declaration with mutable list") {
+                val code = """
+                fun main() {
+                    var myList = mutableListOf(1,2,3)
+                }
+                """
+                val result = subject.compileAndLintWithContext(env, code)
+                assertThat(result).hasSize(1)
+                assertThat(result).hasSourceLocation(2, 5)
+            }
+
+            it("detects var declaration with mutable set") {
+                val code = """
+                fun main() {
+                    var mySet = mutableSetOf(1,2,3)
+                }
+                """
+                val result = subject.compileAndLintWithContext(env, code)
+                assertThat(result).hasSize(1)
+                assertThat(result).hasSourceLocation(2, 5)
+            }
+
+            it("detects var declaration with mutable map") {
+                val code = """
+                fun main() {
+                    var myMap = mutableMapOf("answer" to 42)
+                }
+                """
+                val result = subject.compileAndLintWithContext(env, code)
+                assertThat(result).hasSize(1)
+                assertThat(result).hasSourceLocation(2, 5)
+            }
+
+            it("detects var declaration with ArrayList") {
+                val code = """
+                fun main() {
+                    var myArrayList = ArrayList<Int>()
+                }
+                """
+                val result = subject.compileAndLintWithContext(env, code)
+                assertThat(result).hasSize(1)
+                assertThat(result).hasSourceLocation(2, 5)
+            }
+
+            it("detects var declaration with LinkedHashSet") {
+                val code = """
+                fun main() {
+                    var myLinkedHashSet = LinkedHashSet<Int>()
+                }
+                """
+                val result = subject.compileAndLintWithContext(env, code)
+                assertThat(result).hasSize(1)
+                assertThat(result).hasSourceLocation(2, 5)
+            }
+
+            it("detects var declaration with HashSet") {
+                val code = """
+                fun main() {
+                    var myHashSet = HashSet<Int>()
+                }
+                """
+                val result = subject.compileAndLintWithContext(env, code)
+                assertThat(result).hasSize(1)
+                assertThat(result).hasSourceLocation(2, 5)
+            }
+
+            it("detects var declaration with LinkedHashMap") {
+                val code = """
+                fun main() {
+                    var myLinkedHashMap = LinkedHashMap<String, Int>()
+                }
+                """
+                val result = subject.compileAndLintWithContext(env, code)
+                assertThat(result).hasSize(1)
+                assertThat(result).hasSourceLocation(2, 5)
+            }
+
+            it("detects var declaration with HashMap") {
+                val code = """
+                fun main() {
+                    var myHashMap = HashMap<String, Int>()
+                }
+                """
+                val result = subject.compileAndLintWithContext(env, code)
+                assertThat(result).hasSize(1)
+                assertThat(result).hasSourceLocation(2, 5)
+            }
+        }
+
+        describe("ignores declaration with val") {
+
+            it("does not detect val declaration with mutable list") {
+                val code = """
+                fun main() {
+                    val myList = mutableListOf(1,2,3)
+                }
+                """
+                val result = subject.compileAndLintWithContext(env, code)
+                assertThat(result).isEmpty()
+            }
+
+            it("does not detect val declaration with mutable set") {
+                val code = """
+                fun main() {
+                    val mySet = mutableSetOf(1,2,3)
+                }
+                """
+                val result = subject.compileAndLintWithContext(env, code)
+                assertThat(result).isEmpty()
+            }
+
+            it("does not detect val declaration with mutable map") {
+                val code = """
+                fun main() {
+                    val myMap = mutableMapOf("answer" to 42)
+                }
+                """
+                val result = subject.compileAndLintWithContext(env, code)
+                assertThat(result).isEmpty()
+            }
+
+            it("does not detect val declaration with ArrayList") {
+                val code = """
+                fun main() {
+                    val myArrayList = ArrayList<Int>()
+                }
+                """
+                val result = subject.compileAndLintWithContext(env, code)
+                assertThat(result).isEmpty()
+            }
+
+            it("does not detect val declaration with LinkedHashSet") {
+                val code = """
+                fun main() {
+                    val myLinkedHashSet = LinkedHashSet<Int>()
+                }
+                """
+                val result = subject.compileAndLintWithContext(env, code)
+                assertThat(result).isEmpty()
+            }
+
+            it("does not detect val declaration with HashSet") {
+                val code = """
+                fun main() {
+                    val myHashSet = HashSet<Int>()
+                }
+                """
+                val result = subject.compileAndLintWithContext(env, code)
+                assertThat(result).isEmpty()
+            }
+
+            it("does not detect val declaration with LinkedHashMap") {
+                val code = """
+                fun main() {
+                    val myLinkedHashMap = LinkedHashMap<String, Int>()
+                }
+                """
+                val result = subject.compileAndLintWithContext(env, code)
+                assertThat(result).isEmpty()
+            }
+
+            it("does not detect val declaration with HashMap") {
+                val code = """
+                fun main() {
+                    val myHashMap = HashMap<String, Int>()
+                }
+                """
+                val result = subject.compileAndLintWithContext(env, code)
+                assertThat(result).isEmpty()
+            }
+        }
+
+        describe("ignores declaration with var and immutable types") {
+
+            it("does not detect var declaration with immutable list") {
+                val code = """
+                fun main() {
+                    val myList = listOf(1,2,3)
+                }
+                """
+                val result = subject.compileAndLintWithContext(env, code)
+                assertThat(result).isEmpty()
+            }
+
+            it("does not detect var declaration with immutable set") {
+                val code = """
+                fun main() {
+                    val mySet = setOf(1,2,3)
+                }
+                """
+                val result = subject.compileAndLintWithContext(env, code)
+                assertThat(result).isEmpty()
+            }
+
+            it("does not detect var declaration with immutable map") {
+                val code = """
+                fun main() {
+                    val myMap = mapOf("answer" to 42)
+                }
+                """
+                val result = subject.compileAndLintWithContext(env, code)
+                assertThat(result).isEmpty()
+            }
+        }
+    }
+})

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DoubleMutabilityInCollectionSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DoubleMutabilityInCollectionSpec.kt
@@ -16,210 +16,595 @@ class DoubleMutabilityInCollectionSpec : Spek({
 
     describe("DoubleMutabilityInCollection rule") {
 
-        describe("valid cases") {
+        describe("local variables") {
 
-            it("detects var declaration with mutable list") {
-                val code = """
-                fun main() {
+            describe("valid cases") {
+
+                it("detects var declaration with mutable list") {
+                    val code = """
+                    fun main() {
+                        var myList = mutableListOf(1,2,3)
+                    }
+                    """
+                    val result = subject.compileAndLintWithContext(env, code)
+                    assertThat(result).hasSize(1)
+                    assertThat(result).hasSourceLocation(2, 5)
+                }
+
+                it("detects var declaration with mutable set") {
+                    val code = """
+                    fun main() {
+                        var mySet = mutableSetOf(1,2,3)
+                    }
+                    """
+                    val result = subject.compileAndLintWithContext(env, code)
+                    assertThat(result).hasSize(1)
+                    assertThat(result).hasSourceLocation(2, 5)
+                }
+
+                it("detects var declaration with mutable map") {
+                    val code = """
+                    fun main() {
+                        var myMap = mutableMapOf("answer" to 42)
+                    }
+                    """
+                    val result = subject.compileAndLintWithContext(env, code)
+                    assertThat(result).hasSize(1)
+                    assertThat(result).hasSourceLocation(2, 5)
+                }
+
+                it("detects var declaration with ArrayList") {
+                    val code = """
+                    fun main() {
+                        var myArrayList = ArrayList<Int>()
+                    }
+                    """
+                    val result = subject.compileAndLintWithContext(env, code)
+                    assertThat(result).hasSize(1)
+                    assertThat(result).hasSourceLocation(2, 5)
+                }
+
+                it("detects var declaration with LinkedHashSet") {
+                    val code = """
+                    fun main() {
+                        var myLinkedHashSet = LinkedHashSet<Int>()
+                    }
+                    """
+                    val result = subject.compileAndLintWithContext(env, code)
+                    assertThat(result).hasSize(1)
+                    assertThat(result).hasSourceLocation(2, 5)
+                }
+
+                it("detects var declaration with HashSet") {
+                    val code = """
+                    fun main() {
+                        var myHashSet = HashSet<Int>()
+                    }
+                    """
+                    val result = subject.compileAndLintWithContext(env, code)
+                    assertThat(result).hasSize(1)
+                    assertThat(result).hasSourceLocation(2, 5)
+                }
+
+                it("detects var declaration with LinkedHashMap") {
+                    val code = """
+                    fun main() {
+                        var myLinkedHashMap = LinkedHashMap<String, Int>()
+                    }
+                    """
+                    val result = subject.compileAndLintWithContext(env, code)
+                    assertThat(result).hasSize(1)
+                    assertThat(result).hasSourceLocation(2, 5)
+                }
+
+                it("detects var declaration with HashMap") {
+                    val code = """
+                    fun main() {
+                        var myHashMap = HashMap<String, Int>()
+                    }
+                    """
+                    val result = subject.compileAndLintWithContext(env, code)
+                    assertThat(result).hasSize(1)
+                    assertThat(result).hasSourceLocation(2, 5)
+                }
+            }
+
+            describe("ignores declaration with val") {
+
+                it("does not detect val declaration with mutable list") {
+                    val code = """
+                    fun main() {
+                        val myList = mutableListOf(1,2,3)
+                    }
+                    """
+                    val result = subject.compileAndLintWithContext(env, code)
+                    assertThat(result).isEmpty()
+                }
+
+                it("does not detect val declaration with mutable set") {
+                    val code = """
+                    fun main() {
+                        val mySet = mutableSetOf(1,2,3)
+                    }
+                    """
+                    val result = subject.compileAndLintWithContext(env, code)
+                    assertThat(result).isEmpty()
+                }
+
+                it("does not detect val declaration with mutable map") {
+                    val code = """
+                    fun main() {
+                        val myMap = mutableMapOf("answer" to 42)
+                    }
+                    """
+                    val result = subject.compileAndLintWithContext(env, code)
+                    assertThat(result).isEmpty()
+                }
+
+                it("does not detect val declaration with ArrayList") {
+                    val code = """
+                    fun main() {
+                        val myArrayList = ArrayList<Int>()
+                    }
+                    """
+                    val result = subject.compileAndLintWithContext(env, code)
+                    assertThat(result).isEmpty()
+                }
+
+                it("does not detect val declaration with LinkedHashSet") {
+                    val code = """
+                    fun main() {
+                        val myLinkedHashSet = LinkedHashSet<Int>()
+                    }
+                    """
+                    val result = subject.compileAndLintWithContext(env, code)
+                    assertThat(result).isEmpty()
+                }
+
+                it("does not detect val declaration with HashSet") {
+                    val code = """
+                    fun main() {
+                        val myHashSet = HashSet<Int>()
+                    }
+                    """
+                    val result = subject.compileAndLintWithContext(env, code)
+                    assertThat(result).isEmpty()
+                }
+
+                it("does not detect val declaration with LinkedHashMap") {
+                    val code = """
+                    fun main() {
+                        val myLinkedHashMap = LinkedHashMap<String, Int>()
+                    }
+                    """
+                    val result = subject.compileAndLintWithContext(env, code)
+                    assertThat(result).isEmpty()
+                }
+
+                it("does not detect val declaration with HashMap") {
+                    val code = """
+                    fun main() {
+                        val myHashMap = HashMap<String, Int>()
+                    }
+                    """
+                    val result = subject.compileAndLintWithContext(env, code)
+                    assertThat(result).isEmpty()
+                }
+            }
+
+            describe("ignores declaration with var and immutable types") {
+
+                it("does not detect var declaration with immutable list") {
+                    val code = """
+                    fun main() {
+                        val myList = listOf(1,2,3)
+                    }
+                    """
+                    val result = subject.compileAndLintWithContext(env, code)
+                    assertThat(result).isEmpty()
+                }
+
+                it("does not detect var declaration with immutable set") {
+                    val code = """
+                    fun main() {
+                        val mySet = setOf(1,2,3)
+                    }
+                    """
+                    val result = subject.compileAndLintWithContext(env, code)
+                    assertThat(result).isEmpty()
+                }
+
+                it("does not detect var declaration with immutable map") {
+                    val code = """
+                    fun main() {
+                        val myMap = mapOf("answer" to 42)
+                    }
+                    """
+                    val result = subject.compileAndLintWithContext(env, code)
+                    assertThat(result).isEmpty()
+                }
+            }
+        }
+
+        describe("top level variables") {
+
+            describe("valid cases") {
+
+                it("detects var declaration with mutable list") {
+                    val code = """
                     var myList = mutableListOf(1,2,3)
+                    """
+                    val result = subject.compileAndLintWithContext(env, code)
+                    assertThat(result).hasSize(1)
+                    assertThat(result).hasSourceLocation(1, 1)
                 }
-                """
-                val result = subject.compileAndLintWithContext(env, code)
-                assertThat(result).hasSize(1)
-                assertThat(result).hasSourceLocation(2, 5)
-            }
 
-            it("detects var declaration with mutable set") {
-                val code = """
-                fun main() {
+                it("detects var declaration with mutable set") {
+                    val code = """
                     var mySet = mutableSetOf(1,2,3)
+                    """
+                    val result = subject.compileAndLintWithContext(env, code)
+                    assertThat(result).hasSize(1)
+                    assertThat(result).hasSourceLocation(1, 1)
                 }
-                """
-                val result = subject.compileAndLintWithContext(env, code)
-                assertThat(result).hasSize(1)
-                assertThat(result).hasSourceLocation(2, 5)
-            }
 
-            it("detects var declaration with mutable map") {
-                val code = """
-                fun main() {
+                it("detects var declaration with mutable map") {
+                    val code = """
                     var myMap = mutableMapOf("answer" to 42)
+                    """
+                    val result = subject.compileAndLintWithContext(env, code)
+                    assertThat(result).hasSize(1)
+                    assertThat(result).hasSourceLocation(1, 1)
                 }
-                """
-                val result = subject.compileAndLintWithContext(env, code)
-                assertThat(result).hasSize(1)
-                assertThat(result).hasSourceLocation(2, 5)
-            }
 
-            it("detects var declaration with ArrayList") {
-                val code = """
-                fun main() {
+                it("detects var declaration with ArrayList") {
+                    val code = """
                     var myArrayList = ArrayList<Int>()
+                    """
+                    val result = subject.compileAndLintWithContext(env, code)
+                    assertThat(result).hasSize(1)
+                    assertThat(result).hasSourceLocation(1, 1)
                 }
-                """
-                val result = subject.compileAndLintWithContext(env, code)
-                assertThat(result).hasSize(1)
-                assertThat(result).hasSourceLocation(2, 5)
-            }
 
-            it("detects var declaration with LinkedHashSet") {
-                val code = """
-                fun main() {
+                it("detects var declaration with LinkedHashSet") {
+                    val code = """
                     var myLinkedHashSet = LinkedHashSet<Int>()
+                    """
+                    val result = subject.compileAndLintWithContext(env, code)
+                    assertThat(result).hasSize(1)
+                    assertThat(result).hasSourceLocation(1, 1)
                 }
-                """
-                val result = subject.compileAndLintWithContext(env, code)
-                assertThat(result).hasSize(1)
-                assertThat(result).hasSourceLocation(2, 5)
-            }
 
-            it("detects var declaration with HashSet") {
-                val code = """
-                fun main() {
+                it("detects var declaration with HashSet") {
+                    val code = """
                     var myHashSet = HashSet<Int>()
+                    """
+                    val result = subject.compileAndLintWithContext(env, code)
+                    assertThat(result).hasSize(1)
+                    assertThat(result).hasSourceLocation(1, 1)
                 }
-                """
-                val result = subject.compileAndLintWithContext(env, code)
-                assertThat(result).hasSize(1)
-                assertThat(result).hasSourceLocation(2, 5)
-            }
 
-            it("detects var declaration with LinkedHashMap") {
-                val code = """
-                fun main() {
+                it("detects var declaration with LinkedHashMap") {
+                    val code = """
                     var myLinkedHashMap = LinkedHashMap<String, Int>()
+                    """
+                    val result = subject.compileAndLintWithContext(env, code)
+                    assertThat(result).hasSize(1)
+                    assertThat(result).hasSourceLocation(1, 1)
                 }
-                """
-                val result = subject.compileAndLintWithContext(env, code)
-                assertThat(result).hasSize(1)
-                assertThat(result).hasSourceLocation(2, 5)
-            }
 
-            it("detects var declaration with HashMap") {
-                val code = """
-                fun main() {
+                it("detects var declaration with HashMap") {
+                    val code = """
                     var myHashMap = HashMap<String, Int>()
+                    """
+                    val result = subject.compileAndLintWithContext(env, code)
+                    assertThat(result).hasSize(1)
+                    assertThat(result).hasSourceLocation(1, 1)
                 }
-                """
-                val result = subject.compileAndLintWithContext(env, code)
-                assertThat(result).hasSize(1)
-                assertThat(result).hasSourceLocation(2, 5)
             }
-        }
 
-        describe("ignores declaration with val") {
+            describe("ignores declaration with val") {
 
-            it("does not detect val declaration with mutable list") {
-                val code = """
-                fun main() {
+                it("does not detect val declaration with mutable list") {
+                    val code = """
                     val myList = mutableListOf(1,2,3)
+                    """
+                    val result = subject.compileAndLintWithContext(env, code)
+                    assertThat(result).isEmpty()
                 }
-                """
-                val result = subject.compileAndLintWithContext(env, code)
-                assertThat(result).isEmpty()
-            }
 
-            it("does not detect val declaration with mutable set") {
-                val code = """
-                fun main() {
+                it("does not detect val declaration with mutable set") {
+                    val code = """
                     val mySet = mutableSetOf(1,2,3)
+                    """
+                    val result = subject.compileAndLintWithContext(env, code)
+                    assertThat(result).isEmpty()
                 }
-                """
-                val result = subject.compileAndLintWithContext(env, code)
-                assertThat(result).isEmpty()
-            }
 
-            it("does not detect val declaration with mutable map") {
-                val code = """
-                fun main() {
+                it("does not detect val declaration with mutable map") {
+                    val code = """
                     val myMap = mutableMapOf("answer" to 42)
+                    """
+                    val result = subject.compileAndLintWithContext(env, code)
+                    assertThat(result).isEmpty()
                 }
-                """
-                val result = subject.compileAndLintWithContext(env, code)
-                assertThat(result).isEmpty()
-            }
 
-            it("does not detect val declaration with ArrayList") {
-                val code = """
-                fun main() {
+                it("does not detect val declaration with ArrayList") {
+                    val code = """
                     val myArrayList = ArrayList<Int>()
+                    """
+                    val result = subject.compileAndLintWithContext(env, code)
+                    assertThat(result).isEmpty()
                 }
-                """
-                val result = subject.compileAndLintWithContext(env, code)
-                assertThat(result).isEmpty()
-            }
 
-            it("does not detect val declaration with LinkedHashSet") {
-                val code = """
-                fun main() {
+                it("does not detect val declaration with LinkedHashSet") {
+                    val code = """
                     val myLinkedHashSet = LinkedHashSet<Int>()
+                    """
+                    val result = subject.compileAndLintWithContext(env, code)
+                    assertThat(result).isEmpty()
                 }
-                """
-                val result = subject.compileAndLintWithContext(env, code)
-                assertThat(result).isEmpty()
-            }
 
-            it("does not detect val declaration with HashSet") {
-                val code = """
-                fun main() {
+                it("does not detect val declaration with HashSet") {
+                    val code = """
                     val myHashSet = HashSet<Int>()
+                    """
+                    val result = subject.compileAndLintWithContext(env, code)
+                    assertThat(result).isEmpty()
                 }
-                """
-                val result = subject.compileAndLintWithContext(env, code)
-                assertThat(result).isEmpty()
-            }
 
-            it("does not detect val declaration with LinkedHashMap") {
-                val code = """
-                fun main() {
+                it("does not detect val declaration with LinkedHashMap") {
+                    val code = """
                     val myLinkedHashMap = LinkedHashMap<String, Int>()
+                    """
+                    val result = subject.compileAndLintWithContext(env, code)
+                    assertThat(result).isEmpty()
                 }
-                """
-                val result = subject.compileAndLintWithContext(env, code)
-                assertThat(result).isEmpty()
+
+                it("does not detect val declaration with HashMap") {
+                    val code = """
+                    val myHashMap = HashMap<String, Int>()
+                    """
+                    val result = subject.compileAndLintWithContext(env, code)
+                    assertThat(result).isEmpty()
+                }
             }
 
-            it("does not detect val declaration with HashMap") {
-                val code = """
-                fun main() {
-                    val myHashMap = HashMap<String, Int>()
+            describe("ignores declaration with var and immutable types") {
+
+                it("does not detect var declaration with immutable list") {
+                    val code = """
+                    val myList = listOf(1,2,3)
+                    """
+                    val result = subject.compileAndLintWithContext(env, code)
+                    assertThat(result).isEmpty()
                 }
-                """
-                val result = subject.compileAndLintWithContext(env, code)
-                assertThat(result).isEmpty()
+
+                it("does not detect var declaration with immutable set") {
+                    val code = """
+                    val mySet = setOf(1,2,3)
+                    """
+                    val result = subject.compileAndLintWithContext(env, code)
+                    assertThat(result).isEmpty()
+                }
+
+                it("does not detect var declaration with immutable map") {
+                    val code = """
+                    val myMap = mapOf("answer" to 42)
+                    """
+                    val result = subject.compileAndLintWithContext(env, code)
+                    assertThat(result).isEmpty()
+                }
             }
         }
 
-        describe("ignores declaration with var and immutable types") {
+        describe("class properties") {
 
-            it("does not detect var declaration with immutable list") {
-                val code = """
-                fun main() {
-                    val myList = listOf(1,2,3)
+            describe("valid cases") {
+
+                it("detects var declaration with mutable list") {
+                    val code = """
+                    class MyClass {
+                        var myOtherList = mutableListOf(1,2,3)
+                    }
+                    """
+                    val result = subject.compileAndLintWithContext(env, code)
+                    assertThat(result).hasSize(1)
+                    assertThat(result).hasSourceLocation(2, 5)
                 }
-                """
-                val result = subject.compileAndLintWithContext(env, code)
-                assertThat(result).isEmpty()
+
+                it("detects var declaration with mutable set") {
+                    val code = """
+                    class MyClass {
+                        var mySet = mutableSetOf(1,2,3)
+                    }
+                    """
+                    val result = subject.compileAndLintWithContext(env, code)
+                    assertThat(result).hasSize(1)
+                    assertThat(result).hasSourceLocation(2, 5)
+                }
+
+                it("detects var declaration with mutable map") {
+                    val code = """
+                    class MyClass {
+                        var myMap = mutableMapOf("answer" to 42)
+                    }
+                    """
+                    val result = subject.compileAndLintWithContext(env, code)
+                    assertThat(result).hasSize(1)
+                    assertThat(result).hasSourceLocation(2, 5)
+                }
+
+                it("detects var declaration with ArrayList") {
+                    val code = """
+                    class MyClass {
+                        var myArrayList = ArrayList<Int>()
+                    }
+                    """
+                    val result = subject.compileAndLintWithContext(env, code)
+                    assertThat(result).hasSize(1)
+                    assertThat(result).hasSourceLocation(2, 5)
+                }
+
+                it("detects var declaration with LinkedHashSet") {
+                    val code = """
+                    class MyClass {
+                        var myLinkedHashSet = LinkedHashSet<Int>()
+                    }
+                    """
+                    val result = subject.compileAndLintWithContext(env, code)
+                    assertThat(result).hasSize(1)
+                    assertThat(result).hasSourceLocation(2, 5)
+                }
+
+                it("detects var declaration with HashSet") {
+                    val code = """
+                    class MyClass {
+                        var myHashSet = HashSet<Int>()
+                    }
+                    """
+                    val result = subject.compileAndLintWithContext(env, code)
+                    assertThat(result).hasSize(1)
+                    assertThat(result).hasSourceLocation(2, 5)
+                }
+
+                it("detects var declaration with LinkedHashMap") {
+                    val code = """
+                    class MyClass {
+                        var myLinkedHashMap = LinkedHashMap<String, Int>()
+                    }
+                    """
+                    val result = subject.compileAndLintWithContext(env, code)
+                    assertThat(result).hasSize(1)
+                    assertThat(result).hasSourceLocation(2, 5)
+                }
+
+                it("detects var declaration with HashMap") {
+                    val code = """
+                    class MyClass {
+                        var myHashMap = HashMap<String, Int>()
+                    }
+                    """
+                    val result = subject.compileAndLintWithContext(env, code)
+                    assertThat(result).hasSize(1)
+                    assertThat(result).hasSourceLocation(2, 5)
+                }
             }
 
-            it("does not detect var declaration with immutable set") {
-                val code = """
-                fun main() {
-                    val mySet = setOf(1,2,3)
+            describe("ignores declaration with val") {
+
+                it("does not detect val declaration with mutable list") {
+                    val code = """
+                    class MyClass {
+                        val myList = mutableListOf(1,2,3)
+                    }
+                    """
+                    val result = subject.compileAndLintWithContext(env, code)
+                    assertThat(result).isEmpty()
                 }
-                """
-                val result = subject.compileAndLintWithContext(env, code)
-                assertThat(result).isEmpty()
+
+                it("does not detect val declaration with mutable set") {
+                    val code = """
+                    class MyClass {
+                        val mySet = mutableSetOf(1,2,3)
+                    }
+                    """
+                    val result = subject.compileAndLintWithContext(env, code)
+                    assertThat(result).isEmpty()
+                }
+
+                it("does not detect val declaration with mutable map") {
+                    val code = """
+                    class MyClass {
+                        val myMap = mutableMapOf("answer" to 42)
+                    }
+                    """
+                    val result = subject.compileAndLintWithContext(env, code)
+                    assertThat(result).isEmpty()
+                }
+
+                it("does not detect val declaration with ArrayList") {
+                    val code = """
+                    class MyClass {
+                        val myArrayList = ArrayList<Int>()
+                    }
+                    """
+                    val result = subject.compileAndLintWithContext(env, code)
+                    assertThat(result).isEmpty()
+                }
+
+                it("does not detect val declaration with LinkedHashSet") {
+                    val code = """
+                    class MyClass {
+                        val myLinkedHashSet = LinkedHashSet<Int>()
+                    }
+                    """
+                    val result = subject.compileAndLintWithContext(env, code)
+                    assertThat(result).isEmpty()
+                }
+
+                it("does not detect val declaration with HashSet") {
+                    val code = """
+                    class MyClass {
+                        val myHashSet = HashSet<Int>()
+                    }
+                    """
+                    val result = subject.compileAndLintWithContext(env, code)
+                    assertThat(result).isEmpty()
+                }
+
+                it("does not detect val declaration with LinkedHashMap") {
+                    val code = """
+                    class MyClass {
+                        val myLinkedHashMap = LinkedHashMap<String, Int>()
+                    }
+                    """
+                    val result = subject.compileAndLintWithContext(env, code)
+                    assertThat(result).isEmpty()
+                }
+
+                it("does not detect val declaration with HashMap") {
+                    val code = """
+                    class MyClass {
+                        val myHashMap = HashMap<String, Int>()
+                    }
+                    """
+                    val result = subject.compileAndLintWithContext(env, code)
+                    assertThat(result).isEmpty()
+                }
             }
 
-            it("does not detect var declaration with immutable map") {
-                val code = """
-                fun main() {
-                    val myMap = mapOf("answer" to 42)
+            describe("ignores declaration with var and immutable types") {
+
+                it("does not detect var declaration with immutable list") {
+                    val code = """
+                    class MyClass {
+                        val myList = listOf(1,2,3)
+                    }
+                    """
+                    val result = subject.compileAndLintWithContext(env, code)
+                    assertThat(result).isEmpty()
                 }
-                """
-                val result = subject.compileAndLintWithContext(env, code)
-                assertThat(result).isEmpty()
+
+                it("does not detect var declaration with immutable set") {
+                    val code = """
+                    class MyClass {
+                        val mySet = setOf(1,2,3)
+                    }
+                    """
+                    val result = subject.compileAndLintWithContext(env, code)
+                    assertThat(result).isEmpty()
+                }
+
+                it("does not detect var declaration with immutable map") {
+                    val code = """
+                    class MyClass {
+                        val myMap = mapOf("answer" to 42)
+                    }
+                    """
+                    val result = subject.compileAndLintWithContext(env, code)
+                    assertThat(result).isEmpty()
+                }
             }
         }
     }


### PR DESCRIPTION
I'm adding a new rule that detects if you're declaring a `var` with also a Mutable type like:

```
var myList = mutableListOf(1,2,3)
```

Instead you should prefer to:

```
val myList = mutableListOf(1,2,3)
// OR
var myList = listOf(1,2,3)
```

Having "double mutability" is considered an anti-pattern as the `myList` variable can both be reassigned and `.clear()`-ed.