### PR TITLE
Apply more formatting rules to our code

### DIFF
--- a/buildSrc/src/main/kotlin/UpdateVersionInFileTask.kt
+++ b/buildSrc/src/main/kotlin/UpdateVersionInFileTask.kt
@@ -10,6 +10,7 @@ import java.io.File
 open class UpdateVersionInFileTask : DefaultTask(), Runnable {
 
     private val fileProp: RegularFileProperty = project.objects.fileProperty()
+
     @get:InputFile
     var fileToUpdate: File
         get() = fileProp.get().asFile

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -64,10 +64,30 @@ formatting:
   active: true
   android: false
   autoCorrect: true
+  AnnotationSpacing:
+    active: true
+  EnumEntryNameCase:
+    active: true
+  ImportOrdering:
+    active: true
+  Indentation:
+    active: true
   MaximumLineLength:
     active: false
+  NoEmptyFirstLineInMethodBlock:
+    active: true
   ParameterListWrapping:
     active: false
+  SpacingAroundAngleBrackets:
+    active: true
+  SpacingAroundDoubleColon:
+    active: true
+  SpacingAroundUnaryOperator:
+    active: true
+  SpacingBetweenDeclarationsWithAnnotations:
+    active: true
+  SpacingBetweenDeclarationsWithComments:
+    active: true
 
 potential-bugs:
   UnsafeCast:

--- a/custom-checks/src/main/kotlin/io/github/detekt/custom/SpekTestDiscovery.kt
+++ b/custom-checks/src/main/kotlin/io/github/detekt/custom/SpekTestDiscovery.kt
@@ -100,11 +100,13 @@ class SpekTestDiscovery(config: Config = Config.empty) : Rule(config) {
             val fqType = initExpr?.getType(bindingContext)
                 ?.getJetTypeFqName(false)
             if (fqType != null && fqType !in allowedTypes) {
-                report(CodeSmell(
-                    issue,
-                    Entity.atName(property),
-                    "Variable declarations which do not met the allowed types should be memoized."
-                ))
+                report(
+                    CodeSmell(
+                        issue,
+                        Entity.atName(property),
+                        "Variable declarations which do not met the allowed types should be memoized."
+                    )
+                )
             }
         }
     }

--- a/custom-checks/src/test/kotlin/io/github/detekt/custom/SpekTestDiscoverySpec.kt
+++ b/custom-checks/src/test/kotlin/io/github/detekt/custom/SpekTestDiscoverySpec.kt
@@ -18,11 +18,13 @@ class SpekTestDiscoverySpec : Spek({
         context("top level scope") {
 
             it("allows strings, paths and files by default") {
-                val code = createSpekCode("""
+                val code = createSpekCode(
+                    """
                     val s = "simple"
                     val p = Paths.get("")
                     val f = File("")
-                """)
+                """
+                )
 
                 assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
             }
@@ -44,14 +46,16 @@ class SpekTestDiscoverySpec : Spek({
 
             setOf("describe", "context").forEach { name ->
                 it("allows strings, files and paths by default") {
-                    val code = createSpekCode("""
+                    val code = createSpekCode(
+                        """
                         $name("group") {
                             val s = "simple"
                             val p = Paths.get("")
                             val f = File("")
                             val m by memoized { Any() }
                         }
-                    """)
+                    """
+                    )
 
                     assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
                 }
@@ -59,11 +63,13 @@ class SpekTestDiscoverySpec : Spek({
 
             setOf("describe", "context").forEach { name ->
                 it("disallows non memoized declarations") {
-                    val code = createSpekCode("""
+                    val code = createSpekCode(
+                        """
                         $name("group") {
                             val complex = Any()
                         }
-                    """)
+                    """
+                    )
 
                     assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
                 }

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/CodeSmell.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/CodeSmell.kt
@@ -86,7 +86,11 @@ open class ThresholdedCodeSmell(
     message: String,
     references: List<Entity> = emptyList()
 ) : CodeSmell(
-    issue, entity, message, metrics = listOf(metric), references = references
+    issue,
+    entity,
+    message,
+    metrics = listOf(metric),
+    references = references
 ) {
 
     val value: Int

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Location.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Location.kt
@@ -65,8 +65,10 @@ data class Location @Deprecated("Consider relative path by passing a [FilePath]"
         fun startLineAndColumn(element: PsiElement, offset: Int = 0): PsiDiagnosticUtils.LineAndColumn {
             return try {
                 val range = element.textRange
-                DiagnosticUtils.getLineAndColumnInPsiFile(element.containingFile,
-                    TextRange(range.startOffset + offset, range.endOffset + offset))
+                DiagnosticUtils.getLineAndColumnInPsiFile(
+                    element.containingFile,
+                    TextRange(range.startOffset + offset, range.endOffset + offset)
+                )
             } catch (e: IndexOutOfBoundsException) {
                 // #3317 If any rule mutates the PsiElement, searching the original PsiElement may throw exception.
                 PsiDiagnosticUtils.LineAndColumn(-1, -1, null)

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Severity.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Severity.kt
@@ -11,31 +11,38 @@ enum class Severity {
      * Represents clean coding violations which may lead to maintainability issues.
      */
     CodeSmell,
+
     /**
      * Inspections in this category detect violations of code syntax styles.
      */
     Style,
+
     /**
      * Corresponds to issues that do not prevent the code from working,
      * but may nevertheless represent coding inefficiencies.
      */
     Warning,
+
     /**
      * Corresponds to coding mistakes which could lead to unwanted behavior.
      */
     Defect,
+
     /**
      * Represents code quality issues which only slightly impact the code quality.
      */
     Minor,
+
     /**
      * Issues in this category make the source code confusing and difficult to maintain.
      */
     Maintainability,
+
     /**
      * Places in the source code that can be exploited and possibly result in significant damage.
      */
     Security,
+
     /**
      * Places in the source code which degrade the performance of the application.
      */

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/PathFilters.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/PathFilters.kt
@@ -26,7 +26,6 @@ class PathFilters internal constructor(
      *   return false iff [path] matches any [includes] and [path] does not match any [excludes].
      */
     fun isIgnored(path: Path): Boolean {
-
         fun isIncluded() = includes?.any { it.matches(path) }
         fun isExcluded() = excludes?.any { it.matches(path) }
 

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/PathMatchers.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/PathMatchers.kt
@@ -10,7 +10,6 @@ import java.nio.file.PathMatcher
  * Internally a globbing pattern is transformed to a regex respecting the Windows file system.
  */
 fun pathMatcher(pattern: String): PathMatcher {
-
     val result = when (pattern.substringBefore(":")) {
         "glob" -> pattern
         "regex" -> throw IllegalArgumentException(USE_GLOB_MSG)

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/Validation.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/Validation.kt
@@ -6,7 +6,6 @@ private val identifierRegex = Regex("[aA-zZ]+([-][aA-zZ]+)*")
  * Checks if given string matches the criteria of an id - [aA-zZ]+([-][aA-zZ]+)* .
  */
 internal fun validateIdentifier(id: String) {
-
     require(id.matches(identifierRegex)) {
         "id '$id' must match ${identifierRegex.pattern}"
     }

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/AnnotationExcluderSpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/AnnotationExcluderSpec.kt
@@ -18,11 +18,13 @@ class AnnotationExcluderSpec : Spek({
         val sinceKotlinAnnotation by memoized { psiFactory.createAnnotationEntry("@SinceKotlin") }
 
         val file by memoized {
-            compileContentForTest("""
+            compileContentForTest(
+                """
                 package foo
 
                 import kotlin.jvm.JvmField
-            """.trimIndent())
+                """.trimIndent()
+            )
         }
 
         it("should exclude when the annotation was found") {

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/EntitySpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/EntitySpec.kt
@@ -16,7 +16,8 @@ class EntitySpec : Spek({
     describe("entity signatures") {
         val path = Paths.get("/full/path/to/Test.kt")
         val code by memoized(CachingMode.SCOPE) {
-            compileContentForTest("""
+            compileContentForTest(
+                """
             package test
 
             class C : Any() {
@@ -25,7 +26,8 @@ class EntitySpec : Spek({
             }
 
             fun topLevelFun(number: Int) = Unit
-        """.trimIndent(), path.toString()
+                """.trimIndent(),
+                path.toString()
             )
         }
 

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/PropertiesAwareSpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/PropertiesAwareSpec.kt
@@ -25,10 +25,13 @@ class PropertiesAwareSpec : Spek({
                     register("string", "test")
                     register("number", 5)
                     register("set", setOf(1, 2, 3))
-                    register("any", object : Any() {
-                        override fun equals(other: Any?): Boolean = hashCode() == other.hashCode()
-                        override fun hashCode(): Int = hash
-                    })
+                    register(
+                        "any",
+                        object : Any() {
+                            override fun equals(other: Any?): Boolean = hashCode() == other.hashCode()
+                            override fun hashCode(): Int = hash
+                        }
+                    )
                 }
             }
 

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/internal/InclusionExclusionPatternsSpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/internal/InclusionExclusionPatternsSpec.kt
@@ -70,9 +70,12 @@ class InclusionExclusionPatternsSpec : Spek({
     describe("rule should only run on included files") {
 
         it("should only run on dummies") {
-            val config = TestConfig(mapOf(
-                Config.INCLUDES_KEY to "**Dummy*.kt",
-                Config.EXCLUDES_KEY to "**/library/**"))
+            val config = TestConfig(
+                mapOf(
+                    Config.INCLUDES_KEY to "**Dummy*.kt",
+                    Config.EXCLUDES_KEY to "**/library/**"
+                )
+            )
 
             OnlyLibraryTrackingRule(config).apply {
                 Files.walk(resourceAsPath("library/Library.kt").parent)
@@ -84,9 +87,12 @@ class InclusionExclusionPatternsSpec : Spek({
         }
 
         it("should only run on library file") {
-            val config = TestConfig(mapOf(
-                Config.INCLUDES_KEY to "**Library.kt",
-                Config.EXCLUDES_KEY to "**/library/**"))
+            val config = TestConfig(
+                mapOf(
+                    Config.INCLUDES_KEY to "**Library.kt",
+                    Config.EXCLUDES_KEY to "**/library/**"
+                )
+            )
 
             OnlyLibraryTrackingRule(config).apply {
                 Files.walk(resourceAsPath("library/Library.kt").parent)

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt
@@ -123,11 +123,11 @@ class CliArgs {
     )
     var allRules: Boolean = false
 
+    // nullable for 1.x.x to prefer maxIssues from config file
     @Parameter(
         names = ["--max-issues"],
         description = "Return exit code 0 only when found issues count does not exceed specified issues count."
     )
-    // nullable for 1.x.x to prefer maxIssues from config file
     var maxIssues: Int? = null
 
     @Parameter(
@@ -147,7 +147,8 @@ class CliArgs {
 
     @Parameter(
         names = ["--help", "-h"],
-        help = true, description = "Shows the usage."
+        help = true,
+        description = "Shows the usage."
     )
     var help: Boolean = false
 

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Configurations.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Configurations.kt
@@ -5,7 +5,8 @@ import io.github.detekt.tooling.internal.NotApiButProbablyUsedByUsers
 import io.gitlab.arturbosch.detekt.api.Config
 
 @NotApiButProbablyUsedByUsers
-@Deprecated("""
+@Deprecated(
+    """
     Exposes internal resource name. There should not be a case were just the resource name is needed.
     Please use the DefaultConfigurationProvider to get a default config instance.
 """

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Spec.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Spec.kt
@@ -7,7 +7,6 @@ import io.gitlab.arturbosch.detekt.api.commaSeparatedPattern
 internal fun CliArgs.createSpec(output: Appendable, error: Appendable): ProcessingSpec {
     val args = this
     return ProcessingSpec {
-
         logging {
             debug = args.debug
             outputChannel = output

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/RunnerSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/RunnerSpec.kt
@@ -25,9 +25,12 @@ class RunnerSpec : Spek({
             val tmpReport = createTempFileForTest("RunnerSpec", ".txt")
 
             executeDetekt(
-                "--input", inputPath.toString(),
-                "--report", "txt:$tmpReport",
-                "--config-resource", "/configs/max-issues-2.yml"
+                "--input",
+                inputPath.toString(),
+                "--report",
+                "txt:$tmpReport",
+                "--config-resource",
+                "/configs/max-issues-2.yml"
             )
 
             assertThat(Files.readAllLines(tmpReport)).hasSize(1)
@@ -36,8 +39,10 @@ class RunnerSpec : Spek({
         it("should throw on maxIssues=0") {
             assertThatThrownBy {
                 executeDetekt(
-                    "--input", inputPath.toString(),
-                    "--config-resource", "/configs/max-issues-0.yml"
+                    "--input",
+                    inputPath.toString(),
+                    "--config-resource",
+                    "/configs/max-issues-0.yml"
                 )
             }.isExactlyInstanceOf(MaxIssuesReached::class.java)
         }
@@ -46,9 +51,12 @@ class RunnerSpec : Spek({
             val tmpReport = createTempFileForTest("RunnerSpec", ".txt")
 
             executeDetekt(
-                "--input", inputPath.toString(),
-                "--report", "txt:$tmpReport",
-                "--config-resource", "/configs/max-issues--1.yml"
+                "--input",
+                inputPath.toString(),
+                "--report",
+                "txt:$tmpReport",
+                "--config-resource",
+                "/configs/max-issues--1.yml"
             )
 
             assertThat(Files.readAllLines(tmpReport)).hasSize(1)
@@ -60,10 +68,14 @@ class RunnerSpec : Spek({
                 val tmpReport = createTempFileForTest("RunnerSpec", ".txt")
 
                 executeDetekt(
-                    "--input", inputPath.toString(),
-                    "--report", "txt:$tmpReport",
-                    "--config-resource", "/configs/max-issues-0.yml",
-                    "--baseline", resourceAsPath("configs/baseline-with-two-excludes.xml").toString()
+                    "--input",
+                    inputPath.toString(),
+                    "--report",
+                    "txt:$tmpReport",
+                    "--config-resource",
+                    "/configs/max-issues-0.yml",
+                    "--baseline",
+                    resourceAsPath("configs/baseline-with-two-excludes.xml").toString()
                 )
 
                 assertThat(Files.readAllLines(tmpReport)).isEmpty()
@@ -117,8 +129,10 @@ class RunnerSpec : Spek({
             beforeEachTest {
                 val args = parseArguments(
                     arrayOf(
-                        "--input", inputPath.toString(),
-                        "--config-resource", "/configs/max-issues-0.yml"
+                        "--input",
+                        inputPath.toString(),
+                        "--config-resource",
+                        "/configs/max-issues-0.yml"
                     )
                 )
 
@@ -143,8 +157,10 @@ class RunnerSpec : Spek({
         it("should throw on invalid config property when validation=true") {
             assertThatThrownBy {
                 executeDetekt(
-                    "--input", path.toString(),
-                    "--config-resource", "/configs/invalid-config.yml"
+                    "--input",
+                    path.toString(),
+                    "--config-resource",
+                    "/configs/invalid-config.yml"
                 )
             }.isExactlyInstanceOf(InvalidConfig::class.java)
                 .hasMessageContaining("property")
@@ -153,8 +169,10 @@ class RunnerSpec : Spek({
         it("should throw on invalid config properties when validation=true") {
             assertThatThrownBy {
                 executeDetekt(
-                    "--input", path.toString(),
-                    "--config-resource", "/configs/invalid-configs.yml"
+                    "--input",
+                    path.toString(),
+                    "--config-resource",
+                    "/configs/invalid-configs.yml"
                 )
             }.isExactlyInstanceOf(InvalidConfig::class.java)
                 .hasMessageContaining("properties")
@@ -163,8 +181,10 @@ class RunnerSpec : Spek({
         it("should not throw on invalid config property when validation=false") {
             assertThatCode {
                 executeDetekt(
-                    "--input", path.toString(),
-                    "--config-resource", "/configs/invalid-config_no-validation.yml"
+                    "--input",
+                    path.toString(),
+                    "--config-resource",
+                    "/configs/invalid-config_no-validation.yml"
                 )
             }.doesNotThrowAnyException()
         }
@@ -172,8 +192,10 @@ class RunnerSpec : Spek({
         it("should not throw on deprecation warnings") {
             assertThatCode {
                 executeDetekt(
-                    "--input", path.toString(),
-                    "--config-resource", "/configs/deprecated-property.yml"
+                    "--input",
+                    path.toString(),
+                    "--config-resource",
+                    "/configs/deprecated-property.yml"
                 )
             }.doesNotThrowAnyException()
         }
@@ -186,9 +208,12 @@ class RunnerSpec : Spek({
 
             assertThatThrownBy {
                 executeDetekt(
-                    "--input", inputPath.toString(),
-                    "--report", "txt:$tmp",
-                    "--run-rule", "test:test"
+                    "--input",
+                    inputPath.toString(),
+                    "--report",
+                    "txt:$tmp",
+                    "--run-rule",
+                    "test:test"
                 )
             }.isExactlyInstanceOf(MaxIssuesReached::class.java)
             assertThat(Files.readAllLines(tmp)).hasSize(1)
@@ -222,9 +247,12 @@ class RunnerSpec : Spek({
         it("does fail via cli flag even if config>maxIssues is specified") {
             assertThatThrownBy {
                 executeDetekt(
-                    "--input", inputPath.toString(),
-                    "--max-issues", "0",
-                    "--config-resource", "configs/max-issues--1.yml" // allow any
+                    "--input",
+                    inputPath.toString(),
+                    "--max-issues",
+                    "0",
+                    "--config-resource",
+                    "configs/max-issues--1.yml" // allow any
                 )
             }.isExactlyInstanceOf(MaxIssuesReached::class.java)
                 .hasMessage("Build failed with 1 weighted issues.")

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Analyzer.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Analyzer.kt
@@ -14,9 +14,9 @@ import io.gitlab.arturbosch.detekt.api.internal.CompilerResources
 import io.gitlab.arturbosch.detekt.api.internal.whichDetekt
 import io.gitlab.arturbosch.detekt.api.internal.whichJava
 import io.gitlab.arturbosch.detekt.api.internal.whichOS
+import io.gitlab.arturbosch.detekt.core.config.AllRulesConfig
 import io.gitlab.arturbosch.detekt.core.config.DefaultConfig
 import io.gitlab.arturbosch.detekt.core.config.DisabledAutoCorrectConfig
-import io.gitlab.arturbosch.detekt.core.config.AllRulesConfig
 import io.gitlab.arturbosch.detekt.core.rules.associateRuleIdsToRuleSetIds
 import io.gitlab.arturbosch.detekt.core.rules.isActive
 import io.gitlab.arturbosch.detekt.core.rules.shouldAnalyzeFile

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/BindingContext.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/BindingContext.kt
@@ -28,8 +28,11 @@ internal fun generateBindingContext(
     )
     analyzer.analyzeAndReport(files) {
         TopDownAnalyzerFacadeForJVM.analyzeFilesWithJavaIntegration(
-            environment.project, files, NoScopeRecordCliBindingTrace(),
-            environment.configuration, environment::createPackagePartProvider,
+            environment.project,
+            files,
+            NoScopeRecordCliBindingTrace(),
+            environment.configuration,
+            environment::createPackagePartProvider,
             ::FileBasedDeclarationProviderFactory
         )
     }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/ProcessingSettings.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/ProcessingSettings.kt
@@ -28,7 +28,8 @@ import java.net.URI
 class ProcessingSettings(
     val spec: ProcessingSpec,
     override val config: Config
-) : AutoCloseable, Closeable,
+) : AutoCloseable,
+    Closeable,
     LoggingAware by LoggingFacade(spec.loggingSpec),
     PropertiesAware by PropertiesFacade(),
     EnvironmentAware by EnvironmentFacade(spec.projectSpec, spec.compilerSpec),

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineResultMapping.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineResultMapping.kt
@@ -22,10 +22,9 @@ class BaselineResultMapping : ReportingExtension {
 
     override fun transformFindings(findings: Map<RuleSetId, List<Finding>>): Map<RuleSetId, List<Finding>> {
         val baselineFile = baselineFile
-        require(
-            !createBaseline ||
-                (createBaseline && baselineFile != null)
-        ) { "Invalid baseline options invariant." }
+        require(!createBaseline || (createBaseline && baselineFile != null)) {
+            "Invalid baseline options invariant."
+        }
 
         return baselineFile?.let { findings.transformWithBaseline(it) } ?: findings
     }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineResultMapping.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineResultMapping.kt
@@ -24,7 +24,7 @@ class BaselineResultMapping : ReportingExtension {
         val baselineFile = baselineFile
         require(
             !createBaseline ||
-                    (createBaseline && baselineFile != null)
+                (createBaseline && baselineFile != null)
         ) { "Invalid baseline options invariant." }
 
         return baselineFile?.let { findings.transformWithBaseline(it) } ?: findings

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/BaseConfig.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/BaseConfig.kt
@@ -26,11 +26,15 @@ fun Config.valueOrDefaultInternal(
             default
         }
     } catch (_: ClassCastException) {
-        error("Value \"$result\" set for config parameter \"${keySequence(key)}\" is not of" +
-            " required type ${default::class.simpleName}.")
+        error(
+            "Value \"$result\" set for config parameter \"${keySequence(key)}\" is not of" +
+                " required type ${default::class.simpleName}."
+        )
     } catch (_: NumberFormatException) {
-        error("Value \"$result\" set for config parameter \"${keySequence(key)}\" is not of" +
-            " required type ${default::class.simpleName}.")
+        error(
+            "Value \"$result\" set for config parameter \"${keySequence(key)}\" is not of" +
+                " required type ${default::class.simpleName}."
+        )
     }
 }
 

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/ValidatableConfiguration.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/ValidatableConfiguration.kt
@@ -74,7 +74,6 @@ internal fun validateConfig(
 
     fun testKeys(current: Map<String, Any>, base: Map<String, Any>, parentPath: String?) {
         for (prop in current.keys) {
-
             val propertyPath = "${if (parentPath == null) "" else "$parentPath>"}$prop"
 
             val deprecationWarning = DEPRECATED_PROPERTIES

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/YamlConfig.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/YamlConfig.kt
@@ -50,11 +50,13 @@ class YamlConfig internal constructor(
          * and point to a readable file.
          */
         fun load(path: Path): Config =
-            load(path.toFile().apply {
-                require(exists()) { "Configuration does not exist: $path" }
-                require(isFile) { "Configuration must be a file: $path" }
-                require(canRead()) { "Configuration must be readable: $path" }
-            }.reader())
+            load(
+                path.toFile().apply {
+                    require(exists()) { "Configuration does not exist: $path" }
+                    require(isFile) { "Configuration must be a file: $path" }
+                    require(canRead()) { "Configuration must be readable: $path" }
+                }.reader()
+            )
 
         /**
          * Factory method to load a yaml configuration from a URL.

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/FileProcessorLocatorSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/FileProcessorLocatorSpec.kt
@@ -25,8 +25,8 @@ class FileProcessorLocatorSpec : Spek({
 
             assertThat(processorClasses).isNotEmpty
             processorClasses
-                    .filter { clazz -> processors.firstOrNull { clazz == it.javaClass } == null }
-                    .forEach { fail("$it processor is not loaded by the FileProcessorLocator") }
+                .filter { clazz -> processors.firstOrNull { clazz == it.javaClass } == null }
+                .forEach { fail("$it processor is not loaded by the FileProcessorLocator") }
         }
 
         it("has disabled processors") {
@@ -39,6 +39,6 @@ class FileProcessorLocatorSpec : Spek({
 
 private fun getProcessorClasses(): List<Class<out FileProcessListener>> {
     return Reflections("io.github.detekt.metrics.processors")
-            .getSubTypesOf(FileProcessListener::class.java)
-            .filter { !Modifier.isAbstract(it.modifiers) }
+        .getSubTypesOf(FileProcessListener::class.java)
+        .filter { !Modifier.isAbstract(it.modifiers) }
 }

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/SuppressionSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/SuppressionSpec.kt
@@ -133,7 +133,8 @@ internal class SuppressionSpec : Spek({
         }
 
         it("rule should be suppressed by detekt prefix in uppercase with dot separator") {
-            val ktFile = compileContentForTest("""
+            val ktFile = compileContentForTest(
+                """
             @file:Suppress("Detekt.ALL")
             object SuppressedWithDetektPrefix {
 
@@ -141,14 +142,16 @@ internal class SuppressionSpec : Spek({
                     println("FAILED TEST")
                 }
             }
-            """)
+            """
+            )
             val rule = TestRule()
             rule.visitFile(ktFile)
             assertThat(rule.expected).isNotNull()
         }
 
         it("rule should be suppressed by detekt prefix in lowercase with colon separator") {
-            val ktFile = compileContentForTest("""
+            val ktFile = compileContentForTest(
+                """
             @file:Suppress("detekt:ALL")
             object SuppressedWithDetektPrefix {
 
@@ -156,14 +159,16 @@ internal class SuppressionSpec : Spek({
                     println("FAILED TEST")
                 }
             }
-            """)
+            """
+            )
             val rule = TestRule()
             rule.visitFile(ktFile)
             assertThat(rule.expected).isNotNull()
         }
 
         it("rule should be suppressed by detekt prefix in all caps with colon separator") {
-            val ktFile = compileContentForTest("""
+            val ktFile = compileContentForTest(
+                """
             @file:Suppress("DETEKT:ALL")
             object SuppressedWithDetektPrefix {
 
@@ -171,7 +176,8 @@ internal class SuppressionSpec : Spek({
                     println("FAILED TEST")
                 }
             }
-            """)
+            """
+            )
             val rule = TestRule()
             rule.visitFile(ktFile)
             assertThat(rule.expected).isNotNull()
@@ -181,7 +187,8 @@ internal class SuppressionSpec : Spek({
     describe("suppression based on aliases from config property") {
 
         it("allows to declare") {
-            val ktFile = compileContentForTest("""
+            val ktFile = compileContentForTest(
+                """
             @file:Suppress("detekt:MyTest")
             object SuppressedWithDetektPrefixAndCustomConfigBasedPrefix {
 
@@ -189,7 +196,8 @@ internal class SuppressionSpec : Spek({
                     println("FAILED TEST")
                 }
             }
-            """)
+            """
+            )
             val rule = TestRule(TestConfig(mutableMapOf("aliases" to "[MyTest]")))
             rule.visitFile(ktFile)
             assertThat(rule.expected).isNotNull()

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/CheckConfigurationSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/CheckConfigurationSpec.kt
@@ -21,7 +21,8 @@ class SupportConfigValidationSpec : Spek({
         val testDir by memoized { createTempDirectoryForTest("detekt-sample") }
 
         it("fails when unknown properties are found") {
-            val config = yamlConfigFromContent("""
+            val config = yamlConfigFromContent(
+                """
                 # Properties of custom rule sets get excluded by default.
                 sample-rule-set:
                   TooManyFunctions:
@@ -31,7 +32,8 @@ class SupportConfigValidationSpec : Spek({
                 my_additional_properties:
                   magic_number: 7
                   magic_string: 'Hello World'
-            """)
+            """
+            )
             createProcessingSettings(testDir, config).use {
                 assertThatCode { checkConfiguration(it) }
                     .isInstanceOf(InvalidConfig::class.java)
@@ -41,13 +43,15 @@ class SupportConfigValidationSpec : Spek({
         }
 
         it("fails due to custom config validator want active to be booleans") {
-            val config = yamlConfigFromContent("""
+            val config = yamlConfigFromContent(
+                """
                 # Properties of custom rule sets get excluded by default.
                 sample-rule-set:
                   TooManyFunctions:
                     # This property is tested via the SampleConfigValidator
                     active: 1 # should be true
-            """)
+            """
+            )
             createProcessingSettings(testDir, config).use {
                 assertThatCode { checkConfiguration(it) }
                     .isInstanceOf(InvalidConfig::class.java)
@@ -56,7 +60,8 @@ class SupportConfigValidationSpec : Spek({
         }
 
         it("passes with excluded new properties") {
-            val config = yamlConfigFromContent("""
+            val config = yamlConfigFromContent(
+                """
                config:
                  validation: true
                  # Additional properties can be useful when writing custom extensions.
@@ -74,7 +79,8 @@ class SupportConfigValidationSpec : Spek({
                my_additional_properties:
                  magic_number: 7
                  magic_string: 'Hello World'
-            """)
+            """
+            )
             createProcessingSettings(testDir, config).use {
                 assertThatCode { checkConfiguration(it) }.doesNotThrowAnyException()
             }

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/CompositeConfigTest.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/CompositeConfigTest.kt
@@ -13,10 +13,12 @@ class CompositeConfigTest : Spek({
         val first by memoized { yamlConfig("detekt.yml") }
         val compositeConfig by memoized { CompositeConfig(second, first) }
 
-        it("""
+        it(
+            """
             should have style sub config with active false which is overridden
             in `second` config regardless of default value
-        """) {
+        """
+        ) {
             val styleConfig = compositeConfig.subConfig("style").subConfig("WildcardImport")
             assertThat(styleConfig.valueOrDefault("active", true)).isEqualTo(false)
             assertThat(styleConfig.valueOrDefault("active", false)).isEqualTo(false)

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/ConfigValidationSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/ConfigValidationSpec.kt
@@ -186,13 +186,15 @@ internal class ConfigValidationSpec : Spek({
             ).forEach { (testName, warningsAsErrors) ->
 
                 it(testName) {
-                    val config = yamlConfigFromContent("""
+                    val config = yamlConfigFromContent(
+                        """
                     config:
                       warningsAsErrors: $warningsAsErrors
                     naming:
                       FunctionParameterNaming:
                         ignoreOverriddenFunctions: ''
-                """.trimIndent())
+                        """.trimIndent()
+                    )
 
                     val result = validateConfig(config, config)
 

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/MaxIssueCheckTest.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/MaxIssueCheckTest.kt
@@ -60,10 +60,12 @@ internal class MaxIssueCheckTest : Spek({
     describe("based on config") {
 
         val config by memoized {
-            yamlConfigFromContent("""
+            yamlConfigFromContent(
+                """
                 build:
                     maxIssues: 1
-            """.trimIndent())
+                """.trimIndent()
+            )
         }
 
         it("uses the config for max issues when MaxIssuePolicy == NonSpecified") {

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/YamlConfigSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/YamlConfigSpec.kt
@@ -114,10 +114,12 @@ class YamlConfigSpec : Spek({
 
         it("throws InvalidConfigurationError on invalid structured yaml files") {
             assertThatCode {
-                yamlConfigFromContent("""
+                yamlConfigFromContent(
+                    """
                     map:
                           {}map
-                """.trimIndent())
+                    """.trimIndent()
+                )
             }.isInstanceOf(Config.InvalidConfigurationError::class.java)
                 .hasMessageContaining("Provided configuration file is invalid")
                 .hasCauseInstanceOf(ParserException::class.java)

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/OutputReportsSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/OutputReportsSpec.kt
@@ -74,13 +74,21 @@ internal class OutputReportsSpec : Spek({
                 }
 
                 it("should recognize custom output format") {
-                    assertThat(reports).haveExactly(1,
-                        Condition(Predicate { it.type == reportUnderTest },
-                            "Corresponds exactly to the test output report."))
+                    assertThat(reports).haveExactly(
+                        1,
+                        Condition(
+                            Predicate { it.type == reportUnderTest },
+                            "Corresponds exactly to the test output report."
+                        )
+                    )
 
-                    assertThat(extensions).haveExactly(1,
-                        Condition(Predicate { it is TestOutputReport && it.ending == "yml" },
-                            "Is exactly the test output report."))
+                    assertThat(extensions).haveExactly(
+                        1,
+                        Condition(
+                            Predicate { it is TestOutputReport && it.ending == "yml" },
+                            "Is exactly the test output report."
+                        )
+                    )
                 }
             }
         }

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/FindingsReportSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/FindingsReportSpec.kt
@@ -52,7 +52,8 @@ class FindingsReportSpec : Spek({
         it("reports no findings with rule set containing no smells") {
             val detektion = object : TestDetektion() {
                 override val findings: Map<String, List<Finding>> = mapOf(
-                    Pair("Ruleset", emptyList()))
+                    Pair("Ruleset", emptyList())
+                )
             }
             assertThat(subject.render(detektion)).isNull()
         }

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/ProjectStatisticsReportSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/ProjectStatisticsReportSpec.kt
@@ -16,7 +16,8 @@ class ProjectStatisticsReportSpec : Spek({
             val expected = "Project Statistics:\n\t- M2: 2\n\t- M1: 1\n"
             val detektion = object : TestDetektion() {
                 override val metrics: Collection<ProjectMetric> = listOf(
-                    ProjectMetric("M1", 1, priority = 1), ProjectMetric("M2", 2, priority = 2)
+                    ProjectMetric("M1", 1, priority = 1),
+                    ProjectMetric("M2", 2, priority = 2)
                 )
             }
             assertThat(subject.render(detektion)).isEqualTo(expected)

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/ProjectStatisticsReportSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/ProjectStatisticsReportSpec.kt
@@ -16,7 +16,8 @@ class ProjectStatisticsReportSpec : Spek({
             val expected = "Project Statistics:\n\t- M2: 2\n\t- M1: 1\n"
             val detektion = object : TestDetektion() {
                 override val metrics: Collection<ProjectMetric> = listOf(
-                    ProjectMetric("M1", 1, priority = 1), ProjectMetric("M2", 2, priority = 2))
+                    ProjectMetric("M1", 1, priority = 1), ProjectMetric("M2", 2, priority = 2)
+                )
             }
             assertThat(subject.render(detektion)).isEqualTo(expected)
         }

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/rules/SingleRuleProviderSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/rules/SingleRuleProviderSpec.kt
@@ -40,11 +40,13 @@ internal class SingleRuleProviderSpec : Spek({
 
             arrayOf("true", "false").forEach { value ->
                 it("configures rule with active=$value") {
-                    val config = yamlConfigFromContent("""
+                    val config = yamlConfigFromContent(
+                        """
                     style:
                       MagicNumber:
                         active: $value
-                """.trimIndent())
+                        """.trimIndent()
+                    )
 
                     assertThat(produceRule(provider, config).active).isEqualTo(value.toBoolean())
                 }

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingProvider.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingProvider.kt
@@ -23,5 +23,5 @@ class FormattingProvider : RuleSetProvider {
     override val ruleSetId: String = "formatting"
 
     override fun instance(config: Config) =
-            RuleSet(ruleSetId, listOf(KtLintMultiRule(config)))
+        RuleSet(ruleSetId, listOf(KtLintMultiRule(config)))
 }

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingProvider.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingProvider.kt
@@ -22,6 +22,5 @@ class FormattingProvider : RuleSetProvider {
 
     override val ruleSetId: String = "formatting"
 
-    override fun instance(config: Config) =
-        RuleSet(ruleSetId, listOf(KtLintMultiRule(config)))
+    override fun instance(config: Config) = RuleSet(ruleSetId, listOf(KtLintMultiRule(config)))
 }

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/FinalNewlineSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/FinalNewlineSpec.kt
@@ -20,20 +20,24 @@ class FinalNewlineSpec : Spek({
         }
 
         it("should not report as new line is present") {
-            val findings = FinalNewline(Config.empty).lint("""
+            val findings = FinalNewline(Config.empty).lint(
+                """
                     fun main() = Unit
 
-            """)
+            """
+            )
 
             assertThat(findings).isEmpty()
         }
 
         it("should report new line when configured") {
             val findings = FinalNewline(TestConfig(INSERT_FINAL_NEWLINE to "false"))
-                .lint("""
+                .lint(
+                    """
                 fun main() = Unit
 
-            """)
+            """
+                )
 
             assertThat(findings).hasSize(1)
         }

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingRuleSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingRuleSpec.kt
@@ -15,21 +15,25 @@ class FormattingRuleSpec : Spek({
     describe("formatting rules can be suppressed") {
 
         it("does support suppression only on file level") {
-            val findings = subject.lint("""
+            val findings = subject.lint(
+                """
                 @file:Suppress("NoLineBreakBeforeAssignment")
                 fun main() 
                 = Unit
-            """.trimIndent())
+                """.trimIndent()
+            )
 
             assertThat(findings).isEmpty()
         }
 
         it("does not support suppression on node level") {
-            val findings = subject.lint("""
+            val findings = subject.lint(
+                """
                 @Suppress("NoLineBreakBeforeAssignment")
                 fun main() 
                 = Unit
-            """.trimIndent())
+                """.trimIndent()
+            )
 
             assertThat(findings).hasSize(1)
         }
@@ -38,20 +42,24 @@ class FormattingRuleSpec : Spek({
     describe("formatting rules have a signature") {
 
         it("has no package name") {
-            val findings = subject.lint("""
+            val findings = subject.lint(
+                """
                 fun main() 
                 = Unit
-            """.trimIndent())
+                """.trimIndent()
+            )
 
             assertThat(findings.first().signature).isEqualTo("Test.kt:2")
         }
 
         it("has a package name") {
-            val findings = subject.lint("""
+            val findings = subject.lint(
+                """
                 package test.test.test
                 fun main() 
                 = Unit
-            """.trimIndent())
+                """.trimIndent()
+            )
 
             assertThat(findings.first().signature).isEqualTo("test.test.test.Test.kt:3")
         }

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/ImportOrderingSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/ImportOrderingSpec.kt
@@ -19,7 +19,8 @@ class ImportOrderingSpec : Spek({
     describe("different import ordering layouts") {
 
         it("defaults to the idea layout") {
-            val findings = ImportOrdering(Config.empty).lint("""
+            val findings = ImportOrdering(Config.empty).lint(
+                """
                 import android.app.Activity
                 import android.view.View
                 import android.view.ViewGroup
@@ -31,7 +32,8 @@ class ImportOrderingSpec : Spek({
                 import kotlin.io.Closeable
                 import android.content.Context as Ctx
                 import androidx.fragment.app.Fragment as F
-            """.trimIndent())
+                """.trimIndent()
+            )
 
             assertThat(findings).isEmpty()
         }
@@ -77,7 +79,8 @@ class ImportOrderingSpec : Spek({
         describe("supports custom patterns") {
 
             it("misses a empty line between aliases and other imports") {
-                val findings = ImportOrdering(TestConfig("layout" to "*,|,^*")).lint("""
+                val findings = ImportOrdering(TestConfig("layout" to "*,|,^*")).lint(
+                    """
                     import android.app.Activity
                     import android.view.View
                     import android.view.ViewGroup
@@ -85,12 +88,14 @@ class ImportOrderingSpec : Spek({
                     import kotlin.concurrent.Thread
                     import android.content.Context as Ctx
                     import androidx.fragment.app.Fragment as F
-                """.trimIndent())
+                    """.trimIndent()
+                )
 
                 assertThat(findings).hasSize(1)
             }
             it("passes for empty line between aliases and other imports") {
-                val findings = ImportOrdering(TestConfig("layout" to "*,|,^*")).lint("""
+                val findings = ImportOrdering(TestConfig("layout" to "*,|,^*")).lint(
+                    """
                     import android.app.Activity
                     import android.view.View
                     import android.view.ViewGroup
@@ -99,7 +104,8 @@ class ImportOrderingSpec : Spek({
 
                     import android.content.Context as Ctx
                     import androidx.fragment.app.Fragment as F
-                """.trimIndent())
+                    """.trimIndent()
+                )
 
                 assertThat(findings).isEmpty()
             }

--- a/detekt-generator/build.gradle.kts
+++ b/detekt-generator/build.gradle.kts
@@ -71,7 +71,9 @@ val verifyGeneratorOutput by tasks.registering(Exec::class) {
     standardOutput = configDiff
 
     if (configDiff.toString().isNotEmpty()) {
-        throw GradleException("The default-detekt-config.yml is not up-to-date. " +
-            "You can execute the generateDocumentation Gradle task to update it and commit the changed files.")
+        throw GradleException(
+            "The default-detekt-config.yml is not up-to-date. " +
+                "You can execute the generateDocumentation Gradle task to update it and commit the changed files."
+        )
     }
 }

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/GeneratorArgs.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/GeneratorArgs.kt
@@ -37,7 +37,8 @@ class GeneratorArgs {
 
     @Parameter(
         names = ["--help", "-h"],
-        help = true, description = "Shows the usage."
+        help = true,
+        description = "Shows the usage."
     )
     var help: Boolean = false
 

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/GeneratorArgs.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/GeneratorArgs.kt
@@ -7,28 +7,38 @@ import java.nio.file.Paths
 
 class GeneratorArgs {
 
-    @Parameter(names = ["--input", "-i"],
+    @Parameter(
+        names = ["--input", "-i"],
         required = true,
-        description = "Input paths to analyze.")
+        description = "Input paths to analyze."
+    )
     private var input: String? = null
 
-    @Parameter(names = ["--documentation", "-d"],
+    @Parameter(
+        names = ["--documentation", "-d"],
         required = true,
-        description = "Output path for generated documentation.")
+        description = "Output path for generated documentation."
+    )
     private var documentation: String? = null
 
-    @Parameter(names = ["--config", "-c"],
+    @Parameter(
+        names = ["--config", "-c"],
         required = true,
-        description = "Output path for generated detekt config.")
+        description = "Output path for generated detekt config."
+    )
     private var config: String? = null
 
-    @Parameter(names = ["--cli-options"],
+    @Parameter(
+        names = ["--cli-options"],
         required = true,
-        description = "Output path for generated cli options page.")
+        description = "Output path for generated cli options page."
+    )
     private var cliOptions: String? = null
 
-    @Parameter(names = ["--help", "-h"],
-        help = true, description = "Shows the usage.")
+    @Parameter(
+        names = ["--help", "-h"],
+        help = true, description = "Shows the usage."
+    )
     var help: Boolean = false
 
     val inputPath: List<Path> by lazy {
@@ -41,15 +51,19 @@ class GeneratorArgs {
             .toList()
     }
     val documentationPath: Path
-        get() = Paths.get(checkNotNull(documentation) {
-            "Documentation output path was not initialized by jcommander!"
-        })
+        get() = Paths.get(
+            checkNotNull(documentation) {
+                "Documentation output path was not initialized by jcommander!"
+            }
+        )
 
     val configPath: Path
         get() = Paths.get(checkNotNull(config) { "Configuration output path was not initialized by jcommander!" })
 
     val cliOptionsPath: Path
-        get() = Paths.get(checkNotNull(cliOptions) {
-            "Cli options output path was not initialized by jcommander!"
-        })
+        get() = Paths.get(
+            checkNotNull(cliOptions) {
+                "Cli options output path was not initialized by jcommander!"
+            }
+        )
 }

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/DetektCollector.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/DetektCollector.kt
@@ -49,11 +49,11 @@ class DetektCollector : Collector<RuleSetPage> {
 
     private fun List<Rule>.resolveParentRule(rules: List<Rule>) {
         this.filter { it.debt.isEmpty() && it.severity.isEmpty() }
-                .forEach {
-                    val parentRule = rules.findRuleByName(it.parent)
-                    it.debt = parentRule.debt
-                    it.severity = parentRule.severity
-                }
+            .forEach {
+                val parentRule = rules.findRuleByName(it.parent)
+                it.debt = parentRule.debt
+                it.severity = parentRule.severity
+            }
     }
 
     override fun visit(file: KtFile) {

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/MultiRuleCollector.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/MultiRuleCollector.kt
@@ -48,7 +48,7 @@ class MultiRuleVisitor : DetektVisitor() {
         val rules = mutableListOf<String>()
 
         val ruleProperties = rulesVisitor.ruleProperties
-                .mapNotNull { properties[it] }
+            .mapNotNull { properties[it] }
         rules.addAll(ruleProperties)
         rules.addAll(rulesVisitor.ruleNames)
 
@@ -63,8 +63,8 @@ class MultiRuleVisitor : DetektVisitor() {
 
     override fun visitSuperTypeList(list: KtSuperTypeList) {
         val isMultiRule = list.entries
-                ?.mapNotNull { it.typeAsUserType?.referencedName }
-                ?.any { it == multiRule } ?: false
+            ?.mapNotNull { it.typeAsUserType?.referencedName }
+            ?.any { it == multiRule } ?: false
 
         val containingClass = list.containingClass()
         val className = containingClass?.name
@@ -112,13 +112,17 @@ class RuleListVisitor : DetektVisitor() {
         val argumentExpressions = list.arguments.map { it.getArgumentExpression() }
 
         // Call Expression = Constructor of rule
-        ruleNames.addAll(argumentExpressions
+        ruleNames.addAll(
+            argumentExpressions
                 .filterIsInstance<KtCallExpression>()
-                .map { it.calleeExpression?.text ?: "" })
+                .map { it.calleeExpression?.text ?: "" }
+        )
 
         // Reference Expression = variable we need to search for
-        ruleProperties.addAll(argumentExpressions
+        ruleProperties.addAll(
+            argumentExpressions
                 .filterIsInstance<KtReferenceExpression>()
-                .map { it.text ?: "" })
+                .map { it.text ?: "" }
+        )
     }
 }

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleSetProviderCollector.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleSetProviderCollector.kt
@@ -80,8 +80,10 @@ class RuleSetProviderVisitor : DetektVisitor() {
         super.visitProperty(property)
         if (property.isOverride() && property.name != null && property.name == PROPERTY_RULE_SET_ID) {
             name = (property.initializer as? KtStringTemplateExpression)?.entries?.get(0)?.text
-                ?: throw InvalidDocumentationException("RuleSetProvider class " +
-                        "${property.containingClass()?.name ?: ""} doesn't provide list of rules.")
+                ?: throw InvalidDocumentationException(
+                    "RuleSetProvider class " +
+                        "${property.containingClass()?.name ?: ""} doesn't provide list of rules."
+                )
         }
     }
 
@@ -90,14 +92,14 @@ class RuleSetProviderVisitor : DetektVisitor() {
 
         if (expression.calleeExpression?.text == "RuleSet") {
             val ruleListExpression = expression.valueArguments
-                    .map { it.getArgumentExpression() }
-                    .firstOrNull { it?.referenceExpression()?.text == "listOf" }
+                .map { it.getArgumentExpression() }
+                .firstOrNull { it?.referenceExpression()?.text == "listOf" }
                 ?: throw InvalidDocumentationException("RuleSetProvider $name doesn't provide list of rules.")
 
             val ruleArgumentNames = (ruleListExpression as? KtCallExpression)
-                    ?.valueArguments
-                    ?.map { it.getArgumentExpression() }
-                    ?.mapNotNull { it?.referenceExpression()?.text }
+                ?.valueArguments
+                ?.map { it.getArgumentExpression() }
+                ?.mapNotNull { it?.referenceExpression()?.text }
                 ?: emptyList()
 
             ruleNames.addAll(ruleArgumentNames)

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/exception/InvalidAliasesDeclaration.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/exception/InvalidAliasesDeclaration.kt
@@ -1,5 +1,5 @@
 package io.gitlab.arturbosch.detekt.generator.collection.exception
 
 class InvalidAliasesDeclaration : RuntimeException(
-        "Invalid aliases declaration. Example: override val defaultRuleIdAliases = setOf(\"Name1\", \"Name2\")"
+    "Invalid aliases declaration. Example: override val defaultRuleIdAliases = setOf(\"Name1\", \"Name2\")"
 )

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/CliOptionsPrinter.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/CliOptionsPrinter.kt
@@ -12,7 +12,8 @@ class CliOptionsPrinter {
     }
 
     fun print(filePath: Path) {
-        Files.write(filePath,
+        Files.write(
+            filePath,
             buildString {
                 appendLine("```")
                 jCommander.usageFormatter.usage(this)

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/rulesetpage/ConfigPrinter.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/rulesetpage/ConfigPrinter.kt
@@ -40,12 +40,12 @@ object ConfigPrinter : DocumentationPrinter<List<RuleSetPage>> {
             }
             ruleSet.configuration
                 .forEach { configuration ->
-                if (configuration.defaultValue.isYamlList()) {
-                    list(configuration.name, configuration.defaultValue.toList())
-                } else {
-                    keyValue { configuration.name to configuration.defaultValue }
+                    if (configuration.defaultValue.isYamlList()) {
+                        list(configuration.name, configuration.defaultValue.toList())
+                    } else {
+                        keyValue { configuration.name to configuration.defaultValue }
+                    }
                 }
-            }
             rules.forEach { rule ->
                 node(rule.name) {
                     keyValue { Config.ACTIVE_KEY to "${rule.active}" }
@@ -58,12 +58,12 @@ object ConfigPrinter : DocumentationPrinter<List<RuleSetPage>> {
                     }
                     rule.configuration
                         .forEach { configuration ->
-                        if (configuration.defaultValue.isYamlList()) {
-                            list(configuration.name, configuration.defaultValue.toList())
-                        } else if (configuration.deprecated == null) {
-                            keyValue { configuration.name to configuration.defaultValue }
+                            if (configuration.defaultValue.isYamlList()) {
+                                list(configuration.name, configuration.defaultValue.toList())
+                            } else if (configuration.deprecated == null) {
+                                keyValue { configuration.name to configuration.defaultValue }
+                            }
                         }
-                    }
                 }
             }
             emptyLine()

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/rulesetpage/Exclusion.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/rulesetpage/Exclusion.kt
@@ -23,7 +23,7 @@ abstract class Exclusions {
 private object TestExclusions : Exclusions() {
 
     override val pattern =
-            "['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']"
+        "['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']"
     override val ruleSets = setOf("comments")
     override val rules = setOf(
         "NamingRules",

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/rulesetpage/RuleSetPagePrinter.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/rulesetpage/RuleSetPagePrinter.kt
@@ -42,7 +42,7 @@ object RuleSetPagePrinter : DocumentationPrinter<RuleSetPage> {
 
             paragraph {
                 "${bold { "Active by default" }}: ${if (rule.active) "Yes" else "No"}" +
-                        (rule.activeSince?.let { " - Since $it" } ?: "")
+                    (rule.activeSince?.let { " - Since $it" } ?: "")
             }
 
             if (rule.requiresTypeResolution) {
@@ -75,7 +75,8 @@ object RuleSetPagePrinter : DocumentationPrinter<RuleSetPage> {
                         } else {
                             val defaultValues = it.defaultValue.lines()
                             val defaultValuesString = defaultValues.joinToString {
-                                value -> value.trim().removePrefix("- ")
+                                value ->
+                                value.trim().removePrefix("- ")
                             }
                             item { "${code { it.name }} (default: ${code { defaultValuesString }})" }
                         }

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleSetProviderCollectorSpec.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleSetProviderCollectorSpec.kt
@@ -56,7 +56,7 @@ class RuleSetProviderCollectorSpec : Spek({
         """
             it("throws an exception") {
                 assertThatExceptionOfType(InvalidDocumentationException::class.java)
-                        .isThrownBy { subject.run(code) }
+                    .isThrownBy { subject.run(code) }
             }
         }
 
@@ -73,7 +73,7 @@ class RuleSetProviderCollectorSpec : Spek({
 
             it("throws an exception") {
                 assertThatExceptionOfType(InvalidDocumentationException::class.java)
-                        .isThrownBy { subject.run(code) }
+                    .isThrownBy { subject.run(code) }
             }
         }
 
@@ -179,7 +179,7 @@ class RuleSetProviderCollectorSpec : Spek({
 
             it("throws an exception") {
                 assertThatExceptionOfType(InvalidDocumentationException::class.java)
-                        .isThrownBy { subject.run(code) }
+                    .isThrownBy { subject.run(code) }
             }
         }
 
@@ -202,7 +202,7 @@ class RuleSetProviderCollectorSpec : Spek({
 
             it("throws an exception") {
                 assertThatExceptionOfType(InvalidDocumentationException::class.java)
-                        .isThrownBy { subject.run(code) }
+                    .isThrownBy { subject.run(code) }
             }
         }
 
@@ -222,7 +222,7 @@ class RuleSetProviderCollectorSpec : Spek({
 
             it("throws an exception") {
                 assertThatExceptionOfType(InvalidDocumentationException::class.java)
-                        .isThrownBy { subject.run(code) }
+                    .isThrownBy { subject.run(code) }
             }
         }
 

--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -32,10 +32,12 @@ dependencies {
 
     constraints {
         implementation("org.jetbrains.kotlin:kotlin-reflect:1.4.0") {
-            because("""Android Gradle Plugin 4.1.1 depends on Kotlin 1.3.72 but we should not mix 1.3 and 1.4.
+            because(
+                """Android Gradle Plugin 4.1.1 depends on Kotlin 1.3.72 but we should not mix 1.3 and 1.4.
                 This constraint should be lifted on Android Gradle Plugin 4.2.0. See
                 https://dl.google.com/android/maven2/com/android/tools/build/gradle/4.2.0-beta02/gradle-4.2.0-beta02.pom
-            """)
+            """
+            )
         }
     }
 }
@@ -76,13 +78,17 @@ pluginBundle {
 }
 
 tasks.processResources {
-    filter<org.apache.tools.ant.filters.ReplaceTokens>("tokens" to mapOf(
-        "detektVersion" to project.version as String
-    ))
+    filter<org.apache.tools.ant.filters.ReplaceTokens>(
+        "tokens" to mapOf(
+            "detektVersion" to project.version as String
+        )
+    )
 }
 
 tasks.processTestResources {
-    filter<org.apache.tools.ant.filters.ReplaceTokens>("tokens" to mapOf(
-        "detektVersion" to project.version as String
-    ))
+    filter<org.apache.tools.ant.filters.ReplaceTokens>(
+        "tokens" to mapOf(
+            "detektVersion" to project.version as String
+        )
+    )
 }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -214,8 +214,7 @@ open class Detekt @Inject constructor(
     fun check() {
         if (failFastProp.getOrElse(false)) {
             project.logger.warn(
-                "'failFast' is deprecated. Please use " +
-                    "'buildUponDefaultConfig' together with 'allRules'."
+                "'failFast' is deprecated. Please use 'buildUponDefaultConfig' together with 'allRules'."
             )
         }
 

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -122,6 +122,7 @@ open class Detekt @Inject constructor(
 
     @get:Internal
     internal val failFastProp: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
+
     @Deprecated("Please use the buildUponDefaultConfig and allRules flags instead.", ReplaceWith("allRules"))
     var failFast: Boolean
         @Input
@@ -212,8 +213,10 @@ open class Detekt @Inject constructor(
     @TaskAction
     fun check() {
         if (failFastProp.getOrElse(false)) {
-            project.logger.warn("'failFast' is deprecated. Please use " +
-                    "'buildUponDefaultConfig' together with 'allRules'.")
+            project.logger.warn(
+                "'failFast' is deprecated. Please use " +
+                    "'buildUponDefaultConfig' together with 'allRules'."
+            )
         }
 
         val arguments = mutableListOf(

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
@@ -114,8 +114,7 @@ open class DetektCreateBaselineTask : SourceTask() {
     fun baseline() {
         if (failFast.getOrElse(false)) {
             project.logger.warn(
-                "'failFast' is deprecated. Please use " +
-                    "'buildUponDefaultConfig' together with 'allRules'."
+                "'failFast' is deprecated. Please use 'buildUponDefaultConfig' together with 'allRules'."
             )
         }
 

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
@@ -113,8 +113,10 @@ open class DetektCreateBaselineTask : SourceTask() {
     @TaskAction
     fun baseline() {
         if (failFast.getOrElse(false)) {
-            project.logger.warn("'failFast' is deprecated. Please use " +
-                    "'buildUponDefaultConfig' together with 'allRules'.")
+            project.logger.warn(
+                "'failFast' is deprecated. Please use " +
+                    "'buildUponDefaultConfig' together with 'allRules'."
+            )
         }
 
         val arguments = mutableListOf(

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
@@ -12,6 +12,7 @@ open class DetektExtension @Inject constructor(objects: ObjectFactory) : CodeQua
     var ignoreFailures: Boolean
         @JvmName("ignoreFailures_")
         get() = isIgnoreFailures
+
         @JvmName("ignoreFailures_")
         set(value) {
             isIgnoreFailures = value

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektAndroid.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektAndroid.kt
@@ -24,7 +24,7 @@ internal class DetektAndroid(private val project: Project) {
         project.tasks.register("${DetektPlugin.DETEKT_TASK_NAME}Main") {
             it.group = "verification"
             it.description = "EXPERIMENTAL: Run detekt analysis for production classes across " +
-                    "all variants with type resolution"
+                "all variants with type resolution"
         }
     }
 
@@ -32,7 +32,7 @@ internal class DetektAndroid(private val project: Project) {
         project.tasks.register("${DetektPlugin.DETEKT_TASK_NAME}Test") {
             it.group = "verification"
             it.description = "EXPERIMENTAL: Run detekt analysis for test classes across " +
-                    "all variants with type resolution"
+                "all variants with type resolution"
         }
     }
 
@@ -40,7 +40,7 @@ internal class DetektAndroid(private val project: Project) {
         project.tasks.register("${DetektPlugin.BASELINE_TASK_NAME}Main") {
             it.group = "verification"
             it.description = "EXPERIMENTAL: Creates detekt baseline files for production classes across " +
-                    "all variants with type resolution"
+                "all variants with type resolution"
         }
     }
 
@@ -48,7 +48,7 @@ internal class DetektAndroid(private val project: Project) {
         project.tasks.register("${DetektPlugin.BASELINE_TASK_NAME}Test") {
             it.group = "verification"
             it.description = "EXPERIMENTAL: Creates detekt baseline files for test classes across " +
-                    "all variants with type resolution"
+                "all variants with type resolution"
         }
     }
 
@@ -100,8 +100,8 @@ internal class DetektAndroid(private val project: Project) {
 
     private fun DetektExtension.matchesIgnoredConfiguration(variant: BaseVariant): Boolean =
         ignoredVariants.contains(variant.name) ||
-                ignoredBuildTypes.contains(variant.buildType.name) ||
-                ignoredFlavors.contains(variant.flavorName)
+            ignoredBuildTypes.contains(variant.buildType.name) ||
+            ignoredFlavors.contains(variant.flavorName)
 
     private fun Project.registerAndroidDetektTask(
         bootClasspath: FileCollection,

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/CliArgument.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/CliArgument.kt
@@ -40,10 +40,14 @@ internal data class InputArgument(val fileCollection: FileCollection) : CliArgum
 }
 
 internal data class ClasspathArgument(val fileCollection: FileCollection) : CliArgument() {
-    override fun toArgument() = if (!fileCollection.isEmpty) listOf(
-        CLASSPATH_PARAMETER,
-        fileCollection.joinToString(File.pathSeparator) { it.absolutePath }
-    ) else emptyList()
+    override fun toArgument() = if (!fileCollection.isEmpty) {
+        listOf(
+            CLASSPATH_PARAMETER,
+            fileCollection.joinToString(File.pathSeparator) { it.absolutePath }
+        )
+    } else {
+        emptyList()
+    }
 }
 
 internal data class LanguageVersionArgument(val languageVersion: String?) : CliArgument() {
@@ -90,11 +94,14 @@ internal sealed class BoolCliArgument(open val value: Boolean, val configSwitch:
 internal data class DebugArgument(override val value: Boolean) : BoolCliArgument(value, DEBUG_PARAMETER)
 
 internal data class ParallelArgument(override val value: Boolean) : BoolCliArgument(value, PARALLEL_PARAMETER)
-internal data class DisableDefaultRuleSetArgument(override val value: Boolean) :
-    BoolCliArgument(value, DISABLE_DEFAULT_RULESETS_PARAMETER)
 
-internal data class BuildUponDefaultConfigArgument(override val value: Boolean) :
-    BoolCliArgument(value, BUILD_UPON_DEFAULT_CONFIG_PARAMETER)
+internal data class DisableDefaultRuleSetArgument(
+    override val value: Boolean
+) : BoolCliArgument(value, DISABLE_DEFAULT_RULESETS_PARAMETER)
+
+internal data class BuildUponDefaultConfigArgument(
+    override val value: Boolean
+) : BoolCliArgument(value, BUILD_UPON_DEFAULT_CONFIG_PARAMETER)
 
 internal data class FailFastArgument(override val value: Boolean) : BoolCliArgument(value, FAIL_FAST_PARAMETER)
 

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/CliArgument.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/CliArgument.kt
@@ -42,7 +42,8 @@ internal data class InputArgument(val fileCollection: FileCollection) : CliArgum
 internal data class ClasspathArgument(val fileCollection: FileCollection) : CliArgument() {
     override fun toArgument() = if (!fileCollection.isEmpty) listOf(
         CLASSPATH_PARAMETER,
-        fileCollection.joinToString(File.pathSeparator) { it.absolutePath }) else emptyList()
+        fileCollection.joinToString(File.pathSeparator) { it.absolutePath }
+    ) else emptyList()
 }
 
 internal data class LanguageVersionArgument(val languageVersion: String?) : CliArgument() {

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/DetektInvoker.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/DetektInvoker.kt
@@ -48,7 +48,8 @@ internal class DefaultCliInvoker(
         try {
             val loader = classLoaderCache.getOrCreate(classpath)
             val clazz = loader.loadClass("io.gitlab.arturbosch.detekt.cli.Main")
-            val runner = clazz.getMethod("buildRunner",
+            val runner = clazz.getMethod(
+                "buildRunner",
                 Array<String>::class.java,
                 PrintStream::class.java,
                 PrintStream::class.java

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/report/SarifReportMerger.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/report/SarifReportMerger.kt
@@ -1,8 +1,8 @@
 package io.gitlab.arturbosch.detekt.report
 
-import io.github.detekt.sarif4j.SarifSchema210
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializationFeature
+import io.github.detekt.sarif4j.SarifSchema210
 import java.io.File
 
 /**

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektAndroidTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektAndroidTest.kt
@@ -33,20 +33,24 @@ object DetektAndroidTest : Spek({
                 assertThat(buildResult.output).contains("--report xml:")
                 assertThat(buildResult.output).contains("--report sarif:")
                 assertThat(buildResult.output).doesNotContain("--report txt:")
-                assertThat(buildResult.tasks.map { it.path }).containsAll(listOf(
-                    ":app:detektMain",
-                    ":app:detektDebug"
-                ))
+                assertThat(buildResult.tasks.map { it.path }).containsAll(
+                    listOf(
+                        ":app:detektMain",
+                        ":app:detektDebug"
+                    )
+                )
             }
 
             gradleRunner.runTasksAndCheckResult(":app:detektTest") { buildResult ->
                 assertThat(buildResult.output).contains("--report xml:")
                 assertThat(buildResult.output).contains("--report sarif:")
                 assertThat(buildResult.output).doesNotContain("--report txt:")
-                assertThat(buildResult.tasks.map { it.path }).containsAll(listOf(
-                    ":app:detektDebugUnitTest",
-                    ":app:detektDebugAndroidTest"
-                ))
+                assertThat(buildResult.tasks.map { it.path }).containsAll(
+                    listOf(
+                        ":app:detektDebugUnitTest",
+                        ":app:detektDebugAndroidTest"
+                    )
+                )
             }
 
             gradleRunner.runTasksAndCheckResult(":app:check") { buildResult ->
@@ -102,20 +106,24 @@ object DetektAndroidTest : Spek({
                 assertThat(buildResult.output).contains("--report xml:")
                 assertThat(buildResult.output).contains("--report sarif:")
                 assertThat(buildResult.output).doesNotContain("--report txt:")
-                assertThat(buildResult.tasks.map { it.path }).containsAll(listOf(
-                    ":lib:detektMain",
-                    ":lib:detektDebug"
-                ))
+                assertThat(buildResult.tasks.map { it.path }).containsAll(
+                    listOf(
+                        ":lib:detektMain",
+                        ":lib:detektDebug"
+                    )
+                )
             }
 
             gradleRunner.runTasksAndCheckResult(":lib:detektTest") { buildResult ->
                 assertThat(buildResult.output).contains("--report xml:")
                 assertThat(buildResult.output).contains("--report sarif:")
                 assertThat(buildResult.output).doesNotContain("--report txt:")
-                assertThat(buildResult.tasks.map { it.path }).containsAll(listOf(
-                    ":lib:detektDebugUnitTest",
-                    ":lib:detektDebugAndroidTest"
-                ))
+                assertThat(buildResult.tasks.map { it.path }).containsAll(
+                    listOf(
+                        ":lib:detektDebugUnitTest",
+                        ":lib:detektDebugAndroidTest"
+                    )
+                )
             }
 
             gradleRunner.runTasksAndCheckResult(":lib:check") { buildResult ->
@@ -145,21 +153,25 @@ object DetektAndroidTest : Spek({
             gradleRunner.writeProjectFile("lib/src/main/AndroidManifest.xml", MANIFEST_CONTENT)
 
             gradleRunner.runTasksAndCheckResult(":lib:detektMain") { buildResult ->
-                assertThat(buildResult.tasks.map { it.path }).containsAll(listOf(
-                    ":lib:detektYoungHarryDebug",
-                    ":lib:detektOldHarryDebug",
-                    ":lib:detektOldHarryRelease"
-                ))
+                assertThat(buildResult.tasks.map { it.path }).containsAll(
+                    listOf(
+                        ":lib:detektYoungHarryDebug",
+                        ":lib:detektOldHarryDebug",
+                        ":lib:detektOldHarryRelease"
+                    )
+                )
             }
 
             gradleRunner.runTasksAndCheckResult(":lib:detektTest") { buildResult ->
-                assertThat(buildResult.tasks.map { it.path }).containsAll(listOf(
-                    ":lib:detektYoungHarryDebugUnitTest",
-                    ":lib:detektOldHarryDebugUnitTest",
-                    ":lib:detektOldHarryReleaseUnitTest",
-                    ":lib:detektYoungHarryDebugAndroidTest",
-                    ":lib:detektOldHarryDebugAndroidTest"
-                ))
+                assertThat(buildResult.tasks.map { it.path }).containsAll(
+                    listOf(
+                        ":lib:detektYoungHarryDebugUnitTest",
+                        ":lib:detektOldHarryDebugUnitTest",
+                        ":lib:detektOldHarryReleaseUnitTest",
+                        ":lib:detektYoungHarryDebugAndroidTest",
+                        ":lib:detektOldHarryDebugAndroidTest"
+                    )
+                )
             }
         }
 
@@ -184,21 +196,25 @@ object DetektAndroidTest : Spek({
             gradleRunner.writeProjectFile("lib/src/main/AndroidManifest.xml", MANIFEST_CONTENT)
 
             gradleRunner.runTasksAndCheckResult(":lib:detektMain") { buildResult ->
-                assertThat(buildResult.tasks.map { it.path }).containsAll(listOf(
-                    ":lib:detektYoungHarryDebug",
-                    ":lib:detektOldHarryDebug"
-                )).doesNotContain(
+                assertThat(buildResult.tasks.map { it.path }).containsAll(
+                    listOf(
+                        ":lib:detektYoungHarryDebug",
+                        ":lib:detektOldHarryDebug"
+                    )
+                ).doesNotContain(
                     ":lib:detektOldHarryRelease"
                 )
             }
 
             gradleRunner.runTasksAndCheckResult(":lib:detektTest") { buildResult ->
-                assertThat(buildResult.tasks.map { it.path }).containsAll(listOf(
-                    ":lib:detektYoungHarryDebugUnitTest",
-                    ":lib:detektOldHarryDebugUnitTest",
-                    ":lib:detektYoungHarryDebugAndroidTest",
-                    ":lib:detektOldHarryDebugAndroidTest"
-                )).doesNotContain(
+                assertThat(buildResult.tasks.map { it.path }).containsAll(
+                    listOf(
+                        ":lib:detektYoungHarryDebugUnitTest",
+                        ":lib:detektOldHarryDebugUnitTest",
+                        ":lib:detektYoungHarryDebugAndroidTest",
+                        ":lib:detektOldHarryDebugAndroidTest"
+                    )
+                ).doesNotContain(
                     ":lib:detektOldHarryReleaseUnitTest"
                 )
             }
@@ -225,19 +241,23 @@ object DetektAndroidTest : Spek({
             gradleRunner.writeProjectFile("lib/src/main/AndroidManifest.xml", MANIFEST_CONTENT)
 
             gradleRunner.runTasksAndCheckResult(":lib:detektMain") { buildResult ->
-                assertThat(buildResult.tasks.map { it.path }).containsAll(listOf(
-                    ":lib:detektOldHarryDebug"
-                )).doesNotContain(
+                assertThat(buildResult.tasks.map { it.path }).containsAll(
+                    listOf(
+                        ":lib:detektOldHarryDebug"
+                    )
+                ).doesNotContain(
                     ":lib:detektYoungHarryDebug",
                     ":lib:detektOldHarryRelease"
                 )
             }
 
             gradleRunner.runTasksAndCheckResult(":lib:detektTest") { buildResult ->
-                assertThat(buildResult.tasks.map { it.path }).containsAll(listOf(
-                    ":lib:detektOldHarryDebugUnitTest",
-                    ":lib:detektOldHarryDebugAndroidTest"
-                )).doesNotContain(
+                assertThat(buildResult.tasks.map { it.path }).containsAll(
+                    listOf(
+                        ":lib:detektOldHarryDebugUnitTest",
+                        ":lib:detektOldHarryDebugAndroidTest"
+                    )
+                ).doesNotContain(
                     ":lib:detektYoungHarryDebugUnitTest",
                     ":lib:detektYoungHarryDebugAndroidTest",
                     ":lib:detektOldHarryReleaseUnitTest"
@@ -266,20 +286,24 @@ object DetektAndroidTest : Spek({
             gradleRunner.writeProjectFile("lib/src/main/AndroidManifest.xml", MANIFEST_CONTENT)
 
             gradleRunner.runTasksAndCheckResult(":lib:detektMain") { buildResult ->
-                assertThat(buildResult.tasks.map { it.path }).containsAll(listOf(
-                    ":lib:detektOldHarryDebug",
-                    ":lib:detektOldHarryRelease"
-                )).doesNotContain(
+                assertThat(buildResult.tasks.map { it.path }).containsAll(
+                    listOf(
+                        ":lib:detektOldHarryDebug",
+                        ":lib:detektOldHarryRelease"
+                    )
+                ).doesNotContain(
                     ":lib:detektYoungHarryDebug"
                 )
             }
 
             gradleRunner.runTasksAndCheckResult(":lib:detektTest") { buildResult ->
-                assertThat(buildResult.tasks.map { it.path }).containsAll(listOf(
-                    ":lib:detektOldHarryDebugUnitTest",
-                    ":lib:detektOldHarryDebugAndroidTest",
-                    ":lib:detektOldHarryReleaseUnitTest"
-                )).doesNotContain(
+                assertThat(buildResult.tasks.map { it.path }).containsAll(
+                    listOf(
+                        ":lib:detektOldHarryDebugUnitTest",
+                        ":lib:detektOldHarryDebugAndroidTest",
+                        ":lib:detektOldHarryReleaseUnitTest"
+                    )
+                ).doesNotContain(
                     ":lib:detektYoungHarryDebugUnitTest",
                     ":lib:detektYoungHarryDebugAndroidTest"
                 )

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektMultiplatformTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektMultiplatformTest.kt
@@ -13,7 +13,8 @@ class DetektMultiplatformTest : Spek({
     describe("multiplatform projects - Common target") {
 
         val gradleRunner = setupProject {
-            addSubmodule("shared", 1, 1,
+            addSubmodule(
+                "shared", 1, 1,
                 buildFileContent = """
                     $KMM_PLUGIN_BLOCK
                     kotlin {
@@ -45,7 +46,8 @@ class DetektMultiplatformTest : Spek({
     describe("multiplatform projects - detekt plain only if user opts out") {
 
         val gradleRunner = setupProject {
-            addSubmodule("shared", 1, 1,
+            addSubmodule(
+                "shared", 1, 1,
                 buildFileContent = """
                     $KMM_PLUGIN_BLOCK
                     kotlin {
@@ -73,7 +75,8 @@ class DetektMultiplatformTest : Spek({
 
     describe("multiplatform projects - JVM target") {
         val gradleRunner = setupProject {
-            addSubmodule("shared", 1, 1,
+            addSubmodule(
+                "shared", 1, 1,
                 buildFileContent = """
                     $KMM_PLUGIN_BLOCK
                     kotlin {
@@ -119,9 +122,11 @@ class DetektMultiplatformTest : Spek({
 
     describe(
         "multiplatform projects - Android target",
-        skip = if (isAndroidSdkInstalled()) Skip.No else Skip.Yes("No android sdk.")) {
+        skip = if (isAndroidSdkInstalled()) Skip.No else Skip.Yes("No android sdk.")
+    ) {
         val gradleRunner = setupProject {
-            addSubmodule("shared", 1, 1,
+            addSubmodule(
+                "shared", 1, 1,
                 buildFileContent = """
                     plugins {
                         id "kotlin-multiplatform"
@@ -180,7 +185,8 @@ class DetektMultiplatformTest : Spek({
 
     describe("multiplatform projects - JS target") {
         val gradleRunner = setupProject {
-            addSubmodule("shared", 1, 1,
+            addSubmodule(
+                "shared", 1, 1,
                 buildFileContent = """
                     $KMM_PLUGIN_BLOCK
                     kotlin {
@@ -221,7 +227,8 @@ class DetektMultiplatformTest : Spek({
         }
     }
 
-    describe("multiplatform projects - iOS target",
+    describe(
+        "multiplatform projects - iOS target",
         skip = if (isMacOs()) {
             Skip.No
         } else {
@@ -229,7 +236,8 @@ class DetektMultiplatformTest : Spek({
         }
     ) {
         val gradleRunner = setupProject {
-            addSubmodule("shared", 1, 1,
+            addSubmodule(
+                "shared", 1, 1,
                 buildFileContent = """
                     $KMM_PLUGIN_BLOCK
                     kotlin {

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektMultiplatformTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektMultiplatformTest.kt
@@ -14,7 +14,9 @@ class DetektMultiplatformTest : Spek({
 
         val gradleRunner = setupProject {
             addSubmodule(
-                "shared", 1, 1,
+                "shared",
+                1,
+                1,
                 buildFileContent = """
                     $KMM_PLUGIN_BLOCK
                     kotlin {
@@ -47,7 +49,9 @@ class DetektMultiplatformTest : Spek({
 
         val gradleRunner = setupProject {
             addSubmodule(
-                "shared", 1, 1,
+                "shared",
+                1,
+                1,
                 buildFileContent = """
                     $KMM_PLUGIN_BLOCK
                     kotlin {
@@ -76,7 +80,9 @@ class DetektMultiplatformTest : Spek({
     describe("multiplatform projects - JVM target") {
         val gradleRunner = setupProject {
             addSubmodule(
-                "shared", 1, 1,
+                "shared",
+                1,
+                1,
                 buildFileContent = """
                     $KMM_PLUGIN_BLOCK
                     kotlin {
@@ -126,7 +132,9 @@ class DetektMultiplatformTest : Spek({
     ) {
         val gradleRunner = setupProject {
             addSubmodule(
-                "shared", 1, 1,
+                "shared",
+                1,
+                1,
                 buildFileContent = """
                     plugins {
                         id "kotlin-multiplatform"
@@ -186,7 +194,9 @@ class DetektMultiplatformTest : Spek({
     describe("multiplatform projects - JS target") {
         val gradleRunner = setupProject {
             addSubmodule(
-                "shared", 1, 1,
+                "shared",
+                1,
+                1,
                 buildFileContent = """
                     $KMM_PLUGIN_BLOCK
                     kotlin {
@@ -237,7 +247,9 @@ class DetektMultiplatformTest : Spek({
     ) {
         val gradleRunner = setupProject {
             addSubmodule(
-                "shared", 1, 1,
+                "shared",
+                1,
+                1,
                 buildFileContent = """
                     $KMM_PLUGIN_BLOCK
                     kotlin {

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskMultiModuleIntegrationTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskMultiModuleIntegrationTest.kt
@@ -17,10 +17,12 @@ internal class DetektTaskMultiModuleIntegrationTest : Spek({
 
             describe("using ${builder.gradleBuildName}") {
 
-                it("""
+                it(
+                    """
                     |is applied with defaults to all subprojects individually
                     |without sources in root project using the subprojects block
-                """.trimMargin()) {
+                """.trimMargin()
+                ) {
                     val projectLayout = ProjectLayout(0).apply {
                         addSubmodule("child1", 2)
                         addSubmodule("child2", 4)
@@ -57,10 +59,12 @@ internal class DetektTaskMultiModuleIntegrationTest : Spek({
                     }
                 }
 
-                it("""
+                it(
+                    """
                     |is applied with defaults to main project
                     |and subprojects individually using the allprojects block
-                """.trimMargin()) {
+                """.trimMargin()
+                ) {
                     val projectLayout = ProjectLayout(1).apply {
                         addSubmodule("child1", 2)
                         addSubmodule("child2", 4)

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/GenerateConfigTaskTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/GenerateConfigTaskTest.kt
@@ -24,11 +24,13 @@ class GenerateConfigTaskTest : Spek({
                 }
 
                 it("chooses the last config file when configured") {
-                    val gradleRunner = builder.withDetektConfig("""
+                    val gradleRunner = builder.withDetektConfig(
+                        """
                         |detekt {
                         |   config = files("config/detekt/detekt.yml", "config/other/detekt.yml")
                         |}
-                    """).build()
+                    """
+                    ).build()
 
                     gradleRunner.runTasksAndCheckResult("detektGenerateConfig") { result ->
                         assertThat(result.task(":detektGenerateConfig")?.outcome).isEqualTo(TaskOutcome.SUCCESS)

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/report/XmlReportMergerSpec.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/report/XmlReportMergerSpec.kt
@@ -13,24 +13,28 @@ internal class XmlReportMergerSpec : Spek({
 
         it("passes for same files") {
             val file1 = File.createTempFile("detekt1", "xml").apply {
-                writeText("""
+                writeText(
+                    """
                     <?xml version="1.0" encoding="utf-8"?>
                     <checkstyle version="4.3">
                     <file name="Sample1.kt">
                     $TAB<error line="1" column="1" severity="warning" message="TestMessage" source="detekt.id_a" />
                     </file>
                     </checkstyle>
-                """.trimIndent())
+                    """.trimIndent()
+                )
             }
             val file2 = File.createTempFile("detekt2", "xml").apply {
-                writeText("""
+                writeText(
+                    """
                     <?xml version="1.0" encoding="utf-8"?>
                     <checkstyle version="4.3">
                     <file name="Sample2.kt">
                     $TAB<error line="1" column="1" severity="warning" message="TestMessage" source="detekt.id_b" />
                     </file>
                     </checkstyle>
-                """.trimIndent())
+                    """.trimIndent()
+                )
             }
             val output = File.createTempFile("output", "xml")
             XmlReportMerger.merge(setOf(file1, file2), output)

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/testkit/DslGradleRunner.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/testkit/DslGradleRunner.kt
@@ -81,7 +81,8 @@ class DslGradleRunner @Suppress("LongParameterList") constructor(
                     writeKtFile(
                         dir = File(moduleRoot, moduleSourceDir),
                         className = "My$srcDirIdx${submodule.name}${it}Class",
-                        withCodeSmell = withCodeSmell)
+                        withCodeSmell = withCodeSmell
+                    )
                 }
             }
         }

--- a/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/processors/AbstractProcessor.kt
+++ b/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/processors/AbstractProcessor.kt
@@ -18,8 +18,8 @@ abstract class AbstractProcessor : FileProcessListener {
 
     override fun onFinish(files: List<KtFile>, result: Detektion, bindingContext: BindingContext) {
         val count = files
-                .mapNotNull { it.getUserData(key) }
-                .sum()
+            .mapNotNull { it.getUserData(key) }
+            .sum()
         result.addData(key, count)
     }
 }

--- a/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/processors/AbstractProjectMetricProcessor.kt
+++ b/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/processors/AbstractProjectMetricProcessor.kt
@@ -11,8 +11,8 @@ abstract class AbstractProjectMetricProcessor : AbstractProcessor() {
 
     override fun onFinish(files: List<KtFile>, result: Detektion, bindingContext: BindingContext) {
         val count = files
-                .mapNotNull { it.getUserData(key) }
-                .sum()
+            .mapNotNull { it.getUserData(key) }
+            .sum()
         result.add(ProjectMetric(type, count))
     }
 }

--- a/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/processors/PackageCountProcessor.kt
+++ b/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/processors/PackageCountProcessor.kt
@@ -19,9 +19,9 @@ class PackageCountProcessor : FileProcessListener {
 
     override fun onFinish(files: List<KtFile>, result: Detektion, bindingContext: BindingContext) {
         val count = files
-                .mapNotNull { it.getUserData(key) }
-                .distinct()
-                .size
+            .mapNotNull { it.getUserData(key) }
+            .distinct()
+            .size
         result.add(ProjectMetric(key.toString(), count))
     }
 }

--- a/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/processors/ProjectLLOCProcessor.kt
+++ b/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/processors/ProjectLLOCProcessor.kt
@@ -1,7 +1,7 @@
 package io.github.detekt.metrics.processors
 
-import io.gitlab.arturbosch.detekt.api.DetektVisitor
 import io.github.detekt.metrics.processors.util.LLOC
+import io.gitlab.arturbosch.detekt.api.DetektVisitor
 import org.jetbrains.kotlin.com.intellij.openapi.util.Key
 import org.jetbrains.kotlin.psi.KtFile
 

--- a/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/processors/ProjectSLOCProcessor.kt
+++ b/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/processors/ProjectSLOCProcessor.kt
@@ -24,9 +24,9 @@ class SLOCVisitor : DetektVisitor() {
 
         fun count(lines: List<String>): Int {
             return lines
-                    .map { it.trim() }
-                    .filter { trim -> trim.isNotEmpty() && !comments.any { trim.startsWith(it) } }
-                    .size
+                .map { it.trim() }
+                .filter { trim -> trim.isNotEmpty() && !comments.any { trim.startsWith(it) } }
+                .size
         }
     }
 }

--- a/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/processors/util/LLOC.kt
+++ b/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/processors/util/LLOC.kt
@@ -25,7 +25,6 @@ object LLOC {
         @Suppress("LoopWithTooManyJumpStatements")
         fun run(): Int {
             for (line in lines) {
-
                 val trimmed = line.trim()
 
                 if (trimmed.isEmpty()) {
@@ -83,7 +82,6 @@ object LLOC {
         }
 
         private fun frequency(source: String, part: String): Int {
-
             if (source.isEmpty() || part.isEmpty()) {
                 return 0
             }

--- a/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/CognitiveComplexitySpec.kt
+++ b/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/CognitiveComplexitySpec.kt
@@ -10,7 +10,8 @@ class CognitiveComplexitySpec : Spek({
     describe("cognitive complexity") {
 
         it("sums seven for sumOfPrimes example") {
-            val code = compileContentForTest("""
+            val code = compileContentForTest(
+                """
                 fun sumOfPrimes(max: Int): Int {
                     var total = 0
                     next@ for (i in 1..max) {
@@ -24,20 +25,23 @@ class CognitiveComplexitySpec : Spek({
                     }
                     return total
                 }
-            """)
+            """
+            )
 
             assertThat(CognitiveComplexity.calculate(code)).isEqualTo(7)
         }
 
         it("sums one for getWords example for a single when expression") {
-            val code = compileContentForTest("""
+            val code = compileContentForTest(
+                """
                  fun getWords(number: Int): String = when (number) {
                      1 -> "one"
                      2 -> "a couple"
                      3 -> "a few"
                      else -> "lots"
                  }
-             """)
+             """
+            )
 
             assertThat(CognitiveComplexity.calculate(code)).isEqualTo(1)
         }
@@ -45,62 +49,73 @@ class CognitiveComplexitySpec : Spek({
         describe("recursion") {
 
             it("adds one for recursion inside class") {
-                val code = compileContentForTest("""
+                val code = compileContentForTest(
+                    """
                     class A {
                         fun factorial(n: Int): Int =
                             if (n >= 1) n * this.factorial(n - 1) else 1
                     }
-            """)
+            """
+                )
 
                 assertThat(CognitiveComplexity.calculate(code)).isEqualTo(2)
             }
 
             it("adds one for top level recursion") {
-                val code = compileContentForTest("""
+                val code = compileContentForTest(
+                    """
                     fun factorial(n: Int): Int =
                         if (n >= 1) n * factorial(n - 1) else 1
-                """)
+                """
+                )
 
                 assertThat(CognitiveComplexity.calculate(code)).isEqualTo(2)
             }
 
             it("does not add as it is only the same name") {
-                val code = compileContentForTest("""
+                val code = compileContentForTest(
+                    """
                     object O { fun factorial(i: Int): Int = i - 1 }
                     fun factorial(n: Int): Int =
                         if (n >= 1) n * O.factorial(n - 1) else 1
-                """)
+                """
+                )
 
                 assertThat(CognitiveComplexity.calculate(code)).isEqualTo(1)
             }
         }
 
         it("ignores shorthand operators") {
-            val code = compileContentForTest("""
+            val code = compileContentForTest(
+                """
                 fun parse(args: Array<String>): Nothing = TODO()
                 fun main(args: Array<String>) {
                    args.takeIf { it.size > 3 }?.let(::parse) ?: error("not enough arguments")
                 }
-            """)
+            """
+            )
 
             assertThat(CognitiveComplexity.calculate(code)).isEqualTo(0)
         }
 
         it("adds one per catch clause") {
-            val code = compileContentForTest("""
+            val code = compileContentForTest(
+                """
                 fun main() {
                     try {
                     } catch (e: IllegalArgumentException) {
                     } catch (e: IllegalStateException) {
                     } catch (e: Throwable) {}
                 }
-            """)
+            """
+            )
 
             assertThat(CognitiveComplexity.calculate(code)).isEqualTo(3)
         }
 
         it("adds extra complexity for nesting") {
-            val code = compileContentForTest("""
+            val code = compileContentForTest(
+                """
                 fun main() {
                     try {
                         if (true) { // +1
@@ -114,23 +129,28 @@ class CognitiveComplexitySpec : Spek({
                         do {} while(true) // +2
                     }
                 }
-            """)
+            """
+            )
 
             assertThat(CognitiveComplexity.calculate(code)).isEqualTo(9)
         }
 
         it("adds nesting for lambdas but not complexity") {
-            val code = compileContentForTest("""
+            val code = compileContentForTest(
+                """
                 fun main() { run { if (true) {} } }
-            """)
+            """
+            )
 
             assertThat(CognitiveComplexity.calculate(code)).isEqualTo(2)
         }
 
         it("adds nesting for nested functions but not complexity") {
-            val code = compileContentForTest("""
+            val code = compileContentForTest(
+                """
                 fun main() { fun run() { if (true) {} } }
-            """)
+            """
+            )
 
             assertThat(CognitiveComplexity.calculate(code)).isEqualTo(2)
         }
@@ -138,9 +158,11 @@ class CognitiveComplexitySpec : Spek({
         describe("binary expressions") {
 
             it("does not increment on just a condition") {
-                val code = compileContentForTest("""
+                val code = compileContentForTest(
+                    """
                     fun test(cond: Boolean) = !cond
-                """)
+                """
+                )
 
                 assertThat(CognitiveComplexity.calculate(code)).isEqualTo(0)
             }
@@ -148,31 +170,38 @@ class CognitiveComplexitySpec : Spek({
             describe("increments for every non-like operator") {
 
                 it("adds one for just a &&") {
-                    val code = compileContentForTest("""
+                    val code = compileContentForTest(
+                        """
                         fun test(cond: Boolean) = !cond && !cond
-                    """)
+                    """
+                    )
 
                     assertThat(CognitiveComplexity.calculate(code)).isEqualTo(1)
                 }
 
                 it("adds only one for repeated &&") {
-                    val code = compileContentForTest("""
+                    val code = compileContentForTest(
+                        """
                         fun test(cond: Boolean) = !cond && !cond && !cond
-                    """)
+                    """
+                    )
 
                     assertThat(CognitiveComplexity.calculate(code)).isEqualTo(1)
                 }
 
                 it("adds one per logical alternate operator") {
-                    val code = compileContentForTest("""
+                    val code = compileContentForTest(
+                        """
                         fun test(cond: Boolean) = !cond && !cond || cond
-                    """)
+                    """
+                    )
 
                     assertThat(CognitiveComplexity.calculate(code)).isEqualTo(2)
                 }
 
                 it("adds one per logical alternate operator with like operators in between") {
-                    val code = compileContentForTest("""
+                    val code = compileContentForTest(
+                        """
                         fun test(cond: Boolean) {
                             if (                    // +1
                                 !cond 
@@ -181,39 +210,45 @@ class CognitiveComplexitySpec : Spek({
                                 && cond             // +1
                             ) {}
                         }
-                    """)
+                    """
+                    )
 
                     assertThat(CognitiveComplexity.calculate(code)).isEqualTo(4)
                 }
 
                 it("adds one for negated but similar operators") {
-                    val code = compileContentForTest("""
+                    val code = compileContentForTest(
+                        """
                         fun test(cond: Boolean) {
                             if (                    // +1
                                 !cond 
                                 && !(cond && cond)  // +2
                             ) {}
                         }
-                    """)
+                    """
+                    )
 
                     assertThat(CognitiveComplexity.calculate(code)).isEqualTo(3)
                 }
 
                 it("adds only one for a negated chain of similar operators") {
-                    val code = compileContentForTest("""
+                    val code = compileContentForTest(
+                        """
                         fun test(cond: Boolean) {
                             if (                    // +1
                                 !cond 
                                 && !(cond && cond && cond)  // +2
                             ) {}
                         }
-                    """)
+                    """
+                    )
 
                     assertThat(CognitiveComplexity.calculate(code)).isEqualTo(3)
                 }
 
                 it("adds one for every negated similar operator chain") {
-                    val code = compileContentForTest("""
+                    val code = compileContentForTest(
+                        """
                         fun test(cond: Boolean) {
                             if (                            // +1
                                 !cond 
@@ -221,7 +256,8 @@ class CognitiveComplexitySpec : Spek({
                                 || !(cond || cond)          // +2
                             ) {}
                         }
-                    """)
+                    """
+                    )
 
                     assertThat(CognitiveComplexity.calculate(code)).isEqualTo(5)
                 }

--- a/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/CyclomaticComplexitySpec.kt
+++ b/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/CyclomaticComplexitySpec.kt
@@ -13,9 +13,11 @@ class CyclomaticComplexitySpec : Spek({
     describe("basic function expressions are tested") {
 
         it("counts for safe navigation") {
-            val code = compileContentForTest("""
+            val code = compileContentForTest(
+                """
                     fun test() = null as? String ?: ""
-                """)
+                """
+            )
 
             val actual = CyclomaticComplexity.calculate(code)
 
@@ -23,9 +25,11 @@ class CyclomaticComplexitySpec : Spek({
         }
 
         it("counts if and && and || expressions") {
-            val code = compileContentForTest("""
+            val code = compileContentForTest(
+                """
                     fun test() = if (true || true && false) 1 else 0
-                """)
+                """
+            )
 
             val actual = CyclomaticComplexity.calculate(code)
 
@@ -33,7 +37,8 @@ class CyclomaticComplexitySpec : Spek({
         }
 
         it("counts while, continue and break") {
-            val code = compileContentForTest("""
+            val code = compileContentForTest(
+                """
                     fun test(i: Int) {
                         var j = i
                         while(true) { // 1
@@ -47,7 +52,8 @@ class CyclomaticComplexitySpec : Spek({
                         }
                         println("finished")
                     }
-                """)
+                """
+            )
 
             val actual = CyclomaticComplexity.calculate(code)
 
@@ -58,7 +64,8 @@ class CyclomaticComplexitySpec : Spek({
     describe("counts function calls used for nesting") {
 
         val code by memoized {
-            compileContentForTest("""
+            compileContentForTest(
+                """
                     fun test(i: Int) {
                         (1..10).forEach { println(it) }
                     }
@@ -100,7 +107,8 @@ class CyclomaticComplexitySpec : Spek({
     describe("ignoreSimpleWhenEntries is false") {
 
         it("counts simple when branches as 1") {
-            val function = compileContentForTest("""
+            val function = compileContentForTest(
+                """
                 fun test() {
                     when (System.currentTimeMillis()) {
                         0 -> println("Epoch!")
@@ -108,7 +116,8 @@ class CyclomaticComplexitySpec : Spek({
                         else -> println("Meh")
                     }
                 }
-            """).getFunctionByName("test")
+            """
+            ).getFunctionByName("test")
 
             val actual = CyclomaticComplexity.calculate(function) {
                 ignoreSimpleWhenEntries = false
@@ -118,7 +127,8 @@ class CyclomaticComplexitySpec : Spek({
         }
 
         it("counts block when branches as 1") {
-            val function = compileContentForTest("""
+            val function = compileContentForTest(
+                """
                 fun test() {
                     when (System.currentTimeMillis()) {
                         0 -> {
@@ -128,7 +138,8 @@ class CyclomaticComplexitySpec : Spek({
                         else -> println("Meh")
                     }
                 }
-            """).getFunctionByName("test")
+            """
+            ).getFunctionByName("test")
 
             val actual = CyclomaticComplexity.calculate(function) {
                 ignoreSimpleWhenEntries = false
@@ -141,7 +152,8 @@ class CyclomaticComplexitySpec : Spek({
     describe("ignoreSimpleWhenEntries is true") {
 
         it("counts a when with only simple branches as 1") {
-            val function = compileContentForTest("""
+            val function = compileContentForTest(
+                """
                 fun test() {
                     when (System.currentTimeMillis()) {
                         0 -> println("Epoch!")
@@ -149,7 +161,8 @@ class CyclomaticComplexitySpec : Spek({
                         else -> println("Meh")
                     }
                 }
-            """).getFunctionByName("test")
+            """
+            ).getFunctionByName("test")
 
             val actual = CyclomaticComplexity.calculate(function) {
                 ignoreSimpleWhenEntries = true
@@ -159,7 +172,8 @@ class CyclomaticComplexitySpec : Spek({
         }
 
         it("does not count simple when branches") {
-            val function = compileContentForTest("""
+            val function = compileContentForTest(
+                """
                 fun test() {
                     when (System.currentTimeMillis()) {
                         0 -> {
@@ -172,7 +186,8 @@ class CyclomaticComplexitySpec : Spek({
                         else -> println("Meh")
                     }
                 }
-            """).getFunctionByName("test")
+            """
+            ).getFunctionByName("test")
 
             val actual = CyclomaticComplexity.calculate(function) {
                 ignoreSimpleWhenEntries = true
@@ -182,7 +197,8 @@ class CyclomaticComplexitySpec : Spek({
         }
 
         it("counts block when branches as 1") {
-            val function = compileContentForTest("""
+            val function = compileContentForTest(
+                """
                 fun test() {
                     when (System.currentTimeMillis()) {
                         0 -> {
@@ -197,7 +213,8 @@ class CyclomaticComplexitySpec : Spek({
                         else -> println("Meh")
                     }
                 }
-            """).getFunctionByName("test")
+            """
+            ).getFunctionByName("test")
 
             val actual = CyclomaticComplexity.calculate(function) {
                 ignoreSimpleWhenEntries = true

--- a/detekt-parser/src/main/kotlin/io/github/detekt/parser/KotlinEnvironmentUtils.kt
+++ b/detekt-parser/src/main/kotlin/io/github/detekt/parser/KotlinEnvironmentUtils.kt
@@ -68,7 +68,6 @@ fun createCompilerConfiguration(
     languageVersion: LanguageVersion?,
     jvmTarget: JvmTarget
 ): CompilerConfiguration {
-
     val javaFiles = pathsToAnalyze.flatMap { path ->
         path.toFile().walk()
             .filter { it.isFile && it.extension.equals("java", true) }

--- a/detekt-psi-utils/src/main/kotlin/io/github/detekt/psi/KtFiles.kt
+++ b/detekt-psi-utils/src/main/kotlin/io/github/detekt/psi/KtFiles.kt
@@ -35,9 +35,10 @@ data class FilePath constructor(
 ) {
 
     init {
-        require(basePath == null ||
-            relativePath == null ||
-            absolutePath == basePath.resolve(relativePath).normalize()
+        require(
+            basePath == null ||
+                relativePath == null ||
+                absolutePath == basePath.resolve(relativePath).normalize()
         ) {
             "Absolute path = $absolutePath much match base path = $basePath and relative path = $relativePath"
         }

--- a/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/GuardClauses.kt
+++ b/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/GuardClauses.kt
@@ -29,7 +29,7 @@ inline fun <reified T : KtExpression> KtExpression.isGuardClause(): Boolean {
 fun <T : KtExpression> KtExpression.isIfConditionGuardClause(descendantExpr: T): Boolean {
     val ifExpr = this as? KtIfExpression ?: return false
     return ifExpr.`else` == null &&
-            descendantExpr === ifExpr.then?.lastBlockStatementOrThis()
+        descendantExpr === ifExpr.then?.lastBlockStatementOrThis()
 }
 
 fun KtExpression.isElvisOperatorGuardClause(): Boolean {

--- a/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/Junk.kt
+++ b/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/Junk.kt
@@ -42,6 +42,8 @@ inline fun <reified T : Any> Any.safeAs(): T? = this as? T
 fun KtCallExpression.receiverIsUsed(context: BindingContext): Boolean =
     (parent as? KtQualifiedExpression)?.let {
         val scopeOfApplyCall = parent.parent
-        !((scopeOfApplyCall == null || scopeOfApplyCall is KtBlockExpression) &&
-            (context == BindingContext.EMPTY || !it.isUsedAsExpression(context)))
+        !(
+            (scopeOfApplyCall == null || scopeOfApplyCall is KtBlockExpression) &&
+                (context == BindingContext.EMPTY || !it.isUsedAsExpression(context))
+            )
     } ?: true

--- a/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/KtAnnotatedExtensions.kt
+++ b/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/KtAnnotatedExtensions.kt
@@ -10,9 +10,9 @@ fun KtAnnotated.hasAnnotation(
     val names = annotationNames.toHashSet()
     val predicate: (KtAnnotationEntry) -> Boolean = {
         it.typeReference
-                ?.typeElement
-                ?.safeAs<KtUserType>()
-                ?.referencedName in names
+            ?.typeElement
+            ?.safeAs<KtUserType>()
+            ?.referencedName in names
     }
     return annotationEntries.any(predicate)
 }

--- a/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/KtCallExpression.kt
+++ b/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/KtCallExpression.kt
@@ -9,8 +9,8 @@ import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
 
 fun KtCallExpression.isCalling(fqName: FqName, bindingContext: BindingContext): Boolean {
     return bindingContext != BindingContext.EMPTY &&
-            calleeExpression?.text == fqName.shortName().asString() &&
-            getResolvedCall(bindingContext)?.resultingDescriptor?.fqNameSafe == fqName
+        calleeExpression?.text == fqName.shortName().asString() &&
+        getResolvedCall(bindingContext)?.resultingDescriptor?.fqNameSafe == fqName
 }
 
 fun KtCallExpression.isCallingWithNonNullCheckArgument(

--- a/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/KtModifierList.kt
+++ b/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/KtModifierList.kt
@@ -7,7 +7,7 @@ import org.jetbrains.kotlin.psi.KtModifierListOwner
 import org.jetbrains.kotlin.psi.psiUtil.isPublic
 
 fun KtModifierListOwner.isPublicNotOverridden() =
-        isPublic && !isOverride()
+    isPublic && !isOverride()
 
 fun KtModifierListOwner.isAbstract() = hasModifier(KtTokens.ABSTRACT_KEYWORD)
 

--- a/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/MethodSignature.kt
+++ b/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/MethodSignature.kt
@@ -5,14 +5,14 @@ import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.KtObjectDeclaration
 
 fun KtFunction.isEqualsFunction() =
-        this.name == "equals" && this.isOverride() && hasCorrectEqualsParameter()
+    this.name == "equals" && this.isOverride() && hasCorrectEqualsParameter()
 
 fun KtFunction.isHashCodeFunction() =
-        this.name == "hashCode" && this.isOverride() && this.valueParameters.isEmpty()
+    this.name == "hashCode" && this.isOverride() && this.valueParameters.isEmpty()
 
 private val knownAnys = setOf("Any?", "kotlin.Any?")
 fun KtFunction.hasCorrectEqualsParameter() =
-        this.valueParameters.singleOrNull()?.typeReference?.text in knownAnys
+    this.valueParameters.singleOrNull()?.typeReference?.text in knownAnys
 
 fun KtNamedFunction.isMainFunction() = hasMainSignature() && (this.isTopLevel || isMainInsideObject())
 
@@ -37,7 +37,7 @@ private fun KtNamedFunction.hasMainParameter() =
     valueParameters.isEmpty() || valueParameters.size == 1 && valueParameters[0].typeReference?.text == "Array<String>"
 
 private fun KtNamedFunction.isMainInsideObject() =
-        this.name == "main" &&
-                this.isPublicNotOverridden() &&
-                this.parent?.parent is KtObjectDeclaration &&
-                this.hasAnnotation("JvmStatic", "kotlin.jvm.JvmStatic")
+    this.name == "main" &&
+        this.isPublicNotOverridden() &&
+        this.parent?.parent is KtObjectDeclaration &&
+        this.hasAnnotation("JvmStatic", "kotlin.jvm.JvmStatic")

--- a/detekt-psi-utils/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/MethodSignatureSpec.kt
+++ b/detekt-psi-utils/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/MethodSignatureSpec.kt
@@ -33,7 +33,7 @@ class MethodSignatureSpec : Spek({
             ),
             TestCase(
                 testDescription = "should return method name and params list for full signature method with multiple params " +
-                        "where method name has spaces and special characters",
+                    "where method name has spaces and special characters",
                 methodSignature = "io.gitlab.arturbosch.detekt.SomeClass.`some , method`(kotlin.String)",
                 expectedMethodName = "io.gitlab.arturbosch.detekt.SomeClass.some , method",
                 expectedParams = listOf("kotlin.String")

--- a/detekt-report-html/src/main/kotlin/io/github/detekt/report/html/HtmlOutputReport.kt
+++ b/detekt-report-html/src/main/kotlin/io/github/detekt/report/html/HtmlOutputReport.kt
@@ -164,13 +164,13 @@ private class SUMMARY(
     initialAttributes: Map<String, String>,
     override val consumer: TagConsumer<*>
 ) : HTMLTag(
-    "summary",
-    consumer,
-    initialAttributes,
-    null,
-    false,
-    false
-),
+        "summary",
+        consumer,
+        initialAttributes,
+        null,
+        false,
+        false
+    ),
     CommonAttributeGroupFacadeFlowInteractiveContent
 
 private fun TextLocation.length(): Int = end - start

--- a/detekt-report-html/src/test/kotlin/io/github/detekt/report/html/HtmlOutputReportSpec.kt
+++ b/detekt-report-html/src/test/kotlin/io/github/detekt/report/html/HtmlOutputReportSpec.kt
@@ -112,7 +112,8 @@ class HtmlOutputReportSpec : Spek({
         it("renders a metric report correctly") {
             val detektion = object : TestDetektion() {
                 override val metrics: Collection<ProjectMetric> = listOf(
-                    ProjectMetric("M1", 10000), ProjectMetric("M2", 2)
+                    ProjectMetric("M1", 10000),
+                    ProjectMetric("M2", 2)
                 )
             }
             val result = htmlReport.render(detektion)

--- a/detekt-report-html/src/test/kotlin/io/github/detekt/report/html/HtmlOutputReportSpec.kt
+++ b/detekt-report-html/src/test/kotlin/io/github/detekt/report/html/HtmlOutputReportSpec.kt
@@ -174,7 +174,6 @@ private fun mockKtElement(): KtElement {
 }
 
 private fun createTestDetektionWithMultipleSmells(): Detektion {
-
     val entity1 = createEntity("src/main/com/sample/Sample1.kt", 11 to 1, 10..14, mockKtElement())
     val entity2 = createEntity("src/main/com/sample/Sample2.kt", 22 to 2)
     val entity3 = createEntity("src/main/com/sample/Sample3.kt", 33 to 3)

--- a/detekt-report-html/src/test/kotlin/io/github/detekt/report/html/HtmlUtilsSpec.kt
+++ b/detekt-report-html/src/test/kotlin/io/github/detekt/report/html/HtmlUtilsSpec.kt
@@ -36,7 +36,8 @@ class HtmlUtilsSpec : Spek({
                 snippetCode("ruleName", code.asSequence(), SourceLocation(7, 1), 34)
             }
 
-            assertThat(snippet).isEqualTo("""
+            assertThat(snippet).isEqualTo(
+                """
                 <div>
                   <pre><code><span class="lineno">   4 </span>// reports 1 - a comment with trailing space
                 <span class="lineno">   5 </span>// A comment
@@ -57,7 +58,8 @@ class HtmlUtilsSpec : Spek({
                 snippetCode("ruleName", code.asSequence(), SourceLocation(7, 7), 26)
             }
 
-            assertThat(snippet).isEqualTo("""
+            assertThat(snippet).isEqualTo(
+                """
                 <div>
                   <pre><code><span class="lineno">   4 </span>// reports 1 - a comment with trailing space
                 <span class="lineno">   5 </span>// A comment
@@ -78,7 +80,8 @@ class HtmlUtilsSpec : Spek({
                 snippetCode("ruleName", code.asSequence(), SourceLocation(7, 7), 66)
             }
 
-            assertThat(snippet).isEqualTo("""
+            assertThat(snippet).isEqualTo(
+                """
                 <div>
                   <pre><code><span class="lineno">   4 </span>// reports 1 - a comment with trailing space
                 <span class="lineno">   5 </span>// A comment

--- a/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/SarifDsl.kt
+++ b/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/SarifDsl.kt
@@ -27,20 +27,22 @@ fun SarifSchema210.withDetektRun(config: Config, init: Run.() -> Unit) {
     runs.add(
         Run()
             .withResults(ArrayList())
-            .withTool(tool {
-                driver = component {
-                    guid = "022ca8c2-f6a2-4c95-b107-bb72c43263f3"
-                    name = "detekt"
-                    fullName = name
-                    organization = name
-                    language = "en"
-                    version = VersionProvider.load().current()
-                    semanticVersion = version
-                    downloadUri = URI.create("https://github.com/detekt/detekt/releases/download/v$version/detekt")
-                    informationUri = URI.create("https://detekt.github.io/detekt")
-                    rules = ruleDescriptors(config).values.toSet()
+            .withTool(
+                tool {
+                    driver = component {
+                        guid = "022ca8c2-f6a2-4c95-b107-bb72c43263f3"
+                        name = "detekt"
+                        fullName = name
+                        organization = name
+                        language = "en"
+                        version = VersionProvider.load().current()
+                        semanticVersion = version
+                        downloadUri = URI.create("https://github.com/detekt/detekt/releases/download/v$version/detekt")
+                        informationUri = URI.create("https://detekt.github.io/detekt")
+                        rules = ruleDescriptors(config).values.toSet()
+                    }
                 }
-            })
+            )
             .apply(init)
     )
 }

--- a/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/SarifOutputReport.kt
+++ b/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/SarifOutputReport.kt
@@ -75,22 +75,24 @@ private fun Finding.toResult(ruleSetId: RuleSetId): Result = result {
     ruleId = "detekt.$ruleSetId.$id"
     level = severity.toResultLevel()
     for (location in listOf(location) + references.map { it.location }) {
-        locations.add(Location().apply {
-            physicalLocation = PhysicalLocation().apply {
-                region = Region().apply {
-                    startLine = location.source.line
-                    startColumn = location.source.column
-                }
-                artifactLocation = ArtifactLocation().apply {
-                    if (location.filePath.relativePath != null) {
-                        uri = location.filePath.relativePath?.toUnifiedString()
-                        uriBaseId = SARIF_SRCROOT_PROPERTY
-                    } else {
-                        uri = location.filePath.absolutePath.toUnifiedString()
+        locations.add(
+            Location().apply {
+                physicalLocation = PhysicalLocation().apply {
+                    region = Region().apply {
+                        startLine = location.source.line
+                        startColumn = location.source.column
+                    }
+                    artifactLocation = ArtifactLocation().apply {
+                        if (location.filePath.relativePath != null) {
+                            uri = location.filePath.relativePath?.toUnifiedString()
+                            uriBaseId = SARIF_SRCROOT_PROPERTY
+                        } else {
+                            uri = location.filePath.absolutePath.toUnifiedString()
+                        }
                     }
                 }
             }
-        })
+        )
     }
     message = Message().apply { text = messageOrDescription() }
 }

--- a/detekt-report-sarif/src/test/kotlin/io/github/detekt/report/sarif/SarifOutputReportSpec.kt
+++ b/detekt-report-sarif/src/test/kotlin/io/github/detekt/report/sarif/SarifOutputReportSpec.kt
@@ -33,7 +33,8 @@ class SarifOutputReportSpec : Spek({
                 .stripWhitespace()
 
             assertThat(report).isEqualTo(
-                readResourceContent("vanilla.sarif.json").stripWhitespace())
+                readResourceContent("vanilla.sarif.json").stripWhitespace()
+            )
         }
 
         it("renders multiple issues with relative path") {
@@ -46,9 +47,11 @@ class SarifOutputReportSpec : Spek({
 
             val report = SarifOutputReport()
                 .apply {
-                    init(EmptySetupContext().apply {
-                        register(DETEKT_OUTPUT_REPORT_BASE_PATH_KEY, Paths.get(basePath))
-                    })
+                    init(
+                        EmptySetupContext().apply {
+                            register(DETEKT_OUTPUT_REPORT_BASE_PATH_KEY, Paths.get(basePath))
+                        }
+                    )
                 }
                 .render(result)
                 .stripWhitespace()

--- a/detekt-report-txt/src/test/kotlin/io/github/detekt/report/txt/TxtOutputReportSpec.kt
+++ b/detekt-report-txt/src/test/kotlin/io/github/detekt/report/txt/TxtOutputReportSpec.kt
@@ -29,7 +29,8 @@ class TxtOutputReportSpec : Spek({
             val detektion = TestDetektion(
                 createFinding(ruleName = "TestSmellA"),
                 createFinding(ruleName = "TestSmellB"),
-                createFinding(ruleName = "TestSmellC"))
+                createFinding(ruleName = "TestSmellC")
+            )
             val renderedText = """
                 TestSmellA - [TestEntity] at TestFile.kt:1:1 - Signature=TestEntitySignature
                 TestSmellB - [TestEntity] at TestFile.kt:1:1 - Signature=TestEntitySignature

--- a/detekt-report-xml/src/main/kotlin/io/github/detekt/report/xml/XmlEscape.kt
+++ b/detekt-report-xml/src/main/kotlin/io/github/detekt/report/xml/XmlEscape.kt
@@ -198,7 +198,6 @@ private object Xml10EscapeSymbolsInitializer {
     }
 
     fun initializeXml10(): XmlEscapeSymbols {
-
         val xml10References = XmlEscapeSymbols.References()
 
         /*

--- a/detekt-report-xml/src/main/kotlin/io/github/detekt/report/xml/XmlOutputReport.kt
+++ b/detekt-report-xml/src/main/kotlin/io/github/detekt/report/xml/XmlOutputReport.kt
@@ -28,18 +28,18 @@ class XmlOutputReport : OutputReport() {
 
         smells.groupBy { it.location.filePath.relativePath ?: it.location.filePath.absolutePath }
             .forEach { (filePath, findings) ->
-            lines += "<file name=\"${filePath.toUnifiedString().toXmlString()}\">"
-            findings.forEach {
-                lines += arrayOf(
+                lines += "<file name=\"${filePath.toUnifiedString().toXmlString()}\">"
+                findings.forEach {
+                    lines += arrayOf(
                         "\t<error line=\"${it.location.source.line.toXmlString()}\"",
                         "column=\"${it.location.source.column.toXmlString()}\"",
                         "severity=\"${it.severityLabel.toXmlString()}\"",
                         "message=\"${it.messageOrDescription().toXmlString()}\"",
                         "source=\"${"detekt.${it.id.toXmlString()}"}\" />"
-                ).joinToString(separator = " ")
+                    ).joinToString(separator = " ")
+                }
+                lines += "</file>"
             }
-            lines += "</file>"
-        }
 
         lines += "</checkstyle>"
         return lines.joinToString(separator = "\n")

--- a/detekt-report-xml/src/test/kotlin/io/github/detekt/report/xml/XmlOutputFormatSpec.kt
+++ b/detekt-report-xml/src/test/kotlin/io/github/detekt/report/xml/XmlOutputFormatSpec.kt
@@ -23,14 +23,22 @@ private const val TAB = "\t"
 class XmlOutputFormatSpec : Spek({
 
     val entity1 by memoized {
-        Entity("Sample1", "",
-            Location(SourceLocation(11, 1), TextLocation(0, 10),
-                "src/main/com/sample/Sample1.kt"))
+        Entity(
+            "Sample1", "",
+            Location(
+                SourceLocation(11, 1), TextLocation(0, 10),
+                "src/main/com/sample/Sample1.kt"
+            )
+        )
     }
     val entity2 by memoized {
-        Entity("Sample2", "",
-            Location(SourceLocation(22, 2), TextLocation(0, 20),
-                "src/main/com/sample/Sample2.kt"))
+        Entity(
+            "Sample2", "",
+            Location(
+                SourceLocation(22, 2), TextLocation(0, 20),
+                "src/main/com/sample/Sample2.kt"
+            )
+        )
     }
 
     val outputFormat by memoized { XmlOutputReport() }
@@ -40,10 +48,13 @@ class XmlOutputFormatSpec : Spek({
         it("renders empty report") {
             val result = outputFormat.render(TestDetektion())
 
-            assertThat(result).isEqualTo("""
+            assertThat(result).isEqualTo(
+                """
                 <?xml version="1.0" encoding="UTF-8"?>
                 <checkstyle version="4.3">
-                </checkstyle>""".trimIndent())
+                </checkstyle>
+                """.trimIndent()
+            )
         }
 
         it("renders one reported issue in single file") {
@@ -51,13 +62,16 @@ class XmlOutputFormatSpec : Spek({
 
             val result = outputFormat.render(TestDetektion(smell))
 
-            assertThat(result).isEqualTo("""
+            assertThat(result).isEqualTo(
+                """
                 <?xml version="1.0" encoding="UTF-8"?>
                 <checkstyle version="4.3">
                 <file name="src/main/com/sample/Sample1.kt">
                 $TAB<error line="11" column="1" severity="warning" message="" source="detekt.id_a" />
                 </file>
-                </checkstyle>""".trimIndent())
+                </checkstyle>
+                """.trimIndent()
+            )
         }
 
         it("renders two reported issues in single file") {
@@ -66,14 +80,17 @@ class XmlOutputFormatSpec : Spek({
 
             val result = outputFormat.render(TestDetektion(smell1, smell2))
 
-            assertThat(result).isEqualTo("""
+            assertThat(result).isEqualTo(
+                """
                 <?xml version="1.0" encoding="UTF-8"?>
                 <checkstyle version="4.3">
                 <file name="src/main/com/sample/Sample1.kt">
                 $TAB<error line="11" column="1" severity="warning" message="" source="detekt.id_a" />
                 $TAB<error line="11" column="1" severity="warning" message="" source="detekt.id_b" />
                 </file>
-                </checkstyle>""".trimIndent())
+                </checkstyle>
+                """.trimIndent()
+            )
         }
 
         it("renders one reported issue across multiple files") {
@@ -82,7 +99,8 @@ class XmlOutputFormatSpec : Spek({
 
             val result = outputFormat.render(TestDetektion(smell1, smell2))
 
-            assertThat(result).isEqualTo("""
+            assertThat(result).isEqualTo(
+                """
                 <?xml version="1.0" encoding="UTF-8"?>
                 <checkstyle version="4.3">
                 <file name="src/main/com/sample/Sample1.kt">
@@ -91,7 +109,9 @@ class XmlOutputFormatSpec : Spek({
                 <file name="src/main/com/sample/Sample2.kt">
                 $TAB<error line="22" column="2" severity="warning" message="" source="detekt.id_a" />
                 </file>
-                </checkstyle>""".trimIndent())
+                </checkstyle>
+                """.trimIndent()
+            )
         }
 
         it("renders issues with relative path") {
@@ -108,7 +128,8 @@ class XmlOutputFormatSpec : Spek({
 
             val result = outputFormat.render(TestDetektion(findingA, findingB))
 
-            assertThat(result).isEqualTo("""
+            assertThat(result).isEqualTo(
+                """
                 <?xml version="1.0" encoding="UTF-8"?>
                 <checkstyle version="4.3">
                 <file name="Sample1.kt">
@@ -117,7 +138,9 @@ class XmlOutputFormatSpec : Spek({
                 <file name="Sample2.kt">
                 $TAB<error line="1" column="1" severity="warning" message="TestMessage" source="detekt.id_b" />
                 </file>
-                </checkstyle>""".trimIndent())
+                </checkstyle>
+                """.trimIndent()
+            )
         }
 
         it("renders two reported issues across multiple files") {
@@ -135,7 +158,8 @@ class XmlOutputFormatSpec : Spek({
                 )
             )
 
-            assertThat(result).isEqualTo("""
+            assertThat(result).isEqualTo(
+                """
                 <?xml version="1.0" encoding="UTF-8"?>
                 <checkstyle version="4.3">
                 <file name="src/main/com/sample/Sample1.kt">
@@ -146,7 +170,9 @@ class XmlOutputFormatSpec : Spek({
                 $TAB<error line="22" column="2" severity="warning" message="" source="detekt.id_a" />
                 $TAB<error line="22" column="2" severity="warning" message="" source="detekt.id_b" />
                 </file>
-                </checkstyle>""".trimIndent())
+                </checkstyle>
+                """.trimIndent()
+            )
         }
 
         describe("severity level conversion") {

--- a/detekt-report-xml/src/test/kotlin/io/github/detekt/report/xml/XmlOutputFormatSpec.kt
+++ b/detekt-report-xml/src/test/kotlin/io/github/detekt/report/xml/XmlOutputFormatSpec.kt
@@ -24,18 +24,22 @@ class XmlOutputFormatSpec : Spek({
 
     val entity1 by memoized {
         Entity(
-            "Sample1", "",
+            "Sample1",
+            "",
             Location(
-                SourceLocation(11, 1), TextLocation(0, 10),
+                SourceLocation(11, 1),
+                TextLocation(0, 10),
                 "src/main/com/sample/Sample1.kt"
             )
         )
     }
     val entity2 by memoized {
         Entity(
-            "Sample2", "",
+            "Sample2",
+            "",
             Location(
-                SourceLocation(22, 2), TextLocation(0, 20),
+                SourceLocation(22, 2),
+                TextLocation(0, 20),
                 "src/main/com/sample/Sample2.kt"
             )
         )

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexCondition.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexCondition.kt
@@ -46,7 +46,8 @@ class ComplexCondition(
 ) : ThresholdRule(config, threshold) {
 
     override val issue = Issue(
-        "ComplexCondition", Severity.Maintainability,
+        "ComplexCondition",
+        Severity.Maintainability,
         "Complex conditions should be simplified and extracted into well-named methods if necessary.",
         Debt.TWENTY_MINS
     )

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexCondition.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexCondition.kt
@@ -45,9 +45,11 @@ class ComplexCondition(
     threshold: Int = DEFAULT_CONDITIONS_COUNT
 ) : ThresholdRule(config, threshold) {
 
-    override val issue = Issue("ComplexCondition", Severity.Maintainability,
-            "Complex conditions should be simplified and extracted into well-named methods if necessary.",
-            Debt.TWENTY_MINS)
+    override val issue = Issue(
+        "ComplexCondition", Severity.Maintainability,
+        "Complex conditions should be simplified and extracted into well-named methods if necessary.",
+        Debt.TWENTY_MINS
+    )
 
     override fun visitIfExpression(expression: KtIfExpression) {
         val condition = expression.condition
@@ -77,17 +79,20 @@ class ComplexCondition(
             val conditionString = longestBinExpr.text
             val count = frequency(conditionString, "&&") + frequency(conditionString, "||") + 1
             if (count >= threshold) {
-                report(ThresholdedCodeSmell(issue,
+                report(
+                    ThresholdedCodeSmell(
+                        issue,
                         Entity.from(condition),
                         Metric("SIZE", count, threshold),
                         "This condition is too complex ($count). " +
-                                "Defined complexity threshold for conditions is set to '$threshold'"))
+                            "Defined complexity threshold for conditions is set to '$threshold'"
+                    )
+                )
             }
         }
     }
 
     private fun frequency(source: String, part: String): Int {
-
         if (source.isEmpty() || part.isEmpty()) {
             return 0
         }

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexInterface.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexInterface.kt
@@ -36,7 +36,8 @@ class ComplexInterface(
 ) : ThresholdRule(config, threshold) {
 
     override val issue = Issue(
-        javaClass.simpleName, Severity.Maintainability,
+        javaClass.simpleName,
+        Severity.Maintainability,
         "An interface contains too many functions and properties. " +
             "Large classes tend to handle many things at once. " +
             "An interface should have one responsibility. " +

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexInterface.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexInterface.kt
@@ -35,12 +35,14 @@ class ComplexInterface(
     threshold: Int = DEFAULT_LARGE_INTERFACE_COUNT
 ) : ThresholdRule(config, threshold) {
 
-    override val issue = Issue(javaClass.simpleName, Severity.Maintainability,
-            "An interface contains too many functions and properties. " +
-                    "Large classes tend to handle many things at once. " +
-                    "An interface should have one responsibility. " +
-                    "Split up large interfaces into smaller ones that are easier to understand.",
-            Debt.TWENTY_MINS)
+    override val issue = Issue(
+        javaClass.simpleName, Severity.Maintainability,
+        "An interface contains too many functions and properties. " +
+            "Large classes tend to handle many things at once. " +
+            "An interface should have one responsibility. " +
+            "Split up large interfaces into smaller ones that are easier to understand.",
+        Debt.TWENTY_MINS
+    )
 
     private val includeStaticDeclarations = valueOrDefault(INCLUDE_STATIC_DECLARATIONS, false)
     private val includePrivateDeclarations = valueOrDefault(INCLUDE_PRIVATE_DECLARATIONS, false)
@@ -54,10 +56,12 @@ class ComplexInterface(
             }
             if (size >= threshold) {
                 report(
-                    ThresholdedCodeSmell(issue,
+                    ThresholdedCodeSmell(
+                        issue,
                         Entity.atName(klass),
                         Metric("SIZE: ", size, threshold),
-                        "The interface ${klass.name} is too complex. Consider splitting it up.")
+                        "The interface ${klass.name} is too complex. Consider splitting it up."
+                    )
                 )
             }
         }
@@ -71,7 +75,7 @@ class ComplexInterface(
 
     private fun calculateMembers(body: KtClassBody): Int {
         fun PsiElement.considerPrivate() = includePrivateDeclarations ||
-                this is KtTypeParameterListOwner && !this.isPrivate()
+            this is KtTypeParameterListOwner && !this.isPrivate()
 
         fun PsiElement.isMember() = this is KtNamedFunction || this is KtProperty
 

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexMethod.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexMethod.kt
@@ -52,10 +52,12 @@ class ComplexMethod(
     threshold: Int = DEFAULT_THRESHOLD_METHOD_COMPLEXITY
 ) : ThresholdRule(config, threshold) {
 
-    override val issue = Issue("ComplexMethod",
+    override val issue = Issue(
+        "ComplexMethod",
         Severity.Maintainability,
         "Prefer splitting up complex methods into smaller, easier to understand methods.",
-        Debt.TWENTY_MINS)
+        Debt.TWENTY_MINS
+    )
 
     private val ignoreSingleWhenExpression = valueOrDefault(IGNORE_SINGLE_WHEN_EXPRESSION, false)
     private val ignoreSimpleWhenEntries = valueOrDefault(IGNORE_SIMPLE_WHEN_ENTRIES, false)
@@ -81,7 +83,7 @@ class ComplexMethod(
                     Entity.atName(function),
                     Metric("MCC", complexity, threshold),
                     "The function ${function.nameAsSafeName} appears to be too complex ($complexity). " +
-                            "Defined complexity threshold for methods is set to '$threshold'"
+                        "Defined complexity threshold for methods is set to '$threshold'"
                 )
             )
         }

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LabeledExpression.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LabeledExpression.kt
@@ -63,10 +63,12 @@ import org.jetbrains.kotlin.psi.psiUtil.isExtensionDeclaration
  */
 class LabeledExpression(config: Config = Config.empty) : Rule(config) {
 
-    override val issue: Issue = Issue("LabeledExpression",
-            Severity.Maintainability,
-            "Expression with labels increase complexity and affect maintainability.",
-            Debt.TWENTY_MINS)
+    override val issue: Issue = Issue(
+        "LabeledExpression",
+        Severity.Maintainability,
+        "Expression with labels increase complexity and affect maintainability.",
+        Debt.TWENTY_MINS
+    )
 
     private val ignoredLabels = valueOrDefaultCommaSeparated(IGNORED_LABELS, emptyList())
         .map { it.removePrefix("*").removeSuffix("*") }

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LargeClass.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LargeClass.kt
@@ -30,11 +30,13 @@ class LargeClass(
     threshold: Int = DEFAULT_THRESHOLD_CLASS_LENGTH
 ) : ThresholdRule(config, threshold) {
 
-    override val issue = Issue("LargeClass",
-            Severity.Maintainability,
-            "One class should have one responsibility. Large classes tend to handle many things at once. " +
-                    "Split up large classes into smaller classes that are easier to understand.",
-            Debt.TWENTY_MINS)
+    override val issue = Issue(
+        "LargeClass",
+        Severity.Maintainability,
+        "One class should have one responsibility. Large classes tend to handle many things at once. " +
+            "Split up large classes into smaller classes that are easier to understand.",
+        Debt.TWENTY_MINS
+    )
 
     private val classToLinesCache = IdentityHashMap<KtClassOrObject, Int>()
     private val nestedClassTracking = IdentityHashMap<KtClassOrObject, HashSet<KtClassOrObject>>()
@@ -52,7 +54,8 @@ class LargeClass(
                         issue,
                         Entity.atName(clazz),
                         Metric("SIZE", lines, threshold),
-                        "Class ${clazz.name} is too large. Consider splitting it into smaller pieces.")
+                        "Class ${clazz.name} is too large. Consider splitting it into smaller pieces."
+                    )
                 )
             }
         }
@@ -62,12 +65,12 @@ class LargeClass(
         val lines = classOrObject.linesOfCode()
         classToLinesCache[classOrObject] = lines
         classOrObject.getStrictParentOfType<KtClassOrObject>()
-                ?.let { nestedClassTracking.getOrPut(it) { HashSet() }.add(classOrObject) }
+            ?.let { nestedClassTracking.getOrPut(it) { HashSet() }.add(classOrObject) }
         super.visitClassOrObject(classOrObject)
         findAllNestedClasses(classOrObject)
-                .fold(0) { acc, next -> acc + (classToLinesCache[next] ?: 0) }
-                .takeIf { it > 0 }
-                ?.let { classToLinesCache[classOrObject] = lines - it }
+            .fold(0) { acc, next -> acc + (classToLinesCache[next] ?: 0) }
+            .takeIf { it > 0 }
+            ?.let { classToLinesCache[classOrObject] = lines - it }
     }
 
     private fun findAllNestedClasses(startClass: KtClassOrObject): Sequence<KtClassOrObject> = sequence {

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongMethod.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongMethod.kt
@@ -30,11 +30,13 @@ class LongMethod(
     threshold: Int = DEFAULT_THRESHOLD_METHOD_LENGTH
 ) : ThresholdRule(config, threshold) {
 
-    override val issue = Issue("LongMethod",
-            Severity.Maintainability,
-            "One method should have one responsibility. Long methods tend to handle many things at once. " +
-                    "Prefer smaller methods to make them easier to understand.",
-            Debt.TWENTY_MINS)
+    override val issue = Issue(
+        "LongMethod",
+        Severity.Maintainability,
+        "One method should have one responsibility. Long methods tend to handle many things at once. " +
+            "Prefer smaller methods to make them easier to understand.",
+        Debt.TWENTY_MINS
+    )
 
     private val functionToLinesCache = HashMap<KtNamedFunction, Int>()
     private val functionToBodyLinesCache = HashMap<KtNamedFunction, Int>()
@@ -77,9 +79,9 @@ class LongMethod(
         parentMethods?.let { nestedFunctionTracking.getOrPut(it) { HashSet() }.add(function) }
         super.visitNamedFunction(function)
         findAllNestedFunctions(function)
-                .fold(0) { acc, next -> acc + (functionToLinesCache[next] ?: 0) }
-                .takeIf { it > 0 }
-                ?.let { functionToLinesCache[function] = lines - it }
+            .fold(0) { acc, next -> acc + (functionToLinesCache[next] ?: 0) }
+            .takeIf { it > 0 }
+            ?.let { functionToLinesCache[function] = lines - it }
     }
 
     private fun findAllNestedFunctions(startFunction: KtNamedFunction): Sequence<KtNamedFunction> = sequence {

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterList.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterList.kt
@@ -41,12 +41,14 @@ class LongParameterList(
     config: Config = Config.empty
 ) : Rule(config) {
 
-    override val issue = Issue("LongParameterList",
-            Severity.Maintainability,
-            "The more parameters a function has the more complex it is. Long parameter lists are often " +
-                    "used to control complex algorithms and violate the Single Responsibility Principle. " +
-                    "Prefer functions with short parameter lists.",
-            Debt.TWENTY_MINS)
+    override val issue = Issue(
+        "LongParameterList",
+        Severity.Maintainability,
+        "The more parameters a function has the more complex it is. Long parameter lists are often " +
+            "used to control complex algorithms and violate the Single Responsibility Principle. " +
+            "Prefer functions with short parameter lists.",
+        Debt.TWENTY_MINS
+    )
 
     private val functionThreshold: Int =
         valueOrDefault(FUNCTION_THRESHOLD, valueOrDefault(THRESHOLD, DEFAULT_FUNCTION_THRESHOLD))
@@ -105,14 +107,18 @@ class LongParameterList(
 
         if (parameterNumber >= threshold) {
             val parameterPrint = function.valueParameters.joinToString(separator = ", ") {
-                    it.nameAsSafeName.identifier + ": " + it.typeReference?.text
+                it.nameAsSafeName.identifier + ": " + it.typeReference?.text
             }
 
-            report(ThresholdedCodeSmell(issue,
+            report(
+                ThresholdedCodeSmell(
+                    issue,
                     Entity.from(parameterList),
                     Metric("SIZE", parameterNumber, threshold),
                     "The $identifier($parameterPrint) has too many parameters. " +
-                            "The current threshold is set to $threshold."))
+                        "The current threshold is set to $threshold."
+                )
+            )
         }
     }
 

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/MethodOverloading.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/MethodOverloading.kt
@@ -31,11 +31,13 @@ class MethodOverloading(
     threshold: Int = DEFAULT_THRESHOLD_OVERLOAD_COUNT
 ) : ThresholdRule(config, threshold) {
 
-    override val issue = Issue("MethodOverloading", Severity.Maintainability,
-            "Methods which are overloaded often might be harder to maintain. " +
-                    "Furthermore, these methods are tightly coupled. " +
-                    "Refactor these methods and try to use optional parameters.",
-            Debt.TWENTY_MINS)
+    override val issue = Issue(
+        "MethodOverloading", Severity.Maintainability,
+        "Methods which are overloaded often might be harder to maintain. " +
+            "Furthermore, these methods are tightly coupled. " +
+            "Refactor these methods and try to use optional parameters.",
+        Debt.TWENTY_MINS
+    )
 
     override fun visitKtFile(file: KtFile) {
         val visitor = OverloadedMethodVisitor()

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/MethodOverloading.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/MethodOverloading.kt
@@ -32,7 +32,8 @@ class MethodOverloading(
 ) : ThresholdRule(config, threshold) {
 
     override val issue = Issue(
-        "MethodOverloading", Severity.Maintainability,
+        "MethodOverloading",
+        Severity.Maintainability,
         "Methods which are overloaded often might be harder to maintain. " +
             "Furthermore, these methods are tightly coupled. " +
             "Refactor these methods and try to use optional parameters.",

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NamedArguments.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NamedArguments.kt
@@ -37,7 +37,8 @@ class NamedArguments(
 ) : ThresholdRule(config, threshold) {
 
     override val issue = Issue(
-        "NamedArguments", Severity.Maintainability,
+        "NamedArguments",
+        Severity.Maintainability,
         "Function invocation with more than $threshold parameters must all be named",
         Debt.FIVE_MINS
     )

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedBlockDepth.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedBlockDepth.kt
@@ -34,11 +34,13 @@ class NestedBlockDepth(
     threshold: Int = DEFAULT_THRESHOLD_NESTING
 ) : ThresholdRule(config, threshold) {
 
-    override val issue = Issue("NestedBlockDepth",
-            Severity.Maintainability,
-            "Excessive nesting leads to hidden complexity. " +
-                    "Prefer extracting code to make it easier to understand.",
-            Debt.TWENTY_MINS)
+    override val issue = Issue(
+        "NestedBlockDepth",
+        Severity.Maintainability,
+        "Excessive nesting leads to hidden complexity. " +
+            "Prefer extracting code to make it easier to understand.",
+        Debt.TWENTY_MINS
+    )
 
     override fun visitNamedFunction(function: KtNamedFunction) {
         val visitor = FunctionDepthVisitor(threshold)

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ReplaceSafeCallChainWithRun.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ReplaceSafeCallChainWithRun.kt
@@ -67,8 +67,6 @@ class ReplaceSafeCallChainWithRun(config: Config = Config.empty) : Rule(config) 
             receiver = receiver.receiverExpression
         }
 
-        if (counter >= 1) report(
-            CodeSmell(issue, Entity.from(expression), issue.description)
-        )
+        if (counter >= 1) report(CodeSmell(issue, Entity.from(expression), issue.description))
     }
 }

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ReplaceSafeCallChainWithRun.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ReplaceSafeCallChainWithRun.kt
@@ -43,7 +43,8 @@ import org.jetbrains.kotlin.types.isNullable
 class ReplaceSafeCallChainWithRun(config: Config = Config.empty) : Rule(config) {
 
     override val issue = Issue(
-        javaClass.simpleName, Severity.Maintainability,
+        javaClass.simpleName,
+        Severity.Maintainability,
         "Chains of safe calls on non-nullable types can be surrounded with run {}",
         Debt.TEN_MINS
     )

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/StringLiteralDuplication.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/StringLiteralDuplication.kt
@@ -69,11 +69,14 @@ class StringLiteralDuplication(
         val type = "SIZE: "
         for ((name, value) in visitor.getLiteralsOverThreshold()) {
             val (main, references) = visitor.entitiesForLiteral(name)
-            report(ThresholdedCodeSmell(issue,
-                main,
-                Metric(type + name, value, threshold),
-                issue.description,
-                references)
+            report(
+                ThresholdedCodeSmell(
+                    issue,
+                    main,
+                    Metric(type + name, value, threshold),
+                    issue.description,
+                    references
+                )
             )
         }
     }

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/TooManyFunctions.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/TooManyFunctions.kt
@@ -37,12 +37,14 @@ import org.jetbrains.kotlin.psi.psiUtil.isPrivate
  */
 class TooManyFunctions(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue("TooManyFunctions",
-            Severity.Maintainability,
-            "Too many functions inside a/an file/class/object/interface always indicate a violation of " +
-                    "the single responsibility principle. Maybe the file/class/object/interface wants to manage too " +
-                    "many things at once. Extract functionality which clearly belongs together.",
-            Debt.TWENTY_MINS)
+    override val issue = Issue(
+        "TooManyFunctions",
+        Severity.Maintainability,
+        "Too many functions inside a/an file/class/object/interface always indicate a violation of " +
+            "the single responsibility principle. Maybe the file/class/object/interface wants to manage too " +
+            "many things at once. Extract functionality which clearly belongs together.",
+        Debt.TWENTY_MINS
+    )
 
     private val thresholdInFiles = valueOrDefault(THRESHOLD_IN_FILES, DEFAULT_THRESHOLD)
     private val thresholdInClasses = valueOrDefault(THRESHOLD_IN_CLASSES, DEFAULT_THRESHOLD)
@@ -58,11 +60,15 @@ class TooManyFunctions(config: Config = Config.empty) : Rule(config) {
     override fun visitKtFile(file: KtFile) {
         super.visitKtFile(file)
         if (amountOfTopLevelFunctions >= thresholdInFiles) {
-            report(ThresholdedCodeSmell(issue,
+            report(
+                ThresholdedCodeSmell(
+                    issue,
                     Entity.atPackageOrFirstDecl(file),
                     Metric("SIZE", amountOfTopLevelFunctions, thresholdInFiles),
                     "File '${file.name}' with '$amountOfTopLevelFunctions' functions detected. " +
-                            "Defined threshold inside files is set to '$thresholdInFiles'"))
+                        "Defined threshold inside files is set to '$thresholdInFiles'"
+                )
+            )
         }
         amountOfTopLevelFunctions = 0
     }
@@ -78,31 +84,43 @@ class TooManyFunctions(config: Config = Config.empty) : Rule(config) {
         when {
             klass.isInterface() -> {
                 if (amount >= thresholdInInterfaces) {
-                    report(ThresholdedCodeSmell(issue,
-                        Entity.atName(klass),
-                        Metric("SIZE", amount, thresholdInInterfaces),
-                        "Interface '${klass.name}' with '$amount' functions detected. " +
+                    report(
+                        ThresholdedCodeSmell(
+                            issue,
+                            Entity.atName(klass),
+                            Metric("SIZE", amount, thresholdInInterfaces),
+                            "Interface '${klass.name}' with '$amount' functions detected. " +
                                 "Defined threshold inside interfaces is set to " +
-                                "'$thresholdInInterfaces'"))
+                                "'$thresholdInInterfaces'"
+                        )
+                    )
                 }
             }
             klass.isEnum() -> {
                 if (amount >= thresholdInEnums) {
-                    report(ThresholdedCodeSmell(issue,
-                        Entity.atName(klass),
-                        Metric("SIZE", amount, thresholdInEnums),
-                        "Enum class '${klass.name}' with '$amount' functions detected. " +
+                    report(
+                        ThresholdedCodeSmell(
+                            issue,
+                            Entity.atName(klass),
+                            Metric("SIZE", amount, thresholdInEnums),
+                            "Enum class '${klass.name}' with '$amount' functions detected. " +
                                 "Defined threshold inside enum classes is set to " +
-                                "'$thresholdInEnums'"))
+                                "'$thresholdInEnums'"
+                        )
+                    )
                 }
             }
             else -> {
                 if (amount >= thresholdInClasses) {
-                    report(ThresholdedCodeSmell(issue,
+                    report(
+                        ThresholdedCodeSmell(
+                            issue,
                             Entity.atName(klass),
                             Metric("SIZE", amount, thresholdInClasses),
                             "Class '${klass.name}' with '$amount' functions detected. " +
-                                    "Defined threshold inside classes is set to '$thresholdInClasses'"))
+                                "Defined threshold inside classes is set to '$thresholdInClasses'"
+                        )
+                    )
                 }
             }
         }
@@ -112,11 +130,15 @@ class TooManyFunctions(config: Config = Config.empty) : Rule(config) {
     override fun visitObjectDeclaration(declaration: KtObjectDeclaration) {
         val amount = calcFunctions(declaration)
         if (amount >= thresholdInObjects) {
-            report(ThresholdedCodeSmell(issue,
+            report(
+                ThresholdedCodeSmell(
+                    issue,
                     Entity.from(declaration.nameIdentifier ?: declaration),
                     Metric("SIZE", amount, thresholdInObjects),
                     "Object '${declaration.name}' with '$amount' functions detected. " +
-                            "Defined threshold inside objects is set to '$thresholdInObjects'"))
+                        "Defined threshold inside objects is set to '$thresholdInObjects'"
+                )
+            )
         }
         super.visitObjectDeclaration(declaration)
     }

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexMethodSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexMethodSpec.kt
@@ -19,30 +19,35 @@ class ComplexMethodSpec : Spek({
         context("different complex constructs") {
 
             it("counts different loops") {
-                val findings = ComplexMethod(threshold = 1).compileAndLint("""
+                val findings = ComplexMethod(threshold = 1).compileAndLint(
+                    """
                     fun test() {
                         for (i in 1..10) {}
                         while (true) {}
                         do {} while(true)
                         (1..10).forEach {}
                     }
-                """)
+                """
+                )
 
                 assertThat(findings.first()).isThresholded().withValue(defaultComplexity + 4)
             }
 
             it("counts catch blocks") {
-                val findings = ComplexMethod(threshold = 1).compileAndLint("""
+                val findings = ComplexMethod(threshold = 1).compileAndLint(
+                    """
                     fun test() {
                         try {} catch(e: IllegalArgumentException) {} catch(e: Exception) {} finally {}
                     }
-                """)
+                """
+                )
 
                 assertThat(findings.first()).isThresholded().withValue(defaultComplexity + 2)
             }
 
             it("counts nested conditional statements") {
-                val findings = ComplexMethod(threshold = 1).compileAndLint("""
+                val findings = ComplexMethod(threshold = 1).compileAndLint(
+                    """
                     fun test() {
                         try {
                             while (true) {
@@ -57,7 +62,8 @@ class ComplexMethodSpec : Spek({
                             // only catches count
                         }
                     }
-                """)
+                """
+                )
 
                 assertThat(findings.first()).isThresholded().withValue(defaultComplexity + 4)
             }
@@ -103,8 +109,11 @@ class ComplexMethodSpec : Spek({
             val path = resourceAsPath("ComplexMethods.kt")
 
             it("does not report complex methods with a single when expression") {
-                val config = TestConfig(mapOf(
-                    ComplexMethod.IGNORE_SINGLE_WHEN_EXPRESSION to "true"))
+                val config = TestConfig(
+                    mapOf(
+                        ComplexMethod.IGNORE_SINGLE_WHEN_EXPRESSION to "true"
+                    )
+                )
                 val subject = ComplexMethod(config, threshold = 4)
 
                 assertThat(subject.lint(path)).hasSourceLocations(SourceLocation(43, 5))

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterListSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterListSpec.kt
@@ -10,10 +10,12 @@ class LongParameterListSpec : Spek({
 
     val defaultThreshold = 2
     val defaultConfig by memoized {
-        TestConfig(mapOf(
-            LongParameterList.FUNCTION_THRESHOLD to defaultThreshold,
-            LongParameterList.CONSTRUCTOR_THRESHOLD to defaultThreshold
-        ))
+        TestConfig(
+            mapOf(
+                LongParameterList.FUNCTION_THRESHOLD to defaultThreshold,
+                LongParameterList.CONSTRUCTOR_THRESHOLD to defaultThreshold
+            )
+        )
     }
 
     val subject by memoized { LongParameterList(defaultConfig) }
@@ -81,10 +83,12 @@ class LongParameterListSpec : Spek({
         }
 
         it("does not report long parameter list for constructors of data classes if asked") {
-            val config = TestConfig(mapOf(
-                LongParameterList.IGNORE_DATA_CLASSES to "true",
-                LongParameterList.CONSTRUCTOR_THRESHOLD to "1"
-            ))
+            val config = TestConfig(
+                mapOf(
+                    LongParameterList.IGNORE_DATA_CLASSES to "true",
+                    LongParameterList.CONSTRUCTOR_THRESHOLD to "1"
+                )
+            )
             val rule = LongParameterList(config)
             val code = "data class Data(val a: Int)"
             assertThat(rule.compileAndLint(code)).isEmpty()
@@ -93,11 +97,13 @@ class LongParameterListSpec : Spek({
         describe("constructors and functions with ignored annotations") {
 
             val config by memoized {
-                TestConfig(mapOf(
-                    LongParameterList.IGNORE_ANNOTATED to listOf("Generated", "kotlin.Deprecated", "kotlin.jvm.JvmName"),
-                    LongParameterList.FUNCTION_THRESHOLD to 1,
-                    LongParameterList.CONSTRUCTOR_THRESHOLD to 1
-                ))
+                TestConfig(
+                    mapOf(
+                        LongParameterList.IGNORE_ANNOTATED to listOf("Generated", "kotlin.Deprecated", "kotlin.jvm.JvmName"),
+                        LongParameterList.FUNCTION_THRESHOLD to 1,
+                        LongParameterList.CONSTRUCTOR_THRESHOLD to 1
+                    )
+                )
             }
 
             val rule by memoized { LongParameterList(config) }

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/MethodOverloadingSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/MethodOverloadingSpec.kt
@@ -36,11 +36,13 @@ class MethodOverloadingSpec : Spek({
             }
 
             it("does not report overloaded methods which do not exceed the threshold") {
-                subject.compileAndLint("""
+                subject.compileAndLint(
+                    """
                 class Test {
                     fun x() { }
                     fun x(i: Int) { }
-                }""")
+                }"""
+                )
                 assertThat(subject.findings.size).isZero()
             }
         }
@@ -48,18 +50,22 @@ class MethodOverloadingSpec : Spek({
         context("several overloaded extensions methods") {
 
             it("does not report extension methods with a different receiver") {
-                subject.compileAndLint("""
+                subject.compileAndLint(
+                    """
                 fun Boolean.foo() {}
                 fun Int.foo() {}
-                fun Long.foo() {}""")
+                fun Long.foo() {}"""
+                )
                 assertThat(subject.findings.size).isZero()
             }
 
             it("reports extension methods with the same receiver") {
-                subject.compileAndLint("""
+                subject.compileAndLint(
+                    """
                 fun Int.foo() {}
                 fun Int.foo(i: Int) {}
-                fun Int.foo(i: String) {}""")
+                fun Int.foo(i: String) {}"""
+                )
                 assertThat(subject.findings.size).isEqualTo(1)
             }
         }

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/StringLiteralDuplicationSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/StringLiteralDuplicationSpec.kt
@@ -86,8 +86,8 @@ class StringLiteralDuplicationSpec : Spek({
 
             it("should not fail with invalid regex when disabled") {
                 val configValues = mapOf(
-                        "active" to "false",
-                        StringLiteralDuplication.IGNORE_STRINGS_REGEX to "*lorem"
+                    "active" to "false",
+                    StringLiteralDuplication.IGNORE_STRINGS_REGEX to "*lorem"
                 )
                 val config = TestConfig(configValues)
                 assertFindingWithConfig(regexTestingCode, config, 0)

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/TooManyFunctionsSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/TooManyFunctionsSpec.kt
@@ -11,13 +11,17 @@ class TooManyFunctionsSpec : Spek({
     describe("different declarations with one function as threshold") {
 
         val rule by memoized {
-            TooManyFunctions(TestConfig(mapOf(
-                TooManyFunctions.THRESHOLD_IN_CLASSES to "1",
-                TooManyFunctions.THRESHOLD_IN_ENUMS to "1",
-                TooManyFunctions.THRESHOLD_IN_FILES to "1",
-                TooManyFunctions.THRESHOLD_IN_INTERFACES to "1",
-                TooManyFunctions.THRESHOLD_IN_OBJECTS to "1"
-            )))
+            TooManyFunctions(
+                TestConfig(
+                    mapOf(
+                        TooManyFunctions.THRESHOLD_IN_CLASSES to "1",
+                        TooManyFunctions.THRESHOLD_IN_ENUMS to "1",
+                        TooManyFunctions.THRESHOLD_IN_FILES to "1",
+                        TooManyFunctions.THRESHOLD_IN_INTERFACES to "1",
+                        TooManyFunctions.THRESHOLD_IN_OBJECTS to "1"
+                    )
+                )
+            )
         }
 
         it("finds one function in class") {
@@ -121,11 +125,15 @@ class TooManyFunctionsSpec : Spek({
             }
 
             it("finds no deprecated functions") {
-                val configuredRule = TooManyFunctions(TestConfig(mapOf(
-                    TooManyFunctions.THRESHOLD_IN_CLASSES to "1",
-                    TooManyFunctions.THRESHOLD_IN_FILES to "1",
-                    TooManyFunctions.IGNORE_DEPRECATED to "true"
-                )))
+                val configuredRule = TooManyFunctions(
+                    TestConfig(
+                        mapOf(
+                            TooManyFunctions.THRESHOLD_IN_CLASSES to "1",
+                            TooManyFunctions.THRESHOLD_IN_FILES to "1",
+                            TooManyFunctions.IGNORE_DEPRECATED to "true"
+                        )
+                    )
+                )
                 assertThat(configuredRule.compileAndLint(code)).isEmpty()
             }
         }
@@ -143,11 +151,15 @@ class TooManyFunctionsSpec : Spek({
             }
 
             it("finds no private functions") {
-                val configuredRule = TooManyFunctions(TestConfig(mapOf(
-                    TooManyFunctions.THRESHOLD_IN_CLASSES to "1",
-                    TooManyFunctions.THRESHOLD_IN_FILES to "1",
-                    TooManyFunctions.IGNORE_PRIVATE to "true"
-                )))
+                val configuredRule = TooManyFunctions(
+                    TestConfig(
+                        mapOf(
+                            TooManyFunctions.THRESHOLD_IN_CLASSES to "1",
+                            TooManyFunctions.THRESHOLD_IN_FILES to "1",
+                            TooManyFunctions.IGNORE_PRIVATE to "true"
+                        )
+                    )
+                )
                 assertThat(configuredRule.compileAndLint(code)).isEmpty()
             }
         }
@@ -173,13 +185,17 @@ class TooManyFunctionsSpec : Spek({
                         override fun b() = Unit
                     }
                 """
-                val configuredRule = TooManyFunctions(TestConfig(mapOf(
-                    TooManyFunctions.THRESHOLD_IN_CLASSES to "1",
-                    TooManyFunctions.THRESHOLD_IN_FILES to "1",
-                    TooManyFunctions.IGNORE_PRIVATE to "true",
-                    TooManyFunctions.IGNORE_DEPRECATED to "true",
-                    TooManyFunctions.IGNORE_OVERRIDDEN to "true"
-                )))
+                val configuredRule = TooManyFunctions(
+                    TestConfig(
+                        mapOf(
+                            TooManyFunctions.THRESHOLD_IN_CLASSES to "1",
+                            TooManyFunctions.THRESHOLD_IN_FILES to "1",
+                            TooManyFunctions.IGNORE_PRIVATE to "true",
+                            TooManyFunctions.IGNORE_DEPRECATED to "true",
+                            TooManyFunctions.IGNORE_OVERRIDDEN to "true"
+                        )
+                    )
+                )
                 assertThat(configuredRule.compileAndLint(code)).isEmpty()
             }
         }
@@ -199,20 +215,28 @@ class TooManyFunctionsSpec : Spek({
                 """
 
             it("should not report class with overridden functions, if ignoreOverridden is enabled") {
-                val configuredRule = TooManyFunctions(TestConfig(mapOf(
-                    TooManyFunctions.THRESHOLD_IN_CLASSES to "1",
-                    TooManyFunctions.THRESHOLD_IN_FILES to "1",
-                    TooManyFunctions.IGNORE_OVERRIDDEN to "true"
-                )))
+                val configuredRule = TooManyFunctions(
+                    TestConfig(
+                        mapOf(
+                            TooManyFunctions.THRESHOLD_IN_CLASSES to "1",
+                            TooManyFunctions.THRESHOLD_IN_FILES to "1",
+                            TooManyFunctions.IGNORE_OVERRIDDEN to "true"
+                        )
+                    )
+                )
                 assertThat(configuredRule.compileAndLint(code)).isEmpty()
             }
 
             it("should count overridden functions, if ignoreOverridden is disabled") {
-                val configuredRule = TooManyFunctions(TestConfig(mapOf(
-                    TooManyFunctions.THRESHOLD_IN_CLASSES to "1",
-                    TooManyFunctions.THRESHOLD_IN_FILES to "1",
-                    TooManyFunctions.IGNORE_OVERRIDDEN to "false"
-                )))
+                val configuredRule = TooManyFunctions(
+                    TestConfig(
+                        mapOf(
+                            TooManyFunctions.THRESHOLD_IN_CLASSES to "1",
+                            TooManyFunctions.THRESHOLD_IN_FILES to "1",
+                            TooManyFunctions.IGNORE_OVERRIDDEN to "false"
+                        )
+                    )
+                )
                 assertThat(configuredRule.compileAndLint(code)).hasSize(1)
             }
         }

--- a/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/GlobalCoroutineUsage.kt
+++ b/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/GlobalCoroutineUsage.kt
@@ -49,7 +49,8 @@ class GlobalCoroutineUsage(config: Config = Config.empty) : Rule(config) {
 
     override fun visitDotQualifiedExpression(expression: KtDotQualifiedExpression) {
         if (expression.receiverExpression.text == "GlobalScope" &&
-            expression.getCalleeExpressionIfAny()?.text in listOf("launch", "async")) {
+            expression.getCalleeExpressionIfAny()?.text in listOf("launch", "async")
+        ) {
             report(CodeSmell(issue, Entity.from(expression), MESSAGE))
         }
 

--- a/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/AbsentOrWrongFileLicense.kt
+++ b/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/AbsentOrWrongFileLicense.kt
@@ -47,9 +47,11 @@ class AbsentOrWrongFileLicense(config: Config = Config.empty) : Rule(config) {
     }
 
     private fun KtFile.hasValidLicense(): Boolean =
-        if (hasLicenseHeaderRegex()) getLicenseHeaderRegex().find(text)?.range?.start == 0 else text.startsWith(
-            getLicenseHeader()
-        )
+        if (hasLicenseHeaderRegex()) {
+            getLicenseHeaderRegex().find(text)?.range?.start == 0
+        } else {
+            text.startsWith(getLicenseHeader())
+        }
 
     companion object {
         const val PARAM_LICENSE_TEMPLATE_FILE = "licenseTemplateFile"

--- a/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/AbsentOrWrongFileLicense.kt
+++ b/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/AbsentOrWrongFileLicense.kt
@@ -36,11 +36,13 @@ class AbsentOrWrongFileLicense(config: Config = Config.empty) : Rule(config) {
 
     override fun visitKtFile(file: KtFile) {
         if (!file.hasValidLicense()) {
-            report(CodeSmell(
-                issue,
-                Entity.atPackageOrFirstDecl(file),
-                "Expected license not found or incorrect in the file: ${file.name}."
-            ))
+            report(
+                CodeSmell(
+                    issue,
+                    Entity.atPackageOrFirstDecl(file),
+                    "Expected license not found or incorrect in the file: ${file.name}."
+                )
+            )
         }
     }
 

--- a/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentOverPrivateFunction.kt
+++ b/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentOverPrivateFunction.kt
@@ -21,12 +21,14 @@ import org.jetbrains.kotlin.psi.KtNamedFunction
  */
 class CommentOverPrivateFunction(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue("CommentOverPrivateFunction",
-            Severity.Maintainability,
-            "Comments for private functions should be avoided. " +
-                    "Prefer giving the function an expressive name. " +
-                    "Split it up in smaller, self-explaining functions if necessary.",
-            Debt.TWENTY_MINS)
+    override val issue = Issue(
+        "CommentOverPrivateFunction",
+        Severity.Maintainability,
+        "Comments for private functions should be avoided. " +
+            "Prefer giving the function an expressive name. " +
+            "Split it up in smaller, self-explaining functions if necessary.",
+        Debt.TWENTY_MINS
+    )
 
     override fun visitNamedFunction(function: KtNamedFunction) {
         if (function.hasCommentInPrivateMember()) {
@@ -36,7 +38,8 @@ class CommentOverPrivateFunction(config: Config = Config.empty) : Rule(config) {
                     Entity.atName(function),
                     "The function ${function.nameAsSafeName} " +
                         "has a comment. Prefer renaming the function giving it a more self-explanatory name."
-                ))
+                )
+            )
         }
     }
 }

--- a/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentOverPrivateProperty.kt
+++ b/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentOverPrivateProperty.kt
@@ -21,10 +21,12 @@ import org.jetbrains.kotlin.psi.KtProperty
  */
 class CommentOverPrivateProperty(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue("CommentOverPrivateProperty",
-            Severity.Maintainability,
-            "Private properties should be named such that they explain themselves even without a comment.",
-            Debt.TWENTY_MINS)
+    override val issue = Issue(
+        "CommentOverPrivateProperty",
+        Severity.Maintainability,
+        "Private properties should be named such that they explain themselves even without a comment.",
+        Debt.TWENTY_MINS
+    )
 
     override fun visitProperty(property: KtProperty) {
         if (property.hasCommentInPrivateMember()) {

--- a/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/EndOfSentenceFormat.kt
+++ b/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/EndOfSentenceFormat.kt
@@ -55,7 +55,8 @@ class EndOfSentenceFormat(config: Config = Config.empty) : Rule(config) {
             if (!endOfSentenceFormat.containsMatchIn(text) && !text.lastArgumentMatchesUrl()) {
                 report(
                     CodeSmell(
-                        issue, Entity.from(declaration),
+                        issue,
+                        Entity.from(declaration),
                         "The first sentence of this KDoc does not end with the correct punctuation."
                     )
                 )

--- a/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/EndOfSentenceFormat.kt
+++ b/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/EndOfSentenceFormat.kt
@@ -16,7 +16,7 @@ class KDocStyle(config: Config = Config.empty) : MultiRule() {
     private val endOfSentenceFormat = EndOfSentenceFormat(config)
 
     override val rules = listOf(
-            endOfSentenceFormat
+        endOfSentenceFormat
     )
 
     override fun visitDeclaration(dcl: KtDeclaration) {
@@ -35,13 +35,15 @@ class KDocStyle(config: Config = Config.empty) : MultiRule() {
 @Suppress("MemberNameEqualsClassName")
 class EndOfSentenceFormat(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue(javaClass.simpleName,
-            Severity.Maintainability,
-            "The first sentence in a KDoc comment should end with correct punctuation.",
-            Debt.FIVE_MINS)
+    override val issue = Issue(
+        javaClass.simpleName,
+        Severity.Maintainability,
+        "The first sentence in a KDoc comment should end with correct punctuation.",
+        Debt.FIVE_MINS
+    )
 
     private val endOfSentenceFormat =
-            Regex(valueOrDefault(END_OF_SENTENCE_FORMAT, "([.?!][ \\t\\n\\r\\f<])|([.?!:]\$)"))
+        Regex(valueOrDefault(END_OF_SENTENCE_FORMAT, "([.?!][ \\t\\n\\r\\f<])|([.?!:]\$)"))
     private val htmlTag = Regex("<.+>")
 
     fun verify(declaration: KtDeclaration) {
@@ -51,8 +53,12 @@ class EndOfSentenceFormat(config: Config = Config.empty) : Rule(config) {
                 return
             }
             if (!endOfSentenceFormat.containsMatchIn(text) && !text.lastArgumentMatchesUrl()) {
-                report(CodeSmell(issue, Entity.from(declaration),
-                        "The first sentence of this KDoc does not end with the correct punctuation."))
+                report(
+                    CodeSmell(
+                        issue, Entity.from(declaration),
+                        "The first sentence of this KDoc does not end with the correct punctuation."
+                    )
+                )
             }
         }
     }

--- a/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/LicenceHeaderLoaderExtension.kt
+++ b/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/LicenceHeaderLoaderExtension.kt
@@ -54,7 +54,7 @@ class LicenceHeaderLoaderExtension : FileProcessListener {
                 """
                 Rule '$RULE_NAME': License template file not found at `${templateFile.toAbsolutePath()}`.
                 Create file license header file or check your running path.
-            """.trimIndent()
+                """.trimIndent()
             }
 
             return Files.newBufferedReader(templateFile)

--- a/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicClass.kt
+++ b/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicClass.kt
@@ -28,10 +28,12 @@ import org.jetbrains.kotlin.psi.KtObjectDeclaration
  */
 class UndocumentedPublicClass(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue(javaClass.simpleName,
-            Severity.Maintainability,
-            "Public classes, interfaces and objects require documentation.",
-            Debt.TWENTY_MINS)
+    override val issue = Issue(
+        javaClass.simpleName,
+        Severity.Maintainability,
+        "Public classes, interfaces and objects require documentation.",
+        Debt.TWENTY_MINS
+    )
 
     private val searchInNestedClass = valueOrDefault(SEARCH_IN_NESTED_CLASS, true)
     private val searchInInnerClass = valueOrDefault(SEARCH_IN_INNER_CLASS, true)
@@ -62,7 +64,8 @@ class UndocumentedPublicClass(config: Config = Config.empty) : Rule(config) {
     private fun reportIfUndocumented(element: KtClassOrObject) {
         if (isPublicAndPublicInherited(element) &&
             element.notEnumEntry() &&
-            element.docComment == null) {
+            element.docComment == null
+        ) {
             report(
                 CodeSmell(
                     issue,
@@ -77,7 +80,7 @@ class UndocumentedPublicClass(config: Config = Config.empty) : Rule(config) {
         element.isPublicInherited() && element.isPublicNotOverridden()
 
     private fun KtObjectDeclaration.isCompanionWithoutName() =
-            isCompanion() && nameAsSafeName.asString() == "Companion"
+        isCompanion() && nameAsSafeName.asString() == "Companion"
 
     private fun KtClass.isNestedClass() = !isInterface() && !isTopLevel() && !isInner() && searchInNestedClass
 

--- a/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicFunction.kt
+++ b/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicFunction.kt
@@ -19,9 +19,11 @@ import org.jetbrains.kotlin.psi.psiUtil.isPublic
  */
 class UndocumentedPublicFunction(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue(javaClass.simpleName,
+    override val issue = Issue(
+        javaClass.simpleName,
         Severity.Maintainability,
-        "Public functions require documentation.", Debt.TWENTY_MINS)
+        "Public functions require documentation.", Debt.TWENTY_MINS
+    )
 
     override fun visitNamedFunction(function: KtNamedFunction) {
         if (function.funKeyword == null && function.isLocal) return

--- a/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicFunction.kt
+++ b/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicFunction.kt
@@ -22,7 +22,8 @@ class UndocumentedPublicFunction(config: Config = Config.empty) : Rule(config) {
     override val issue = Issue(
         javaClass.simpleName,
         Severity.Maintainability,
-        "Public functions require documentation.", Debt.TWENTY_MINS
+        "Public functions require documentation.",
+        Debt.TWENTY_MINS
     )
 
     override fun visitNamedFunction(function: KtNamedFunction) {

--- a/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicProperty.kt
+++ b/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicProperty.kt
@@ -25,9 +25,11 @@ import org.jetbrains.kotlin.psi.psiUtil.isPublic
  */
 class UndocumentedPublicProperty(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue(javaClass.simpleName,
-            Severity.Maintainability,
-            "Public properties require documentation.", Debt.TWENTY_MINS)
+    override val issue = Issue(
+        javaClass.simpleName,
+        Severity.Maintainability,
+        "Public properties require documentation.", Debt.TWENTY_MINS
+    )
 
     override fun visitPrimaryConstructor(constructor: KtPrimaryConstructor) {
         if (constructor.isPublicInherited()) {

--- a/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicProperty.kt
+++ b/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicProperty.kt
@@ -28,7 +28,8 @@ class UndocumentedPublicProperty(config: Config = Config.empty) : Rule(config) {
     override val issue = Issue(
         javaClass.simpleName,
         Severity.Maintainability,
-        "Public properties require documentation.", Debt.TWENTY_MINS
+        "Public properties require documentation.",
+        Debt.TWENTY_MINS
     )
 
     override fun visitPrimaryConstructor(constructor: KtPrimaryConstructor) {

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/AbsentOrWrongFileLicenseSpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/AbsentOrWrongFileLicenseSpec.kt
@@ -23,10 +23,12 @@ internal class AbsentOrWrongFileLicenseSpec : Spek({
         context("file with correct license header") {
 
             it("reports nothing") {
-                val findings = checkLicence("""
+                val findings = checkLicence(
+                    """
                     /* LICENSE */
                     package cases
-                """)
+                """
+                )
 
                 assertThat(findings).isEmpty()
             }
@@ -35,10 +37,12 @@ internal class AbsentOrWrongFileLicenseSpec : Spek({
         context("file with incorrect license header") {
 
             it("reports missed license header") {
-                val findings = checkLicence("""
+                val findings = checkLicence(
+                    """
                     /* WRONG LICENSE */
                     package cases
-                """)
+                """
+                )
 
                 assertThat(findings).hasSize(1)
             }
@@ -47,9 +51,11 @@ internal class AbsentOrWrongFileLicenseSpec : Spek({
         context("file with absent license header") {
 
             it("reports missed license header") {
-                val findings = checkLicence("""
+                val findings = checkLicence(
+                    """
                     package cases
-                """)
+                """
+                )
 
                 assertThat(findings).hasSize(1)
             }
@@ -58,7 +64,8 @@ internal class AbsentOrWrongFileLicenseSpec : Spek({
         context("file with correct license header using regex matching") {
 
             it("reports nothing for 2016") {
-                val findings = checkLicence("""
+                val findings = checkLicence(
+                    """
                     //
                     // Copyright 2016 Artur Bosch & Contributors
                     //     http://www.apache.org/licenses/LICENSE-2.0
@@ -66,13 +73,16 @@ internal class AbsentOrWrongFileLicenseSpec : Spek({
                     // limitations under the License.
                     //
                     package cases
-                """.trimIndent(), isRegexLicense = true)
+                    """.trimIndent(),
+                    isRegexLicense = true
+                )
 
                 assertThat(findings).isEmpty()
             }
 
             it("reports nothing for 2021") {
-                val findings = checkLicence("""
+                val findings = checkLicence(
+                    """
                     //
                     // Copyright 2021 Artur Bosch & Contributors
                     //     http://www.apache.org/licenses/LICENSE-2.0
@@ -80,7 +90,9 @@ internal class AbsentOrWrongFileLicenseSpec : Spek({
                     // limitations under the License.
                     //
                     package cases
-                """.trimIndent(), isRegexLicense = true)
+                    """.trimIndent(),
+                    isRegexLicense = true
+                )
 
                 assertThat(findings).isEmpty()
             }
@@ -89,15 +101,19 @@ internal class AbsentOrWrongFileLicenseSpec : Spek({
         context("file with incorrect license header using regex matching") {
 
             it("file with missing license header") {
-                val findings = checkLicence("""
+                val findings = checkLicence(
+                    """
                     package cases
-                """.trimIndent(), isRegexLicense = true)
+                    """.trimIndent(),
+                    isRegexLicense = true
+                )
 
                 assertThat(findings).hasSize(1)
             }
 
             it("file with license header not on the first line") {
-                val findings = checkLicence("""
+                val findings = checkLicence(
+                    """
                     package cases
                     //
                     // Copyright 2021 Artur Bosch & Contributors
@@ -105,24 +121,30 @@ internal class AbsentOrWrongFileLicenseSpec : Spek({
                     // See the License for the specific language governing permissions and
                     // limitations under the License.
                     //
-                """.trimIndent(), isRegexLicense = true)
+                    """.trimIndent(),
+                    isRegexLicense = true
+                )
 
                 assertThat(findings).hasSize(1)
             }
 
             it("file with incomplete license header") {
-                val findings = checkLicence("""
+                val findings = checkLicence(
+                    """
                     //
                     // Copyright 2021 Artur Bosch & Contributors
                     //
                     package cases
-                """.trimIndent(), isRegexLicense = true)
+                    """.trimIndent(),
+                    isRegexLicense = true
+                )
 
                 assertThat(findings).hasSize(1)
             }
 
             it("file with too many empty likes in license header") {
-                val findings = checkLicence("""
+                val findings = checkLicence(
+                    """
                     //
                     //
                     // Copyright 2021 Artur Bosch & Contributors
@@ -131,13 +153,16 @@ internal class AbsentOrWrongFileLicenseSpec : Spek({
                     // limitations under the License.
                     //
                     package cases
-                """.trimIndent(), isRegexLicense = true)
+                    """.trimIndent(),
+                    isRegexLicense = true
+                )
 
                 assertThat(findings).hasSize(1)
             }
 
             it("file with incorrect year in license header") {
-                val findings = checkLicence("""
+                val findings = checkLicence(
+                    """
                     //
                     // Copyright 202 Artur Bosch & Contributors
                     //     http://www.apache.org/licenses/LICENSE-2.0
@@ -145,7 +170,9 @@ internal class AbsentOrWrongFileLicenseSpec : Spek({
                     // limitations under the License.
                     //
                     package cases
-                """.trimIndent(), isRegexLicense = true)
+                    """.trimIndent(),
+                    isRegexLicense = true
+                )
 
                 assertThat(findings).hasSize(1)
             }

--- a/detekt-rules-empty/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyBlocks.kt
+++ b/detekt-rules-empty/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyBlocks.kt
@@ -48,21 +48,21 @@ class EmptyBlocks(val config: Config = Config.empty) : MultiRule() {
     private val emptyWhileBlock = EmptyWhileBlock(config)
 
     override val rules: List<Rule> = listOf(
-            emptyCatchBlock,
-            emptyClassBlock,
-            emptyDefaultConstructor,
-            emptyDoWhileBlock,
-            emptyElseBlock,
-            emptyFinallyBlock,
-            emptyForBlock,
-            emptyFunctionBlock,
-            emptyIfBlock,
-            emptyInitBlock,
-            emptyKtFile,
-            emptySecondaryConstructorBlock,
-            emptyTryBlock,
-            emptyWhenBlock,
-            emptyWhileBlock
+        emptyCatchBlock,
+        emptyClassBlock,
+        emptyDefaultConstructor,
+        emptyDoWhileBlock,
+        emptyElseBlock,
+        emptyFinallyBlock,
+        emptyForBlock,
+        emptyFunctionBlock,
+        emptyIfBlock,
+        emptyInitBlock,
+        emptyKtFile,
+        emptySecondaryConstructorBlock,
+        emptyTryBlock,
+        emptyWhenBlock,
+        emptyWhileBlock
     )
 
     override fun visitKtFile(file: KtFile) {

--- a/detekt-rules-empty/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyCatchBlock.kt
+++ b/detekt-rules-empty/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyCatchBlock.kt
@@ -18,10 +18,10 @@ import org.jetbrains.kotlin.psi.KtCatchClause
 class EmptyCatchBlock(config: Config) : EmptyRule(
     config = config,
     description =
-        "Empty catch block detected. " +
+    "Empty catch block detected. " +
         "Empty catch blocks indicate that an exception is ignored and not handled.",
     codeSmellMessage =
-        "Empty catch block detected. If the exception can be safely ignored, " +
+    "Empty catch block detected. If the exception can be safely ignored, " +
         "name the exception according to one of the exemptions as per the configuration of this rule."
 ) {
 

--- a/detekt-rules-empty/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyClassBlock.kt
+++ b/detekt-rules-empty/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyClassBlock.kt
@@ -23,7 +23,8 @@ class EmptyClassBlock(config: Config) : EmptyRule(config) {
             if (body.declarations.isEmpty()) {
                 report(
                     CodeSmell(
-                        issue, Entity.from(body),
+                        issue,
+                        Entity.from(body),
                         "The class or object ${classOrObject.name} is empty."
                     )
                 )

--- a/detekt-rules-empty/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyClassBlock.kt
+++ b/detekt-rules-empty/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyClassBlock.kt
@@ -21,8 +21,12 @@ class EmptyClassBlock(config: Config) : EmptyRule(config) {
 
         classOrObject.body?.let { body ->
             if (body.declarations.isEmpty()) {
-                report(CodeSmell(issue, Entity.from(body),
-                    "The class or object ${classOrObject.name} is empty."))
+                report(
+                    CodeSmell(
+                        issue, Entity.from(body),
+                        "The class or object ${classOrObject.name} is empty."
+                    )
+                )
             }
         }
     }

--- a/detekt-rules-empty/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyDefaultConstructor.kt
+++ b/detekt-rules-empty/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyDefaultConstructor.kt
@@ -20,8 +20,9 @@ class EmptyDefaultConstructor(config: Config) : EmptyRule(config = config) {
 
     override fun visitPrimaryConstructor(constructor: KtPrimaryConstructor) {
         if (hasSuitableSignature(constructor) &&
-                isNotCalled(constructor) &&
-                !isExpectedAnnotationClass(constructor)) {
+            isNotCalled(constructor) &&
+            !isExpectedAnnotationClass(constructor)
+        ) {
             report(CodeSmell(issue, Entity.from(constructor), "An empty default constructor can be removed."))
         }
     }
@@ -38,9 +39,9 @@ class EmptyDefaultConstructor(config: Config) : EmptyRule(config = config) {
     }
 
     private fun hasSuitableSignature(constructor: KtPrimaryConstructor) =
-            hasPublicVisibility(constructor.visibilityModifierType()) &&
-                    constructor.annotationEntries.isEmpty() &&
-                    constructor.valueParameters.isEmpty()
+        hasPublicVisibility(constructor.visibilityModifierType()) &&
+            constructor.annotationEntries.isEmpty() &&
+            constructor.valueParameters.isEmpty()
 
     private fun hasPublicVisibility(visibility: KtModifierKeywordToken?): Boolean {
         return visibility == null || visibility == KtTokens.PUBLIC_KEYWORD

--- a/detekt-rules-empty/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyKtFile.kt
+++ b/detekt-rules-empty/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyKtFile.kt
@@ -14,11 +14,13 @@ class EmptyKtFile(config: Config) : EmptyRule(config) {
 
     override fun visitKtFile(file: KtFile) {
         if (file.text.isNullOrBlank()) {
-            report(CodeSmell(
-                issue,
-                Entity.atPackageOrFirstDecl(file),
-                "The empty Kotlin file ${file.name} can be removed."
-            ))
+            report(
+                CodeSmell(
+                    issue,
+                    Entity.atPackageOrFirstDecl(file),
+                    "The empty Kotlin file ${file.name} can be removed."
+                )
+            )
         }
     }
 }

--- a/detekt-rules-empty/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyRule.kt
+++ b/detekt-rules-empty/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyRule.kt
@@ -21,10 +21,12 @@ abstract class EmptyRule(
     private val codeSmellMessage: String = "This empty block of code can be removed."
 ) : Rule(config) {
 
-    override val issue = Issue(javaClass.simpleName,
-            Severity.Minor,
-            description,
-            Debt.FIVE_MINS)
+    override val issue = Issue(
+        javaClass.simpleName,
+        Severity.Minor,
+        description,
+        Debt.FIVE_MINS
+    )
 
     fun KtExpression.addFindingIfBlockExprIsEmpty() {
         checkBlockExpr(false)

--- a/detekt-rules-empty/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyBlocksMultiRuleSpec.kt
+++ b/detekt-rules-empty/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyBlocksMultiRuleSpec.kt
@@ -39,7 +39,8 @@ class EmptyBlocksMultiRuleSpec : Spek({
         }
 
         it("reports no duplicated findings - issue #1605") {
-            val findings = subject.compileAndLint("""
+            val findings = subject.compileAndLint(
+                """
                 class EmptyBlocks {
                     class EmptyClass {}
                     fun exceptionHandling() {
@@ -49,7 +50,8 @@ class EmptyBlocksMultiRuleSpec : Spek({
                         }
                     }
                 }
-            """)
+            """
+            )
             assertThat(findings).hasSize(2)
         }
     }

--- a/detekt-rules-empty/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyCodeSpec.kt
+++ b/detekt-rules-empty/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyCodeSpec.kt
@@ -1,11 +1,11 @@
 package io.gitlab.arturbosch.detekt.rules.empty
 
+import io.github.detekt.test.utils.compileForTest
+import io.github.detekt.test.utils.resourceAsPath
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.compileAndLint
-import io.github.detekt.test.utils.compileForTest
-import io.github.detekt.test.utils.resourceAsPath
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
@@ -124,8 +124,10 @@ class EmptyCodeSpec : Spek({
         }
 
         it("doesNotFailWithInvalidRegexWhenDisabled") {
-            val configValues = mapOf("active" to "false",
-                    EmptyCatchBlock.ALLOWED_EXCEPTION_NAME_REGEX to "*foo")
+            val configValues = mapOf(
+                "active" to "false",
+                EmptyCatchBlock.ALLOWED_EXCEPTION_NAME_REGEX to "*foo"
+            )
             val config = TestConfig(configValues)
             assertThat(EmptyCatchBlock(config).compileAndLint(regexTestingCode)).isEmpty()
         }

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/CastToNullableType.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/CastToNullableType.kt
@@ -44,7 +44,7 @@ class CastToNullableType(config: Config = Config.empty) : Rule(config) {
         val nullableTypeElement = expression.right?.typeElement as? KtNullableType ?: return
 
         val message = "Use the safe cast ('as? ${nullableTypeElement.innerType?.text}')" +
-                " instead of 'as ${nullableTypeElement.text}'."
+            " instead of 'as ${nullableTypeElement.text}'."
         report(CodeSmell(issue, Entity.from(expression), message))
     }
 }

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DuplicateCaseInWhenExpression.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DuplicateCaseInWhenExpression.kt
@@ -34,10 +34,12 @@ import org.jetbrains.kotlin.psi.KtWhenExpression
  */
 class DuplicateCaseInWhenExpression(config: Config) : Rule(config) {
 
-    override val issue = Issue("DuplicateCaseInWhenExpression",
-            Severity.Warning,
-            "Duplicated case statements in when expression. Both cases should be merged.",
-            Debt.TEN_MINS)
+    override val issue = Issue(
+        "DuplicateCaseInWhenExpression",
+        Severity.Warning,
+        "Duplicated case statements in when expression. Both cases should be merged.",
+        Debt.TEN_MINS
+    )
 
     override fun visitWhenExpression(expression: KtWhenExpression) {
         val distinctEntries = expression.entries.distinctBy { entry -> entry.conditions.joinToString { it.text } }
@@ -46,8 +48,12 @@ class DuplicateCaseInWhenExpression(config: Config) : Rule(config) {
             val duplicateEntries = expression.entries
                 .subtract(distinctEntries)
                 .map { entry -> entry.conditions.joinToString { it.text } }
-            report(CodeSmell(issue, Entity.from(expression),
-                "When expression has multiple case statements for ${duplicateEntries.joinToString("; ")}."))
+            report(
+                CodeSmell(
+                    issue, Entity.from(expression),
+                    "When expression has multiple case statements for ${duplicateEntries.joinToString("; ")}."
+                )
+            )
         }
     }
 }

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DuplicateCaseInWhenExpression.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DuplicateCaseInWhenExpression.kt
@@ -50,7 +50,8 @@ class DuplicateCaseInWhenExpression(config: Config) : Rule(config) {
                 .map { entry -> entry.conditions.joinToString { it.text } }
             report(
                 CodeSmell(
-                    issue, Entity.from(expression),
+                    issue,
+                    Entity.from(expression),
                     "When expression has multiple case statements for ${duplicateEntries.joinToString("; ")}."
                 )
             )

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsAlwaysReturnsTrueOrFalse.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsAlwaysReturnsTrueOrFalse.kt
@@ -40,13 +40,15 @@ import org.jetbrains.kotlin.psi.psiUtil.collectDescendantsOfType
  */
 class EqualsAlwaysReturnsTrueOrFalse(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue("EqualsAlwaysReturnsTrueOrFalse",
-            Severity.Defect,
-            "Having an equals method which always returns true or false is not a good idea. " +
-                    "It does not follow the contract of this method. " +
-                    "Consider a good default implementation. " +
-                    "For example this == other",
-            Debt.TWENTY_MINS)
+    override val issue = Issue(
+        "EqualsAlwaysReturnsTrueOrFalse",
+        Severity.Defect,
+        "Having an equals method which always returns true or false is not a good idea. " +
+            "It does not follow the contract of this method. " +
+            "Consider a good default implementation. " +
+            "For example this == other",
+        Debt.TWENTY_MINS
+    )
 
     override fun visitNamedFunction(function: KtNamedFunction) {
         if (function.isEqualsFunction() && function.returnsBooleanConstant()) {
@@ -56,7 +58,8 @@ class EqualsAlwaysReturnsTrueOrFalse(config: Config = Config.empty) : Rule(confi
                     Entity.atName(function),
                     "This equals function always returns the same " +
                         "result regardless of the input parameters."
-                ))
+                )
+            )
         }
     }
 
@@ -77,8 +80,10 @@ class EqualsAlwaysReturnsTrueOrFalse(config: Config = Config.empty) : Rule(confi
         val allReturnExpressions = bodyExpression.collectDescendantsOfType<KtReturnExpression>()
         val hasNoNestedReturnExpression = allReturnExpressions.size == returnExpressionsInBlock.size
         return lastValidReturnExpression?.isBooleanConstant() == true &&
-                (hasNoNestedReturnExpression ||
-                        allReturnExpressions.all { it.returnedExpression?.text == lastValidReturnExpression.text })
+            (
+                hasNoNestedReturnExpression ||
+                    allReturnExpressions.all { it.returnedExpression?.text == lastValidReturnExpression.text }
+                )
     }
 
     private fun PsiElement.isBooleanConstant() = node.elementType == KtNodeTypes.BOOLEAN_CONSTANT

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsWithHashCodeExist.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsWithHashCodeExist.kt
@@ -77,7 +77,8 @@ class EqualsWithHashCodeExist(config: Config = Config.empty) : Rule(config) {
         if (queue.pop().violation()) {
             report(
                 CodeSmell(
-                    issue, Entity.atName(classOrObject),
+                    issue,
+                    Entity.atName(classOrObject),
                     "A class should always override hashCode " +
                         "when overriding equals and the other way around."
                 )

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsWithHashCodeExist.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsWithHashCodeExist.kt
@@ -48,13 +48,15 @@ import java.util.ArrayDeque
  */
 class EqualsWithHashCodeExist(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue("EqualsWithHashCodeExist",
-            Severity.Defect,
-            "Always override hashCode when you override equals. " +
-                    "All hash-based collections depend on objects meeting the equals-contract. " +
-                    "Two equal objects must produce the same hashcode. When inheriting equals or hashcode, " +
-                    "override the inherited and call the super method for clarification.",
-            Debt.FIVE_MINS)
+    override val issue = Issue(
+        "EqualsWithHashCodeExist",
+        Severity.Defect,
+        "Always override hashCode when you override equals. " +
+            "All hash-based collections depend on objects meeting the equals-contract. " +
+            "Two equal objects must produce the same hashcode. When inheriting equals or hashcode, " +
+            "override the inherited and call the super method for clarification.",
+        Debt.FIVE_MINS
+    )
 
     private val queue = ArrayDeque<ViolationHolder>(MAXIMUM_EXPECTED_NESTED_CLASSES)
 
@@ -73,8 +75,13 @@ class EqualsWithHashCodeExist(config: Config = Config.empty) : Rule(config) {
         queue.push(ViolationHolder())
         super.visitClassOrObject(classOrObject)
         if (queue.pop().violation()) {
-            report(CodeSmell(issue, Entity.atName(classOrObject), "A class should always override hashCode " +
-                    "when overriding equals and the other way around."))
+            report(
+                CodeSmell(
+                    issue, Entity.atName(classOrObject),
+                    "A class should always override hashCode " +
+                        "when overriding equals and the other way around."
+                )
+            )
         }
     }
 

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ExplicitGarbageCollectionCall.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ExplicitGarbageCollectionCall.kt
@@ -27,12 +27,14 @@ import org.jetbrains.kotlin.psi.psiUtil.getReceiverExpression
  */
 class ExplicitGarbageCollectionCall(config: Config) : Rule(config) {
 
-    override val issue = Issue("ExplicitGarbageCollectionCall",
-            Severity.Defect,
-            "Don't try to be smarter than the JVM. Your code should work independently if the garbage " +
-                    "collector is disabled or not. If you face memory issues, " +
-                    "try tuning the JVM options instead of relying on code itself.",
-            Debt.TWENTY_MINS)
+    override val issue = Issue(
+        "ExplicitGarbageCollectionCall",
+        Severity.Defect,
+        "Don't try to be smarter than the JVM. Your code should work independently if the garbage " +
+            "collector is disabled or not. If you face memory issues, " +
+            "try tuning the JVM options instead of relying on code itself.",
+        Debt.TWENTY_MINS
+    )
 
     override fun visitCallExpression(expression: KtCallExpression) {
         expression.getCallNameExpression()?.let {
@@ -44,8 +46,12 @@ class ExplicitGarbageCollectionCall(config: Config) : Rule(config) {
         if (it.textMatches("gc") || it.textMatches("runFinalization")) {
             it.getReceiverExpression()?.let {
                 when (it.text) {
-                    "System", "Runtime.getRuntime()" -> report(CodeSmell(issue, Entity.from(expression),
-                            "An explicit call to the Garbage Collector as in ${it.text} should not be made."))
+                    "System", "Runtime.getRuntime()" -> report(
+                        CodeSmell(
+                            issue, Entity.from(expression),
+                            "An explicit call to the Garbage Collector as in ${it.text} should not be made."
+                        )
+                    )
                 }
             }
         }

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ExplicitGarbageCollectionCall.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ExplicitGarbageCollectionCall.kt
@@ -48,7 +48,8 @@ class ExplicitGarbageCollectionCall(config: Config) : Rule(config) {
                 when (it.text) {
                     "System", "Runtime.getRuntime()" -> report(
                         CodeSmell(
-                            issue, Entity.from(expression),
+                            issue,
+                            Entity.from(expression),
                             "An explicit call to the Garbage Collector as in ${it.text} should not be made."
                         )
                     )

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ImplicitDefaultLocale.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ImplicitDefaultLocale.kt
@@ -46,9 +46,9 @@ import org.jetbrains.kotlin.resolve.calls.callUtil.getType
 class ImplicitDefaultLocale(config: Config = Config.empty) : Rule(config) {
 
     override val issue = Issue(
-            "ImplicitDefaultLocale", Severity.CodeSmell,
-            "Implicit default locale used for string processing. Consider using explicit locale.",
-            Debt.FIVE_MINS
+        "ImplicitDefaultLocale", Severity.CodeSmell,
+        "Implicit default locale used for string processing. Consider using explicit locale.",
+        Debt.FIVE_MINS
     )
 
     override fun visitDotQualifiedExpression(expression: KtDotQualifiedExpression) {
@@ -70,8 +70,9 @@ class ImplicitDefaultLocale(config: Config = Config.empty) : Rule(config) {
         ) {
             report(
                 CodeSmell(
-                issue, Entity.from(expression),
-                "${expression.text} uses implicitly default locale for string formatting.")
+                    issue, Entity.from(expression),
+                    "${expression.text} uses implicitly default locale for string formatting."
+                )
             )
         }
     }
@@ -79,11 +80,15 @@ class ImplicitDefaultLocale(config: Config = Config.empty) : Rule(config) {
     private fun checkCaseConversion(expression: KtQualifiedExpression) {
         if (isStringOrNullableString(expression.receiverExpression.getType(bindingContext)) &&
             expression.isCalleeCaseConversion() &&
-            expression.isCalleeNoArgs()) {
-            report(CodeSmell(
-                issue,
-                Entity.from(expression),
-                "${expression.text} uses implicitly default locale for case conversion."))
+            expression.isCalleeNoArgs()
+        ) {
+            report(
+                CodeSmell(
+                    issue,
+                    Entity.from(expression),
+                    "${expression.text} uses implicitly default locale for case conversion."
+                )
+            )
         }
     }
 }

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ImplicitDefaultLocale.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ImplicitDefaultLocale.kt
@@ -46,7 +46,8 @@ import org.jetbrains.kotlin.resolve.calls.callUtil.getType
 class ImplicitDefaultLocale(config: Config = Config.empty) : Rule(config) {
 
     override val issue = Issue(
-        "ImplicitDefaultLocale", Severity.CodeSmell,
+        "ImplicitDefaultLocale",
+        Severity.CodeSmell,
         "Implicit default locale used for string processing. Consider using explicit locale.",
         Debt.FIVE_MINS
     )
@@ -70,7 +71,8 @@ class ImplicitDefaultLocale(config: Config = Config.empty) : Rule(config) {
         ) {
             report(
                 CodeSmell(
-                    issue, Entity.from(expression),
+                    issue,
+                    Entity.from(expression),
                     "${expression.text} uses implicitly default locale for string formatting."
                 )
             )

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/InvalidRange.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/InvalidRange.kt
@@ -35,18 +35,24 @@ import org.jetbrains.kotlin.psi.KtBinaryExpression
  */
 class InvalidRange(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue(javaClass.simpleName,
-            Severity.Defect,
-            "If a for loops condition is false before the first iteration, the loop will never get executed.",
-            Debt.TEN_MINS)
+    override val issue = Issue(
+        javaClass.simpleName,
+        Severity.Defect,
+        "If a for loops condition is false before the first iteration, the loop will never get executed.",
+        Debt.TEN_MINS
+    )
 
     private val minimumSize = 3
 
     override fun visitBinaryExpression(expression: KtBinaryExpression) {
         val range = expression.children
         if (range.size >= minimumSize && hasInvalidLoopRange(range)) {
-            report(CodeSmell(issue, Entity.from(expression),
-                    "This loop will never be executed due to its expression."))
+            report(
+                CodeSmell(
+                    issue, Entity.from(expression),
+                    "This loop will never be executed due to its expression."
+                )
+            )
         }
         super.visitBinaryExpression(expression)
     }

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/InvalidRange.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/InvalidRange.kt
@@ -49,7 +49,8 @@ class InvalidRange(config: Config = Config.empty) : Rule(config) {
         if (range.size >= minimumSize && hasInvalidLoopRange(range)) {
             report(
                 CodeSmell(
-                    issue, Entity.from(expression),
+                    issue,
+                    Entity.from(expression),
                     "This loop will never be executed due to its expression."
                 )
             )

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IteratorHasNextCallsNextMethod.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IteratorHasNextCallsNextMethod.kt
@@ -32,18 +32,25 @@ import org.jetbrains.kotlin.psi.psiUtil.getSuperNames
  */
 class IteratorHasNextCallsNextMethod(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue("IteratorHasNextCallsNextMethod", Severity.Defect,
-            "The hasNext() method of an Iterator implementation should not call the next() method. " +
-                    "The state of the iterator should not be changed inside the hasNext() method. " +
-                    "The hasNext() method is not supposed to have any side effects.",
-            Debt.TEN_MINS)
+    override val issue = Issue(
+        "IteratorHasNextCallsNextMethod", Severity.Defect,
+        "The hasNext() method of an Iterator implementation should not call the next() method. " +
+            "The state of the iterator should not be changed inside the hasNext() method. " +
+            "The hasNext() method is not supposed to have any side effects.",
+        Debt.TEN_MINS
+    )
 
     override fun visitClassOrObject(classOrObject: KtClassOrObject) {
         if (classOrObject.getSuperNames().contains("Iterator")) {
             val hasNextMethod = classOrObject.findFunctionByName("hasNext")
             if (hasNextMethod != null && callsNextMethod(hasNextMethod)) {
-                report(CodeSmell(issue, Entity.atName(classOrObject), "Calling hasNext() on an Iterator should " +
-                        "have no side-effects. Calling next() is a side effect."))
+                report(
+                    CodeSmell(
+                        issue, Entity.atName(classOrObject),
+                        "Calling hasNext() on an Iterator should " +
+                            "have no side-effects. Calling next() is a side effect."
+                    )
+                )
             }
         }
         super.visitClassOrObject(classOrObject)

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IteratorHasNextCallsNextMethod.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IteratorHasNextCallsNextMethod.kt
@@ -33,7 +33,8 @@ import org.jetbrains.kotlin.psi.psiUtil.getSuperNames
 class IteratorHasNextCallsNextMethod(config: Config = Config.empty) : Rule(config) {
 
     override val issue = Issue(
-        "IteratorHasNextCallsNextMethod", Severity.Defect,
+        "IteratorHasNextCallsNextMethod",
+        Severity.Defect,
         "The hasNext() method of an Iterator implementation should not call the next() method. " +
             "The state of the iterator should not be changed inside the hasNext() method. " +
             "The hasNext() method is not supposed to have any side effects.",
@@ -46,7 +47,8 @@ class IteratorHasNextCallsNextMethod(config: Config = Config.empty) : Rule(confi
             if (hasNextMethod != null && callsNextMethod(hasNextMethod)) {
                 report(
                     CodeSmell(
-                        issue, Entity.atName(classOrObject),
+                        issue,
+                        Entity.atName(classOrObject),
                         "Calling hasNext() on an Iterator should " +
                             "have no side-effects. Calling next() is a side effect."
                     )

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IteratorNotThrowingNoSuchElementException.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IteratorNotThrowingNoSuchElementException.kt
@@ -47,18 +47,24 @@ import org.jetbrains.kotlin.psi.psiUtil.getSuperNames
  */
 class IteratorNotThrowingNoSuchElementException(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue("IteratorNotThrowingNoSuchElementException", Severity.Defect,
-            "The next() method of an Iterator implementation should throw a NoSuchElementException " +
-                    "when there are no more elements to return",
-            Debt.TEN_MINS)
+    override val issue = Issue(
+        "IteratorNotThrowingNoSuchElementException", Severity.Defect,
+        "The next() method of an Iterator implementation should throw a NoSuchElementException " +
+            "when there are no more elements to return",
+        Debt.TEN_MINS
+    )
 
     override fun visitClassOrObject(classOrObject: KtClassOrObject) {
         if (classOrObject.getSuperNames().contains("Iterator")) {
             val nextMethod = classOrObject.findFunctionByName("next")
             if (nextMethod != null && !nextMethod.throwsNoSuchElementExceptionThrown()) {
-                report(CodeSmell(issue, Entity.atName(classOrObject),
+                report(
+                    CodeSmell(
+                        issue, Entity.atName(classOrObject),
                         "This implementation of Iterator does not correctly implement the next() method as " +
-                                "it doesn't throw a NoSuchElementException when no elements remain in the Iterator."))
+                            "it doesn't throw a NoSuchElementException when no elements remain in the Iterator."
+                    )
+                )
             }
         }
         super.visitClassOrObject(classOrObject)

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IteratorNotThrowingNoSuchElementException.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IteratorNotThrowingNoSuchElementException.kt
@@ -48,7 +48,8 @@ import org.jetbrains.kotlin.psi.psiUtil.getSuperNames
 class IteratorNotThrowingNoSuchElementException(config: Config = Config.empty) : Rule(config) {
 
     override val issue = Issue(
-        "IteratorNotThrowingNoSuchElementException", Severity.Defect,
+        "IteratorNotThrowingNoSuchElementException",
+        Severity.Defect,
         "The next() method of an Iterator implementation should throw a NoSuchElementException " +
             "when there are no more elements to return",
         Debt.TEN_MINS
@@ -60,7 +61,8 @@ class IteratorNotThrowingNoSuchElementException(config: Config = Config.empty) :
             if (nextMethod != null && !nextMethod.throwsNoSuchElementExceptionThrown()) {
                 report(
                     CodeSmell(
-                        issue, Entity.atName(classOrObject),
+                        issue,
+                        Entity.atName(classOrObject),
                         "This implementation of Iterator does not correctly implement the next() method as " +
                             "it doesn't throw a NoSuchElementException when no elements remain in the Iterator."
                     )

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/LateinitUsage.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/LateinitUsage.kt
@@ -34,11 +34,13 @@ import org.jetbrains.kotlin.psi.psiUtil.containingClass
  */
 class LateinitUsage(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue(javaClass.simpleName,
-            Severity.Defect,
-            "Usage of lateinit detected. Using lateinit for property initialization " +
-                    "is error prone, try using constructor injection or delegation.",
-            Debt.TWENTY_MINS)
+    override val issue = Issue(
+        javaClass.simpleName,
+        Severity.Defect,
+        "Usage of lateinit detected. Using lateinit for property initialization " +
+            "is error prone, try using constructor injection or delegation.",
+        Debt.TWENTY_MINS
+    )
 
     private val excludeAnnotatedProperties = valueOrDefaultCommaSeparated(EXCLUDE_ANNOTATED_PROPERTIES, emptyList())
         .map { it.removePrefix("*").removeSuffix("*") }
@@ -61,10 +63,10 @@ class LateinitUsage(config: Config = Config.empty) : Rule(config) {
         val annotationExcluder = AnnotationExcluder(root, excludeAnnotatedProperties)
 
         properties.filterNot { annotationExcluder.shouldExclude(it.annotationEntries) }
-                .filterNot { it.containingClass()?.name?.matches(ignoreOnClassesPattern) == true }
-                .forEach {
-                    report(CodeSmell(issue, Entity.from(it), "Usages of lateinit should be avoided."))
-                }
+            .filterNot { it.containingClass()?.name?.matches(ignoreOnClassesPattern) == true }
+            .forEach {
+                report(CodeSmell(issue, Entity.from(it), "Usages of lateinit should be avoided."))
+            }
     }
 
     companion object {

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MapGetWithNotNullAssertionOperator.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MapGetWithNotNullAssertionOperator.kt
@@ -49,7 +49,7 @@ class MapGetWithNotNullAssertionOperator(config: Config) : Rule(config) {
             "MapGetWithNotNullAssertionOperator",
             Severity.CodeSmell,
             "map.get() with not-null assertion operator (!!) can result in a NullPointerException. " +
-                    "Consider usage of map.getValue(), map.getOrDefault() or map.getOrElse() instead.",
+                "Consider usage of map.getValue(), map.getOrDefault() or map.getOrElse() instead.",
             Debt.FIVE_MINS
         )
 

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnconditionalJumpStatementInLoop.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnconditionalJumpStatementInLoop.kt
@@ -37,15 +37,23 @@ import org.jetbrains.kotlin.psi.psiUtil.siblings
  */
 class UnconditionalJumpStatementInLoop(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue(javaClass.simpleName, Severity.Defect,
+    override val issue = Issue(
+        javaClass.simpleName, Severity.Defect,
         "An unconditional jump statement in a loop is useless. " +
-            "The loop itself is only executed once.", Debt.TEN_MINS)
+            "The loop itself is only executed once.",
+        Debt.TEN_MINS
+    )
 
     override fun visitLoopExpression(loopExpression: KtLoopExpression) {
         if (hasJumpStatement(loopExpression.body)) {
-            report(CodeSmell(issue, Entity.from(loopExpression), "This loop contains an unconditional " +
-                "jump expression which " +
-                "essentially renders it useless as it will exit the loop during the first iteration."))
+            report(
+                CodeSmell(
+                    issue, Entity.from(loopExpression),
+                    "This loop contains an unconditional " +
+                        "jump expression which " +
+                        "essentially renders it useless as it will exit the loop during the first iteration."
+                )
+            )
         }
         super.visitLoopExpression(loopExpression)
     }

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnconditionalJumpStatementInLoop.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnconditionalJumpStatementInLoop.kt
@@ -38,7 +38,8 @@ import org.jetbrains.kotlin.psi.psiUtil.siblings
 class UnconditionalJumpStatementInLoop(config: Config = Config.empty) : Rule(config) {
 
     override val issue = Issue(
-        javaClass.simpleName, Severity.Defect,
+        javaClass.simpleName,
+        Severity.Defect,
         "An unconditional jump statement in a loop is useless. " +
             "The loop itself is only executed once.",
         Debt.TEN_MINS
@@ -48,7 +49,8 @@ class UnconditionalJumpStatementInLoop(config: Config = Config.empty) : Rule(con
         if (hasJumpStatement(loopExpression.body)) {
             report(
                 CodeSmell(
-                    issue, Entity.from(loopExpression),
+                    issue,
+                    Entity.from(loopExpression),
                     "This loop contains an unconditional " +
                         "jump expression which " +
                         "essentially renders it useless as it will exit the loop during the first iteration."

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessaryNotNullOperator.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessaryNotNullOperator.kt
@@ -45,7 +45,8 @@ class UnnecessaryNotNullOperator(config: Config = Config.empty) : Rule(config) {
         if (compilerReports.any { it.factory == Errors.UNNECESSARY_NOT_NULL_ASSERTION }) {
             report(
                 CodeSmell(
-                    issue, Entity.from(expression),
+                    issue,
+                    Entity.from(expression),
                     "${expression.text} contains an unnecessary " +
                         "not-null (!!) operators"
                 )

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessarySafeCall.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessarySafeCall.kt
@@ -72,7 +72,8 @@ class UnnecessarySafeCall(config: Config = Config.empty) : Rule(config) {
             }
             report(
                 CodeSmell(
-                    issue, Entity.from(expression),
+                    issue,
+                    Entity.from(expression),
                     "${expression.text} contains an unnecessary " +
                         "safe call operator"
                 )

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnreachableCode.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnreachableCode.kt
@@ -38,8 +38,10 @@ import org.jetbrains.kotlin.resolve.BindingContext
 class UnreachableCode(config: Config = Config.empty) : Rule(config) {
 
     override val issue = Issue(
-        "UnreachableCode", Severity.Warning,
-        "Unreachable code detected. This code should be removed", Debt.TEN_MINS
+        "UnreachableCode",
+        Severity.Warning,
+        "Unreachable code detected. This code should be removed",
+        Debt.TEN_MINS
     )
 
     override fun visitExpression(expression: KtExpression) {

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCallOnNullableType.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCallOnNullableType.kt
@@ -51,7 +51,8 @@ class UnsafeCallOnNullableType(config: Config = Config.empty) : Rule(config) {
         ) {
             report(
                 CodeSmell(
-                    issue, Entity.from(expression),
+                    issue,
+                    Entity.from(expression),
                     "Calling !! on a nullable type will throw a " +
                         "NullPointerException at runtime in case the value is null. It should be avoided."
                 )

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCast.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCast.kt
@@ -53,7 +53,8 @@ class UnsafeCast(config: Config = Config.empty) : Rule(config) {
         ) {
             report(
                 CodeSmell(
-                    issue, Entity.from(expression),
+                    issue,
+                    Entity.from(expression),
                     "${expression.left.text} cast to ${expression.right?.text ?: ""} cannot succeed."
                 )
             )

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UselessPostfixExpression.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UselessPostfixExpression.kt
@@ -56,7 +56,8 @@ import org.jetbrains.kotlin.psi.psiUtil.isPropertyParameter
 class UselessPostfixExpression(config: Config = Config.empty) : Rule(config) {
 
     override val issue: Issue = Issue(
-        "UselessPostfixExpression", Severity.Defect,
+        "UselessPostfixExpression",
+        Severity.Defect,
         "The incremented or decremented value is unused. This value is replaced with the original value.",
         Debt.TWENTY_MINS
     )
@@ -109,7 +110,8 @@ class UselessPostfixExpression(config: Config = Config.empty) : Rule(config) {
     private fun report(postfixExpression: KtPostfixExpression) {
         report(
             CodeSmell(
-                issue, Entity.from(postfixExpression),
+                issue,
+                Entity.from(postfixExpression),
                 "The result of the postfix expression: " +
                     "${postfixExpression.text} will not be used and is therefore useless."
             )

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UselessPostfixExpression.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UselessPostfixExpression.kt
@@ -55,16 +55,18 @@ import org.jetbrains.kotlin.psi.psiUtil.isPropertyParameter
  */
 class UselessPostfixExpression(config: Config = Config.empty) : Rule(config) {
 
-    override val issue: Issue = Issue("UselessPostfixExpression", Severity.Defect,
-            "The incremented or decremented value is unused. This value is replaced with the original value.",
-            Debt.TWENTY_MINS)
+    override val issue: Issue = Issue(
+        "UselessPostfixExpression", Severity.Defect,
+        "The incremented or decremented value is unused. This value is replaced with the original value.",
+        Debt.TWENTY_MINS
+    )
 
     var properties = setOf<String?>()
 
     override fun visitClass(klass: KtClass) {
         properties = klass.getProperties()
-                .map { it.name }
-                .union(klass.primaryConstructorParameters.filter { it.isPropertyParameter() }.map { it.name })
+            .map { it.name }
+            .union(klass.primaryConstructorParameters.filter { it.isPropertyParameter() }.map { it.name })
         super.visitClass(klass)
     }
 
@@ -76,7 +78,7 @@ class UselessPostfixExpression(config: Config = Config.empty) : Rule(config) {
         }
 
         getPostfixExpressionChilds(expression.returnedExpression)
-                ?.forEach { report(it) }
+            ?.forEach { report(it) }
     }
 
     override fun visitBinaryExpression(expression: KtBinaryExpression) {
@@ -84,11 +86,12 @@ class UselessPostfixExpression(config: Config = Config.empty) : Rule(config) {
         val leftIdentifierText = expression.left?.text
         checkPostfixExpression(postfixExpression, leftIdentifierText)
         getPostfixExpressionChilds(expression.right)
-                ?.forEach { checkPostfixExpression(it, leftIdentifierText) }
+            ?.forEach { checkPostfixExpression(it, leftIdentifierText) }
     }
 
     private fun KtExpression.asPostFixExpression() = if (this is KtPostfixExpression &&
-            (operationToken === PLUSPLUS || operationToken === MINUSMINUS)) this else null
+        (operationToken === PLUSPLUS || operationToken === MINUSMINUS)
+    ) this else null
 
     private fun checkPostfixExpression(postfixExpression: KtPostfixExpression?, leftIdentifierText: String?) {
         if (postfixExpression != null && leftIdentifierText == postfixExpression.firstChild?.text) {
@@ -104,8 +107,13 @@ class UselessPostfixExpression(config: Config = Config.empty) : Rule(config) {
     }
 
     private fun report(postfixExpression: KtPostfixExpression) {
-        report(CodeSmell(issue, Entity.from(postfixExpression), "The result of the postfix expression: " +
-                "${postfixExpression.text} will not be used and is therefore useless."))
+        report(
+            CodeSmell(
+                issue, Entity.from(postfixExpression),
+                "The result of the postfix expression: " +
+                    "${postfixExpression.text} will not be used and is therefore useless."
+            )
+        )
     }
 
     private fun getPostfixExpressionChilds(expression: KtExpression?) =

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsAlwaysReturnsTrueOrFalseSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsAlwaysReturnsTrueOrFalseSpec.kt
@@ -2,8 +2,8 @@ package io.gitlab.arturbosch.detekt.rules.bugs
 
 import io.github.detekt.test.utils.resourceAsPath
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.test.lint
 import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/LateinitUsageSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/LateinitUsageSpec.kt
@@ -1,7 +1,7 @@
 package io.gitlab.arturbosch.detekt.rules.bugs
 
-import io.gitlab.arturbosch.detekt.test.compileAndLint
 import io.gitlab.arturbosch.detekt.test.TestConfig
+import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.spekframework.spek2.Spek

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnconditionalJumpStatementInLoopSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnconditionalJumpStatementInLoopSpec.kt
@@ -69,31 +69,36 @@ class UnconditionalJumpStatementInLoopSpec : Spek({
         }
 
         it("does not report an conditional elvis continue") {
-            val findings = subject.compileAndLint("""
+            val findings = subject.compileAndLint(
+                """
                 fun main() {
                     fun compute(i: Int) = null
                     for (i in 1..5)  
                         return compute(i) ?: continue
                 }
-            """)
+            """
+            )
 
             assertThat(findings).isEmpty()
         }
 
         it("reports conditional elvis return") {
-            val findings = subject.compileAndLint("""
+            val findings = subject.compileAndLint(
+                """
                 fun main() {
                     fun compute(i: Int) = null
                     for (i in 1..5)  
                         return compute(i) ?: return
                 }
-            """)
+            """
+            )
 
             assertThat(findings).hasSize(1)
         }
 
         it("does not report a return after a conditional jump") {
-            val findings = subject.compileAndLint("""
+            val findings = subject.compileAndLint(
+                """
                 fun f(): Int {
                     for (i in 0 until 10) {
                         val a = i * i
@@ -113,7 +118,8 @@ class UnconditionalJumpStatementInLoopSpec : Spek({
                     }
                     return 0
                 }
-            """)
+            """
+            )
 
             assertThat(findings).isEmpty()
         }

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ExceptionRaisedInUnexpectedLocation.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ExceptionRaisedInUnexpectedLocation.kt
@@ -34,13 +34,16 @@ import org.jetbrains.kotlin.psi.psiUtil.anyDescendantOfType
  */
 class ExceptionRaisedInUnexpectedLocation(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue("ExceptionRaisedInUnexpectedLocation", Severity.CodeSmell,
-            "This method is not expected to throw exceptions. This can cause weird behavior.",
-            Debt.TWENTY_MINS)
+    override val issue = Issue(
+        "ExceptionRaisedInUnexpectedLocation", Severity.CodeSmell,
+        "This method is not expected to throw exceptions. This can cause weird behavior.",
+        Debt.TWENTY_MINS
+    )
 
     private val methods = valueOrDefaultCommaSeparated(
         METHOD_NAMES,
-        listOf("toString", "hashCode", "equals", "finalize"))
+        listOf("toString", "hashCode", "equals", "finalize")
+    )
 
     override fun visitNamedFunction(function: KtNamedFunction) {
         if (isPotentialMethod(function) && hasThrowExpression(function.bodyExpression)) {
@@ -57,7 +60,7 @@ class ExceptionRaisedInUnexpectedLocation(config: Config = Config.empty) : Rule(
     private fun isPotentialMethod(function: KtNamedFunction) = methods.any { function.name == it }
 
     private fun hasThrowExpression(declaration: KtExpression?) =
-            declaration?.anyDescendantOfType<KtThrowExpression>() == true
+        declaration?.anyDescendantOfType<KtThrowExpression>() == true
 
     companion object {
         const val METHOD_NAMES = "methodNames"

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ExceptionRaisedInUnexpectedLocation.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ExceptionRaisedInUnexpectedLocation.kt
@@ -35,7 +35,8 @@ import org.jetbrains.kotlin.psi.psiUtil.anyDescendantOfType
 class ExceptionRaisedInUnexpectedLocation(config: Config = Config.empty) : Rule(config) {
 
     override val issue = Issue(
-        "ExceptionRaisedInUnexpectedLocation", Severity.CodeSmell,
+        "ExceptionRaisedInUnexpectedLocation",
+        Severity.CodeSmell,
         "This method is not expected to throw exceptions. This can cause weird behavior.",
         Debt.TWENTY_MINS
     )

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/InstanceOfCheckForException.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/InstanceOfCheckForException.kt
@@ -46,7 +46,8 @@ import org.jetbrains.kotlin.types.typeUtil.isSubtypeOf
 class InstanceOfCheckForException(config: Config = Config.empty) : Rule(config) {
 
     override val issue = Issue(
-        "InstanceOfCheckForException", Severity.CodeSmell,
+        "InstanceOfCheckForException",
+        Severity.CodeSmell,
         "Instead of checking for a general exception type and checking for a specific exception type " +
             "use multiple catch blocks.",
         Debt.TWENTY_MINS

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/InstanceOfCheckForException.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/InstanceOfCheckForException.kt
@@ -45,10 +45,12 @@ import org.jetbrains.kotlin.types.typeUtil.isSubtypeOf
  */
 class InstanceOfCheckForException(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue("InstanceOfCheckForException", Severity.CodeSmell,
-            "Instead of checking for a general exception type and checking for a specific exception type " +
-                    "use multiple catch blocks.",
-            Debt.TWENTY_MINS)
+    override val issue = Issue(
+        "InstanceOfCheckForException", Severity.CodeSmell,
+        "Instead of checking for a general exception type and checking for a specific exception type " +
+            "use multiple catch blocks.",
+        Debt.TWENTY_MINS
+    )
 
     override fun visitCatchSection(catchClause: KtCatchClause) {
         val catchParameter = catchClause.catchParameter ?: return

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/NotImplementedDeclaration.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/NotImplementedDeclaration.kt
@@ -30,7 +30,8 @@ import org.jetbrains.kotlin.resolve.calls.callUtil.getCalleeExpressionIfAny
 class NotImplementedDeclaration(config: Config = Config.empty) : Rule(config) {
 
     override val issue = Issue(
-        "NotImplementedDeclaration", Severity.CodeSmell,
+        "NotImplementedDeclaration",
+        Severity.CodeSmell,
         "The NotImplementedDeclaration should only be used when a method stub is necessary. " +
             "This defers the development of the functionality of this function. " +
             "Hence, the NotImplementedDeclaration should only serve as a temporary declaration. " +

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/NotImplementedDeclaration.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/NotImplementedDeclaration.kt
@@ -29,12 +29,14 @@ import org.jetbrains.kotlin.resolve.calls.callUtil.getCalleeExpressionIfAny
  */
 class NotImplementedDeclaration(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue("NotImplementedDeclaration", Severity.CodeSmell,
-            "The NotImplementedDeclaration should only be used when a method stub is necessary. " +
-                    "This defers the development of the functionality of this function. " +
-                    "Hence, the NotImplementedDeclaration should only serve as a temporary declaration. " +
-                    "Before releasing, this type of declaration should be removed.",
-            Debt.TWENTY_MINS)
+    override val issue = Issue(
+        "NotImplementedDeclaration", Severity.CodeSmell,
+        "The NotImplementedDeclaration should only be used when a method stub is necessary. " +
+            "This defers the development of the functionality of this function. " +
+            "Hence, the NotImplementedDeclaration should only serve as a temporary declaration. " +
+            "Before releasing, this type of declaration should be removed.",
+        Debt.TWENTY_MINS
+    )
 
     override fun visitThrowExpression(expression: KtThrowExpression) {
         val calleeExpression = expression.thrownExpression?.getCalleeExpressionIfAny()

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/PrintStackTrace.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/PrintStackTrace.kt
@@ -48,15 +48,18 @@ import org.jetbrains.kotlin.psi.psiUtil.getReceiverExpression
  */
 class PrintStackTrace(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue("PrintStackTrace", Severity.CodeSmell,
-            "Do not print an stack trace. " +
-                    "These debug statements should be replaced with a logger or removed.",
-            Debt.TWENTY_MINS)
+    override val issue = Issue(
+        "PrintStackTrace", Severity.CodeSmell,
+        "Do not print an stack trace. " +
+            "These debug statements should be replaced with a logger or removed.",
+        Debt.TWENTY_MINS
+    )
 
     override fun visitCallExpression(expression: KtCallExpression) {
         val callNameExpression = expression.getCallNameExpression()
         if (callNameExpression?.text == "dumpStack" &&
-                callNameExpression.getReceiverExpression()?.text == "Thread") {
+            callNameExpression.getReceiverExpression()?.text == "Thread"
+        ) {
             report(CodeSmell(issue, Entity.from(expression), issue.description))
         }
     }

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/PrintStackTrace.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/PrintStackTrace.kt
@@ -49,7 +49,8 @@ import org.jetbrains.kotlin.psi.psiUtil.getReceiverExpression
 class PrintStackTrace(config: Config = Config.empty) : Rule(config) {
 
     override val issue = Issue(
-        "PrintStackTrace", Severity.CodeSmell,
+        "PrintStackTrace",
+        Severity.CodeSmell,
         "Do not print an stack trace. " +
             "These debug statements should be replaced with a logger or removed.",
         Debt.TWENTY_MINS

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/RethrowCaughtException.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/RethrowCaughtException.kt
@@ -50,9 +50,11 @@ import org.jetbrains.kotlin.psi.KtThrowExpression
  */
 class RethrowCaughtException(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue("RethrowCaughtException", Severity.CodeSmell,
-            "Do not rethrow a caught exception of the same type.",
-            Debt.FIVE_MINS)
+    override val issue = Issue(
+        "RethrowCaughtException", Severity.CodeSmell,
+        "Do not rethrow a caught exception of the same type.",
+        Debt.FIVE_MINS
+    )
 
     override fun visitCatchSection(catchClause: KtCatchClause) {
         val exceptionName = catchClause.catchParameter?.name ?: return

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/RethrowCaughtException.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/RethrowCaughtException.kt
@@ -51,7 +51,8 @@ import org.jetbrains.kotlin.psi.KtThrowExpression
 class RethrowCaughtException(config: Config = Config.empty) : Rule(config) {
 
     override val issue = Issue(
-        "RethrowCaughtException", Severity.CodeSmell,
+        "RethrowCaughtException",
+        Severity.CodeSmell,
         "Do not rethrow a caught exception of the same type.",
         Debt.FIVE_MINS
     )

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ReturnFromFinally.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ReturnFromFinally.kt
@@ -45,8 +45,10 @@ import org.jetbrains.kotlin.types.KotlinType
 class ReturnFromFinally(config: Config = Config.empty) : Rule(config) {
 
     override val issue = Issue(
-        "ReturnFromFinally", Severity.Defect,
-        "Do not return within a finally statement. This can discard exceptions.", Debt.TWENTY_MINS
+        "ReturnFromFinally",
+        Severity.Defect,
+        "Do not return within a finally statement. This can discard exceptions.",
+        Debt.TWENTY_MINS
     )
 
     private val ignoreLabeled = valueOrDefault(IGNORE_LABELED, false)

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedException.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedException.kt
@@ -79,12 +79,14 @@ import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
  */
 class SwallowedException(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue("SwallowedException", Severity.CodeSmell,
+    override val issue = Issue(
+        "SwallowedException", Severity.CodeSmell,
         "The caught exception is swallowed. The original exception could be lost.",
-        Debt.TWENTY_MINS)
+        Debt.TWENTY_MINS
+    )
 
     private val ignoredExceptionTypes = valueOrDefaultCommaSeparated(IGNORED_EXCEPTION_TYPES, defaultIgnoredExceptions)
-            .map { it.removePrefix("*").removeSuffix("*") }
+        .map { it.removePrefix("*").removeSuffix("*") }
 
     private val allowedExceptionNameRegex by LazyRegex(ALLOWED_EXCEPTION_NAME_REGEX, ALLOWED_EXCEPTION_NAME)
 
@@ -92,7 +94,8 @@ class SwallowedException(config: Config = Config.empty) : Rule(config) {
         val exceptionType = catchClause.catchParameter?.typeReference?.text
         if (!ignoredExceptionTypes.any { exceptionType?.contains(it, ignoreCase = true) == true } &&
             isExceptionSwallowedOrUnused(catchClause) &&
-            !catchClause.isAllowedExceptionName(allowedExceptionNameRegex)) {
+            !catchClause.isAllowedExceptionName(allowedExceptionNameRegex)
+        ) {
             report(CodeSmell(issue, Entity.from(catchClause), issue.description))
         }
     }

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedException.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedException.kt
@@ -80,7 +80,8 @@ import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
 class SwallowedException(config: Config = Config.empty) : Rule(config) {
 
     override val issue = Issue(
-        "SwallowedException", Severity.CodeSmell,
+        "SwallowedException",
+        Severity.CodeSmell,
         "The caught exception is swallowed. The original exception could be lost.",
         Debt.TWENTY_MINS
     )

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionFromFinally.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionFromFinally.kt
@@ -28,9 +28,11 @@ import org.jetbrains.kotlin.psi.psiUtil.forEachDescendantOfType
  */
 class ThrowingExceptionFromFinally(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue("ThrowingExceptionFromFinally", Severity.Defect,
-            "Do not throw an exception within a finally statement. This can discard exceptions and is confusing.",
-            Debt.TWENTY_MINS)
+    override val issue = Issue(
+        "ThrowingExceptionFromFinally", Severity.Defect,
+        "Do not throw an exception within a finally statement. This can discard exceptions and is confusing.",
+        Debt.TWENTY_MINS
+    )
 
     override fun visitFinallySection(finallySection: KtFinallySection) {
         finallySection.finalExpression.forEachDescendantOfType<KtThrowExpression> {

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionFromFinally.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionFromFinally.kt
@@ -29,7 +29,8 @@ import org.jetbrains.kotlin.psi.psiUtil.forEachDescendantOfType
 class ThrowingExceptionFromFinally(config: Config = Config.empty) : Rule(config) {
 
     override val issue = Issue(
-        "ThrowingExceptionFromFinally", Severity.Defect,
+        "ThrowingExceptionFromFinally",
+        Severity.Defect,
         "Do not throw an exception within a finally statement. This can discard exceptions and is confusing.",
         Debt.TWENTY_MINS
     )

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionInMain.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionInMain.kt
@@ -26,8 +26,10 @@ import org.jetbrains.kotlin.psi.psiUtil.anyDescendantOfType
 class ThrowingExceptionInMain(config: Config = Config.empty) : Rule(config) {
 
     override val issue = Issue(
-        "ThrowingExceptionInMain", Severity.CodeSmell,
-        "The main method should not throw an exception.", Debt.TWENTY_MINS
+        "ThrowingExceptionInMain",
+        Severity.CodeSmell,
+        "The main method should not throw an exception.",
+        Debt.TWENTY_MINS
     )
 
     override fun visitNamedFunction(function: KtNamedFunction) {

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionInMain.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionInMain.kt
@@ -25,8 +25,10 @@ import org.jetbrains.kotlin.psi.psiUtil.anyDescendantOfType
  */
 class ThrowingExceptionInMain(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue("ThrowingExceptionInMain", Severity.CodeSmell,
-            "The main method should not throw an exception.", Debt.TWENTY_MINS)
+    override val issue = Issue(
+        "ThrowingExceptionInMain", Severity.CodeSmell,
+        "The main method should not throw an exception.", Debt.TWENTY_MINS
+    )
 
     override fun visitNamedFunction(function: KtNamedFunction) {
         if (function.isMainFunction() && containsThrowExpression(function)) {

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionsWithoutMessageOrCause.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionsWithoutMessageOrCause.kt
@@ -42,18 +42,21 @@ import org.jetbrains.kotlin.psi.KtCallExpression
  */
 class ThrowingExceptionsWithoutMessageOrCause(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue("ThrowingExceptionsWithoutMessageOrCause", Severity.Warning,
-            "A call to the default constructor of an exception was detected. " +
-                    "Instead one of the constructor overloads should be called. " +
-                    "This allows to provide more meaningful exceptions.",
-            Debt.FIVE_MINS)
+    override val issue = Issue(
+        "ThrowingExceptionsWithoutMessageOrCause", Severity.Warning,
+        "A call to the default constructor of an exception was detected. " +
+            "Instead one of the constructor overloads should be called. " +
+            "This allows to provide more meaningful exceptions.",
+        Debt.FIVE_MINS
+    )
 
     private val exceptions = valueOrDefaultCommaSeparated(EXCEPTIONS, exceptionsDefaults)
 
     override fun visitCallExpression(expression: KtCallExpression) {
         val calleeExpressionText = expression.calleeExpression?.text
         if (exceptions.any { calleeExpressionText?.equals(it, ignoreCase = true) == true } &&
-            expression.valueArguments.isEmpty()) {
+            expression.valueArguments.isEmpty()
+        ) {
             report(CodeSmell(issue, Entity.from(expression), issue.description))
         }
         super.visitCallExpression(expression)

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionsWithoutMessageOrCause.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionsWithoutMessageOrCause.kt
@@ -43,7 +43,8 @@ import org.jetbrains.kotlin.psi.KtCallExpression
 class ThrowingExceptionsWithoutMessageOrCause(config: Config = Config.empty) : Rule(config) {
 
     override val issue = Issue(
-        "ThrowingExceptionsWithoutMessageOrCause", Severity.Warning,
+        "ThrowingExceptionsWithoutMessageOrCause",
+        Severity.Warning,
         "A call to the default constructor of an exception was detected. " +
             "Instead one of the constructor overloads should be called. " +
             "This allows to provide more meaningful exceptions.",

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingNewInstanceOfSameException.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingNewInstanceOfSameException.kt
@@ -42,7 +42,8 @@ import org.jetbrains.kotlin.psi.psiUtil.findDescendantOfType
 class ThrowingNewInstanceOfSameException(config: Config = Config.empty) : Rule(config) {
 
     override val issue = Issue(
-        "ThrowingNewInstanceOfSameException", Severity.Defect,
+        "ThrowingNewInstanceOfSameException",
+        Severity.Defect,
         "Avoid catch blocks that rethrow a caught exception wrapped inside a new instance of the same exception.",
         Debt.FIVE_MINS
     )

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingNewInstanceOfSameException.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingNewInstanceOfSameException.kt
@@ -41,9 +41,11 @@ import org.jetbrains.kotlin.psi.psiUtil.findDescendantOfType
  */
 class ThrowingNewInstanceOfSameException(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue("ThrowingNewInstanceOfSameException", Severity.Defect,
-            "Avoid catch blocks that rethrow a caught exception wrapped inside a new instance of the same exception.",
-            Debt.FIVE_MINS)
+    override val issue = Issue(
+        "ThrowingNewInstanceOfSameException", Severity.Defect,
+        "Avoid catch blocks that rethrow a caught exception wrapped inside a new instance of the same exception.",
+        Debt.FIVE_MINS
+    )
 
     override fun visitCatchSection(catchClause: KtCatchClause) {
         val parameterName = catchClause.catchParameter?.name
@@ -51,8 +53,8 @@ class ThrowingNewInstanceOfSameException(config: Config = Config.empty) : Rule(c
         val throwExpression = catchClause.catchBody?.findDescendantOfType<KtThrowExpression> {
             val thrownExpression = it.thrownExpression as? KtCallExpression
             thrownExpression != null &&
-                    createsSameExceptionType(thrownExpression, typeReference) &&
-                    hasSameExceptionParameter(thrownExpression.valueArguments, parameterName)
+                createsSameExceptionType(thrownExpression, typeReference) &&
+                hasSameExceptionParameter(thrownExpression.valueArguments, parameterName)
         }
         if (throwExpression != null) {
             report(CodeSmell(issue, Entity.from(throwExpression), issue.description))

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionCaught.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionCaught.kt
@@ -58,7 +58,8 @@ class TooGenericExceptionCaught(config: Config) : Rule(config) {
     )
 
     private val exceptions: Set<String> = valueOrDefault(
-        CAUGHT_EXCEPTIONS_PROPERTY, caughtExceptionDefaults
+        CAUGHT_EXCEPTIONS_PROPERTY,
+        caughtExceptionDefaults
     ).toHashSet()
 
     private val allowedExceptionNameRegex by LazyRegex(ALLOWED_EXCEPTION_NAME_REGEX, ALLOWED_EXCEPTION_NAME)

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionCaught.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionCaught.kt
@@ -49,21 +49,25 @@ import org.jetbrains.kotlin.psi.KtTypeReference
  */
 class TooGenericExceptionCaught(config: Config) : Rule(config) {
 
-    override val issue = Issue(javaClass.simpleName,
-            Severity.Defect,
-            "Caught exception is too generic. " +
-                    "Prefer catching specific exceptions to the case that is currently handled.",
-            Debt.TWENTY_MINS)
+    override val issue = Issue(
+        javaClass.simpleName,
+        Severity.Defect,
+        "Caught exception is too generic. " +
+            "Prefer catching specific exceptions to the case that is currently handled.",
+        Debt.TWENTY_MINS
+    )
 
     private val exceptions: Set<String> = valueOrDefault(
-            CAUGHT_EXCEPTIONS_PROPERTY, caughtExceptionDefaults).toHashSet()
+        CAUGHT_EXCEPTIONS_PROPERTY, caughtExceptionDefaults
+    ).toHashSet()
 
     private val allowedExceptionNameRegex by LazyRegex(ALLOWED_EXCEPTION_NAME_REGEX, ALLOWED_EXCEPTION_NAME)
 
     override fun visitCatchSection(catchClause: KtCatchClause) {
         catchClause.catchParameter?.let {
             if (isTooGenericException(it.typeReference) &&
-                !catchClause.isAllowedExceptionName(allowedExceptionNameRegex)) {
+                !catchClause.isAllowedExceptionName(allowedExceptionNameRegex)
+            ) {
                 report(CodeSmell(issue, Entity.from(it), issue.description))
             }
         }
@@ -81,12 +85,12 @@ class TooGenericExceptionCaught(config: Config) : Rule(config) {
 }
 
 val caughtExceptionDefaults = listOf(
-        "ArrayIndexOutOfBoundsException",
-        "Error",
-        "Exception",
-        "IllegalMonitorStateException",
-        "NullPointerException",
-        "IndexOutOfBoundsException",
-        "RuntimeException",
-        "Throwable"
+    "ArrayIndexOutOfBoundsException",
+    "Error",
+    "Exception",
+    "IllegalMonitorStateException",
+    "NullPointerException",
+    "IndexOutOfBoundsException",
+    "RuntimeException",
+    "Throwable"
 )

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionThrown.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionThrown.kt
@@ -54,14 +54,16 @@ class TooGenericExceptionThrown(config: Config) : Rule(config) {
 
     override fun visitThrowExpression(expression: KtThrowExpression) {
         expression.thrownExpression?.referenceExpression()?.text?.let {
-            if (it in exceptions) report(
-                CodeSmell(
-                    issue,
-                    Entity.from(expression),
-                    "$it is a too generic " +
-                        "Exception. Prefer throwing specific exceptions that indicate a specific error case."
+            if (it in exceptions) {
+                report(
+                    CodeSmell(
+                        issue,
+                        Entity.from(expression),
+                        "$it is a too generic Exception. " +
+                            "Prefer throwing specific exceptions that indicate a specific error case."
+                    )
                 )
-            )
+            }
         }
         super.visitThrowExpression(expression)
     }

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionThrown.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionThrown.kt
@@ -56,7 +56,8 @@ class TooGenericExceptionThrown(config: Config) : Rule(config) {
         expression.thrownExpression?.referenceExpression()?.text?.let {
             if (it in exceptions) report(
                 CodeSmell(
-                    issue, Entity.from(expression),
+                    issue,
+                    Entity.from(expression),
                     "$it is a too generic " +
                         "Exception. Prefer throwing specific exceptions that indicate a specific error case."
                 )

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionThrown.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionThrown.kt
@@ -42,18 +42,25 @@ import org.jetbrains.kotlin.psi.psiUtil.referenceExpression
  */
 class TooGenericExceptionThrown(config: Config) : Rule(config) {
 
-    override val issue = Issue(javaClass.simpleName,
-            Severity.Defect,
-            "Thrown exception is too generic. Prefer throwing project specific exceptions to handle error cases.",
-            Debt.TWENTY_MINS)
+    override val issue = Issue(
+        javaClass.simpleName,
+        Severity.Defect,
+        "Thrown exception is too generic. Prefer throwing project specific exceptions to handle error cases.",
+        Debt.TWENTY_MINS
+    )
 
     private val exceptions: Set<String> =
         valueOrDefault(THROWN_EXCEPTIONS_PROPERTY, thrownExceptionDefaults).toHashSet()
 
     override fun visitThrowExpression(expression: KtThrowExpression) {
         expression.thrownExpression?.referenceExpression()?.text?.let {
-            if (it in exceptions) report(CodeSmell(issue, Entity.from(expression), "$it is a too generic " +
-                    "Exception. Prefer throwing specific exceptions that indicate a specific error case."))
+            if (it in exceptions) report(
+                CodeSmell(
+                    issue, Entity.from(expression),
+                    "$it is a too generic " +
+                        "Exception. Prefer throwing specific exceptions that indicate a specific error case."
+                )
+            )
         }
         super.visitThrowExpression(expression)
     }
@@ -64,8 +71,8 @@ class TooGenericExceptionThrown(config: Config) : Rule(config) {
 }
 
 val thrownExceptionDefaults = listOf(
-        "Error",
-        "Exception",
-        "Throwable",
-        "RuntimeException"
+    "Error",
+    "Exception",
+    "Throwable",
+    "RuntimeException"
 )

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ExceptionRaisedInUnexpectedLocationSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ExceptionRaisedInUnexpectedLocationSpec.kt
@@ -25,19 +25,23 @@ class ExceptionRaisedInUnexpectedLocationSpec : Spek({
 
         it("reports the configured method") {
             val config = TestConfig(mapOf(ExceptionRaisedInUnexpectedLocation.METHOD_NAMES to listOf("toDo", "todo2")))
-            val findings = ExceptionRaisedInUnexpectedLocation(config).compileAndLint("""
+            val findings = ExceptionRaisedInUnexpectedLocation(config).compileAndLint(
+                """
             fun toDo() {
                 throw IllegalStateException()
-            }""")
+            }"""
+            )
             assertThat(findings).hasSize(1)
         }
 
         it("reports the configured method with String") {
             val config = TestConfig(mapOf(ExceptionRaisedInUnexpectedLocation.METHOD_NAMES to "toDo,todo2"))
-            val findings = ExceptionRaisedInUnexpectedLocation(config).compileAndLint("""
+            val findings = ExceptionRaisedInUnexpectedLocation(config).compileAndLint(
+                """
             fun toDo() {
                 throw IllegalStateException()
-            }""")
+            }"""
+            )
             assertThat(findings).hasSize(1)
         }
     }

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionsWithoutMessageOrCauseSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionsWithoutMessageOrCauseSpec.kt
@@ -9,7 +9,7 @@ import org.spekframework.spek2.style.specification.describe
 class ThrowingExceptionsWithoutMessageOrCauseSpec : Spek({
     val subject by memoized {
         ThrowingExceptionsWithoutMessageOrCause(
-                TestConfig(ThrowingExceptionsWithoutMessageOrCause.EXCEPTIONS to listOf("IllegalArgumentException"))
+            TestConfig(ThrowingExceptionsWithoutMessageOrCause.EXCEPTIONS to listOf("IllegalArgumentException"))
         )
     }
 

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionCaughtSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionCaughtSpec.kt
@@ -56,8 +56,8 @@ class TooGenericExceptionCaughtSpec : Spek({
 
         it("should not fail when disabled with invalid regex on allowed exception names") {
             val configRules = mapOf(
-                    "active" to "false",
-                    TooGenericExceptionCaught.ALLOWED_EXCEPTION_NAME_REGEX to "*MyException"
+                "active" to "false",
+                TooGenericExceptionCaught.ALLOWED_EXCEPTION_NAME_REGEX to "*MyException"
             )
             val config = TestConfig(configRules)
             val rule = TooGenericExceptionCaught(config)

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ClassNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ClassNaming.kt
@@ -32,10 +32,13 @@ class ClassNaming(config: Config = Config.empty) : Rule(config) {
 
     override fun visitClassOrObject(classOrObject: KtClassOrObject) {
         if (!classOrObject.identifierName().matches(classPattern)) {
-            report(CodeSmell(
-                issue,
-                Entity.atName(classOrObject),
-                message = "Class and Object names should match the pattern: $classPattern"))
+            report(
+                CodeSmell(
+                    issue,
+                    Entity.atName(classOrObject),
+                    message = "Class and Object names should match the pattern: $classPattern"
+                )
+            )
         }
     }
 

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ConstructorParameterNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ConstructorParameterNaming.kt
@@ -26,10 +26,12 @@ import org.jetbrains.kotlin.psi.psiUtil.isPrivate
  */
 class ConstructorParameterNaming(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue(javaClass.simpleName,
-            Severity.Style,
-            "Constructor parameter names should follow the naming convention set in the projects configuration.",
-            debt = Debt.FIVE_MINS)
+    override val issue = Issue(
+        javaClass.simpleName,
+        Severity.Style,
+        "Constructor parameter names should follow the naming convention set in the projects configuration.",
+        debt = Debt.FIVE_MINS
+    )
 
     private val parameterPattern by LazyRegex(PARAMETER_PATTERN, "[a-z][A-Za-z\\d]*")
     private val privateParameterPattern by LazyRegex(PRIVATE_PARAMETER_PATTERN, "[a-z][A-Za-z\\d]*")
@@ -44,18 +46,24 @@ class ConstructorParameterNaming(config: Config = Config.empty) : Rule(config) {
         val identifier = parameter.identifierName()
         if (parameter.isPrivate()) {
             if (!identifier.matches(privateParameterPattern)) {
-                report(CodeSmell(
+                report(
+                    CodeSmell(
                         issue,
                         Entity.from(parameter),
                         message = "Constructor private parameter names should " +
-                                "match the pattern: $privateParameterPattern"))
+                            "match the pattern: $privateParameterPattern"
+                    )
+                )
             }
         } else {
             if (!identifier.matches(parameterPattern)) {
-                report(CodeSmell(
+                report(
+                    CodeSmell(
                         issue,
                         Entity.from(parameter),
-                        message = "Constructor parameter names should match the pattern: $parameterPattern"))
+                        message = "Constructor parameter names should match the pattern: $parameterPattern"
+                    )
+                )
             }
         }
     }

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/EnumNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/EnumNaming.kt
@@ -19,19 +19,24 @@ import org.jetbrains.kotlin.psi.KtEnumEntry
  */
 class EnumNaming(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue(javaClass.simpleName,
-            Severity.Style,
-            "Enum names should follow the naming convention set in the projects configuration.",
-            debt = Debt.FIVE_MINS)
+    override val issue = Issue(
+        javaClass.simpleName,
+        Severity.Style,
+        "Enum names should follow the naming convention set in the projects configuration.",
+        debt = Debt.FIVE_MINS
+    )
 
     private val enumEntryPattern by LazyRegex(ENUM_PATTERN, "[A-Z][_a-zA-Z0-9]*")
 
     override fun visitEnumEntry(enumEntry: KtEnumEntry) {
         if (!enumEntry.identifierName().matches(enumEntryPattern)) {
-            report(CodeSmell(
+            report(
+                CodeSmell(
                     issue,
                     Entity.from(enumEntry.nameIdentifier ?: enumEntry),
-                    message = "Enum entry names should match the pattern: $enumEntryPattern"))
+                    message = "Enum entry names should match the pattern: $enumEntryPattern"
+                )
+            )
         }
     }
 

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ForbiddenClassName.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ForbiddenClassName.kt
@@ -20,7 +20,8 @@ import org.jetbrains.kotlin.psi.KtClassOrObject
 class ForbiddenClassName(config: Config = Config.empty) : Rule(config) {
 
     override val issue = Issue(
-        javaClass.simpleName, Severity.Style,
+        javaClass.simpleName,
+        Severity.Style,
         "Forbidden class name as per configuration detected.",
         Debt.FIVE_MINS
     )

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ForbiddenClassName.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ForbiddenClassName.kt
@@ -19,9 +19,11 @@ import org.jetbrains.kotlin.psi.KtClassOrObject
  */
 class ForbiddenClassName(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue(javaClass.simpleName, Severity.Style,
-            "Forbidden class name as per configuration detected.",
-            Debt.FIVE_MINS)
+    override val issue = Issue(
+        javaClass.simpleName, Severity.Style,
+        "Forbidden class name as per configuration detected.",
+        Debt.FIVE_MINS
+    )
     private val forbiddenNames = valueOrDefaultCommaSeparated(FORBIDDEN_NAME, emptyList())
         .map { it.removePrefix("*").removeSuffix("*") }
 

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionMaxLength.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionMaxLength.kt
@@ -33,7 +33,8 @@ class FunctionMaxLength(config: Config = Config.empty) : Rule(config) {
                 CodeSmell(
                     issue,
                     Entity.atName(function),
-                    message = "Function names should be at most $maximumFunctionNameLength characters long.")
+                    message = "Function names should be at most $maximumFunctionNameLength characters long."
+                )
             )
         }
     }

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionMinLength.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionMinLength.kt
@@ -33,7 +33,8 @@ class FunctionMinLength(config: Config = Config.empty) : Rule(config) {
                 CodeSmell(
                     issue,
                     Entity.atName(function),
-                    message = "Function names should be at least $minimumFunctionNameLength characters long.")
+                    message = "Function names should be at least $minimumFunctionNameLength characters long."
+                )
             )
         }
     }

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNaming.kt
@@ -31,10 +31,12 @@ class FunctionNaming(config: Config = Config.empty) : Rule(config) {
 
     override val defaultRuleIdAliases: Set<String> = setOf("FunctionName")
 
-    override val issue = Issue(javaClass.simpleName,
-            Severity.Style,
-            "Function names should follow the naming convention set in the configuration.",
-            debt = Debt.FIVE_MINS)
+    override val issue = Issue(
+        javaClass.simpleName,
+        Severity.Style,
+        "Function names should follow the naming convention set in the configuration.",
+        debt = Debt.FIVE_MINS
+    )
 
     private val functionPattern by LazyRegex(FUNCTION_PATTERN, "([a-z][a-zA-Z0-9]*)|(`.*`)")
     private val excludeClassPattern by LazyRegex(EXCLUDE_CLASS_PATTERN, "$^")
@@ -51,12 +53,14 @@ class FunctionNaming(config: Config = Config.empty) : Rule(config) {
         val functionName = function.nameIdentifier?.text ?: return
         if (!function.isContainingExcludedClassOrObject(excludeClassPattern) &&
             !functionName.matches(functionPattern) &&
-            functionName != function.typeReference?.name) {
+            functionName != function.typeReference?.name
+        ) {
             report(
                 CodeSmell(
                     issue,
                     Entity.atName(function),
-                    message = "Function names should match the pattern: $functionPattern")
+                    message = "Function names should match the pattern: $functionPattern"
+                )
             )
         }
     }

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionParameterNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionParameterNaming.kt
@@ -27,10 +27,12 @@ import org.jetbrains.kotlin.psi.KtParameter
  */
 class FunctionParameterNaming(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue(javaClass.simpleName,
-            Severity.Style,
-            "Function parameter names should follow the naming convention set in the projects configuration.",
-            debt = Debt.FIVE_MINS)
+    override val issue = Issue(
+        javaClass.simpleName,
+        Severity.Style,
+        "Function parameter names should follow the naming convention set in the projects configuration.",
+        debt = Debt.FIVE_MINS
+    )
 
     private val parameterPattern by LazyRegex(PARAMETER_PATTERN, "[a-z][A-Za-z\\d]*")
     private val excludeClassPattern by LazyRegex(EXCLUDE_CLASS_PATTERN, "$^")
@@ -47,10 +49,13 @@ class FunctionParameterNaming(config: Config = Config.empty) : Rule(config) {
 
         val identifier = parameter.identifierName()
         if (!identifier.matches(parameterPattern)) {
-            report(CodeSmell(
+            report(
+                CodeSmell(
                     issue,
                     Entity.from(parameter),
-                    message = "Function parameter names should match the pattern: $parameterPattern"))
+                    message = "Function parameter names should match the pattern: $parameterPattern"
+                )
+            )
         }
     }
 

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MatchingDeclarationName.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MatchingDeclarationName.kt
@@ -79,8 +79,13 @@ class MatchingDeclarationName(config: Config = Config.empty) : Rule(config) {
             val filename = file.fileNameWithoutSuffix()
             if (declarationName != filename && hasNoMatchingTypeAlias(filename)) {
                 val entity = Entity.from(declaration).copy(ktElement = file)
-                report(CodeSmell(issue, entity, "The file name '$filename' " +
-                    "does not match the name of the single top-level declaration '$declarationName'."))
+                report(
+                    CodeSmell(
+                        issue, entity,
+                        "The file name '$filename' " +
+                            "does not match the name of the single top-level declaration '$declarationName'."
+                    )
+                )
             }
         }
     }

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MatchingDeclarationName.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MatchingDeclarationName.kt
@@ -81,7 +81,8 @@ class MatchingDeclarationName(config: Config = Config.empty) : Rule(config) {
                 val entity = Entity.from(declaration).copy(ktElement = file)
                 report(
                     CodeSmell(
-                        issue, entity,
+                        issue,
+                        entity,
                         "The file name '$filename' " +
                             "does not match the name of the single top-level declaration '$declarationName'."
                     )

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MemberNameEqualsClassName.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MemberNameEqualsClassName.kt
@@ -59,7 +59,8 @@ import org.jetbrains.kotlin.resolve.BindingContext
 class MemberNameEqualsClassName(config: Config = Config.empty) : Rule(config) {
 
     override val issue = Issue(
-        javaClass.simpleName, Severity.Style,
+        javaClass.simpleName,
+        Severity.Style,
         "A member should not be given the same name as its parent class or object.",
         Debt.FIVE_MINS
     )

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MemberNameEqualsClassName.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MemberNameEqualsClassName.kt
@@ -58,21 +58,23 @@ import org.jetbrains.kotlin.resolve.BindingContext
  */
 class MemberNameEqualsClassName(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue(javaClass.simpleName, Severity.Style,
-            "A member should not be given the same name as its parent class or object.",
-            Debt.FIVE_MINS)
+    override val issue = Issue(
+        javaClass.simpleName, Severity.Style,
+        "A member should not be given the same name as its parent class or object.",
+        Debt.FIVE_MINS
+    )
 
     private val classMessage = "A member is named after the class. This might result in confusion. " +
-            "Either rename the member or change it to a constructor."
+        "Either rename the member or change it to a constructor."
     private val objectMessage = "A member is named after the object. " +
-            "This might result in confusion. Please rename the member."
+        "This might result in confusion. Please rename the member."
 
     private val ignoreOverridden = valueOrDefault(IGNORE_OVERRIDDEN, valueOrDefault(IGNORE_OVERRIDDEN_FUNCTION, true))
 
     override fun visitClass(klass: KtClass) {
         if (!klass.isInterface()) {
             (getMisnamedMembers(klass, klass.name) + getMisnamedCompanionObjectMembers(klass))
-                    .forEach { report(CodeSmell(issue, Entity.from(it), classMessage)) }
+                .forEach { report(CodeSmell(issue, Entity.from(it), classMessage)) }
         }
         super.visitClass(klass)
     }
@@ -80,7 +82,7 @@ class MemberNameEqualsClassName(config: Config = Config.empty) : Rule(config) {
     override fun visitObjectDeclaration(declaration: KtObjectDeclaration) {
         if (!declaration.isCompanion()) {
             getMisnamedMembers(declaration, declaration.name)
-                    .forEach { report(CodeSmell(issue, Entity.from(it), objectMessage)) }
+                .forEach { report(CodeSmell(issue, Entity.from(it), objectMessage)) }
         }
         super.visitObjectDeclaration(declaration)
     }
@@ -94,9 +96,9 @@ class MemberNameEqualsClassName(config: Config = Config.empty) : Rule(config) {
 
     private fun getMisnamedCompanionObjectMembers(klass: KtClass): Sequence<KtNamedDeclaration> {
         return klass.companionObjects
-                .asSequence()
-                .flatMap { getMisnamedMembers(it, klass.name) }
-                .filterNot { it is KtNamedFunction && isFactoryMethod(it, klass) }
+            .asSequence()
+            .flatMap { getMisnamedMembers(it, klass.name) }
+            .filterNot { it is KtNamedFunction && isFactoryMethod(it, klass) }
     }
 
     private fun isFactoryMethod(function: KtNamedFunction, klass: KtClass): Boolean {

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingRules.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingRules.kt
@@ -34,21 +34,21 @@ class NamingRules(config: Config = Config.empty) : MultiRule() {
     private val functionParameterNamingRule = FunctionParameterNaming(config)
 
     override val rules: List<Rule> = listOf(
-            variableNamingRule,
-            variableMinNameLengthRule,
-            variableMaxNameLengthRule,
-            topLevelPropertyRule,
-            objectConstantNamingRule,
-            nonBooleanPropertyPrefixedWithIsRule,
-            packageNamingRule,
-            classOrObjectNamingRule,
-            enumEntryNamingRule,
-            functionNamingRule,
-            functionMaxNameLengthRule,
-            functionMinNameLengthRule,
-            forbiddenClassNameRule,
-            constructorParameterNamingRule,
-            functionParameterNamingRule
+        variableNamingRule,
+        variableMinNameLengthRule,
+        variableMaxNameLengthRule,
+        topLevelPropertyRule,
+        objectConstantNamingRule,
+        nonBooleanPropertyPrefixedWithIsRule,
+        packageNamingRule,
+        classOrObjectNamingRule,
+        enumEntryNamingRule,
+        functionNamingRule,
+        functionMaxNameLengthRule,
+        functionMinNameLengthRule,
+        forbiddenClassNameRule,
+        constructorParameterNamingRule,
+        functionParameterNamingRule
     )
 
     override fun visitPackageDirective(directive: KtPackageDirective) {
@@ -103,5 +103,5 @@ class NamingRules(config: Config = Config.empty) : MultiRule() {
     }
 
     private fun KtVariableDeclaration.withinObjectDeclaration(): Boolean =
-            this.getNonStrictParentOfType<KtObjectDeclaration>() != null
+        this.getNonStrictParentOfType<KtObjectDeclaration>() != null
 }

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/PackageNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/PackageNaming.kt
@@ -32,10 +32,13 @@ class PackageNaming(config: Config = Config.empty) : Rule(config) {
     override fun visitPackageDirective(directive: KtPackageDirective) {
         val name = directive.qualifiedName
         if (name.isNotEmpty() && !name.matches(packagePattern)) {
-            report(CodeSmell(
-                issue,
-                Entity.from(directive),
-                message = "Package name should match the pattern: $packagePattern"))
+            report(
+                CodeSmell(
+                    issue,
+                    Entity.from(directive),
+                    message = "Package name should match the pattern: $packagePattern"
+                )
+            )
         }
     }
 

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/TopLevelPropertyNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/TopLevelPropertyNaming.kt
@@ -24,10 +24,12 @@ import org.jetbrains.kotlin.psi.psiUtil.isPrivate
  */
 class TopLevelPropertyNaming(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue(javaClass.simpleName,
-            Severity.Style,
-            "Top level property names should follow the naming convention set in the projects configuration.",
-            debt = Debt.FIVE_MINS)
+    override val issue = Issue(
+        javaClass.simpleName,
+        Severity.Style,
+        "Top level property names should follow the naming convention set in the projects configuration.",
+        debt = Debt.FIVE_MINS
+    )
 
     private val constantPattern by LazyRegex(CONSTANT_PATTERN, "[A-Z][_A-Z0-9]*")
     private val propertyPattern by LazyRegex(PROPERTY_PATTERN, "[A-Za-z][_A-Za-z0-9]*")

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableNaming.kt
@@ -27,10 +27,12 @@ import org.jetbrains.kotlin.resolve.calls.util.isSingleUnderscore
  */
 class VariableNaming(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue(javaClass.simpleName,
-            Severity.Style,
-            "Variable names should follow the naming convention set in the projects configuration.",
-            debt = Debt.FIVE_MINS)
+    override val issue = Issue(
+        javaClass.simpleName,
+        Severity.Style,
+        "Variable names should follow the naming convention set in the projects configuration.",
+        debt = Debt.FIVE_MINS
+    )
 
     private val variablePattern by LazyRegex(VARIABLE_PATTERN, "[a-z][A-Za-z0-9]*")
     private val privateVariablePattern by LazyRegex(PRIVATE_VARIABLE_PATTERN, "(_)?[a-z][A-Za-z0-9]*")
@@ -59,10 +61,13 @@ class VariableNaming(config: Config = Config.empty) : Rule(config) {
     }
 
     private fun report(property: KtProperty, message: String) {
-        report(CodeSmell(
-            issue,
-            Entity.atName(property),
-            message = message))
+        report(
+            CodeSmell(
+                issue,
+                Entity.atName(property),
+                message = message
+            )
+        )
     }
 
     companion object {

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/util/ExcludeClass.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/util/ExcludeClass.kt
@@ -6,7 +6,7 @@ import org.jetbrains.kotlin.psi.psiUtil.containingClass
 import org.jetbrains.kotlin.psi.psiUtil.containingClassOrObject
 
 internal fun KtDeclaration.isContainingExcludedClassOrObject(pattern: Regex) =
-        containingClassOrObject?.identifierName()?.matches(pattern) == true
+    containingClassOrObject?.identifierName()?.matches(pattern) == true
 
 internal fun KtDeclaration.isContainingExcludedClass(pattern: Regex) =
-        containingClass()?.identifierName()?.matches(pattern) == true
+    containingClass()?.identifierName()?.matches(pattern) == true

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ClassNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ClassNamingSpec.kt
@@ -11,7 +11,7 @@ class ClassNamingSpec : Spek({
 
         it("should detect no violations") {
             val findings = ClassNaming().compileAndLint(
-                    """
+                """
                     class MyClassWithNumbers5
 
                     class NamingConventions {
@@ -23,7 +23,7 @@ class ClassNamingSpec : Spek({
 
         it("should find two violations") {
             val findings = ClassNaming().compileAndLint(
-                    """
+                """
                     class _NamingConventions
 
                     class namingConventions {}
@@ -35,10 +35,12 @@ class ClassNamingSpec : Spek({
 
         it("should ignore the issue by alias suppression") {
             assertThat(
-                ClassNaming().compileAndLint("""
+                ClassNaming().compileAndLint(
+                    """
                     @Suppress("ClassName")
                     class namingConventions {}
-                """)
+                """
+                )
             ).isEmpty()
         }
     }

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/EnumNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/EnumNamingSpec.kt
@@ -11,7 +11,7 @@ class EnumNamingSpec : Spek({
 
         it("should detect no violation") {
             val findings = EnumNaming().compileAndLint(
-                    """
+                """
                 enum class WorkFlow {
                     ACTIVE, NOT_ACTIVE, Unknown, Number1
                 }

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ForbiddenClassNameSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ForbiddenClassNameSpec.kt
@@ -16,16 +16,20 @@ class ForbiddenClassNameSpec : Spek({
                 class TestManager {} // violation
                 class TestProvider {} // violation
                 class TestHolder"""
-            assertThat(ForbiddenClassName(TestConfig(mapOf(FORBIDDEN_NAME to listOf("Manager", "Provider"))))
-                    .compileAndLint(code))
-                    .hasSize(2)
+            assertThat(
+                ForbiddenClassName(TestConfig(mapOf(FORBIDDEN_NAME to listOf("Manager", "Provider"))))
+                    .compileAndLint(code)
+            )
+                .hasSize(2)
         }
 
         it("should report a class that starts with a forbidden name") {
             val code = "class TestProvider {}"
-            assertThat(ForbiddenClassName(TestConfig(mapOf(FORBIDDEN_NAME to listOf("test"))))
-                    .compileAndLint(code))
-                    .hasSize(1)
+            assertThat(
+                ForbiddenClassName(TestConfig(mapOf(FORBIDDEN_NAME to listOf("test"))))
+                    .compileAndLint(code)
+            )
+                .hasSize(1)
         }
 
         it("should report classes with forbidden names using config string") {
@@ -33,8 +37,10 @@ class ForbiddenClassNameSpec : Spek({
                 class TestManager {} // violation
                 class TestProvider {} // violation
                 class TestHolder"""
-            assertThat(ForbiddenClassName(TestConfig(mapOf(FORBIDDEN_NAME to "Manager, Provider")))
-                .compileAndLint(code))
+            assertThat(
+                ForbiddenClassName(TestConfig(mapOf(FORBIDDEN_NAME to "Manager, Provider")))
+                    .compileAndLint(code)
+            )
                 .hasSize(2)
         }
     }

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MatchingDeclarationNameSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MatchingDeclarationNameSpec.kt
@@ -1,8 +1,8 @@
 package io.gitlab.arturbosch.detekt.rules.naming
 
+import io.github.detekt.test.utils.compileContentForTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.github.detekt.test.utils.compileContentForTest
 import io.gitlab.arturbosch.detekt.test.lint
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
@@ -22,7 +22,8 @@ internal class MatchingDeclarationNameSpec : Spek({
             it("should pass for suppress") {
                 val ktFile = compileContentForTest(
                     """@file:Suppress("MatchingDeclarationName") object O""",
-                    filename = "Objects.kt")
+                    filename = "Objects.kt"
+                )
                 val findings = MatchingDeclarationName().lint(ktFile)
                 assertThat(findings).isEmpty()
             }
@@ -40,50 +41,65 @@ internal class MatchingDeclarationNameSpec : Spek({
             }
 
             it("should pass for enum declaration") {
-                val ktFile = compileContentForTest("""
+                val ktFile = compileContentForTest(
+                    """
                     enum class E {
                         ONE, TWO, THREE
                     }
-                """, filename = "E.kt")
+                """,
+                    filename = "E.kt"
+                )
                 val findings = MatchingDeclarationName().lint(ktFile)
                 assertThat(findings).isEmpty()
             }
 
             it("should pass for multiple declaration") {
-                val ktFile = compileContentForTest("""
+                val ktFile = compileContentForTest(
+                    """
                     class C
                     object O
                     fun a() = 5
-                """, filename = "MultiDeclarations.kt")
+                """,
+                    filename = "MultiDeclarations.kt"
+                )
                 val findings = MatchingDeclarationName().lint(ktFile)
                 assertThat(findings).isEmpty()
             }
 
             it("should pass for class declaration with utility functions") {
-                val ktFile = compileContentForTest("""
+                val ktFile = compileContentForTest(
+                    """
                     class C
                     fun a() = 5
                     fun C.b() = 5
-                """, filename = "C.kt")
+                """,
+                    filename = "C.kt"
+                )
                 val findings = MatchingDeclarationName().lint(ktFile)
                 assertThat(findings).isEmpty()
             }
 
             it("should pass for class declaration not as first declaration with utility functions") {
-                val ktFile = compileContentForTest("""
+                val ktFile = compileContentForTest(
+                    """
                     fun a() = 5
                     fun C.b() = 5
                     class C
-                """, filename = "Classes.kt")
+                """,
+                    filename = "Classes.kt"
+                )
                 val findings = MatchingDeclarationName().lint(ktFile)
                 assertThat(findings).isEmpty()
             }
 
             it("should pass for private class declaration") {
-                val ktFile = compileContentForTest("""
+                val ktFile = compileContentForTest(
+                    """
                 private class C
                 fun a() = 5
-            """, filename = "b.kt")
+            """,
+                    filename = "b.kt"
+                )
                 val findings = MatchingDeclarationName().lint(ktFile)
                 assertThat(findings).isEmpty()
             }
@@ -110,7 +126,8 @@ internal class MatchingDeclarationNameSpec : Spek({
             it("should not pass for object declaration even with suppress on the object") {
                 val ktFile = compileContentForTest(
                     """@Suppress("MatchingDeclarationName") object O""",
-                    filename = "Objects.kt")
+                    filename = "Objects.kt"
+                )
                 val findings = MatchingDeclarationName().lint(ktFile)
                 assertThat(findings).hasSourceLocation(1, 1)
             }
@@ -122,11 +139,14 @@ internal class MatchingDeclarationNameSpec : Spek({
             }
 
             it("should not pass for class declaration as first declaration with utility functions") {
-                val ktFile = compileContentForTest("""
+                val ktFile = compileContentForTest(
+                    """
                     class C
                     fun a() = 5
                     fun C.b() = 5
-                """.trimIndent(), filename = "ClassUtils.kt")
+                    """.trimIndent(),
+                    filename = "ClassUtils.kt"
+                )
                 val findings = MatchingDeclarationName().lint(ktFile)
                 assertThat(findings).hasSourceLocation(1, 1)
             }
@@ -138,11 +158,14 @@ internal class MatchingDeclarationNameSpec : Spek({
             }
 
             it("should not pass for enum declaration") {
-                val ktFile = compileContentForTest("""
+                val ktFile = compileContentForTest(
+                    """
                     enum class NOT_E {
                         ONE, TWO, THREE
                     }
-                """.trimIndent(), filename = "E.kt")
+                    """.trimIndent(),
+                    filename = "E.kt"
+                )
                 val findings = MatchingDeclarationName().lint(ktFile)
                 assertThat(findings).hasSourceLocation(1, 1)
             }
@@ -157,15 +180,20 @@ internal class MatchingDeclarationNameSpec : Spek({
                 assertThat(findings).hasSize(1)
             }
 
-            it("""
+            it(
+                """
                 should not pass for class declaration not as first declaration with utility functions
                 when mustBeFirst is false.
-            """.trimIndent()) {
-                val ktFile = compileContentForTest("""
+                """.trimIndent()
+            ) {
+                val ktFile = compileContentForTest(
+                    """
                     fun a() = 5
                     fun C.b() = 5
                     class C
-                """, filename = "Classes.kt")
+                """,
+                    filename = "Classes.kt"
+                )
                 val findings = MatchingDeclarationName(
                     TestConfig("mustBeFirst" to "false")
                 ).lint(ktFile)

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingConventionCustomPatternTest.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingConventionCustomPatternTest.kt
@@ -69,7 +69,9 @@ class NamingConventionCustomPatternTest : Spek({
 
         it("should use custom name for method and class") {
             val rule = NamingRules(testConfig)
-            assertThat(rule.compileAndLint("""
+            assertThat(
+                rule.compileAndLint(
+                    """
             class aBbD{
                 fun `name with back ticks`(){
                   val `123var` = ""
@@ -79,29 +81,39 @@ class NamingConventionCustomPatternTest : Spek({
                   const val lowerCaseConst = ""
                 }
             }
-        """)).isEmpty()
+        """
+                )
+            ).isEmpty()
         }
 
         it("should use custom name for constant") {
             val rule = NamingRules(testConfig)
-            assertThat(rule.compileAndLint("""
+            assertThat(
+                rule.compileAndLint(
+                    """
             class aBbD{
                 companion object {
                   const val lowerCaseConst = ""
                 }
             }
-        """)).isEmpty()
+        """
+                )
+            ).isEmpty()
         }
 
         it("should use custom name for enum") {
             val rule = NamingRules(testConfig)
-            assertThat(rule.compileAndLint("""
+            assertThat(
+                rule.compileAndLint(
+                    """
             class aBbD{
                 enum class aBbD {
                     enum1, enum2
                 }
             }
-        """)).isEmpty()
+        """
+                )
+            ).isEmpty()
         }
 
         it("should use custom name for package") {

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNamingSpec.kt
@@ -162,10 +162,12 @@ class ObjectPropertyNamingSpec : Spek({
     describe("variables and constants in objects with custom config") {
 
         val config by memoized {
-            TestConfig(mapOf(
-                ObjectPropertyNaming.CONSTANT_PATTERN to "_[A-Za-z]*",
-                ObjectPropertyNaming.PRIVATE_PROPERTY_PATTERN to ".*"
-            ))
+            TestConfig(
+                mapOf(
+                    ObjectPropertyNaming.CONSTANT_PATTERN to "_[A-Za-z]*",
+                    ObjectPropertyNaming.PRIVATE_PROPERTY_PATTERN to ".*"
+                )
+            )
         }
         val subject by memoized { ObjectPropertyNaming(config) }
 
@@ -192,9 +194,11 @@ class ObjectPropertyNamingSpec : Spek({
 
     describe("local properties") {
         it("should not detect local properties") {
-            val config = TestConfig(mapOf(
-                ObjectPropertyNaming.PROPERTY_PATTERN to "valid"
-            ))
+            val config = TestConfig(
+                mapOf(
+                    ObjectPropertyNaming.PROPERTY_PATTERN to "valid"
+                )
+            )
             val subject = ObjectPropertyNaming(config)
 
             val code = """

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/PackageNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/PackageNamingSpec.kt
@@ -11,10 +11,12 @@ class PackageNamingSpec : Spek({
 
         it("should ignore the issue by alias suppression") {
             assertThat(
-                PackageNaming().compileAndLint("""
+                PackageNaming().compileAndLint(
+                    """
                     @file:Suppress("PackageDirectoryMismatch")
                     package FOO.BAR
-                """)
+                """
+                )
             ).isEmpty()
         }
 

--- a/detekt-rules-performance/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/ForEachOnRange.kt
+++ b/detekt-rules-performance/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/ForEachOnRange.kt
@@ -45,10 +45,12 @@ import org.jetbrains.kotlin.psi.psiUtil.getReceiverExpression
  */
 class ForEachOnRange(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue("ForEachOnRange",
-            Severity.Performance,
-            "Using the forEach method on ranges has a heavy performance cost. Prefer using simple for loops.",
-            Debt.FIVE_MINS)
+    override val issue = Issue(
+        "ForEachOnRange",
+        Severity.Performance,
+        "Using the forEach method on ranges has a heavy performance cost. Prefer using simple for loops.",
+        Debt.FIVE_MINS
+    )
 
     private val minimumRangeSize = 3
     private val rangeOperators = setOf("..", "downTo", "until", "step")

--- a/detekt-rules-performance/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/UnnecessaryTemporaryInstantiation.kt
+++ b/detekt-rules-performance/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/UnnecessaryTemporaryInstantiation.kt
@@ -28,15 +28,18 @@ import org.jetbrains.kotlin.psi.KtExpression
  */
 class UnnecessaryTemporaryInstantiation(config: Config = Config.empty) : Rule(config) {
 
-    override val issue: Issue = Issue("UnnecessaryTemporaryInstantiation", Severity.Performance,
-            "Avoid temporary objects when converting primitive types to String.",
-            Debt.FIVE_MINS)
+    override val issue: Issue = Issue(
+        "UnnecessaryTemporaryInstantiation", Severity.Performance,
+        "Avoid temporary objects when converting primitive types to String.",
+        Debt.FIVE_MINS
+    )
 
     private val types: Set<String> = hashSetOf("Boolean", "Byte", "Short", "Integer", "Long", "Float", "Double")
 
     override fun visitCallExpression(expression: KtCallExpression) {
         if (isPrimitiveWrapperType(expression.calleeExpression) &&
-                isToStringMethod(expression.nextSibling?.nextSibling)) {
+            isToStringMethod(expression.nextSibling?.nextSibling)
+        ) {
             report(CodeSmell(issue, Entity.from(expression), issue.description))
         }
     }

--- a/detekt-rules-performance/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/UnnecessaryTemporaryInstantiation.kt
+++ b/detekt-rules-performance/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/UnnecessaryTemporaryInstantiation.kt
@@ -29,7 +29,8 @@ import org.jetbrains.kotlin.psi.KtExpression
 class UnnecessaryTemporaryInstantiation(config: Config = Config.empty) : Rule(config) {
 
     override val issue: Issue = Issue(
-        "UnnecessaryTemporaryInstantiation", Severity.Performance,
+        "UnnecessaryTemporaryInstantiation",
+        Severity.Performance,
         "Avoid temporary objects when converting primitive types to String.",
         Debt.FIVE_MINS
     )

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ClassOrdering.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ClassOrdering.kt
@@ -56,7 +56,7 @@ class ClassOrdering(config: Config = Config.empty) : Rule(config) {
     override val issue = Issue(
         javaClass.simpleName, Severity.Style,
         "Class contents should be in this order: Property declarations/initializer blocks; secondary constructors; " +
-                "method declarations then companion objects.",
+            "method declarations then companion objects.",
         Debt.FIVE_MINS
     )
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ClassOrdering.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ClassOrdering.kt
@@ -54,7 +54,8 @@ import org.jetbrains.kotlin.psi.KtSecondaryConstructor
 class ClassOrdering(config: Config = Config.empty) : Rule(config) {
 
     override val issue = Issue(
-        javaClass.simpleName, Severity.Style,
+        javaClass.simpleName,
+        Severity.Style,
         "Class contents should be in this order: Property declarations/initializer blocks; secondary constructors; " +
             "method declarations then companion objects.",
         Debt.FIVE_MINS

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/CollapsibleIfStatements.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/CollapsibleIfStatements.kt
@@ -38,7 +38,8 @@ import org.jetbrains.kotlin.psi.psiUtil.getChildrenOfType
 class CollapsibleIfStatements(config: Config = Config.empty) : Rule(config) {
 
     override val issue = Issue(
-        "CollapsibleIfStatements", Severity.Style,
+        "CollapsibleIfStatements",
+        Severity.Style,
         "Two if statements which could be collapsed were detected. " +
             "These statements can be merged to improve readability.",
         Debt.FIVE_MINS

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/CollapsibleIfStatements.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/CollapsibleIfStatements.kt
@@ -37,10 +37,12 @@ import org.jetbrains.kotlin.psi.psiUtil.getChildrenOfType
  */
 class CollapsibleIfStatements(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue("CollapsibleIfStatements", Severity.Style,
-            "Two if statements which could be collapsed were detected. " +
-                    "These statements can be merged to improve readability.",
-            Debt.FIVE_MINS)
+    override val issue = Issue(
+        "CollapsibleIfStatements", Severity.Style,
+        "Two if statements which could be collapsed were detected. " +
+            "These statements can be merged to improve readability.",
+        Debt.FIVE_MINS
+    )
 
     override fun visitIfExpression(expression: KtIfExpression) {
         if (isNotElseIfOrElse(expression) && hasOneKtIfExpression(expression)) {
@@ -50,7 +52,7 @@ class CollapsibleIfStatements(config: Config = Config.empty) : Rule(config) {
     }
 
     private fun isNotElseIfOrElse(expression: KtIfExpression) =
-            expression.`else` == null && expression.parent !is KtContainerNodeForControlStructureBody
+        expression.`else` == null && expression.parent !is KtContainerNodeForControlStructureBody
 
     private fun hasOneKtIfExpression(expression: KtIfExpression): Boolean {
         val statement = expression.then?.getChildrenOfType<KtExpression>()?.singleOrNull()

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/DataClassContainsFunctions.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/DataClassContainsFunctions.kt
@@ -29,19 +29,21 @@ import org.jetbrains.kotlin.psi.KtNamedFunction
  */
 class DataClassContainsFunctions(config: Config = Config.empty) : Rule(config) {
 
-    override val issue: Issue = Issue("DataClassContainsFunctions",
-            Severity.Style,
-            "Data classes should mainly be used to store data and should not have any extra functions. " +
-                    "(Compiler will automatically generate equals, toString and hashCode functions)",
-            Debt.TWENTY_MINS)
+    override val issue: Issue = Issue(
+        "DataClassContainsFunctions",
+        Severity.Style,
+        "Data classes should mainly be used to store data and should not have any extra functions. " +
+            "(Compiler will automatically generate equals, toString and hashCode functions)",
+        Debt.TWENTY_MINS
+    )
 
     private val conversionFunctionPrefix = SplitPattern(valueOrDefault(CONVERSION_FUNCTION_PREFIX, "to"))
 
     override fun visitClass(klass: KtClass) {
         if (klass.isData()) {
             klass.body?.declarations
-                    ?.filterIsInstance<KtNamedFunction>()
-                    ?.forEach { checkFunction(klass, it) }
+                ?.filterIsInstance<KtNamedFunction>()
+                ?.forEach { checkFunction(klass, it) }
         }
         super.visitClass(klass)
     }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/DataClassShouldBeImmutable.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/DataClassShouldBeImmutable.kt
@@ -35,7 +35,7 @@ class DataClassShouldBeImmutable(config: Config = Config.empty) : Rule(config) {
         "DataClassShouldBeImmutable",
         Severity.Style,
         "Data classes should mainly be immutable and should not have any side effects. " +
-                "(To copy an object altering some of its properties use the copy function)",
+            "(To copy an object altering some of its properties use the copy function)",
         Debt.TWENTY_MINS
     )
 
@@ -58,7 +58,7 @@ class DataClassShouldBeImmutable(config: Config = Config.empty) : Rule(config) {
                 issue,
                 Entity.from(element),
                 "The data class $className contains a mutable property. " +
-                        "The offending property is called $propertyName"
+                    "The offending property is called $propertyName"
             )
         )
     }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/DestructuringDeclarationWithTooManyEntries.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/DestructuringDeclarationWithTooManyEntries.kt
@@ -30,7 +30,7 @@ class DestructuringDeclarationWithTooManyEntries(config: Config = Config.empty) 
         javaClass.simpleName,
         Severity.Style,
         "The destructuring declaration contains too many entries, making it difficult to read. Consider refactoring " +
-                "to avoid using a destructuring declaration for this case.",
+            "to avoid using a destructuring declaration for this case.",
         Debt.TEN_MINS
     )
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/EqualsNullCall.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/EqualsNullCall.kt
@@ -25,9 +25,11 @@ import org.jetbrains.kotlin.psi.KtCallExpression
  */
 class EqualsNullCall(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue("EqualsNullCall", Severity.Style,
-            "Equals() method is called with null as parameter. Consider using == to compare to null.",
-            Debt.FIVE_MINS)
+    override val issue = Issue(
+        "EqualsNullCall", Severity.Style,
+        "Equals() method is called with null as parameter. Consider using == to compare to null.",
+        Debt.FIVE_MINS
+    )
 
     override fun visitCallExpression(expression: KtCallExpression) {
         if (expression.calleeExpression?.text == "equals" && hasNullParameter(expression)) {

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/EqualsNullCall.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/EqualsNullCall.kt
@@ -26,7 +26,8 @@ import org.jetbrains.kotlin.psi.KtCallExpression
 class EqualsNullCall(config: Config = Config.empty) : Rule(config) {
 
     override val issue = Issue(
-        "EqualsNullCall", Severity.Style,
+        "EqualsNullCall",
+        Severity.Style,
         "Equals() method is called with null as parameter. Consider using == to compare to null.",
         Debt.FIVE_MINS
     )

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitItLambdaParameter.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitItLambdaParameter.kt
@@ -42,17 +42,21 @@ import org.jetbrains.kotlin.psi.KtLambdaExpression
  * </compliant>
  */
 class ExplicitItLambdaParameter(val config: Config) : Rule(config) {
-    override val issue = Issue(javaClass.simpleName, Severity.Style,
-            "Declaring lambda parameters as `it` is redundant.", Debt.FIVE_MINS)
+    override val issue = Issue(
+        javaClass.simpleName, Severity.Style,
+        "Declaring lambda parameters as `it` is redundant.", Debt.FIVE_MINS
+    )
 
     override fun visitLambdaExpression(lambdaExpression: KtLambdaExpression) {
         super.visitLambdaExpression(lambdaExpression)
         val parameterNames = lambdaExpression.valueParameters.map { it.name }
         if (IT_LITERAL in parameterNames) {
-            report(CodeSmell(
+            report(
+                CodeSmell(
                     issue, Entity.from(lambdaExpression),
                     "This explicit usage of `it` as the lambda parameter name can be omitted."
-            ))
+                )
+            )
         }
     }
 }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitItLambdaParameter.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitItLambdaParameter.kt
@@ -43,8 +43,10 @@ import org.jetbrains.kotlin.psi.KtLambdaExpression
  */
 class ExplicitItLambdaParameter(val config: Config) : Rule(config) {
     override val issue = Issue(
-        javaClass.simpleName, Severity.Style,
-        "Declaring lambda parameters as `it` is redundant.", Debt.FIVE_MINS
+        javaClass.simpleName,
+        Severity.Style,
+        "Declaring lambda parameters as `it` is redundant.",
+        Debt.FIVE_MINS
     )
 
     override fun visitLambdaExpression(lambdaExpression: KtLambdaExpression) {
@@ -53,7 +55,8 @@ class ExplicitItLambdaParameter(val config: Config) : Rule(config) {
         if (IT_LITERAL in parameterNames) {
             report(
                 CodeSmell(
-                    issue, Entity.from(lambdaExpression),
+                    issue,
+                    Entity.from(lambdaExpression),
                     "This explicit usage of `it` as the lambda parameter name can be omitted."
                 )
             )

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExpressionBodySyntax.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExpressionBodySyntax.kt
@@ -45,7 +45,8 @@ class ExpressionBodySyntax(config: Config = Config.empty) : Rule(config) {
         Severity.Style,
         "Functions with exact one statement, the return statement," +
             " can be rewritten with ExpressionBodySyntax.",
-        Debt.FIVE_MINS)
+        Debt.FIVE_MINS
+    )
 
     private val includeLineWrapping = valueOrDefault(INCLUDE_LINE_WRAPPING, false)
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenComment.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenComment.kt
@@ -33,10 +33,12 @@ import org.jetbrains.kotlin.psi.psiUtil.collectDescendantsOfType
  */
 class ForbiddenComment(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue(javaClass.simpleName,
-            Severity.Style,
-            "Flags a forbidden comment.",
-            Debt.TEN_MINS)
+    override val issue = Issue(
+        javaClass.simpleName,
+        Severity.Style,
+        "Flags a forbidden comment.",
+        Debt.TEN_MINS
+    )
 
     private val values: List<String> = valueOrDefaultCommaSeparated(VALUES, listOf("TODO:", "FIXME:", "STOPSHIP:"))
 
@@ -61,8 +63,13 @@ class ForbiddenComment(config: Config = Config.empty) : Rule(config) {
 
         values.forEach {
             if (text.contains(it, ignoreCase = true)) {
-                report(CodeSmell(issue, Entity.from(comment), "This comment contains '$it' that has been " +
-                    "defined as forbidden in detekt."))
+                report(
+                    CodeSmell(
+                        issue, Entity.from(comment),
+                        "This comment contains '$it' that has been " +
+                            "defined as forbidden in detekt."
+                    )
+                )
             }
         }
     }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenComment.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenComment.kt
@@ -65,7 +65,8 @@ class ForbiddenComment(config: Config = Config.empty) : Rule(config) {
             if (text.contains(it, ignoreCase = true)) {
                 report(
                     CodeSmell(
-                        issue, Entity.from(comment),
+                        issue,
+                        Entity.from(comment),
                         "This comment contains '$it' that has been " +
                             "defined as forbidden in detekt."
                     )

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenImport.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenImport.kt
@@ -32,7 +32,7 @@ class ForbiddenImport(config: Config = Config.empty) : Rule(config) {
         javaClass.simpleName,
         Severity.Style,
         "Mark forbidden imports. A forbidden import could be an import for an unstable / experimental api" +
-                "and hence you might want to mark it as forbidden in order to get warned about the usage.",
+            "and hence you might want to mark it as forbidden in order to get warned about the usage.",
         Debt.TEN_MINS
     )
 
@@ -49,8 +49,9 @@ class ForbiddenImport(config: Config = Config.empty) : Rule(config) {
         if (forbiddenImports.any { it.matches(import) } || containsForbiddenPattern(import)) {
             report(
                 CodeSmell(
-                    issue, Entity.from(importDirective), "The import " +
-                            "$import has been forbidden in the Detekt config."
+                    issue, Entity.from(importDirective),
+                    "The import " +
+                        "$import has been forbidden in the Detekt config."
                 )
             )
         }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenImport.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenImport.kt
@@ -49,7 +49,8 @@ class ForbiddenImport(config: Config = Config.empty) : Rule(config) {
         if (forbiddenImports.any { it.matches(import) } || containsForbiddenPattern(import)) {
             report(
                 CodeSmell(
-                    issue, Entity.from(importDirective),
+                    issue,
+                    Entity.from(importDirective),
                     "The import " +
                         "$import has been forbidden in the Detekt config."
                 )

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/FunctionOnlyReturningConstant.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/FunctionOnlyReturningConstant.kt
@@ -44,7 +44,8 @@ import org.jetbrains.kotlin.psi.psiUtil.containingClass
 class FunctionOnlyReturningConstant(config: Config = Config.empty) : Rule(config) {
 
     override val issue = Issue(
-        javaClass.simpleName, Severity.Style,
+        javaClass.simpleName,
+        Severity.Style,
         "A function that only returns a constant is misleading. " +
             "Consider declaring a constant instead",
         Debt.TEN_MINS
@@ -54,7 +55,8 @@ class FunctionOnlyReturningConstant(config: Config = Config.empty) : Rule(config
     private val ignoreActualFunction = valueOrDefault(IGNORE_ACTUAL_FUNCTION, true)
     private val excludedFunctions = SplitPattern(valueOrDefault(EXCLUDED_FUNCTIONS, "describeContents"))
     private val excludeAnnotatedFunctions = valueOrDefaultCommaSeparated(
-        EXCLUDE_ANNOTATED_FUNCTION, listOf("dagger.Provides")
+        EXCLUDE_ANNOTATED_FUNCTION,
+        listOf("dagger.Provides")
     )
         .map { it.removePrefix("*").removeSuffix("*") }
     private lateinit var annotationExcluder: AnnotationExcluder

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/FunctionOnlyReturningConstant.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/FunctionOnlyReturningConstant.kt
@@ -43,16 +43,19 @@ import org.jetbrains.kotlin.psi.psiUtil.containingClass
  */
 class FunctionOnlyReturningConstant(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue(javaClass.simpleName, Severity.Style,
+    override val issue = Issue(
+        javaClass.simpleName, Severity.Style,
         "A function that only returns a constant is misleading. " +
             "Consider declaring a constant instead",
-        Debt.TEN_MINS)
+        Debt.TEN_MINS
+    )
 
     private val ignoreOverridableFunction = valueOrDefault(IGNORE_OVERRIDABLE_FUNCTION, true)
     private val ignoreActualFunction = valueOrDefault(IGNORE_ACTUAL_FUNCTION, true)
     private val excludedFunctions = SplitPattern(valueOrDefault(EXCLUDED_FUNCTIONS, "describeContents"))
     private val excludeAnnotatedFunctions = valueOrDefaultCommaSeparated(
-            EXCLUDE_ANNOTATED_FUNCTION, listOf("dagger.Provides"))
+        EXCLUDE_ANNOTATED_FUNCTION, listOf("dagger.Provides")
+    )
         .map { it.removePrefix("*").removeSuffix("*") }
     private lateinit var annotationExcluder: AnnotationExcluder
 
@@ -64,13 +67,15 @@ class FunctionOnlyReturningConstant(config: Config = Config.empty) : Rule(config
     override fun visitNamedFunction(function: KtNamedFunction) {
         if (isNotIgnored(function) &&
             isNotExcluded(function) &&
-            isReturningAConstant(function)) {
+            isReturningAConstant(function)
+        ) {
             report(
                 CodeSmell(
                     issue,
                     Entity.atName(function),
                     "${function.nameAsSafeName} is returning a constant. Prefer declaring a constant instead."
-                ))
+                )
+            )
         }
         super.visitNamedFunction(function)
     }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/Junk.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/Junk.kt
@@ -13,7 +13,7 @@ import org.jetbrains.kotlin.psi.psiUtil.getNonStrictParentOfType
  */
 internal fun findFirstKtElementInParents(file: KtFile, offset: Int, line: String): PsiElement? {
     return file.elementsInRange(TextRange.create(offset - line.length, offset))
-            .plus(file.findElementAt(offset))
-            .mapNotNull { it?.getNonStrictParentOfType() }
-            .firstOrNull()
+        .plus(file.findElementAt(offset))
+        .mapNotNull { it?.getNonStrictParentOfType() }
+        .firstOrNull()
 }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/LibraryEntitiesShouldNotBePublic.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/LibraryEntitiesShouldNotBePublic.kt
@@ -48,17 +48,25 @@ class LibraryEntitiesShouldNotBePublic(ruleSetConfig: Config = Config.empty) : R
 
     override fun visitTypeAlias(typeAlias: KtTypeAlias) {
         if (typeAlias.isPublic) {
-            report(CodeSmell(issue,
-                Entity.from(typeAlias),
-                "TypeAlias ${typeAlias.nameAsSafeName} should not be public"))
+            report(
+                CodeSmell(
+                    issue,
+                    Entity.from(typeAlias),
+                    "TypeAlias ${typeAlias.nameAsSafeName} should not be public"
+                )
+            )
         }
     }
 
     override fun visitNamedFunction(function: KtNamedFunction) {
         if (function.isTopLevel && function.isPublic) {
-            report(CodeSmell(issue,
-                Entity.from(function),
-                "Top level function ${function.nameAsSafeName} should not be public"))
+            report(
+                CodeSmell(
+                    issue,
+                    Entity.from(function),
+                    "Top level function ${function.nameAsSafeName} should not be public"
+                )
+            )
         }
     }
 }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/LoopWithTooManyJumpStatements.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/LoopWithTooManyJumpStatements.kt
@@ -35,9 +35,12 @@ import org.jetbrains.kotlin.psi.KtLoopExpression
  */
 class LoopWithTooManyJumpStatements(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue(javaClass.simpleName, Severity.Style,
-            "The loop contains more than one break or continue statement. " +
-                    "The code should be refactored to increase readability.", Debt.TEN_MINS)
+    override val issue = Issue(
+        javaClass.simpleName, Severity.Style,
+        "The loop contains more than one break or continue statement. " +
+            "The code should be refactored to increase readability.",
+        Debt.TEN_MINS
+    )
 
     private val maxJumpCount = valueOrDefault(MAX_JUMP_COUNT, 1)
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/LoopWithTooManyJumpStatements.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/LoopWithTooManyJumpStatements.kt
@@ -36,7 +36,8 @@ import org.jetbrains.kotlin.psi.KtLoopExpression
 class LoopWithTooManyJumpStatements(config: Config = Config.empty) : Rule(config) {
 
     override val issue = Issue(
-        javaClass.simpleName, Severity.Style,
+        javaClass.simpleName,
+        Severity.Style,
         "The loop contains more than one break or continue statement. " +
             "The code should be refactored to increase readability.",
         Debt.TEN_MINS

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumber.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumber.kt
@@ -92,7 +92,8 @@ import java.util.Locale
 class MagicNumber(config: Config = Config.empty) : Rule(config) {
 
     override val issue = Issue(
-        javaClass.simpleName, Severity.Style,
+        javaClass.simpleName,
+        Severity.Style,
         "Report magic numbers. Magic number is a numeric literal that is not defined as a constant " +
             "and hence it's unclear what the purpose of this number is. " +
             "It's better to declare such numbers as constants and give them a proper name. " +
@@ -137,7 +138,8 @@ class MagicNumber(config: Config = Config.empty) : Rule(config) {
         if (number != null && !ignoredNumbers.contains(number)) {
             report(
                 CodeSmell(
-                    issue, Entity.from(expression),
+                    issue,
+                    Entity.from(expression),
                     "This expression contains a magic number." +
                         " Consider defining it to a well named constant."
                 )

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumber.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumber.kt
@@ -91,15 +91,18 @@ import java.util.Locale
 @Suppress("TooManyFunctions")
 class MagicNumber(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue(javaClass.simpleName, Severity.Style,
-            "Report magic numbers. Magic number is a numeric literal that is not defined as a constant " +
-                    "and hence it's unclear what the purpose of this number is. " +
-                    "It's better to declare such numbers as constants and give them a proper name. " +
-                    "By default, -1, 0, 1, and 2 are not considered to be magic numbers.", Debt.TEN_MINS)
+    override val issue = Issue(
+        javaClass.simpleName, Severity.Style,
+        "Report magic numbers. Magic number is a numeric literal that is not defined as a constant " +
+            "and hence it's unclear what the purpose of this number is. " +
+            "It's better to declare such numbers as constants and give them a proper name. " +
+            "By default, -1, 0, 1, and 2 are not considered to be magic numbers.",
+        Debt.TEN_MINS
+    )
 
     private val ignoredNumbers = valueOrDefaultCommaSeparated(IGNORE_NUMBERS, listOf("-1", "0", "1", "2"))
-            .map { parseAsDouble(it) }
-            .sorted()
+        .map { parseAsDouble(it) }
+        .sorted()
 
     private val ignoreAnnotation = valueOrDefault(IGNORE_ANNOTATION, false)
     private val ignoreHashCodeFunction = valueOrDefault(IGNORE_HASH_CODE, true)
@@ -109,7 +112,7 @@ class MagicNumber(config: Config = Config.empty) : Rule(config) {
     private val ignoreEnums = valueOrDefault(IGNORE_ENUMS, false)
     private val ignoreConstantDeclaration = valueOrDefault(IGNORE_CONSTANT_DECLARATION, true)
     private val ignoreCompanionObjectPropertyDeclaration =
-            valueOrDefault(IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION, true)
+        valueOrDefault(IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION, true)
     private val ignoreRanges = valueOrDefault(IGNORE_RANGES, false)
     private val ignoreExtensionFunctions = valueOrDefault(IGNORE_EXTENSION_FUNCTIONS, true)
 
@@ -118,7 +121,8 @@ class MagicNumber(config: Config = Config.empty) : Rule(config) {
         if (elementType != KtNodeTypes.INTEGER_CONSTANT && elementType != KtNodeTypes.FLOAT_CONSTANT) return
 
         if (isIgnoredByConfig(expression) || expression.isPartOfFunctionReturnConstant() ||
-                expression.isPartOfConstructorOrFunctionConstant()) {
+            expression.isPartOfConstructorOrFunctionConstant()
+        ) {
             return
         }
 
@@ -131,8 +135,13 @@ class MagicNumber(config: Config = Config.empty) : Rule(config) {
 
         val number = parseAsDoubleOrNull(rawNumber)
         if (number != null && !ignoredNumbers.contains(number)) {
-            report(CodeSmell(issue, Entity.from(expression), "This expression contains a magic number." +
-                    " Consider defining it to a well named constant."))
+            report(
+                CodeSmell(
+                    issue, Entity.from(expression),
+                    "This expression contains a magic number." +
+                        " Consider defining it to a well named constant."
+                )
+            )
         }
     }
 
@@ -169,11 +178,11 @@ class MagicNumber(config: Config = Config.empty) : Rule(config) {
 
     private fun normalizeForParsingAsDouble(text: String): String {
         return text.trim()
-                .toLowerCase(Locale.US)
-                .replace("_", "")
-                .removeSuffix("l")
-                .removeSuffix("d")
-                .removeSuffix("f")
+            .toLowerCase(Locale.US)
+            .replace("_", "")
+            .removeSuffix("l")
+            .removeSuffix("d")
+            .removeSuffix("f")
     }
 
     private fun KtConstantExpression.isNamedArgument(): Boolean {
@@ -194,10 +203,10 @@ class MagicNumber(config: Config = Config.empty) : Rule(config) {
 
     private fun KtConstantExpression.isPartOfConstructorOrFunctionConstant(): Boolean {
         return parent is KtParameter &&
-                when (parent.parent.parent) {
-                    is KtNamedFunction, is KtPrimaryConstructor, is KtSecondaryConstructor -> true
-                    else -> false
-                }
+            when (parent.parent.parent) {
+                is KtNamedFunction, is KtPrimaryConstructor, is KtSecondaryConstructor -> true
+                else -> false
+            }
     }
 
     private fun KtConstantExpression.isPartOfRange(): Boolean {
@@ -205,7 +214,7 @@ class MagicNumber(config: Config = Config.empty) : Rule(config) {
         val rangeOperators = setOf("downTo", "until", "step")
         return if (theParent is KtBinaryExpression) {
             theParent.operationToken == KtTokens.RANGE ||
-                    theParent.operationReference.getReferencedName() in rangeOperators
+                theParent.operationReference.getReferencedName() in rangeOperators
         } else {
             false
         }
@@ -235,7 +244,7 @@ class MagicNumber(config: Config = Config.empty) : Rule(config) {
         isProperty() && getNonStrictParentOfType<KtProperty>()?.isConstant() ?: false
 
     private fun PsiElement.hasUnaryMinusPrefix(): Boolean = this is KtPrefixExpression &&
-            (firstChild as? KtOperationReferenceExpression)?.operationSignTokenType == KtTokens.MINUS
+        (firstChild as? KtOperationReferenceExpression)?.operationSignTokenType == KtTokens.MINUS
 
     companion object {
         const val IGNORE_NUMBERS = "ignoreNumbers"

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLength.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLength.kt
@@ -24,19 +24,21 @@ import io.gitlab.arturbosch.detekt.rules.lastArgumentMatchesUrl
  */
 class MaxLineLength(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue(javaClass.simpleName,
-            Severity.Style,
-            "Line detected that is longer than the defined maximum line length in the code style.",
-            Debt.FIVE_MINS)
+    override val issue = Issue(
+        javaClass.simpleName,
+        Severity.Style,
+        "Line detected that is longer than the defined maximum line length in the code style.",
+        Debt.FIVE_MINS
+    )
 
     private val lengthThreshold: Int =
-            valueOrDefault(MAX_LINE_LENGTH, DEFAULT_IDEA_LINE_LENGTH)
+        valueOrDefault(MAX_LINE_LENGTH, DEFAULT_IDEA_LINE_LENGTH)
     private val excludePackageStatements: Boolean =
-            valueOrDefault(EXCLUDE_PACKAGE_STATEMENTS, true)
+        valueOrDefault(EXCLUDE_PACKAGE_STATEMENTS, true)
     private val excludeImportStatements: Boolean =
-            valueOrDefault(EXCLUDE_IMPORT_STATEMENTS, true)
+        valueOrDefault(EXCLUDE_IMPORT_STATEMENTS, true)
     private val excludeCommentStatements: Boolean =
-            valueOrDefault(EXCLUDE_COMMENT_STATEMENTS, false)
+        valueOrDefault(EXCLUDE_COMMENT_STATEMENTS, false)
 
     fun visit(element: KtFileContent) {
         var offset = 0
@@ -65,8 +67,8 @@ class MaxLineLength(config: Config = Config.empty) : Rule(config) {
 
     private fun isIgnoredStatement(line: String): Boolean {
         return containsIgnoredPackageStatement(line) ||
-                containsIgnoredImportStatement(line) ||
-                containsIgnoredCommentStatement(line)
+            containsIgnoredImportStatement(line) ||
+            containsIgnoredCommentStatement(line)
     }
 
     private fun containsIgnoredPackageStatement(line: String): Boolean {
@@ -85,8 +87,8 @@ class MaxLineLength(config: Config = Config.empty) : Rule(config) {
         if (!excludeCommentStatements) return false
 
         return line.trimStart().startsWith("//") ||
-                line.trimStart().startsWith("/*") ||
-                line.trimStart().startsWith("*")
+            line.trimStart().startsWith("/*") ||
+            line.trimStart().startsWith("*")
     }
 
     companion object {

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MayBeConst.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MayBeConst.kt
@@ -46,8 +46,11 @@ class MayBeConst(config: Config = Config.empty) : Rule(config) {
     )
 
     private val binaryTokens = hashSetOf<KtSingleValueToken>(
-        KtTokens.PLUS, KtTokens.MINUS, KtTokens.MUL,
-        KtTokens.DIV, KtTokens.PERC
+        KtTokens.PLUS,
+        KtTokens.MINUS,
+        KtTokens.MUL,
+        KtTokens.DIV,
+        KtTokens.PERC
     )
 
     private val topLevelConstants = HashSet<String?>()

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MayBeConst.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MayBeConst.kt
@@ -38,13 +38,17 @@ import org.jetbrains.kotlin.psi.psiUtil.containingClassOrObject
  */
 class MayBeConst(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue(javaClass.simpleName,
-            Severity.Style,
-            "Reports vals that can be const val instead.",
-            Debt.FIVE_MINS)
+    override val issue = Issue(
+        javaClass.simpleName,
+        Severity.Style,
+        "Reports vals that can be const val instead.",
+        Debt.FIVE_MINS
+    )
 
-    private val binaryTokens = hashSetOf<KtSingleValueToken>(KtTokens.PLUS, KtTokens.MINUS, KtTokens.MUL,
-            KtTokens.DIV, KtTokens.PERC)
+    private val binaryTokens = hashSetOf<KtSingleValueToken>(
+        KtTokens.PLUS, KtTokens.MINUS, KtTokens.MUL,
+        KtTokens.DIV, KtTokens.PERC
+    )
 
     private val topLevelConstants = HashSet<String?>()
     private val companionObjectConstants = HashSet<String?>()
@@ -52,9 +56,9 @@ class MayBeConst(config: Config = Config.empty) : Rule(config) {
     override fun visitKtFile(file: KtFile) {
         topLevelConstants.clear()
         val topLevelProperties = file.declarations
-                .filterIsInstance<KtProperty>()
-                .filter { it.isTopLevel && it.isConstant() }
-                .mapNotNull { it.name }
+            .filterIsInstance<KtProperty>()
+            .filter { it.isTopLevel && it.isConstant() }
+            .mapNotNull { it.name }
         topLevelConstants.addAll(topLevelProperties)
         super.visitKtFile(file)
     }
@@ -64,9 +68,9 @@ class MayBeConst(config: Config = Config.empty) : Rule(config) {
             return
         }
         val constProperties = declaration.declarations
-                .filterIsInstance<KtProperty>()
-                .filter { it.isConstant() }
-                .mapNotNull { it.name }
+            .filterIsInstance<KtProperty>()
+            .filter { it.isConstant() }
+            .mapNotNull { it.name }
         companionObjectConstants.addAll(constProperties)
         super.visitObjectDeclaration(declaration)
         companionObjectConstants.removeAll(constProperties)
@@ -100,35 +104,35 @@ class MayBeConst(config: Config = Config.empty) : Rule(config) {
 
     private fun KtProperty.cannotBeConstant(): Boolean {
         return isLocal ||
-                isVar ||
-                getter != null ||
-                isConstant() ||
-                isOverride()
+            isVar ||
+            getter != null ||
+            isConstant() ||
+            isOverride()
     }
 
     private fun KtProperty.isInObject() =
-            !isTopLevel && containingClassOrObject !is KtObjectDeclaration
+        !isTopLevel && containingClassOrObject !is KtObjectDeclaration
 
     private fun KtExpression.isConstantExpression(): Boolean {
         return this is KtStringTemplateExpression && !hasInterpolation() ||
-                node.elementType == KtNodeTypes.BOOLEAN_CONSTANT ||
-                node.elementType == KtNodeTypes.INTEGER_CONSTANT ||
-                node.elementType == KtNodeTypes.CHARACTER_CONSTANT ||
-                node.elementType == KtNodeTypes.FLOAT_CONSTANT ||
-                topLevelConstants.contains(text) ||
-                companionObjectConstants.contains(text) ||
-                isBinaryExpression(this) ||
-                isParenthesizedExpression(this)
+            node.elementType == KtNodeTypes.BOOLEAN_CONSTANT ||
+            node.elementType == KtNodeTypes.INTEGER_CONSTANT ||
+            node.elementType == KtNodeTypes.CHARACTER_CONSTANT ||
+            node.elementType == KtNodeTypes.FLOAT_CONSTANT ||
+            topLevelConstants.contains(text) ||
+            companionObjectConstants.contains(text) ||
+            isBinaryExpression(this) ||
+            isParenthesizedExpression(this)
     }
 
     private fun isParenthesizedExpression(expression: KtExpression) =
-            (expression as? KtParenthesizedExpression)?.expression?.isConstantExpression() == true
+        (expression as? KtParenthesizedExpression)?.expression?.isConstantExpression() == true
 
     private fun isBinaryExpression(expression: KtExpression): Boolean {
         return expression is KtBinaryExpression &&
-                expression.node.elementType == KtNodeTypes.BINARY_EXPRESSION &&
-                binaryTokens.contains(expression.operationToken) &&
-                expression.left?.isConstantExpression() == true &&
-                expression.right?.isConstantExpression() == true
+            expression.node.elementType == KtNodeTypes.BINARY_EXPRESSION &&
+            binaryTokens.contains(expression.operationToken) &&
+            expression.left?.isConstantExpression() == true &&
+            expression.right?.isConstantExpression() == true
     }
 }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ModifierOrder.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ModifierOrder.kt
@@ -53,29 +53,31 @@ import org.jetbrains.kotlin.psi.psiUtil.allChildren
  */
 class ModifierOrder(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue(javaClass.simpleName,
-            Severity.Style,
-            "Modifiers are not in the correct order.",
-            Debt.FIVE_MINS)
+    override val issue = Issue(
+        javaClass.simpleName,
+        Severity.Style,
+        "Modifiers are not in the correct order.",
+        Debt.FIVE_MINS
+    )
 
     // subset of KtTokens.MODIFIER_KEYWORDS_ARRAY
     private val order = arrayOf(
-            PUBLIC_KEYWORD, PROTECTED_KEYWORD, PRIVATE_KEYWORD, INTERNAL_KEYWORD,
-            EXPECT_KEYWORD, ACTUAL_KEYWORD,
-            FINAL_KEYWORD, OPEN_KEYWORD, ABSTRACT_KEYWORD, SEALED_KEYWORD, CONST_KEYWORD,
-            EXTERNAL_KEYWORD,
-            OVERRIDE_KEYWORD,
-            LATEINIT_KEYWORD,
-            TAILREC_KEYWORD,
-            VARARG_KEYWORD,
-            SUSPEND_KEYWORD,
-            INNER_KEYWORD,
-            ENUM_KEYWORD, ANNOTATION_KEYWORD, FUN_KEYWORD,
-            COMPANION_KEYWORD,
-            INLINE_KEYWORD,
-            INFIX_KEYWORD,
-            OPERATOR_KEYWORD,
-            DATA_KEYWORD
+        PUBLIC_KEYWORD, PROTECTED_KEYWORD, PRIVATE_KEYWORD, INTERNAL_KEYWORD,
+        EXPECT_KEYWORD, ACTUAL_KEYWORD,
+        FINAL_KEYWORD, OPEN_KEYWORD, ABSTRACT_KEYWORD, SEALED_KEYWORD, CONST_KEYWORD,
+        EXTERNAL_KEYWORD,
+        OVERRIDE_KEYWORD,
+        LATEINIT_KEYWORD,
+        TAILREC_KEYWORD,
+        VARARG_KEYWORD,
+        SUSPEND_KEYWORD,
+        INNER_KEYWORD,
+        ENUM_KEYWORD, ANNOTATION_KEYWORD, FUN_KEYWORD,
+        COMPANION_KEYWORD,
+        INLINE_KEYWORD,
+        INFIX_KEYWORD,
+        OPERATOR_KEYWORD,
+        DATA_KEYWORD
     )
 
     override fun visitModifierList(list: KtModifierList) {
@@ -90,9 +92,16 @@ class ModifierOrder(config: Config = Config.empty) : Rule(config) {
         if (modifiers != sortedModifiers) {
             val modifierString = sortedModifiers.joinToString(" ") { it.text }
 
-            report(CodeSmell(Issue(javaClass.simpleName, Severity.Style,
-                    "Modifier order should be: $modifierString", Debt(mins = 1)), Entity.from(list),
-                    "Modifier order should be: $modifierString"))
+            report(
+                CodeSmell(
+                    Issue(
+                        javaClass.simpleName, Severity.Style,
+                        "Modifier order should be: $modifierString", Debt(mins = 1)
+                    ),
+                    Entity.from(list),
+                    "Modifier order should be: $modifierString"
+                )
+            )
         }
     }
 }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ModifierOrder.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ModifierOrder.kt
@@ -95,8 +95,10 @@ class ModifierOrder(config: Config = Config.empty) : Rule(config) {
             report(
                 CodeSmell(
                     Issue(
-                        javaClass.simpleName, Severity.Style,
-                        "Modifier order should be: $modifierString", Debt(mins = 1)
+                        javaClass.simpleName,
+                        Severity.Style,
+                        "Modifier order should be: $modifierString",
+                        Debt(mins = 1)
                     ),
                     Entity.from(list),
                     "Modifier order should be: $modifierString"

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MultilineLambdaItParameter.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MultilineLambdaItParameter.kt
@@ -65,8 +65,10 @@ import org.jetbrains.kotlin.resolve.BindingContext
 @RequiresTypeResolution
 class MultilineLambdaItParameter(val config: Config) : Rule(config) {
     override val issue = Issue(
-        javaClass.simpleName, Severity.Style,
-        "Multiline lambdas should not use `it` as a parameter name", Debt.FIVE_MINS
+        javaClass.simpleName,
+        Severity.Style,
+        "Multiline lambdas should not use `it` as a parameter name",
+        Debt.FIVE_MINS
     )
 
     override fun visitLambdaExpression(lambdaExpression: KtLambdaExpression) {
@@ -81,7 +83,8 @@ class MultilineLambdaItParameter(val config: Config) : Rule(config) {
             IT_LITERAL in parameterNames ->
                 report(
                     CodeSmell(
-                        issue, Entity.from(lambdaExpression),
+                        issue,
+                        Entity.from(lambdaExpression),
                         "The parameter name in a multiline lambda should not be an explicit `it`. " +
                             "Consider giving your parameter a readable and descriptive name."
                     )
@@ -91,7 +94,8 @@ class MultilineLambdaItParameter(val config: Config) : Rule(config) {
                 if (lambdaExpression.hasImplicitParameter(bindingContext)) {
                     report(
                         CodeSmell(
-                            issue, Entity.from(lambdaExpression),
+                            issue,
+                            Entity.from(lambdaExpression),
                             "The implicit `it` should be used in a multiline lambda. " +
                                 "Consider giving your parameter a readable and descriptive name."
                         )

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/NestedClassesVisibility.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/NestedClassesVisibility.kt
@@ -40,7 +40,8 @@ import org.jetbrains.kotlin.psi.KtEnumEntry
 class NestedClassesVisibility(config: Config = Config.empty) : Rule(config) {
 
     override val issue: Issue = Issue(
-        "NestedClassesVisibility", Severity.Style,
+        "NestedClassesVisibility",
+        Severity.Style,
         "The explicit public modifier still results in an internal nested class.",
         Debt.FIVE_MINS
     )

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/NestedClassesVisibility.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/NestedClassesVisibility.kt
@@ -39,9 +39,11 @@ import org.jetbrains.kotlin.psi.KtEnumEntry
  */
 class NestedClassesVisibility(config: Config = Config.empty) : Rule(config) {
 
-    override val issue: Issue = Issue("NestedClassesVisibility", Severity.Style,
-            "The explicit public modifier still results in an internal nested class.",
-            Debt.FIVE_MINS)
+    override val issue: Issue = Issue(
+        "NestedClassesVisibility", Severity.Style,
+        "The explicit public modifier still results in an internal nested class.",
+        Debt.FIVE_MINS
+    )
 
     override fun visitClass(klass: KtClass) {
         if (!klass.isInterface() && klass.isTopLevel() && klass.isInternal()) {
@@ -51,9 +53,9 @@ class NestedClassesVisibility(config: Config = Config.empty) : Rule(config) {
 
     private fun checkDeclarations(klass: KtClass) {
         klass.declarations
-                .filterIsInstance<KtClassOrObject>()
-                .filter { it.hasModifier(KtTokens.PUBLIC_KEYWORD) && it.isNoEnum() && it.isNoCompanionObj() }
-                .forEach { report(CodeSmell(issue, Entity.from(it), issue.description)) }
+            .filterIsInstance<KtClassOrObject>()
+            .filter { it.hasModifier(KtTokens.PUBLIC_KEYWORD) && it.isNoEnum() && it.isNoCompanionObj() }
+            .forEach { report(CodeSmell(issue, Entity.from(it), issue.description)) }
     }
 
     private fun KtClassOrObject.isNoEnum() = !this.hasModifier(KtTokens.ENUM_KEYWORD) && this !is KtEnumEntry

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/NewLineAtEndOfFile.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/NewLineAtEndOfFile.kt
@@ -16,16 +16,22 @@ import org.jetbrains.kotlin.psi.KtFile
  */
 class NewLineAtEndOfFile(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue(javaClass.simpleName,
+    override val issue = Issue(
+        javaClass.simpleName,
         Severity.Style,
         "Checks whether files end with a line separator.",
-        Debt.FIVE_MINS)
+        Debt.FIVE_MINS
+    )
 
     override fun visitKtFile(file: KtFile) {
         val text = file.text
         if (text.isNotEmpty() && text.last() != '\n') {
-            report(CodeSmell(issue, Entity.atPackageOrFirstDecl(file),
-                "The file ${file.name} is not ending with a new line."))
+            report(
+                CodeSmell(
+                    issue, Entity.atPackageOrFirstDecl(file),
+                    "The file ${file.name} is not ending with a new line."
+                )
+            )
         }
     }
 }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/NewLineAtEndOfFile.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/NewLineAtEndOfFile.kt
@@ -28,7 +28,8 @@ class NewLineAtEndOfFile(config: Config = Config.empty) : Rule(config) {
         if (text.isNotEmpty() && text.last() != '\n') {
             report(
                 CodeSmell(
-                    issue, Entity.atPackageOrFirstDecl(file),
+                    issue,
+                    Entity.atPackageOrFirstDecl(file),
                     "The file ${file.name} is not ending with a new line."
                 )
             )

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/NoTabs.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/NoTabs.kt
@@ -23,15 +23,17 @@ import org.jetbrains.kotlin.psi.KtStringTemplateEntryWithExpression
  */
 class NoTabs(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue(javaClass.simpleName,
-            Severity.Style,
-            "Checks if tabs are used in Kotlin files.",
-            Debt.FIVE_MINS)
+    override val issue = Issue(
+        javaClass.simpleName,
+        Severity.Style,
+        "Checks if tabs are used in Kotlin files.",
+        Debt.FIVE_MINS
+    )
 
     fun findTabs(file: KtFile) {
         file.collectWhitespaces()
-                .filter { it.isTab() }
-                .forEach { report(CodeSmell(issue, Entity.from(it), "Tab character is in use.")) }
+            .filter { it.isTab() }
+            .forEach { report(CodeSmell(issue, Entity.from(it), "Tab character is in use.")) }
     }
 
     private fun KtFile.collectWhitespaces(): List<PsiWhiteSpace> {
@@ -50,5 +52,5 @@ class NoTabs(config: Config = Config.empty) : Rule(config) {
     }
 
     private fun PsiWhiteSpace.isStringInterpolated(): Boolean =
-            this.isPartOf<KtStringTemplateEntryWithExpression>()
+        this.isPartOf<KtStringTemplateEntryWithExpression>()
 }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/OptionalAbstractKeyword.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/OptionalAbstractKeyword.kt
@@ -37,8 +37,10 @@ import org.jetbrains.kotlin.psi.psiUtil.getChildrenOfType
 class OptionalAbstractKeyword(config: Config = Config.empty) : Rule(config) {
 
     override val issue: Issue = Issue(
-        javaClass.simpleName, Severity.Style,
-        "Unnecessary abstract modifier in interface", Debt.FIVE_MINS
+        javaClass.simpleName,
+        Severity.Style,
+        "Unnecessary abstract modifier in interface",
+        Debt.FIVE_MINS
     )
 
     override fun visitClass(klass: KtClass) {

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/OptionalAbstractKeyword.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/OptionalAbstractKeyword.kt
@@ -36,8 +36,10 @@ import org.jetbrains.kotlin.psi.psiUtil.getChildrenOfType
  */
 class OptionalAbstractKeyword(config: Config = Config.empty) : Rule(config) {
 
-    override val issue: Issue = Issue(javaClass.simpleName, Severity.Style,
-            "Unnecessary abstract modifier in interface", Debt.FIVE_MINS)
+    override val issue: Issue = Issue(
+        javaClass.simpleName, Severity.Style,
+        "Unnecessary abstract modifier in interface", Debt.FIVE_MINS
+    )
 
     override fun visitClass(klass: KtClass) {
         if (klass.isInterface()) {

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/OptionalWhenBraces.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/OptionalWhenBraces.kt
@@ -33,10 +33,12 @@ import org.jetbrains.kotlin.psi.KtWhenExpression
  */
 class OptionalWhenBraces(config: Config = Config.empty) : Rule(config) {
 
-    override val issue: Issue = Issue(javaClass.simpleName,
-            Severity.Style,
-            "Optional braces in when expression",
-            Debt.FIVE_MINS)
+    override val issue: Issue = Issue(
+        javaClass.simpleName,
+        Severity.Style,
+        "Optional braces in when expression",
+        Debt.FIVE_MINS
+    )
 
     override fun visitWhenExpression(expression: KtWhenExpression) {
         for (entry in expression.entries) {

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ProtectedMemberInFinalClass.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ProtectedMemberInFinalClass.kt
@@ -38,7 +38,7 @@ class ProtectedMemberInFinalClass(config: Config = Config.empty) : Rule(config) 
     override val issue = Issue(
         javaClass.simpleName, Severity.Warning,
         "Member with protected visibility in final class is private. " +
-                "Consider using private or internal as modifier.",
+            "Consider using private or internal as modifier.",
         Debt.FIVE_MINS
     )
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ProtectedMemberInFinalClass.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ProtectedMemberInFinalClass.kt
@@ -36,7 +36,8 @@ import org.jetbrains.kotlin.psi.psiUtil.isProtected
 class ProtectedMemberInFinalClass(config: Config = Config.empty) : Rule(config) {
 
     override val issue = Issue(
-        javaClass.simpleName, Severity.Warning,
+        javaClass.simpleName,
+        Severity.Warning,
         "Member with protected visibility in final class is private. " +
             "Consider using private or internal as modifier.",
         Debt.FIVE_MINS

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantExplicitType.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantExplicitType.kt
@@ -47,7 +47,8 @@ import org.jetbrains.kotlin.types.typeUtil.isLong
 class RedundantExplicitType(config: Config) : Rule(config) {
 
     override val issue = Issue(
-        "RedundantExplicitType", Severity.Style,
+        "RedundantExplicitType",
+        Severity.Style,
         "Type does not need to be stated explicitly and can be removed.",
         Debt.FIVE_MINS
     )

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantVisibilityModifierRule.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantVisibilityModifierRule.kt
@@ -121,7 +121,8 @@ class RedundantVisibilityModifierRule(config: Config = Config.empty) : Rule(conf
             super.visitNamedFunction(function)
             if (function.isExplicitlyPublicNotOverridden()) {
                 report(
-                    CodeSmell(issue,
+                    CodeSmell(
+                        issue,
                         Entity.atName(function),
                         message = "${function.name} is explicitly marked as public. " +
                             "Functions are public by default so this modifier is redundant."

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/SafeCast.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/SafeCast.kt
@@ -36,10 +36,10 @@ import org.jetbrains.kotlin.psi.KtNameReferenceExpression
 class SafeCast(config: Config = Config.empty) : Rule(config) {
 
     override val issue = Issue(
-            javaClass.simpleName,
-            Severity.Style,
-            "Safe cast instead of if-else-null",
-            Debt.FIVE_MINS
+        javaClass.simpleName,
+        Severity.Style,
+        "Safe cast instead of if-else-null",
+        Debt.FIVE_MINS
     )
 
     override fun visitIfExpression(expression: KtIfExpression) {

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/SerialVersionUIDInSerializableClass.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/SerialVersionUIDInSerializableClass.kt
@@ -43,7 +43,8 @@ import org.jetbrains.kotlin.psi.KtProperty
 class SerialVersionUIDInSerializableClass(config: Config = Config.empty) : Rule(config) {
 
     override val issue = Issue(
-        javaClass.simpleName, Severity.Warning,
+        javaClass.simpleName,
+        Severity.Warning,
         "A class which implements the Serializable interface does not define a correct serialVersionUID field. " +
             "The serialVersionUID field should be a constant long value inside a companion object.",
         Debt.FIVE_MINS
@@ -57,7 +58,8 @@ class SerialVersionUIDInSerializableClass(config: Config = Config.empty) : Rule(
             if (companionObject == null || !hasCorrectSerialVersionUUID(companionObject)) {
                 report(
                     CodeSmell(
-                        issue, Entity.from(klass),
+                        issue,
+                        Entity.from(klass),
                         "The class ${klass.nameAsSafeName} implements" +
                             " the Serializable interface and should thus define a serialVersionUID."
                     )
@@ -74,7 +76,8 @@ class SerialVersionUIDInSerializableClass(config: Config = Config.empty) : Rule(
         ) {
             report(
                 CodeSmell(
-                    issue, Entity.from(declaration),
+                    issue,
+                    Entity.from(declaration),
                     "The object ${declaration.nameAsSafeName} " +
                         "implements the Serializable interface and should thus define a serialVersionUID."
                 )

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/SerialVersionUIDInSerializableClass.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/SerialVersionUIDInSerializableClass.kt
@@ -42,10 +42,12 @@ import org.jetbrains.kotlin.psi.KtProperty
  */
 class SerialVersionUIDInSerializableClass(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue(javaClass.simpleName, Severity.Warning,
-            "A class which implements the Serializable interface does not define a correct serialVersionUID field. " +
-                    "The serialVersionUID field should be a constant long value inside a companion object.",
-            Debt.FIVE_MINS)
+    override val issue = Issue(
+        javaClass.simpleName, Severity.Warning,
+        "A class which implements the Serializable interface does not define a correct serialVersionUID field. " +
+            "The serialVersionUID field should be a constant long value inside a companion object.",
+        Debt.FIVE_MINS
+    )
 
     private val versionUID = "serialVersionUID"
 
@@ -53,8 +55,13 @@ class SerialVersionUIDInSerializableClass(config: Config = Config.empty) : Rule(
         if (!klass.isInterface() && isImplementingSerializable(klass)) {
             val companionObject = klass.companionObject()
             if (companionObject == null || !hasCorrectSerialVersionUUID(companionObject)) {
-                report(CodeSmell(issue, Entity.from(klass), "The class ${klass.nameAsSafeName} implements" +
-                        " the Serializable interface and should thus define a serialVersionUID."))
+                report(
+                    CodeSmell(
+                        issue, Entity.from(klass),
+                        "The class ${klass.nameAsSafeName} implements" +
+                            " the Serializable interface and should thus define a serialVersionUID."
+                    )
+                )
             }
         }
         super.visitClass(klass)
@@ -62,16 +69,22 @@ class SerialVersionUIDInSerializableClass(config: Config = Config.empty) : Rule(
 
     override fun visitObjectDeclaration(declaration: KtObjectDeclaration) {
         if (!declaration.isCompanion() &&
-                isImplementingSerializable(declaration) &&
-                !hasCorrectSerialVersionUUID(declaration)) {
-            report(CodeSmell(issue, Entity.from(declaration), "The object ${declaration.nameAsSafeName} " +
-                    "implements the Serializable interface and should thus define a serialVersionUID."))
+            isImplementingSerializable(declaration) &&
+            !hasCorrectSerialVersionUUID(declaration)
+        ) {
+            report(
+                CodeSmell(
+                    issue, Entity.from(declaration),
+                    "The object ${declaration.nameAsSafeName} " +
+                        "implements the Serializable interface and should thus define a serialVersionUID."
+                )
+            )
         }
         super.visitObjectDeclaration(declaration)
     }
 
     private fun isImplementingSerializable(classOrObject: KtClassOrObject) =
-            classOrObject.superTypeListEntries.any { it.text == "Serializable" }
+        classOrObject.superTypeListEntries.any { it.text == "Serializable" }
 
     private fun hasCorrectSerialVersionUUID(declaration: KtObjectDeclaration): Boolean {
         val property = declaration.body?.properties?.firstOrNull { it.name == versionUID }
@@ -84,8 +97,8 @@ class SerialVersionUIDInSerializableClass(config: Config = Config.empty) : Rule(
 
     private fun hasLongAssignment(property: KtProperty): Boolean {
         val assignmentText = property.children
-                .singleOrNull { it is KtConstantExpression || it is KtPrefixExpression }?.text
+            .singleOrNull { it is KtConstantExpression || it is KtPrefixExpression }?.text
         return assignmentText != null && assignmentText.last() == 'L' &&
-                assignmentText.substring(0, assignmentText.length - 1).toLongOrNull() != null
+            assignmentText.substring(0, assignmentText.length - 1).toLongOrNull() != null
     }
 }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/SpacingBetweenPackageAndImports.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/SpacingBetweenPackageAndImports.kt
@@ -37,9 +37,11 @@ import org.jetbrains.kotlin.psi.psiUtil.siblings
  */
 class SpacingBetweenPackageAndImports(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue(javaClass.simpleName, Severity.Style,
-            "Violation of the package declaration style.",
-            Debt.FIVE_MINS)
+    override val issue = Issue(
+        javaClass.simpleName, Severity.Style,
+        "Violation of the package declaration style.",
+        Debt.FIVE_MINS
+    )
 
     override fun visitKtFile(file: KtFile) {
         if (file.hasPackage() && file.anyDescendantOfType<KtClassOrObject>()) {
@@ -57,13 +59,16 @@ class SpacingBetweenPackageAndImports(config: Config = Config.empty) : Rule(conf
     private fun checkPackageDeclaration(importList: KtImportList) {
         val prevSibling = importList.prevSibling
         if (isPackageDeclaration(prevSibling) || prevSibling is PsiWhiteSpace) {
-            checkLinebreakAfterElement(prevSibling, "There should be exactly one empty line in between the " +
-                    "package declaration and the list of imports.")
+            checkLinebreakAfterElement(
+                prevSibling,
+                "There should be exactly one empty line in between the " +
+                    "package declaration and the list of imports."
+            )
         }
     }
 
     private fun isPackageDeclaration(element: PsiElement?) =
-            element is KtPackageDirective && element.text.isNotEmpty()
+        element is KtPackageDirective && element.text.isNotEmpty()
 
     private fun checkKtElementsDeclaration(importList: KtImportList) {
         val ktElement = importList.siblings(withItself = false).filterIsInstance<KtElement>().firstOrNull() ?: return
@@ -71,8 +76,11 @@ class SpacingBetweenPackageAndImports(config: Config = Config.empty) : Rule(conf
         if (nextSibling is PsiWhiteSpace || nextSibling is KtElement) {
             val name = (ktElement as? KtClassOrObject)?.name ?: "the class or object"
 
-            checkLinebreakAfterElement(nextSibling, "There should be exactly one empty line in between the " +
-                    "list of imports and the declaration of $name.")
+            checkLinebreakAfterElement(
+                nextSibling,
+                "There should be exactly one empty line in between the " +
+                    "list of imports and the declaration of $name."
+            )
         }
     }
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/SpacingBetweenPackageAndImports.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/SpacingBetweenPackageAndImports.kt
@@ -38,7 +38,8 @@ import org.jetbrains.kotlin.psi.psiUtil.siblings
 class SpacingBetweenPackageAndImports(config: Config = Config.empty) : Rule(config) {
 
     override val issue = Issue(
-        javaClass.simpleName, Severity.Style,
+        javaClass.simpleName,
+        Severity.Style,
         "Violation of the package declaration style.",
         Debt.FIVE_MINS
     )

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ThrowsCount.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ThrowsCount.kt
@@ -74,7 +74,7 @@ class ThrowsCount(config: Config = Config.empty) : Rule(config) {
                         issue,
                         Entity.atName(function),
                         "Too many throw statements in the function" +
-                                " ${function.nameAsSafeName}. The maximum number of allowed throw statements is $max."
+                            " ${function.nameAsSafeName}. The maximum number of allowed throw statements is $max."
                     )
                 )
             }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ThrowsCount.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ThrowsCount.kt
@@ -43,7 +43,8 @@ import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
 class ThrowsCount(config: Config = Config.empty) : Rule(config) {
 
     override val issue = Issue(
-        javaClass.simpleName, Severity.Style,
+        javaClass.simpleName,
+        Severity.Style,
         "Restrict the number of throw statements in methods.",
         Debt.TEN_MINS
     )

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/TrailingWhitespace.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/TrailingWhitespace.kt
@@ -14,10 +14,12 @@ import io.gitlab.arturbosch.detekt.rules.isPartOfString
  */
 class TrailingWhitespace(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue(javaClass.simpleName,
-            Severity.Style,
-            "Checks which lines end with a whitespace.",
-            Debt.FIVE_MINS)
+    override val issue = Issue(
+        javaClass.simpleName,
+        Severity.Style,
+        "Checks which lines end with a whitespace.",
+        Debt.FIVE_MINS
+    )
 
     fun visit(fileContent: KtFileContent) {
         var offset = 0

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiterals.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiterals.kt
@@ -37,10 +37,13 @@ import java.util.Locale
  */
 class UnderscoresInNumericLiterals(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue(javaClass.simpleName, Severity.Style,
-            "Report missing or invalid underscores in decimal base 10 numeric literals. Numeric literals " +
-                    "should be underscore separated to increase readability. Underscores that do not make groups of " +
-                    "3 digits are also reported.", Debt.FIVE_MINS)
+    override val issue = Issue(
+        javaClass.simpleName, Severity.Style,
+        "Report missing or invalid underscores in decimal base 10 numeric literals. Numeric literals " +
+            "should be underscore separated to increase readability. Underscores that do not make groups of " +
+            "3 digits are also reported.",
+        Debt.FIVE_MINS
+    )
 
     private val underscoreNumberRegex = Regex("[0-9]{1,3}(_[0-9]{3})*")
 
@@ -62,14 +65,19 @@ class UnderscoresInNumericLiterals(config: Config = Config.empty) : Rule(config)
 
     private fun reportIfInvalidUnderscorePattern(expression: KtConstantExpression, numberString: String) {
         if (!numberString.matches(underscoreNumberRegex)) {
-            report(CodeSmell(issue, Entity.from(expression), "This numeric literal should be separated " +
-                    "by underscores in order to increase readability."))
+            report(
+                CodeSmell(
+                    issue, Entity.from(expression),
+                    "This numeric literal should be separated " +
+                        "by underscores in order to increase readability."
+                )
+            )
         }
     }
 
     private fun isNotDecimalNumber(rawText: String): Boolean {
         return rawText.replace("_", "").toDoubleOrNull() == null || rawText.startsWith(HEX_PREFIX) ||
-                rawText.startsWith(BIN_PREFIX)
+            rawText.startsWith(BIN_PREFIX)
     }
 
     private fun KtConstantExpression.isSerialUidProperty(): Boolean {
@@ -90,10 +98,10 @@ class UnderscoresInNumericLiterals(config: Config = Config.empty) : Rule(config)
 
     private fun normalizeForMatching(text: String): String {
         return text.trim()
-                .toLowerCase(Locale.US)
-                .removeSuffix("l")
-                .removeSuffix("d")
-                .removeSuffix("f")
+            .toLowerCase(Locale.US)
+            .removeSuffix("l")
+            .removeSuffix("d")
+            .removeSuffix("f")
     }
 
     companion object {

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiterals.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiterals.kt
@@ -38,7 +38,8 @@ import java.util.Locale
 class UnderscoresInNumericLiterals(config: Config = Config.empty) : Rule(config) {
 
     override val issue = Issue(
-        javaClass.simpleName, Severity.Style,
+        javaClass.simpleName,
+        Severity.Style,
         "Report missing or invalid underscores in decimal base 10 numeric literals. Numeric literals " +
             "should be underscore separated to increase readability. Underscores that do not make groups of " +
             "3 digits are also reported.",
@@ -67,7 +68,8 @@ class UnderscoresInNumericLiterals(config: Config = Config.empty) : Rule(config)
         if (!numberString.matches(underscoreNumberRegex)) {
             report(
                 CodeSmell(
-                    issue, Entity.from(expression),
+                    issue,
+                    Entity.from(expression),
                     "This numeric literal should be separated " +
                         "by underscores in order to increase readability."
                 )

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAbstractClass.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAbstractClass.kt
@@ -54,7 +54,8 @@ class UnnecessaryAbstractClass(config: Config = Config.empty) : Rule(config) {
 
     override val issue =
         Issue(
-            "UnnecessaryAbstractClass", Severity.Style,
+            "UnnecessaryAbstractClass",
+            Severity.Style,
             "An abstract class is unnecessary and can be refactored. " +
                 "An abstract class should have both abstract and concrete properties or functions. " +
                 noConcreteMember + " " + noAbstractMember,
@@ -62,7 +63,8 @@ class UnnecessaryAbstractClass(config: Config = Config.empty) : Rule(config) {
         )
 
     private val excludeAnnotatedClasses = valueOrDefaultCommaSeparated(
-        EXCLUDE_ANNOTATED_CLASSES, listOf("dagger.Module")
+        EXCLUDE_ANNOTATED_CLASSES,
+        listOf("dagger.Module")
     )
         .map { it.removePrefix("*").removeSuffix("*") }
     private lateinit var annotationExcluder: AnnotationExcluder

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAbstractClass.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAbstractClass.kt
@@ -53,14 +53,17 @@ class UnnecessaryAbstractClass(config: Config = Config.empty) : Rule(config) {
     private val noAbstractMember = "An abstract class without an abstract member can be refactored to a concrete class."
 
     override val issue =
-            Issue("UnnecessaryAbstractClass", Severity.Style,
-                    "An abstract class is unnecessary and can be refactored. " +
-                            "An abstract class should have both abstract and concrete properties or functions. " +
-                            noConcreteMember + " " + noAbstractMember,
-                    Debt.FIVE_MINS)
+        Issue(
+            "UnnecessaryAbstractClass", Severity.Style,
+            "An abstract class is unnecessary and can be refactored. " +
+                "An abstract class should have both abstract and concrete properties or functions. " +
+                noConcreteMember + " " + noAbstractMember,
+            Debt.FIVE_MINS
+        )
 
     private val excludeAnnotatedClasses = valueOrDefaultCommaSeparated(
-            EXCLUDE_ANNOTATED_CLASSES, listOf("dagger.Module"))
+        EXCLUDE_ANNOTATED_CLASSES, listOf("dagger.Module")
+    )
         .map { it.removePrefix("*").removeSuffix("*") }
     private lateinit var annotationExcluder: AnnotationExcluder
 
@@ -109,7 +112,7 @@ class UnnecessaryAbstractClass(config: Config = Config.empty) : Rule(config) {
             members.indexOfFirst { it is KtNamedDeclaration && it.isAbstract() == isAbstract }
 
         private fun isAbstractClassWithoutConcreteMembers(indexOfFirstAbstractMember: Int) =
-                indexOfFirstAbstractMember == 0 && hasNoConcreteMemberLeft() && hasNoConstructorParameter(klass)
+            indexOfFirstAbstractMember == 0 && hasNoConcreteMemberLeft() && hasNoConstructorParameter(klass)
 
         private fun hasNoConcreteMemberLeft() = indexOfFirstMember(false, namedMembers.drop(1)) == -1
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryApply.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryApply.kt
@@ -43,8 +43,10 @@ import org.jetbrains.kotlin.resolve.BindingContext
 class UnnecessaryApply(config: Config) : Rule(config) {
 
     override val issue = Issue(
-        javaClass.simpleName, Severity.Style,
-        "The `apply` usage is unnecessary", Debt.FIVE_MINS
+        javaClass.simpleName,
+        Severity.Style,
+        "The `apply` usage is unnecessary",
+        Debt.FIVE_MINS
     )
 
     override fun visitCallExpression(expression: KtCallExpression) {

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryApply.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryApply.kt
@@ -67,7 +67,6 @@ class UnnecessaryApply(config: Config) : Rule(config) {
 }
 
 private fun KtCallExpression.hasOnlyOneMemberAccessStatement(): Boolean {
-
     fun KtExpression.notAnAssignment() =
         safeAs<KtBinaryExpression>()
             ?.operationToken != KtTokens.EQ

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryFilter.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryFilter.kt
@@ -45,7 +45,8 @@ import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameOrNull
 class UnnecessaryFilter(config: Config = Config.empty) : Rule(config) {
 
     override val issue: Issue = Issue(
-        "UnnecessaryFilter", Severity.Style,
+        "UnnecessaryFilter",
+        Severity.Style,
         "filter() with other collection operations may be simplified.",
         Debt.FIVE_MINS
     )
@@ -78,7 +79,8 @@ class UnnecessaryFilter(config: Config = Config.empty) : Rule(config) {
 
         report(
             CodeSmell(
-                issue, Entity.from(this),
+                issue,
+                Entity.from(this),
                 "'${this.text}' can be replaced by '${correctOperator ?: shortName} ${this.lambda()?.text}'"
             )
         )

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryInheritance.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryInheritance.kt
@@ -23,8 +23,10 @@ import org.jetbrains.kotlin.psi.KtClassOrObject
 class UnnecessaryInheritance(config: Config = Config.empty) : Rule(config) {
 
     override val issue: Issue = Issue(
-        javaClass.simpleName, Severity.Style,
-        "The extended super type is unnecessary.", Debt.FIVE_MINS
+        javaClass.simpleName,
+        Severity.Style,
+        "The extended super type is unnecessary.",
+        Debt.FIVE_MINS
     )
 
     override fun visitClassOrObject(classOrObject: KtClassOrObject) {

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryInheritance.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryInheritance.kt
@@ -22,8 +22,10 @@ import org.jetbrains.kotlin.psi.KtClassOrObject
  */
 class UnnecessaryInheritance(config: Config = Config.empty) : Rule(config) {
 
-    override val issue: Issue = Issue(javaClass.simpleName, Severity.Style,
-            "The extended super type is unnecessary.", Debt.FIVE_MINS)
+    override val issue: Issue = Issue(
+        javaClass.simpleName, Severity.Style,
+        "The extended super type is unnecessary.", Debt.FIVE_MINS
+    )
 
     override fun visitClassOrObject(classOrObject: KtClassOrObject) {
         for (superEntry in classOrObject.superTypeListEntries) {

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLet.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLet.kt
@@ -46,8 +46,10 @@ import org.jetbrains.kotlin.resolve.BindingContext
 class UnnecessaryLet(config: Config) : Rule(config) {
 
     override val issue = Issue(
-        javaClass.simpleName, Severity.Style,
-        "The `let` usage is unnecessary", Debt.FIVE_MINS
+        javaClass.simpleName,
+        Severity.Style,
+        "The `let` usage is unnecessary",
+        Debt.FIVE_MINS
     )
 
     override fun visitCallExpression(expression: KtCallExpression) {
@@ -70,7 +72,8 @@ class UnnecessaryLet(config: Config) : Rule(config) {
             if (lambdaReferenceCount == 0 && !expression.receiverIsUsed(bindingContext) && isNullSafeOperator) {
                 report(
                     CodeSmell(
-                        issue, Entity.from(expression),
+                        issue,
+                        Entity.from(expression),
                         "let expression can be replaces with a simple if"
                     )
                 )

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryParentheses.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryParentheses.kt
@@ -38,9 +38,11 @@ import org.jetbrains.kotlin.psi.KtPsiUtil
  */
 class UnnecessaryParentheses(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue("UnnecessaryParentheses", Severity.Style,
-            "Unnecessary parentheses don't add any value to the code and should be removed.",
-            Debt.FIVE_MINS)
+    override val issue = Issue(
+        "UnnecessaryParentheses", Severity.Style,
+        "Unnecessary parentheses don't add any value to the code and should be removed.",
+        Debt.FIVE_MINS
+    )
 
     override fun visitParenthesizedExpression(expression: KtParenthesizedExpression) {
         super.visitParenthesizedExpression(expression)
@@ -49,7 +51,7 @@ class UnnecessaryParentheses(config: Config = Config.empty) : Rule(config) {
 
         if (KtPsiUtil.areParenthesesUseless(expression)) {
             val message = "Parentheses in ${expression.text} are unnecessary and can be replaced with: " +
-                    "${KtPsiUtil.deparenthesize(expression)?.text}"
+                "${KtPsiUtil.deparenthesize(expression)?.text}"
             report(CodeSmell(issue, Entity.from(expression), message))
         }
     }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryParentheses.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryParentheses.kt
@@ -39,7 +39,8 @@ import org.jetbrains.kotlin.psi.KtPsiUtil
 class UnnecessaryParentheses(config: Config = Config.empty) : Rule(config) {
 
     override val issue = Issue(
-        "UnnecessaryParentheses", Severity.Style,
+        "UnnecessaryParentheses",
+        Severity.Style,
         "Unnecessary parentheses don't add any value to the code and should be removed.",
         Debt.FIVE_MINS
     )

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UntilInsteadOfRangeTo.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UntilInsteadOfRangeTo.kt
@@ -30,10 +30,12 @@ import org.jetbrains.kotlin.psi.KtOperationReferenceExpression
  */
 class UntilInsteadOfRangeTo(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue(javaClass.simpleName,
-            Severity.Style,
-            "'..' call can be replaced with 'until'",
-            Debt.FIVE_MINS)
+    override val issue = Issue(
+        javaClass.simpleName,
+        Severity.Style,
+        "'..' call can be replaced with 'until'",
+        Debt.FIVE_MINS
+    )
 
     private val minimumSize = 3
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedImports.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedImports.kt
@@ -31,10 +31,11 @@ import org.jetbrains.kotlin.resolve.descriptorUtil.getImportableDescriptor
 class UnusedImports(config: Config) : Rule(config) {
 
     override val issue = Issue(
-            javaClass.simpleName,
-            Severity.Style,
-            "Unused Imports are dead code and should be removed.",
-            Debt.FIVE_MINS)
+        javaClass.simpleName,
+        Severity.Style,
+        "Unused Imports are dead code and should be removed.",
+        Debt.FIVE_MINS
+    )
 
     override fun visit(root: KtFile) {
         with(UnusedImportsVisitor(bindingContext)) {
@@ -55,7 +56,7 @@ class UnusedImports(config: Config) : Rule(config) {
 
         fun unusedImports(): List<KtImportDirective> {
             fun KtImportDirective.isFromSamePackage() =
-                    importedFqName?.parent() == currentPackage && alias == null
+                importedFqName?.parent() == currentPackage && alias == null
 
             @Suppress("ReturnCount")
             fun KtImportDirective.isNotUsed(): Boolean {
@@ -90,8 +91,8 @@ class UnusedImports(config: Config) : Rule(config) {
                 .filter {
                     val identifier = it.identifier()
                     identifier?.contains("*")?.not() == true &&
-                            !operatorSet.contains(identifier) &&
-                            !componentNRegex.matches(identifier)
+                        !operatorSet.contains(identifier) &&
+                        !componentNRegex.matches(identifier)
                 }
                 .toList()
             super.visitImportList(importList)
@@ -115,8 +116,8 @@ class UnusedImports(config: Config) : Rule(config) {
             val kdoc = dcl.docComment?.getDefaultSection()
 
             kdoc?.getChildrenOfType<KDocTag>()
-                    ?.map { it.text }
-                    ?.forEach { handleKDoc(it) }
+                ?.map { it.text }
+                ?.forEach { handleKDoc(it) }
 
             kdoc?.getContent()?.let {
                 handleKDoc(it)
@@ -126,8 +127,8 @@ class UnusedImports(config: Config) : Rule(config) {
 
         private fun handleKDoc(content: String) {
             kotlinDocReferencesRegExp.findAll(content, 0)
-                    .map { it.groupValues[1] }
-                    .forEach { namedReferencesInKDoc.add(it.split(".")[0]) }
+                .map { it.groupValues[1] }
+                .forEach { namedReferencesInKDoc.add(it.split(".")[0]) }
             kotlinDocBlockTagReferenceRegExp.find(content)?.let {
                 val str = it.groupValues[2].split(whiteSpaceRegex)[0]
                 namedReferencesInKDoc.add(str.split(".")[0])
@@ -136,9 +137,11 @@ class UnusedImports(config: Config) : Rule(config) {
     }
 
     companion object {
-        private val operatorSet = setOf("unaryPlus", "unaryMinus", "not", "inc", "dec", "plus", "minus", "times", "div",
+        private val operatorSet = setOf(
+            "unaryPlus", "unaryMinus", "not", "inc", "dec", "plus", "minus", "times", "div",
             "mod", "rangeTo", "contains", "get", "set", "invoke", "plusAssign", "minusAssign", "timesAssign",
-            "divAssign", "modAssign", "equals", "compareTo", "iterator", "getValue", "setValue", "provideDelegate")
+            "divAssign", "modAssign", "equals", "compareTo", "iterator", "getValue", "setValue", "provideDelegate"
+        )
 
         private val kotlinDocReferencesRegExp = Regex("\\[([^]]+)](?!\\[)")
         private val kotlinDocBlockTagReferenceRegExp = Regex("^@(see|throws|exception) (.+)")

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateClass.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateClass.kt
@@ -44,10 +44,12 @@ class UnusedPrivateClass(config: Config = Config.empty) : Rule(config) {
 
     override val defaultRuleIdAliases: Set<String> = setOf("unused")
 
-    override val issue: Issue = Issue("UnusedPrivateClass",
-            Severity.Maintainability,
-            "Private class is unused.",
-            Debt.FIVE_MINS)
+    override val issue: Issue = Issue(
+        "UnusedPrivateClass",
+        Severity.Maintainability,
+        "Private class is unused.",
+        Debt.FIVE_MINS
+    )
 
     override fun visit(root: KtFile) {
         super.visit(root)
@@ -84,8 +86,8 @@ class UnusedPrivateClass(config: Config = Config.empty) : Rule(config) {
                 privateClasses.add(klass)
             }
             klass.getSuperTypeList()?.entries
-                    ?.mapNotNull { it.typeReference }
-                    ?.forEach { registerAccess(it) }
+                ?.mapNotNull { it.typeReference }
+                ?.forEach { registerAccess(it) }
             super.visitClass(klass)
         }
 
@@ -105,8 +107,8 @@ class UnusedPrivateClass(config: Config = Config.empty) : Rule(config) {
 
             // Try with the type with generics (e.g. Foo<Any>, Foo<Any>?)
             (typeReference.typeElement?.orInnerType() as? KtUserType)
-                    ?.referencedName
-                    ?.run { namedClasses.add(this) }
+                ?.referencedName
+                ?.run { namedClasses.add(this) }
 
             // Try with the type being a generic argument of other type (e.g. List<Foo>, List<Foo?>)
             typeReference.typeElement?.run {
@@ -161,18 +163,18 @@ class UnusedPrivateClass(config: Config = Config.empty) : Rule(config) {
             checkReceiverForClassUsage(expression.receiverExpression)
             if (expression.isEmptyLHS) {
                 expression.safeAs<KtCallableReferenceExpression>()
-                        ?.callableReference
-                        ?.takeIf { looksLikeAClassName(it.getReferencedName()) }
-                        ?.let { namedClasses.add(it.getReferencedName()) }
+                    ?.callableReference
+                    ?.takeIf { looksLikeAClassName(it.getReferencedName()) }
+                    ?.let { namedClasses.add(it.getReferencedName()) }
             }
             super.visitDoubleColonExpression(expression)
         }
 
         private fun checkReceiverForClassUsage(receiver: KtExpression?) {
             (receiver as? KtNameReferenceExpression)
-                    ?.text
-                    ?.takeIf { looksLikeAClassName(it) }
-                    ?.let { namedClasses.add(it) }
+                ?.text
+                ?.takeIf { looksLikeAClassName(it) }
+                ?.let { namedClasses.add(it) }
         }
 
         override fun visitDotQualifiedExpression(expression: KtDotQualifiedExpression) {
@@ -183,7 +185,7 @@ class UnusedPrivateClass(config: Config = Config.empty) : Rule(config) {
         // Without type resolution it is hard to tell if this is really a class or part of a package.
         // We use "first char is uppercase" as a heuristic in conjunction with "KtNameReferenceExpression"
         private fun looksLikeAClassName(maybeClassName: String) =
-                maybeClassName.firstOrNull()?.isUpperCase() == true
+            maybeClassName.firstOrNull()?.isUpperCase() == true
     }
 }
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
@@ -267,7 +267,8 @@ private class UnusedPropertyVisitor(allowedNames: Regex) : UnusedMemberVisitor(a
             .filter { it.nameAsSafeName.identifier !in nameAccesses }
             .map {
                 CodeSmell(
-                    issue, Entity.from(it),
+                    issue,
+                    Entity.from(it),
                     "Private property ${it.nameAsSafeName.identifier} is unused."
                 )
             }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
@@ -56,10 +56,12 @@ class UnusedPrivateMember(config: Config = Config.empty) : Rule(config) {
 
     override val defaultRuleIdAliases: Set<String> = setOf("UNUSED_VARIABLE", "UNUSED_PARAMETER", "unused")
 
-    override val issue: Issue = Issue("UnusedPrivateMember",
+    override val issue: Issue = Issue(
+        "UnusedPrivateMember",
         Severity.Maintainability,
         "Private member is unused.",
-        Debt.FIVE_MINS)
+        Debt.FIVE_MINS
+    )
 
     private val allowedNames by LazyRegex(ALLOWED_NAMES_PATTERN, "(_|ignored|expected|serialVersionUID)")
 
@@ -264,8 +266,10 @@ private class UnusedPropertyVisitor(allowedNames: Regex) : UnusedMemberVisitor(a
         return properties
             .filter { it.nameAsSafeName.identifier !in nameAccesses }
             .map {
-                CodeSmell(issue, Entity.from(it),
-                    "Private property ${it.nameAsSafeName.identifier} is unused.")
+                CodeSmell(
+                    issue, Entity.from(it),
+                    "Private property ${it.nameAsSafeName.identifier} is unused."
+                )
             }
     }
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseCheckOrError.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseCheckOrError.kt
@@ -39,7 +39,8 @@ import org.jetbrains.kotlin.psi.KtThrowExpression
 class UseCheckOrError(config: Config = Config.empty) : Rule(config) {
 
     override val issue = Issue(
-        "UseCheckOrError", Severity.Style,
+        "UseCheckOrError",
+        Severity.Style,
         "Use check() or error() instead of throwing an IllegalStateException.",
         Debt.FIVE_MINS
     )

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseCheckOrError.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseCheckOrError.kt
@@ -48,7 +48,8 @@ class UseCheckOrError(config: Config = Config.empty) : Rule(config) {
         if (expression.isOnlyExpressionInLambda()) return
 
         if (expression.isIllegalStateException() &&
-            expression.arguments.isEmptyOrSingleStringArgument(bindingContext)) {
+            expression.arguments.isEmptyOrSingleStringArgument(bindingContext)
+        ) {
             report(CodeSmell(issue, Entity.from(expression), issue.description))
         }
     }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseDataClass.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseDataClass.kt
@@ -100,7 +100,8 @@ class UseDataClass(config: Config = Config.empty) : Rule(config) {
                 }
                 report(
                     CodeSmell(
-                        issue, Entity.from(klass),
+                        issue,
+                        Entity.from(klass),
                         "The class ${klass.nameAsSafeName} defines no " +
                             "functionality and only holds data. Consider converting it to a data class."
                     )

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseDataClass.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseDataClass.kt
@@ -53,10 +53,12 @@ import org.jetbrains.kotlin.types.KotlinType
  */
 class UseDataClass(config: Config = Config.empty) : Rule(config) {
 
-    override val issue: Issue = Issue("UseDataClass",
-            Severity.Style,
-            "Classes that do nothing but hold data should be replaced with a data class.",
-            Debt.FIVE_MINS)
+    override val issue: Issue = Issue(
+        "UseDataClass",
+        Severity.Style,
+        "Classes that do nothing but hold data should be replaced with a data class.",
+        Debt.FIVE_MINS
+    )
 
     private val excludeAnnotatedClasses = valueOrDefaultCommaSeparated(EXCLUDE_ANNOTATED_CLASSES, emptyList())
         .map { it.removePrefix("*").removeSuffix("*") }
@@ -75,7 +77,8 @@ class UseDataClass(config: Config = Config.empty) : Rule(config) {
             return
         }
         if (klass.isClosedForExtension() && klass.onlyExtendsSimpleInterfaces() &&
-            !annotationExcluder.shouldExclude(klass.annotationEntries)) {
+            !annotationExcluder.shouldExclude(klass.annotationEntries)
+        ) {
             val declarations = klass.body?.declarations.orEmpty()
             val properties = declarations.filterIsInstance<KtProperty>()
             val functions = declarations.filterIsInstance<KtNamedFunction>()
@@ -83,7 +86,7 @@ class UseDataClass(config: Config = Config.empty) : Rule(config) {
             val propertyParameters = klass.extractConstructorPropertyParameters()
 
             val primaryConstructor = bindingContext[BindingContext.DECLARATION_TO_DESCRIPTOR, klass.primaryConstructor]
-                    as? ClassConstructorDescriptor
+                as? ClassConstructorDescriptor
             val primaryConstructorParameterTypes = primaryConstructor?.valueParameters?.map { it.type }.orEmpty()
             val classType = primaryConstructor?.containingDeclaration?.defaultType
             val containsFunctions = functions.all { it.isDefaultFunction(classType, primaryConstructorParameterTypes) }
@@ -97,8 +100,9 @@ class UseDataClass(config: Config = Config.empty) : Rule(config) {
                 }
                 report(
                     CodeSmell(
-                        issue, Entity.from(klass), "The class ${klass.nameAsSafeName} defines no " +
-                                "functionality and only holds data. Consider converting it to a data class."
+                        issue, Entity.from(klass),
+                        "The class ${klass.nameAsSafeName} defines no " +
+                            "functionality and only holds data. Consider converting it to a data class."
                     )
                 )
             }
@@ -117,23 +121,23 @@ class UseDataClass(config: Config = Config.empty) : Rule(config) {
     }
 
     private fun isIncorrectClassType(klass: KtClass) =
-            klass.isData() ||
-                    klass.isEnum() ||
-                    klass.isAnnotation() ||
-                    klass.isSealed() ||
-                    klass.isInline()
+        klass.isData() ||
+            klass.isEnum() ||
+            klass.isAnnotation() ||
+            klass.isSealed() ||
+            klass.isInline()
 
     private fun hasOnlyPrivateConstructors(klass: KtClass): Boolean {
         val primaryConstructor = klass.primaryConstructor
         return (primaryConstructor == null || primaryConstructor.isPrivate()) &&
-                klass.secondaryConstructors.all { it.isPrivate() }
+            klass.secondaryConstructors.all { it.isPrivate() }
     }
 
     private fun KtClass.extractConstructorPropertyParameters(): List<KtParameter> =
-            getPrimaryConstructorParameterList()
-                    ?.parameters
-                    ?.filter { it.isPropertyParameter() }
-                    .orEmpty()
+        getPrimaryConstructorParameterList()
+            ?.parameters
+            ?.filter { it.isPropertyParameter() }
+            .orEmpty()
 
     private fun KtNamedFunction.isDefaultFunction(
         classType: KotlinType?,
@@ -148,8 +152,8 @@ class UseDataClass(config: Config = Config.empty) : Rule(config) {
                     val returnType = descriptor?.returnType
                     val parameterTypes = descriptor?.valueParameters?.map { it.type }.orEmpty()
                     returnType == classType &&
-                            parameterTypes.size == primaryConstructorParameterTypes.size &&
-                            parameterTypes.zip(primaryConstructorParameterTypes).all { it.first == it.second }
+                        parameterTypes.size == primaryConstructorParameterTypes.size &&
+                        parameterTypes.zip(primaryConstructorParameterTypes).all { it.first == it.second }
                 } else {
                     true
                 }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIfInsteadOfWhen.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIfInsteadOfWhen.kt
@@ -27,17 +27,20 @@ import org.jetbrains.kotlin.psi.KtWhenExpression
  */
 class UseIfInsteadOfWhen(config: Config = Config.empty) : Rule(config) {
 
-    override val issue: Issue = Issue("UseIfInsteadOfWhen",
-            Severity.Style,
-            "Binary expressions are better expressed using an 'if' expression than a 'when' expression.",
-            Debt.FIVE_MINS)
+    override val issue: Issue = Issue(
+        "UseIfInsteadOfWhen",
+        Severity.Style,
+        "Binary expressions are better expressed using an 'if' expression than a 'when' expression.",
+        Debt.FIVE_MINS
+    )
 
     override fun visitWhenExpression(expression: KtWhenExpression) {
         super.visitWhenExpression(expression)
 
         if (expression.entries.size == 2 &&
             expression.elseExpression != null &&
-            expression.entries.none { it.conditions.size > 1 }) {
+            expression.entries.none { it.conditions.size > 1 }
+        ) {
             report(
                 CodeSmell(
                     issue,

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseRequire.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseRequire.kt
@@ -43,7 +43,8 @@ class UseRequire(config: Config = Config.empty) : Rule(config) {
         if (expression.isOnlyExpressionInBlock()) return
 
         if (expression.isEnclosedByConditionalStatement() &&
-            expression.arguments.isEmptyOrSingleStringArgument(bindingContext)) {
+            expression.arguments.isEmptyOrSingleStringArgument(bindingContext)
+        ) {
             report(CodeSmell(issue, Entity.from(expression), issue.description))
         }
     }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseRequire.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseRequire.kt
@@ -32,7 +32,8 @@ import org.jetbrains.kotlin.psi.KtThrowExpression
 class UseRequire(config: Config = Config.empty) : Rule(config) {
 
     override val issue = Issue(
-        "UseRequire", Severity.Style,
+        "UseRequire",
+        Severity.Style,
         "Use require() instead of throwing an IllegalArgumentException.",
         Debt.FIVE_MINS
     )

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UtilityClassWithPublicConstructor.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UtilityClassWithPublicConstructor.kt
@@ -76,7 +76,8 @@ class UtilityClassWithPublicConstructor(config: Config = Config.empty) : Rule(co
                 if (utilityClassConstructor.hasPublicConstructorWithoutParameters()) {
                     report(
                         CodeSmell(
-                            issue, Entity.from(klass),
+                            issue,
+                            Entity.from(klass),
                             "The class ${klass.nameAsSafeName} only contains" +
                                 " utility functions. Consider defining it as an object."
                         )
@@ -84,7 +85,8 @@ class UtilityClassWithPublicConstructor(config: Config = Config.empty) : Rule(co
                 } else if (klass.isOpen() && utilityClassConstructor.hasNonPublicConstructorWithoutParameters()) {
                     report(
                         CodeSmell(
-                            issue, Entity.from(klass),
+                            issue,
+                            Entity.from(klass),
                             "The utility class ${klass.nameAsSafeName} should be final."
                         )
                     )

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UtilityClassWithPublicConstructor.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UtilityClassWithPublicConstructor.kt
@@ -60,11 +60,13 @@ import org.jetbrains.kotlin.psi.psiUtil.isPublic
  */
 class UtilityClassWithPublicConstructor(config: Config = Config.empty) : Rule(config) {
 
-    override val issue: Issue = Issue(javaClass.simpleName,
-            Severity.Style,
-            "The class declaration is unnecessary because it only contains utility functions. " +
-                    "An object declaration should be used instead.",
-            Debt.FIVE_MINS)
+    override val issue: Issue = Issue(
+        javaClass.simpleName,
+        Severity.Style,
+        "The class declaration is unnecessary because it only contains utility functions. " +
+            "An object declaration should be used instead.",
+        Debt.FIVE_MINS
+    )
 
     override fun visitClass(klass: KtClass) {
         if (canBeCheckedForUtilityClass(klass)) {
@@ -72,12 +74,20 @@ class UtilityClassWithPublicConstructor(config: Config = Config.empty) : Rule(co
             val declarations = klass.body?.declarations
             if (hasOnlyUtilityClassMembers(declarations)) {
                 if (utilityClassConstructor.hasPublicConstructorWithoutParameters()) {
-                    report(CodeSmell(issue, Entity.from(klass),
+                    report(
+                        CodeSmell(
+                            issue, Entity.from(klass),
                             "The class ${klass.nameAsSafeName} only contains" +
-                                    " utility functions. Consider defining it as an object."))
+                                " utility functions. Consider defining it as an object."
+                        )
+                    )
                 } else if (klass.isOpen() && utilityClassConstructor.hasNonPublicConstructorWithoutParameters()) {
-                    report(CodeSmell(issue, Entity.from(klass),
-                            "The utility class ${klass.nameAsSafeName} should be final."))
+                    report(
+                        CodeSmell(
+                            issue, Entity.from(klass),
+                            "The utility class ${klass.nameAsSafeName} should be final."
+                        )
+                    )
                 }
             }
         }
@@ -86,9 +96,9 @@ class UtilityClassWithPublicConstructor(config: Config = Config.empty) : Rule(co
 
     private fun canBeCheckedForUtilityClass(klass: KtClass): Boolean {
         return !klass.isInterface() &&
-                !klass.superTypeListEntries.any() &&
-                !klass.isAnnotation() &&
-                !klass.isSealed()
+            !klass.superTypeListEntries.any() &&
+            !klass.isAnnotation() &&
+            !klass.isSealed()
     }
 
     private fun hasOnlyUtilityClassMembers(declarations: List<KtDeclaration>?): Boolean {
@@ -108,7 +118,7 @@ class UtilityClassWithPublicConstructor(config: Config = Config.empty) : Rule(co
     }
 
     private fun isCompanionObject(declaration: KtDeclaration) =
-            (declaration as? KtObjectDeclaration)?.isCompanion() == true
+        (declaration as? KtObjectDeclaration)?.isCompanion() == true
 
     internal class UtilityClassConstructor(private val klass: KtClass) {
 
@@ -123,7 +133,7 @@ class UtilityClassWithPublicConstructor(config: Config = Config.empty) : Rule(co
             }
             val secondaryConstructors = klass.secondaryConstructors
             return secondaryConstructors.isEmpty() ||
-                    secondaryConstructors.any { it.isPublic == publicModifier && it.valueParameters.isEmpty() }
+                secondaryConstructors.any { it.isPublic == publicModifier && it.valueParameters.isEmpty() }
         }
     }
 }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/VarCouldBeVal.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/VarCouldBeVal.kt
@@ -45,10 +45,12 @@ class VarCouldBeVal(config: Config = Config.empty) : Rule(config) {
 
     override val defaultRuleIdAliases: Set<String> = setOf("CanBeVal")
 
-    override val issue: Issue = Issue("VarCouldBeVal",
-            Severity.Maintainability,
-            "Var declaration could be val.",
-            Debt.FIVE_MINS)
+    override val issue: Issue = Issue(
+        "VarCouldBeVal",
+        Severity.Maintainability,
+        "Var declaration could be val.",
+        Debt.FIVE_MINS
+    )
 
     override fun visitNamedFunction(function: KtNamedFunction) {
         if (function.isSomehowNested()) {
@@ -65,11 +67,12 @@ class VarCouldBeVal(config: Config = Config.empty) : Rule(config) {
     }
 
     private fun KtNamedFunction.isSomehowNested() =
-            getStrictParentOfType<KtNamedFunction>() != null
+        getStrictParentOfType<KtNamedFunction>() != null
 
     private class AssignmentVisitor : DetektVisitor() {
 
         private val declarations = mutableSetOf<KtNamedDeclaration>()
+
         // an easy way to find declarations when walking up the contexts of an assignment
         private val contextsByDeclarationName = mutableMapOf<String, MutableSet<PsiElement>>()
         private val assignments = mutableMapOf<String, MutableSet<PsiElement>>()
@@ -77,7 +80,7 @@ class VarCouldBeVal(config: Config = Config.empty) : Rule(config) {
         fun getNonReAssignedDeclarations(): List<KtNamedDeclaration> {
             return declarations.filter { declaration ->
                 assignments[declaration.nameAsSafeName.identifier]
-                        ?.let { declaration.parent !in it }
+                    ?.let { declaration.parent !in it }
                     ?: true
             }
         }
@@ -114,7 +117,8 @@ class VarCouldBeVal(config: Config = Config.empty) : Rule(config) {
         private fun extractAssignedName(expression: KtBinaryExpression): String? {
             val leftSide = expression.left
             if (leftSide is KtDotQualifiedExpression &&
-                    leftSide.receiverExpression is KtThisExpression) {
+                leftSide.receiverExpression is KtThisExpression
+            ) {
                 return leftSide.selectorExpression?.text
             }
             return leftSide?.text

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/WildcardImport.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/WildcardImport.kt
@@ -45,16 +45,19 @@ import org.jetbrains.kotlin.psi.KtImportDirective
  */
 class WildcardImport(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue(javaClass.simpleName,
-            Severity.Style,
-            "Wildcard imports should be replaced with imports using fully qualified class names. " +
-                    "Wildcard imports can lead to naming conflicts. " +
-                    "A library update can introduce naming clashes with your classes which " +
-                    "results in compilation errors.",
-            Debt.FIVE_MINS)
+    override val issue = Issue(
+        javaClass.simpleName,
+        Severity.Style,
+        "Wildcard imports should be replaced with imports using fully qualified class names. " +
+            "Wildcard imports can lead to naming conflicts. " +
+            "A library update can introduce naming clashes with your classes which " +
+            "results in compilation errors.",
+        Debt.FIVE_MINS
+    )
 
     private val excludedImports = valueOrDefaultCommaSeparated(
-            EXCLUDED_IMPORTS, listOf("java.util.*", "kotlinx.android.synthetic.*"))
+        EXCLUDED_IMPORTS, listOf("java.util.*", "kotlinx.android.synthetic.*")
+    )
         .map { it.removePrefix("*").removeSuffix("*") }
 
     override fun visitImportDirective(importDirective: KtImportDirective) {
@@ -67,8 +70,13 @@ class WildcardImport(config: Config = Config.empty) : Rule(config) {
             if (excludedImports.any { import.contains(it, ignoreCase = true) }) {
                 return
             }
-            report(CodeSmell(issue, Entity.from(importDirective), "$import " +
-                    "is a wildcard import. Replace it with fully qualified imports."))
+            report(
+                CodeSmell(
+                    issue, Entity.from(importDirective),
+                    "$import " +
+                        "is a wildcard import. Replace it with fully qualified imports."
+                )
+            )
         }
     }
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/WildcardImport.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/WildcardImport.kt
@@ -56,7 +56,8 @@ class WildcardImport(config: Config = Config.empty) : Rule(config) {
     )
 
     private val excludedImports = valueOrDefaultCommaSeparated(
-        EXCLUDED_IMPORTS, listOf("java.util.*", "kotlinx.android.synthetic.*")
+        EXCLUDED_IMPORTS,
+        listOf("java.util.*", "kotlinx.android.synthetic.*")
     )
         .map { it.removePrefix("*").removeSuffix("*") }
 
@@ -72,7 +73,8 @@ class WildcardImport(config: Config = Config.empty) : Rule(config) {
             }
             report(
                 CodeSmell(
-                    issue, Entity.from(importDirective),
+                    issue,
+                    Entity.from(importDirective),
                     "$import " +
                         "is a wildcard import. Replace it with fully qualified imports."
                 )

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/MandatoryBracesIfStatements.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/MandatoryBracesIfStatements.kt
@@ -13,7 +13,7 @@ import org.jetbrains.kotlin.psi.KtIfExpression
 import org.jetbrains.kotlin.psi.psiUtil.siblings
 
 private const val DESCRIPTION = "Multi-line if statement was found that does not have braces. " +
-        "These should be added to improve readability."
+    "These should be added to improve readability."
 
 /**
  * This rule detects multi-line `if` statements which do not have braces.
@@ -46,15 +46,15 @@ class MandatoryBracesIfStatements(config: Config = Config.empty) : Rule(config) 
     }
 
     private fun hasNewLine(element: PsiElement?): Boolean =
-            element
-                    ?.siblings(forward = true, withItself = false)
-                    ?.takeWhile { it.text != "else" }
-                    ?.firstOrNull { it.textContains('\n') } != null
+        element
+            ?.siblings(forward = true, withItself = false)
+            ?.takeWhile { it.text != "else" }
+            ?.firstOrNull { it.textContains('\n') } != null
 
     private fun KtIfExpression.isNotBlockExpression(): Boolean = this.then !is KtBlockExpression
 
     private fun KtIfExpression.isNotBlockOrIfExpression(): Boolean =
-            this.`else` != null &&
-                    this.`else` !is KtIfExpression &&
-                    this.`else` !is KtBlockExpression
+        this.`else` != null &&
+            this.`else` !is KtIfExpression &&
+            this.`else` !is KtBlockExpression
 }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/OptionalUnit.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/OptionalUnit.kt
@@ -48,10 +48,11 @@ import org.jetbrains.kotlin.utils.addToStdlib.firstIsInstanceOrNull
 class OptionalUnit(config: Config = Config.empty) : Rule(config) {
 
     override val issue = Issue(
-            javaClass.simpleName,
-            Severity.Style,
-            "Return type of 'Unit' is unnecessary and can be safely removed.",
-            Debt.FIVE_MINS)
+        javaClass.simpleName,
+        Severity.Style,
+        "Return type of 'Unit' is unnecessary and can be safely removed.",
+        Debt.FIVE_MINS
+    )
 
     override fun visitNamedFunction(function: KtNamedFunction) {
         if (function.hasDeclaredReturnType()) {
@@ -66,22 +67,26 @@ class OptionalUnit(config: Config = Config.empty) : Rule(config) {
         val statements = expression.statements
         val lastStatement = statements.lastOrNull() ?: return
         statements
-                .filter {
-                    when {
-                        it !is KtNameReferenceExpression || it.text != UNIT -> false
-                        it != lastStatement || bindingContext == BindingContext.EMPTY -> true
-                        !it.isUsedAsExpression(bindingContext) -> true
-                        else -> {
-                            val prev =
-                                it.siblings(forward = false, withItself = false).firstIsInstanceOrNull<KtExpression>()
-                            prev?.getType(bindingContext)?.isUnit() == true && prev.canBeUsedAsValue()
-                        }
+            .filter {
+                when {
+                    it !is KtNameReferenceExpression || it.text != UNIT -> false
+                    it != lastStatement || bindingContext == BindingContext.EMPTY -> true
+                    !it.isUsedAsExpression(bindingContext) -> true
+                    else -> {
+                        val prev =
+                            it.siblings(forward = false, withItself = false).firstIsInstanceOrNull<KtExpression>()
+                        prev?.getType(bindingContext)?.isUnit() == true && prev.canBeUsedAsValue()
                     }
                 }
-                .onEach {
-                    report(CodeSmell(issue, Entity.from(expression),
-                            "A single Unit expression is unnecessary and can safely be removed"))
-                }
+            }
+            .onEach {
+                report(
+                    CodeSmell(
+                        issue, Entity.from(expression),
+                        "A single Unit expression is unnecessary and can safely be removed"
+                    )
+                )
+            }
         super.visitBlockExpression(expression)
     }
 
@@ -114,7 +119,7 @@ class OptionalUnit(config: Config = Config.empty) : Rule(config) {
     }
 
     private fun createMessage(function: KtNamedFunction) = "The function ${function.name} " +
-            "defines a return type of Unit. This is unnecessary and can safely be removed."
+        "defines a return type of Unit. This is unnecessary and can safely be removed."
 
     companion object {
         private const val UNIT = "Unit"

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/OptionalUnit.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/OptionalUnit.kt
@@ -82,7 +82,8 @@ class OptionalUnit(config: Config = Config.empty) : Rule(config) {
             .onEach {
                 report(
                     CodeSmell(
-                        issue, Entity.from(expression),
+                        issue,
+                        Entity.from(expression),
                         "A single Unit expression is unnecessary and can safely be removed"
                     )
                 )

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/PreferToOverPairSyntax.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/PreferToOverPairSyntax.kt
@@ -33,7 +33,8 @@ import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameOrNull
 @RequiresTypeResolution
 class PreferToOverPairSyntax(config: Config = Config.empty) : Rule(config) {
     override val issue = Issue(
-        "PreferToOverPairSyntax", Severity.Style,
+        "PreferToOverPairSyntax",
+        Severity.Style,
         "Pair was created using the Pair constructor, using the to syntax is preferred.",
         Debt.FIVE_MINS
     )
@@ -46,7 +47,8 @@ class PreferToOverPairSyntax(config: Config = Config.empty) : Rule(config) {
             val arg = expression.valueArguments.joinToString(" to ") { it.text }
             report(
                 CodeSmell(
-                    issue, Entity.from(expression),
+                    issue,
+                    Entity.from(expression),
                     message = "Pair is created by using the pair constructor. " +
                         "This can replaced by `$arg`"
                 )

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ClassOrderingSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ClassOrderingSpec.kt
@@ -76,8 +76,10 @@ class ClassOrderingSpec : Spek({
 
             val findings = subject.compileAndLint(code)
             assertThat(findings).hasSize(1)
-            assertThat(findings[0].message).isEqualTo("OutOfOrder (secondary constructor) " +
-                "should not come before class initializer")
+            assertThat(findings[0].message).isEqualTo(
+                "OutOfOrder (secondary constructor) " +
+                    "should not come before class initializer"
+            )
         }
 
         it("reports when secondary constructor is out of order") {
@@ -101,8 +103,10 @@ class ClassOrderingSpec : Spek({
 
             val findings = subject.compileAndLint(code)
             assertThat(findings).hasSize(1)
-            assertThat(findings[0].message).isEqualTo("OutOfOrder (secondary constructor) " +
-                "should not come before y (property)")
+            assertThat(findings[0].message).isEqualTo(
+                "OutOfOrder (secondary constructor) " +
+                    "should not come before y (property)"
+            )
         }
 
         it("reports when method is out of order") {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/DataClassContainsFunctionsSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/DataClassContainsFunctionsSpec.kt
@@ -1,7 +1,7 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
-import io.gitlab.arturbosch.detekt.test.compileAndLint
 import io.gitlab.arturbosch.detekt.test.TestConfig
+import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/DestructuringDeclarationWithTooManyEntriesSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/DestructuringDeclarationWithTooManyEntriesSpec.kt
@@ -25,7 +25,7 @@ class DestructuringDeclarationWithTooManyEntriesSpec : Spek({
                     println(b)
                     println(c)
                 }
-            """.trimIndent()
+                """.trimIndent()
                 assertThat(subject.compileAndLint(code)).isEmpty()
             }
 
@@ -40,7 +40,7 @@ class DestructuringDeclarationWithTooManyEntriesSpec : Spek({
                     println(c)
                     println(d)
                 }
-            """.trimIndent()
+                """.trimIndent()
                 assertThat(subject.compileAndLint(code)).hasSize(1)
             }
 
@@ -54,7 +54,7 @@ class DestructuringDeclarationWithTooManyEntriesSpec : Spek({
                         println(b)
                     }
                 }
-            """.trimIndent()
+                """.trimIndent()
                 assertThat(subject.compileAndLint(code)).isEmpty()
             }
 
@@ -71,7 +71,7 @@ class DestructuringDeclarationWithTooManyEntriesSpec : Spek({
                         println(d)
                     }
                 }
-            """.trimIndent()
+                """.trimIndent()
                 assertThat(subject.compileAndLint(code)).hasSize(1)
             }
         }
@@ -91,7 +91,7 @@ class DestructuringDeclarationWithTooManyEntriesSpec : Spek({
                     println(x)
                     println(y)
                 }
-            """.trimIndent()
+                """.trimIndent()
                 assertThat(configuredRule.compileAndLint(code)).isEmpty()
             }
 
@@ -103,7 +103,7 @@ class DestructuringDeclarationWithTooManyEntriesSpec : Spek({
                     println(b)
                     println(c)
                 }
-            """.trimIndent()
+                """.trimIndent()
                 assertThat(configuredRule.compileAndLint(code)).hasSize(1)
             }
         }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/EqualsOnSignatureLineSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/EqualsOnSignatureLineSpec.kt
@@ -13,27 +13,32 @@ class EqualsOnSignatureLineSpec : Spek({
 
         context("with expression syntax and without a return type") {
             it("reports when the equals is on a new line") {
-                val findings = subject.compileAndLint("""
+                val findings = subject.compileAndLint(
+                    """
                     fun foo()
                         = 1
-                """)
+                """
+                )
                 assertThat(findings).hasSize(1)
             }
 
             it("does not report when the equals is on the same line") {
-                val findings = subject.compileAndLint("""
+                val findings = subject.compileAndLint(
+                    """
                 fun foo() = 1
 
                 fun bar() =
                     2
-                """)
+                """
+                )
                 assertThat(findings).isEmpty()
             }
         }
 
         context("with expression syntax and with a return type") {
             it("reports when the equals is on a new line") {
-                val findings = subject.compileAndLint("""
+                val findings = subject.compileAndLint(
+                    """
                 fun one(): Int
                     = 1
 
@@ -46,12 +51,14 @@ class EqualsOnSignatureLineSpec : Spek({
                     foo: String
                 ): Int
                     = 3
-                """)
+                """
+                )
                 assertThat(findings).hasSize(3)
             }
 
             it("does not report when the equals is on the same line") {
-                val findings = subject.compileAndLint("""
+                val findings = subject.compileAndLint(
+                    """
                 fun one(): Int =
                     1
 
@@ -80,14 +87,16 @@ class EqualsOnSignatureLineSpec : Spek({
                 :
                 Int =
                     6
-                """)
+                """
+                )
                 assertThat(findings).isEmpty()
             }
         }
 
         context("with expression syntax and with a where clause") {
             it("reports when the equals is on a new line") {
-                val findings = subject.compileAndLint("""
+                val findings = subject.compileAndLint(
+                    """
                 fun <V> one(): Int where V : Number
                     = 1
 
@@ -101,12 +110,14 @@ class EqualsOnSignatureLineSpec : Spek({
                 ): Int
                     where V : Number
                     = 3
-                """)
+                """
+                )
                 assertThat(findings).hasSize(3)
             }
 
             it("does not report when the equals is on the same line") {
-                val findings = subject.compileAndLint("""
+                val findings = subject.compileAndLint(
+                    """
                 fun <V> one(): Int where V : Number =
                     1
 
@@ -114,13 +125,15 @@ class EqualsOnSignatureLineSpec : Spek({
                     where V : Number =
                     2
 
-                """)
+                """
+                )
                 assertThat(findings).isEmpty()
             }
         }
 
         it("does not report non-expression functions") {
-            val findings = subject.compileAndLint("""
+            val findings = subject.compileAndLint(
+                """
             fun foo() {
             }
 
@@ -133,7 +146,8 @@ class EqualsOnSignatureLineSpec : Spek({
             Unit
             {
             }
-            """)
+            """
+            )
             assertThat(findings).isEmpty()
         }
     }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitItLambdaParameterSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitItLambdaParameterSpec.kt
@@ -12,45 +12,55 @@ class ExplicitItLambdaParameterSpec : Spek({
     describe("ExplicitItLambdaParameter rule") {
         context("single parameter lambda with name `it` declared explicitly") {
             it("reports when parameter type is not declared") {
-                val findings = subject.compileAndLint("""
+                val findings = subject.compileAndLint(
+                    """
                 fun f() {
                     val digits = 1234.let { it -> listOf(it) }
-                }""")
+                }"""
+                )
                 assertThat(findings).hasSize(1)
             }
             it("reports when parameter type is declared explicitly") {
-                val findings = subject.compileAndLint("""
+                val findings = subject.compileAndLint(
+                    """
                 fun f() {
                     val lambda = { it: Int -> it.toString() }
-                }""")
+                }"""
+                )
                 assertThat(findings).hasSize(1)
             }
         }
         context("no parameter declared explicitly") {
             it("does not report implicit `it` parameter usage") {
-                val findings = subject.compileAndLint("""
+                val findings = subject.compileAndLint(
+                    """
                 fun f() {
                     val lambda = { i: Int -> i.toString() }
                     val digits = 1234.let { lambda(it) }.toList()
                     val flat = listOf(listOf(1), listOf(2)).flatMap { it }
-                }""")
+                }"""
+                )
                 assertThat(findings).isEmpty()
             }
         }
 
         context("multiple parameters one of which with name `it` declared explicitly") {
             it("reports when parameter types are not declared") {
-                val findings = subject.compileAndLint("""
+                val findings = subject.compileAndLint(
+                    """
                 fun f() {
                     val flat = listOf(listOf(1), listOf(2)).mapIndexed { index, it -> it + index }
-                }""")
+                }"""
+                )
                 assertThat(findings).hasSize(1)
             }
             it("reports when parameter types are declared explicitly") {
-                val findings = subject.compileAndLint("""
+                val findings = subject.compileAndLint(
+                    """
                 fun f() {
                     val lambda = { it: Int, that: String -> it.toString() + that }
-                }""")
+                }"""
+                )
                 assertThat(findings).hasSize(1)
             }
         }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExpressionBodySyntaxSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExpressionBodySyntaxSpec.kt
@@ -15,51 +15,69 @@ class ExpressionBodySyntaxSpec : Spek({
         context("several return statements") {
 
             it("reports constant return") {
-                assertThat(subject.compileAndLint("""
+                assertThat(
+                    subject.compileAndLint(
+                        """
                     fun stuff(): Int {
                         return 5
                     }
                 """
-                )).hasSize(1)
+                    )
+                ).hasSize(1)
             }
 
             it("reports return statement with method chain") {
-                assertThat(subject.compileAndLint("""
+                assertThat(
+                    subject.compileAndLint(
+                        """
                     fun stuff(): String {
                         return StringBuilder().append(0).toString()
                     }
                 """
-                )).hasSize(1)
+                    )
+                ).hasSize(1)
             }
 
             it("reports return statements with conditionals") {
-                assertThat(subject.compileAndLint("""
+                assertThat(
+                    subject.compileAndLint(
+                        """
                     fun stuff(): Int {
                         return if (true) return 5 else return 3
                     }
                     fun stuff(): Int {
                         return try { return 5 } catch (e: Exception) { return 3 }
                     }
-                """)).hasSize(2)
+                """
+                    )
+                ).hasSize(2)
             }
 
             it("does not report multiple if statements") {
-                assertThat(subject.compileAndLint("""
+                assertThat(
+                    subject.compileAndLint(
+                        """
                     fun stuff(): Boolean {
                         if (true) return true
                         return false
                     }
-                """)).isEmpty()
+                """
+                    )
+                ).isEmpty()
             }
 
             it("does not report when using shortcut return") {
-                assertThat(subject.compileAndLint("""
+                assertThat(
+                    subject.compileAndLint(
+                        """
                     fun caller(): String {
                         return callee("" as String? ?: return "")
                     }
 
                     fun callee(a: String): String = ""
-                """)).isEmpty()
+                """
+                    )
+                ).isEmpty()
             }
         }
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenCommentSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenCommentSpec.kt
@@ -81,7 +81,8 @@ class ForbiddenCommentSpec : Spek({
 
             listOf(
                 TestConfig(mapOf(ForbiddenComment.VALUES to "Banana")),
-                TestConfig(mapOf(ForbiddenComment.VALUES to listOf("Banana"))))
+                TestConfig(mapOf(ForbiddenComment.VALUES to listOf("Banana")))
+            )
                 .forEach { config ->
                     val banana = "// Banana."
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenImportSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenImportSpec.kt
@@ -55,8 +55,13 @@ class ForbiddenImportSpec : Spek({
 
         it("should report kotlin.SinceKotlin and kotlin.jvm.JvmField when specified via fully qualified names list") {
             val findings =
-                ForbiddenImport(TestConfig(mapOf(
-                    ForbiddenImport.IMPORTS to listOf("kotlin.SinceKotlin", "kotlin.jvm.JvmField")))).lint(code)
+                ForbiddenImport(
+                    TestConfig(
+                        mapOf(
+                            ForbiddenImport.IMPORTS to listOf("kotlin.SinceKotlin", "kotlin.jvm.JvmField")
+                        )
+                    )
+                ).lint(code)
             assertThat(findings).hasSize(2)
         }
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCallSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCallSpec.kt
@@ -267,8 +267,12 @@ class ForbiddenMethodCallSpec : Spek({
                 }
             """
             val findings = ForbiddenMethodCall(
-                TestConfig(mapOf(ForbiddenMethodCall.METHODS to
-                        listOf("io.gitlab.arturbosch.detekt.rules.style.defaultParamsMethod(kotlin.String,kotlin.Int)")))
+                TestConfig(
+                    mapOf(
+                        ForbiddenMethodCall.METHODS to
+                            listOf("io.gitlab.arturbosch.detekt.rules.style.defaultParamsMethod(kotlin.String,kotlin.Int)")
+                    )
+                )
             ).compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasSourceLocation(6, 13)

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/LibraryCodeMustSpecifyReturnTypeSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/LibraryCodeMustSpecifyReturnTypeSpec.kt
@@ -19,14 +19,19 @@ internal class LibraryCodeMustSpecifyReturnTypeSpec : Spek({
 
         it("should not report without explicit filters set") {
             val subject = LibraryCodeMustSpecifyReturnType(TestConfig(Config.EXCLUDES_KEY to "**"))
-            assertThat(subject.compileAndLintWithContext(env, """
+            assertThat(
+                subject.compileAndLintWithContext(
+                    env,
+                    """
                 fun foo() = 5
                 val bar = 5
                 class A {
                     fun b() = 2
                     val c = 2
                 }
-            """)).isEmpty()
+            """
+                )
+            ).isEmpty()
         }
 
         val subject by memoized {
@@ -36,82 +41,135 @@ internal class LibraryCodeMustSpecifyReturnTypeSpec : Spek({
         describe("positive cases") {
 
             it("should report a top level function") {
-                assertThat(subject.compileAndLintWithContext(env, """
+                assertThat(
+                    subject.compileAndLintWithContext(
+                        env,
+                        """
                     fun foo() = 5
-                """)).hasSize(1)
+                """
+                    )
+                ).hasSize(1)
             }
 
             it("should report a top level property") {
-                assertThat(subject.compileAndLintWithContext(env, """
+                assertThat(
+                    subject.compileAndLintWithContext(
+                        env,
+                        """
                     val foo = 5
-                """)).hasSize(1)
+                """
+                    )
+                ).hasSize(1)
             }
 
             it("should report a public class with public members") {
-                assertThat(subject.compileAndLintWithContext(env, """
+                assertThat(
+                    subject.compileAndLintWithContext(
+                        env,
+                        """
                     class A {
                         val foo = 5
                         fun bar() = 5
                     }
-                """)).hasSize(2)
+                """
+                    )
+                ).hasSize(2)
             }
 
             it("should report a public class with protected members") {
-                assertThat(subject.compileAndLintWithContext(env, """
+                assertThat(
+                    subject.compileAndLintWithContext(
+                        env,
+                        """
                     open class A {
                         protected val foo = 5
                         protected fun bar() = 5
                     }
-                """)).hasSize(2)
+                """
+                    )
+                ).hasSize(2)
             }
         }
 
         describe("negative cases with public scope") {
 
             it("should not report a top level function") {
-                assertThat(subject.compileAndLintWithContext(env, """
+                assertThat(
+                    subject.compileAndLintWithContext(
+                        env,
+                        """
                     fun foo(): Int = 5
-                """)).isEmpty()
+                """
+                    )
+                ).isEmpty()
             }
 
             it("should not report a non expression function") {
-                assertThat(subject.compileAndLintWithContext(env, """
+                assertThat(
+                    subject.compileAndLintWithContext(
+                        env,
+                        """
                     fun foo() {}
-                """)).isEmpty()
+                """
+                    )
+                ).isEmpty()
             }
 
             it("should not report a top level property") {
-                assertThat(subject.compileAndLintWithContext(env, """
+                assertThat(
+                    subject.compileAndLintWithContext(
+                        env,
+                        """
                     val foo: Int = 5
-                """)).isEmpty()
+                """
+                    )
+                ).isEmpty()
             }
 
             it("should not report a public class with public members") {
-                assertThat(subject.compileAndLintWithContext(env, """
+                assertThat(
+                    subject.compileAndLintWithContext(
+                        env,
+                        """
                     class A {
                         val foo: Int = 5
                         fun bar(): Int = 5
                     }
-                """)).isEmpty()
+                """
+                    )
+                ).isEmpty()
             }
         }
         describe("negative cases with no public scope") {
 
             it("should not report a private top level function") {
-                assertThat(subject.lintWithContext(env, """
+                assertThat(
+                    subject.lintWithContext(
+                        env,
+                        """
                     internal fun bar() = 5
                     private fun foo() = 5
-                """)).isEmpty()
+                """
+                    )
+                ).isEmpty()
             }
 
             it("should not report a internal top level property") {
-                assertThat(subject.compileAndLintWithContext(env, """
+                assertThat(
+                    subject.compileAndLintWithContext(
+                        env,
+                        """
                     internal val foo = 5
-                """)).isEmpty()
+                """
+                    )
+                ).isEmpty()
             }
 
             it("should not report members and local variables") {
-                assertThat(subject.compileAndLintWithContext(env, """
+                assertThat(
+                    subject.compileAndLintWithContext(
+                        env,
+                        """
                     internal class A {
                         internal val foo = 5
                         private fun bar() {
@@ -119,16 +177,23 @@ internal class LibraryCodeMustSpecifyReturnTypeSpec : Spek({
                             val a = 5
                         }
                     }
-                """)).isEmpty()
+                """
+                    )
+                ).isEmpty()
             }
 
             it("should not report effectively private properties and functions") {
-                assertThat(subject.compileAndLintWithContext(env, """
+                assertThat(
+                    subject.compileAndLintWithContext(
+                        env,
+                        """
                     internal class A {
                         fun baz() = 5
                         val qux = 5
                     }
-                """)).isEmpty()
+                """
+                    )
+                ).isEmpty()
             }
         }
     }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/LibraryEntitiesShouldNotBePublicTest.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/LibraryEntitiesShouldNotBePublicTest.kt
@@ -13,9 +13,12 @@ internal class LibraryEntitiesShouldNotBePublicTest : Spek({
         it("should not report without explicit filters set") {
             val subject = LibraryEntitiesShouldNotBePublic(TestConfig(Config.EXCLUDES_KEY to "**"))
             assertThat(
-                subject.compileAndLint("""
+                subject.compileAndLint(
+                    """
                     class A 
-            """)).isEmpty()
+            """
+                )
+            ).isEmpty()
         }
 
         val subject by memoized {
@@ -24,62 +27,94 @@ internal class LibraryEntitiesShouldNotBePublicTest : Spek({
 
         describe("positive cases") {
             it("should report a class") {
-                assertThat(subject.compileAndLint("""
+                assertThat(
+                    subject.compileAndLint(
+                        """
                     class A
-                """)).hasSize(1)
+                """
+                    )
+                ).hasSize(1)
             }
 
             it("should report a class with function") {
-                assertThat(subject.compileAndLint("""
+                assertThat(
+                    subject.compileAndLint(
+                        """
                     class A {
                         fun foo(): Int{
                             return 1
                         }
                     }
-                """)).hasSize(1)
+                """
+                    )
+                ).hasSize(1)
             }
 
             it("should report a typealias") {
-                assertThat(subject.compileAndLint("""
+                assertThat(
+                    subject.compileAndLint(
+                        """
                     typealias A = List<String>
-                """)).hasSize(1)
+                """
+                    )
+                ).hasSize(1)
             }
 
             it("should report a typealias and a function") {
-                assertThat(subject.compileAndLint("""
+                assertThat(
+                    subject.compileAndLint(
+                        """
                     typealias A = List<String>
                     fun foo() = Unit
-                """)).hasSize(2)
+                """
+                    )
+                ).hasSize(2)
             }
 
             it("should report a function") {
-                assertThat(subject.compileAndLint("""
+                assertThat(
+                    subject.compileAndLint(
+                        """
                     fun foo() = Unit
-                """)).hasSize(1)
+                """
+                    )
+                ).hasSize(1)
             }
         }
 
         describe("negative cases") {
             it("should not report a class") {
-                assertThat(subject.compileAndLint("""
+                assertThat(
+                    subject.compileAndLint(
+                        """
                     internal class A {
                         fun foo(): Int{
                             return 1
                         }
                     }
-                """)).isEmpty()
+                """
+                    )
+                ).isEmpty()
             }
 
             it("should not report a class with function") {
-                assertThat(subject.compileAndLint("""
+                assertThat(
+                    subject.compileAndLint(
+                        """
                     internal class A
-                """)).isEmpty()
+                """
+                    )
+                ).isEmpty()
             }
 
             it("should not report a typealias") {
-                assertThat(subject.compileAndLint("""
+                assertThat(
+                    subject.compileAndLint(
+                        """
                     internal typealias A = List<String>
-                """)).isEmpty()
+                """
+                    )
+                ).isEmpty()
             }
         }
     }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumberSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumberSpec.kt
@@ -385,13 +385,13 @@ class MagicNumberSpec : Spek({
 
             it("should report all without ignore flags") {
                 val config = TestConfig(
-                        mapOf(
-                                MagicNumber.IGNORE_PROPERTY_DECLARATION to "false",
-                                MagicNumber.IGNORE_ANNOTATION to "false",
-                                MagicNumber.IGNORE_HASH_CODE to "false",
-                                MagicNumber.IGNORE_CONSTANT_DECLARATION to "false",
-                                MagicNumber.IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "false"
-                        )
+                    mapOf(
+                        MagicNumber.IGNORE_PROPERTY_DECLARATION to "false",
+                        MagicNumber.IGNORE_ANNOTATION to "false",
+                        MagicNumber.IGNORE_HASH_CODE to "false",
+                        MagicNumber.IGNORE_CONSTANT_DECLARATION to "false",
+                        MagicNumber.IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "false"
+                    )
                 )
 
                 val findings = MagicNumber(config).lint(code)
@@ -408,13 +408,13 @@ class MagicNumberSpec : Spek({
 
             it("should not report any issues with all ignore flags") {
                 val config = TestConfig(
-                        mapOf(
-                                MagicNumber.IGNORE_PROPERTY_DECLARATION to "true",
-                                MagicNumber.IGNORE_ANNOTATION to "true",
-                                MagicNumber.IGNORE_HASH_CODE to "true",
-                                MagicNumber.IGNORE_CONSTANT_DECLARATION to "true",
-                                MagicNumber.IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "true"
-                        )
+                    mapOf(
+                        MagicNumber.IGNORE_PROPERTY_DECLARATION to "true",
+                        MagicNumber.IGNORE_ANNOTATION to "true",
+                        MagicNumber.IGNORE_HASH_CODE to "true",
+                        MagicNumber.IGNORE_CONSTANT_DECLARATION to "true",
+                        MagicNumber.IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "true"
+                    )
                 )
 
                 val findings = MagicNumber(config).lint(code)
@@ -440,11 +440,11 @@ class MagicNumberSpec : Spek({
 
             it("should not report any issues when ignoring properties but not constants nor companion objects") {
                 val config = TestConfig(
-                        mapOf(
-                                MagicNumber.IGNORE_PROPERTY_DECLARATION to "true",
-                                MagicNumber.IGNORE_CONSTANT_DECLARATION to "false",
-                                MagicNumber.IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "false"
-                        )
+                    mapOf(
+                        MagicNumber.IGNORE_PROPERTY_DECLARATION to "true",
+                        MagicNumber.IGNORE_CONSTANT_DECLARATION to "false",
+                        MagicNumber.IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "false"
+                    )
                 )
 
                 val findings = MagicNumber(config).lint(code)
@@ -453,11 +453,11 @@ class MagicNumberSpec : Spek({
 
             it("should not report any issues when ignoring properties and constants but not companion objects") {
                 val config = TestConfig(
-                        mapOf(
-                                MagicNumber.IGNORE_PROPERTY_DECLARATION to "true",
-                                MagicNumber.IGNORE_CONSTANT_DECLARATION to "true",
-                                MagicNumber.IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "false"
-                        )
+                    mapOf(
+                        MagicNumber.IGNORE_PROPERTY_DECLARATION to "true",
+                        MagicNumber.IGNORE_CONSTANT_DECLARATION to "true",
+                        MagicNumber.IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "false"
+                    )
                 )
 
                 val findings = MagicNumber(config).lint(code)
@@ -466,11 +466,11 @@ class MagicNumberSpec : Spek({
 
             it("should not report any issues when ignoring properties, constants and companion objects") {
                 val config = TestConfig(
-                        mapOf(
-                                MagicNumber.IGNORE_PROPERTY_DECLARATION to "true",
-                                MagicNumber.IGNORE_CONSTANT_DECLARATION to "true",
-                                MagicNumber.IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "true"
-                        )
+                    mapOf(
+                        MagicNumber.IGNORE_PROPERTY_DECLARATION to "true",
+                        MagicNumber.IGNORE_CONSTANT_DECLARATION to "true",
+                        MagicNumber.IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "true"
+                    )
                 )
 
                 val findings = MagicNumber(config).lint(code)
@@ -479,11 +479,11 @@ class MagicNumberSpec : Spek({
 
             it("should not report any issues when ignoring companion objects but not properties and constants") {
                 val config = TestConfig(
-                        mapOf(
-                                MagicNumber.IGNORE_PROPERTY_DECLARATION to "false",
-                                MagicNumber.IGNORE_CONSTANT_DECLARATION to "false",
-                                MagicNumber.IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "true"
-                        )
+                    mapOf(
+                        MagicNumber.IGNORE_PROPERTY_DECLARATION to "false",
+                        MagicNumber.IGNORE_CONSTANT_DECLARATION to "false",
+                        MagicNumber.IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "true"
+                    )
                 )
 
                 val findings = MagicNumber(config).lint(code)
@@ -492,11 +492,11 @@ class MagicNumberSpec : Spek({
 
             it("should report property when ignoring constants but not properties and companion objects") {
                 val config = TestConfig(
-                        mapOf(
-                                MagicNumber.IGNORE_PROPERTY_DECLARATION to "false",
-                                MagicNumber.IGNORE_CONSTANT_DECLARATION to "true",
-                                MagicNumber.IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "false"
-                        )
+                    mapOf(
+                        MagicNumber.IGNORE_PROPERTY_DECLARATION to "false",
+                        MagicNumber.IGNORE_CONSTANT_DECLARATION to "true",
+                        MagicNumber.IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "false"
+                    )
                 )
 
                 val findings = MagicNumber(config).lint(code)
@@ -505,11 +505,11 @@ class MagicNumberSpec : Spek({
 
             it("should report property and constant when not ignoring properties, constants nor companion objects") {
                 val config = TestConfig(
-                        mapOf(
-                                MagicNumber.IGNORE_PROPERTY_DECLARATION to "false",
-                                MagicNumber.IGNORE_CONSTANT_DECLARATION to "false",
-                                MagicNumber.IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "false"
-                        )
+                    mapOf(
+                        MagicNumber.IGNORE_PROPERTY_DECLARATION to "false",
+                        MagicNumber.IGNORE_CONSTANT_DECLARATION to "false",
+                        MagicNumber.IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "false"
+                    )
                 )
 
                 val findings = MagicNumber(config).lint(code)
@@ -579,11 +579,11 @@ class MagicNumberSpec : Spek({
 
                 it("should ignore named arguments in parameter annotations - #1115") {
                     val code =
-                            "@JvmStatic fun setCustomDimension(@IntRange(from = 0, to = 19) index: Int, value: String?) {}"
+                        "@JvmStatic fun setCustomDimension(@IntRange(from = 0, to = 19) index: Int, value: String?) {}"
                     MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NAMED_ARGUMENT to "true")))
-                            .lint(code)
-                            .assert()
-                            .isEmpty()
+                        .lint(code)
+                        .assert()
+                        .isEmpty()
                 }
             }
 
@@ -710,13 +710,13 @@ class MagicNumberSpec : Spek({
         context("a number as part of a range") {
 
             listOf(
-                    "val range = 1..27",
-                    "val range = (1..27)",
-                    "val range = 27 downTo 1",
-                    "val range = 1 until 27 step 1",
-                    "val inRange = 1 in 1..27",
-                    "val inRange = (1 in 27 downTo 0 step 1)",
-                    "val inRange = (1..27 step 1).last"
+                "val range = 1..27",
+                "val range = (1..27)",
+                "val range = 27 downTo 1",
+                "val range = 1 until 27 step 1",
+                "val inRange = 1 in 1..27",
+                "val inRange = (1 in 27 downTo 0 step 1)",
+                "val inRange = (1..27 step 1).last"
             ).forEach { codeWithMagicNumberInRange ->
                 it("'$codeWithMagicNumberInRange' reports a code smell by default") {
                     val code = codeWithMagicNumberInRange
@@ -725,12 +725,12 @@ class MagicNumberSpec : Spek({
                 it("'$codeWithMagicNumberInRange' reports a code smell if ranges are not ignored") {
                     val code = codeWithMagicNumberInRange
                     assertThat(MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_RANGES to "false"))).lint(code))
-                            .hasSize(1)
+                        .hasSize(1)
                 }
                 it("'$codeWithMagicNumberInRange' reports no finding if ranges are ignored") {
                     val code = codeWithMagicNumberInRange
                     assertThat(MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_RANGES to "true"))).lint(code))
-                            .isEmpty()
+                        .isEmpty()
                 }
             }
 
@@ -762,9 +762,14 @@ class MagicNumberSpec : Spek({
         context("meaningful variables - #1536") {
 
             val rule by memoized {
-                MagicNumber(TestConfig(mapOf(
-                    MagicNumber.IGNORE_LOCAL_VARIABLES to "true",
-                    MagicNumber.IGNORE_NAMED_ARGUMENT to "true")))
+                MagicNumber(
+                    TestConfig(
+                        mapOf(
+                            MagicNumber.IGNORE_LOCAL_VARIABLES to "true",
+                            MagicNumber.IGNORE_NAMED_ARGUMENT to "true"
+                        )
+                    )
+                )
             }
 
             it("should report 3") {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLengthSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLengthSpec.kt
@@ -63,31 +63,43 @@ class MaxLineLengthSpec : Spek({
             val fileContent by memoized { KtFileContent(file, lines) }
 
             it("should not report the package statement and import statements by default") {
-                val rule = MaxLineLength(TestConfig(mapOf(
-                    MaxLineLength.MAX_LINE_LENGTH to "60"
-                )))
+                val rule = MaxLineLength(
+                    TestConfig(
+                        mapOf(
+                            MaxLineLength.MAX_LINE_LENGTH to "60"
+                        )
+                    )
+                )
 
                 rule.visit(fileContent)
                 assertThat(rule.findings).isEmpty()
             }
 
             it("should report the package statement and import statements if they're enabled") {
-                val rule = MaxLineLength(TestConfig(mapOf(
-                    MaxLineLength.MAX_LINE_LENGTH to "60",
-                    MaxLineLength.EXCLUDE_PACKAGE_STATEMENTS to "false",
-                    MaxLineLength.EXCLUDE_IMPORT_STATEMENTS to "false"
-                )))
+                val rule = MaxLineLength(
+                    TestConfig(
+                        mapOf(
+                            MaxLineLength.MAX_LINE_LENGTH to "60",
+                            MaxLineLength.EXCLUDE_PACKAGE_STATEMENTS to "false",
+                            MaxLineLength.EXCLUDE_IMPORT_STATEMENTS to "false"
+                        )
+                    )
+                )
 
                 rule.visit(fileContent)
                 assertThat(rule.findings).hasSize(2)
             }
 
             it("should not report anything if both package and import statements are disabled") {
-                val rule = MaxLineLength(TestConfig(mapOf(
-                    MaxLineLength.MAX_LINE_LENGTH to "60",
-                    MaxLineLength.EXCLUDE_PACKAGE_STATEMENTS to "true",
-                    MaxLineLength.EXCLUDE_IMPORT_STATEMENTS to "true"
-                )))
+                val rule = MaxLineLength(
+                    TestConfig(
+                        mapOf(
+                            MaxLineLength.MAX_LINE_LENGTH to "60",
+                            MaxLineLength.EXCLUDE_PACKAGE_STATEMENTS to "true",
+                            MaxLineLength.EXCLUDE_IMPORT_STATEMENTS to "true"
+                        )
+                    )
+                )
 
                 rule.visit(fileContent)
                 assertThat(rule.findings).isEmpty()
@@ -101,31 +113,43 @@ class MaxLineLengthSpec : Spek({
             val fileContent by memoized { KtFileContent(file, lines) }
 
             it("should report the package statement, import statements, line and comments by default") {
-                val rule = MaxLineLength(TestConfig(mapOf(
-                    MaxLineLength.MAX_LINE_LENGTH to "60"
-                )))
+                val rule = MaxLineLength(
+                    TestConfig(
+                        mapOf(
+                            MaxLineLength.MAX_LINE_LENGTH to "60"
+                        )
+                    )
+                )
 
                 rule.visit(fileContent)
                 assertThat(rule.findings).hasSize(8)
             }
 
             it("should report the package statement, import statements, line and comments if they're enabled") {
-                val rule = MaxLineLength(TestConfig(mapOf(
-                    MaxLineLength.MAX_LINE_LENGTH to "60",
-                    MaxLineLength.EXCLUDE_PACKAGE_STATEMENTS to "false",
-                    MaxLineLength.EXCLUDE_IMPORT_STATEMENTS to "false",
-                    MaxLineLength.EXCLUDE_COMMENT_STATEMENTS to "false"
-                )))
+                val rule = MaxLineLength(
+                    TestConfig(
+                        mapOf(
+                            MaxLineLength.MAX_LINE_LENGTH to "60",
+                            MaxLineLength.EXCLUDE_PACKAGE_STATEMENTS to "false",
+                            MaxLineLength.EXCLUDE_IMPORT_STATEMENTS to "false",
+                            MaxLineLength.EXCLUDE_COMMENT_STATEMENTS to "false"
+                        )
+                    )
+                )
 
                 rule.visit(fileContent)
                 assertThat(rule.findings).hasSize(8)
             }
 
             it("should not report comments if they're disabled") {
-                val rule = MaxLineLength(TestConfig(mapOf(
-                    MaxLineLength.MAX_LINE_LENGTH to "60",
-                    MaxLineLength.EXCLUDE_COMMENT_STATEMENTS to "true"
-                )))
+                val rule = MaxLineLength(
+                    TestConfig(
+                        mapOf(
+                            MaxLineLength.MAX_LINE_LENGTH to "60",
+                            MaxLineLength.EXCLUDE_COMMENT_STATEMENTS to "true"
+                        )
+                    )
+                )
 
                 rule.visit(fileContent)
                 assertThat(rule.findings).hasSize(5)
@@ -148,42 +172,58 @@ class MaxLineLengthSpec : Spek({
             val fileContent by memoized { KtFileContent(file, lines) }
 
             it("should only the function line by default") {
-                val rule = MaxLineLength(TestConfig(mapOf(
-                    MaxLineLength.MAX_LINE_LENGTH to "60"
-                )))
+                val rule = MaxLineLength(
+                    TestConfig(
+                        mapOf(
+                            MaxLineLength.MAX_LINE_LENGTH to "60"
+                        )
+                    )
+                )
 
                 rule.visit(fileContent)
                 assertThat(rule.findings).hasSize(1)
             }
 
             it("should report the package statement, import statements and line if they're not excluded") {
-                val rule = MaxLineLength(TestConfig(mapOf(
-                    MaxLineLength.MAX_LINE_LENGTH to "60",
-                    MaxLineLength.EXCLUDE_PACKAGE_STATEMENTS to "false",
-                    MaxLineLength.EXCLUDE_IMPORT_STATEMENTS to "false"
-                )))
+                val rule = MaxLineLength(
+                    TestConfig(
+                        mapOf(
+                            MaxLineLength.MAX_LINE_LENGTH to "60",
+                            MaxLineLength.EXCLUDE_PACKAGE_STATEMENTS to "false",
+                            MaxLineLength.EXCLUDE_IMPORT_STATEMENTS to "false"
+                        )
+                    )
+                )
 
                 rule.visit(fileContent)
                 assertThat(rule.findings).hasSize(3)
             }
 
             it("should report only method if both package and import statements are disabled") {
-                val rule = MaxLineLength(TestConfig(mapOf(
-                    MaxLineLength.MAX_LINE_LENGTH to "60",
-                    MaxLineLength.EXCLUDE_PACKAGE_STATEMENTS to "true",
-                    MaxLineLength.EXCLUDE_IMPORT_STATEMENTS to "true"
-                )))
+                val rule = MaxLineLength(
+                    TestConfig(
+                        mapOf(
+                            MaxLineLength.MAX_LINE_LENGTH to "60",
+                            MaxLineLength.EXCLUDE_PACKAGE_STATEMENTS to "true",
+                            MaxLineLength.EXCLUDE_IMPORT_STATEMENTS to "true"
+                        )
+                    )
+                )
 
                 rule.visit(fileContent)
                 assertThat(rule.findings).hasSize(1)
             }
 
             it("should report correct line and column for function with excessive length") {
-                val rule = MaxLineLength(TestConfig(mapOf(
-                    MaxLineLength.MAX_LINE_LENGTH to "60",
-                    MaxLineLength.EXCLUDE_PACKAGE_STATEMENTS to "true",
-                    MaxLineLength.EXCLUDE_IMPORT_STATEMENTS to "true"
-                )))
+                val rule = MaxLineLength(
+                    TestConfig(
+                        mapOf(
+                            MaxLineLength.MAX_LINE_LENGTH to "60",
+                            MaxLineLength.EXCLUDE_PACKAGE_STATEMENTS to "true",
+                            MaxLineLength.EXCLUDE_IMPORT_STATEMENTS to "true"
+                        )
+                    )
+                )
 
                 rule.visit(fileContent)
                 assertThat(rule.findings).hasSize(1)

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/NoTabsSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/NoTabsSpec.kt
@@ -1,8 +1,8 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.github.detekt.test.utils.compileForTest
 import io.gitlab.arturbosch.detekt.rules.Case
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.github.detekt.test.utils.compileForTest
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantVisibilityModifierRuleSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantVisibilityModifierRuleSpec.kt
@@ -167,7 +167,8 @@ class RedundantVisibilityModifierRuleSpec : Spek({
         describe("Explicit API mode") {
 
             val code by memoized {
-                compileContentForTest("""
+                compileContentForTest(
+                    """
                     public class A() {
                         fun f()
                     }"""

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCountSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCountSpec.kt
@@ -178,16 +178,20 @@ class ReturnCountSpec : Spek({
             """
 
             it("should not count all four guard clauses") {
-                val findings = ReturnCount(TestConfig(
-                    ReturnCount.EXCLUDE_GUARD_CLAUSES to "true"
-                )).compileAndLint(code)
+                val findings = ReturnCount(
+                    TestConfig(
+                        ReturnCount.EXCLUDE_GUARD_CLAUSES to "true"
+                    )
+                ).compileAndLint(code)
                 assertThat(findings).isEmpty()
             }
 
             it("should count all four guard clauses") {
-                val findings = ReturnCount(TestConfig(
-                    ReturnCount.EXCLUDE_GUARD_CLAUSES to "false"
-                )).compileAndLint(code)
+                val findings = ReturnCount(
+                    TestConfig(
+                        ReturnCount.EXCLUDE_GUARD_CLAUSES to "false"
+                    )
+                ).compileAndLint(code)
                 assertThat(findings).hasSize(1)
             }
         }
@@ -260,10 +264,14 @@ class ReturnCountSpec : Spek({
         """
 
             it("should not get flagged") {
-                val findings = ReturnCount(TestConfig(mapOf(
-                    ReturnCount.MAX to "2",
-                    ReturnCount.EXCLUDED_FUNCTIONS to "test")
-                )).compileAndLint(code)
+                val findings = ReturnCount(
+                    TestConfig(
+                        mapOf(
+                            ReturnCount.MAX to "2",
+                            ReturnCount.EXCLUDED_FUNCTIONS to "test"
+                        )
+                    )
+                ).compileAndLint(code)
                 assertThat(findings).isEmpty()
             }
         }
@@ -299,10 +307,14 @@ class ReturnCountSpec : Spek({
         """
 
             it("should flag none of the ignored functions") {
-                val findings = ReturnCount(TestConfig(mapOf(
-                    ReturnCount.MAX to "2",
-                    ReturnCount.EXCLUDED_FUNCTIONS to "test1,test2")
-                )).compileAndLint(code)
+                val findings = ReturnCount(
+                    TestConfig(
+                        mapOf(
+                            ReturnCount.MAX to "2",
+                            ReturnCount.EXCLUDED_FUNCTIONS to "test1,test2"
+                        )
+                    )
+                ).compileAndLint(code)
                 assertThat(findings).hasSize(1)
             }
         }
@@ -424,16 +436,20 @@ class ReturnCountSpec : Spek({
 
             it("should count labeled returns from lambda when activated") {
                 val findings = ReturnCount(
-                    TestConfig(mapOf(ReturnCount.EXCLUDE_RETURN_FROM_LAMBDA to "false"))).lint(code)
+                    TestConfig(mapOf(ReturnCount.EXCLUDE_RETURN_FROM_LAMBDA to "false"))
+                ).lint(code)
                 assertThat(findings).hasSize(1)
             }
 
             it("should be empty when labeled returns are de-activated") {
                 val findings = ReturnCount(
-                    TestConfig(mapOf(
-                        ReturnCount.EXCLUDE_LABELED to "true",
-                        ReturnCount.EXCLUDE_RETURN_FROM_LAMBDA to "false"
-                    ))).lint(code)
+                    TestConfig(
+                        mapOf(
+                            ReturnCount.EXCLUDE_LABELED to "true",
+                            ReturnCount.EXCLUDE_RETURN_FROM_LAMBDA to "false"
+                        )
+                    )
+                ).lint(code)
                 assertThat(findings).isEmpty()
             }
         }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/TrailingWhitespaceSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/TrailingWhitespaceSpec.kt
@@ -1,7 +1,7 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
-import io.gitlab.arturbosch.detekt.test.assertThat
 import io.github.detekt.test.utils.compileContentForTest
+import io.gitlab.arturbosch.detekt.test.assertThat
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiteralsSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiteralsSpec.kt
@@ -19,7 +19,7 @@ class UnderscoresInNumericLiteralsSpec : Spek({
 
         it("should be reported if acceptableDecimalLength is 4") {
             val findings = UnderscoresInNumericLiterals(
-                    TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "4"))
+                TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "4"))
             ).compileAndLint(code)
             assertThat(findings).isNotEmpty
         }
@@ -44,7 +44,7 @@ class UnderscoresInNumericLiteralsSpec : Spek({
 
         it("should not be reported if acceptableDecimalLength is 8") {
             val findings = UnderscoresInNumericLiterals(
-                    TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "8"))
+                TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "8"))
             ).compileAndLint(code)
             assertThat(findings).isEmpty()
         }
@@ -60,7 +60,7 @@ class UnderscoresInNumericLiteralsSpec : Spek({
 
         it("should be reported if acceptableDecimalLength is 4") {
             val findings = UnderscoresInNumericLiterals(
-                    TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "4"))
+                TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "4"))
             ).compileAndLint(code)
             assertThat(findings).isNotEmpty
         }
@@ -76,7 +76,7 @@ class UnderscoresInNumericLiteralsSpec : Spek({
 
         it("should be reported if acceptableDecimalLength is 4") {
             val findings = UnderscoresInNumericLiterals(
-                    TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "4"))
+                TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "4"))
             ).compileAndLint(code)
             assertThat(findings).isNotEmpty
         }
@@ -101,7 +101,7 @@ class UnderscoresInNumericLiteralsSpec : Spek({
 
         it("should not be reported if ignored acceptableDecimalLength is 8") {
             val findings = UnderscoresInNumericLiterals(
-                    TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "8"))
+                TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "8"))
             ).compileAndLint(code)
             assertThat(findings).isEmpty()
         }
@@ -126,7 +126,7 @@ class UnderscoresInNumericLiteralsSpec : Spek({
 
         it("should be reported if acceptableDecimalLength is 4") {
             val findings = UnderscoresInNumericLiterals(
-                    TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "4"))
+                TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "4"))
             ).compileAndLint(code)
             assertThat(findings).isNotEmpty
         }
@@ -160,7 +160,7 @@ class UnderscoresInNumericLiteralsSpec : Spek({
 
         it("should still be reported even if acceptableDecimalLength is 7") {
             val findings = UnderscoresInNumericLiterals(
-                    TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "7"))
+                TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "7"))
             ).compileAndLint(code)
             assertThat(findings).isNotEmpty
         }
@@ -300,7 +300,7 @@ class UnderscoresInNumericLiteralsSpec : Spek({
 
         it("should not be reported if acceptableDecimalLength is 6") {
             val findings = UnderscoresInNumericLiterals(
-                    TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "6"))
+                TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "6"))
             ).compileAndLint(code)
             assertThat(findings).isEmpty()
         }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAbstractClassSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAbstractClassSpec.kt
@@ -14,9 +14,13 @@ class UnnecessaryAbstractClassSpec : Spek({
 
     val env: KotlinCoreEnvironment by memoized()
     val subject by memoized {
-        UnnecessaryAbstractClass(TestConfig(mapOf(
-            UnnecessaryAbstractClass.EXCLUDE_ANNOTATED_CLASSES to listOf("Deprecated")
-        )))
+        UnnecessaryAbstractClass(
+            TestConfig(
+                mapOf(
+                    UnnecessaryAbstractClass.EXCLUDE_ANNOTATED_CLASSES to listOf("Deprecated")
+                )
+            )
+        )
     }
 
     describe("UnnecessaryAbstractClass rule") {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryApplySpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryApplySpec.kt
@@ -21,20 +21,25 @@ class UnnecessaryApplySpec : Spek({
         context("unnecessary apply expressions that can be changed to ordinary method call") {
 
             it("reports an apply on non-nullable type") {
-                val findings = subject.compileAndLintWithContext(env, """
+                val findings = subject.compileAndLintWithContext(
+                    env,
+                    """
                     fun f() {
                         val a: Int = 0
                         a.apply {
                             plus(1)
                         }
                     }
-                """)
+                """
+                )
                 assertThat(findings).hasSize(1)
                 assertThat(findings.first().message).isEqualTo("apply expression can be omitted")
             }
 
             it("reports an apply on nullable type") {
-                val findings = subject.compileAndLintWithContext(env, """
+                val findings = subject.compileAndLintWithContext(
+                    env,
+                    """
                     fun f() {
                         val a: Int? = null
                         // Resolution: we can't say here if plus is on 'this' or just a side effect when a is not null
@@ -43,13 +48,17 @@ class UnnecessaryApplySpec : Spek({
                             plus(1)
                         }
                     }
-                """)
+                """
+                )
                 assertThat(findings).hasSize(1)
                 assertThat(findings.first().message).isEqualTo("apply can be replaced with let or an if")
             }
 
             it("reports a false negative apply on nullable type - #1485") {
-                assertThat(subject.compileAndLintWithContext(env, """
+                assertThat(
+                    subject.compileAndLintWithContext(
+                        env,
+                        """
                     val a: Any? = Any()
                     fun Any.b() = Unit
                     
@@ -58,22 +67,32 @@ class UnnecessaryApplySpec : Spek({
                             b()
                         }
                     }
-                """)).hasSize(1)
+                """
+                    )
+                ).hasSize(1)
             }
 
             it("does not report an apply with lambda block") {
-                assertThat(subject.compileAndLintWithContext(env, """
+                assertThat(
+                    subject.compileAndLintWithContext(
+                        env,
+                        """
                     fun f() {
                         val a: Int? = null
                         a?.apply({
                             plus(1)
                         })
                     }
-                """)).isEmpty()
+                """
+                    )
+                ).isEmpty()
             }
 
             it("does not report single statement in apply used as function argument") {
-                assertThat(subject.compileAndLintWithContext(env, """
+                assertThat(
+                    subject.compileAndLintWithContext(
+                        env,
+                        """
                     fun b(i: Int?) {}
 
                     fun main() {
@@ -82,11 +101,16 @@ class UnnecessaryApplySpec : Spek({
                             toString()
                         })
                     }
-               """)).isEmpty()
+               """
+                    )
+                ).isEmpty()
             }
 
             it("does not report single assignment statement in apply used as function argument - #1517") {
-                assertThat(subject.compileAndLintWithContext(env, """
+                assertThat(
+                    subject.compileAndLintWithContext(
+                        env,
+                        """
                     class C {
                         var prop = 0
                     }
@@ -104,21 +128,28 @@ class UnnecessaryApplySpec : Spek({
                         )
                     }
                 """
-                )).isEmpty()
+                    )
+                ).isEmpty()
             }
 
             it("does not report if result of apply is used - #2938") {
-                assertThat(subject.compileAndLint("""
+                assertThat(
+                    subject.compileAndLint(
+                        """
                     fun main() {
                         val a = listOf(mutableListOf(""))
                                     .map { it.apply { add("") } }
                     }
                 """
-                )).isEmpty()
+                    )
+                ).isEmpty()
             }
 
             it("does not report applies with lambda body containing more than one statement") {
-                assertThat(subject.compileAndLintWithContext(env, """
+                assertThat(
+                    subject.compileAndLintWithContext(
+                        env,
+                        """
                     fun b(i: Int?) {}
 
                     fun main() {
@@ -136,64 +167,94 @@ class UnnecessaryApplySpec : Spek({
                             plus(2)
                         })
                     }
-                """)).isEmpty()
+                """
+                    )
+                ).isEmpty()
             }
         }
 
         context("reported false positives - #1305") {
 
             it("is used within an assignment expr itself") {
-                assertThat(subject.compileAndLintWithContext(env, """
+                assertThat(
+                    subject.compileAndLintWithContext(
+                        env,
+                        """
                     class C {
                         fun f() = true
                     }
                     
                     val a = C().apply { f() }
-                """)).isEmpty()
+                """
+                    )
+                ).isEmpty()
             }
 
             it("is used as return type of extension function") {
-                assertThat(subject.compileAndLintWithContext(env, """
+                assertThat(
+                    subject.compileAndLintWithContext(
+                        env,
+                        """
                     class C(var prop: Int)
                     
                     fun Int.f() = C(5).apply { prop = 10 }
-                """)).isEmpty()
+                """
+                    )
+                ).isEmpty()
             }
 
             it("should not flag apply when assigning property on this") {
-                assertThat(subject.compileAndLintWithContext(env, """
+                assertThat(
+                    subject.compileAndLintWithContext(
+                        env,
+                        """
                     class C(var prop: Int) {
                         private val c by lazy {
                             C(1).apply { prop = 3 }
                         }
                     }
-                """)).isEmpty()
+                """
+                    )
+                ).isEmpty()
             }
 
             it("should not report apply when using it after returning something") {
-                assertThat(subject.compileAndLintWithContext(env, """
+                assertThat(
+                    subject.compileAndLintWithContext(
+                        env,
+                        """
                     class C(var prop: Int)
                     
                     fun f() = (C(5)).apply { prop = 10 }
-                """)).isEmpty()
+                """
+                    )
+                ).isEmpty()
             }
 
             it("should not report apply usage inside safe chained expressions") {
-                assertThat(subject.compileAndLintWithContext(env, """
+                assertThat(
+                    subject.compileAndLintWithContext(
+                        env,
+                        """
                     fun f() {
                         val arguments = listOf(1,2,3)
                             ?.map { it * 2 }
                             ?.apply { if (true) 4 }
                             ?: listOf(0)
                     }
-                """)).isEmpty()
+                """
+                    )
+                ).isEmpty()
             }
         }
 
         context("false positive in single nesting expressions - #1473") {
 
             it("should not report the if expression") {
-                assertThat(subject.compileAndLintWithContext(env, """
+                assertThat(
+                    subject.compileAndLintWithContext(
+                        env,
+                        """
                     class C {
                         fun has() = true
                     }
@@ -205,11 +266,16 @@ class UnnecessaryApplySpec : Spek({
                             }
                         }
                     }
-                """)).isEmpty()
+                """
+                    )
+                ).isEmpty()
             }
 
             it("should report reference expressions") {
-                assertThat(subject.compileAndLintWithContext(env, """
+                assertThat(
+                    subject.compileAndLintWithContext(
+                        env,
+                        """
                     class C { 
                     	val prop = 5 
                     }
@@ -223,14 +289,19 @@ class UnnecessaryApplySpec : Spek({
                             this.prop
                         }
                     }
-                """)).hasSize(2)
+                """
+                    )
+                ).hasSize(2)
             }
         }
 
         context("false positive when it's used as an expression - #2435") {
 
             it("do not report when it's used as an assignment") {
-                assertThat(subject.compileAndLintWithContext(env, """
+                assertThat(
+                    subject.compileAndLintWithContext(
+                        env,
+                        """
                     class C {
                         fun f() {}
                     }
@@ -243,11 +314,15 @@ class UnnecessaryApplySpec : Spek({
                         }
                     }
                 """
-                )).isEmpty()
+                    )
+                ).isEmpty()
             }
 
             it("do not report when it's used as the last statement of a block inside lambda") {
-                assertThat(subject.compileAndLintWithContext(env, """
+                assertThat(
+                    subject.compileAndLintWithContext(
+                        env,
+                        """
                     class C {
                         fun f() {}
                     }
@@ -263,7 +338,8 @@ class UnnecessaryApplySpec : Spek({
                         }
                     }
                 """
-                )).isEmpty()
+                    )
+                ).isEmpty()
             }
         }
     }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryFilterSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryFilterSpec.kt
@@ -1,8 +1,8 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.rules.setupKotlinEnvironment
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
 import io.gitlab.arturbosch.detekt.test.assertThat
+import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryInheritanceSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryInheritanceSpec.kt
@@ -12,9 +12,11 @@ class UnnecessaryInheritanceSpec : Spek({
     describe("check inherit classes") {
 
         it("has unnecessary super type declarations") {
-            val findings = subject.lint("""
+            val findings = subject.lint(
+                """
                 class A : Any()
-                class B : Object()""")
+                class B : Object()"""
+            )
             assertThat(findings).hasSize(2)
         }
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLetSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLetSpec.kt
@@ -17,154 +17,198 @@ class UnnecessaryLetSpec : Spek({
 
     describe("UnnecessaryLet rule") {
         it("reports unnecessary lets that can be changed to ordinary method call 1") {
-            val findings = subject.compileAndLintWithContext(env, """
+            val findings = subject.compileAndLintWithContext(
+                env,
+                """
                 fun f() {
                     val a: Int = 1
                     a.let { it.plus(1) }
                     a.let { that -> that.plus(1) }
-                }""")
+                }"""
+            )
             assertThat(findings).hasSize(2)
             assertThat(findings).allMatch { it.message == MESSAGE_OMIT_LET }
         }
 
         it("reports unnecessary lets that can be changed to ordinary method call 2") {
-            val findings = subject.compileAndLintWithContext(env, """
+            val findings = subject.compileAndLintWithContext(
+                env,
+                """
                 fun f() {
                     val a: Int? = null
                     a?.let { it.plus(1) }
                     a?.let { that -> that.plus(1) }
-                }""")
+                }"""
+            )
             assertThat(findings).hasSize(2)
             assertThat(findings).allMatch { it.message == MESSAGE_OMIT_LET }
         }
 
         it("reports unnecessary lets that can be changed to ordinary method call 3") {
-            val findings = subject.compileAndLintWithContext(env, """
+            val findings = subject.compileAndLintWithContext(
+                env,
+                """
                 fun f() {
                     val a: Int? = null
                     a?.let { that -> that.plus(1) }?.let { it.plus(1) }
-                }""")
+                }"""
+            )
             assertThat(findings).hasSize(2)
             assertThat(findings).allMatch { it.message == MESSAGE_OMIT_LET }
         }
 
         it("reports unnecessary lets that can be changed to ordinary method call 4") {
-            val findings = subject.compileAndLintWithContext(env, """
+            val findings = subject.compileAndLintWithContext(
+                env,
+                """
                 fun f() {
                     val a: Int = 1
                     a.let { 1.plus(1) }
                     a.let { that -> 1.plus(1) }
-                }""")
+                }"""
+            )
             assertThat(findings).hasSize(2)
             assertThat(findings).allMatch { it.message == MESSAGE_OMIT_LET }
         }
 
         it("reports unnecessary lets that can be changed to ordinary method call 5") {
-            val findings = subject.compileAndLintWithContext(env, """
+            val findings = subject.compileAndLintWithContext(
+                env,
+                """
                 fun f() {
                     val a: Int = 1
                     val x = a.let { 1.plus(1) }
                     val y = a.let { that -> 1.plus(1) }
-                }""")
+                }"""
+            )
             assertThat(findings).hasSize(2)
             assertThat(findings).allMatch { it.message == MESSAGE_OMIT_LET }
         }
 
         it("reports unnecessary lets that can be replaced with an if") {
-            val findings = subject.compileAndLintWithContext(env, """
+            val findings = subject.compileAndLintWithContext(
+                env,
+                """
                 fun f() {
                     val a: Int? = null
                     a?.let { 1.plus(1) }
                     a?.let { that -> 1.plus(1) }
-                }""")
+                }"""
+            )
             assertThat(findings).hasSize(2)
             assertThat(findings).allMatch { it.message == MESSAGE_USE_IF }
         }
 
         it("reports unnecessary lets that can be changed to ordinary method call 7") {
-            val findings = subject.compileAndLintWithContext(env, """
+            val findings = subject.compileAndLintWithContext(
+                env,
+                """
                 fun f() {
                     val a: Int? = null
                     a.let { print(it) }
                     a.let { that -> print(that) }
-                }""")
+                }"""
+            )
             assertThat(findings).hasSize(2)
             assertThat(findings).allMatch { it.message == MESSAGE_OMIT_LET }
         }
 
         it("reports unnecessary lets that can be changed to ordinary method call 8") {
-            val findings = subject.compileAndLintWithContext(env, """
+            val findings = subject.compileAndLintWithContext(
+                env,
+                """
                 fun f() {
                     val a: Int? = null
                     a?.let { it?.plus(1) }
                     a?.let { that -> that?.plus(1) }
-                }""")
+                }"""
+            )
             assertThat(findings).hasSize(2)
             assertThat(findings).allMatch { it.message == MESSAGE_OMIT_LET }
         }
 
         it("reports use of let without the safe call operator when we use an argument") {
-            val findings = subject.compileAndLintWithContext(env, """
+            val findings = subject.compileAndLintWithContext(
+                env,
+                """
                 fun f() {
                     val f: (Int?) -> Boolean = { true }
                     val a: Int? = null
                     a.let(f)
-                }""")
+                }"""
+            )
             assertThat(findings).hasSize(1)
             assertThat(findings).allMatch { it.message == MESSAGE_OMIT_LET }
         }
 
         it("does not report lets used for function calls 1") {
-            val findings = subject.compileAndLintWithContext(env, """
+            val findings = subject.compileAndLintWithContext(
+                env,
+                """
                 fun f() {
                     val a: Int? = null
                     a?.let { print(it) }
                     a?.let { that -> 1.plus(that) }
-                }""")
+                }"""
+            )
             assertThat(findings).isEmpty()
         }
 
         it("does not report lets used for function calls 2") {
-            val findings = subject.compileAndLintWithContext(env, """
+            val findings = subject.compileAndLintWithContext(
+                env,
+                """
                 fun f() {
                     val a: Int? = null
                     a?.let { that -> 1.plus(that) }?.let { print(it) }
-                }""")
+                }"""
+            )
             assertThat(findings).isEmpty()
         }
 
         it("does not report \"can be replaced by if\" because you will need an else too") {
-            val findings = subject.compileAndLintWithContext(env, """
+            val findings = subject.compileAndLintWithContext(
+                env,
+                """
                 fun f() {
                     val a: Int? = null
                     val x = a?.let { 1.plus(1) }
                     val y = a?.let { that -> 1.plus(1) }
-                }""")
+                }"""
+            )
             assertThat(findings).isEmpty()
         }
 
         it("does not report a let where returned value is used - #2987") {
-            val findings = subject.compileAndLintWithContext(env, """
+            val findings = subject.compileAndLintWithContext(
+                env,
+                """
                 fun f() {
                     val a = listOf<List<String>?>(listOf(""))
                         .map { list -> list?.let { it + it } }
                 }
-                """)
+                """
+            )
             assertThat(findings).isEmpty()
         }
 
         it("does not report use of let with the safe call operator when we use an argument") {
-            val findings = subject.compileAndLintWithContext(env, """
+            val findings = subject.compileAndLintWithContext(
+                env,
+                """
                 fun f() {
                     val f: (Int?) -> Boolean = { true }
                     val a: Int? = null
                     a?.let(f)
-                }""")
+                }"""
+            )
             assertThat(findings).hasSize(0)
         }
 
         it("does not report lets with lambda body containing more than one statement") {
-            val findings = subject.compileAndLintWithContext(env, """
+            val findings = subject.compileAndLintWithContext(
+                env,
+                """
                 fun f() {
                     val a: Int? = null
                     val b: Int = 1
@@ -191,12 +235,15 @@ class UnnecessaryLetSpec : Spek({
                         it.plus(1)
                         it.plus(2)
                     }
-                }""")
+                }"""
+            )
             assertThat(findings).isEmpty()
         }
 
         it("does not report lets where it is used multiple times") {
-            val findings = subject.compileAndLintWithContext(env, """
+            val findings = subject.compileAndLintWithContext(
+                env,
+                """
                 fun f() {
                     val a: Int? = null
                     val b: Int = 1
@@ -204,7 +251,8 @@ class UnnecessaryLetSpec : Spek({
                     b.let { it.plus(it) }
                     a?.let { foo -> foo.plus(foo) }
                     b.let { foo -> foo.plus(foo) }
-                }""")
+                }"""
+            )
             assertThat(findings).isEmpty()
         }
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseArrayLiteralsInAnnotationsSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseArrayLiteralsInAnnotationsSpec.kt
@@ -12,21 +12,25 @@ class UseArrayLiteralsInAnnotationsSpec : Spek({
     describe("suggests replacing arrayOf with [] syntax") {
 
         it("finds an arrayOf usage") {
-            val findings = subject.compileAndLint("""
+            val findings = subject.compileAndLint(
+                """
             annotation class Test(val values: Array<String>)
             @Test(arrayOf("value"))
             fun test() = Unit
-        """)
+        """
+            )
 
             assertThat(findings).hasSize(1)
         }
 
         it("expects [] syntax") {
-            val findings = subject.compileAndLint("""
+            val findings = subject.compileAndLint(
+                """
             annotation class Test(val values: Array<String>)
             @Test(["value"])
             fun test() = Unit
-        """)
+        """
+            )
 
             assertThat(findings).isEmpty()
         }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/MandatoryBracesIfStatementsSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/MandatoryBracesIfStatementsSpec.kt
@@ -12,56 +12,65 @@ class MandatoryBracesIfStatementsSpec : Spek({
     describe("if statements which should have braces") {
 
         it("reports a simple if") {
-            val findings = subject.compileAndLint("""
+            val findings = subject.compileAndLint(
+                """
             fun f() {
                 if (true)
                     println()
             }
-            """)
+            """
+            )
 
             assertThat(findings).hasSize(1)
             assertThat(findings).hasTextLocations(32 to 41)
         }
 
         it("reports a simple if with a single statement in multiple lines") {
-            val findings = subject.compileAndLint("""
+            val findings = subject.compileAndLint(
+                """
                 fun f() {
                 	if (true) 50
                         .toString()
                 }
-            """)
+            """
+            )
 
             assertThat(findings).hasSize(1)
         }
 
         it("reports if-else with a single statement in multiple lines") {
-            val findings = subject.compileAndLint("""
+            val findings = subject.compileAndLint(
+                """
                 fun f() {
                 	if (true) 50
                         .toString() else 50
                         .toString()
                 }
-            """)
+            """
+            )
 
             assertThat(findings).hasSize(2)
         }
 
         it("reports if-else") {
-            val findings = subject.compileAndLint("""
+            val findings = subject.compileAndLint(
+                """
             fun f() {
                 if (true)
                     println()
                 else
                     println()
             }
-            """)
+            """
+            )
 
             assertThat(findings).hasSize(2)
             assertThat(findings).hasTextLocations(32 to 41, 59 to 68)
         }
 
         it("reports if-else with else-if") {
-            val findings = subject.compileAndLint("""
+            val findings = subject.compileAndLint(
+                """
             fun f() {
                 if (true)
                     println()
@@ -70,28 +79,32 @@ class MandatoryBracesIfStatementsSpec : Spek({
                 else
                     println()
             }
-            """)
+            """
+            )
 
             assertThat(findings).hasSize(3)
             assertThat(findings).hasTextLocations(32 to 41, 70 to 79, 97 to 106)
         }
 
         it("reports if with braces but else without") {
-            val findings = subject.compileAndLint("""
+            val findings = subject.compileAndLint(
+                """
             fun f() {
                 if (true) {
                     println()
                 } else
                     println()
             }
-            """)
+            """
+            )
 
             assertThat(findings).hasSize(1)
             assertThat(findings).hasTextLocations(63 to 72)
         }
 
         it("reports else with braces but if without") {
-            val findings = subject.compileAndLint("""
+            val findings = subject.compileAndLint(
+                """
             fun f() {
                 if (true)
                     println()
@@ -99,31 +112,36 @@ class MandatoryBracesIfStatementsSpec : Spek({
                     println()
                 }
             }
-            """)
+            """
+            )
 
             assertThat(findings).hasSize(1)
             assertThat(findings).hasTextLocations(32 to 41)
         }
 
         it("reports else in new line") {
-            val findings = subject.compileAndLint("""
+            val findings = subject.compileAndLint(
+                """
             fun f() {
                 if (true) println()
                 else println()
             }
-            """)
+            """
+            )
 
             assertThat(findings).hasSize(1)
             assertThat(findings).hasTextLocations(24 to 33)
         }
 
         it("reports only else body on new line") {
-            val findings = subject.compileAndLint("""
+            val findings = subject.compileAndLint(
+                """
             fun f() {
                 if (true) println() else
                     println()
             }
-            """)
+            """
+            )
 
             assertThat(findings).hasSize(1)
             assertThat(findings).hasTextLocations(47 to 56)

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/OptionalUnitSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/OptionalUnitSpec.kt
@@ -44,7 +44,8 @@ class OptionalUnitSpec : Spek({
             it("should report the correct violation message") {
                 findings.forEach {
                     assertThat(it.message).endsWith(
-                        " defines a return type of Unit. This is unnecessary and can safely be removed.")
+                        " defines a return type of Unit. This is unnecessary and can safely be removed."
+                    )
                 }
             }
         }
@@ -102,7 +103,8 @@ class OptionalUnitSpec : Spek({
         context("several Unit references") {
 
             it("should not report Unit reference") {
-                val findings = subject.compileAndLint("""
+                val findings = subject.compileAndLint(
+                    """
                     fun returnsNothing(u: Unit, us: () -> String) {
                         val u1 = u is Unit
                         val u2: Unit = Unit
@@ -110,7 +112,8 @@ class OptionalUnitSpec : Spek({
                         Unit.equals(null)
                         val i: (Int) -> Unit = { _ -> }
                     }
-                """)
+                """
+                )
                 assertThat(findings).isEmpty()
             }
         }

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/SuppressingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/SuppressingSpec.kt
@@ -1,5 +1,7 @@
 package io.gitlab.arturbosch.detekt.rules
 
+import io.github.detekt.test.utils.compileForTest
+import io.github.detekt.test.utils.resourceAsPath
 import io.gitlab.arturbosch.detekt.api.RuleSet
 import io.gitlab.arturbosch.detekt.core.rules.visitFile
 import io.gitlab.arturbosch.detekt.rules.complexity.ComplexCondition
@@ -8,8 +10,6 @@ import io.gitlab.arturbosch.detekt.rules.complexity.LongParameterList
 import io.gitlab.arturbosch.detekt.rules.complexity.StringLiteralDuplication
 import io.gitlab.arturbosch.detekt.rules.complexity.TooManyFunctions
 import io.gitlab.arturbosch.detekt.test.TestConfig
-import io.github.detekt.test.utils.compileForTest
-import io.github.detekt.test.utils.resourceAsPath
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek

--- a/detekt-sample-extensions/src/main/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/rules/TooManyFunctions.kt
+++ b/detekt-sample-extensions/src/main/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/rules/TooManyFunctions.kt
@@ -28,7 +28,8 @@ class TooManyFunctions : Rule() {
         if (amount > THRESHOLD) {
             report(
                 CodeSmell(
-                    issue, Entity.atPackageOrFirstDecl(file),
+                    issue,
+                    Entity.atPackageOrFirstDecl(file),
                     message = "The file ${file.name} has $amount function declarations. " +
                         "Threshold is specified with $THRESHOLD."
                 )

--- a/detekt-sample-extensions/src/main/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/rules/TooManyFunctions.kt
+++ b/detekt-sample-extensions/src/main/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/rules/TooManyFunctions.kt
@@ -26,9 +26,13 @@ class TooManyFunctions : Rule() {
     override fun visitKtFile(file: KtFile) {
         super.visitKtFile(file)
         if (amount > THRESHOLD) {
-            report(CodeSmell(issue, Entity.atPackageOrFirstDecl(file),
-                message = "The file ${file.name} has $amount function declarations. " +
-                    "Threshold is specified with $THRESHOLD."))
+            report(
+                CodeSmell(
+                    issue, Entity.atPackageOrFirstDecl(file),
+                    message = "The file ${file.name} has $amount function declarations. " +
+                        "Threshold is specified with $THRESHOLD."
+                )
+            )
         }
         amount = 0
     }

--- a/detekt-sample-extensions/src/main/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/rules/TooManyFunctionsTwo.kt
+++ b/detekt-sample-extensions/src/main/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/rules/TooManyFunctionsTwo.kt
@@ -32,12 +32,15 @@ class TooManyFunctionsTwo(config: Config) : ThresholdRule(config, THRESHOLD) {
     override fun visitKtFile(file: KtFile) {
         super.visitKtFile(file)
         if (amount > threshold) {
-            report(ThresholdedCodeSmell(issue,
-                entity = Entity.from(file),
-                metric = Metric(type = "SIZE", value = amount, threshold = THRESHOLD),
-                message = "The file ${file.name} has $amount function declarations. " +
-                    "Threshold is specified with $THRESHOLD.",
-                references = emptyList())
+            report(
+                ThresholdedCodeSmell(
+                    issue,
+                    entity = Entity.from(file),
+                    metric = Metric(type = "SIZE", value = amount, threshold = THRESHOLD),
+                    message = "The file ${file.name} has $amount function declarations. " +
+                        "Threshold is specified with $THRESHOLD.",
+                    references = emptyList()
+                )
             )
         }
         amount = 0

--- a/detekt-sample-extensions/src/test/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/SampleConfigValidatorSpec.kt
+++ b/detekt-sample-extensions/src/test/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/SampleConfigValidatorSpec.kt
@@ -7,11 +7,13 @@ import org.spekframework.spek2.Spek
 internal class SampleConfigValidatorSpec : Spek({
 
     test("warns if active property is not a boolean") {
-        val config = yamlConfigFromContent("""
+        val config = yamlConfigFromContent(
+            """
             sample:
               TooManyFunctions:
                 active: 1
-        """.trimIndent())
+            """.trimIndent()
+        )
 
         val warnings = SampleConfigValidator().validate(config)
 

--- a/detekt-sample-extensions/src/test/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/processors/NumberOfLoopsProcessorSpec.kt
+++ b/detekt-sample-extensions/src/test/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/processors/NumberOfLoopsProcessorSpec.kt
@@ -1,7 +1,7 @@
 package io.gitlab.arturbosch.detekt.sample.extensions.processors
 
-import io.gitlab.arturbosch.detekt.api.DetektVisitor
 import io.github.detekt.test.utils.compileContentForTest
+import io.gitlab.arturbosch.detekt.api.DetektVisitor
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.resolve.BindingContext
 import org.spekframework.spek2.Spek

--- a/detekt-sample-extensions/src/test/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/processors/QualifiedNameProcessorTest.kt
+++ b/detekt-sample-extensions/src/test/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/processors/QualifiedNameProcessorTest.kt
@@ -1,10 +1,10 @@
 package io.gitlab.arturbosch.detekt.sample.extensions.processors
 
+import io.github.detekt.test.utils.compileContentForTest
 import io.gitlab.arturbosch.detekt.api.Detektion
 import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.api.Notification
 import io.gitlab.arturbosch.detekt.api.ProjectMetric
-import io.github.detekt.test.utils.compileContentForTest
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.com.intellij.openapi.util.Key
 import org.jetbrains.kotlin.com.intellij.util.keyFMap.KeyFMap

--- a/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/KotlinCoreEnvironmentWrapper.kt
+++ b/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/KotlinCoreEnvironmentWrapper.kt
@@ -1,10 +1,10 @@
 package io.github.detekt.test.utils
 
-import java.io.File
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.jetbrains.kotlin.com.intellij.openapi.Disposable
 import org.jetbrains.kotlin.com.intellij.openapi.util.Disposer
 import org.jetbrains.kotlin.psi.KtPsiFactory
+import java.io.File
 
 /**
  * Make sure to always call [dispose] or use a [use] block when working with [KotlinCoreEnvironment]s.

--- a/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/KtTestCompiler.kt
+++ b/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/KtTestCompiler.kt
@@ -30,7 +30,8 @@ internal object KtTestCompiler : KtCompiler() {
     fun compileFromContent(@Language("kotlin") content: String, filename: String = TEST_FILENAME): KtFile =
         psiFileFactory.createPhysicalFile(
             filename,
-            StringUtilRt.convertLineSeparators(content))
+            StringUtilRt.convertLineSeparators(content)
+        )
 
     /**
      * Not sure why but this function only works from this context.

--- a/detekt-test-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/KotlinEnvironmentTestSetup.kt
+++ b/detekt-test-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/KotlinEnvironmentTestSetup.kt
@@ -8,6 +8,7 @@ import org.spekframework.spek2.lifecycle.CachingMode
 fun Root.setupKotlinEnvironment() {
     val wrapper by memoized(CachingMode.SCOPE, { createEnvironment() }, { it.dispose() })
 
-    @Suppress("UNUSED_VARIABLE") // name is used for delegation
+    @Suppress("UNUSED_VARIABLE")
+    // name is used for delegation
     val env: KotlinCoreEnvironment by memoized(CachingMode.EACH_GROUP) { wrapper.env }
 }

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/FindingsAssertions.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/FindingsAssertions.kt
@@ -14,23 +14,23 @@ fun assertThat(finding: Finding) = FindingAssert(finding)
 fun List<Finding>.assert() = FindingsAssert(this)
 
 class FindingsAssert(actual: List<Finding>) :
-        AbstractListAssert<FindingsAssert, List<Finding>,
-                Finding, FindingAssert>(actual, FindingsAssert::class.java) {
+    AbstractListAssert<FindingsAssert, List<Finding>,
+        Finding, FindingAssert>(actual, FindingsAssert::class.java) {
 
     override fun newAbstractIterableAssert(iterable: MutableIterable<Finding>): FindingsAssert {
         throw UnsupportedOperationException("not implemented")
     }
 
     override fun toAssert(value: Finding?, description: String?): FindingAssert =
-            FindingAssert(value).`as`(description)
+        FindingAssert(value).`as`(description)
 
     fun hasSourceLocations(vararg expected: SourceLocation) = apply {
         val actualSources = actual.asSequence()
-                .map { it.location.source }
-                .sortedWith(compareBy({ it.line }, { it.column }))
+            .map { it.location.source }
+            .sortedWith(compareBy({ it.line }, { it.column }))
 
         val expectedSources = expected.asSequence()
-                .sortedWith(compareBy({ it.line }, { it.column }))
+            .sortedWith(compareBy({ it.line }, { it.column }))
 
         if (!Objects.deepEquals(actualSources.toList(), expectedSources.toList())) {
             failWithMessage(
@@ -45,12 +45,12 @@ class FindingsAssert(actual: List<Finding>) :
 
     fun hasTextLocations(vararg expected: Pair<Int, Int>) = apply {
         val actualSources = actual.asSequence()
-                .map { it.location.text }
-                .sortedWith(compareBy({ it.start }, { it.end }))
+            .map { it.location.text }
+            .sortedWith(compareBy({ it.start }, { it.end }))
 
         val expectedSources = expected.asSequence()
-                .map { (start, end) -> TextLocation(start, end) }
-                .sortedWith(compareBy({ it.start }, { it.end }))
+            .map { (start, end) -> TextLocation(start, end) }
+            .sortedWith(compareBy({ it.start }, { it.end }))
 
         if (!Objects.deepEquals(actualSources.toList(), expectedSources.toList())) {
             failWithMessage(

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/RuleExtensions.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/RuleExtensions.kt
@@ -67,8 +67,12 @@ fun BaseRule.compileAndLintWithContext(
 
 private fun getContextForPaths(environment: KotlinCoreEnvironment, paths: List<KtFile>) =
     TopDownAnalyzerFacadeForJVM.analyzeFilesWithJavaIntegration(
-        environment.project, paths, NoScopeRecordCliBindingTrace(),
-        environment.configuration, environment::createPackagePartProvider, ::FileBasedDeclarationProviderFactory
+        environment.project,
+        paths,
+        NoScopeRecordCliBindingTrace(),
+        environment.configuration,
+        environment::createPackagePartProvider,
+        ::FileBasedDeclarationProviderFactory
     ).bindingContext
 
 fun BaseRule.lint(ktFile: KtFile): List<Finding> = findingsAfterVisit(ktFile)

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/RuleExtensions.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/RuleExtensions.kt
@@ -48,6 +48,7 @@ fun BaseRule.lintWithContext(
     }
     val bindingContext = getContextForPaths(environment, listOf(ktFile) + additionalKtFiles)
     val languageVersionSettings = environment.configuration.languageVersionSettings
+
     @Suppress("DEPRECATION")
     val dataFlowValueFactory = DataFlowValueFactoryImpl(languageVersionSettings)
     val compilerResources = CompilerResources(languageVersionSettings, dataFlowValueFactory)
@@ -55,8 +56,8 @@ fun BaseRule.lintWithContext(
 }
 
 fun BaseRule.compileAndLintWithContext(
-        environment: KotlinCoreEnvironment,
-        @Language("kotlin") content: String
+    environment: KotlinCoreEnvironment,
+    @Language("kotlin") content: String
 ): List<Finding> {
     if (shouldCompileTestSnippets) {
         KotlinScriptEngine.compile(content)

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/ThresholdedCodeSmellAssert.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/ThresholdedCodeSmellAssert.kt
@@ -13,7 +13,8 @@ fun FindingAssert.isThresholded(): ThresholdedCodeSmellAssert {
 
 class ThresholdedCodeSmellAssert(actual: ThresholdedCodeSmell?) :
     AbstractAssert<ThresholdedCodeSmellAssert, ThresholdedCodeSmell>(
-        actual, ThresholdedCodeSmellAssert::class.java) {
+        actual, ThresholdedCodeSmellAssert::class.java
+    ) {
 
     fun withValue(expected: Int) = hasValue(expected).let { this }
 

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/ThresholdedCodeSmellAssert.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/ThresholdedCodeSmellAssert.kt
@@ -13,7 +13,8 @@ fun FindingAssert.isThresholded(): ThresholdedCodeSmellAssert {
 
 class ThresholdedCodeSmellAssert(actual: ThresholdedCodeSmell?) :
     AbstractAssert<ThresholdedCodeSmellAssert, ThresholdedCodeSmell>(
-        actual, ThresholdedCodeSmellAssert::class.java
+        actual,
+        ThresholdedCodeSmellAssert::class.java
     ) {
 
     fun withValue(expected: Int) = hasValue(expected).let { this }

--- a/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/dsl/ConfigSpecBuilder.kt
+++ b/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/dsl/ConfigSpecBuilder.kt
@@ -9,6 +9,7 @@ class ConfigSpecBuilder : Builder<ConfigSpec> {
 
     var shouldValidateBeforeAnalysis: Boolean = true
     var knownPatterns: Collection<String> = emptyList()
+
     var useDefaultConfig: Boolean = false // false to be backwards compatible in 1.X
     var resources: Collection<URL> = emptyList()
     var configPaths: Collection<Path> = emptyList()

--- a/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/dsl/ProcessingSpecBuilder.kt
+++ b/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/dsl/ProcessingSpecBuilder.kt
@@ -5,11 +5,11 @@ import io.github.detekt.tooling.api.spec.CompilerSpec
 import io.github.detekt.tooling.api.spec.ConfigSpec
 import io.github.detekt.tooling.api.spec.ExecutionSpec
 import io.github.detekt.tooling.api.spec.ExtensionsSpec
-import io.github.detekt.tooling.api.spec.RulesSpec
 import io.github.detekt.tooling.api.spec.LoggingSpec
 import io.github.detekt.tooling.api.spec.ProcessingSpec
 import io.github.detekt.tooling.api.spec.ProjectSpec
 import io.github.detekt.tooling.api.spec.ReportsSpec
+import io.github.detekt.tooling.api.spec.RulesSpec
 
 internal fun processingSpec(init: ProcessingSpecBuilder.() -> Unit): ProcessingSpec =
     ProcessingSpecBuilder().apply(init).build()

--- a/detekt-tooling/src/test/kotlin/io/github/detekt/tooling/api/PluginsSpec.kt
+++ b/detekt-tooling/src/test/kotlin/io/github/detekt/tooling/api/PluginsSpec.kt
@@ -3,7 +3,6 @@ package io.github.detekt.tooling.api
 import io.github.detekt.tooling.dsl.ExtensionsSpecBuilder
 import io.github.detekt.tooling.internal.PluginsHolder
 import org.assertj.core.api.Assertions.assertThatCode
-
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 import java.nio.file.Paths

--- a/scripts/compare_releases.main.kts
+++ b/scripts/compare_releases.main.kts
@@ -22,7 +22,6 @@ import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
-
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths

--- a/scripts/github-milestone-report.main.kts
+++ b/scripts/github-milestone-report.main.kts
@@ -32,7 +32,6 @@ class GithubMilestoneReport : CliktCommand() {
     private val milestone: Int? by option("-m", help = "Milestone number. Default: latest milestone.").int()
 
     override fun run() {
-
         // connect to GitHub
         val github: GitHub = GitHub.connectAnonymously()
         val ghRepository: GHRepository = github.getUser(user).getRepository(project)


### PR DESCRIPTION
Fixes #3593

I enabled more formatting rules for this project and run detekt with autocorrect. Then I run ktlint 0.41.0 with the `--experimental` argument and push the changes that doesn't conflict with the current rules. And finally I fixed some minor style things manually.

I can't enable the rules:
- `ArgumentListWrapping` because it have conflicts with `Indentation`
- `AnnotationOnSeparateLine` because it have false positives.