### PR TITLE
Replace @requiresTypeResolution kdoc tag with @RequiresTypeResolution annotation

### DIFF
--- a/detekt-api/api/detekt-api.api
+++ b/detekt-api/api/detekt-api.api
@@ -451,6 +451,9 @@ public final class io/gitlab/arturbosch/detekt/api/ReportingExtension$DefaultImp
 	public static fun transformFindings (Lio/gitlab/arturbosch/detekt/api/ReportingExtension;Ljava/util/Map;)Ljava/util/Map;
 }
 
+public abstract interface annotation class io/gitlab/arturbosch/detekt/api/RequiresTypeResolution : java/lang/annotation/Annotation {
+}
+
 public abstract class io/gitlab/arturbosch/detekt/api/Rule : io/gitlab/arturbosch/detekt/api/internal/BaseRule, io/gitlab/arturbosch/detekt/api/ConfigAware {
 	public fun <init> ()V
 	public fun <init> (Lio/gitlab/arturbosch/detekt/api/Config;Lio/gitlab/arturbosch/detekt/api/Context;)V

--- a/detekt-api/api/detekt-api.api
+++ b/detekt-api/api/detekt-api.api
@@ -451,9 +451,6 @@ public final class io/gitlab/arturbosch/detekt/api/ReportingExtension$DefaultImp
 	public static fun transformFindings (Lio/gitlab/arturbosch/detekt/api/ReportingExtension;Ljava/util/Map;)Ljava/util/Map;
 }
 
-public abstract interface annotation class io/gitlab/arturbosch/detekt/api/RequiresTypeResolution : java/lang/annotation/Annotation {
-}
-
 public abstract class io/gitlab/arturbosch/detekt/api/Rule : io/gitlab/arturbosch/detekt/api/internal/BaseRule, io/gitlab/arturbosch/detekt/api/ConfigAware {
 	public fun <init> ()V
 	public fun <init> (Lio/gitlab/arturbosch/detekt/api/Config;Lio/gitlab/arturbosch/detekt/api/Context;)V

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/RequiresTypeResolution.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/RequiresTypeResolution.kt
@@ -1,0 +1,9 @@
+package io.gitlab.arturbosch.detekt.api
+
+/**
+ * A Rule can be annotated with this to indicate that it needs type resolution to be enabled in order to work.
+ */
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+@MustBeDocumented
+annotation class RequiresTypeResolution

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/RequiresTypeResolution.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/RequiresTypeResolution.kt
@@ -1,7 +1,7 @@
 package io.gitlab.arturbosch.detekt.api.internal
 
 /**
- * A Rule can be annotated with this to indicate that it needs type resolution to be enabled in order to work.
+ * Annotated [io.gitlab.arturbosch.detekt.api.Rule] requires type resolution to work.
  */
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.SOURCE)

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/RequiresTypeResolution.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/RequiresTypeResolution.kt
@@ -1,9 +1,8 @@
-package io.gitlab.arturbosch.detekt.api
+package io.gitlab.arturbosch.detekt.api.internal
 
 /**
  * A Rule can be annotated with this to indicate that it needs type resolution to be enabled in order to work.
  */
 @Target(AnnotationTarget.CLASS)
-@Retention(AnnotationRetention.RUNTIME)
-@MustBeDocumented
+@Retention(AnnotationRetention.SOURCE)
 annotation class RequiresTypeResolution

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/Annotations.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/Annotations.kt
@@ -1,0 +1,7 @@
+package io.gitlab.arturbosch.detekt.generator.collection
+
+import org.jetbrains.kotlin.psi.KtClassOrObject
+import kotlin.reflect.KClass
+
+fun KtClassOrObject.isAnnotatedWith(annotation: KClass<out Annotation>) =
+    annotationEntries.any { it.shortName?.identifier == annotation.simpleName }

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/KDocTags.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/KDocTags.kt
@@ -6,51 +6,55 @@ import org.jetbrains.kotlin.kdoc.psi.impl.KDocTag
 import org.jetbrains.kotlin.psi.KtClassOrObject
 
 fun KtClassOrObject.parseConfigurationTags() =
-        kDocSection()?.findTagsByName(TAG_CONFIGURATION)
-                ?.filter { it.isValidConfigurationTag() }
-                ?.map { it.parseConfigTag() }
-            ?: emptyList()
+    kDocSection()?.findTagsByName(TAG_CONFIGURATION)
+        ?.filter { it.isValidConfigurationTag() }
+        ?.map { it.parseConfigTag() }
+        ?: emptyList()
 
 fun KtClassOrObject.kDocSection(): KDocSection? = docComment?.getDefaultSection()
 
-fun KDocTag.parseConfigTag(): Configuration {
+fun KtClassOrObject.hasKDocTag(tagName: String) = kDocSection()?.findTagByName(tagName) != null
+
+private fun KDocTag.parseConfigTag(): Configuration {
     val content: String = getContent()
     val delimiterIndex = content.indexOf('-')
     val name = content.substring(0, delimiterIndex - 1)
     val defaultValue = configurationDefaultValueRegex.find(content)
-            ?.groupValues
-            ?.get(1)
-            ?.trim() ?: ""
+        ?.groupValues
+        ?.get(1)
+        ?.trim() ?: ""
     val deprecatedMessage = configurationDeprecatedRegex.find(content)
-            ?.groupValues
-            ?.get(1)
-            ?.trim()
+        ?.groupValues
+        ?.get(1)
+        ?.trim()
     val description = content.substring(delimiterIndex + 1)
-            .replace(configurationDefaultValueRegex, "")
-            .replace(configurationDeprecatedRegex, "")
-            .trim()
+        .replace(configurationDefaultValueRegex, "")
+        .replace(configurationDeprecatedRegex, "")
+        .trim()
     return Configuration(name, description, defaultValue, deprecatedMessage)
 }
 
 private const val EXPECTED_CONFIGURATION_FORMAT =
-        "Expected format: @configuration {paramName} - {paramDescription} (default: `{defaultValue}`)."
+    "Expected format: @configuration {paramName} - {paramDescription} (default: `{defaultValue}`)."
 
-fun KDocTag.isValidConfigurationTag(entity: String = "Rule"): Boolean {
+private fun KDocTag.isValidConfigurationTag(entity: String = "Rule"): Boolean {
     val content: String = getContent()
     if (!content.contains(" - ")) {
         throw InvalidDocumentationException(
-                "[${containingFile.name}] $entity '$content' doesn't seem to contain a description.\n" +
-                        EXPECTED_CONFIGURATION_FORMAT)
+            "[${containingFile.name}] $entity '$content' doesn't seem to contain a description.\n" +
+                EXPECTED_CONFIGURATION_FORMAT
+        )
     }
     if (content.substringAfter("`", "").substringBeforeLast("`", "").isBlank()) {
         val parameterName = content.substringBefore(" - ")
         throw InvalidDocumentationException(
-                "[${containingFile.name}] $entity '$parameterName' doesn't seem to contain a default value.\n" +
-                        EXPECTED_CONFIGURATION_FORMAT)
+            "[${containingFile.name}] $entity '$parameterName' doesn't seem to contain a default value.\n" +
+                EXPECTED_CONFIGURATION_FORMAT
+        )
     }
     return true
 }
 
-val configurationDefaultValueRegex = "\\(default: `(.+)`\\)".toRegex(RegexOption.DOT_MATCHES_ALL)
-val configurationDeprecatedRegex = "\\(deprecated: \"(.+)\"\\)".toRegex(RegexOption.DOT_MATCHES_ALL)
-const val TAG_CONFIGURATION = "configuration"
+private val configurationDefaultValueRegex = "\\(default: `(.+)`\\)".toRegex(RegexOption.DOT_MATCHES_ALL)
+private val configurationDeprecatedRegex = "\\(deprecated: \"(.+)\"\\)".toRegex(RegexOption.DOT_MATCHES_ALL)
+private const val TAG_CONFIGURATION = "configuration"

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleVisitor.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleVisitor.kt
@@ -2,8 +2,8 @@ package io.gitlab.arturbosch.detekt.generator.collection
 
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.DetektVisitor
-import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.ThresholdRule
+import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 import io.gitlab.arturbosch.detekt.generator.collection.exception.InvalidAliasesDeclaration
 import io.gitlab.arturbosch.detekt.generator.collection.exception.InvalidCodeExampleDocumentationException

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleVisitor.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleVisitor.kt
@@ -101,12 +101,15 @@ internal class RuleVisitor : DetektVisitor() {
         }
 
         autoCorrect = classOrObject.kDocSection()?.findTagByName(TAG_AUTO_CORRECT) != null
-        requiresTypeResolution = classOrObject.kDocSection()?.findTagByName(TAG_REQUIRES_TYPE_RESOLUTION) != null
+        requiresTypeResolution = classOrObject.requiresTypeResolution()
 
         val comment = classOrObject.kDocSection()?.getContent()?.trim()?.replace("@@", "@") ?: return
         extractRuleDocumentation(comment)
         configuration.addAll(classOrObject.parseConfigurationTags())
     }
+
+    private fun KtClassOrObject.requiresTypeResolution() =
+        kDocSection()?.findTagByName(TAG_REQUIRES_TYPE_RESOLUTION) != null
 
     private fun extractRuleDocumentation(comment: String) {
         val nonCompliantIndex = comment.indexOf(TAG_NONCOMPLIANT)

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleVisitor.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleVisitor.kt
@@ -18,9 +18,7 @@ import org.jetbrains.kotlin.psi.KtValueArgument
 import org.jetbrains.kotlin.psi.psiUtil.containingClass
 import org.jetbrains.kotlin.psi.psiUtil.getSuperNames
 import java.lang.reflect.Modifier
-import kotlin.reflect.KClass
 
-@Suppress("TooManyFunctions")
 internal class RuleVisitor : DetektVisitor() {
 
     val containsRule
@@ -104,19 +102,12 @@ internal class RuleVisitor : DetektVisitor() {
         }
 
         autoCorrect = classOrObject.hasKDocTag(TAG_AUTO_CORRECT)
-        requiresTypeResolution = classOrObject.requiresTypeResolution()
+        requiresTypeResolution = classOrObject.isAnnotatedWith(RequiresTypeResolution::class)
 
         val comment = classOrObject.kDocSection()?.getContent()?.trim()?.replace("@@", "@") ?: return
         extractRuleDocumentation(comment)
         configuration.addAll(classOrObject.parseConfigurationTags())
     }
-
-    private fun KtClassOrObject.hasKDocTag(tagName: String) = kDocSection()?.findTagByName(tagName) != null
-
-    private fun KtClassOrObject.requiresTypeResolution() = isAnnotatedWith(RequiresTypeResolution::class)
-
-    private fun KtClassOrObject.isAnnotatedWith(annotation: KClass<out Annotation>) =
-        annotationEntries.any { it.shortName?.identifier == annotation.simpleName }
 
     private fun extractRuleDocumentation(comment: String) {
         val nonCompliantIndex = comment.indexOf(TAG_NONCOMPLIANT)

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleVisitor.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleVisitor.kt
@@ -61,9 +61,9 @@ internal class RuleVisitor : DetektVisitor() {
 
     override fun visitSuperTypeList(list: KtSuperTypeList) {
         val isRule = list.entries
-                ?.asSequence()
-                ?.map { it.typeAsUserType?.referencedName }
-                ?.any { ruleClasses.contains(it) } ?: false
+            ?.asSequence()
+            ?.map { it.typeAsUserType?.referencedName }
+            ?.any { ruleClasses.contains(it) } ?: false
 
         val containingClass = list.containingClass()
         val className = containingClass?.name
@@ -117,7 +117,8 @@ internal class RuleVisitor : DetektVisitor() {
                 extractCompliantDocumentation(comment, compliantIndex)
             }
             compliantIndex != -1 -> throw InvalidCodeExampleDocumentationException(
-                    "Rule $name contains a compliant without a noncompliant code definition")
+                "Rule $name contains a compliant without a noncompliant code definition"
+            )
             else -> description = comment
         }
     }
@@ -126,12 +127,13 @@ internal class RuleVisitor : DetektVisitor() {
         val nonCompliantEndIndex = comment.indexOf(ENDTAG_NONCOMPLIANT)
         if (nonCompliantEndIndex == -1) {
             throw InvalidCodeExampleDocumentationException(
-                    "Rule $name contains an incorrect noncompliant code definition")
+                "Rule $name contains an incorrect noncompliant code definition"
+            )
         }
         description = comment.substring(0, nonCompliantIndex).trim()
         nonCompliant = comment.substring(nonCompliantIndex + TAG_NONCOMPLIANT.length, nonCompliantEndIndex)
-                .trimStartingLineBreaks()
-                .trimEnd()
+            .trimStartingLineBreaks()
+            .trimEnd()
     }
 
     private fun extractCompliantDocumentation(comment: String, compliantIndex: Int) {
@@ -139,31 +141,36 @@ internal class RuleVisitor : DetektVisitor() {
         if (compliantIndex != -1) {
             if (compliantEndIndex == -1) {
                 throw InvalidCodeExampleDocumentationException(
-                        "Rule $name contains an incorrect compliant code definition")
+                    "Rule $name contains an incorrect compliant code definition"
+                )
             }
             compliant = comment.substring(compliantIndex + TAG_COMPLIANT.length, compliantEndIndex)
-                    .trimStartingLineBreaks()
-                    .trimEnd()
+                .trimStartingLineBreaks()
+                .trimEnd()
         }
     }
 
     private fun extractAliases(klass: KtClass) {
         val initializer = klass.getProperties()
-                .singleOrNull { it.name == "defaultRuleIdAliases" }
-                ?.initializer
+            .singleOrNull { it.name == "defaultRuleIdAliases" }
+            ?.initializer
         if (initializer != null) {
-            aliases = (initializer as? KtCallExpression
-                ?: throw InvalidAliasesDeclaration())
-                    .valueArguments
-                    .joinToString(", ") { it.text.replace("\"", "") }
+            aliases = (
+                initializer as? KtCallExpression
+                    ?: throw InvalidAliasesDeclaration()
+                )
+                .valueArguments
+                .joinToString(", ") { it.text.replace("\"", "") }
         }
     }
 
     private fun extractIssueSeverityAndDebt(klass: KtClass) {
-        val arguments = (klass.getProperties()
+        val arguments = (
+            klass.getProperties()
                 .singleOrNull { it.name == "issue" }
-                ?.initializer as? KtCallExpression)
-                ?.valueArguments ?: emptyList()
+                ?.initializer as? KtCallExpression
+            )
+            ?.valueArguments ?: emptyList()
 
         if (arguments.size >= ISSUE_ARGUMENT_SIZE) {
             severity = getArgument(arguments[1], "Severity")
@@ -188,10 +195,10 @@ internal class RuleVisitor : DetektVisitor() {
 
     companion object {
         private val ruleClasses = listOf(
-                io.gitlab.arturbosch.detekt.api.Rule::class.simpleName,
-                FormattingRule::class.simpleName,
-                ThresholdRule::class.simpleName,
-                EmptyRule::class.simpleName
+            io.gitlab.arturbosch.detekt.api.Rule::class.simpleName,
+            FormattingRule::class.simpleName,
+            ThresholdRule::class.simpleName,
+            EmptyRule::class.simpleName
         )
 
         private const val TAG_ACTIVE = "active"

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleVisitor.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleVisitor.kt
@@ -113,8 +113,7 @@ internal class RuleVisitor : DetektVisitor() {
 
     private fun KtClassOrObject.hasKDocTag(tagName: String) = kDocSection()?.findTagByName(tagName) != null
 
-    private fun KtClassOrObject.requiresTypeResolution() =
-        isAnnotatedWith(RequiresTypeResolution::class) || hasKDocTag(TAG_REQUIRES_TYPE_RESOLUTION)
+    private fun KtClassOrObject.requiresTypeResolution() = isAnnotatedWith(RequiresTypeResolution::class)
 
     private fun KtClassOrObject.isAnnotatedWith(annotation: KClass<out Annotation>) =
         annotationEntries.any { it.shortName?.identifier == annotation.simpleName }
@@ -215,7 +214,6 @@ internal class RuleVisitor : DetektVisitor() {
         private const val TAG_ACTIVE = "active"
         private const val SINCE_KEYWORD = "since"
         private const val TAG_AUTO_CORRECT = "autoCorrect"
-        private const val TAG_REQUIRES_TYPE_RESOLUTION = "requiresTypeResolution"
         private const val TAG_NONCOMPLIANT = "<noncompliant>"
         private const val ENDTAG_NONCOMPLIANT = "</noncompliant>"
         private const val TAG_COMPLIANT = "<compliant>"

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleCollectorSpec.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleCollectorSpec.kt
@@ -205,18 +205,6 @@ class RuleCollectorSpec : Spek({
 
         it("collects the flag that it requires type resolution") {
             val code = """
-                /**
-                 * description
-                 * @requiresTypeResolution
-                 */
-                class SomeRandomClass : Rule
-            """
-            val items = subject.run(code)
-            assertThat(items[0].requiresTypeResolution).isTrue()
-        }
-
-        it("collects the flag that it requires type resolution from annotation") {
-            val code = """
                 import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
                 
                 /**

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleCollectorSpec.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleCollectorSpec.kt
@@ -212,7 +212,32 @@ class RuleCollectorSpec : Spek({
                 class SomeRandomClass : Rule
             """
             val items = subject.run(code)
-            assertThat(items).hasSize(1)
+            assertThat(items[0].requiresTypeResolution).isTrue()
+        }
+
+        it("collects the flag that it requires type resolution from annotation") {
+            val code = """
+                import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
+                
+                /**
+                 * description
+                 */
+                @RequiresTypeResolution
+                class SomeRandomClass : Rule
+            """
+            val items = subject.run(code)
+            assertThat(items[0].requiresTypeResolution).isTrue()
+        }
+
+        it("collects the flag that it requires type resolution from fully qualified annotation") {
+            val code = """
+                /**
+                 * description
+                 */
+                @io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
+                class SomeRandomClass : Rule
+            """
+            val items = subject.run(code)
             assertThat(items[0].requiresTypeResolution).isTrue()
         }
 

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleCollectorSpec.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleCollectorSpec.kt
@@ -203,6 +203,19 @@ class RuleCollectorSpec : Spek({
             assertThat(items[0].configuration).hasSize(2)
         }
 
+        it("collects the flag that it requires type resolution") {
+            val code = """
+                /**
+                 * description
+                 * @requiresTypeResolution
+                 */
+                class SomeRandomClass : Rule
+            """
+            val items = subject.run(code)
+            assertThat(items).hasSize(1)
+            assertThat(items[0].requiresTypeResolution).isTrue()
+        }
+
         it("config option doesn't have a default value") {
             val code = """
                 /**

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleCollectorSpec.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleCollectorSpec.kt
@@ -205,7 +205,7 @@ class RuleCollectorSpec : Spek({
 
         it("collects the flag that it requires type resolution") {
             val code = """
-                import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
+                import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
                 
                 /**
                  * description
@@ -222,7 +222,7 @@ class RuleCollectorSpec : Spek({
                 /**
                  * description
                  */
-                @io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
+                @io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
                 class SomeRandomClass : Rule
             """
             val items = subject.run(code)

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NamedArguments.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NamedArguments.kt
@@ -5,9 +5,9 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.ThresholdRule
+import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.calls.callUtil.getParameterForArgument

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NamedArguments.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NamedArguments.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.ThresholdRule
 import org.jetbrains.kotlin.psi.KtCallExpression
@@ -28,8 +29,8 @@ import org.jetbrains.kotlin.resolve.calls.callUtil.getResolvedCall
  * </compliant>
  *
  * @configuration threshold - number of parameters that triggers this inspection (default: `3`)
- * @requiresTypeResolution
  */
+@RequiresTypeResolution
 class NamedArguments(
     config: Config = Config.empty,
     threshold: Int = DEFAULT_FUNCTION_THRESHOLD

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ReplaceSafeCallChainWithRun.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ReplaceSafeCallChainWithRun.kt
@@ -5,9 +5,9 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import org.jetbrains.kotlin.psi.KtSafeQualifiedExpression
 import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.calls.callUtil.getResolvedCall
@@ -42,9 +42,11 @@ import org.jetbrains.kotlin.types.isNullable
 @RequiresTypeResolution
 class ReplaceSafeCallChainWithRun(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue(javaClass.simpleName, Severity.Maintainability,
+    override val issue = Issue(
+        javaClass.simpleName, Severity.Maintainability,
         "Chains of safe calls on non-nullable types can be surrounded with run {}",
-            Debt.TEN_MINS)
+        Debt.TEN_MINS
+    )
 
     override fun visitSafeQualifiedExpression(expression: KtSafeQualifiedExpression) {
         super.visitSafeQualifiedExpression(expression)

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ReplaceSafeCallChainWithRun.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ReplaceSafeCallChainWithRun.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.psi.KtSafeQualifiedExpression
@@ -37,8 +38,8 @@ import org.jetbrains.kotlin.types.isNullable
  * } ?: emptyList()
  * </compliant>
  *
- * @requiresTypeResolution
  */
+@RequiresTypeResolution
 class ReplaceSafeCallChainWithRun(config: Config = Config.empty) : Rule(config) {
 
     override val issue = Issue(javaClass.simpleName, Severity.Maintainability,

--- a/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/RedundantSuspendModifier.kt
+++ b/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/RedundantSuspendModifier.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.descriptors.FunctionDescriptor
@@ -51,8 +52,8 @@ import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
  * }
  * </compliant>
  *
- * @requiresTypeResolution
  */
+@RequiresTypeResolution
 class RedundantSuspendModifier(config: Config) : Rule(config) {
 
     override val issue = Issue(

--- a/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/RedundantSuspendModifier.kt
+++ b/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/RedundantSuspendModifier.kt
@@ -5,9 +5,9 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import org.jetbrains.kotlin.descriptors.FunctionDescriptor
 import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.descriptors.PropertyDescriptor

--- a/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SleepInsteadOfDelay.kt
+++ b/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SleepInsteadOfDelay.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
@@ -36,8 +37,8 @@ import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameOrNull
  * }
  * </compliant>
  *
- * @requiresTypeResolution
  */
+@RequiresTypeResolution
 class SleepInsteadOfDelay(config: Config = Config.empty) : Rule(config) {
     override val issue = Issue(
         javaClass.simpleName,

--- a/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SleepInsteadOfDelay.kt
+++ b/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SleepInsteadOfDelay.kt
@@ -5,9 +5,9 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtExpression

--- a/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunWithFlowReturnType.kt
+++ b/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunWithFlowReturnType.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.js.descriptorUtils.getJetTypeFqName
@@ -56,8 +57,8 @@ import org.jetbrains.kotlin.types.typeUtil.supertypes
  * }
  * </compliant>
  *
- * @requiresTypeResolution
  */
+@RequiresTypeResolution
 class SuspendFunWithFlowReturnType(config: Config) : Rule(config) {
 
     override val issue = Issue(

--- a/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunWithFlowReturnType.kt
+++ b/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunWithFlowReturnType.kt
@@ -5,9 +5,9 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import org.jetbrains.kotlin.js.descriptorUtils.getJetTypeFqName
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtNamedFunction

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/Deprecation.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/Deprecation.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
@@ -15,8 +16,8 @@ import org.jetbrains.kotlin.resolve.BindingContext
 /**
  * Deprecated elements are expected to be removed in future. Alternatives should be found if possible.
  *
- * @requiresTypeResolution
  */
+@RequiresTypeResolution
 class Deprecation(config: Config) : Rule(config) {
 
     override val issue = Issue(

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/Deprecation.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/Deprecation.kt
@@ -5,9 +5,9 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.diagnostics.Errors
 import org.jetbrains.kotlin.psi.KtNamedDeclaration

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DontDowncastCollectionTypes.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DontDowncastCollectionTypes.kt
@@ -5,9 +5,9 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.rules.safeAs
 import org.jetbrains.kotlin.js.descriptorUtils.nameIfStandardType
 import org.jetbrains.kotlin.psi.KtBinaryExpressionWithTypeRHS

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DontDowncastCollectionTypes.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DontDowncastCollectionTypes.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.rules.safeAs
@@ -36,8 +37,8 @@ import org.jetbrains.kotlin.resolve.calls.callUtil.getType
  * list.toMutableList().add(42)
  * </compliant>
  *
- * @requiresTypeResolution
  */
+@RequiresTypeResolution
 class DontDowncastCollectionTypes(config: Config) : Rule(config) {
 
     override val issue = Issue(

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ExitOutsideMain.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ExitOutsideMain.kt
@@ -5,9 +5,9 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.rules.isMainFunction
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtNamedFunction

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ExitOutsideMain.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ExitOutsideMain.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.rules.isMainFunction
@@ -42,8 +43,8 @@ import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameOrNull
  * }
  * </compliant>
  *
- * @requiresTypeResolution
  */
+@RequiresTypeResolution
 class ExitOutsideMain(config: Config = Config.empty) : Rule(config) {
 
     override val issue = Issue(

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/HasPlatformType.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/HasPlatformType.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.descriptors.CallableDescriptor
@@ -35,8 +36,8 @@ import org.jetbrains.kotlin.types.isFlexible
  * }
  * </compliant>
  *
- * @requiresTypeResolution
  */
+@RequiresTypeResolution
 class HasPlatformType(config: Config) : Rule(config) {
 
     override val issue = Issue(

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/HasPlatformType.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/HasPlatformType.kt
@@ -5,9 +5,9 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import org.jetbrains.kotlin.descriptors.CallableDescriptor
 import org.jetbrains.kotlin.psi.KtCallableDeclaration
 import org.jetbrains.kotlin.psi.KtElement

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValue.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValue.kt
@@ -5,9 +5,9 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.internal.valueOrDefaultCommaSeparated
 import io.gitlab.arturbosch.detekt.api.simplePatternToRegex
 import org.jetbrains.kotlin.psi.KtCallExpression
@@ -41,18 +41,18 @@ import org.jetbrains.kotlin.types.typeUtil.isUnit
 class IgnoredReturnValue(config: Config = Config.empty) : Rule(config) {
 
     override val issue: Issue = Issue(
-            "IgnoredReturnValue",
-            Severity.Defect,
-            "This call returns a value which is ignored",
-            Debt.TWENTY_MINS
+        "IgnoredReturnValue",
+        Severity.Defect,
+        "This call returns a value which is ignored",
+        Debt.TWENTY_MINS
     )
 
     private val annotationsRegexes = valueOrDefaultCommaSeparated(
-                RETURN_VALUE_ANNOTATIONS,
-                DEFAULT_RETURN_VALUE_ANNOTATIONS
-            )
-            .distinct()
-            .map { it.simplePatternToRegex() }
+        RETURN_VALUE_ANNOTATIONS,
+        DEFAULT_RETURN_VALUE_ANNOTATIONS
+    )
+        .distinct()
+        .map { it.simplePatternToRegex() }
 
     private val restrictToAnnotatedMethods: Boolean = valueOrDefault(
         RESTRICT_TO_ANNOTATED_METHODS,

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValue.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValue.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.internal.valueOrDefaultCommaSeparated
@@ -35,8 +36,8 @@ import org.jetbrains.kotlin.types.typeUtil.isUnit
  * @configuration restrictToAnnotatedMethods - if the rule should check only annotated methods. (default: `true`)
  * @configuration returnValueAnnotations - List of glob patterns to be used as inspection annotation (default: `['*.CheckReturnValue', '*.CheckResult']`)
  *
- * @requiresTypeResolution
  */
+@RequiresTypeResolution
 class IgnoredReturnValue(config: Config = Config.empty) : Rule(config) {
 
     override val issue: Issue = Issue(

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ImplicitUnitReturnType.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ImplicitUnitReturnType.kt
@@ -5,9 +5,9 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.calls.callUtil.getResolvedCall

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ImplicitUnitReturnType.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ImplicitUnitReturnType.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.psi.KtNamedFunction
@@ -35,8 +36,8 @@ import org.jetbrains.kotlin.resolve.calls.callUtil.getResolvedCall
  * fun safeUnitReturn(): Unit = println("Hello Unit")
  * </compliant>
  *
- * @requiresTypeResolution
  */
+@RequiresTypeResolution
 class ImplicitUnitReturnType(config: Config) : Rule(config) {
 
     override val issue = Issue(

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingWhenCase.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingWhenCase.kt
@@ -5,9 +5,9 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import org.jetbrains.kotlin.cfg.WhenChecker
 import org.jetbrains.kotlin.cfg.WhenMissingCase
 import org.jetbrains.kotlin.psi.KtWhenExpression

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingWhenCase.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingWhenCase.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.cfg.WhenChecker
@@ -66,8 +67,8 @@ import org.jetbrains.kotlin.resolve.calls.callUtil.getType
  *
  * @active since v1.2.0
  *
- * @requiresTypeResolution
  */
+@RequiresTypeResolution
 class MissingWhenCase(config: Config = Config.empty) : Rule(config) {
 
     override val issue: Issue = Issue(

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/NullableToStringCall.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/NullableToStringCall.kt
@@ -5,9 +5,9 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.rules.safeAs
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.descriptors.CallableDescriptor
@@ -66,7 +66,8 @@ class NullableToStringCall(config: Config = Config.empty) : Rule(config) {
         val targetExpression = simpleOrCallExpression.targetExpression() ?: return
 
         if (simpleOrCallExpression.safeAs<KtCallExpression>()?.calleeExpression?.text == "toString" &&
-            simpleOrCallExpression.descriptor()?.fqNameOrNull() == toString) {
+            simpleOrCallExpression.descriptor()?.fqNameOrNull() == toString
+        ) {
             report(targetExpression)
         } else if (targetExpression.parent is KtStringTemplateEntry && targetExpression.isNullable()) {
             report(targetExpression.parent)

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/NullableToStringCall.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/NullableToStringCall.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.rules.safeAs
@@ -46,9 +47,8 @@ import org.jetbrains.kotlin.types.isNullable
  *     return "${a ?: "-"}"
  * }
  * </compliant>
- *
- * @requiresTypeResolution
  */
+@RequiresTypeResolution
 @Suppress("ReturnCount")
 class NullableToStringCall(config: Config = Config.empty) : Rule(config) {
     override val issue = Issue(

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/RedundantElseInWhen.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/RedundantElseInWhen.kt
@@ -5,9 +5,9 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import org.jetbrains.kotlin.diagnostics.Errors
 import org.jetbrains.kotlin.psi.KtWhenExpression
 import org.jetbrains.kotlin.resolve.BindingContext

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/RedundantElseInWhen.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/RedundantElseInWhen.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.diagnostics.Errors
@@ -57,8 +58,8 @@ import org.jetbrains.kotlin.resolve.BindingContext
  * </compliant>
  *
  * @active since v1.2.0
- * @requiresTypeResolution
  */
+@RequiresTypeResolution
 class RedundantElseInWhen(config: Config = Config.empty) : Rule(config) {
 
     override val issue: Issue = Issue(

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessaryNotNullOperator.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessaryNotNullOperator.kt
@@ -5,9 +5,9 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import org.jetbrains.kotlin.diagnostics.Errors
 import org.jetbrains.kotlin.psi.KtUnaryExpression
 import org.jetbrains.kotlin.resolve.BindingContext
@@ -30,10 +30,12 @@ import org.jetbrains.kotlin.resolve.BindingContext
 @RequiresTypeResolution
 class UnnecessaryNotNullOperator(config: Config = Config.empty) : Rule(config) {
 
-    override val issue: Issue = Issue("UnnecessaryNotNullOperator",
-            Severity.Defect,
-            "Unnecessary not-null unary operator (!!) detected.",
-            Debt.FIVE_MINS)
+    override val issue: Issue = Issue(
+        "UnnecessaryNotNullOperator",
+        Severity.Defect,
+        "Unnecessary not-null unary operator (!!) detected.",
+        Debt.FIVE_MINS
+    )
 
     override fun visitUnaryExpression(expression: KtUnaryExpression) {
         super.visitUnaryExpression(expression)
@@ -41,8 +43,13 @@ class UnnecessaryNotNullOperator(config: Config = Config.empty) : Rule(config) {
 
         val compilerReports = bindingContext.diagnostics.forElement(expression.operationReference)
         if (compilerReports.any { it.factory == Errors.UNNECESSARY_NOT_NULL_ASSERTION }) {
-            report(CodeSmell(issue, Entity.from(expression), "${expression.text} contains an unnecessary " +
-                    "not-null (!!) operators"))
+            report(
+                CodeSmell(
+                    issue, Entity.from(expression),
+                    "${expression.text} contains an unnecessary " +
+                        "not-null (!!) operators"
+                )
+            )
         }
     }
 }

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessaryNotNullOperator.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessaryNotNullOperator.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.diagnostics.Errors
@@ -25,8 +26,8 @@ import org.jetbrains.kotlin.resolve.BindingContext
  * </compliant>
  *
  * @active since v1.16.0
- * @requiresTypeResolution
  */
+@RequiresTypeResolution
 class UnnecessaryNotNullOperator(config: Config = Config.empty) : Rule(config) {
 
     override val issue: Issue = Issue("UnnecessaryNotNullOperator",

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessarySafeCall.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessarySafeCall.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
@@ -30,8 +31,8 @@ import org.jetbrains.kotlin.types.ErrorType
  * </compliant>
  *
  * @active since v1.16.0
- * @requiresTypeResolution
  */
+@RequiresTypeResolution
 class UnnecessarySafeCall(config: Config = Config.empty) : Rule(config) {
 
     override val issue: Issue = Issue(

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessarySafeCall.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessarySafeCall.kt
@@ -5,9 +5,9 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
 import org.jetbrains.kotlin.diagnostics.DiagnosticWithParameters1
 import org.jetbrains.kotlin.diagnostics.Errors
@@ -72,8 +72,9 @@ class UnnecessarySafeCall(config: Config = Config.empty) : Rule(config) {
             }
             report(
                 CodeSmell(
-                    issue, Entity.from(expression), "${expression.text} contains an unnecessary " +
-                            "safe call operator"
+                    issue, Entity.from(expression),
+                    "${expression.text} contains an unnecessary " +
+                        "safe call operator"
                 )
             )
         }

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnreachableCatchBlock.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnreachableCatchBlock.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.rules.safeAs
@@ -44,8 +45,8 @@ import org.jetbrains.kotlin.resolve.descriptorUtil.isSubclassOf
  * }
  * </compliant>
  *
- * @requiresTypeResolution
  */
+@RequiresTypeResolution
 class UnreachableCatchBlock(config: Config = Config.empty) : Rule(config) {
     override val issue = Issue(
         javaClass.simpleName,

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnreachableCatchBlock.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnreachableCatchBlock.kt
@@ -5,9 +5,9 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.rules.safeAs
 import org.jetbrains.kotlin.descriptors.ClassDescriptor
 import org.jetbrains.kotlin.psi.KtCatchClause

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnreachableCode.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnreachableCode.kt
@@ -5,9 +5,9 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import org.jetbrains.kotlin.diagnostics.Errors
 import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.resolve.BindingContext
@@ -37,8 +37,10 @@ import org.jetbrains.kotlin.resolve.BindingContext
 @RequiresTypeResolution
 class UnreachableCode(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue("UnreachableCode", Severity.Warning,
-            "Unreachable code detected. This code should be removed", Debt.TEN_MINS)
+    override val issue = Issue(
+        "UnreachableCode", Severity.Warning,
+        "Unreachable code detected. This code should be removed", Debt.TEN_MINS
+    )
 
     override fun visitExpression(expression: KtExpression) {
         super.visitExpression(expression)

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnreachableCode.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnreachableCode.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.diagnostics.Errors
@@ -32,8 +33,8 @@ import org.jetbrains.kotlin.resolve.BindingContext
  * </noncompliant>
  *
  * @active since v1.0.0
- * @requiresTypeResolution
  */
+@RequiresTypeResolution
 class UnreachableCode(config: Config = Config.empty) : Rule(config) {
 
     override val issue = Issue("UnreachableCode", Severity.Warning,

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCallOnNullableType.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCallOnNullableType.kt
@@ -5,9 +5,9 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtPostfixExpression
 import org.jetbrains.kotlin.resolve.BindingContext
@@ -36,10 +36,12 @@ import org.jetbrains.kotlin.types.typeUtil.nullability
  */
 @RequiresTypeResolution
 class UnsafeCallOnNullableType(config: Config = Config.empty) : Rule(config) {
-    override val issue: Issue = Issue("UnsafeCallOnNullableType",
-            Severity.Defect,
-            "It will throw a NullPointerException at runtime if your nullable value is null.",
-            Debt.TWENTY_MINS)
+    override val issue: Issue = Issue(
+        "UnsafeCallOnNullableType",
+        Severity.Defect,
+        "It will throw a NullPointerException at runtime if your nullable value is null.",
+        Debt.TWENTY_MINS
+    )
 
     override fun visitPostfixExpression(expression: KtPostfixExpression) {
         super.visitPostfixExpression(expression)
@@ -47,8 +49,13 @@ class UnsafeCallOnNullableType(config: Config = Config.empty) : Rule(config) {
         if (expression.operationToken == KtTokens.EXCLEXCL &&
             expression.baseExpression?.getType(bindingContext)?.nullability() == TypeNullability.NULLABLE
         ) {
-            report(CodeSmell(issue, Entity.from(expression), "Calling !! on a nullable type will throw a " +
-                    "NullPointerException at runtime in case the value is null. It should be avoided."))
+            report(
+                CodeSmell(
+                    issue, Entity.from(expression),
+                    "Calling !! on a nullable type will throw a " +
+                        "NullPointerException at runtime in case the value is null. It should be avoided."
+                )
+            )
         }
     }
 }

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCallOnNullableType.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCallOnNullableType.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.lexer.KtTokens
@@ -32,8 +33,8 @@ import org.jetbrains.kotlin.types.typeUtil.nullability
  * </compliant>
  *
  * @active since v1.2.0
- * @requiresTypeResolution
  */
+@RequiresTypeResolution
 class UnsafeCallOnNullableType(config: Config = Config.empty) : Rule(config) {
     override val issue: Issue = Issue("UnsafeCallOnNullableType",
             Severity.Defect,

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCast.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCast.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.diagnostics.Errors
@@ -31,8 +32,8 @@ import org.jetbrains.kotlin.resolve.BindingContext
  * </compliant>
  *
  * @active since v1.16.0
- * @requiresTypeResolution
  */
+@RequiresTypeResolution
 class UnsafeCast(config: Config = Config.empty) : Rule(config) {
 
     override val defaultRuleIdAliases: Set<String> = setOf("UNCHECKED_CAST")

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCast.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCast.kt
@@ -5,9 +5,9 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import org.jetbrains.kotlin.diagnostics.Errors
 import org.jetbrains.kotlin.psi.KtBinaryExpressionWithTypeRHS
 import org.jetbrains.kotlin.resolve.BindingContext
@@ -38,19 +38,25 @@ class UnsafeCast(config: Config = Config.empty) : Rule(config) {
 
     override val defaultRuleIdAliases: Set<String> = setOf("UNCHECKED_CAST")
 
-    override val issue: Issue = Issue("UnsafeCast",
-            Severity.Defect,
-            "Cast operator throws an exception if the cast is not possible.",
-            Debt.TWENTY_MINS)
+    override val issue: Issue = Issue(
+        "UnsafeCast",
+        Severity.Defect,
+        "Cast operator throws an exception if the cast is not possible.",
+        Debt.TWENTY_MINS
+    )
 
     override fun visitBinaryWithTypeRHSExpression(expression: KtBinaryExpressionWithTypeRHS) {
         if (bindingContext == BindingContext.EMPTY) return
 
         if (bindingContext.diagnostics.forElement(expression.operationReference)
-                .any { it.factory == Errors.CAST_NEVER_SUCCEEDS }
+            .any { it.factory == Errors.CAST_NEVER_SUCCEEDS }
         ) {
-            report(CodeSmell(issue, Entity.from(expression),
-                    "${expression.left.text} cast to ${expression.right?.text ?: ""} cannot succeed."))
+            report(
+                CodeSmell(
+                    issue, Entity.from(expression),
+                    "${expression.left.text} cast to ${expression.right?.text ?: ""} cannot succeed."
+                )
+            )
         }
 
         super.visitBinaryWithTypeRHSExpression(expression)

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnusedUnaryOperator.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnusedUnaryOperator.kt
@@ -5,9 +5,9 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import org.jetbrains.kotlin.builtins.KotlinBuiltIns
 import org.jetbrains.kotlin.com.intellij.psi.PsiComment
 import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnusedUnaryOperator.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnusedUnaryOperator.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.builtins.KotlinBuiltIns
@@ -35,8 +36,8 @@ import org.jetbrains.kotlin.resolve.calls.callUtil.getResolvedCall
  * println(x) // 10
  * </compliant>
  *
- * @requiresTypeResolution
  */
+@RequiresTypeResolution
 class UnusedUnaryOperator(config: Config = Config.empty) : Rule(config) {
     override val issue = Issue(
         javaClass.simpleName,

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ObjectExtendsThrowable.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ObjectExtendsThrowable.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.psi.KtObjectDeclaration
@@ -37,8 +38,8 @@ import org.jetbrains.kotlin.types.typeUtil.supertypes
  * class AuthException : RuntimeException()
  * </compliant>
  *
- * @requiresTypeResolution
  */
+@RequiresTypeResolution
 class ObjectExtendsThrowable(config: Config = Config.empty) : Rule(config) {
     override val issue = Issue(
         id = "ObjectExtendsThrowable",

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ObjectExtendsThrowable.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ObjectExtendsThrowable.kt
@@ -5,9 +5,9 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import org.jetbrains.kotlin.psi.KtObjectDeclaration
 import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.types.typeUtil.isNotNullThrowable
@@ -45,11 +45,11 @@ class ObjectExtendsThrowable(config: Config = Config.empty) : Rule(config) {
         id = "ObjectExtendsThrowable",
         severity = Severity.CodeSmell,
         description = "An `object` should not extend and type of Throwable. Throwables are " +
-                "stateful and should be instantiated only when needed for when a specific error " +
-                "occurs. An `object`, being a singleton, that extends any type of Throwable " +
-                "consequently introduces a global singleton exception whose instance may be " +
-                "inadvertently reused from multiple places, thus introducing shared mutable " +
-                "state.",
+            "stateful and should be instantiated only when needed for when a specific error " +
+            "occurs. An `object`, being a singleton, that extends any type of Throwable " +
+            "consequently introduces a global singleton exception whose instance may be " +
+            "inadvertently reused from multiple places, thus introducing shared mutable " +
+            "state.",
         debt = Debt.TEN_MINS
     )
 

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ReturnFromFinally.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ReturnFromFinally.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.psi.KtBlockExpression
@@ -39,8 +40,8 @@ import org.jetbrains.kotlin.types.KotlinType
  *
  * @configuration ignoreLabeled - ignores labeled return statements (default: `false`)
  * @active since v1.16.0
- * @requiresTypeResolution
  */
+@RequiresTypeResolution
 class ReturnFromFinally(config: Config = Config.empty) : Rule(config) {
 
     override val issue = Issue("ReturnFromFinally", Severity.Defect,

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ReturnFromFinally.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ReturnFromFinally.kt
@@ -5,9 +5,9 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import org.jetbrains.kotlin.psi.KtBlockExpression
 import org.jetbrains.kotlin.psi.KtFinallySection
 import org.jetbrains.kotlin.psi.KtReturnExpression
@@ -44,8 +44,10 @@ import org.jetbrains.kotlin.types.KotlinType
 @RequiresTypeResolution
 class ReturnFromFinally(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue("ReturnFromFinally", Severity.Defect,
-        "Do not return within a finally statement. This can discard exceptions.", Debt.TWENTY_MINS)
+    override val issue = Issue(
+        "ReturnFromFinally", Severity.Defect,
+        "Do not return within a finally statement. This can discard exceptions.", Debt.TWENTY_MINS
+    )
 
     private val ignoreLabeled = valueOrDefault(IGNORE_LABELED, false)
 
@@ -63,7 +65,7 @@ class ReturnFromFinally(config: Config = Config.empty) : Rule(config) {
                     issue = issue,
                     entity = Entity.Companion.from(finallyBlock),
                     message = "Contents of the finally block do not affect " +
-                            "the result of the expression."
+                        "the result of the expression."
                 )
             )
         }
@@ -71,7 +73,7 @@ class ReturnFromFinally(config: Config = Config.empty) : Rule(config) {
         finallyBlock.finalExpression
             .collectDescendantsOfType<KtReturnExpression> { returnExpression ->
                 isReturnFromTargetFunction(finallyBlock.finalExpression, returnExpression) &&
-                        canFilterLabeledExpression(returnExpression)
+                    canFilterLabeledExpression(returnExpression)
             }
             .forEach { report(CodeSmell(issue, Entity.from(it), issue.description)) }
     }

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NoNameShadowing.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NoNameShadowing.kt
@@ -5,9 +5,9 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import org.jetbrains.kotlin.diagnostics.Errors
 import org.jetbrains.kotlin.psi.KtDestructuringDeclarationEntry
 import org.jetbrains.kotlin.psi.KtLambdaExpression
@@ -83,18 +83,21 @@ class NoNameShadowing(config: Config = Config.empty) : Rule(config) {
         super.visitLambdaExpression(lambdaExpression)
         if (bindingContext != BindingContext.EMPTY &&
             lambdaExpression.hasImplicitParameter() &&
-            lambdaExpression.hasParentImplicitParameterLambda()) {
-            report(CodeSmell(
-                issue,
-                Entity.from(lambdaExpression),
-                "Name shadowed: implicit lambda parameter 'it'"
-            ))
+            lambdaExpression.hasParentImplicitParameterLambda()
+        ) {
+            report(
+                CodeSmell(
+                    issue,
+                    Entity.from(lambdaExpression),
+                    "Name shadowed: implicit lambda parameter 'it'"
+                )
+            )
         }
     }
 
     private fun KtLambdaExpression.hasImplicitParameter(): Boolean =
         valueParameters.isEmpty() &&
-                bindingContext[BindingContext.FUNCTION, functionLiteral]?.valueParameters?.singleOrNull() != null
+            bindingContext[BindingContext.FUNCTION, functionLiteral]?.valueParameters?.singleOrNull() != null
 
     private fun KtLambdaExpression.hasParentImplicitParameterLambda(): Boolean =
         getParentOfTypesAndPredicate(true, KtLambdaExpression::class.java) { it.hasImplicitParameter() } != null

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NoNameShadowing.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NoNameShadowing.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.diagnostics.Errors
@@ -44,8 +45,8 @@ import org.jetbrains.kotlin.resolve.BindingContext
  * }
  * </compliant>
  *
- * @requiresTypeResolution
  */
+@RequiresTypeResolution
 class NoNameShadowing(config: Config = Config.empty) : Rule(config) {
     override val issue = Issue(
         javaClass.simpleName,

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NonBooleanPropertyPrefixedWithIs.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NonBooleanPropertyPrefixedWithIs.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.rules.identifierName
@@ -26,9 +27,8 @@ import org.jetbrains.kotlin.resolve.typeBinding.createTypeBindingForReturnType
  * <compliant>
  * val isEnabled: Boolean = false
  * </compliant>
- *
- * @requiresTypeResolution
  */
+@RequiresTypeResolution
 class NonBooleanPropertyPrefixedWithIs(config: Config = Config.empty) : Rule(config) {
 
     private val kotlinBooleanTypeName = "kotlin.Boolean"

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NonBooleanPropertyPrefixedWithIs.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NonBooleanPropertyPrefixedWithIs.kt
@@ -5,9 +5,9 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.rules.identifierName
 import org.jetbrains.kotlin.js.descriptorUtils.getJetTypeFqName
 import org.jetbrains.kotlin.psi.KtCallableDeclaration

--- a/detekt-rules-performance/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/ArrayPrimitive.kt
+++ b/detekt-rules-performance/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/ArrayPrimitive.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.builtins.KotlinBuiltIns
@@ -40,8 +41,8 @@ import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameOrNull
  * </compliant>
  *
  * @active since v1.2.0
- * @requiresTypeResolution
  */
+@RequiresTypeResolution
 class ArrayPrimitive(config: Config = Config.empty) : Rule(config) {
     override val issue = Issue(
         "ArrayPrimitive",

--- a/detekt-rules-performance/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/ArrayPrimitive.kt
+++ b/detekt-rules-performance/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/ArrayPrimitive.kt
@@ -5,9 +5,9 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import org.jetbrains.kotlin.builtins.KotlinBuiltIns
 import org.jetbrains.kotlin.builtins.PrimitiveType
 import org.jetbrains.kotlin.descriptors.CallableDescriptor

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCall.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCall.kt
@@ -5,9 +5,9 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.internal.valueOrDefaultCommaSeparated
 import io.gitlab.arturbosch.detekt.rules.extractMethodNameAndParams
 import org.jetbrains.kotlin.js.descriptorUtils.getJetTypeFqName
@@ -46,7 +46,7 @@ class ForbiddenMethodCall(config: Config = Config.empty) : Rule(config) {
         javaClass.simpleName,
         Severity.Style,
         "Mark forbidden methods. A forbidden method could be an invocation of an unstable / experimental " +
-                "method and hence you might want to mark it as forbidden in order to get warned about the usage.",
+            "method and hence you might want to mark it as forbidden in order to get warned about the usage.",
         Debt.TEN_MINS
     )
 
@@ -95,7 +95,7 @@ class ForbiddenMethodCall(config: Config = Config.empty) : Rule(config) {
                                 issue,
                                 Entity.from(expression),
                                 "The method ${it.first}(${expectedParamTypes?.joinToString() ?: ""}) " +
-                                        "has been forbidden in the Detekt config."
+                                    "has been forbidden in the Detekt config."
                             )
                         )
                     }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCall.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCall.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.internal.valueOrDefaultCommaSeparated
@@ -37,8 +38,8 @@ import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameOrNull
  * with this concrete signature.
  *  (default: `['kotlin.io.println', 'kotlin.io.print']`)
  *
- * @requiresTypeResolution
  */
+@RequiresTypeResolution
 class ForbiddenMethodCall(config: Config = Config.empty) : Rule(config) {
 
     override val issue = Issue(

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenVoid.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenVoid.kt
@@ -5,9 +5,9 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.rules.isOverride
 import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.KtParameter
@@ -68,7 +68,7 @@ class ForbiddenVoid(config: Config = Config.empty) : Rule(config) {
 
     private fun KtTypeReference.isPartOfOverriddenSignature() =
         (isPartOfReturnTypeOfFunction() || isParameterTypeOfFunction()) &&
-                getStrictParentOfType<KtNamedFunction>()?.isOverride() == true
+            getStrictParentOfType<KtNamedFunction>()?.isOverride() == true
 
     private fun KtTypeReference.isPartOfReturnTypeOfFunction() =
         getStrictParentOfType<KtNamedFunction>()

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenVoid.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenVoid.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.rules.isOverride
@@ -36,8 +37,8 @@ import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameOrNull
  * @configuration ignoreOverridden - ignores void types in signatures of overridden functions (default: `false`)
  * @configuration ignoreUsageInGenerics - ignore void types as generic arguments (default: `false`)
  *
- * @requiresTypeResolution
  */
+@RequiresTypeResolution
 class ForbiddenVoid(config: Config = Config.empty) : Rule(config) {
 
     override val issue = Issue(

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/LibraryCodeMustSpecifyReturnType.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/LibraryCodeMustSpecifyReturnType.kt
@@ -5,9 +5,9 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import org.jetbrains.kotlin.psi.KtCallableDeclaration
 import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.KtProperty
@@ -57,11 +57,13 @@ class LibraryCodeMustSpecifyReturnType(config: Config = Config.empty) : Rule(con
             return
         }
         if (property.explicitReturnTypeRequired()) {
-            report(CodeSmell(
-                issue,
-                Entity.atName(property),
-                "Library property '${property.nameAsSafeName}' without explicit return type."
-            ))
+            report(
+                CodeSmell(
+                    issue,
+                    Entity.atName(property),
+                    "Library property '${property.nameAsSafeName}' without explicit return type."
+                )
+            )
         }
         super.visitProperty(property)
     }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/LibraryCodeMustSpecifyReturnType.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/LibraryCodeMustSpecifyReturnType.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.psi.KtCallableDeclaration
@@ -38,9 +39,9 @@ import org.jetbrains.kotlin.resolve.checkers.ExplicitApiDeclarationChecker
  * }
  * </compliant>
  *
- * @requiresTypeResolution
  * @active since v1.2.0
  */
+@RequiresTypeResolution
 class LibraryCodeMustSpecifyReturnType(config: Config = Config.empty) : Rule(config) {
 
     override val issue = Issue(

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MultilineLambdaItParameter.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MultilineLambdaItParameter.kt
@@ -5,9 +5,9 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.rules.IT_LITERAL
 import org.jetbrains.kotlin.psi.KtLambdaExpression
 import org.jetbrains.kotlin.resolve.BindingContext

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MultilineLambdaItParameter.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MultilineLambdaItParameter.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.rules.IT_LITERAL
@@ -60,8 +61,8 @@ import org.jetbrains.kotlin.resolve.BindingContext
  * }
  * </compliant>
  *
- * @requiresTypeResolution
  */
+@RequiresTypeResolution
 class MultilineLambdaItParameter(val config: Config) : Rule(config) {
     override val issue = Issue(
         javaClass.simpleName, Severity.Style,

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantHigherOrderMapUsage.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantHigherOrderMapUsage.kt
@@ -5,9 +5,9 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import org.jetbrains.kotlin.descriptors.ValueParameterDescriptor
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.psi.KtCallExpression

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantHigherOrderMapUsage.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantHigherOrderMapUsage.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.descriptors.ValueParameterDescriptor
@@ -68,8 +69,8 @@ import org.jetbrains.kotlin.types.KotlinType
  * }
  * </compliant>
  *
- * @requiresTypeResolution
  */
+@RequiresTypeResolution
 @Suppress("ReturnCount")
 class RedundantHigherOrderMapUsage(config: Config = Config.empty) : Rule(config) {
     override val issue: Issue = Issue(

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryApply.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryApply.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.rules.receiverIsUsed
@@ -37,8 +38,8 @@ import org.jetbrains.kotlin.resolve.BindingContext
  * </compliant>
  *
  * @active since v1.16.0
- * @requiresTypeResolution
  */
+@RequiresTypeResolution
 class UnnecessaryApply(config: Config) : Rule(config) {
 
     override val issue = Issue(javaClass.simpleName, Severity.Style,

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryApply.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryApply.kt
@@ -5,9 +5,9 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.rules.receiverIsUsed
 import io.gitlab.arturbosch.detekt.rules.safeAs
 import org.jetbrains.kotlin.lexer.KtTokens
@@ -42,8 +42,10 @@ import org.jetbrains.kotlin.resolve.BindingContext
 @RequiresTypeResolution
 class UnnecessaryApply(config: Config) : Rule(config) {
 
-    override val issue = Issue(javaClass.simpleName, Severity.Style,
-            "The `apply` usage is unnecessary", Debt.FIVE_MINS)
+    override val issue = Issue(
+        javaClass.simpleName, Severity.Style,
+        "The `apply` usage is unnecessary", Debt.FIVE_MINS
+    )
 
     override fun visitCallExpression(expression: KtCallExpression) {
         super.visitCallExpression(expression)
@@ -51,8 +53,9 @@ class UnnecessaryApply(config: Config) : Rule(config) {
         if (bindingContext == BindingContext.EMPTY) return
 
         if (expression.isApplyExpr() &&
-                expression.hasOnlyOneMemberAccessStatement() &&
-                !expression.receiverIsUsed(bindingContext)) {
+            expression.hasOnlyOneMemberAccessStatement() &&
+            !expression.receiverIsUsed(bindingContext)
+        ) {
             val message = if (expression.parent is KtSafeQualifiedExpression) {
                 "apply can be replaced with let or an if"
             } else {
@@ -66,13 +69,13 @@ class UnnecessaryApply(config: Config) : Rule(config) {
 private fun KtCallExpression.hasOnlyOneMemberAccessStatement(): Boolean {
 
     fun KtExpression.notAnAssignment() =
-            safeAs<KtBinaryExpression>()
-                    ?.operationToken != KtTokens.EQ
+        safeAs<KtBinaryExpression>()
+            ?.operationToken != KtTokens.EQ
 
     fun KtExpression.isMemberAccess() =
-            this is KtReferenceExpression ||
-                    this is KtCallExpression ||
-                    this.safeAs<KtDotQualifiedExpression>()?.receiverExpression is KtThisExpression
+        this is KtReferenceExpression ||
+            this is KtCallExpression ||
+            this.safeAs<KtDotQualifiedExpression>()?.receiverExpression is KtThisExpression
 
     val lambdaBody = firstLambdaArg?.bodyExpression
     if (lambdaBody?.children?.size == 1) {

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryFilter.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryFilter.kt
@@ -1,12 +1,13 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
-import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.Debt
-import io.gitlab.arturbosch.detekt.api.Rule
-import io.gitlab.arturbosch.detekt.api.Entity
-import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtElement
@@ -39,8 +40,8 @@ import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameOrNull
  *      .none { it > 1 }
  * </compliant>
  *
- * @requiresTypeResolution
  */
+@RequiresTypeResolution
 class UnnecessaryFilter(config: Config = Config.empty) : Rule(config) {
 
     override val issue: Issue = Issue(

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryFilter.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryFilter.kt
@@ -5,9 +5,9 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtElement

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLet.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLet.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.rules.IT_LITERAL
@@ -40,8 +41,8 @@ import org.jetbrains.kotlin.resolve.BindingContext
  * val b = a?.let { 1.plus(1) }
  * </compliant>
  *
- * @requiresTypeResolution
  */
+@RequiresTypeResolution
 class UnnecessaryLet(config: Config) : Rule(config) {
 
     override val issue = Issue(

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLet.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLet.kt
@@ -5,9 +5,9 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.rules.IT_LITERAL
 import io.gitlab.arturbosch.detekt.rules.LET_LITERAL
 import io.gitlab.arturbosch.detekt.rules.receiverIsUsed

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseCheckNotNull.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseCheckNotNull.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.rules.isCallingWithNonNullCheckArgument
@@ -22,9 +23,8 @@ import org.jetbrains.kotlin.resolve.BindingContext
  * <compliant>
  * checkNotNull(x)
  * </compliant>
- *
- * @requiresTypeResolution
  */
+@RequiresTypeResolution
 class UseCheckNotNull(config: Config = Config.empty) : Rule(config) {
     override val issue = Issue(
         "UseCheckNotNull",

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseCheckNotNull.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseCheckNotNull.kt
@@ -5,9 +5,9 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.rules.isCallingWithNonNullCheckArgument
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.psi.KtCallExpression

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseEmptyCounterpart.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseEmptyCounterpart.kt
@@ -5,9 +5,9 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.resolve.calls.callUtil.getResolvedCall

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseEmptyCounterpart.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseEmptyCounterpart.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.name.FqName
@@ -31,8 +32,8 @@ import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameOrNull
  * emptySet()
  * </compliant>
  *
- * @requiresTypeResolution
  */
+@RequiresTypeResolution
 class UseEmptyCounterpart(config: Config) : Rule(config) {
 
     override val issue = Issue(

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIfEmptyOrIfBlank.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIfEmptyOrIfBlank.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.KtNodeTypes
@@ -45,8 +46,8 @@ import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameOrNull
  * }
  * </compliant>
  *
- * @requiresTypeResolution
  */
+@RequiresTypeResolution
 @Suppress("ReturnCount", "ComplexMethod")
 class UseIfEmptyOrIfBlank(config: Config = Config.empty) : Rule(config) {
     override val issue: Issue = Issue(

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIfEmptyOrIfBlank.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIfEmptyOrIfBlank.kt
@@ -5,9 +5,9 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import org.jetbrains.kotlin.KtNodeTypes
 import org.jetbrains.kotlin.builtins.KotlinBuiltIns
 import org.jetbrains.kotlin.lexer.KtTokens

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIsNullOrEmpty.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIsNullOrEmpty.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.builtins.StandardNames
@@ -42,8 +43,8 @@ import org.jetbrains.kotlin.utils.addToStdlib.safeAs
  * if (x.isNullOrEmpty()) return
  * </compliant>
  *
- * @requiresTypeResolution
  */
+@RequiresTypeResolution
 @Suppress("TooManyFunctions")
 class UseIsNullOrEmpty(config: Config = Config.empty) : Rule(config) {
     override val issue: Issue = Issue(

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIsNullOrEmpty.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIsNullOrEmpty.kt
@@ -5,9 +5,9 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import org.jetbrains.kotlin.builtins.StandardNames
 import org.jetbrains.kotlin.descriptors.ClassDescriptor
 import org.jetbrains.kotlin.lexer.KtTokens
@@ -135,7 +135,7 @@ class UseIsNullOrEmpty(config: Config = Config.empty) : Rule(config) {
             ?: safeAs<KtDotQualifiedExpression>()?.selectorExpression.safeAs<KtCallExpression>()
             ?: return false
         return callExpression.calleeExpression?.text in fqNames.map { it.shortName().asString() } &&
-                callExpression.getResolvedCall(bindingContext)?.resultingDescriptor?.fqNameOrNull() in fqNames
+            callExpression.getResolvedCall(bindingContext)?.resultingDescriptor?.fqNameOrNull() in fqNames
     }
 
     private fun KtSimpleNameExpression.classFqName() =
@@ -170,7 +170,7 @@ class UseIsNullOrEmpty(config: Config = Config.empty) : Rule(config) {
         private val stringClass = StandardNames.FqNames.string.toSafe()
 
         private val isEmptyFunctions = collectionClasses.map { FqName("$it.isEmpty") } +
-                listOf("kotlin.collections.isEmpty", "kotlin.text.isEmpty").map(::FqName)
+            listOf("kotlin.collections.isEmpty", "kotlin.text.isEmpty").map(::FqName)
 
         private val countFunctions = listOf("kotlin.collections.count", "kotlin.text.count").map(::FqName)
     }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseOrEmpty.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseOrEmpty.kt
@@ -5,9 +5,9 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.psi.KtBinaryExpression

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseOrEmpty.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseOrEmpty.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.lexer.KtTokens
@@ -38,8 +39,8 @@ import org.jetbrains.kotlin.types.typeUtil.makeNotNullable
  * }
  * </compliant>
  *
- * @requiresTypeResolution
  */
+@RequiresTypeResolution
 class UseOrEmpty(config: Config = Config.empty) : Rule(config) {
     override val issue: Issue = Issue(
         "UseOrEmpty",

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseRequireNotNull.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseRequireNotNull.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.rules.isCallingWithNonNullCheckArgument
@@ -22,9 +23,8 @@ import org.jetbrains.kotlin.resolve.BindingContext
  * <compliant>
  * requireNotNull(x)
  * </compliant>
- *
- * @requiresTypeResolution
  */
+@RequiresTypeResolution
 class UseRequireNotNull(config: Config = Config.empty) : Rule(config) {
     override val issue = Issue(
         "UseRequireNotNull",

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseRequireNotNull.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseRequireNotNull.kt
@@ -5,9 +5,9 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.rules.isCallingWithNonNullCheckArgument
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.psi.KtCallExpression

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UselessCallOnNotNull.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UselessCallOnNotNull.kt
@@ -5,9 +5,9 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtQualifiedExpression
@@ -51,8 +51,8 @@ class UselessCallOnNotNull(config: Config = Config.empty) : Rule(config) {
         "UselessCallOnNotNull",
         Severity.Performance,
         "This call on non-null reference may be reduced or removed. Some calls are intended to be called on nullable " +
-                "collection or text types (e.g. String?). When this call is used on a reference to a non-null type " +
-                "(e.g. String) it is redundant and will have no effect, so it can be removed.",
+            "collection or text types (e.g. String?). When this call is used on a reference to a non-null type " +
+            "(e.g. String) it is redundant and will have no effect, so it can be removed.",
         Debt.FIVE_MINS
     )
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UselessCallOnNotNull.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UselessCallOnNotNull.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.name.FqName
@@ -43,8 +44,8 @@ import org.jetbrains.kotlin.types.isNullable
  * </compliant>
  *
  * @active since v1.2.0
- * @requiresTypeResolution
  */
+@RequiresTypeResolution
 class UselessCallOnNotNull(config: Config = Config.empty) : Rule(config) {
     override val issue: Issue = Issue(
         "UselessCallOnNotNull",

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/PreferToOverPairSyntax.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/PreferToOverPairSyntax.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.rules.safeAs
@@ -28,8 +29,8 @@ import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameOrNull
  * val pair = 1 to 2
  * </compliant>
  *
- * @requiresTypeResolution
  */
+@RequiresTypeResolution
 class PreferToOverPairSyntax(config: Config = Config.empty) : Rule(config) {
     override val issue = Issue("PreferToOverPairSyntax", Severity.Style,
             "Pair was created using the Pair constructor, using the to syntax is preferred.",

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/PreferToOverPairSyntax.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/PreferToOverPairSyntax.kt
@@ -5,9 +5,9 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.rules.safeAs
 import org.jetbrains.kotlin.descriptors.ClassConstructorDescriptor
 import org.jetbrains.kotlin.name.FqName
@@ -32,9 +32,11 @@ import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameOrNull
  */
 @RequiresTypeResolution
 class PreferToOverPairSyntax(config: Config = Config.empty) : Rule(config) {
-    override val issue = Issue("PreferToOverPairSyntax", Severity.Style,
-            "Pair was created using the Pair constructor, using the to syntax is preferred.",
-            Debt.FIVE_MINS)
+    override val issue = Issue(
+        "PreferToOverPairSyntax", Severity.Style,
+        "Pair was created using the Pair constructor, using the to syntax is preferred.",
+        Debt.FIVE_MINS
+    )
 
     override fun visitCallExpression(expression: KtCallExpression) {
         super.visitCallExpression(expression)
@@ -42,9 +44,13 @@ class PreferToOverPairSyntax(config: Config = Config.empty) : Rule(config) {
         if (bindingContext == BindingContext.EMPTY) return
         if (expression.isPairConstructor()) {
             val arg = expression.valueArguments.joinToString(" to ") { it.text }
-            report(CodeSmell(issue, Entity.from(expression),
+            report(
+                CodeSmell(
+                    issue, Entity.from(expression),
                     message = "Pair is created by using the pair constructor. " +
-                            "This can replaced by `$arg`"))
+                        "This can replaced by `$arg`"
+                )
+            )
         }
     }
 

--- a/docs/pages/gettingstarted/type-resolution.md
+++ b/docs/pages/gettingstarted/type-resolution.md
@@ -44,7 +44,7 @@ With type resolution, Detekt has access to all the symbols and types of your cod
 
 If you're running Detekt **without** type resolution, all the rules that require type resolution **will not run**.
 
-All the rules that require type resolution are annotated with [`@requiresTypeResolution`](https://github.com/detekt/detekt/search?q=%5C%40requiresTypeResolution) in the KDoc. 
+All the rules that require type resolution are annotated with [`@RequiresTypeResolution`](https://github.com/detekt/detekt/search?q=%40RequiresTypeResolution). 
 
 Moreover, their official documentation in the Detekt website will mention _Requires Type Resolution_ ([like here](./potential-bugs.html#unnecessarysafecall)).
 


### PR DESCRIPTION
This PR belongs to #3562 and replaces the @requiresTypeResolution kdoc tag with a @RequiresTypeResolution annotation.

There are a few things that I would like to point out/discuss:
* I still have some formatting issues. That is why there is one commit that just reformats the code according to the ktlint plugin
* I added the annotation to the detekt API which might be a bit premature. Maybe it should be placed in `internal` until it is stable?
* I started out adding `@UnstableApi` to the annotation but that would all rules to require to add `@OptIn(UnstableApi::class)` which does not feel right either.
* Adding a `@Suppress("TooManyFunctions")` to the `RuleVisitor` does not feel great, but I thinkt the code reads much better with those extension functions. Suggestions are welcome.