### PR TITLE
Decouple Gradle projects

### DIFF
--- a/detekt-api/build.gradle.kts
+++ b/detekt-api/build.gradle.kts
@@ -11,7 +11,6 @@ dependencies {
     api(kotlin("compiler-embeddable"))
     api(project(":detekt-psi-utils"))
 
-    testImplementation(project(":detekt-parser"))
     testImplementation(project(":detekt-test"))
 
     testFixturesApi(kotlin("stdlib-jdk8"))

--- a/detekt-cli/build.gradle.kts
+++ b/detekt-cli/build.gradle.kts
@@ -1,5 +1,3 @@
-import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
-
 plugins {
     id("com.github.johnrengelman.shadow")
     module
@@ -10,9 +8,7 @@ application {
     mainClassName = "io.gitlab.arturbosch.detekt.cli.Main"
 }
 
-tasks.withType<ShadowJar>().configureEach {
-    mergeServiceFiles()
-}
+val bundledRules by configurations.creating
 
 dependencies {
     implementation(kotlin("stdlib-jdk8"))
@@ -20,10 +16,15 @@ dependencies {
     implementation(project(":detekt-tooling"))
     implementation(project(":detekt-parser"))
     runtimeOnly(project(":detekt-core"))
-    runtimeOnly(project(":detekt-rules"))
 
     testImplementation(project(":detekt-test"))
-    testImplementation(project(":detekt-rules"))
+
+    bundledRules(project(":detekt-rules"))
+}
+
+tasks.shadowJar {
+    mergeServiceFiles()
+    configurations = listOf(project.configurations.runtimeClasspath.get(), bundledRules)
 }
 
 val moveJarForIntegrationTest by tasks.registering {

--- a/detekt-cli/build.gradle.kts
+++ b/detekt-cli/build.gradle.kts
@@ -27,13 +27,8 @@ tasks.shadowJar {
     configurations = listOf(project.configurations.runtimeClasspath.get(), bundledRules)
 }
 
-val moveJarForIntegrationTest by tasks.registering {
-    dependsOn(tasks.named("shadowJar"))
-    doLast {
-        copy {
-            from(tasks.named("shadowJar"))
-            into(rootProject.buildDir)
-            rename { "detekt-cli-all.jar" }
-        }
-    }
+tasks.register<Copy>("moveJarForIntegrationTest") {
+    from(tasks.shadowJar)
+    into(rootProject.buildDir)
+    rename { "detekt-cli-all.jar" }
 }

--- a/detekt-cli/build.gradle.kts
+++ b/detekt-cli/build.gradle.kts
@@ -11,7 +11,6 @@ application {
 val bundledRules by configurations.creating
 
 dependencies {
-    implementation(kotlin("stdlib-jdk8"))
     implementation("com.beust:jcommander")
     implementation(project(":detekt-tooling"))
     implementation(project(":detekt-parser"))

--- a/detekt-core/build.gradle.kts
+++ b/detekt-core/build.gradle.kts
@@ -14,7 +14,7 @@ dependencies {
     implementation(project(":detekt-report-xml"))
     implementation(project(":detekt-report-sarif"))
 
-    testImplementation(project(":detekt-rules"))
+    testRuntimeOnly(project(":detekt-rules"))
     testImplementation(project(":detekt-test"))
     testImplementation(testFixtures(project(":detekt-api")))
 }

--- a/detekt-formatting/build.gradle.kts
+++ b/detekt-formatting/build.gradle.kts
@@ -24,7 +24,7 @@ val depsToPackage = setOf(
     "com.pinterest.ktlint"
 )
 
-tasks.withType<Jar>().configureEach {
+tasks.jar {
     duplicatesStrategy = DuplicatesStrategy.INCLUDE // allow duplicates
     dependsOn(configurations.runtimeClasspath)
     from({
@@ -34,13 +34,8 @@ tasks.withType<Jar>().configureEach {
     })
 }
 
-val moveJarForIntegrationTest by tasks.registering {
-    dependsOn(tasks.named("jar"))
-    doLast {
-        copy {
-            from(tasks.named("jar"))
-            into(rootProject.buildDir)
-            rename { "detekt-formatting.jar" }
-        }
-    }
+tasks.register<Copy>("moveJarForIntegrationTest") {
+    from(tasks.jar)
+    into(rootProject.buildDir)
+    rename { "detekt-formatting.jar" }
 }

--- a/detekt-generator/build.gradle.kts
+++ b/detekt-generator/build.gradle.kts
@@ -7,7 +7,6 @@ plugins {
 dependencies {
     implementation(project(":detekt-parser"))
     implementation(project(":detekt-api"))
-    implementation(project(":detekt-rules"))
     implementation(project(":detekt-rules-empty"))
     implementation(project(":detekt-formatting"))
     implementation(project(":detekt-cli"))

--- a/detekt-rules/build.gradle.kts
+++ b/detekt-rules/build.gradle.kts
@@ -3,20 +3,27 @@ plugins {
 }
 
 dependencies {
-    compileOnly(project(":detekt-api"))
-    implementation(project(":detekt-rules-complexity"))
-    implementation(project(":detekt-rules-coroutines"))
-    implementation(project(":detekt-rules-documentation"))
-    implementation(project(":detekt-rules-empty"))
-    implementation(project(":detekt-rules-errorprone"))
-    implementation(project(":detekt-rules-exceptions"))
-    implementation(project(":detekt-rules-naming"))
-    implementation(project(":detekt-rules-performance"))
-    implementation(project(":detekt-rules-style"))
+    runtimeOnly(project(":detekt-rules-complexity"))
+    runtimeOnly(project(":detekt-rules-coroutines"))
+    runtimeOnly(project(":detekt-rules-documentation"))
+    runtimeOnly(project(":detekt-rules-empty"))
+    runtimeOnly(project(":detekt-rules-errorprone"))
+    runtimeOnly(project(":detekt-rules-exceptions"))
+    runtimeOnly(project(":detekt-rules-naming"))
+    runtimeOnly(project(":detekt-rules-performance"))
+    runtimeOnly(project(":detekt-rules-style"))
 
     testImplementation(project(":detekt-core"))
-    testImplementation(project(":detekt-parser"))
     testImplementation(project(":detekt-test"))
+    testImplementation(project(":detekt-rules-complexity"))
+    testImplementation(project(":detekt-rules-coroutines"))
+    testImplementation(project(":detekt-rules-documentation"))
+    testImplementation(project(":detekt-rules-empty"))
+    testImplementation(project(":detekt-rules-errorprone"))
+    testImplementation(project(":detekt-rules-exceptions"))
+    testImplementation(project(":detekt-rules-naming"))
+    testImplementation(project(":detekt-rules-performance"))
+    testImplementation(project(":detekt-rules-style"))
 }
 
 tasks.build { finalizedBy(":detekt-generator:generateDocumentation") }


### PR DESCRIPTION
This reduces the number of subprojects that have to be recompiled when there's a change to one of the rules, saving quite a bit of time when building the project.

The most interesting change is in the detekt-cli build file since the shadow jar config has changed. The new config can be verified by executing the resulting jar with `--debug` and confirming that the bundled rulesets have been registered.