### PR TITLE
Ignore actual members in UnusedPrivateMember

### DIFF
--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
@@ -11,6 +11,7 @@ import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
 import io.gitlab.arturbosch.detekt.rules.isAbstract
+import io.gitlab.arturbosch.detekt.rules.isActual
 import io.gitlab.arturbosch.detekt.rules.isExpect
 import io.gitlab.arturbosch.detekt.rules.isExternal
 import io.gitlab.arturbosch.detekt.rules.isMainFunction
@@ -255,7 +256,8 @@ private class UnusedParameterVisitor(allowedNames: Regex) : UnusedMemberVisitor(
     private fun KtNamedFunction.isRelevant() = !isAllowedToHaveUnusedParameters()
 
     private fun KtNamedFunction.isAllowedToHaveUnusedParameters() =
-        isAbstract() || isOpen() || isOverride() || isOperator() || isMainFunction() || isExternal() || isExpect()
+        isAbstract() || isOpen() || isOverride() || isOperator() || isMainFunction() || isExternal() ||
+            isExpect() || isActual()
 }
 
 private class UnusedPropertyVisitor(allowedNames: Regex) : UnusedMemberVisitor(allowedNames) {
@@ -292,7 +294,10 @@ private class UnusedPropertyVisitor(allowedNames: Regex) : UnusedMemberVisitor(a
     override fun visitPrimaryConstructor(constructor: KtPrimaryConstructor) {
         super.visitPrimaryConstructor(constructor)
         constructor.valueParameters
-            .filter { (it.isPrivate() || !it.hasValOrVar()) && it.containingClassOrObject?.isExpect() == false }
+            .filter {
+                (it.isPrivate() || (!it.hasValOrVar() && !constructor.isActual())) &&
+                    it.containingClassOrObject?.isExpect() == false
+            }
             .forEach { maybeAddUnusedProperty(it) }
     }
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMemberSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMemberSpec.kt
@@ -84,17 +84,31 @@ class UnusedPrivateMemberSpec : Spek({
 
     describe("actual functions and classes") {
 
-        it("reports unused parameters in actual functions") {
+        it("should not report unused parameters in actual functions") {
             val code = """
                 actual class Foo {
                     actual fun bar(i: Int) {}
                     actual fun baz(i: Int, s: String) {}
                 }
             """
-            assertThat(subject.lint(code)).hasSize(3)
+            assertThat(subject.lint(code)).isEmpty()
         }
 
-        it("reports unused parameters in constructors") {
+        it("should not report unused parameters in actual constructors") {
+            val code = """
+                actual class Foo actual constructor(bar: String) {}
+            """
+            assertThat(subject.lint(code)).isEmpty()
+        }
+
+        it("should not report unused actual fields defined as parameters of primary constructors") {
+            val code = """
+                actual class Foo actual constructor(actual val bar: String) {}
+            """
+            assertThat(subject.lint(code)).isEmpty()
+        }
+
+        it("reports unused private fields defined as parameters of primary constructors") {
             val code = """
                 actual class Foo actual constructor(private val bar: String) {}
             """


### PR DESCRIPTION
The general rule of thumb should be:
- if a rule is ignored for `abstract` members, it should be ignored for `expect` members,
- if a rule is ignored for **overridden** members, it should be ignored for `actual` members.

See also:
- #3388
- #3390

Related to #3415
