### PR TITLE
Gradle - set a default value for baseline

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
@@ -4,6 +4,7 @@ import org.gradle.api.Action
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.plugins.quality.CodeQualityExtension
+import org.gradle.util.GradleVersion
 import java.io.File
 import javax.inject.Inject
 
@@ -26,7 +27,16 @@ open class DetektExtension @Inject constructor(objects: ObjectFactory) : CodeQua
     var input: ConfigurableFileCollection =
         objects.fileCollection().from(DEFAULT_SRC_DIR_JAVA, DEFAULT_SRC_DIR_KOTLIN)
 
-    var baseline: File? = null
+    var baseline: File? = objects.fileProperty()
+        .run {
+            if (GradleVersion.current() < GradleVersion.version("6.0")) {
+                set(File("baseline.xml"))
+                this
+            } else {
+                fileValue(File("baseline.xml"))
+            }
+        }
+        .get().asFile
 
     var basePath: String? = null
 

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/CreateBaselineTaskDslTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/CreateBaselineTaskDslTest.kt
@@ -35,7 +35,7 @@ internal class CreateBaselineTaskDslTest : Spek({
                     }
                 }
 
-                it("can not be executed when baseline file is not specified") {
+                it("can be executed when baseline file is not specified") {
                     val baselineFilename = "baseline.xml"
 
                     val detektConfig = """
@@ -52,9 +52,9 @@ internal class CreateBaselineTaskDslTest : Spek({
                         .withDetektConfig(detektConfig)
                         .build()
 
-                    gradleRunner.runTasksAndExpectFailure("detektBaseline") { result ->
-                        assertThat(result.output).contains("No value has been specified for property 'baseline'")
-                        assertThat(projectFile(baselineFilename)).doesNotExist()
+                    gradleRunner.runTasksAndCheckResult("detektBaseline") { result ->
+                        assertThat(result.task(":detektBaseline")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+                        assertThat(projectFile(baselineFilename)).exists()
                     }
                 }
 

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/CreateBaselineTaskDslTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/CreateBaselineTaskDslTest.kt
@@ -34,6 +34,53 @@ internal class CreateBaselineTaskDslTest : Spek({
                         assertThat(projectFile(baselineFilename)).exists()
                     }
                 }
+
+                it("can not be executed when baseline file is not specified") {
+                    val baselineFilename = "baseline.xml"
+
+                    val detektConfig = """
+                        |detekt {
+                        |}
+                        """
+                    val gradleRunner = builder
+                        .withProjectLayout(
+                            ProjectLayout(
+                                numberOfSourceFilesInRootPerSourceDir = 1,
+                                numberOfCodeSmellsInRootPerSourceDir = 1,
+                            )
+                        )
+                        .withDetektConfig(detektConfig)
+                        .build()
+
+                    gradleRunner.runTasksAndExpectFailure("detektBaseline") { result ->
+                        assertThat(result.output).contains("No value has been specified for property 'baseline'")
+                        assertThat(projectFile(baselineFilename)).doesNotExist()
+                    }
+                }
+
+                it("can not be executed when baseline file is specified null") {
+                    val baselineFilename = "baseline.xml"
+
+                    val detektConfig = """
+                        |detekt {
+                        |   baseline = null
+                        |}
+                        """
+                    val gradleRunner = builder
+                        .withProjectLayout(
+                            ProjectLayout(
+                                numberOfSourceFilesInRootPerSourceDir = 1,
+                                numberOfCodeSmellsInRootPerSourceDir = 1,
+                            )
+                        )
+                        .withDetektConfig(detektConfig)
+                        .build()
+
+                    gradleRunner.runTasksAndExpectFailure("detektBaseline") { result ->
+                        assertThat(result.output).contains("No value has been specified for property 'baseline'")
+                        assertThat(projectFile(baselineFilename)).doesNotExist()
+                    }
+                }
             }
         }
     }

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/CreateBaselineTaskDslTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/CreateBaselineTaskDslTest.kt
@@ -1,6 +1,7 @@
 package io.gitlab.arturbosch.detekt
 
 import io.gitlab.arturbosch.detekt.testkit.DslTestBuilder
+import io.gitlab.arturbosch.detekt.testkit.ProjectLayout
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.TaskOutcome
 import org.spekframework.spek2.Spek
@@ -19,8 +20,13 @@ internal class CreateBaselineTaskDslTest : Spek({
                         |}
                         """
                     val gradleRunner = builder
+                        .withProjectLayout(
+                            ProjectLayout(
+                                numberOfSourceFilesInRootPerSourceDir = 1,
+                                numberOfCodeSmellsInRootPerSourceDir = 1,
+                            )
+                        )
                         .withDetektConfig(detektConfig)
-                        .withBaseline(baselineFilename)
                         .build()
 
                     gradleRunner.runTasksAndCheckResult("detektBaseline") { result ->

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektAndroidTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektAndroidTest.kt
@@ -13,7 +13,9 @@ object DetektAndroidTest : Spek({
         skip = if (isAndroidSdkInstalled()) Skip.No else Skip.Yes("No android sdk.")
     ) {
         describe("configures android tasks for android application") {
-            val projectLayout = ProjectLayout(numberOfSourceFilesInRootPerSourceDir = 0).apply {
+            val projectLayout = ProjectLayout(
+                numberOfSourceFilesInRootPerSourceDir = 0,
+            ).apply {
                 addSubmodule(
                     name = "app",
                     numberOfSourceFilesPerSourceDir = 1,
@@ -23,7 +25,15 @@ object DetektAndroidTest : Spek({
                         $ANDROID_BLOCK
                         $DETEKT_BLOCK
                     """.trimIndent(),
-                    srcDirs = listOf("src/main/java", "src/debug/java", "src/test/java", "src/androidTest/java")
+                    srcDirs = listOf("src/main/java", "src/debug/java", "src/test/java", "src/androidTest/java"),
+                    baselineFiles = listOf(
+                        "baseline.xml",
+                        "baseline-release.xml",
+                        "baseline-debug.xml",
+                        "baseline-releaseUnitTest.xml",
+                        "baseline-debugUnitTest.xml",
+                        "baseline-debugAndroidTest.xml"
+                    )
                 )
             }
             val gradleRunner = createGradleRunnerAndSetupProject(projectLayout)
@@ -31,6 +41,8 @@ object DetektAndroidTest : Spek({
 
             it("task :app:detektMain") {
                 gradleRunner.runTasksAndCheckResult(":app:detektMain") { buildResult ->
+                    assertThat(buildResult.output).containsPattern("""--baseline \S*[/\\]baseline-release.xml """)
+                    assertThat(buildResult.output).containsPattern("""--baseline \S*[/\\]baseline-debug.xml """)
                     assertThat(buildResult.output).contains("--report xml:")
                     assertThat(buildResult.output).contains("--report sarif:")
                     assertThat(buildResult.output).doesNotContain("--report txt:")
@@ -45,6 +57,9 @@ object DetektAndroidTest : Spek({
 
             it("task :app:detektTest") {
                 gradleRunner.runTasksAndCheckResult(":app:detektTest") { buildResult ->
+                    assertThat(buildResult.output).containsPattern("""--baseline \S*[/\\]baseline-releaseUnitTest.xml """)
+                    assertThat(buildResult.output).containsPattern("""--baseline \S*[/\\]baseline-debugUnitTest.xml """)
+                    assertThat(buildResult.output).containsPattern("""--baseline \S*[/\\]baseline-debugAndroidTest.xml """)
                     assertThat(buildResult.output).contains("--report xml:")
                     assertThat(buildResult.output).contains("--report sarif:")
                     assertThat(buildResult.output).doesNotContain("--report txt:")
@@ -59,6 +74,7 @@ object DetektAndroidTest : Spek({
 
             it("task :app:check") {
                 gradleRunner.runTasksAndCheckResult(":app:check") { buildResult ->
+                    assertThat(buildResult.output).containsPattern("""--baseline \S*[/\\]baseline.xml """)
                     assertThat(buildResult.task(":app:detekt")).isNotNull
                     assertThat(buildResult.output).contains("--report xml:")
                     assertThat(buildResult.output).contains("--report sarif:")
@@ -113,7 +129,15 @@ object DetektAndroidTest : Spek({
                         $ANDROID_BLOCK
                         $DETEKT_BLOCK
                     """.trimIndent(),
-                    srcDirs = listOf("src/main/java", "src/debug/java", "src/test/java", "src/androidTest/java")
+                    srcDirs = listOf("src/main/java", "src/debug/java", "src/test/java", "src/androidTest/java"),
+                    baselineFiles = listOf(
+                        "baseline.xml",
+                        "baseline-release.xml",
+                        "baseline-debug.xml",
+                        "baseline-releaseUnitTest.xml",
+                        "baseline-debugUnitTest.xml",
+                        "baseline-debugAndroidTest.xml"
+                    )
                 )
             }
             val gradleRunner = createGradleRunnerAndSetupProject(projectLayout)
@@ -121,6 +145,8 @@ object DetektAndroidTest : Spek({
 
             it("task :lib:detektMain") {
                 gradleRunner.runTasksAndCheckResult(":lib:detektMain") { buildResult ->
+                    assertThat(buildResult.output).containsPattern("""--baseline \S*[/\\]baseline-release.xml """)
+                    assertThat(buildResult.output).containsPattern("""--baseline \S*[/\\]baseline-debug.xml """)
                     assertThat(buildResult.output).contains("--report xml:")
                     assertThat(buildResult.output).contains("--report sarif:")
                     assertThat(buildResult.output).doesNotContain("--report txt:")
@@ -135,6 +161,9 @@ object DetektAndroidTest : Spek({
 
             it("task :lib:detektTest") {
                 gradleRunner.runTasksAndCheckResult(":lib:detektTest") { buildResult ->
+                    assertThat(buildResult.output).containsPattern("""--baseline \S*[/\\]baseline-releaseUnitTest.xml """)
+                    assertThat(buildResult.output).containsPattern("""--baseline \S*[/\\]baseline-debugUnitTest.xml """)
+                    assertThat(buildResult.output).containsPattern("""--baseline \S*[/\\]baseline-debugAndroidTest.xml """)
                     assertThat(buildResult.output).contains("--report xml:")
                     assertThat(buildResult.output).contains("--report sarif:")
                     assertThat(buildResult.output).doesNotContain("--report txt:")
@@ -149,6 +178,7 @@ object DetektAndroidTest : Spek({
 
             it(":lib:check") {
                 gradleRunner.runTasksAndCheckResult(":lib:check") { buildResult ->
+                    assertThat(buildResult.output).containsPattern("""--baseline \S*[/\\]baseline.xml """)
                     assertThat(buildResult.task(":lib:detekt")).isNotNull
                     assertThat(buildResult.output).contains("--report xml:")
                     assertThat(buildResult.output).contains("--report sarif:")

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektJvmTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektJvmTest.kt
@@ -12,6 +12,7 @@ object DetektJvmTest : Spek({
         val gradleRunner = DslGradleRunner(
             projectLayout = ProjectLayout(numberOfSourceFilesInRootPerSourceDir = 1),
             buildFileName = "build.gradle",
+            baselineFiles = listOf("baseline.xml", "baseline-main.xml", "baseline-test.xml"),
             mainBuildFileContent = """
                 plugins {
                     id "org.jetbrains.kotlin.jvm"
@@ -37,6 +38,7 @@ object DetektJvmTest : Spek({
 
         it("configures detekt type resolution task main") {
             gradleRunner.runTasksAndCheckResult(":detektMain") { buildResult ->
+                assertThat(buildResult.output).containsPattern("""--baseline \S*[/\\]baseline-main.xml """)
                 assertThat(buildResult.output).contains("--report xml:")
                 assertThat(buildResult.output).contains("--report sarif:")
                 assertThat(buildResult.output).doesNotContain("--report txt:")
@@ -46,6 +48,7 @@ object DetektJvmTest : Spek({
 
         it("configures detekt type resolution task test") {
             gradleRunner.runTasksAndCheckResult(":detektTest") { buildResult ->
+                assertThat(buildResult.output).containsPattern("""--baseline \S*[/\\]baseline-test.xml """)
                 assertThat(buildResult.output).contains("--report xml:")
                 assertThat(buildResult.output).contains("--report sarif:")
                 assertThat(buildResult.output).doesNotContain("--report txt:")

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektMultiplatformTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektMultiplatformTest.kt
@@ -24,7 +24,8 @@ class DetektMultiplatformTest : Spek({
                     }
                     $DETEKT_BLOCK
                 """.trimIndent(),
-                srcDirs = listOf("src/commonMain/kotlin", "src/commonTest/kotlin")
+                srcDirs = listOf("src/commonMain/kotlin", "src/commonTest/kotlin"),
+                baselineFiles = listOf("baseline.xml", "baseline-metadataMain.xml")
             )
         }
 
@@ -34,6 +35,7 @@ class DetektMultiplatformTest : Spek({
 
         it("configures detekt task without type resolution") {
             gradleRunner.runTasksAndCheckResult(":shared:detektMetadataMain") {
+                assertThat(it.output).containsPattern("""--baseline \S*[/\\]baseline.xml """)
                 assertDetektWithoutClasspath(it)
             }
         }
@@ -96,7 +98,8 @@ class DetektMultiplatformTest : Spek({
                     "src/commonTest/kotlin",
                     "src/jvmBackendMain/kotlin",
                     "src/jvmEmbeddedMain/kotlin",
-                )
+                ),
+                baselineFiles = listOf("baseline.xml", "baseline-main.xml")
             )
         }
 
@@ -107,11 +110,16 @@ class DetektMultiplatformTest : Spek({
             gradleRunner.runTasks(":shared:detektBaselineJvmEmbeddedTest")
         }
 
-        it("configures detekt task with type resolution") {
+        it("configures detekt task with type resolution backend") {
             gradleRunner.runTasksAndCheckResult(":shared:detektJvmBackendMain") {
+                assertThat(it.output).containsPattern("""--baseline \S*[/\\]baseline-main.xml """)
                 assertDetektWithClasspath(it)
             }
+        }
+
+        it("configures detekt task with type resolution embedded") {
             gradleRunner.runTasksAndCheckResult(":shared:detektJvmEmbeddedMain") {
+                assertThat(it.output).containsPattern("""--baseline \S*[/\\]baseline-main.xml """)
                 assertDetektWithClasspath(it)
             }
         }
@@ -162,7 +170,8 @@ class DetektMultiplatformTest : Spek({
                     "src/androidMain/kotlin",
                     "src/commonMain/kotlin",
                     "src/commonTest/kotlin"
-                )
+                ),
+                baselineFiles = listOf("baseline.xml", "baseline-debug.xml", "baseline-release.xml")
             )
         }
 
@@ -177,9 +186,11 @@ class DetektMultiplatformTest : Spek({
 
         it("configures detekt task with type resolution") {
             gradleRunner.runTasksAndCheckResult(":shared:detektAndroidDebug") {
+                assertThat(it.output).containsPattern("""--baseline \S*[/\\]baseline-debug.xml """)
                 assertDetektWithClasspath(it)
             }
             gradleRunner.runTasksAndCheckResult(":shared:detektAndroidRelease") {
+                assertThat(it.output).containsPattern("""--baseline \S*[/\\]baseline-release.xml """)
                 assertDetektWithClasspath(it)
             }
         }
@@ -211,7 +222,8 @@ class DetektMultiplatformTest : Spek({
                     "src/commonTest/kotlin",
                     "src/jsMain/kotlin",
                     "src/jsTest/kotlin",
-                )
+                ),
+                baselineFiles = listOf("baseline.xml")
             )
         }
 
@@ -222,9 +234,11 @@ class DetektMultiplatformTest : Spek({
 
         it("configures detekt task without type resolution") {
             gradleRunner.runTasksAndCheckResult(":shared:detektJsMain") {
+                assertThat(it.output).containsPattern("""--baseline \S*[/\\]baseline.xml """)
                 assertDetektWithoutClasspath(it)
             }
             gradleRunner.runTasksAndCheckResult(":shared:detektJsTest") {
+                assertThat(it.output).containsPattern("""--baseline \S*[/\\]baseline.xml """)
                 assertDetektWithoutClasspath(it)
             }
         }
@@ -265,7 +279,8 @@ class DetektMultiplatformTest : Spek({
                     "src/iosX64Main/kotlin",
                     "src/iosX64Test/kotlin",
                     "src/iosMain/kotlin",
-                )
+                ),
+                baselineFiles = listOf("baseline.xml")
             )
         }
 
@@ -278,15 +293,19 @@ class DetektMultiplatformTest : Spek({
 
         it("configures detekt task without type resolution") {
             gradleRunner.runTasksAndCheckResult(":shared:detektIosArm64Main") {
+                assertThat(it.output).containsPattern("""--baseline \S*[/\\]baseline.xml """)
                 assertDetektWithoutClasspath(it)
             }
             gradleRunner.runTasksAndCheckResult(":shared:detektIosArm64Test") {
+                assertThat(it.output).containsPattern("""--baseline \S*[/\\]baseline.xml """)
                 assertDetektWithoutClasspath(it)
             }
             gradleRunner.runTasksAndCheckResult(":shared:detektIosX64Main") {
+                assertThat(it.output).containsPattern("""--baseline \S*[/\\]baseline.xml """)
                 assertDetektWithoutClasspath(it)
             }
             gradleRunner.runTasksAndCheckResult(":shared:detektIosX64Test") {
+                assertThat(it.output).containsPattern("""--baseline \S*[/\\]baseline.xml """)
                 assertDetektWithoutClasspath(it)
             }
         }

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektPlainTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektPlainTest.kt
@@ -41,6 +41,7 @@ object DetektPlainTest : Spek({
         val gradleRunner = DslGradleRunner(
             projectLayout = ProjectLayout(numberOfSourceFilesInRootPerSourceDir = 1),
             buildFileName = "build.gradle",
+            baselineFiles = listOf("baseline.xml"),
             mainBuildFileContent = """
                 plugins {
                     id "org.jetbrains.kotlin.jvm"
@@ -66,6 +67,7 @@ object DetektPlainTest : Spek({
 
         it("configures detekt plain task") {
             gradleRunner.runTasksAndCheckResult(":detekt") { buildResult ->
+                assertThat(buildResult.output).containsPattern("""--baseline \S*[/\\]baseline.xml """)
                 assertThat(buildResult.output).contains("--report xml:")
                 assertThat(buildResult.output).contains("--report sarif:")
                 assertThat(buildResult.output).doesNotContain("--report txt:")


### PR DESCRIPTION
This fix #1260

Now that we don't create baselines when we don't need them and we allow empty baselines we can fix this old issue.

- It adds `baseline.xml` as default value in our gradle plugin
- And it make the baseline names of multiplatform a bit more consistents. This is a breacking change but as far as I know this part is experimental so it should not be a big problem.