### PR TITLE
Fail the tests when we use deprecated code in our gradle plugin

### DIFF
--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/testkit/DslGradleRunner.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/testkit/DslGradleRunner.kt
@@ -113,6 +113,7 @@ class DslGradleRunner @Suppress("LongParameterList") constructor(
             if (dryRun) {
                 add("-Pdetekt-dry-run=true")
             }
+            add("--warning-mode=fail")
             addAll(tasks.toList())
         }
 


### PR DESCRIPTION
What do you think about adding this to our tests? We should not use deprecated code in our plugin to avoid compatibility problems with future versions of gradle.

I must say that I don't know gradle enough to fix the current warnings so if someone knows how please feel free to go for it.

This is more an issue than a PR but I created it like this so you can see the output of the tests. What do you think, should we have this enable by default? Could this create too much trouble because we need to give backword and forward compatibility?