### PR TITLE
Remove useless config `continuationIndentSize`

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -277,7 +277,6 @@ formatting:
     active: false
     autoCorrect: true
     indentSize: 4
-    continuationIndentSize: 4
   MaximumLineLength:
     active: true
     maxLineLength: 120

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/EditorConfigConstants.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/EditorConfigConstants.kt
@@ -1,20 +1,17 @@
 package io.gitlab.arturbosch.detekt.formatting
 
 const val INDENT_SIZE_KEY = "indent_size"
-const val CONTINUATION_INDENT_SIZE_KEY = "continuation_indent_size"
 const val MAX_LINE_LENGTH_KEY = "max_line_length"
 const val INSERT_FINAL_NEWLINE_KEY = "insert_final_newline"
 const val KOTLIN_IMPORTS_LAYOUT_KEY = "kotlin_imports_layout"
 
 val knownEditorConfigProps = setOf(
     INDENT_SIZE_KEY,
-    CONTINUATION_INDENT_SIZE_KEY,
     MAX_LINE_LENGTH_KEY,
     INSERT_FINAL_NEWLINE_KEY,
     KOTLIN_IMPORTS_LAYOUT_KEY
 )
 
 const val DEFAULT_INDENT = 4
-const val DEFAULT_CONTINUATION_INDENT = 4
 const val ANDROID_MAX_LINE_LENGTH = 100
 const val DEFAULT_IDEA_LINE_LENGTH = 120

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/Indentation.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/Indentation.kt
@@ -2,8 +2,6 @@ package io.gitlab.arturbosch.detekt.formatting.wrappers
 
 import com.pinterest.ktlint.ruleset.standard.IndentationRule
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.formatting.CONTINUATION_INDENT_SIZE_KEY
-import io.gitlab.arturbosch.detekt.formatting.DEFAULT_CONTINUATION_INDENT
 import io.gitlab.arturbosch.detekt.formatting.DEFAULT_INDENT
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 import io.gitlab.arturbosch.detekt.formatting.INDENT_SIZE_KEY
@@ -12,7 +10,6 @@ import io.gitlab.arturbosch.detekt.formatting.INDENT_SIZE_KEY
  * See <a href="https://ktlint.github.io/#rule-indentation">ktlint-website</a> for documentation.
  *
  * @configuration indentSize - indentation size (default: `4`)
- * @configuration continuationIndentSize - continuation indentation size (default: `4`)
  *
  * @autoCorrect since v1.0.0
  */
@@ -22,15 +19,12 @@ class Indentation(config: Config) : FormattingRule(config) {
     override val issue = issueFor("Reports mis-indented code")
 
     private val indentSize = valueOrDefault(INDENT_SIZE, DEFAULT_INDENT)
-    private val continuationIndentSize = valueOrDefault(CONTINUATION_INDENT_SIZE, DEFAULT_CONTINUATION_INDENT)
 
     override fun overrideEditorConfig() = mapOf(
-        INDENT_SIZE_KEY to indentSize,
-        CONTINUATION_INDENT_SIZE_KEY to continuationIndentSize
+        INDENT_SIZE_KEY to indentSize
     )
 
     companion object {
         const val INDENT_SIZE = "indentSize"
-        const val CONTINUATION_INDENT_SIZE = "continuationIndentSize"
     }
 }


### PR DESCRIPTION
This fixes #3533 by not exposing useless configs.

Although this PR reduces confusion for our users. This is still a breaking change though, and I am open to delaying this until the next major breaking version.