### PR TITLE
Support factory exemption for generic classes

### DIFF
--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MemberNameEqualsClassName.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MemberNameEqualsClassName.kt
@@ -17,6 +17,7 @@ import org.jetbrains.kotlin.psi.KtDeclaration
 import org.jetbrains.kotlin.psi.KtNamedDeclaration
 import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.KtObjectDeclaration
+import org.jetbrains.kotlin.psi.KtUserType
 import org.jetbrains.kotlin.resolve.BindingContext
 
 /**
@@ -101,7 +102,10 @@ class MemberNameEqualsClassName(config: Config = Config.empty) : Rule(config) {
     private fun isFactoryMethod(function: KtNamedFunction, klass: KtClass): Boolean {
         val typeReference = function.typeReference
         return when {
-            typeReference != null -> typeReference.text == klass.name
+            typeReference != null -> {
+                val refName = (typeReference.typeElement as? KtUserType)?.referencedName ?: typeReference.text
+                refName == klass.name
+            }
             function.bodyExpression !is KtBlockExpression -> {
                 val functionDescriptor = function.descriptor() as? FunctionDescriptor
                 functionDescriptor?.returnType?.constructor?.declarationDescriptor == klass.descriptor()

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MemberNameEqualsClassNameSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MemberNameEqualsClassNameSpec.kt
@@ -237,6 +237,22 @@ class MemberNameEqualsClassNameSpec : Spek({
                 assertThat(MemberNameEqualsClassName().compileAndLintWithContext(env, code)).isEmpty()
             }
 
+            it("doesn't report a generic factory function") {
+                val code = """
+                    data class GenericClass<T>(val wrapped: T) {
+                        companion object {
+                            fun <T> genericClass(wrapped: T): GenericClass<T> {
+                                return GenericClass(wrapped)
+                            }
+                            fun genericClass(): GenericClass<String> {
+                                return GenericClass("wrapped")
+                            }
+                        }
+                    }
+                """
+                assertThat(MemberNameEqualsClassName().compileAndLintWithContext(env, code)).isEmpty()
+            }
+
             it("doesn't report a body-less factory function") {
                 val code = """
                     open class A {


### PR DESCRIPTION
Compare the referenced type name instead of the fully
qualified generic type name when possible.

Fixes #3591