### PR TITLE
RFC - Initial idea for @Configuration annotation

### DIFF
--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/Configuration.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/Configuration.kt
@@ -1,0 +1,7 @@
+package io.gitlab.arturbosch.detekt.api.internal
+
+@Target(AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.SOURCE)
+annotation class Configuration(
+    val description: String,
+)

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/PathFilters.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/PathFilters.kt
@@ -79,3 +79,10 @@ fun Config.valueOrDefaultCommaSeparated(
         fallBack()
     }
 }
+
+fun Config.valueOrDefaultCommaSeparated(
+    key: String,
+    default: Set<String>
+): Set<String> {
+    return valueOrDefaultCommaSeparated(key, default.toList()).toSet()
+}

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/Annotations.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/Annotations.kt
@@ -1,16 +1,16 @@
 package io.gitlab.arturbosch.detekt.generator.collection
 
+import org.jetbrains.kotlin.psi.KtAnnotated
 import org.jetbrains.kotlin.psi.KtAnnotationEntry
-import org.jetbrains.kotlin.psi.KtClassOrObject
 import kotlin.reflect.KClass
 
-fun KtClassOrObject.isAnnotatedWith(annotation: KClass<out Annotation>): Boolean =
+fun KtAnnotated.isAnnotatedWith(annotation: KClass<out Annotation>): Boolean =
     annotationEntries.any { it.isOfType(annotation) }
 
-fun KtClassOrObject.firstAnnotationParameter(annotation: KClass<out Annotation>): String =
+fun KtAnnotated.firstAnnotationParameter(annotation: KClass<out Annotation>): String =
     checkNotNull(firstAnnotationParameterOrNull(annotation))
 
-fun KtClassOrObject.firstAnnotationParameterOrNull(annotation: KClass<out Annotation>): String? =
+fun KtAnnotated.firstAnnotationParameterOrNull(annotation: KClass<out Annotation>): String? =
     annotationEntries
         .firstOrNull { it.isOfType(annotation) }
         ?.firstParameterOrNull()
@@ -25,6 +25,9 @@ private fun KtAnnotationEntry.firstParameterOrNull() =
         ?.text
         ?.withoutQuotes()
 
-private fun String.withoutQuotes() = removePrefix(QUOTES).removeSuffix(QUOTES)
+private fun String.withoutQuotes() = removePrefix(QUOTES)
+    .removeSuffix(QUOTES)
+    .replace(STRING_CONCAT_REGEX, "")
 
 private const val QUOTES = "\""
+private val STRING_CONCAT_REGEX = """["]\s*\+[\n\s]*["]""".toRegex()

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/ConfigurationAnnotations.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/ConfigurationAnnotations.kt
@@ -1,0 +1,37 @@
+package io.gitlab.arturbosch.detekt.generator.collection
+
+import io.gitlab.arturbosch.detekt.generator.collection.exception.InvalidDocumentationException
+import org.jetbrains.kotlin.psi.KtParameter
+import io.gitlab.arturbosch.detekt.api.internal.Configuration as ConfigAnnotation
+
+fun KtParameter.parseConfigurationAnnotation(): Configuration? {
+    return if (isAnnotatedWith(ConfigAnnotation::class)) toConfiguration() else null
+}
+
+private fun KtParameter.toConfiguration(): Configuration {
+    val parameterName: String = checkNotNull(name)
+    val deprecationMessage = firstAnnotationParameterOrNull(Deprecated::class)
+
+    val descriptionWithDefault: String = firstAnnotationParameter(ConfigAnnotation::class)
+    val matchResult = DESC_REGEX.matchEntire(descriptionWithDefault)
+        ?: throw InvalidDocumentationException(
+            "[${containingFile.name}] '$parameterName' doesn't seem to contain a default value.\n" +
+                EXPECTED_CONFIGURATION_FORMAT
+        )
+
+    val description = checkNotNull(matchResult.groups["description"]?.value)
+    val defaultValue = checkNotNull(matchResult.groups["defaultValue"]?.value)
+
+    return Configuration(
+        name = parameterName,
+        description = description,
+        defaultValue = defaultValue,
+        deprecated = deprecationMessage
+    )
+}
+
+private val DESC_REGEX = """^\s*(?<description>.*)\s+\(default:\s*`(?<defaultValue>.+)`\)\s*$"""
+    .toRegex(RegexOption.DOT_MATCHES_ALL)
+
+private const val EXPECTED_CONFIGURATION_FORMAT =
+    """Expected format: @Configuration("{paramDescription} (default: `{defaultValue}`)")"""

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleSetProviderCollector.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleSetProviderCollector.kt
@@ -102,7 +102,7 @@ class RuleSetProviderVisitor : DetektVisitor() {
 
             val ruleArgumentNames = (ruleListExpression as? KtCallExpression)
                 ?.valueArguments
-                ?.map { it.getArgumentExpression() }
+                ?.mapNotNull { it.getArgumentExpression() }
                 ?.mapNotNull(this::guessRuleNameOrNull)
                 ?: emptyList()
 
@@ -110,15 +110,12 @@ class RuleSetProviderVisitor : DetektVisitor() {
         }
     }
 
-    private fun guessRuleNameOrNull(expressionOrNull: KtExpression?): String? {
-        return expressionOrNull?.let {
-            when (it) {
-                // constructor
-                is KtCallExpression -> it.referenceExpression()?.text
-                // factory method
-                is KtDotQualifiedExpression -> it.receiverExpression.text
-                else -> null
-            }
+    private fun guessRuleNameOrNull(expression: KtExpression): String? =
+        when (expression) {
+            // constructor
+            is KtCallExpression -> expression.referenceExpression()?.text
+            // factory method
+            is KtDotQualifiedExpression -> expression.receiverExpression.text
+            else -> null
         }
-    }
 }

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleSetProviderCollectorSpec.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleSetProviderCollectorSpec.kt
@@ -281,5 +281,33 @@ class RuleSetProviderCollectorSpec : Spek({
                 assertThat(items[0].rules).containsExactly(ruleName, secondRuleName)
             }
         }
+        context("a correct RuleSetProvider class using a factory method") {
+            val description = "This is a description"
+            val ruleSetId = "test"
+            val ruleName = "TestRule"
+            val code = """
+            package foo
+
+            /**
+             * $description
+             *
+             * @active since v1.0.0
+             */
+            class TestProvider: RuleSetProvider {
+                override val ruleSetId: String = "$ruleSetId"
+
+                override fun instance(config: Config): RuleSet {
+                    return RuleSet(ruleSetId, listOf(
+                            $ruleName.create(config),
+                    ))
+                }
+            }
+        """
+
+            it("collects a rule") {
+                val items = subject.run(code)
+                assertThat(items[0].rules).containsExactly(ruleName)
+            }
+        }
     }
 })

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexMethod.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexMethod.kt
@@ -10,8 +10,8 @@ import io.gitlab.arturbosch.detekt.api.Metric
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.ThresholdRule
 import io.gitlab.arturbosch.detekt.api.ThresholdedCodeSmell
-import io.gitlab.arturbosch.detekt.api.internal.Configuration
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
+import io.gitlab.arturbosch.detekt.api.internal.Configuration
 import io.gitlab.arturbosch.detekt.api.internal.valueOrDefaultCommaSeparated
 import org.jetbrains.kotlin.psi.KtBlockExpression
 import org.jetbrains.kotlin.psi.KtExpression
@@ -119,6 +119,7 @@ class ComplexMethod(
 
     companion object {
         const val DEFAULT_THRESHOLD_METHOD_COMPLEXITY = 15
+
         // Still to do: Disable custom rule check for annotated rules
         //  io.gitlab.arturbosch.detekt.core.ConfigAssert#checkOptions
         const val IGNORE_SINGLE_WHEN_EXPRESSION = "ignoreSingleWhenExpression"

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexMethod.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexMethod.kt
@@ -37,15 +37,6 @@ import org.jetbrains.kotlin.psi.KtWhenExpression
  * - __Exceptions__ - `catch`, `use`
  * - __Scope Functions__ - `let`, `run`, `with`, `apply`, and `also` ->
  *  [Reference](https://kotlinlang.org/docs/reference/scope-functions.html)
- *
- * @configuration threshold - McCabe's Cyclomatic Complexity (MCC) number for a method (default: `15`)
- * @configuration ignoreSingleWhenExpression - Ignores a complex method if it only contains a single when expression.
- * (default: `false`)
- * @configuration ignoreSimpleWhenEntries - Whether to ignore simple (braceless) when entries. (default: `false`)
- * @configuration ignoreNestingFunctions - Whether to ignore functions which are often used instead of an `if` or
- * `for` statement (default: `false`)
- * @configuration nestingFunctions - Comma separated list of function names which add complexity
- * (default: `[run, let, apply, with, also, use, forEach, isNotNull, ifNull]`)
  */
 @ActiveByDefault(since = "1.0.0")
 class ComplexMethod(

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexMethod.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexMethod.kt
@@ -131,10 +131,10 @@ class ComplexMethod(
         fun create(ruleSetConfig: Config): ComplexMethod {
             val config = ruleSetConfig.subConfig("ComplexMethod")
             val threshold = config.valueOrDefault("threshold", DEFAULT_THRESHOLD_METHOD_COMPLEXITY)
-            val ignoreSingleWhenExpression = config.valueOrDefault("ignoreSingleWhenExpression", false)
-            val ignoreSimpleWhenEntries = config.valueOrDefault("ignoreSimpleWhenEntries", false)
-            val ignoreNestingFunctions = config.valueOrDefault("ignoreNestingFunctions", false)
-            val nestingFunctions = config.valueOrDefaultCommaSeparated("nestingFunctions", DEFAULT_NESTING_FUNCTIONS)
+            val ignoreSingleWhenExpression = config.valueOrDefault(IGNORE_SINGLE_WHEN_EXPRESSION, false)
+            val ignoreSimpleWhenEntries = config.valueOrDefault(IGNORE_SIMPLE_WHEN_ENTRIES, false)
+            val ignoreNestingFunctions = config.valueOrDefault(IGNORE_NESTING_FUNCTIONS, false)
+            val nestingFunctions = config.valueOrDefaultCommaSeparated(NESTING_FUNCTIONS, DEFAULT_NESTING_FUNCTIONS)
 
             return ComplexMethod(
                 config = ruleSetConfig,

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexityProvider.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexityProvider.kt
@@ -20,7 +20,7 @@ class ComplexityProvider : DefaultRuleSetProvider {
             LongMethod(config),
             LargeClass(config),
             ComplexInterface(config),
-            ComplexMethod(config),
+            ComplexMethod.create(config),
             StringLiteralDuplication(config),
             MethodOverloading(config),
             NestedBlockDepth(config),

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexMethodSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexMethodSpec.kt
@@ -1,6 +1,7 @@
 package io.gitlab.arturbosch.detekt.rules.complexity
 
 import io.github.detekt.test.utils.resourceAsPath
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
@@ -9,6 +10,8 @@ import io.gitlab.arturbosch.detekt.test.isThresholded
 import io.gitlab.arturbosch.detekt.test.lint
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
+
+private val defaultConfigMap: Map<String, Any> = mapOf("threshold" to "1")
 
 class ComplexMethodSpec : Spek({
 
@@ -19,7 +22,7 @@ class ComplexMethodSpec : Spek({
         context("different complex constructs") {
 
             it("counts different loops") {
-                val findings = ComplexMethod(threshold = 1).compileAndLint(
+                val findings = ComplexMethod.create(TestConfig(defaultConfigMap)).compileAndLint(
                     """
                     fun test() {
                         for (i in 1..10) {}
@@ -34,7 +37,7 @@ class ComplexMethodSpec : Spek({
             }
 
             it("counts catch blocks") {
-                val findings = ComplexMethod(threshold = 1).compileAndLint(
+                val findings = ComplexMethod.create(TestConfig(defaultConfigMap)).compileAndLint(
                     """
                     fun test() {
                         try {} catch(e: IllegalArgumentException) {} catch(e: Exception) {} finally {}
@@ -46,7 +49,7 @@ class ComplexMethodSpec : Spek({
             }
 
             it("counts nested conditional statements") {
-                val findings = ComplexMethod(threshold = 1).compileAndLint(
+                val findings = ComplexMethod.create(TestConfig(defaultConfigMap)).compileAndLint(
                     """
                     fun test() {
                         try {
@@ -79,27 +82,27 @@ class ComplexMethodSpec : Spek({
                 """
 
             it("counts three with nesting function 'forEach'") {
-                val config = TestConfig(mapOf(ComplexMethod.IGNORE_NESTING_FUNCTIONS to "false"))
+                val config = TestConfig(defaultConfigMap.plus("ignoreNestingFunctions" to "false"))
                 assertExpectedComplexityValue(code, config, expectedValue = 3)
             }
 
             it("can ignore nesting functions like 'forEach'") {
-                val config = TestConfig(mapOf(ComplexMethod.IGNORE_NESTING_FUNCTIONS to "true"))
+                val config = TestConfig(defaultConfigMap.plus("ignoreNestingFunctions" to "true"))
                 assertExpectedComplexityValue(code, config, expectedValue = 2)
             }
 
             it("skips all if if the nested functions is empty") {
-                val config = TestConfig(mapOf(ComplexMethod.NESTING_FUNCTIONS to ""))
+                val config = TestConfig(defaultConfigMap.plus("nestingFunctions" to ""))
                 assertExpectedComplexityValue(code, config, expectedValue = 2)
             }
 
             it("skips 'forEach' as it is not specified") {
-                val config = TestConfig(mapOf(ComplexMethod.NESTING_FUNCTIONS to "let,apply,also"))
+                val config = TestConfig(defaultConfigMap.plus("nestingFunctions" to "let,apply,also"))
                 assertExpectedComplexityValue(code, config, expectedValue = 2)
             }
 
             it("skips 'forEach' as it is not specified list") {
-                val config = TestConfig(mapOf(ComplexMethod.NESTING_FUNCTIONS to listOf("let", "apply", "also")))
+                val config = TestConfig(defaultConfigMap.plus("nestingFunctions" to listOf("let", "apply", "also")))
                 assertExpectedComplexityValue(code, config, expectedValue = 2)
             }
         }
@@ -111,16 +114,18 @@ class ComplexMethodSpec : Spek({
             it("does not report complex methods with a single when expression") {
                 val config = TestConfig(
                     mapOf(
-                        ComplexMethod.IGNORE_SINGLE_WHEN_EXPRESSION to "true"
+                        "threshold" to "4",
+                        "ignoreSingleWhenExpression" to "true"
                     )
                 )
-                val subject = ComplexMethod(config, threshold = 4)
+                val subject = ComplexMethod.create(config)
 
                 assertThat(subject.lint(path)).hasSourceLocations(SourceLocation(43, 5))
             }
 
             it("reports all complex methods") {
-                val subject = ComplexMethod(threshold = 4)
+                val config = TestConfig(mapOf("threshold" to "4"))
+                val subject = ComplexMethod.create(config)
 
                 assertThat(subject.lint(path)).hasSourceLocations(
                     SourceLocation(6, 5),
@@ -132,8 +137,8 @@ class ComplexMethodSpec : Spek({
             }
 
             it("does not trip for a reasonable amount of simple when entries when ignoreSimpleWhenEntries is true") {
-                val config = TestConfig(mapOf(ComplexMethod.IGNORE_SIMPLE_WHEN_ENTRIES to "true"))
-                val subject = ComplexMethod(config)
+                val config = TestConfig(mapOf("ignoreSimpleWhenEntries" to "true"))
+                val subject = ComplexMethod.create(config)
                 val code = """
                      fun f() {
                         val map = HashMap<Any, String>()
@@ -209,14 +214,14 @@ class ComplexMethodSpec : Spek({
             """
 
             it("should not count these overridden functions to base functions complexity") {
-                assertThat(ComplexMethod().compileAndLint(code)).isEmpty()
+                assertThat(ComplexMethod.create(Config.empty).compileAndLint(code)).isEmpty()
             }
         }
     }
 })
 
 private fun assertExpectedComplexityValue(code: String, config: TestConfig, expectedValue: Int) {
-    val findings = ComplexMethod(config, threshold = 1).lint(code)
+    val findings = ComplexMethod.create(config).lint(code)
 
     assertThat(findings).hasSourceLocations(SourceLocation(1, 5))
 

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexMethodSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexMethodSpec.kt
@@ -3,6 +3,10 @@ package io.gitlab.arturbosch.detekt.rules.complexity
 import io.github.detekt.test.utils.resourceAsPath
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.SourceLocation
+import io.gitlab.arturbosch.detekt.rules.complexity.ComplexMethod.Companion.IGNORE_NESTING_FUNCTIONS
+import io.gitlab.arturbosch.detekt.rules.complexity.ComplexMethod.Companion.IGNORE_SIMPLE_WHEN_ENTRIES
+import io.gitlab.arturbosch.detekt.rules.complexity.ComplexMethod.Companion.IGNORE_SINGLE_WHEN_EXPRESSION
+import io.gitlab.arturbosch.detekt.rules.complexity.ComplexMethod.Companion.NESTING_FUNCTIONS
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLint
@@ -82,27 +86,27 @@ class ComplexMethodSpec : Spek({
                 """
 
             it("counts three with nesting function 'forEach'") {
-                val config = TestConfig(defaultConfigMap.plus("ignoreNestingFunctions" to "false"))
+                val config = TestConfig(defaultConfigMap.plus(IGNORE_NESTING_FUNCTIONS to "false"))
                 assertExpectedComplexityValue(code, config, expectedValue = 3)
             }
 
             it("can ignore nesting functions like 'forEach'") {
-                val config = TestConfig(defaultConfigMap.plus("ignoreNestingFunctions" to "true"))
+                val config = TestConfig(defaultConfigMap.plus(IGNORE_NESTING_FUNCTIONS to "true"))
                 assertExpectedComplexityValue(code, config, expectedValue = 2)
             }
 
             it("skips all if if the nested functions is empty") {
-                val config = TestConfig(defaultConfigMap.plus("nestingFunctions" to ""))
+                val config = TestConfig(defaultConfigMap.plus(NESTING_FUNCTIONS to ""))
                 assertExpectedComplexityValue(code, config, expectedValue = 2)
             }
 
             it("skips 'forEach' as it is not specified") {
-                val config = TestConfig(defaultConfigMap.plus("nestingFunctions" to "let,apply,also"))
+                val config = TestConfig(defaultConfigMap.plus(NESTING_FUNCTIONS to "let,apply,also"))
                 assertExpectedComplexityValue(code, config, expectedValue = 2)
             }
 
             it("skips 'forEach' as it is not specified list") {
-                val config = TestConfig(defaultConfigMap.plus("nestingFunctions" to listOf("let", "apply", "also")))
+                val config = TestConfig(defaultConfigMap.plus(NESTING_FUNCTIONS to listOf("let", "apply", "also")))
                 assertExpectedComplexityValue(code, config, expectedValue = 2)
             }
         }
@@ -115,7 +119,7 @@ class ComplexMethodSpec : Spek({
                 val config = TestConfig(
                     mapOf(
                         "threshold" to "4",
-                        "ignoreSingleWhenExpression" to "true"
+                        IGNORE_SINGLE_WHEN_EXPRESSION to "true"
                     )
                 )
                 val subject = ComplexMethod.create(config)
@@ -137,7 +141,7 @@ class ComplexMethodSpec : Spek({
             }
 
             it("does not trip for a reasonable amount of simple when entries when ignoreSimpleWhenEntries is true") {
-                val config = TestConfig(mapOf("ignoreSimpleWhenEntries" to "true"))
+                val config = TestConfig(mapOf(IGNORE_SIMPLE_WHEN_ENTRIES to "true"))
                 val subject = ComplexMethod.create(config)
                 val code = """
                      fun f() {


### PR DESCRIPTION
This is what I have got so far. I had not realized that there were so many custom checks on rules and rule providers.

### What has been done
* I created an annotation that can be applied to value parameters 
* I picked a random rule (`ComplexMethod`) to illustrate what it would look like 
* The rule is configured by exposing all config options in the constructor binding them to immutable fields.
* The mapping between the config and those fields is done in a factory method
* In the RuleSetProvider the factory method is used

### What would come next
* Extract the documentation and default conifg from the annotation instead of the kdoc
* Create an annotation processor to generate a `[RuleName]Factory` similar to the factory method
* Disable  some custom rule checks for rules that have the annotations

### And still after that
* Infer the default property value from the annotated parameter for documentation and default config 
* Adapt the pattern to more rules
* ...

Since this is quite a change, I would like your opinions on whether this is worth the effort and if this going in the right direction or what else you had in mind when you saw the issue come up.