### PR TITLE
Fix rules not appearing in the sarif output

### DIFF
--- a/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/RuleDescriptors.kt
+++ b/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/RuleDescriptors.kt
@@ -12,7 +12,7 @@ import java.util.Locale
 import java.util.ServiceLoader
 
 fun ruleDescriptors(config: Config): HashMap<String, ReportingDescriptor> {
-    val sets = ServiceLoader.load(RuleSetProvider::class.java)
+    val sets = ServiceLoader.load(RuleSetProvider::class.java, SarifOutputReport::class.java.classLoader)
         .map { it.instance(config.subConfig(it.ruleSetId)) }
     val descriptors = HashMap<String, ReportingDescriptor>()
     for (ruleSet in sets) {


### PR DESCRIPTION
This partially addresses #3554. The problem is that all the detekt extensions are loaded by plugin loader, which also loads `SarifOutputReport`. However, `ServiceLoader.load(Class<>)` by default will with the current thread context's loader, which is the main detekt loader and will not load anything.

I would recommend merging this now instead of waiting for the next major release.

## Before detekt.sarif
```
{
  "$schema" : "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
  "version" : "2.1.0",
  "runs" : [ {
    "tool" : {
      "driver" : {
        "guid" : "022ca8c2-f6a2-4c95-b107-bb72c43263f3",
        "name" : "detekt",
        "organization" : "detekt",
        "fullName" : "detekt",
        "version" : "1.16.0",
        "semanticVersion" : "1.16.0",
        "downloadUri" : "https://github.com/detekt/detekt/releases/download/v1.16.0/detekt",
        "informationUri" : "https://detekt.github.io/detekt",
        "rules" : [ ],
        "language" : "en"
      }
    },
    "results" : [ ]
  } ]
}
```

## After detekt.sarif - SARIF validation passed
```{
  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
  "version": "2.1.0",
  "runs": [
    {
      "results": [
      ],
      "tool": {
        "driver": {
          "downloadUri": "https://github.com/detekt/detekt/releases/download/v1.16.0/detekt",
          "fullName": "detekt",
          "guid": "022ca8c2-f6a2-4c95-b107-bb72c43263f3",
          "informationUri": "https://detekt.github.io/detekt",
          "language": "en",
          "name": "detekt",
          "organization": "detekt",
          "rules": [
            {
              "helpUri": "https://detekt.github.io/detekt/style.html#classordering",
              "id": "detekt.style.ClassOrdering",
              "name": "ClassOrdering",
              "shortDescription": {
                "text": "Class contents should be in this order: Property declarations/initializer blocks; secondary constructors; method declarations then companion objects."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/style.html#collapsibleifstatements",
              "id": "detekt.style.CollapsibleIfStatements",
              "name": "CollapsibleIfStatements",
              "shortDescription": {
                "text": "Two if statements which could be collapsed were detected. These statements can be merged to improve readability."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/style.html#destructuringdeclarationwithtoomanyentries",
              "id": "detekt.style.DestructuringDeclarationWithTooManyEntries",
              "name": "DestructuringDeclarationWithTooManyEntries",
              "shortDescription": {
                "text": "The destructuring declaration contains too many entries, making it difficult to read. Consider refactoring to avoid using a destructuring declaration for this case."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/style.html#returncount",
              "id": "detekt.style.ReturnCount",
              "name": "ReturnCount",
              "shortDescription": {
                "text": "Restrict the number of return statements in methods."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/style.html#throwscount",
              "id": "detekt.style.ThrowsCount",
              "name": "ThrowsCount",
              "shortDescription": {
                "text": "Restrict the number of throw statements in methods."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/style.html#newlineatendoffile",
              "id": "detekt.style.NewLineAtEndOfFile",
              "name": "NewLineAtEndOfFile",
              "shortDescription": {
                "text": "Checks whether files end with a line separator."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/style.html#wildcardimport",
              "id": "detekt.style.WildcardImport",
              "name": "WildcardImport",
              "shortDescription": {
                "text": "Wildcard imports should be replaced with imports using fully qualified class names. Wildcard imports can lead to naming conflicts. A library update can introduce naming clashes with your classes which results in compilation errors."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/style.html#maxlinelength",
              "id": "detekt.style.MaxLineLength",
              "name": "MaxLineLength",
              "shortDescription": {
                "text": "Line detected that is longer than the defined maximum line length in the code style."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/style.html#trailingwhitespace",
              "id": "detekt.style.TrailingWhitespace",
              "name": "TrailingWhitespace",
              "shortDescription": {
                "text": "Checks which lines end with a whitespace."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/style.html#notabs",
              "id": "detekt.style.NoTabs",
              "name": "NoTabs",
              "shortDescription": {
                "text": "Checks if tabs are used in Kotlin files."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/style.html#equalsonsignatureline",
              "id": "detekt.style.EqualsOnSignatureLine",
              "name": "EqualsOnSignatureLine",
              "shortDescription": {
                "text": "Equals signs for expression style functions should be on the same line as the signature"
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/style.html#equalsnullcall",
              "id": "detekt.style.EqualsNullCall",
              "name": "EqualsNullCall",
              "shortDescription": {
                "text": "Equals() method is called with null as parameter. Consider using == to compare to null."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/style.html#forbiddencomment",
              "id": "detekt.style.ForbiddenComment",
              "name": "ForbiddenComment",
              "shortDescription": {
                "text": "Flags a forbidden comment."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/style.html#forbiddenimport",
              "id": "detekt.style.ForbiddenImport",
              "name": "ForbiddenImport",
              "shortDescription": {
                "text": "Mark forbidden imports. A forbidden import could be an import for an unstable / experimental apiand hence you might want to mark it as forbidden in order to get warned about the usage."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/style.html#forbiddenmethodcall",
              "id": "detekt.style.ForbiddenMethodCall",
              "name": "ForbiddenMethodCall",
              "shortDescription": {
                "text": "Mark forbidden methods. A forbidden method could be an invocation of an unstable / experimental method and hence you might want to mark it as forbidden in order to get warned about the usage."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/style.html#forbiddenpublicdataclass",
              "id": "detekt.style.ForbiddenPublicDataClass",
              "name": "ForbiddenPublicDataClass",
              "shortDescription": {
                "text": "The data classes are bad for the binary compatibility in public APIs. Avoid to use it."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/style.html#functiononlyreturningconstant",
              "id": "detekt.style.FunctionOnlyReturningConstant",
              "name": "FunctionOnlyReturningConstant",
              "shortDescription": {
                "text": "A function that only returns a constant is misleading. Consider declaring a constant instead"
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/style.html#spacingbetweenpackageandimports",
              "id": "detekt.style.SpacingBetweenPackageAndImports",
              "name": "SpacingBetweenPackageAndImports",
              "shortDescription": {
                "text": "Violation of the package declaration style."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/style.html#loopwithtoomanyjumpstatements",
              "id": "detekt.style.LoopWithTooManyJumpStatements",
              "name": "LoopWithTooManyJumpStatements",
              "shortDescription": {
                "text": "The loop contains more than one break or continue statement. The code should be refactored to increase readability."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/style.html#safecast",
              "id": "detekt.style.SafeCast",
              "name": "SafeCast",
              "shortDescription": {
                "text": "Safe cast instead of if-else-null"
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/style.html#unnecessaryabstractclass",
              "id": "detekt.style.UnnecessaryAbstractClass",
              "name": "UnnecessaryAbstractClass",
              "shortDescription": {
                "text": "An abstract class is unnecessary and can be refactored. An abstract class should have both abstract and concrete properties or functions. An abstract class without a concrete member can be refactored to an interface. An abstract class without an abstract member can be refactored to a concrete class."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/style.html#unnecessaryannotationusesitetarget",
              "id": "detekt.style.UnnecessaryAnnotationUseSiteTarget",
              "name": "UnnecessaryAnnotationUseSiteTarget",
              "shortDescription": {
                "text": "Unnecessary Annotation use-site Target. It can be removed."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/style.html#unnecessaryparentheses",
              "id": "detekt.style.UnnecessaryParentheses",
              "name": "UnnecessaryParentheses",
              "shortDescription": {
                "text": "Unnecessary parentheses don't add any value to the code and should be removed."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/style.html#unnecessaryinheritance",
              "id": "detekt.style.UnnecessaryInheritance",
              "name": "UnnecessaryInheritance",
              "shortDescription": {
                "text": "The extended super type is unnecessary."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/style.html#utilityclasswithpublicconstructor",
              "id": "detekt.style.UtilityClassWithPublicConstructor",
              "name": "UtilityClassWithPublicConstructor",
              "shortDescription": {
                "text": "The class declaration is unnecessary because it only contains utility functions. An object declaration should be used instead."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/style.html#optionalabstractkeyword",
              "id": "detekt.style.OptionalAbstractKeyword",
              "name": "OptionalAbstractKeyword",
              "shortDescription": {
                "text": "Unnecessary abstract modifier in interface"
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/style.html#optionalwhenbraces",
              "id": "detekt.style.OptionalWhenBraces",
              "name": "OptionalWhenBraces",
              "shortDescription": {
                "text": "Optional braces in when expression"
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/style.html#optionalunit",
              "id": "detekt.style.OptionalUnit",
              "name": "OptionalUnit",
              "shortDescription": {
                "text": "Return type of 'Unit' is unnecessary and can be safely removed."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/style.html#protectedmemberinfinalclass",
              "id": "detekt.style.ProtectedMemberInFinalClass",
              "name": "ProtectedMemberInFinalClass",
              "shortDescription": {
                "text": "Member with protected visibility in final class is private. Consider using private or internal as modifier."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/style.html#serialversionuidinserializableclass",
              "id": "detekt.style.SerialVersionUIDInSerializableClass",
              "name": "SerialVersionUIDInSerializableClass",
              "shortDescription": {
                "text": "A class which implements the Serializable interface does not define a correct serialVersionUID field. The serialVersionUID field should be a constant long value inside a companion object."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/style.html#magicnumber",
              "id": "detekt.style.MagicNumber",
              "name": "MagicNumber",
              "shortDescription": {
                "text": "Report magic numbers. Magic number is a numeric literal that is not defined as a constant and hence it's unclear what the purpose of this number is. It's better to declare such numbers as constants and give them a proper name. By default, -1, 0, 1, and 2 are not considered to be magic numbers."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/style.html#modifierorder",
              "id": "detekt.style.ModifierOrder",
              "name": "ModifierOrder",
              "shortDescription": {
                "text": "Modifiers are not in the correct order."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/style.html#dataclasscontainsfunctions",
              "id": "detekt.style.DataClassContainsFunctions",
              "name": "DataClassContainsFunctions",
              "shortDescription": {
                "text": "Data classes should mainly be used to store data and should not have any extra functions. (Compiler will automatically generate equals, toString and hashCode functions)"
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/style.html#dataclassshouldbeimmutable",
              "id": "detekt.style.DataClassShouldBeImmutable",
              "name": "DataClassShouldBeImmutable",
              "shortDescription": {
                "text": "Data classes should mainly be immutable and should not have any side effects. (To copy an object altering some of its properties use the copy function)"
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/style.html#usedataclass",
              "id": "detekt.style.UseDataClass",
              "name": "UseDataClass",
              "shortDescription": {
                "text": "Classes that do nothing but hold data should be replaced with a data class."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/style.html#unusedimports",
              "id": "detekt.style.UnusedImports",
              "name": "UnusedImports",
              "shortDescription": {
                "text": "Unused Imports are dead code and should be removed."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/style.html#unusedprivateclass",
              "id": "detekt.style.UnusedPrivateClass",
              "name": "UnusedPrivateClass",
              "shortDescription": {
                "text": "Private class is unused."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/style.html#unusedprivatemember",
              "id": "detekt.style.UnusedPrivateMember",
              "name": "UnusedPrivateMember",
              "shortDescription": {
                "text": "Private member is unused."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/style.html#expressionbodysyntax",
              "id": "detekt.style.ExpressionBodySyntax",
              "name": "ExpressionBodySyntax",
              "shortDescription": {
                "text": "Functions with exact one statement, the return statement, can be rewritten with ExpressionBodySyntax."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/style.html#nestedclassesvisibility",
              "id": "detekt.style.NestedClassesVisibility",
              "name": "NestedClassesVisibility",
              "shortDescription": {
                "text": "The explicit public modifier still results in an internal nested class."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/style.html#redundantvisibilitymodifierrule",
              "id": "detekt.style.RedundantVisibilityModifierRule",
              "name": "RedundantVisibilityModifierRule",
              "shortDescription": {
                "text": "Checks for redundant visibility modifiers."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/style.html#untilinsteadofrangeto",
              "id": "detekt.style.UntilInsteadOfRangeTo",
              "name": "UntilInsteadOfRangeTo",
              "shortDescription": {
                "text": "'..' call can be replaced with 'until'"
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/style.html#unnecessaryapply",
              "id": "detekt.style.UnnecessaryApply",
              "name": "UnnecessaryApply",
              "shortDescription": {
                "text": "The `apply` usage is unnecessary"
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/style.html#unnecessaryfilter",
              "id": "detekt.style.UnnecessaryFilter",
              "name": "UnnecessaryFilter",
              "shortDescription": {
                "text": "filter() with other collection operations may be simplified."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/style.html#unnecessarylet",
              "id": "detekt.style.UnnecessaryLet",
              "name": "UnnecessaryLet",
              "shortDescription": {
                "text": "The `let` usage is unnecessary"
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/style.html#maybeconst",
              "id": "detekt.style.MayBeConst",
              "name": "MayBeConst",
              "shortDescription": {
                "text": "Reports vals that can be const val instead."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/style.html#prefertooverpairsyntax",
              "id": "detekt.style.PreferToOverPairSyntax",
              "name": "PreferToOverPairSyntax",
              "shortDescription": {
                "text": "Pair was created using the Pair constructor, using the to syntax is preferred."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/style.html#mandatorybracesifstatements",
              "id": "detekt.style.MandatoryBracesIfStatements",
              "name": "MandatoryBracesIfStatements",
              "shortDescription": {
                "text": "Multi-line if statement was found that does not have braces. These should be added to improve readability."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/style.html#mandatorybracesloops",
              "id": "detekt.style.MandatoryBracesLoops",
              "name": "MandatoryBracesLoops",
              "shortDescription": {
                "text": "Multi-line loop was found that does not have braces. These should be added to improve readability."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/style.html#varcouldbeval",
              "id": "detekt.style.VarCouldBeVal",
              "name": "VarCouldBeVal",
              "shortDescription": {
                "text": "Var declaration could be val."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/style.html#forbiddenvoid",
              "id": "detekt.style.ForbiddenVoid",
              "name": "ForbiddenVoid",
              "shortDescription": {
                "text": "`Unit` should be used instead of `Void`."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/style.html#explicititlambdaparameter",
              "id": "detekt.style.ExplicitItLambdaParameter",
              "name": "ExplicitItLambdaParameter",
              "shortDescription": {
                "text": "Declaring lambda parameters as `it` is redundant."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/style.html#explicitcollectionelementaccessmethod",
              "id": "detekt.style.ExplicitCollectionElementAccessMethod",
              "name": "ExplicitCollectionElementAccessMethod",
              "shortDescription": {
                "text": "Prefer usage of indexed access operator [] for map element access or insert methods"
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/style.html#uselesscallonnotnull",
              "id": "detekt.style.UselessCallOnNotNull",
              "name": "UselessCallOnNotNull",
              "shortDescription": {
                "text": "This call on non-null reference may be reduced or removed. Some calls are intended to be called on nullable collection or text types (e.g. String?). When this call is used on a reference to a non-null type (e.g. String) it is redundant and will have no effect, so it can be removed."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/style.html#underscoresinnumericliterals",
              "id": "detekt.style.UnderscoresInNumericLiterals",
              "name": "UnderscoresInNumericLiterals",
              "shortDescription": {
                "text": "Report missing or invalid underscores in decimal base 10 numeric literals. Numeric literals should be underscore separated to increase readability. Underscores that do not make groups of 3 digits are also reported."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/style.html#userequire",
              "id": "detekt.style.UseRequire",
              "name": "UseRequire",
              "shortDescription": {
                "text": "Use require() instead of throwing an IllegalArgumentException."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/style.html#usecheckorerror",
              "id": "detekt.style.UseCheckOrError",
              "name": "UseCheckOrError",
              "shortDescription": {
                "text": "Use check() or error() instead of throwing an IllegalStateException."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/style.html#useifinsteadofwhen",
              "id": "detekt.style.UseIfInsteadOfWhen",
              "name": "UseIfInsteadOfWhen",
              "shortDescription": {
                "text": "Binary expressions are better expressed using an 'if' expression than a 'when' expression."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/style.html#redundantexplicittype",
              "id": "detekt.style.RedundantExplicitType",
              "name": "RedundantExplicitType",
              "shortDescription": {
                "text": "Type does not need to be stated explicitly and can be removed."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/style.html#libraryentitiesshouldnotbepublic",
              "id": "detekt.style.LibraryEntitiesShouldNotBePublic",
              "name": "LibraryEntitiesShouldNotBePublic",
              "shortDescription": {
                "text": "Library class should not be public"
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/style.html#librarycodemustspecifyreturntype",
              "id": "detekt.style.LibraryCodeMustSpecifyReturnType",
              "name": "LibraryCodeMustSpecifyReturnType",
              "shortDescription": {
                "text": "Library functions/properties should have an explicit return type. Inferred return type can easily be changed by mistake which may lead to breaking changes."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/style.html#usearrayliteralsinannotations",
              "id": "detekt.style.UseArrayLiteralsInAnnotations",
              "name": "UseArrayLiteralsInAnnotations",
              "shortDescription": {
                "text": "Array literals '[...]' should be preferred as they are more readable than 'arrayOf(...)' expressions."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/style.html#useemptycounterpart",
              "id": "detekt.style.UseEmptyCounterpart",
              "name": "UseEmptyCounterpart",
              "shortDescription": {
                "text": "Instantiation of an object's \"empty\" state should use the object's \"empty\" initializer"
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/style.html#usechecknotnull",
              "id": "detekt.style.UseCheckNotNull",
              "name": "UseCheckNotNull",
              "shortDescription": {
                "text": "Use checkNotNull() instead of check() for checking not-null."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/style.html#userequirenotnull",
              "id": "detekt.style.UseRequireNotNull",
              "name": "UseRequireNotNull",
              "shortDescription": {
                "text": "Use requireNotNull() instead of require() for checking not-null."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/style.html#redundanthigherordermapusage",
              "id": "detekt.style.RedundantHigherOrderMapUsage",
              "name": "RedundantHigherOrderMapUsage",
              "shortDescription": {
                "text": "Checks for Redundant 'map' calls."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/style.html#useifemptyorifblank",
              "id": "detekt.style.UseIfEmptyOrIfBlank",
              "name": "UseIfEmptyOrIfBlank",
              "shortDescription": {
                "text": "Use 'ifEmpty' or 'ifBlank' instead of 'isEmpty' or 'isBlank' to assign default value."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/style.html#multilinelambdaitparameter",
              "id": "detekt.style.MultilineLambdaItParameter",
              "name": "MultilineLambdaItParameter",
              "shortDescription": {
                "text": "Multiline lambdas should not use `it` as a parameter name"
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/style.html#useisnullorempty",
              "id": "detekt.style.UseIsNullOrEmpty",
              "name": "UseIsNullOrEmpty",
              "shortDescription": {
                "text": "Use 'isNullOrEmpty()' call instead of 'x == null || x.isEmpty()'"
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/style.html#useorempty",
              "id": "detekt.style.UseOrEmpty",
              "name": "UseOrEmpty",
              "shortDescription": {
                "text": "Use 'orEmpty()' call instead of '?: emptyList()'"
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/complexity.html#longparameterlist",
              "id": "detekt.complexity.LongParameterList",
              "name": "LongParameterList",
              "shortDescription": {
                "text": "The more parameters a function has the more complex it is. Long parameter lists are often used to control complex algorithms and violate the Single Responsibility Principle. Prefer functions with short parameter lists."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/complexity.html#longmethod",
              "id": "detekt.complexity.LongMethod",
              "name": "LongMethod",
              "shortDescription": {
                "text": "One method should have one responsibility. Long methods tend to handle many things at once. Prefer smaller methods to make them easier to understand."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/complexity.html#largeclass",
              "id": "detekt.complexity.LargeClass",
              "name": "LargeClass",
              "shortDescription": {
                "text": "One class should have one responsibility. Large classes tend to handle many things at once. Split up large classes into smaller classes that are easier to understand."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/complexity.html#complexinterface",
              "id": "detekt.complexity.ComplexInterface",
              "name": "ComplexInterface",
              "shortDescription": {
                "text": "An interface contains too many functions and properties. Large classes tend to handle many things at once. An interface should have one responsibility. Split up large interfaces into smaller ones that are easier to understand."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/complexity.html#complexmethod",
              "id": "detekt.complexity.ComplexMethod",
              "name": "ComplexMethod",
              "shortDescription": {
                "text": "Prefer splitting up complex methods into smaller, easier to understand methods."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/complexity.html#stringliteralduplication",
              "id": "detekt.complexity.StringLiteralDuplication",
              "name": "StringLiteralDuplication",
              "shortDescription": {
                "text": "Multiple occurrences of the same string literal within a single file detected."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/complexity.html#methodoverloading",
              "id": "detekt.complexity.MethodOverloading",
              "name": "MethodOverloading",
              "shortDescription": {
                "text": "Methods which are overloaded often might be harder to maintain. Furthermore, these methods are tightly coupled. Refactor these methods and try to use optional parameters."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/complexity.html#nestedblockdepth",
              "id": "detekt.complexity.NestedBlockDepth",
              "name": "NestedBlockDepth",
              "shortDescription": {
                "text": "Excessive nesting leads to hidden complexity. Prefer extracting code to make it easier to understand."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/complexity.html#toomanyfunctions",
              "id": "detekt.complexity.TooManyFunctions",
              "name": "TooManyFunctions",
              "shortDescription": {
                "text": "Too many functions inside a/an file/class/object/interface always indicate a violation of the single responsibility principle. Maybe the file/class/object/interface wants to manage too many things at once. Extract functionality which clearly belongs together."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/complexity.html#complexcondition",
              "id": "detekt.complexity.ComplexCondition",
              "name": "ComplexCondition",
              "shortDescription": {
                "text": "Complex conditions should be simplified and extracted into well-named methods if necessary."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/complexity.html#labeledexpression",
              "id": "detekt.complexity.LabeledExpression",
              "name": "LabeledExpression",
              "shortDescription": {
                "text": "Expression with labels increase complexity and affect maintainability."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/complexity.html#replacesafecallchainwithrun",
              "id": "detekt.complexity.ReplaceSafeCallChainWithRun",
              "name": "ReplaceSafeCallChainWithRun",
              "shortDescription": {
                "text": "Chains of safe calls on non-nullable types can be surrounded with run {}"
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/complexity.html#namedarguments",
              "id": "detekt.complexity.NamedArguments",
              "name": "NamedArguments",
              "shortDescription": {
                "text": "Function invocation with more than 3 parameters must all be named"
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/coroutines.html#globalcoroutineusage",
              "id": "detekt.coroutines.GlobalCoroutineUsage",
              "name": "GlobalCoroutineUsage",
              "shortDescription": {
                "text": "Usage of GlobalScope instance is highly discouraged"
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/coroutines.html#redundantsuspendmodifier",
              "id": "detekt.coroutines.RedundantSuspendModifier",
              "name": "RedundantSuspendModifier",
              "shortDescription": {
                "text": "`suspend` modifier is only needed for functions that contain suspending calls"
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/coroutines.html#sleepinsteadofdelay",
              "id": "detekt.coroutines.SleepInsteadOfDelay",
              "name": "SleepInsteadOfDelay",
              "shortDescription": {
                "text": "Usage of Thread.sleep() in coroutines can potentially halt multiple coroutines at once."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/coroutines.html#suspendfunwithflowreturntype",
              "id": "detekt.coroutines.SuspendFunWithFlowReturnType",
              "name": "SuspendFunWithFlowReturnType",
              "shortDescription": {
                "text": "`suspend` modifier should not be used for functions that return a Coroutines Flow type. Flows are cold streams and invoking a function that returns one should not produce any side effects."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/comments.html#commentoverprivatefunction",
              "id": "detekt.comments.CommentOverPrivateFunction",
              "name": "CommentOverPrivateFunction",
              "shortDescription": {
                "text": "Comments for private functions should be avoided. Prefer giving the function an expressive name. Split it up in smaller, self-explaining functions if necessary."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/comments.html#commentoverprivateproperty",
              "id": "detekt.comments.CommentOverPrivateProperty",
              "name": "CommentOverPrivateProperty",
              "shortDescription": {
                "text": "Private properties should be named such that they explain themselves even without a comment."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/comments.html#endofsentenceformat",
              "id": "detekt.comments.EndOfSentenceFormat",
              "name": "EndOfSentenceFormat",
              "shortDescription": {
                "text": "The first sentence in a KDoc comment should end with correct punctuation."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/comments.html#undocumentedpublicclass",
              "id": "detekt.comments.UndocumentedPublicClass",
              "name": "UndocumentedPublicClass",
              "shortDescription": {
                "text": "Public classes, interfaces and objects require documentation."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/comments.html#undocumentedpublicfunction",
              "id": "detekt.comments.UndocumentedPublicFunction",
              "name": "UndocumentedPublicFunction",
              "shortDescription": {
                "text": "Public functions require documentation."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/comments.html#undocumentedpublicproperty",
              "id": "detekt.comments.UndocumentedPublicProperty",
              "name": "UndocumentedPublicProperty",
              "shortDescription": {
                "text": "Public properties require documentation."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/comments.html#absentorwrongfilelicense",
              "id": "detekt.comments.AbsentOrWrongFileLicense",
              "name": "AbsentOrWrongFileLicense",
              "shortDescription": {
                "text": "License text is absent or incorrect in the file."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/empty-blocks.html#emptycatchblock",
              "id": "detekt.empty-blocks.EmptyCatchBlock",
              "name": "EmptyCatchBlock",
              "shortDescription": {
                "text": "Empty catch block detected. Empty catch blocks indicate that an exception is ignored and not handled."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/empty-blocks.html#emptyclassblock",
              "id": "detekt.empty-blocks.EmptyClassBlock",
              "name": "EmptyClassBlock",
              "shortDescription": {
                "text": "Empty block of code detected. As they serve no purpose they should be removed."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/empty-blocks.html#emptydefaultconstructor",
              "id": "detekt.empty-blocks.EmptyDefaultConstructor",
              "name": "EmptyDefaultConstructor",
              "shortDescription": {
                "text": "Empty block of code detected. As they serve no purpose they should be removed."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/empty-blocks.html#emptydowhileblock",
              "id": "detekt.empty-blocks.EmptyDoWhileBlock",
              "name": "EmptyDoWhileBlock",
              "shortDescription": {
                "text": "Empty block of code detected. As they serve no purpose they should be removed."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/empty-blocks.html#emptyelseblock",
              "id": "detekt.empty-blocks.EmptyElseBlock",
              "name": "EmptyElseBlock",
              "shortDescription": {
                "text": "Empty block of code detected. As they serve no purpose they should be removed."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/empty-blocks.html#emptyfinallyblock",
              "id": "detekt.empty-blocks.EmptyFinallyBlock",
              "name": "EmptyFinallyBlock",
              "shortDescription": {
                "text": "Empty block of code detected. As they serve no purpose they should be removed."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/empty-blocks.html#emptyforblock",
              "id": "detekt.empty-blocks.EmptyForBlock",
              "name": "EmptyForBlock",
              "shortDescription": {
                "text": "Empty block of code detected. As they serve no purpose they should be removed."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/empty-blocks.html#emptyfunctionblock",
              "id": "detekt.empty-blocks.EmptyFunctionBlock",
              "name": "EmptyFunctionBlock",
              "shortDescription": {
                "text": "Empty block of code detected. As they serve no purpose they should be removed."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/empty-blocks.html#emptyifblock",
              "id": "detekt.empty-blocks.EmptyIfBlock",
              "name": "EmptyIfBlock",
              "shortDescription": {
                "text": "Empty block of code detected. As they serve no purpose they should be removed."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/empty-blocks.html#emptyinitblock",
              "id": "detekt.empty-blocks.EmptyInitBlock",
              "name": "EmptyInitBlock",
              "shortDescription": {
                "text": "Empty block of code detected. As they serve no purpose they should be removed."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/empty-blocks.html#emptyktfile",
              "id": "detekt.empty-blocks.EmptyKtFile",
              "name": "EmptyKtFile",
              "shortDescription": {
                "text": "Empty block of code detected. As they serve no purpose they should be removed."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/empty-blocks.html#emptysecondaryconstructor",
              "id": "detekt.empty-blocks.EmptySecondaryConstructor",
              "name": "EmptySecondaryConstructor",
              "shortDescription": {
                "text": "Empty block of code detected. As they serve no purpose they should be removed."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/empty-blocks.html#emptytryblock",
              "id": "detekt.empty-blocks.EmptyTryBlock",
              "name": "EmptyTryBlock",
              "shortDescription": {
                "text": "Empty block of code detected. As they serve no purpose they should be removed."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/empty-blocks.html#emptywhenblock",
              "id": "detekt.empty-blocks.EmptyWhenBlock",
              "name": "EmptyWhenBlock",
              "shortDescription": {
                "text": "Empty block of code detected. As they serve no purpose they should be removed."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/empty-blocks.html#emptywhileblock",
              "id": "detekt.empty-blocks.EmptyWhileBlock",
              "name": "EmptyWhileBlock",
              "shortDescription": {
                "text": "Empty block of code detected. As they serve no purpose they should be removed."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/potential-bugs.html#deprecation",
              "id": "detekt.potential-bugs.Deprecation",
              "name": "Deprecation",
              "shortDescription": {
                "text": "Deprecated elements should not be used."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/potential-bugs.html#dontdowncastcollectiontypes",
              "id": "detekt.potential-bugs.DontDowncastCollectionTypes",
              "name": "DontDowncastCollectionTypes",
              "shortDescription": {
                "text": "Down-casting immutable collection types is breaking the collection contract"
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/potential-bugs.html#duplicatecaseinwhenexpression",
              "id": "detekt.potential-bugs.DuplicateCaseInWhenExpression",
              "name": "DuplicateCaseInWhenExpression",
              "shortDescription": {
                "text": "Duplicated case statements in when expression. Both cases should be merged."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/potential-bugs.html#equalsalwaysreturnstrueorfalse",
              "id": "detekt.potential-bugs.EqualsAlwaysReturnsTrueOrFalse",
              "name": "EqualsAlwaysReturnsTrueOrFalse",
              "shortDescription": {
                "text": "Having an equals method which always returns true or false is not a good idea. It does not follow the contract of this method. Consider a good default implementation. For example this == other"
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/potential-bugs.html#equalswithhashcodeexist",
              "id": "detekt.potential-bugs.EqualsWithHashCodeExist",
              "name": "EqualsWithHashCodeExist",
              "shortDescription": {
                "text": "Always override hashCode when you override equals. All hash-based collections depend on objects meeting the equals-contract. Two equal objects must produce the same hashcode. When inheriting equals or hashcode, override the inherited and call the super method for clarification."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/potential-bugs.html#exitoutsidemain",
              "id": "detekt.potential-bugs.ExitOutsideMain",
              "name": "ExitOutsideMain",
              "shortDescription": {
                "text": "Do not directly exit the process outside the `main` function. Throw an exception instead."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/potential-bugs.html#explicitgarbagecollectioncall",
              "id": "detekt.potential-bugs.ExplicitGarbageCollectionCall",
              "name": "ExplicitGarbageCollectionCall",
              "shortDescription": {
                "text": "Don't try to be smarter than the JVM. Your code should work independently if the garbage collector is disabled or not. If you face memory issues, try tuning the JVM options instead of relying on code itself."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/potential-bugs.html#hasplatformtype",
              "id": "detekt.potential-bugs.HasPlatformType",
              "name": "HasPlatformType",
              "shortDescription": {
                "text": "Platform types must be declared explicitly in public APIs."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/potential-bugs.html#implicitdefaultlocale",
              "id": "detekt.potential-bugs.ImplicitDefaultLocale",
              "name": "ImplicitDefaultLocale",
              "shortDescription": {
                "text": "Implicit default locale used for string processing. Consider using explicit locale."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/potential-bugs.html#invalidrange",
              "id": "detekt.potential-bugs.InvalidRange",
              "name": "InvalidRange",
              "shortDescription": {
                "text": "If a for loops condition is false before the first iteration, the loop will never get executed."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/potential-bugs.html#iteratorhasnextcallsnextmethod",
              "id": "detekt.potential-bugs.IteratorHasNextCallsNextMethod",
              "name": "IteratorHasNextCallsNextMethod",
              "shortDescription": {
                "text": "The hasNext() method of an Iterator implementation should not call the next() method. The state of the iterator should not be changed inside the hasNext() method. The hasNext() method is not supposed to have any side effects."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/potential-bugs.html#iteratornotthrowingnosuchelementexception",
              "id": "detekt.potential-bugs.IteratorNotThrowingNoSuchElementException",
              "name": "IteratorNotThrowingNoSuchElementException",
              "shortDescription": {
                "text": "The next() method of an Iterator implementation should throw a NoSuchElementException when there are no more elements to return"
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/potential-bugs.html#lateinitusage",
              "id": "detekt.potential-bugs.LateinitUsage",
              "name": "LateinitUsage",
              "shortDescription": {
                "text": "Usage of lateinit detected. Using lateinit for property initialization is error prone, try using constructor injection or delegation."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/potential-bugs.html#mapgetwithnotnullassertionoperator",
              "id": "detekt.potential-bugs.MapGetWithNotNullAssertionOperator",
              "name": "MapGetWithNotNullAssertionOperator",
              "shortDescription": {
                "text": "map.get() with not-null assertion operator (!!) can result in a NullPointerException. Consider usage of map.getValue(), map.getOrDefault() or map.getOrElse() instead."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/potential-bugs.html#missingwhencase",
              "id": "detekt.potential-bugs.MissingWhenCase",
              "name": "MissingWhenCase",
              "shortDescription": {
                "text": "Check usage of `when` used as a statement and don't compare all enum or sealed class cases."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/potential-bugs.html#redundantelseinwhen",
              "id": "detekt.potential-bugs.RedundantElseInWhen",
              "name": "RedundantElseInWhen",
              "shortDescription": {
                "text": "Check for redundant `else` case in `when` expression when used as statement."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/potential-bugs.html#unconditionaljumpstatementinloop",
              "id": "detekt.potential-bugs.UnconditionalJumpStatementInLoop",
              "name": "UnconditionalJumpStatementInLoop",
              "shortDescription": {
                "text": "An unconditional jump statement in a loop is useless. The loop itself is only executed once."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/potential-bugs.html#unnecessarynotnulloperator",
              "id": "detekt.potential-bugs.UnnecessaryNotNullOperator",
              "name": "UnnecessaryNotNullOperator",
              "shortDescription": {
                "text": "Unnecessary not-null unary operator (!!) detected."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/potential-bugs.html#unnecessarysafecall",
              "id": "detekt.potential-bugs.UnnecessarySafeCall",
              "name": "UnnecessarySafeCall",
              "shortDescription": {
                "text": "Unnecessary safe call operator detected."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/potential-bugs.html#unreachablecode",
              "id": "detekt.potential-bugs.UnreachableCode",
              "name": "UnreachableCode",
              "shortDescription": {
                "text": "Unreachable code detected. This code should be removed"
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/potential-bugs.html#unsafecallonnullabletype",
              "id": "detekt.potential-bugs.UnsafeCallOnNullableType",
              "name": "UnsafeCallOnNullableType",
              "shortDescription": {
                "text": "It will throw a NullPointerException at runtime if your nullable value is null."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/potential-bugs.html#unsafecast",
              "id": "detekt.potential-bugs.UnsafeCast",
              "name": "UnsafeCast",
              "shortDescription": {
                "text": "Cast operator throws an exception if the cast is not possible."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/potential-bugs.html#uselesspostfixexpression",
              "id": "detekt.potential-bugs.UselessPostfixExpression",
              "name": "UselessPostfixExpression",
              "shortDescription": {
                "text": "The incremented or decremented value is unused. This value is replaced with the original value."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/potential-bugs.html#wrongequalstypeparameter",
              "id": "detekt.potential-bugs.WrongEqualsTypeParameter",
              "name": "WrongEqualsTypeParameter",
              "shortDescription": {
                "text": "Wrong parameter type for equals() method found. To correctly override the equals() method use Any?"
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/potential-bugs.html#ignoredreturnvalue",
              "id": "detekt.potential-bugs.IgnoredReturnValue",
              "name": "IgnoredReturnValue",
              "shortDescription": {
                "text": "This call returns a value which is ignored"
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/potential-bugs.html#implicitunitreturntype",
              "id": "detekt.potential-bugs.ImplicitUnitReturnType",
              "name": "ImplicitUnitReturnType",
              "shortDescription": {
                "text": "Functions using expression statements have an implicit return type.\nChanging the type of the expression accidentally, changes the function return type.\nThis may lead to backward incompatibility.\nUse a block statement to make clear this function will never return a value."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/potential-bugs.html#nullabletostringcall",
              "id": "detekt.potential-bugs.NullableToStringCall",
              "name": "NullableToStringCall",
              "shortDescription": {
                "text": "This call may return the string \"null\""
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/potential-bugs.html#unreachablecatchblock",
              "id": "detekt.potential-bugs.UnreachableCatchBlock",
              "name": "UnreachableCatchBlock",
              "shortDescription": {
                "text": "Unreachable catch block detected."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/potential-bugs.html#casttonullabletype",
              "id": "detekt.potential-bugs.CastToNullableType",
              "name": "CastToNullableType",
              "shortDescription": {
                "text": "Disallow to cast to nullable types"
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/potential-bugs.html#unusedunaryoperator",
              "id": "detekt.potential-bugs.UnusedUnaryOperator",
              "name": "UnusedUnaryOperator",
              "shortDescription": {
                "text": "This unary operator is not used"
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/exceptions.html#toogenericexceptioncaught",
              "id": "detekt.exceptions.TooGenericExceptionCaught",
              "name": "TooGenericExceptionCaught",
              "shortDescription": {
                "text": "Caught exception is too generic. Prefer catching specific exceptions to the case that is currently handled."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/exceptions.html#exceptionraisedinunexpectedlocation",
              "id": "detekt.exceptions.ExceptionRaisedInUnexpectedLocation",
              "name": "ExceptionRaisedInUnexpectedLocation",
              "shortDescription": {
                "text": "This method is not expected to throw exceptions. This can cause weird behavior."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/exceptions.html#toogenericexceptionthrown",
              "id": "detekt.exceptions.TooGenericExceptionThrown",
              "name": "TooGenericExceptionThrown",
              "shortDescription": {
                "text": "Thrown exception is too generic. Prefer throwing project specific exceptions to handle error cases."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/exceptions.html#notimplementeddeclaration",
              "id": "detekt.exceptions.NotImplementedDeclaration",
              "name": "NotImplementedDeclaration",
              "shortDescription": {
                "text": "The NotImplementedDeclaration should only be used when a method stub is necessary. This defers the development of the functionality of this function. Hence, the NotImplementedDeclaration should only serve as a temporary declaration. Before releasing, this type of declaration should be removed."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/exceptions.html#printstacktrace",
              "id": "detekt.exceptions.PrintStackTrace",
              "name": "PrintStackTrace",
              "shortDescription": {
                "text": "Do not print an stack trace. These debug statements should be replaced with a logger or removed."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/exceptions.html#instanceofcheckforexception",
              "id": "detekt.exceptions.InstanceOfCheckForException",
              "name": "InstanceOfCheckForException",
              "shortDescription": {
                "text": "Instead of checking for a general exception type and checking for a specific exception type use multiple catch blocks."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/exceptions.html#throwingexceptionswithoutmessageorcause",
              "id": "detekt.exceptions.ThrowingExceptionsWithoutMessageOrCause",
              "name": "ThrowingExceptionsWithoutMessageOrCause",
              "shortDescription": {
                "text": "A call to the default constructor of an exception was detected. Instead one of the constructor overloads should be called. This allows to provide more meaningful exceptions."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/exceptions.html#returnfromfinally",
              "id": "detekt.exceptions.ReturnFromFinally",
              "name": "ReturnFromFinally",
              "shortDescription": {
                "text": "Do not return within a finally statement. This can discard exceptions."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/exceptions.html#throwingexceptionfromfinally",
              "id": "detekt.exceptions.ThrowingExceptionFromFinally",
              "name": "ThrowingExceptionFromFinally",
              "shortDescription": {
                "text": "Do not throw an exception within a finally statement. This can discard exceptions and is confusing."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/exceptions.html#throwingexceptioninmain",
              "id": "detekt.exceptions.ThrowingExceptionInMain",
              "name": "ThrowingExceptionInMain",
              "shortDescription": {
                "text": "The main method should not throw an exception."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/exceptions.html#rethrowcaughtexception",
              "id": "detekt.exceptions.RethrowCaughtException",
              "name": "RethrowCaughtException",
              "shortDescription": {
                "text": "Do not rethrow a caught exception of the same type."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/exceptions.html#throwingnewinstanceofsameexception",
              "id": "detekt.exceptions.ThrowingNewInstanceOfSameException",
              "name": "ThrowingNewInstanceOfSameException",
              "shortDescription": {
                "text": "Avoid catch blocks that rethrow a caught exception wrapped inside a new instance of the same exception."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/exceptions.html#swallowedexception",
              "id": "detekt.exceptions.SwallowedException",
              "name": "SwallowedException",
              "shortDescription": {
                "text": "The caught exception is swallowed. The original exception could be lost."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/exceptions.html#objectextendsthrowable",
              "id": "detekt.exceptions.ObjectExtendsThrowable",
              "name": "ObjectExtendsThrowable",
              "shortDescription": {
                "text": "An `object` should not extend and type of Throwable. Throwables are stateful and should be instantiated only when needed for when a specific error occurs. An `object`, being a singleton, that extends any type of Throwable consequently introduces a global singleton exception whose instance may be inadvertently reused from multiple places, thus introducing shared mutable state."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/naming.html#matchingdeclarationname",
              "id": "detekt.naming.MatchingDeclarationName",
              "name": "MatchingDeclarationName",
              "shortDescription": {
                "text": "If a source file contains only a single non-private top-level class or object, the file name should reflect the case-sensitive name plus the .kt extension."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/naming.html#membernameequalsclassname",
              "id": "detekt.naming.MemberNameEqualsClassName",
              "name": "MemberNameEqualsClassName",
              "shortDescription": {
                "text": "A member should not be given the same name as its parent class or object."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/naming.html#variablenaming",
              "id": "detekt.naming.VariableNaming",
              "name": "VariableNaming",
              "shortDescription": {
                "text": "Variable names should follow the naming convention set in the projects configuration."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/naming.html#variableminlength",
              "id": "detekt.naming.VariableMinLength",
              "name": "VariableMinLength",
              "shortDescription": {
                "text": "Variable names should not be shorter than the minimum defined in the configuration."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/naming.html#variablemaxlength",
              "id": "detekt.naming.VariableMaxLength",
              "name": "VariableMaxLength",
              "shortDescription": {
                "text": "Variable names should not be longer than the maximum set in the configuration."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/naming.html#toplevelpropertynaming",
              "id": "detekt.naming.TopLevelPropertyNaming",
              "name": "TopLevelPropertyNaming",
              "shortDescription": {
                "text": "Top level property names should follow the naming convention set in the projects configuration."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/naming.html#objectpropertynaming",
              "id": "detekt.naming.ObjectPropertyNaming",
              "name": "ObjectPropertyNaming",
              "shortDescription": {
                "text": "Property names inside objects should follow the naming convention set in the projects configuration."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/naming.html#nonbooleanpropertyprefixedwithis",
              "id": "detekt.naming.NonBooleanPropertyPrefixedWithIs",
              "name": "NonBooleanPropertyPrefixedWithIs",
              "shortDescription": {
                "text": "Only boolean property names can start with 'is' prefix."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/naming.html#packagenaming",
              "id": "detekt.naming.PackageNaming",
              "name": "PackageNaming",
              "shortDescription": {
                "text": "Package names should match the naming convention set in the configuration."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/naming.html#classnaming",
              "id": "detekt.naming.ClassNaming",
              "name": "ClassNaming",
              "shortDescription": {
                "text": "A class or object's name should fit the naming pattern defined in the projects configuration."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/naming.html#enumnaming",
              "id": "detekt.naming.EnumNaming",
              "name": "EnumNaming",
              "shortDescription": {
                "text": "Enum names should follow the naming convention set in the projects configuration."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/naming.html#functionnaming",
              "id": "detekt.naming.FunctionNaming",
              "name": "FunctionNaming",
              "shortDescription": {
                "text": "Function names should follow the naming convention set in the configuration."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/naming.html#functionmaxlength",
              "id": "detekt.naming.FunctionMaxLength",
              "name": "FunctionMaxLength",
              "shortDescription": {
                "text": "Function names should not be longer than the maximum set in the project configuration."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/naming.html#functionminlength",
              "id": "detekt.naming.FunctionMinLength",
              "name": "FunctionMinLength",
              "shortDescription": {
                "text": "Function names should not be shorter than the minimum defined in the configuration."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/naming.html#forbiddenclassname",
              "id": "detekt.naming.ForbiddenClassName",
              "name": "ForbiddenClassName",
              "shortDescription": {
                "text": "Forbidden class name as per configuration detected."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/naming.html#constructorparameternaming",
              "id": "detekt.naming.ConstructorParameterNaming",
              "name": "ConstructorParameterNaming",
              "shortDescription": {
                "text": "Constructor parameter names should follow the naming convention set in the projects configuration."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/naming.html#functionparameternaming",
              "id": "detekt.naming.FunctionParameterNaming",
              "name": "FunctionParameterNaming",
              "shortDescription": {
                "text": "Function parameter names should follow the naming convention set in the projects configuration."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/naming.html#invalidpackagedeclaration",
              "id": "detekt.naming.InvalidPackageDeclaration",
              "name": "InvalidPackageDeclaration",
              "shortDescription": {
                "text": "Kotlin source files should be stored in the directory corresponding to its package statement."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/naming.html#nonameshadowing",
              "id": "detekt.naming.NoNameShadowing",
              "name": "NoNameShadowing",
              "shortDescription": {
                "text": "Disallows shadowing variable declarations."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/performance.html#foreachonrange",
              "id": "detekt.performance.ForEachOnRange",
              "name": "ForEachOnRange",
              "shortDescription": {
                "text": "Using the forEach method on ranges has a heavy performance cost. Prefer using simple for loops."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/performance.html#spreadoperator",
              "id": "detekt.performance.SpreadOperator",
              "name": "SpreadOperator",
              "shortDescription": {
                "text": "In most cases using a spread operator causes a full copy of the array to be created before calling a method. This may result in a performance penalty."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/performance.html#unnecessarytemporaryinstantiation",
              "id": "detekt.performance.UnnecessaryTemporaryInstantiation",
              "name": "UnnecessaryTemporaryInstantiation",
              "shortDescription": {
                "text": "Avoid temporary objects when converting primitive types to String."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/performance.html#arrayprimitive",
              "id": "detekt.performance.ArrayPrimitive",
              "name": "ArrayPrimitive",
              "shortDescription": {
                "text": "Using Array<Primitive> leads to implicit boxing and a performance hit"
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/custom-checks.html#spektestdiscovery",
              "id": "detekt.custom-checks.SpekTestDiscovery",
              "name": "SpekTestDiscovery",
              "shortDescription": {
                "text": "Spek tests can be quite expensive during test discovery.\nCompared to Junit5, Spek does not only use reflection to discover the test classes but also needs\nto instantiate and run the constructor closure to find tests.\nTry using only simple setup code to not slow down the startup of single tests or test suites."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/formatting.html#annotationonseparateline",
              "id": "detekt.formatting.AnnotationOnSeparateLine",
              "name": "AnnotationOnSeparateLine",
              "shortDescription": {
                "text": "Multiple annotations should be placed on separate lines. "
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/formatting.html#annotationspacing",
              "id": "detekt.formatting.AnnotationSpacing",
              "name": "AnnotationSpacing",
              "shortDescription": {
                "text": "There should not be empty lines between an annotation and the object that it's annotating"
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/formatting.html#argumentlistwrapping",
              "id": "detekt.formatting.ArgumentListWrapping",
              "name": "ArgumentListWrapping",
              "shortDescription": {
                "text": "Reports incorrect argument list wrapping"
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/formatting.html#chainwrapping",
              "id": "detekt.formatting.ChainWrapping",
              "name": "ChainWrapping",
              "shortDescription": {
                "text": "Checks if condition chaining is wrapped right"
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/formatting.html#commentspacing",
              "id": "detekt.formatting.CommentSpacing",
              "name": "CommentSpacing",
              "shortDescription": {
                "text": "Checks if comments have the right spacing"
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/formatting.html#enumentrynamecase",
              "id": "detekt.formatting.EnumEntryNameCase",
              "name": "EnumEntryNameCase",
              "shortDescription": {
                "text": "Reports enum entries with names that don't meet standard conventions."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/formatting.html#filename",
              "id": "detekt.formatting.Filename",
              "name": "Filename",
              "shortDescription": {
                "text": "Checks if top level class matches the filename"
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/formatting.html#finalnewline",
              "id": "detekt.formatting.FinalNewline",
              "name": "FinalNewline",
              "shortDescription": {
                "text": "Detects missing final newlines"
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/formatting.html#importordering",
              "id": "detekt.formatting.ImportOrdering",
              "name": "ImportOrdering",
              "shortDescription": {
                "text": "Detects imports in non default order"
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/formatting.html#indentation",
              "id": "detekt.formatting.Indentation",
              "name": "Indentation",
              "shortDescription": {
                "text": "Reports mis-indented code"
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/formatting.html#maximumlinelength",
              "id": "detekt.formatting.MaximumLineLength",
              "name": "MaximumLineLength",
              "shortDescription": {
                "text": "Reports lines with exceeded length"
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/formatting.html#modifierordering",
              "id": "detekt.formatting.ModifierOrdering",
              "name": "ModifierOrdering",
              "shortDescription": {
                "text": "Detects modifiers in non default order"
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/formatting.html#multilineifelse",
              "id": "detekt.formatting.MultiLineIfElse",
              "name": "MultiLineIfElse",
              "shortDescription": {
                "text": "Detects multiline if-else statements without braces"
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/formatting.html#noblanklinebeforerbrace",
              "id": "detekt.formatting.NoBlankLineBeforeRbrace",
              "name": "NoBlankLineBeforeRbrace",
              "shortDescription": {
                "text": "Detects blank lines before rbraces"
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/formatting.html#noconsecutiveblanklines",
              "id": "detekt.formatting.NoConsecutiveBlankLines",
              "name": "NoConsecutiveBlankLines",
              "shortDescription": {
                "text": "Reports consecutive blank lines"
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/formatting.html#noemptyclassbody",
              "id": "detekt.formatting.NoEmptyClassBody",
              "name": "NoEmptyClassBody",
              "shortDescription": {
                "text": "Reports empty class bodies"
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/formatting.html#noemptyfirstlineinmethodblock",
              "id": "detekt.formatting.NoEmptyFirstLineInMethodBlock",
              "name": "NoEmptyFirstLineInMethodBlock",
              "shortDescription": {
                "text": "Reports methods that have an empty first line."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/formatting.html#nolinebreakafterelse",
              "id": "detekt.formatting.NoLineBreakAfterElse",
              "name": "NoLineBreakAfterElse",
              "shortDescription": {
                "text": "Reports line breaks after else"
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/formatting.html#nolinebreakbeforeassignment",
              "id": "detekt.formatting.NoLineBreakBeforeAssignment",
              "name": "NoLineBreakBeforeAssignment",
              "shortDescription": {
                "text": "Reports line breaks before assignment"
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/formatting.html#nomultiplespaces",
              "id": "detekt.formatting.NoMultipleSpaces",
              "name": "NoMultipleSpaces",
              "shortDescription": {
                "text": "Reports multiple space usages"
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/formatting.html#nosemicolons",
              "id": "detekt.formatting.NoSemicolons",
              "name": "NoSemicolons",
              "shortDescription": {
                "text": "Detects semicolons"
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/formatting.html#notrailingspaces",
              "id": "detekt.formatting.NoTrailingSpaces",
              "name": "NoTrailingSpaces",
              "shortDescription": {
                "text": "Detects trailing spaces"
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/formatting.html#nounitreturn",
              "id": "detekt.formatting.NoUnitReturn",
              "name": "NoUnitReturn",
              "shortDescription": {
                "text": "Detects optional 'Unit' return types"
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/formatting.html#nounusedimports",
              "id": "detekt.formatting.NoUnusedImports",
              "name": "NoUnusedImports",
              "shortDescription": {
                "text": "Detects unused imports"
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/formatting.html#nowildcardimports",
              "id": "detekt.formatting.NoWildcardImports",
              "name": "NoWildcardImports",
              "shortDescription": {
                "text": "Detects wildcast import usages"
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/formatting.html#packagename",
              "id": "detekt.formatting.PackageName",
              "name": "PackageName",
              "shortDescription": {
                "text": "Checks package name is formatted correctly"
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/formatting.html#parameterlistwrapping",
              "id": "detekt.formatting.ParameterListWrapping",
              "name": "ParameterListWrapping",
              "shortDescription": {
                "text": "Detects mis-aligned parameter lists"
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/formatting.html#spacingaroundanglebrackets",
              "id": "detekt.formatting.SpacingAroundAngleBrackets",
              "name": "SpacingAroundAngleBrackets",
              "shortDescription": {
                "text": "Reports spaces around angle brackets"
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/formatting.html#spacingaroundcolon",
              "id": "detekt.formatting.SpacingAroundColon",
              "name": "SpacingAroundColon",
              "shortDescription": {
                "text": "Reports spaces around colons"
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/formatting.html#spacingaroundcomma",
              "id": "detekt.formatting.SpacingAroundComma",
              "name": "SpacingAroundComma",
              "shortDescription": {
                "text": "Reports spaces around commas"
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/formatting.html#spacingaroundcurly",
              "id": "detekt.formatting.SpacingAroundCurly",
              "name": "SpacingAroundCurly",
              "shortDescription": {
                "text": "Reports spaces around curly braces"
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/formatting.html#spacingarounddoublecolon",
              "id": "detekt.formatting.SpacingAroundDoubleColon",
              "name": "SpacingAroundDoubleColon",
              "shortDescription": {
                "text": "Reports spaces around double colons"
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/formatting.html#spacingarounddot",
              "id": "detekt.formatting.SpacingAroundDot",
              "name": "SpacingAroundDot",
              "shortDescription": {
                "text": "Reports spaces around member invocation operator (dot)."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/formatting.html#spacingaroundkeyword",
              "id": "detekt.formatting.SpacingAroundKeyword",
              "name": "SpacingAroundKeyword",
              "shortDescription": {
                "text": "Reports spaces around keywords"
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/formatting.html#spacingaroundoperators",
              "id": "detekt.formatting.SpacingAroundOperators",
              "name": "SpacingAroundOperators",
              "shortDescription": {
                "text": "Reports spaces around operators"
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/formatting.html#spacingaroundparens",
              "id": "detekt.formatting.SpacingAroundParens",
              "name": "SpacingAroundParens",
              "shortDescription": {
                "text": "Reports spaces around parentheses"
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/formatting.html#spacingaroundrangeoperator",
              "id": "detekt.formatting.SpacingAroundRangeOperator",
              "name": "SpacingAroundRangeOperator",
              "shortDescription": {
                "text": "Reports spaces around range operator"
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/formatting.html#spacingaroundunaryoperator",
              "id": "detekt.formatting.SpacingAroundUnaryOperator",
              "name": "SpacingAroundUnaryOperator",
              "shortDescription": {
                "text": "Reports spaces around unary operator"
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/formatting.html#spacingbetweendeclarationswithannotations",
              "id": "detekt.formatting.SpacingBetweenDeclarationsWithAnnotations",
              "name": "SpacingBetweenDeclarationsWithAnnotations",
              "shortDescription": {
                "text": "Declarations and declarations with annotations should have an empty space between."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/formatting.html#spacingbetweendeclarationswithcomments",
              "id": "detekt.formatting.SpacingBetweenDeclarationsWithComments",
              "name": "SpacingBetweenDeclarationsWithComments",
              "shortDescription": {
                "text": "Declarations and declarations with comments should have an empty space between."
              }
            },
            {
              "helpUri": "https://detekt.github.io/detekt/formatting.html#stringtemplate",
              "id": "detekt.formatting.StringTemplate",
              "name": "StringTemplate",
              "shortDescription": {
                "text": "Detects simplifications in template strings"
              }
            }
          ],
          "semanticVersion": "1.16.0",
          "version": "1.16.0"
        }
      }
    }
  ]
}
```