### PR TITLE
Update files to support `main` branch in order to remove oppressive language

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,4 +3,4 @@ Please search among the [Pull requests](https://github.com/detekt/detekt/pulls) 
 
 Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Link to relevant issues if possible.
 
-For more information, see the [CONTRIBUTING guide](https://github.com/detekt/detekt/blob/master/.github/CONTRIBUTING.md).
+For more information, see the [CONTRIBUTING guide](https://github.com/detekt/detekt/blob/main/.github/CONTRIBUTING.md).

--- a/.github/workflows/codecoverage.yaml
+++ b/.github/workflows/codecoverage.yaml
@@ -3,7 +3,7 @@ name: Code Coverage
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
       - '**'

--- a/.github/workflows/deploy-snapshot.yaml
+++ b/.github/workflows/deploy-snapshot.yaml
@@ -3,7 +3,7 @@ name: Deploy Snapshot
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   gradle:

--- a/.github/workflows/deploy-website.yaml
+++ b/.github/workflows/deploy-website.yaml
@@ -3,7 +3,7 @@ name: Deploy Website
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   build-detekt-docs:

--- a/.github/workflows/detekt-with-type-resolution.yaml
+++ b/.github/workflows/detekt-with-type-resolution.yaml
@@ -3,7 +3,7 @@ name: detekt with type resolution
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
       - '**'

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -2,7 +2,7 @@ name: Validate Gradle Wrapper
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
       - '**'

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -3,7 +3,7 @@ name: Pre Merge Checks
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
       - '**'

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![gradle plugin](https://img.shields.io/maven-metadata/v/https/plugins.gradle.org/m2/io/gitlab/arturbosch/detekt/io.gitlab.arturbosch.detekt.gradle.plugin/maven-metadata.xml.svg?label=Gradle&style=flat-square)](https://plugins.gradle.org/plugin/io.gitlab.arturbosch.detekt)
 
 ![Pre Merge Checks](https://github.com/detekt/detekt/workflows/Pre%20Merge%20Checks/badge.svg?event=push)
-[![codecov](https://codecov.io/gh/detekt/detekt/branch/master/graph/badge.svg)](https://codecov.io/gh/detekt/detekt)
+[![codecov](https://codecov.io/gh/detekt/detekt/branch/main/graph/badge.svg)](https://codecov.io/gh/detekt/detekt)
 [![CodeFactor](https://www.codefactor.io/repository/github/detekt/detekt/badge)](https://www.codefactor.io/repository/github/detekt/detekt)
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Farturbosch%2Fdetekt-intellij-plugin.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2Farturbosch%2Fdetekt?ref=badge_shield)
 [![Awesome Kotlin Badge](https://kotlin.link/awesome-kotlin.svg)](https://github.com/KotlinBy/awesome-kotlin)
@@ -45,9 +45,9 @@ Visit [the project website](https://detekt.github.io/detekt/) for installation g
 - [Suppressing issues via baseline file](https://detekt.github.io/detekt/baseline.html)
 - [Configuring detekt](https://detekt.github.io/detekt/configurations.html)
 - Sample Gradle integrations examples:
-    - [multi project (Kotlin DSL) with precompiled script plugin](https://github.com/detekt/detekt/blob/master/buildSrc/src/main/kotlin/detekt.gradle.kts)
-    - [single project (Groovy DSL)](https://github.com/arturbosch/kutils/blob/master/build.gradle)
-    - [single project (Unofficial Maven plugin)](https://github.com/detekt/sonar-kotlin/blob/master/pom.xml)
+    - [multi project (Kotlin DSL) with precompiled script plugin](https://github.com/detekt/detekt/blob/main/buildSrc/src/main/kotlin/detekt.gradle.kts)
+    - [single project (Groovy DSL)](https://github.com/arturbosch/kutils/blob/main/build.gradle)
+    - [single project (Unofficial Maven plugin)](https://github.com/detekt/sonar-kotlin/blob/main/pom.xml)
     - [setup additional detekt task for all modules (Kotlin DSL)](https://github.com/detekt/detekt/blob/3357abba87e1550c65b6610012bb291e0fbb64ce/build.gradle.kts#L280-L295)
     - [setup additional formatting task for all modules (Kotlin DSL)](https://github.com/detekt/detekt/blob/3357abba87e1550c65b6610012bb291e0fbb64ce/build.gradle.kts#L262-L278)
 

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,7 +1,7 @@
 object Versions {
 
     const val DETEKT: String = "1.16.0"
-    const val SNAPSHOT_NAME: String = "master"
+    const val SNAPSHOT_NAME: String = "main"
     const val JVM_TARGET: String = "1.8"
     const val JACOCO: String = "0.8.6"
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -12,7 +12,7 @@ site_title: A static code analyzer for Kotlin
 company_name: The detekt Team
 # this appears in the footer
 
-github_editme_path: detekt/detekt/tree/master/docs/
+github_editme_path: detekt/detekt/tree/main/docs/
 # if you're using Github, provide the basepath to the branch you've created for reviews, following the sample here. if not, leave this value blank.
 
 # gitlab_editme_path: tomjoht/documentation-theme-jekyll/blob/gh-pages/

--- a/docs/pages/changelog 1.x.x.md
+++ b/docs/pages/changelog 1.x.x.md
@@ -650,7 +650,7 @@ See all issues at: [1.11.0-RC1](https://github.com/detekt/detekt/milestone/69)
 - New rules: `IgnoredReturnValue`, `ImplictUnitReturnType`
 - The complexity report (console/html) now calculates the [cognitive complexity metric](https://www.sonarsource.com/docs/CognitiveComplexity.pdf) for your project.
 - Issues at functions and classes are now reported at the identifiers. This is especially helpful in the IntelliJ plugin.
-- Extension authors can now manipulate the findings with the new [ReportingExtension](https://github.com/detekt/detekt/blob/master/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/ReportingExtension.kt).
+- Extension authors can now manipulate the findings with the new [ReportingExtension](https://github.com/detekt/detekt/blob/main/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/ReportingExtension.kt).
 - `detekt-formatting` was updated to use KtLint 0.37.2 which includes a lot of improvements and changes. Please see their [changelog](https://github.com/pinterest/ktlint/releases/tag/0.37.0).
     - New wrapper rules: `SpacingAroundDoubleColon`, `SpacingBetweenDeclarationsWithCommentsRule`, `SpacingBetweenDeclarationsWithAnnotationsRule`
     - You can configure the [layoutPattern](https://github.com/pinterest/ktlint/blob/0.37.0/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/ImportOrderingRule.kt#L18) for `ImportOrdering` in detekt's configuration file.

--- a/docs/pages/configurations.md
+++ b/docs/pages/configurations.md
@@ -14,7 +14,7 @@ _detekt_ uses a yaml style configuration file for various things:
 - output reports
 - processors
 
-See the [default-detekt-config.yml](https://github.com/detekt/detekt/blob/master/detekt-core/src/main/resources/default-detekt-config.yml)
+See the [default-detekt-config.yml](https://github.com/detekt/detekt/blob/main/detekt-core/src/main/resources/default-detekt-config.yml)
 file for all defined configuration options and their default values. 
 
 _Note:_ When using a custom config file, the default values are ignored unless you also set the `--build-upon-default-config` flag.

--- a/docs/pages/extensions.md
+++ b/docs/pages/extensions.md
@@ -7,7 +7,7 @@ summary:
 ---
 
 The following page describes how to extend detekt and how to customize it to your domain-specific needs.
-The associated **code samples** to this guide can be found in the package [detekt/detekt-sample-extensions](https://github.com/detekt/detekt/tree/master/detekt-sample-extensions).
+The associated **code samples** to this guide can be found in the package [detekt/detekt-sample-extensions](https://github.com/detekt/detekt/tree/main/detekt-sample-extensions).
 
 #### <a name="customrulesets">Custom RuleSets</a>
 
@@ -199,7 +199,7 @@ So you have implemented your own rules or other extensions and want to integrate
 into your `detekt` run? Great, make sure to have a `jar` with all your needed dependencies 
 minus the ones `detekt` brings itself.
 
-Take a look at our [sample project](https://github.com/detekt/detekt/tree/master/detekt-sample-extensions) on how to achieve this with gradle.
+Take a look at our [sample project](https://github.com/detekt/detekt/tree/main/detekt-sample-extensions) on how to achieve this with gradle.
 
 ##### Integrate your extension with the detekt CLI
 

--- a/docs/pages/snapshots.md
+++ b/docs/pages/snapshots.md
@@ -10,7 +10,7 @@ This page explains how you can use our **latest snapshots** to test upcoming unr
 
 ## Where to download snapshots
 
-You can find the latest snapshot on [sonatype](https://oss.sonatype.org/#view-repositories;snapshots~browsestorage~io/gitlab/arturbosch/detekt). A new snapshot is published after every merge to `master` from the [Deploy Snapshot](https://github.com/detekt/detekt/actions?query=workflow%3A%22Deploy+Snapshot%22) Github Action workflow. 
+You can find the latest snapshot on [sonatype](https://oss.sonatype.org/#view-repositories;snapshots~browsestorage~io/gitlab/arturbosch/detekt). A new snapshot is published after every merge to `main` from the [Deploy Snapshot](https://github.com/detekt/detekt/actions?query=workflow%3A%22Deploy+Snapshot%22) Github Action workflow. 
 
 ## Gradle setup with Buildscript
 


### PR DESCRIPTION
Renaming branch is mostly automated. This PR hopefully should address most required manual changes in addition to https://github.com/github/renaming

```
Renaming a branch will:
- Re-target any open pull requests
- Update any draft releases based on the branch
- Move any branch protection rules that explicitly reference the old name
- Update the branch used to build GitHub Pages, if applicable
- Show a notice to repository contributors, maintainers, and admins on the repository homepage with instructions to update local copies of the repository
-  Show a notice to contributors who git push to the old branch
-  Redirect web requests for the old branch name to the new branch name
-  Return a "Moved Permanently" response in API requests for the old branch name
```