### PR TITLE
Include detekt-rules on CLI runtime classpath

### DIFF
--- a/detekt-cli/build.gradle.kts
+++ b/detekt-cli/build.gradle.kts
@@ -8,22 +8,18 @@ application {
     mainClassName = "io.gitlab.arturbosch.detekt.cli.Main"
 }
 
-val bundledRules by configurations.creating
-
 dependencies {
     implementation("com.beust:jcommander")
     implementation(project(":detekt-tooling"))
     implementation(project(":detekt-parser"))
     runtimeOnly(project(":detekt-core"))
+    runtimeOnly(project(":detekt-rules"))
 
     testImplementation(project(":detekt-test"))
-
-    bundledRules(project(":detekt-rules"))
 }
 
 tasks.shadowJar {
     mergeServiceFiles()
-    configurations = listOf(project.configurations.runtimeClasspath.get(), bundledRules)
 }
 
 tasks.register<Copy>("moveJarForIntegrationTest") {


### PR DESCRIPTION
Removing detekt-rules from the CLI runtime classpath in #3611 caused some issues with Gradle's up-to-date & dependency checks and made the build behave strangely when running `detekt` tasks on the project (rule changes weren't being picked up when the `detekt` task ran).

This fixes that problem.

I also seem to have to restart the Gradle daemon when making rule changes for that to be picked up on new `detekt` runs - I suspect the class loader cache but I don't know enough about it, or if this is a new issue or not.