### PR TITLE
Skip ios tests if no ci

### DIFF
--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektMultiplatformTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektMultiplatformTest.kt
@@ -239,7 +239,7 @@ class DetektMultiplatformTest : Spek({
 
     describe(
         "multiplatform projects - iOS target",
-        skip = if (isMacOs()) {
+        skip = if (isMacOs() && isCI()) {
             Skip.No
         } else {
             Skip.Yes("Not on MacOS.")
@@ -349,4 +349,6 @@ private val DETEKT_BLOCK = """
     }
 """.trimIndent()
 
-fun isMacOs() = System.getProperty("os.name").contains("mac", ignoreCase = true)
+private fun isMacOs() = System.getProperty("os.name").contains("mac", ignoreCase = true)
+
+private fun isCI() = System.getProperty("CI").toBoolean()


### PR DESCRIPTION
This is just a workaround for #3617. @chao2zhang reported the same issue (https://github.com/detekt/detekt/pull/3619#issuecomment-808989016) so I think that we should merge this until we fix the issue properly.