### PR TITLE
Simplify Gradle config

### DIFF
--- a/buildSrc/src/main/kotlin/module.gradle.kts
+++ b/buildSrc/src/main/kotlin/module.gradle.kts
@@ -72,26 +72,13 @@ dependencies {
     testRuntimeOnly("org.spekframework.spek2:spek-runner-junit5")
 }
 
-val sourcesJar by tasks.registering(Jar::class) {
-    dependsOn(tasks.classes)
-    archiveClassifier.set("sources")
-    from(sourceSets.main.get().allSource)
-}
-
-val javadocJar by tasks.registering(Jar::class) {
-    from(tasks.javadoc)
-    archiveClassifier.set("javadoc")
-}
-
-artifacts {
-    archives(sourcesJar)
-    archives(javadocJar)
+java {
+    withSourcesJar()
+    withJavadocJar()
 }
 
 publishing {
     publications.named<MavenPublication>(DETEKT_PUBLICATION) {
         from(components["java"])
-        artifact(sourcesJar.get())
-        artifact(javadocJar.get())
     }
 }

--- a/buildSrc/src/main/kotlin/module.gradle.kts
+++ b/buildSrc/src/main/kotlin/module.gradle.kts
@@ -45,8 +45,6 @@ tasks.withType<Test>().configureEach {
 }
 
 tasks.withType<KotlinCompile>().configureEach {
-    sourceCompatibility = JavaVersion.VERSION_1_8.toString()
-    targetCompatibility = JavaVersion.VERSION_1_8.toString()
     kotlinOptions {
         jvmTarget = Versions.JVM_TARGET
         languageVersion = "1.4"


### PR DESCRIPTION
Uses [withJavadocJar](https://docs.gradle.org/current/javadoc/org/gradle/api/plugins/JavaPluginExtension.html#withJavadocJar--) and [withSourcesJar](https://docs.gradle.org/current/javadoc/org/gradle/api/plugins/JavaPluginExtension.html#withSourcesJar--) which are functionally equivalent to the config that was removed.

The new config also avoids configuring the javadoc/sourcesjar tasks during Gradle's configuration phase.

Tested by publishing to mavenLocal on my machine. The javadoc jars are empty anyway with the current config, and sources are published as expected.