### PR TITLE
Kotlin 1.5.0

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -13,7 +13,7 @@ repositories {
 }
 
 object Plugins {
-    const val KOTLIN = "1.4.32"
+    const val KOTLIN = "1.5.0-M2"
     const val DETEKT = "1.16.0"
     const val GITHUB_RELEASE = "2.2.12"
     const val SHADOW = "6.1.0"

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -2,7 +2,6 @@ object Versions {
 
     const val DETEKT: String = "1.16.0"
     const val SNAPSHOT_NAME: String = "main"
-    const val JVM_TARGET: String = "1.8"
     const val JACOCO: String = "0.8.6"
 
     fun currentOrSnapshot(): String {

--- a/buildSrc/src/main/kotlin/module.gradle.kts
+++ b/buildSrc/src/main/kotlin/module.gradle.kts
@@ -46,7 +46,6 @@ tasks.withType<Test>().configureEach {
 
 tasks.withType<KotlinCompile>().configureEach {
     kotlinOptions {
-        jvmTarget = Versions.JVM_TARGET
         languageVersion = "1.4"
         freeCompilerArgs = listOf(
             "-progressive",


### PR DESCRIPTION
Smoke test Kotlin 1.5 with new IR backend which is used by default.

Todo:
- [x] update Gradle config now that Java 1.8 bytecode is generated by default
- [ ] Update to Kotlin 1.5.0 final
- [ ] Update languageVersion to "1.5" (or should this be held back?)