### PR TITLE
Idea references

### DIFF
--- a/docs/_posts/2019-03-03-configure-detekt-on-root-project.md
+++ b/docs/_posts/2019-03-03-configure-detekt-on-root-project.md
@@ -25,14 +25,6 @@ subprojecs {
             xml.enabled = true
             html.enabled = true
         }
-    
-        idea {
-            path = "$userHome/.idea"
-            codeStyleScheme = "$userHome/.idea/idea-code-style.xml"
-            inspectionsProfile = "$userHome/.idea/inspect.xml"
-            report = "project.projectDir/reports"
-            mask = "*.kt"
-        }
     }
 }
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,6 @@ summary:
 - Specify code smell thresholds to break your build or print a warning
 - Code Smell baseline and ignore lists for legacy projects
 - [Gradle plugin](#gradleplugin) for code analysis via Gradle builds
-- Gradle tasks to use local `IntelliJ` distribution for [formatting and inspecting](#idea) Kotlin code
 - Optionally configure detekt for each sub module by using [profiles](#closure) (gradle-plugin)
 - [SonarQube integration](https://github.com/arturbosch/sonar-kotlin)
 - Extensible by own rule sets and `FileProcessListener's`

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,6 @@ summary:
 - Specify code smell thresholds to break your build or print a warning
 - Code Smell baseline and ignore lists for legacy projects
 - [Gradle plugin](pages/gettingstarted/gradle.md) for code analysis via Gradle builds
-- Optionally configure detekt for each sub module by using profiles (gradle-plugin)
 - [SonarQube integration](https://github.com/detekt/sonar-kotlin)
 - Extensible by own rule sets and `FileProcessListener's`
 - [IntelliJ integration](https://github.com/detekt/detekt-intellij-plugin)

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,9 +16,9 @@ summary:
 - Suppress findings with Kotlin's `@Suppress` and Java's `@SuppressWarnings` annotations
 - Specify code smell thresholds to break your build or print a warning
 - Code Smell baseline and ignore lists for legacy projects
-- [Gradle plugin](#gradleplugin) for code analysis via Gradle builds
-- Optionally configure detekt for each sub module by using [profiles](#closure) (gradle-plugin)
-- [SonarQube integration](https://github.com/arturbosch/sonar-kotlin)
+- [Gradle plugin](pages/gettingstarted/gradle.md) for code analysis via Gradle builds
+- Optionally configure detekt for each sub module by using profiles (gradle-plugin)
+- [SonarQube integration](https://github.com/detekt/sonar-kotlin)
 - Extensible by own rule sets and `FileProcessListener's`
 - [IntelliJ integration](https://github.com/detekt/detekt-intellij-plugin)
 - Unofficial [Maven plugin](https://github.com/Ozsie/detekt-maven-plugin) by [Ozsie](https://github.com/Ozsie)

--- a/docs/pages/gettingstarted/gradle.md
+++ b/docs/pages/gettingstarted/gradle.md
@@ -23,8 +23,6 @@ The detekt Gradle plugin will generate multiple tasks:
  run when executing `gradle check`.
 - `detektGenerateConfig` - Generates a default detekt configuration file into your project directory.
 - `detektBaseline` - Similar to `detekt`, but creates a code smell baseline. Further detekt runs will only feature new smells not in this list.
-- `detektIdeaFormat` - Uses a local `idea` installation to format your Kotlin (and other) code according to the specified `code-style.xml`.
-- `detektIdeaInspect` - Uses a local `idea` installation to run inspections on your Kotlin (and other) code according to the specified `inspections.xml` profile.
 
 In addition to these standard tasks, the plugin will also generate a set of experimental tasks that have
 [type resolution](type-resolution.md) enabled. This happens for both, pure JVM projects and Android projects that have


### PR DESCRIPTION
We had some references to old tasks and configurations related with idea. This PR remove those references because they no longer exist.

Context: https://kotlinlang.slack.com/archives/C88E12QH4/p1617047735036800

I fixed some broken links too.