### PR TITLE
Add DeprecatedBlockTag rule

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -57,6 +57,8 @@ comments:
     active: false
   CommentOverPrivateProperty:
     active: false
+  DeprecatedBlockTag:
+    active: false
   EndOfSentenceFormat:
     active: false
     endOfSentenceFormat: '([.?!][ \t\n\r\f<])|([.?!:]$)'

--- a/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentSmellProvider.kt
+++ b/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentSmellProvider.kt
@@ -20,6 +20,7 @@ class CommentSmellProvider : DefaultRuleSetProvider {
             CommentOverPrivateFunction(config),
             CommentOverPrivateProperty(config),
             KDocStyle(config),
+            DeprecatedBlockTag(config),
             UndocumentedPublicClass(config),
             UndocumentedPublicFunction(config),
             UndocumentedPublicProperty(config),

--- a/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentSmellProvider.kt
+++ b/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentSmellProvider.kt
@@ -20,7 +20,6 @@ class CommentSmellProvider : DefaultRuleSetProvider {
             CommentOverPrivateFunction(config),
             CommentOverPrivateProperty(config),
             KDocStyle(config),
-            DeprecatedBlockTag(config),
             UndocumentedPublicClass(config),
             UndocumentedPublicFunction(config),
             UndocumentedPublicProperty(config),

--- a/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/DeprecatedBlockTag.kt
+++ b/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/DeprecatedBlockTag.kt
@@ -1,0 +1,71 @@
+package io.gitlab.arturbosch.detekt.rules.documentation
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import org.jetbrains.kotlin.psi.KtDeclaration
+
+// Note: this could probably be added to the KDocStyle class in EndOfSentenceFormat.kt
+
+/**
+ * This rule reports use of the `@deprecated` block tag in KDoc comments. Deprecation must be specified using a
+ * `@Deprecated` annotation as adding a `@deprecated` block tag in KDoc comments has no effect. The `@Deprecated`
+ * annotation constructor has dedicated fields for a message and a type (warning, error, etc.). You can also use the
+ * `@ReplaceWith` annotation to specify how to solve the deprecation automatically via the IDE.
+ *
+ * <noncompliant>
+ * /**
+ *  * This function prints a message followed by a new line.
+ *  *
+ *  * @deprecated Useless, the Kotlin standard library can already do this. Replace with println.
+ *  */
+ * fun printThenNewline(what: String) {
+ *     // ...
+ * }
+ * </noncompliant>
+ *
+ * <compliant>
+ * /**
+ *  * This function prints a message followed by a new line.
+ *  */
+ * &#64;Deprecated("Useless, the Kotlin standard library can already do this.")
+ * &#64;ReplaceWith("println(what)")
+ * fun printThenNewline(what: String) {
+ *     // ...
+ * }
+ * </compliant>
+ */
+class DeprecatedBlockTag(config: Config = Config.empty) : Rule(config) {
+    override val issue = Issue(
+        "DeprecatedBlockTag",
+        Severity.Defect,
+        "Do not use the @deprecated block tag, which is not supported by KDoc. " +
+            "Use the @Deprecated annotation instead.",
+        Debt.FIVE_MINS
+    )
+
+    override fun visitDeclaration(dcl: KtDeclaration) {
+        super.visitDeclaration(dcl)
+        verify(dcl)
+    }
+
+    private fun verify(dcl: KtDeclaration) {
+        dcl.docComment?.getAllSections()?.forEach { section ->
+            section.findTagsByName("deprecated").forEach { tag ->
+                report(
+                    CodeSmell(
+                        issue,
+                        Entity.from(dcl),
+                        "@deprecated tag block does not properly report deprecation in Kotlin, use @Deprecated " +
+                            "annotation instead",
+                        references = listOf(Entity.from(tag))
+                    )
+                )
+            }
+        }
+    }
+}

--- a/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/DeprecatedBlockTag.kt
+++ b/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/DeprecatedBlockTag.kt
@@ -9,8 +9,6 @@ import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.psi.KtDeclaration
 
-// Note: this could probably be added to the KDocStyle class in EndOfSentenceFormat.kt
-
 /**
  * This rule reports use of the `@deprecated` block tag in KDoc comments. Deprecation must be specified using a
  * `@Deprecated` annotation as adding a `@deprecated` block tag in KDoc comments

--- a/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/DeprecatedBlockTag.kt
+++ b/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/DeprecatedBlockTag.kt
@@ -13,7 +13,8 @@ import org.jetbrains.kotlin.psi.KtDeclaration
 
 /**
  * This rule reports use of the `@deprecated` block tag in KDoc comments. Deprecation must be specified using a
- * `@Deprecated` annotation as adding a `@deprecated` block tag in KDoc comments has no effect. The `@Deprecated`
+ * `@Deprecated` annotation as adding a `@deprecated` block tag in KDoc comments
+ * [has no effect and is not supported](https://kotlinlang.org/docs/kotlin-doc.html#suppress). The `@Deprecated`
  * annotation constructor has dedicated fields for a message and a type (warning, error, etc.). You can also use the
  * `@ReplaceWith` annotation to specify how to solve the deprecation automatically via the IDE.
  *

--- a/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/DeprecatedBlockTag.kt
+++ b/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/DeprecatedBlockTag.kt
@@ -54,7 +54,7 @@ class DeprecatedBlockTag(config: Config = Config.empty) : Rule(config) {
         verify(dcl)
     }
 
-    private fun verify(dcl: KtDeclaration) {
+    fun verify(dcl: KtDeclaration) {
         dcl.docComment?.getAllSections()?.forEach { section ->
             section.findTagsByName("deprecated").forEach { tag ->
                 report(

--- a/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/EndOfSentenceFormat.kt
+++ b/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/EndOfSentenceFormat.kt
@@ -5,25 +5,10 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.MultiRule
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.rules.lastArgumentMatchesUrl
 import org.jetbrains.kotlin.psi.KtDeclaration
-
-class KDocStyle(config: Config = Config.empty) : MultiRule() {
-
-    private val endOfSentenceFormat = EndOfSentenceFormat(config)
-
-    override val rules = listOf(
-        endOfSentenceFormat
-    )
-
-    override fun visitDeclaration(dcl: KtDeclaration) {
-        super.visitDeclaration(dcl)
-        endOfSentenceFormat.verify(dcl)
-    }
-}
 
 /**
  * This rule validates the end of the first sentence of a KDoc comment.

--- a/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/EndOfSentenceFormat.kt
+++ b/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/EndOfSentenceFormat.kt
@@ -31,6 +31,11 @@ class EndOfSentenceFormat(config: Config = Config.empty) : Rule(config) {
         Regex(valueOrDefault(END_OF_SENTENCE_FORMAT, "([.?!][ \\t\\n\\r\\f<])|([.?!:]\$)"))
     private val htmlTag = Regex("<.+>")
 
+    override fun visitDeclaration(dcl: KtDeclaration) {
+        super.visitDeclaration(dcl)
+        verify(dcl)
+    }
+
     fun verify(declaration: KtDeclaration) {
         declaration.docComment?.let {
             val text = it.getDefaultSection().getContent()

--- a/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/KDocStyle.kt
+++ b/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/KDocStyle.kt
@@ -6,14 +6,17 @@ import org.jetbrains.kotlin.psi.KtDeclaration
 
 class KDocStyle(config: Config = Config.empty) : MultiRule() {
 
+    private val deprecatedBlockTag = DeprecatedBlockTag(config)
     private val endOfSentenceFormat = EndOfSentenceFormat(config)
 
     override val rules = listOf(
+        deprecatedBlockTag,
         endOfSentenceFormat
     )
 
     override fun visitDeclaration(dcl: KtDeclaration) {
         super.visitDeclaration(dcl)
+        deprecatedBlockTag.verify(dcl)
         endOfSentenceFormat.verify(dcl)
     }
 }

--- a/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/KDocStyle.kt
+++ b/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/KDocStyle.kt
@@ -1,0 +1,19 @@
+package io.gitlab.arturbosch.detekt.rules.documentation
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.MultiRule
+import org.jetbrains.kotlin.psi.KtDeclaration
+
+class KDocStyle(config: Config = Config.empty) : MultiRule() {
+
+    private val endOfSentenceFormat = EndOfSentenceFormat(config)
+
+    override val rules = listOf(
+        endOfSentenceFormat
+    )
+
+    override fun visitDeclaration(dcl: KtDeclaration) {
+        super.visitDeclaration(dcl)
+        endOfSentenceFormat.verify(dcl)
+    }
+}

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/DeprecatedBlockTagSpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/DeprecatedBlockTagSpec.kt
@@ -90,8 +90,7 @@ class DeprecatedBlockTagSpec : Spek({
                          *
                          * @deprecated Do not use that
                          */
-                        constructor(something: String) {
-                        }
+                        constructor(something: String)
                     }
                 """
                 assertThat(subject.compileAndLint(code)).hasSize(1)
@@ -107,7 +106,7 @@ class DeprecatedBlockTagSpec : Spek({
                              * 
                              * @deprecated Do not use it
                              */
-                            set(value) = { println(value) }
+                            set(value) { println(value) }
                     }
                 """
                 assertThat(subject.compileAndLint(code)).hasSize(1)
@@ -123,7 +122,7 @@ class DeprecatedBlockTagSpec : Spek({
                              * @deprecated Do not use it
                              */
                             get() = 10
-                            set(value) = { println(value) }
+                            set(value) { println(value) }
                     }
                 """
                 assertThat(subject.compileAndLint(code)).hasSize(1)

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/DeprecatedBlockTagSpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/DeprecatedBlockTagSpec.kt
@@ -1,6 +1,5 @@
 package io.gitlab.arturbosch.detekt.rules.documentation
 
-import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.spekframework.spek2.Spek
@@ -22,25 +21,21 @@ class DeprecatedBlockTagSpec : Spek({
         }
 
         describe("reporting deprecation tag on kdoc block") {
-            var result = listOf<Finding>()
-            beforeEachTest {
-                val code = """
+            val code = """
                 /**
                  * I am a KDoc block
                  * 
                  * @deprecated oh no, this should not be here
                  */
                 fun ohNo() { }
-                """
-                result = subject.compileAndLint(code)
-            }
+            """
 
             it("has found something") {
-                assertThat(result).hasSize(1)
+                assertThat(subject.compileAndLint(code)).hasSize(1)
             }
 
             it("correct message") {
-                assertThat(result[0]).hasMessage(
+                assertThat(subject.compileAndLint(code)[0]).hasMessage(
                     "@deprecated tag block does not properly report " +
                         "deprecation in Kotlin, use @Deprecated annotation instead"
                 )

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/DeprecatedBlockTagSpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/DeprecatedBlockTagSpec.kt
@@ -1,0 +1,150 @@
+package io.gitlab.arturbosch.detekt.rules.documentation
+
+import io.gitlab.arturbosch.detekt.api.Finding
+import io.gitlab.arturbosch.detekt.test.assertThat
+import io.gitlab.arturbosch.detekt.test.compileAndLint
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+class DeprecatedBlockTagSpec : Spek({
+    val subject by memoized { DeprecatedBlockTag() }
+    describe("DeprecatedBlockTag rule") {
+        it("does not report regular kdoc block") {
+            val code = """
+                /**
+                 * This is just a regular kdoc block.
+                 *
+                 * Nothing to see here...
+                 */
+                val v = 2
+                """
+            assertThat(subject.compileAndLint(code)).hasSize(0)
+        }
+
+        describe("reporting deprecation tag on kdoc block") {
+            var result = listOf<Finding>()
+            beforeEachTest {
+                val code = """
+                /**
+                 * I am a KDoc block
+                 * 
+                 * @deprecated oh no, this should not be here
+                 */
+                fun ohNo() { }
+                """
+                result = subject.compileAndLint(code)
+            }
+
+            it("has found something") {
+                assertThat(result).hasSize(1)
+            }
+
+            it("correct message") {
+                assertThat(result[0]).hasMessage(
+                    "@deprecated tag block does not properly report " +
+                        "deprecation in Kotlin, use @Deprecated annotation instead"
+                )
+            }
+        }
+
+        describe("reporting deprecation tag wherever @Deprecated is available") {
+
+            it("report deprecation tag on class") {
+                val code = """
+                /**
+                 * Hello there
+                 *
+                 * @deprecated This thing is deprecated
+                 */
+                class Thing { }
+                """
+                assertThat(subject.compileAndLint(code)).hasSize(1)
+            }
+
+            it("report deprecation tag on property") {
+                val code = """
+                class Thing {
+                    /**
+                     * A thing you should not use
+                     *
+                     * @deprecated Do not use that
+                     */
+                    val doNotUseMe = 0
+                }
+                """
+                assertThat(subject.compileAndLint(code)).hasSize(1)
+            }
+
+            it("report deprecation tag on annotation class") {
+                val code = """
+                    /**
+                     * An annotation you should not use
+                     *
+                     * @deprecated Do not use that
+                     */
+                    annotation class Thing()
+                """
+                assertThat(subject.compileAndLint(code)).hasSize(1)
+            }
+
+            it("report deprecation tag on constructor") {
+                val code = """
+                    class Thing {
+                        /**
+                         * A constructor you should not use
+                         *
+                         * @deprecated Do not use that
+                         */
+                        constructor(something: String) {
+                        }
+                    }
+                """
+                assertThat(subject.compileAndLint(code)).hasSize(1)
+            }
+
+            it("report deprecation tag on property setter") {
+                val code = """
+                    class Thing {
+                        var someProperty: Int
+                            get() = 10
+                            /**
+                             * Do not use this setter
+                             * 
+                             * @deprecated Do not use it
+                             */
+                            set(value) = { println(value) }
+                    }
+                """
+                assertThat(subject.compileAndLint(code)).hasSize(1)
+            }
+
+            it("report deprecation tag on property getter") {
+                val code = """
+                    class Thing {
+                        var someProperty: Int
+                            /**
+                             * Do not use this getter
+                             * 
+                             * @deprecated Do not use it
+                             */
+                            get() = 10
+                            set(value) = { println(value) }
+                    }
+                """
+                assertThat(subject.compileAndLint(code)).hasSize(1)
+            }
+
+            it("report deprecation tag on typealias") {
+                val code = """
+                    /**
+                     * This alias is pointless, do not use it
+                     *
+                     * @deprecated Do not use this typealias
+                     */
+                    typealias VeryString = String
+                """
+                assertThat(subject.compileAndLint(code)).hasSize(1)
+            }
+        }
+    }
+})

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/EndOfSentenceFormatSpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/EndOfSentenceFormatSpec.kt
@@ -6,7 +6,7 @@ import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
 class EndOfSentenceFormatSpec : Spek({
-    val subject by memoized { KDocStyle() }
+    val subject by memoized { EndOfSentenceFormat() }
 
     describe("KDocStyle rule") {
 


### PR DESCRIPTION
<!-- A similar PR may already be submitted!
Please search among the [Pull requests](https://github.com/detekt/detekt/pulls) before creating one.

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Link to relevant issues if possible.

For more information, see the [CONTRIBUTING guide](https://github.com/detekt/detekt/blob/main/.github/CONTRIBUTING.md).
-->

This PR adds a rule that checks for `@deprecated` tags in KDoc comments. These tags are [discouraged by the official Kotlin documentation as they work in Java but do nothing in Kotlin](https://kotlinlang.org/docs/kotlin-doc.html)

> KDoc does not support the `@deprecated` tag. Instead, please use the `@Deprecated` annotation.

This is a fairly important rule for people who come from Java and used `@deprecated` in their Javadoc. IntelliJ IDEA does not actually warn about this.

This is quite a simple rule too, feel free to tell me if I did anything wrong!

Also fixed a bug where `EndOfSentenceFormat` did not work on its own, and its tests relied on `KDocStyle` instead of `EndOfSentenceFormat`.