### PR TITLE
Update to Kotlin 1.4.32

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -13,7 +13,7 @@ repositories {
 }
 
 object Plugins {
-    const val KOTLIN = "1.4.21"
+    const val KOTLIN = "1.4.32"
     const val DETEKT = "1.16.0"
     const val GITHUB_RELEASE = "2.2.12"
     const val SHADOW = "6.1.0"


### PR DESCRIPTION
It's not officially released yet (though the JARs were published to Maven Central) so there's no changelog to confirm [KT-45007](https://youtrack.jetbrains.com/issue/KT-45007) fix was included, but the issue on YouTrack states it's fixed in this version so it should be safe to update.

See https://github.com/detekt/detekt/issues/3514#issuecomment-791612636