### PR TITLE
Add src/test/java and src/test/kotlin by default in PlainDetekt

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
@@ -23,8 +23,13 @@ open class DetektExtension @Inject constructor(objects: ObjectFactory) : CodeQua
 
     val reports = DetektReports()
 
-    var input: ConfigurableFileCollection =
-        objects.fileCollection().from(DEFAULT_SRC_DIR_JAVA, DEFAULT_SRC_DIR_KOTLIN)
+    var input: ConfigurableFileCollection = objects.fileCollection()
+        .from(
+            DEFAULT_SRC_DIR_JAVA,
+            DEFAULT_TEST_SRC_DIR_JAVA,
+            DEFAULT_SRC_DIR_KOTLIN,
+            DEFAULT_TEST_SRC_DIR_KOTLIN,
+        )
 
     var baseline: File? = null
 
@@ -68,7 +73,9 @@ open class DetektExtension @Inject constructor(objects: ObjectFactory) : CodeQua
 
     companion object {
         const val DEFAULT_SRC_DIR_JAVA = "src/main/java"
+        const val DEFAULT_TEST_SRC_DIR_JAVA = "src/test/java"
         const val DEFAULT_SRC_DIR_KOTLIN = "src/main/kotlin"
+        const val DEFAULT_TEST_SRC_DIR_KOTLIN = "src/test/kotlin"
         const val DEFAULT_DEBUG_VALUE = false
         const val DEFAULT_PARALLEL_VALUE = false
         const val DEFAULT_AUTO_CORRECT_VALUE = false

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskDslTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskDslTest.kt
@@ -54,8 +54,10 @@ internal object DetektTaskDslTest : Spek({
 
                     it("set as input all the kotlin files in src/main/java and src/main/kotlin") {
                         val file1 = gradleRunner.projectFile("src/main/java/My0Root0Class.kt")
-                        val file2 = gradleRunner.projectFile("src/main/kotlin/My2Root0Class.kt")
-                        assertThat(result.output).contains("--input $file1,$file2 ")
+                        val file2 = gradleRunner.projectFile("src/test/java/My1Root0Class.kt")
+                        val file3 = gradleRunner.projectFile("src/main/kotlin/My2Root0Class.kt")
+                        val file4 = gradleRunner.projectFile("src/test/kotlin/My3Root0Class.kt")
+                        assertThat(result.output).contains("--input $file1,$file2,$file3,$file4 ")
                     }
                 }
 

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskDslTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskDslTest.kt
@@ -51,6 +51,12 @@ internal object DetektTaskDslTest : Spek({
                         val sarifReportFile = gradleRunner.projectFile("build/reports/detekt/detekt.sarif")
                         assertThat(result.output).doesNotContain("--report sarif:$sarifReportFile")
                     }
+
+                    it("set as input all the kotlin files in src/main/java and src/main/kotlin") {
+                        val file1 = gradleRunner.projectFile("src/main/java/My0Root0Class.kt")
+                        val file2 = gradleRunner.projectFile("src/main/kotlin/My2Root0Class.kt")
+                        assertThat(result.output).contains("--input $file1,$file2 ")
+                    }
                 }
 
                 describe("without multiple detekt configs") {

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/testkit/ProjectLayout.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/testkit/ProjectLayout.kt
@@ -3,7 +3,7 @@ package io.gitlab.arturbosch.detekt.testkit
 class ProjectLayout(
     val numberOfSourceFilesInRootPerSourceDir: Int,
     val numberOfCodeSmellsInRootPerSourceDir: Int = 0,
-    val srcDirs: List<String> = listOf("src/main/java", "src/test/java")
+    val srcDirs: List<String> = listOf("src/main/java", "src/test/java", "src/main/kotlin", "src/test/kotlin")
 ) {
 
     private val mutableSubmodules: MutableList<Submodule> = mutableListOf()


### PR DESCRIPTION
We aren't adding the source sets `src/test/java` and `src/test/kotlin` in the PlainDetekt. It have little sense that we don't add those by default because our default configuration take those sources into account.