### PR TITLE
Print top 5 smells when failing on threshold

### DIFF
--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/tooling/AnalysisFacade.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/tooling/AnalysisFacade.kt
@@ -1,18 +1,12 @@
 package io.gitlab.arturbosch.detekt.core.tooling
 
-import io.github.detekt.tooling.api.AnalysisResult
-import io.github.detekt.tooling.api.Detekt
-import io.github.detekt.tooling.api.DetektError
-import io.github.detekt.tooling.api.InvalidConfig
-import io.github.detekt.tooling.api.MaxIssuesReached
-import io.github.detekt.tooling.api.UnexpectedError
+import io.github.detekt.tooling.api.*
 import io.github.detekt.tooling.api.spec.ProcessingSpec
 import io.github.detekt.tooling.internal.DefaultAnalysisResult
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Detektion
 import io.gitlab.arturbosch.detekt.core.ProcessingSettings
 import io.gitlab.arturbosch.detekt.core.config.MaxIssueCheck
-import io.gitlab.arturbosch.detekt.core.config.getOrComputeWeightedAmountOfIssues
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.resolve.BindingContext
 import java.nio.file.Path
@@ -57,8 +51,7 @@ class AnalysisFacade(
         }
 
         val error = runCatching {
-            val amount = result.getOrComputeWeightedAmountOfIssues(config)
-            MaxIssueCheck(spec.rulesSpec, config).check(amount)
+            MaxIssueCheck(spec.rulesSpec, config).check(result)
         }.exceptionOrNull()
 
         return when {


### PR DESCRIPTION
When detekt build fails due to threshold (see `maxIssues`), the concluding error message does not help you find what got you over the threshold. Instead, it sends you to go over the log, and look for issues found.
This has two problems:
1. The build log can be very long, and it may take time to go over it
2. I case you have many existing issues with small weight, and one new issue with big weight - it becomes a search for a needle in a hay-stack.

### I'll elaborate on problem 2:
#### Background
In my team, adoption of Detekt is slow. There are some that embrace Detekt, some that are indifferent, and some who would rather see it removed. The main issue is the question "what rules should we adopt?", combined with the fact that when we added Detekt we already had thousands of warnings.
So after tweaking and disabling some rules, and adding some custom ones, we now have ±500.
But we still don't want to fail the build over any minor issue that is yet in dissagreement.
So the solution was to pick a few that we consider **critical** (all of them custom rules that reveal a certain bug), **give them 
weight `10001`, and set the threshold to `10000`**.
#### Problem
Now the build fails only on these "critical" issues, but when it does - it's hard to tell by the build's log.
Running the plugin in IntelliJ helps, but it's another step to take, and you'd have to make sure you're on the exact commit etc.

#### Solution
What this commit aims to do, is change the print in case of threshold-failure, to something like this:
```
Build failed with 300 weighted issues. Top 5:
  10001      ExpectWithoutToBe   /src/test/foo/BarTest.kt:56
  1          MaximumLineLength   /src/main/foo/Bar.kt:145
  1          MaximumLineLength   /src/main/foo/Qux.kt:172
  1          ComplexCondition    /src/main/foo/Quux.kt:172
  1          LongMethod          /src/main/foo/Quuz.kt:172
```
Now the user knows immediately exactly what broke the build


I didn't know about [custom reports](https://detekt.github.io/detekt/extensions.html#custom-reports) API when I wrote this,
but I think this is a reasonable default format for this message - I think everyone can benefit from it. I'm guessing there are other Detekt users that use the threshold mechanism in a similar way.