### PR TITLE
Add MayBeConstant as alias for MayBeConst

### DIFF
--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MayBeConst.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MayBeConst.kt
@@ -45,6 +45,8 @@ class MayBeConst(config: Config = Config.empty) : Rule(config) {
         Debt.FIVE_MINS
     )
 
+    override val defaultRuleIdAliases = setOf("MayBeConstant")
+
     private val binaryTokens = hashSetOf<KtSingleValueToken>(
         KtTokens.PLUS,
         KtTokens.MINUS,


### PR DESCRIPTION
Workaround for #3643 meanwhile we can't change the name of the rule