### PR TITLE
Improve Deprecation and Documentation for allRules

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -122,6 +122,7 @@ open class Detekt @Inject constructor(
 
     @get:Internal
     internal val failFastProp: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
+    @Deprecated("Please use the buildUponDefaultConfig and allRules flags instead.", ReplaceWith("allRules"))
     var failFast: Boolean
         @Input
         get() = failFastProp.getOrElse(false)

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
@@ -74,6 +74,7 @@ open class DetektCreateBaselineTask : SourceTask() {
 
     @get:Input
     @get:Optional
+    @Deprecated("Please use the buildUponDefaultConfig and allRules flags instead.", ReplaceWith("allRules"))
     val failFast: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
 
     @get:Input

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
@@ -35,6 +35,7 @@ open class DetektExtension @Inject constructor(objects: ObjectFactory) : CodeQua
 
     var parallel: Boolean = DEFAULT_PARALLEL_VALUE
 
+    @Deprecated("Please use the buildUponDefaultConfig and allRules flags instead.", ReplaceWith("allRules"))
     var failFast: Boolean = DEFAULT_FAIL_FAST_VALUE
 
     var allRules: Boolean = DEFAULT_ALL_RULES_VALUE

--- a/docs/pages/gettingstarted/gradle.md
+++ b/docs/pages/gettingstarted/gradle.md
@@ -189,42 +189,83 @@ For more information about how to configure the repositories read [about the rep
 
 ```groovy
 detekt {
-    toolVersion = "{{ site.detekt_version }}"                                 // Version of Detekt that will be used. When unspecified the latest detekt version found will be used. Override to stay on the same version.
-    input = files(                                        // The directories where detekt looks for source files. Defaults to `files("src/main/java", "src/main/kotlin")`.
+    // Version of Detekt that will be used. When unspecified the latest detekt
+    // version found will be used. Override to stay on the same version.
+    toolVersion = "{{ site.detekt_version }}"
+    
+    // The directories where detekt looks for source files. 
+    // Defaults to `files("src/main/java", "src/main/kotlin")`.
+    input = files(
         "src/main/kotlin",
         "gensrc/main/kotlin"
     )
-    parallel = false                                      // Builds the AST in parallel. Rules are always executed in parallel. Can lead to speedups in larger projects. `false` by default.
-    config = files("path/to/config.yml")                  // Define the detekt configuration(s) you want to use. Defaults to the default detekt configuration.
-    buildUponDefaultConfig = false                        // Interpret config files as updates to the default config. `false` by default.
-    baseline = file("path/to/baseline.xml")               // Specifying a baseline file. All findings stored in this file in subsequent runs of detekt.
-    disableDefaultRuleSets = false                        // Disables all default detekt rulesets and will only run detekt with custom rules defined in plugins passed in with `detektPlugins` configuration. `false` by default.
-    debug = false                                         // Adds debug output during task execution. `false` by default.
-    ignoreFailures = false                                // If set to `true` the build does not fail when the maxIssues count was reached. Defaults to `false`.
-    ignoredBuildTypes = ["release"]                       // Android: Don't create tasks for the specified build types (e.g. "release")
-    ignoredFlavors = ["production"]                       // Android: Don't create tasks for the specified build flavor (e.g. "production")
-    ignoredVariants = ["productionRelease"]               // Android: Don't create tasks for the specified build variants (e.g. "productionRelease")
-    basePath = projectDir                                 // Specify the base path for file paths in the formatted reports. If not set, all file paths reported will be absolute file path.
+    
+    // Builds the AST in parallel. Rules are always executed in parallel. 
+    // Can lead to speedups in larger projects. `false` by default.
+    parallel = false
+    
+    // Define the detekt configuration(s) you want to use. 
+    // Defaults to the default detekt configuration.
+    config = files("path/to/config.yml")
+    
+    // Applies the config files on top of detekt's default config file. `false` by default.
+    buildUponDefaultConfig = false
+    
+    // Turns on all the rules. `false` by default.
+    allRules = false
+    
+    // Specifying a baseline file. All findings stored in this file in subsequent runs of detekt.
+    baseline = file("path/to/baseline.xml")
+    
+    // Disables all default detekt rulesets and will only run detekt with custom rules
+    // defined in plugins passed in with `detektPlugins` configuration. `false` by default.
+    disableDefaultRuleSets = false
+    
+    // Adds debug output during task execution. `false` by default.
+    debug = false                                         
+    
+    // If set to `true` the build does not fail when the
+    // maxIssues count was reached. Defaults to `false`.
+    ignoreFailures = false
+    
+    // Android: Don't create tasks for the specified build types (e.g. "release")
+    ignoredBuildTypes = ["release"]
+    
+    // Android: Don't create tasks for the specified build flavor (e.g. "production")
+    ignoredFlavors = ["production"]
+    
+    // Android: Don't create tasks for the specified build variants (e.g. "productionRelease")
+    ignoredVariants = ["productionRelease"]
+    
+    // Specify the base path for file paths in the formatted reports. 
+    // If not set, all file paths reported will be absolute file path.
+    basePath = projectDir
+    
     reports {
+        // Enable/Disable XML report (default: true)
         xml {
-            enabled = true                                // Enable/Disable XML report (default: true)
-            destination = file("build/reports/detekt.xml") // Path where XML report will be stored (default: `build/reports/detekt/detekt.xml`)
+            enabled = true                                
+            destination = file("build/reports/detekt.xml")
         }
+        // Enable/Disable HTML report (default: true)
         html {
-            enabled = true                                // Enable/Disable HTML report (default: true)
-            destination = file("build/reports/detekt.html") // Path where HTML report will be stored (default: `build/reports/detekt/detekt.html`)
+            enabled = true
+            destination = file("build/reports/detekt.html")
         }
+        // Enable/Disable TXT report (default: true)
         txt {
-            enabled = true                                // Enable/Disable TXT report (default: true)
-            destination = file("build/reports/detekt.txt") // Path where TXT report will be stored (default: `build/reports/detekt/detekt.txt`)
+            enabled = true                                
+            destination = file("build/reports/detekt.txt")
         }
+        // Enable/Disable SARIF report (default: false)
         sarif {
-            enabled = true                                // Enable/Disable SARIF report (default: false)
-            destination = file("build/reports/detekt.sarif") // Path where SARIF report will be stored (default: `build/reports/detekt/detekt.sarif`)
+            enabled = true                                
+            destination = file("build/reports/detekt.sarif")
         }
         custom {
-            reportId = "CustomJsonReport"                   // The simple class name of your custom report.
-            destination = file("build/reports/detekt.json") // Path where report will be stored
+            // The simple class name of your custom report.
+            reportId = "CustomJsonReport"                   
+            destination = file("build/reports/detekt.json")
         }
     }
 }
@@ -234,35 +275,80 @@ detekt {
 
 ```kotlin
 detekt {
-    toolVersion = "{{ site.detekt_version }}"                                 // Version of Detekt that will be used. When unspecified the latest detekt version found will be used. Override to stay on the same version.
-    input = files("src/main/java", "src/main/kotlin")     // The directories where detekt looks for source files. Defaults to `files("src/main/java", "src/main/kotlin")`.
-    parallel = false                                      // Builds the AST in parallel. Rules are always executed in parallel. Can lead to speedups in larger projects. `false` by default.
-    config = files("path/to/config.yml")                  // Define the detekt configuration(s) you want to use. Defaults to the default detekt configuration.
-    buildUponDefaultConfig = false                        // Interpret config files as updates to the default config. `false` by default.
-    baseline = file("path/to/baseline.xml")               // Specifying a baseline file. All findings stored in this file in subsequent runs of detekt.
-    disableDefaultRuleSets = false                        // Disables all default detekt rulesets and will only run detekt with custom rules defined in plugins passed in with `detektPlugins` configuration. `false` by default.
-    debug = false                                         // Adds debug output during task execution. `false` by default.
-    ignoreFailures = false                                // If set to `true` the build does not fail when the maxIssues count was reached. Defaults to `false`.
-    ignoredBuildTypes = listOf("release")                 // Android: Don't create tasks for the specified build types (e.g. "release")
-    ignoredFlavors = listOf("production")                 // Android: Don't create tasks for the specified build flavor (e.g. "production")
-    ignoredVariants = listOf("productionRelease")         // Android: Don't create tasks for the specified build variants (e.g. "productionRelease")
-    basePath = projectDir                                 // Specify the base path for file paths in the formatted reports. If not set, all file paths reported will be absolute file path.
+    // Version of Detekt that will be used. When unspecified the latest detekt
+    // version found will be used. Override to stay on the same version.
+    toolVersion = "{{ site.detekt_version }}"
+    
+    // The directories where detekt looks for source files. 
+    // Defaults to `files("src/main/java", "src/main/kotlin")`.
+    input = files("src/main/java", "src/main/kotlin")     
+    
+    // Builds the AST in parallel. Rules are always executed in parallel. 
+    // Can lead to speedups in larger projects. `false` by default.
+    parallel = false
+    
+    // Define the detekt configuration(s) you want to use. 
+    // Defaults to the default detekt configuration.
+    config = files("path/to/config.yml")
+    
+    // Applies the config files on top of detekt's default config file. `false` by default.
+    buildUponDefaultConfig = false
+    
+    // Turns on all the rules. `false` by default.
+    allRules = false
+    
+    // Specifying a baseline file. All findings stored in this file in subsequent runs of detekt.
+    baseline = file("path/to/baseline.xml")
+    
+    // Disables all default detekt rulesets and will only run detekt with custom rules
+    // defined in plugins passed in with `detektPlugins` configuration. `false` by default.
+    disableDefaultRuleSets = false
+    
+    // Adds debug output during task execution. `false` by default.
+    debug = false                                         
+    
+    // If set to `true` the build does not fail when the
+    // maxIssues count was reached. Defaults to `false`.
+    ignoreFailures = false
+    
+    // Android: Don't create tasks for the specified build types (e.g. "release")
+    ignoredBuildTypes = listOf("release")
+    
+    // Android: Don't create tasks for the specified build flavor (e.g. "production")
+    ignoredFlavors = listOf("production")
+    
+    // Android: Don't create tasks for the specified build variants (e.g. "productionRelease")
+    ignoredVariants = listOf("productionRelease")
+    
+    // Specify the base path for file paths in the formatted reports. 
+    // If not set, all file paths reported will be absolute file path.
+    basePath = projectDir
+    
     reports {
+        // Enable/Disable XML report (default: true)
         xml {
-            enabled = true                                // Enable/Disable XML report (default: true)
-            destination = file("build/reports/detekt.xml") // Path where XML report will be stored (default: `build/reports/detekt/detekt.xml`)
+            enabled = true
+            destination = file("build/reports/detekt.xml")
         }
+        // Enable/Disable HTML report (default: true)
         html {
-            enabled = true                                // Enable/Disable HTML report (default: true)
-            destination = file("build/reports/detekt.html") // Path where HTML report will be stored (default: `build/reports/detekt/detekt.html`)
+            enabled = true
+            destination = file("build/reports/detekt.html")
         }
+        // Enable/Disable TXT report (default: true)
         txt {
-            enabled = true                                // Enable/Disable TXT report (default: true)
-            destination = file("build/reports/detekt.txt") // Path where TXT report will be stored (default: `build/reports/detekt/detekt.txt`)
+            enabled = true
+            destination = file("build/reports/detekt.txt")
+        }
+        // Enable/Disable SARIF report (default: false)
+        sarif {
+            enabled = true                                
+            destination = file("build/reports/detekt.sarif")
         }
         custom {
-            reportId = "CustomJsonReport"                 // The simple class name of your custom report.
-            destination = file("build/reports/detekt.json") // Path where report will be stored
+            // The simple class name of your custom report.
+            reportId = "CustomJsonReport"
+            destination = file("build/reports/detekt.json")
         }
     }
 }


### PR DESCRIPTION
Fixes #3567 

This PR adds:
- Documentation for the `allRules` property in the Gradle documentation page
- A Deprecation annotation on the `allRules` accessors in the extention an the tasks.
- More spacing in the Gradle config page as it's getting harder to read
