### PR TITLE
Drop support to Gradle 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ You can find [other ways to install detekt here](https://detekt.github.io/detekt
 
 #### with Gradle
 
-Gradle 5.4+ is required:
+Gradle 6.0+ is required:
 
 ```kotlin
 buildscript {

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/GradleVersionTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/GradleVersionTest.kt
@@ -29,9 +29,9 @@ object GradleVersionTest : Spek({
 
 private fun getGradleVersionsUnderTest() =
     if (getJdkVersion() < 13) {
-        listOf("5.4", "6.7")
+        listOf("6.0", "6.8")
     } else {
-        listOf("6.7")
+        listOf("6.7", "6.8")
     }
 
 private fun getJdkVersion(): Int {

--- a/docs/pages/gettingstarted/gradle.md
+++ b/docs/pages/gettingstarted/gradle.md
@@ -10,7 +10,7 @@ redirect_from:
 summary:
 ---
 
-detekt requires Gradle 5.4 or higher.
+detekt requires Gradle 6.0 or higher.
 
 ## <a name="tasks">Available plugin tasks</a>
 


### PR DESCRIPTION
Drop support to gradle 5.

5.0 was release at [16/Apr/2019](https://gradle.org/releases/). This moves the support 6.0. It was release at [08/Nov/2019](https://gradle.org/releases/). Maybe we coud be even more aggresive here but I think that 6.0 is a safe commitment.

As a reference the Gradle Android Plugin set the [minimum gradle version to 6.1 at April 2020]( https://developer.android.com/studio/releases/gradle-plugin#4-0-0). And the last version of the AGP requires Gradle 6.5