### PR TITLE
SarifOutputReportSpec: Correctly detect Windows root directory on local development machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ If you contributed to detekt but your name is not in the list, please feel free 
 - [Severn Everett](https://github.com/severn-everett) - New rule: SleepInsteadOfDelay
 - [Adam Kobor](https://github.com/adamkobor) - New rule: MultilineLambdaItParameter
 - [Slawomir Czerwinski](https://github.com/sczerwinski) - Rule improvement: FunctionOnlyReturningConstant
+- [Ivo Smid](https://github.com/bedla) - Fix Local development on Windows
 
 ### Mentions
 

--- a/detekt-report-sarif/src/test/kotlin/io/github/detekt/report/sarif/SarifOutputReportSpec.kt
+++ b/detekt-report-sarif/src/test/kotlin/io/github/detekt/report/sarif/SarifOutputReportSpec.kt
@@ -56,7 +56,7 @@ class SarifOutputReportSpec : Spek({
             val expectedReport = readResourceContent("relative_path.sarif.json")
                 .stripWhitespace()
 
-            // Note: On Github CI, windows file URI is on D: drive (during development it is usually on C: drive)
+            // Note: Github CI uses D: drive, but it could be any drive for local development
             val systemAwareExpectedReport = if (whichOS().startsWith("windows", ignoreCase = true)) {
                 val winRoot = Paths.get("/").toAbsolutePath().toString().replace("\\", "/")
                 expectedReport.replace("file:///", "file://$winRoot")

--- a/detekt-report-sarif/src/test/kotlin/io/github/detekt/report/sarif/SarifOutputReportSpec.kt
+++ b/detekt-report-sarif/src/test/kotlin/io/github/detekt/report/sarif/SarifOutputReportSpec.kt
@@ -56,9 +56,10 @@ class SarifOutputReportSpec : Spek({
             val expectedReport = readResourceContent("relative_path.sarif.json")
                 .stripWhitespace()
 
-            // Note: On Github CI, windows file URI is on D: drive
+            // Note: On Github CI, windows file URI is on D: drive (during development it is usually on C: drive)
             val systemAwareExpectedReport = if (whichOS().startsWith("windows", ignoreCase = true)) {
-                expectedReport.replace("file:///", "file://D:/")
+                val winRoot = Paths.get("/").toAbsolutePath().toString().replace("\\", "/")
+                expectedReport.replace("file:///", "file://$winRoot")
             } else {
                 expectedReport
             }


### PR DESCRIPTION
Hi,
while experimenting with Detekt source code I found that test SarifOutputReportSpec is failing on my Windows machine because of C: vs D: Windows root dir detection. So I have created this PR to solve this problem.
Hope it helps and is ok,
Ivos