### PR TITLE
fix for KtNamedFunction.isMainFunction()

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ If you contributed to detekt but your name is not in the list, please feel free 
 - [Adam Kobor](https://github.com/adamkobor) - New rule: MultilineLambdaItParameter
 - [Slawomir Czerwinski](https://github.com/sczerwinski) - Rule improvement: FunctionOnlyReturningConstant
 - [Ivo Smid](https://github.com/bedla) - Fix Local development on Windows
+- [Krzysztof Kruczynski](https://github.com/krzykrucz) - Rule fix: ThrowingExceptionInMain, ExitOutsideMain
 
 ### Mentions
 

--- a/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/MethodSignature.kt
+++ b/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/MethodSignature.kt
@@ -34,9 +34,9 @@ private fun KtNamedFunction.hasMainSignature() =
     this.name == "main" && this.isPublicNotOverridden() && this.hasMainParameter()
 
 private fun KtNamedFunction.hasMainParameter() =
-    valueParameters.isEmpty()
-        || valueParameters.size == 1 && valueParameters[0].typeReference?.text == "Array<String>"
-        || (valueParameters.size == 1 && valueParameters[0].isVarArg && valueParameters[0].typeReference?.text == "String")
+    valueParameters.isEmpty() ||
+        (valueParameters.size == 1 && valueParameters[0].typeReference?.text == "Array<String>") ||
+        (valueParameters.size == 1 && valueParameters[0].isVarArg && valueParameters[0].typeReference?.text == "String")
 
 private fun KtNamedFunction.isMainInsideObject() =
     this.name == "main" &&

--- a/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/MethodSignature.kt
+++ b/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/MethodSignature.kt
@@ -34,7 +34,9 @@ private fun KtNamedFunction.hasMainSignature() =
     this.name == "main" && this.isPublicNotOverridden() && this.hasMainParameter()
 
 private fun KtNamedFunction.hasMainParameter() =
-    valueParameters.isEmpty() || valueParameters.size == 1 && valueParameters[0].typeReference?.text == "Array<String>"
+    valueParameters.isEmpty()
+        || valueParameters.size == 1 && valueParameters[0].typeReference?.text == "Array<String>"
+        || (valueParameters.size == 1 && valueParameters[0].isVarArg && valueParameters[0].typeReference?.text == "String")
 
 private fun KtNamedFunction.isMainInsideObject() =
     this.name == "main" &&

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionInMainSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionInMainSpec.kt
@@ -14,9 +14,10 @@ class ThrowingExceptionInMainSpec : Spek({
         it("reports a runnable main function which throws an exception") {
             val code = """
                 fun main(args: Array<String>) { throw IllegalArgumentException() }
+                fun main(vararg args: String) { throw IllegalArgumentException() }
                 fun main() { throw IllegalArgumentException() }
             """
-            assertThat(subject.compileAndLint(code)).hasSize(2)
+            assertThat(subject.compileAndLint(code)).hasSize(3)
         }
 
         it("reports runnable main functions with @JvmStatic annotation which throw an exception") {


### PR DESCRIPTION
Fixes the issue that `vararg` variation of `main` function was not taken into account in `KtNamedFunction#isMainFunction`.

As a result fixes also rules using this function: `ThrowingExceptionInMain`, `ExitOutsideMain`.