### PR TITLE
Support Gradle config cache in detekt's build

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,6 @@
+import io.gitlab.arturbosch.detekt.Detekt
+import io.gitlab.arturbosch.detekt.DetektCreateBaselineTask
+
 plugins {
     kotlin("jvm") apply false
     jacoco
@@ -38,4 +41,66 @@ tasks {
             xml.destination = file("$buildDir/reports/jacoco/report.xml")
         }
     }
+}
+
+val analysisDir = file(projectDir)
+val baselineFile = file("$rootDir/config/detekt/baseline.xml")
+val configFile = file("$rootDir/config/detekt/detekt.yml")
+val statisticsConfigFile = file("$rootDir/config/detekt/statistics.yml")
+
+val kotlinFiles = "**/*.kt"
+val kotlinScriptFiles = "**/*.kts"
+val resourceFiles = "**/resources/**"
+val buildFiles = "**/build/**"
+
+val detektFormat by tasks.registering(Detekt::class) {
+    description = "Formats whole project."
+    parallel = true
+    disableDefaultRuleSets = true
+    buildUponDefaultConfig = true
+    autoCorrect = true
+    setSource(analysisDir)
+    config.setFrom(listOf(statisticsConfigFile, configFile))
+    include(kotlinFiles)
+    include(kotlinScriptFiles)
+    exclude(resourceFiles)
+    exclude(buildFiles)
+    baseline.set(baselineFile)
+    reports {
+        xml.enabled = false
+        html.enabled = false
+        txt.enabled = false
+    }
+}
+
+val detektAll by tasks.registering(Detekt::class) {
+    description = "Runs the whole project at once."
+    parallel = true
+    buildUponDefaultConfig = true
+    setSource(analysisDir)
+    config.setFrom(listOf(statisticsConfigFile, configFile))
+    include(kotlinFiles)
+    include(kotlinScriptFiles)
+    exclude(resourceFiles)
+    exclude(buildFiles)
+    baseline.set(baselineFile)
+    reports {
+        xml.enabled = false
+        html.enabled = false
+        txt.enabled = false
+    }
+}
+
+val detektProjectBaseline by tasks.registering(DetektCreateBaselineTask::class) {
+    description = "Overrides current baseline."
+    buildUponDefaultConfig.set(true)
+    ignoreFailures.set(true)
+    parallel.set(true)
+    setSource(analysisDir)
+    config.setFrom(listOf(statisticsConfigFile, configFile))
+    include(kotlinFiles)
+    include(kotlinScriptFiles)
+    exclude(resourceFiles)
+    exclude(buildFiles)
+    baseline.set(baselineFile)
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -16,7 +16,7 @@ object Plugins {
     const val KOTLIN = "1.4.21"
     const val DETEKT = "1.16.0"
     const val GITHUB_RELEASE = "2.2.12"
-    const val SHADOW = "5.2.0"
+    const val SHADOW = "6.1.0"
     const val VERSIONS = "0.28.0"
     const val SONAR = "2.8"
     const val DOKKA = "1.4.10"

--- a/buildSrc/src/main/kotlin/detekt.gradle.kts
+++ b/buildSrc/src/main/kotlin/detekt.gradle.kts
@@ -1,104 +1,36 @@
 import io.gitlab.arturbosch.detekt.Detekt
-import io.gitlab.arturbosch.detekt.DetektCreateBaselineTask
 import io.gitlab.arturbosch.detekt.extensions.DetektExtension
 
 plugins {
     id("io.gitlab.arturbosch.detekt")
 }
 
-val analysisDir = file(projectDir)
 val baselineFile = file("$rootDir/config/detekt/baseline.xml")
-val configFile = file("$rootDir/config/detekt/detekt.yml")
-val statisticsConfigFile = file("$rootDir/config/detekt/statistics.yml")
 
-val kotlinFiles = "**/*.kt"
-val kotlinScriptFiles = "**/*.kts"
-val resourceFiles = "**/resources/**"
-val buildFiles = "**/build/**"
-
-subprojects {
-
-    apply {
-        plugin("io.gitlab.arturbosch.detekt")
-    }
-
-    tasks.withType<Detekt>().configureEach {
-        jvmTarget = "1.8"
-    }
-
-    detekt {
-        input = objects.fileCollection().from(
-            DetektExtension.DEFAULT_SRC_DIR_JAVA,
-            "src/test/java",
-            DetektExtension.DEFAULT_SRC_DIR_KOTLIN,
-            "src/test/kotlin"
-        )
-        buildUponDefaultConfig = true
-        baseline = baselineFile
-
-        reports {
-            xml.enabled = true
-            html.enabled = true
-            txt.enabled = true
-            sarif.enabled = true
-        }
-    }
-
-    dependencies {
-        detekt(project(":detekt-cli"))
-        detektPlugins(project(":custom-checks"))
-        detektPlugins(project(":detekt-formatting"))
-    }
+tasks.withType<Detekt>().configureEach {
+    jvmTarget = "1.8"
 }
 
-val detektFormat by tasks.registering(Detekt::class) {
-    description = "Formats whole project."
-    parallel = true
-    disableDefaultRuleSets = true
+detekt {
+    input = objects.fileCollection().from(
+        DetektExtension.DEFAULT_SRC_DIR_JAVA,
+        "src/test/java",
+        DetektExtension.DEFAULT_SRC_DIR_KOTLIN,
+        "src/test/kotlin"
+    )
     buildUponDefaultConfig = true
-    autoCorrect = true
-    setSource(analysisDir)
-    config.setFrom(listOf(statisticsConfigFile, configFile))
-    include(kotlinFiles)
-    include(kotlinScriptFiles)
-    exclude(resourceFiles)
-    exclude(buildFiles)
-    baseline.set(baselineFile)
+    baseline = baselineFile
+
     reports {
-        xml.enabled = false
-        html.enabled = false
-        txt.enabled = false
+        xml.enabled = true
+        html.enabled = true
+        txt.enabled = true
+        sarif.enabled = true
     }
 }
 
-val detektAll by tasks.registering(Detekt::class) {
-    description = "Runs the whole project at once."
-    parallel = true
-    buildUponDefaultConfig = true
-    setSource(analysisDir)
-    config.setFrom(listOf(statisticsConfigFile, configFile))
-    include(kotlinFiles)
-    include(kotlinScriptFiles)
-    exclude(resourceFiles)
-    exclude(buildFiles)
-    baseline.set(baselineFile)
-    reports {
-        xml.enabled = false
-        html.enabled = false
-        txt.enabled = false
-    }
-}
-
-val detektProjectBaseline by tasks.registering(DetektCreateBaselineTask::class) {
-    description = "Overrides current baseline."
-    buildUponDefaultConfig.set(true)
-    ignoreFailures.set(true)
-    parallel.set(true)
-    setSource(analysisDir)
-    config.setFrom(listOf(statisticsConfigFile, configFile))
-    include(kotlinFiles)
-    include(kotlinScriptFiles)
-    exclude(resourceFiles)
-    exclude(buildFiles)
-    baseline.set(baselineFile)
+dependencies {
+    detekt(project(":detekt-cli"))
+    detektPlugins(project(":custom-checks"))
+    detektPlugins(project(":detekt-formatting"))
 }

--- a/buildSrc/src/main/kotlin/module.gradle.kts
+++ b/buildSrc/src/main/kotlin/module.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     kotlin("jvm")
     `maven-publish`
     jacoco
+    id("detekt")
 }
 
 // bundle detekt's version for all jars to use it at runtime

--- a/detekt-generator/build.gradle.kts
+++ b/detekt-generator/build.gradle.kts
@@ -27,7 +27,7 @@ val ruleModules = rootProject.subprojects
     .filterNot { it == "detekt-rules" }
     .map { "${rootProject.rootDir}/$it/src/main/kotlin" }
 
-val generateDocumentation by tasks.registering {
+val generateDocumentation by tasks.registering(JavaExec::class) {
     dependsOn(tasks.assemble, ":detekt-api:dokkaJekyll")
     description = "Generates detekt documentation and the default config.yml based on Rule KDoc"
     group = "documentation"
@@ -44,42 +44,31 @@ val generateDocumentation by tasks.registering {
         file(cliOptionsFile)
     )
 
-    doLast {
-        javaexec {
-            classpath(
-                configurations.runtimeClasspath.get(),
-                configurations.compileClasspath.get(),
-                sourceSets.main.get().output
-            )
-            main = "io.gitlab.arturbosch.detekt.generator.Main"
-            args = listOf(
-                "--input",
-                ruleModules.joinToString(",") + "," + "${rootProject.rootDir}/detekt-formatting/src/main/kotlin",
-                "--documentation",
-                documentationDir,
-                "--config",
-                configDir,
-                "--cli-options",
-                cliOptionsFile
-            )
-        }
-    }
+    classpath(
+        configurations.runtimeClasspath.get(),
+        configurations.compileClasspath.get(),
+        sourceSets.main.get().output
+    )
+    main = "io.gitlab.arturbosch.detekt.generator.Main"
+    args = listOf(
+        "--input",
+        ruleModules.joinToString(",") + "," + "${rootProject.rootDir}/detekt-formatting/src/main/kotlin",
+        "--documentation",
+        documentationDir,
+        "--config",
+        configDir,
+        "--cli-options",
+        cliOptionsFile
+    )
 }
 
-val verifyGeneratorOutput by tasks.registering {
+val verifyGeneratorOutput by tasks.registering(Exec::class) {
     dependsOn(generateDocumentation)
     description = "Verifies that the default-detekt-config.yml is up-to-date"
-    doLast {
-        assertDefaultConfigUpToDate()
-    }
-}
-
-fun assertDefaultConfigUpToDate() {
     val configDiff = ByteArrayOutputStream()
-    exec {
-        commandLine = listOf("git", "diff", defaultConfigFile)
-        standardOutput = configDiff
-    }
+
+    commandLine = listOf("git", "diff", defaultConfigFile)
+    standardOutput = configDiff
 
     if (configDiff.toString().isNotEmpty()) {
         throw GradleException("The default-detekt-config.yml is not up-to-date. " +

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -33,7 +33,7 @@ include(
 
 // build scan plugin can only be applied in settings file
 plugins {
-    id("com.gradle.enterprise") version "3.3.1"
+    id("com.gradle.enterprise") version "3.6"
 }
 
 gradleEnterprise {


### PR DESCRIPTION
A few improvements to eventually allow the Gradle configuration cache to be used when building detekt.

There are changes required in some Gradle plugins used by the detekt build before this will work:
* Kotlin 1.4.30 or higher
* Gradle 7.0 (or 6.8.4 which should include a backported fix for an issue)
* https://github.com/Kotlin/dokka/issues/1217 to be fixed
* https://github.com/Kotlin/binary-compatibility-validator/pull/50 to be merged & released