### PR TITLE
Replace @since KDoc tag with @SinceDetekt

### DIFF
--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/SinceDetekt.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/SinceDetekt.kt
@@ -1,0 +1,11 @@
+package io.gitlab.arturbosch.detekt.api.internal
+
+/**
+ * Specifies the first version of Detekt where a declaration has appeared.
+ * Generally this should be used to indicate the version in which a rule was added.
+ *
+ * @property version the version in the following formats: `<major>.<minor>` or `<major>.<minor>.<patch>`
+ */
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.BINARY)
+annotation class SinceDetekt(val version: String)

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/Annotations.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/Annotations.kt
@@ -1,0 +1,24 @@
+package io.gitlab.arturbosch.detekt.generator.collection
+
+import org.jetbrains.kotlin.psi.KtAnnotationEntry
+import org.jetbrains.kotlin.psi.KtClassOrObject
+import kotlin.reflect.KClass
+
+fun KtClassOrObject.firstAnnotationParameterOrNull(annotation: KClass<out Annotation>): String? =
+    annotationEntries
+        .firstOrNull { it.isOfType(annotation) }
+        ?.firstParameterOrNull()
+
+private fun KtAnnotationEntry.isOfType(annotation: KClass<out Annotation>) =
+    shortName?.identifier == annotation.simpleName
+
+private fun KtAnnotationEntry.firstParameterOrNull() =
+    valueArguments
+        .firstOrNull()
+        ?.getArgumentExpression()
+        ?.text
+        ?.withoutQuotes()
+
+private fun String.withoutQuotes() = removePrefix(QUOTES).removeSuffix(QUOTES)
+
+private const val QUOTES = "\""

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/Rule.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/Rule.kt
@@ -13,5 +13,6 @@ data class Rule(
     val configuration: List<Configuration> = listOf(),
     val autoCorrect: Boolean = false,
     var inMultiRule: String? = null,
-    val requiresTypeResolution: Boolean = false
+    val requiresTypeResolution: Boolean = false,
+    val sinceDetektVersion: String? = null,
 )

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/out/Markdown.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/out/Markdown.kt
@@ -54,4 +54,4 @@ inline fun MarkdownContent.list(listContent: MarkdownList.() -> Unit) {
 }
 
 inline fun MarkdownList.item(item: () -> String) = append("* ${item()}\n")
-inline fun MarkdownList.description(description: () -> String) = append("   ${description()}\n")
+inline fun MarkdownList.description(description: () -> String) = append("  ${description()}\n")

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/rulesetpage/RuleSetPagePrinter.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/rulesetpage/RuleSetPagePrinter.kt
@@ -58,6 +58,12 @@ object RuleSetPagePrinter : DocumentationPrinter<RuleSetPage> {
                 }
             }
 
+            if (!rule.sinceDetektVersion.isNullOrEmpty()) {
+                paragraph {
+                    "${bold { "Since" }}: ${rule.sinceDetektVersion}"
+                }
+            }
+
             if (rule.configuration.isNotEmpty()) {
                 h4 { "Configuration options:" }
                 list {
@@ -69,8 +75,8 @@ object RuleSetPagePrinter : DocumentationPrinter<RuleSetPage> {
                             description { "${bold { "Deprecated" }}: ${it.deprecated}" }
                         } else {
                             val defaultValues = it.defaultValue.lines()
-                            val defaultValuesString = defaultValues.joinToString {
-                                value -> value.trim().removePrefix("- ")
+                            val defaultValuesString = defaultValues.joinToString { value ->
+                                value.trim().removePrefix("- ")
                             }
                             item { "${code { it.name }} (default: ${code { defaultValuesString }})" }
                         }

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/rulesetpage/RuleSetPagePrinter.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/rulesetpage/RuleSetPagePrinter.kt
@@ -46,23 +46,11 @@ object RuleSetPagePrinter : DocumentationPrinter<RuleSetPage> {
                 }
             }
 
-            if (rule.debt.isNotEmpty()) {
-                paragraph {
-                    "${bold { "Debt" }}: ${rule.debt}"
-                }
-            }
+            printLabeledParagraph("Debt", rule.debt)
 
-            if (!rule.aliases.isNullOrEmpty()) {
-                paragraph {
-                    "${bold { "Aliases" }}: ${rule.aliases}"
-                }
-            }
+            printLabeledParagraph("Aliases", rule.aliases)
 
-            if (!rule.sinceDetektVersion.isNullOrEmpty()) {
-                paragraph {
-                    "${bold { "Since" }}: ${rule.sinceDetektVersion}"
-                }
-            }
+            printLabeledParagraph("Since", rule.sinceDetektVersion)
 
             if (rule.configuration.isNotEmpty()) {
                 h4 { "Configuration options:" }
@@ -86,6 +74,14 @@ object RuleSetPagePrinter : DocumentationPrinter<RuleSetPage> {
             }
 
             printRuleCodeExamples(rule)
+        }
+    }
+
+    private fun MarkdownContent.printLabeledParagraph(label: String, valueOrNull: String?) {
+        if (valueOrNull.isNullOrBlank()) return
+
+        paragraph {
+            "${bold { label }}: $valueOrNull"
         }
     }
 

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleCollectorSpec.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleCollectorSpec.kt
@@ -330,5 +330,40 @@ class RuleCollectorSpec : Spek({
             """
             assertThatExceptionOfType(InvalidDocumentationException::class.java).isThrownBy { subject.run(code) }
         }
+
+        context("handles SinceDetekt annotations") {
+            it("extracts the version with positional parameter") {
+                val code = """
+                    /**
+                     * description
+                     */
+                    @SinceDetekt("1.2.3")
+                    class SomeRandomClass : Rule
+                """
+                val items = subject.run(code)
+                assertThat(items[0].sinceDetektVersion).isEqualTo("1.2.3")
+            }
+            it("extracts the version with named parameter") {
+                val code = """
+                    /**
+                     * description
+                     */
+                    @SinceDetekt(version = "1.2.3")
+                    class SomeRandomClass : Rule
+                """
+                val items = subject.run(code)
+                assertThat(items[0].sinceDetektVersion).isEqualTo("1.2.3")
+            }
+            it("does not extract a version if annotation not present") {
+                val code = """
+                    /**
+                     * description
+                     */
+                    class SomeRandomClass : Rule
+                """
+                val items = subject.run(code)
+                assertThat(items[0].sinceDetektVersion).isNull()
+            }
+        }
     }
 })

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/util/RuleSetPageCreator.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/util/RuleSetPageCreator.kt
@@ -21,6 +21,7 @@ internal fun createRules(): List<Rule> {
         severity = "Defect",
         debt = "10min",
         aliases = "alias1, alias2",
+        sinceDetektVersion = "1.2.3",
         parent = "",
         configuration = listOf(
             Configuration("conf1", "a config option", "foo", null),

--- a/detekt-generator/src/test/resources/RuleSet.md
+++ b/detekt-generator/src/test/resources/RuleSet.md
@@ -8,17 +8,19 @@ a wildcard import
 
 **Aliases**: alias1, alias2
 
+**Since**: 1.2.3
+
 #### Configuration options:
 
 * `conf1` (default: `foo`)
 
-   a config option
+  a config option
 
 * ~~`conf2`~~ (default: `false`)
 
-   **Deprecated**: use conf1 instead
+  **Deprecated**: use conf1 instead
 
-   deprecated config
+  deprecated config
 
 #### Noncompliant Code:
 

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/NullableToStringCall.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/NullableToStringCall.kt
@@ -7,6 +7,7 @@ import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.internal.SinceDetekt
 import io.gitlab.arturbosch.detekt.rules.safeAs
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.descriptors.CallableDescriptor
@@ -47,10 +48,10 @@ import org.jetbrains.kotlin.types.isNullable
  * }
  * </compliant>
  *
- * @since 1.11.0
  * @requiresTypeResolution
  */
 @Suppress("ReturnCount")
+@SinceDetekt("1.11.0")
 class NullableToStringCall(config: Config = Config.empty) : Rule(config) {
     override val issue = Issue(
         javaClass.simpleName,
@@ -67,7 +68,8 @@ class NullableToStringCall(config: Config = Config.empty) : Rule(config) {
         val targetExpression = simpleOrCallExpression.targetExpression() ?: return
 
         if (simpleOrCallExpression.safeAs<KtCallExpression>()?.calleeExpression?.text == "toString" &&
-            simpleOrCallExpression.descriptor()?.fqNameOrNull() == toString) {
+            simpleOrCallExpression.descriptor()?.fqNameOrNull() == toString
+        ) {
             report(targetExpression)
         } else if (targetExpression.parent is KtStringTemplateEntry && targetExpression.isNullable()) {
             report(targetExpression.parent)

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NonBooleanPropertyPrefixedWithIs.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NonBooleanPropertyPrefixedWithIs.kt
@@ -7,6 +7,7 @@ import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.internal.SinceDetekt
 import io.gitlab.arturbosch.detekt.rules.identifierName
 import org.jetbrains.kotlin.js.descriptorUtils.getJetTypeFqName
 import org.jetbrains.kotlin.psi.KtCallableDeclaration
@@ -27,9 +28,9 @@ import org.jetbrains.kotlin.resolve.typeBinding.createTypeBindingForReturnType
  * val isEnabled: Boolean = false
  * </compliant>
  *
- * @since 1.12.0
  * @requiresTypeResolution
  */
+@SinceDetekt("1.12.0")
 class NonBooleanPropertyPrefixedWithIs(config: Config = Config.empty) : Rule(config) {
 
     private val kotlinBooleanTypeName = "kotlin.Boolean"

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/LibraryEntitiesShouldNotBePublic.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/LibraryEntitiesShouldNotBePublic.kt
@@ -7,6 +7,7 @@ import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.internal.SinceDetekt
 import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.KtTypeAlias
@@ -25,9 +26,9 @@ import org.jetbrains.kotlin.psi.psiUtil.isPublic
  * internal class A
  * </compliant>
  *
- * @since 1.11.0
  * @active since v1.16.0
  */
+@SinceDetekt("1.11.0")
 class LibraryEntitiesShouldNotBePublic(ruleSetConfig: Config = Config.empty) : Rule(ruleSetConfig) {
 
     override val issue: Issue = Issue(
@@ -49,17 +50,25 @@ class LibraryEntitiesShouldNotBePublic(ruleSetConfig: Config = Config.empty) : R
 
     override fun visitTypeAlias(typeAlias: KtTypeAlias) {
         if (typeAlias.isPublic) {
-            report(CodeSmell(issue,
-                Entity.from(typeAlias),
-                "TypeAlias ${typeAlias.nameAsSafeName} should not be public"))
+            report(
+                CodeSmell(
+                    issue,
+                    Entity.from(typeAlias),
+                    "TypeAlias ${typeAlias.nameAsSafeName} should not be public"
+                )
+            )
         }
     }
 
     override fun visitNamedFunction(function: KtNamedFunction) {
         if (function.isTopLevel && function.isPublic) {
-            report(CodeSmell(issue,
-                Entity.from(function),
-                "Top level function ${function.nameAsSafeName} should not be public"))
+            report(
+                CodeSmell(
+                    issue,
+                    Entity.from(function),
+                    "Top level function ${function.nameAsSafeName} should not be public"
+                )
+            )
         }
     }
 }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseCheckNotNull.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseCheckNotNull.kt
@@ -7,6 +7,7 @@ import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.internal.SinceDetekt
 import io.gitlab.arturbosch.detekt.rules.isCallingWithNonNullCheckArgument
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.psi.KtCallExpression
@@ -23,9 +24,9 @@ import org.jetbrains.kotlin.resolve.BindingContext
  * checkNotNull(x)
  * </compliant>
  *
- * @since 1.12.0
  * @requiresTypeResolution
  */
+@SinceDetekt("1.12.0")
 class UseCheckNotNull(config: Config = Config.empty) : Rule(config) {
     override val issue = Issue(
         "UseCheckNotNull",

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseRequireNotNull.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseRequireNotNull.kt
@@ -7,6 +7,7 @@ import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.internal.SinceDetekt
 import io.gitlab.arturbosch.detekt.rules.isCallingWithNonNullCheckArgument
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.psi.KtCallExpression
@@ -23,9 +24,9 @@ import org.jetbrains.kotlin.resolve.BindingContext
  * requireNotNull(x)
  * </compliant>
  *
- * @since 1.12.0
  * @requiresTypeResolution
  */
+@SinceDetekt("1.12.0")
 class UseRequireNotNull(config: Config = Config.empty) : Rule(config) {
     override val issue = Issue(
         "UseRequireNotNull",


### PR DESCRIPTION
This also belongs to #3562 and replaces the rarely used `@since` KDoc tag with a `@SinceDetekt` annotation. Name and structure are "inspired by" `@kotlin.SinceKotlin`.