### PR TITLE
Add --stacktrace to help triage CI flakiness

### DIFF
--- a/.github/workflows/deploy-snapshot.yaml
+++ b/.github/workflows/deploy-snapshot.yaml
@@ -31,7 +31,7 @@ jobs:
         java-version: 8
 
     - name: Build detekt
-      run: ./gradlew build --build-cache --parallel
+      run: ./gradlew build --build-cache --stacktrace
 
     - name: Deploy Snapshot
       env:

--- a/.github/workflows/deploy-website.yaml
+++ b/.github/workflows/deploy-website.yaml
@@ -31,7 +31,7 @@ jobs:
           java-version: 11
 
       - name: Build Detekt Documentation
-        run: ./gradlew :detekt-generator:generateDocumentation --build-cache --parallel
+        run: ./gradlew :detekt-generator:generateDocumentation --build-cache --stacktrace
 
       - name: Upload Generated Rules documentation
         uses: actions/upload-artifact@v2

--- a/.github/workflows/detekt-with-type-resolution.yaml
+++ b/.github/workflows/detekt-with-type-resolution.yaml
@@ -34,7 +34,7 @@ jobs:
           java-version: 11
 
       - name: Package executable jar
-        run: ./gradlew jar shadowJar moveJarForIntegrationTest
+        run: ./gradlew jar shadowJar moveJarForIntegrationTest --stacktrace
 
       - name: Run detekt-cli with argsfile
         run: java -jar ./build/detekt-cli-all.jar "@./config/detekt/argsfile"
@@ -71,4 +71,4 @@ jobs:
         java-version: 11
 
     - name: Run analysis
-      run: ./gradlew detektMain detektTest --build-cache --parallel
+      run: ./gradlew detektMain detektTest --build-cache --stacktrace

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -53,7 +53,7 @@ jobs:
 
 
     - name: Build detekt
-      run: ./gradlew build moveJarForIntegrationTest --parallel -x detekt
+      run: ./gradlew build moveJarForIntegrationTest -x detekt --stacktrace
     - name: Run detekt-cli --help
       run: java -jar ./build/detekt-cli-all.jar --help
     - name: Run detekt-cli with argsfile
@@ -85,7 +85,7 @@ jobs:
       with:
         java-version: 14
     - name: Verify Generated Detekt Config File
-      run: ./gradlew verifyGeneratorOutput
+      run: ./gradlew verifyGeneratorOutput --stacktrace
 
 
   compile-test-snippets:
@@ -113,4 +113,4 @@ jobs:
         with:
           java-version: 15
       - name: Build and compile test snippets
-        run: ./gradlew test -x ":detekt-gradle-plugin:test" -Pcompile-test-snippets=true --parallel
+        run: ./gradlew test -x ":detekt-gradle-plugin:test" -Pcompile-test-snippets=true --stacktrace


### PR DESCRIPTION
There seem to be a recent spike of CI random failures such as
https://github.com/detekt/detekt/pull/3595/checks?check_run_id=2178012720

I am adding `--stacktrace` to all gradle commands in CI to yield more debugging information in the CI failure.
(Some gradle commands already come with `--stacktrace`)
Meanwhile, I am also removing `--parallel` since we already have it set to true in `gradle.properties`.