### PR TITLE
Fix CI failure for deploy-snapshot

### DIFF
--- a/buildSrc/src/main/kotlin/module.gradle.kts
+++ b/buildSrc/src/main/kotlin/module.gradle.kts
@@ -93,8 +93,5 @@ publishing {
         from(components["java"])
         artifact(sourcesJar.get())
         artifact(javadocJar.get())
-        if (project.name == "detekt-cli") {
-            artifact(tasks.getByName("shadowJar"))
-        }
     }
 }


### PR DESCRIPTION
## Summary
Deploy snapshot has been broken since #3574
```
Execution failed for task ':detekt-cli:publishDetektPublicationPublicationToSonatypeSnapshotRepository'.
> Failed to publish publication 'DetektPublication' to repository 'sonatypeSnapshot'
   > Invalid publication 'DetektPublication': multiple artifacts with the identical extension and classifier ('jar', 'all').
```

The problem is that we bumped the shadow from 5.2.0 to 6.1.0. It turns out that Shadow 6.0.0 has a behavior change that shadowed jar is added to the publishing artifacts by default. It is likely impacted by this change https://github.com/johnrengelman/shadow/commit/5c572a68bebf712a99854685d6c2834d146f9924

## Testing done
I have manually verified that we are adding one and only one `detekt-cli-1.16.0-all.jar` into publishing artifacts through local debugging.