### PR TITLE
Add support for fallback property

### DIFF
--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/ConfigProperty.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/ConfigProperty.kt
@@ -7,10 +7,10 @@ import kotlin.reflect.KProperty
 fun <T : Any> config(defaultValue: T): ReadOnlyProperty<ConfigAware, T> =
     SimpleConfigProperty(defaultValue)
 
-fun <T : Any> fallbackConfig(fallbackProperty: String, defaultValue: T): ReadOnlyProperty<ConfigAware, T> =
+fun <T : Any> configWithFallback(fallbackProperty: String, defaultValue: T): ReadOnlyProperty<ConfigAware, T> =
     FallbackConfigProperty(fallbackProperty, defaultValue)
 
-fun listConfig(defaultValue: List<String>): ReadOnlyProperty<ConfigAware, List<String>> =
+fun configList(defaultValue: List<String>): ReadOnlyProperty<ConfigAware, List<String>> =
     ListConfigProperty(defaultValue)
 
 private class SimpleConfigProperty<T : Any>(private val defaultValue: T) : ReadOnlyProperty<ConfigAware, T> {

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/ConfigProperty.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/ConfigProperty.kt
@@ -13,12 +13,22 @@ fun <T : Any> configWithFallback(fallbackPropertyName: String, defaultValue: T):
 private fun <T : Any> getValueOrDefault(configAware: ConfigAware, propertyName: String, defaultValue: T): T {
     @Suppress("UNCHECKED_CAST")
     return when (defaultValue) {
-        is List<*> -> configAware.valueOrDefaultCommaSeparated(propertyName, defaultValue as List<String>) as T
+        is List<*> -> {
+            if (defaultValue.all { it is String }) {
+                val defaultValueAsListOfStrings = defaultValue as List<String>
+                configAware.valueOrDefaultCommaSeparated(propertyName, defaultValueAsListOfStrings) as T
+            } else {
+                error("Only lists of strings are supported. '$propertyName' is invalid. ")
+            }
+        }
         is String,
         is Boolean,
         is Int,
         is Long -> configAware.valueOrDefault(propertyName, defaultValue)
-        else -> error("${defaultValue.javaClass} is not supported as ")
+        else -> error(
+            "${defaultValue.javaClass} is not supported for delegated config property '$propertyName'. " +
+                "Use one of String, Boolean, Int, Long or List<String> instead."
+        )
     }
 }
 

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/ConfigProperty.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/ConfigProperty.kt
@@ -4,14 +4,14 @@ import io.gitlab.arturbosch.detekt.api.ConfigAware
 import kotlin.properties.ReadOnlyProperty
 import kotlin.reflect.KProperty
 
-fun config(defaultValue: List<String>): ReadOnlyProperty<ConfigAware, List<String>> =
-    ListConfigProperty(defaultValue)
-
 fun <T : Any> config(defaultValue: T): ReadOnlyProperty<ConfigAware, T> =
     SimpleConfigProperty(defaultValue)
 
-fun <T : Any> config(fallbackProperty: String, defaultValue: T): ReadOnlyProperty<ConfigAware, T> =
+fun <T : Any> fallbackConfig(fallbackProperty: String, defaultValue: T): ReadOnlyProperty<ConfigAware, T> =
     FallbackConfigProperty(fallbackProperty, defaultValue)
+
+fun listConfig(defaultValue: List<String>): ReadOnlyProperty<ConfigAware, List<String>> =
+    ListConfigProperty(defaultValue)
 
 private class SimpleConfigProperty<T : Any>(private val defaultValue: T) : ReadOnlyProperty<ConfigAware, T> {
     override fun getValue(thisRef: ConfigAware, property: KProperty<*>): T {

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/ConfigProperty.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/ConfigProperty.kt
@@ -7,8 +7,8 @@ import kotlin.reflect.KProperty
 fun <T : Any> config(defaultValue: T): ReadOnlyProperty<ConfigAware, T> =
     SimpleConfigProperty(defaultValue)
 
-fun <T : Any> configWithFallback(fallbackProperty: String, defaultValue: T): ReadOnlyProperty<ConfigAware, T> =
-    FallbackConfigProperty(fallbackProperty, defaultValue)
+fun <T : Any> configWithFallback(fallbackPropertyName: String, defaultValue: T): ReadOnlyProperty<ConfigAware, T> =
+    FallbackConfigProperty(fallbackPropertyName, defaultValue)
 
 fun configList(defaultValue: List<String>): ReadOnlyProperty<ConfigAware, List<String>> =
     ListConfigProperty(defaultValue)
@@ -20,11 +20,11 @@ private class SimpleConfigProperty<T : Any>(private val defaultValue: T) : ReadO
 }
 
 private class FallbackConfigProperty<T : Any>(
-    private val fallbackProperty: String,
+    private val fallbackPropertyName: String,
     private val defaultValue: T
 ) : ReadOnlyProperty<ConfigAware, T> {
     override fun getValue(thisRef: ConfigAware, property: KProperty<*>): T {
-        return thisRef.valueOrDefault(property.name, thisRef.valueOrDefault(fallbackProperty, defaultValue))
+        return thisRef.valueOrDefault(property.name, thisRef.valueOrDefault(fallbackPropertyName, defaultValue))
     }
 }
 

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/ConfigProperty.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/ConfigProperty.kt
@@ -4,18 +4,27 @@ import io.gitlab.arturbosch.detekt.api.ConfigAware
 import kotlin.properties.ReadOnlyProperty
 import kotlin.reflect.KProperty
 
-fun config(defaultValue: String): ReadOnlyProperty<ConfigAware, String> = simpleConfig(defaultValue)
-fun config(defaultValue: Int): ReadOnlyProperty<ConfigAware, Int> = simpleConfig(defaultValue)
-fun config(defaultValue: Long): ReadOnlyProperty<ConfigAware, Long> = simpleConfig(defaultValue)
-fun config(defaultValue: Boolean): ReadOnlyProperty<ConfigAware, Boolean> = simpleConfig(defaultValue)
-fun config(defaultValue: List<String>): ReadOnlyProperty<ConfigAware, List<String>> = ListConfigProperty(defaultValue)
+fun config(defaultValue: List<String>): ReadOnlyProperty<ConfigAware, List<String>> =
+    ListConfigProperty(defaultValue)
 
-private fun <T : Any> simpleConfig(defaultValue: T): ReadOnlyProperty<ConfigAware, T> =
+fun <T : Any> config(defaultValue: T): ReadOnlyProperty<ConfigAware, T> =
     SimpleConfigProperty(defaultValue)
+
+fun <T : Any> config(fallbackProperty: String, defaultValue: T): ReadOnlyProperty<ConfigAware, T> =
+    FallbackConfigProperty(fallbackProperty, defaultValue)
 
 private class SimpleConfigProperty<T : Any>(private val defaultValue: T) : ReadOnlyProperty<ConfigAware, T> {
     override fun getValue(thisRef: ConfigAware, property: KProperty<*>): T {
         return thisRef.valueOrDefault(property.name, defaultValue)
+    }
+}
+
+private class FallbackConfigProperty<T : Any>(
+    private val fallbackProperty: String,
+    private val defaultValue: T
+) : ReadOnlyProperty<ConfigAware, T> {
+    override fun getValue(thisRef: ConfigAware, property: KProperty<*>): T {
+        return thisRef.valueOrDefault(property.name, thisRef.valueOrDefault(fallbackProperty, defaultValue))
     }
 }
 

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/internal/ConfigPropertySpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/internal/ConfigPropertySpec.kt
@@ -9,6 +9,9 @@ import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
+private val A_REGEX = Regex("a-z")
+private val A_LIST_OF_INTS = listOf(1)
+
 class ConfigPropertySpec : Spek({
 
     describe("Config property delegate") {
@@ -56,35 +59,31 @@ class ConfigPropertySpec : Spek({
             }
         }
         context("Boolean property") {
-            val configValue = false
-            val defaultValue = true
             val subject by memoized {
-                object : TestConfigAware("present" to configValue) {
-                    val present: Boolean by config(defaultValue)
-                    val notPresent: Boolean by config(defaultValue)
+                object : TestConfigAware("present" to false) {
+                    val present: Boolean by config(true)
+                    val notPresent: Boolean by config(true)
                 }
             }
             it("uses the value provided in config if present") {
-                assertThat(subject.present).isEqualTo(configValue)
+                assertThat(subject.present).isEqualTo(false)
             }
             it("uses the default value if not present") {
-                assertThat(subject.notPresent).isEqualTo(defaultValue)
+                assertThat(subject.notPresent).isEqualTo(true)
             }
         }
         context("Boolean property defined as string") {
-            val configValue = false
-            val defaultValue = true
             val subject by memoized {
-                object : TestConfigAware("present" to "$configValue") {
-                    val present: Boolean by config(defaultValue)
-                    val notPresent: Boolean by config(defaultValue)
+                object : TestConfigAware("present" to "false") {
+                    val present: Boolean by config(true)
+                    val notPresent: Boolean by config(true)
                 }
             }
             it("uses the value provided in config if present") {
-                assertThat(subject.present).isEqualTo(configValue)
+                assertThat(subject.present).isEqualTo(false)
             }
             it("uses the default value if not present") {
-                assertThat(subject.notPresent).isEqualTo(defaultValue)
+                assertThat(subject.notPresent).isEqualTo(true)
             }
         }
         context("String list property") {
@@ -139,12 +138,10 @@ class ConfigPropertySpec : Spek({
             }
         }
         context("Invalid property type") {
-            val defaultRegex = Regex("a-z")
-            val defaultList = listOf(1)
             val subject by memoized {
                 object : TestConfigAware() {
-                    val regexProp: Regex by config(defaultRegex)
-                    val listProp: List<Int> by config(defaultList)
+                    val regexProp: Regex by config(A_REGEX)
+                    val listProp: List<Int> by config(A_LIST_OF_INTS)
                 }
             }
             it("fails when invalid regex property is accessed") {

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/internal/ConfigPropertySpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/internal/ConfigPropertySpec.kt
@@ -1,0 +1,101 @@
+package io.gitlab.arturbosch.detekt.api.internal
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.ConfigAware
+import io.gitlab.arturbosch.detekt.api.RuleId
+import io.gitlab.arturbosch.detekt.test.TestConfig
+import org.assertj.core.api.Assertions.assertThat
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+class ConfigPropertySpec : Spek({
+
+    describe("Config property delegate") {
+        context("string property") {
+            val configValue = "value"
+            val defaultValue = "default"
+            val subject by memoized {
+                object : TestConfigAware("present" to configValue) {
+                    val present: String by config(defaultValue)
+                    val notPresent: String by config(defaultValue)
+                }
+            }
+            it("uses the value provided in config if present") {
+                assertThat(subject.present).isEqualTo(configValue)
+            }
+            it("uses the default value if not present") {
+                assertThat(subject.notPresent).isEqualTo(defaultValue)
+            }
+        }
+        context("Int property") {
+            val configValue = 99
+            val defaultValue = -1
+            val subject by memoized {
+                object : TestConfigAware("present" to configValue) {
+                    val present: Int by config(defaultValue)
+                    val notPresent: Int by config(defaultValue)
+                }
+            }
+            it("uses the value provided in config if present") {
+                assertThat(subject.present).isEqualTo(configValue)
+            }
+            it("uses the default value if not present") {
+                assertThat(subject.notPresent).isEqualTo(defaultValue)
+            }
+        }
+        context("Int property defined as string") {
+            val configValue = 99
+            val subject by memoized {
+                object : TestConfigAware("present" to "$configValue") {
+                    val present: Int by config(-1)
+                }
+            }
+            it("uses the value provided in config if present") {
+                assertThat(subject.present).isEqualTo(configValue)
+            }
+        }
+        context("String list property") {
+            val defaultValue by memoized { listOf("x") }
+            val subject by memoized {
+                object : TestConfigAware("present" to "a,b,c") {
+                    val present: List<String> by config(defaultValue)
+                    val notPresent: List<String> by config(defaultValue)
+                }
+            }
+            it("uses the value provided in config if present") {
+                assertThat(subject.present).isEqualTo(listOf("a", "b", "c"))
+            }
+            it("uses the default value if not present") {
+                assertThat(subject.notPresent).isEqualTo(defaultValue)
+            }
+        }
+        context("Int property with fallback") {
+            val configValue = 99
+            val defaultValue = 0
+            val fallbackValue = -1
+            val subject by memoized {
+                object : TestConfigAware("present" to "$configValue", "fallback" to fallbackValue) {
+                    val present: Int by config("fallback", defaultValue)
+                    val notPresentWithFallback: Int by config("fallback", defaultValue)
+                    val notPresentFallbackMissing: Int by config("missing", defaultValue)
+                }
+            }
+            it("uses the value provided in config if present") {
+                assertThat(subject.present).isEqualTo(configValue)
+            }
+            it("uses the value from fallback property if value is missing and fallback exists") {
+                assertThat(subject.notPresentWithFallback).isEqualTo(fallbackValue)
+            }
+            it("uses the default value if not present") {
+                assertThat(subject.notPresentFallbackMissing).isEqualTo(defaultValue)
+            }
+        }
+    }
+})
+
+private open class TestConfigAware(private vararg val data: Pair<String, Any>) : ConfigAware {
+    override val ruleId: RuleId
+        get() = "test"
+    override val ruleSetConfig: Config
+        get() = TestConfig(data.toMap())
+}

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/internal/ConfigPropertySpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/internal/ConfigPropertySpec.kt
@@ -58,8 +58,8 @@ class ConfigPropertySpec : Spek({
             val defaultValue by memoized { listOf("x") }
             val subject by memoized {
                 object : TestConfigAware("present" to "a,b,c") {
-                    val present: List<String> by config(defaultValue)
-                    val notPresent: List<String> by config(defaultValue)
+                    val present: List<String> by listConfig(defaultValue)
+                    val notPresent: List<String> by listConfig(defaultValue)
                 }
             }
             it("uses the value provided in config if present") {
@@ -75,9 +75,9 @@ class ConfigPropertySpec : Spek({
             val fallbackValue = -1
             val subject by memoized {
                 object : TestConfigAware("present" to "$configValue", "fallback" to fallbackValue) {
-                    val present: Int by config("fallback", defaultValue)
-                    val notPresentWithFallback: Int by config("fallback", defaultValue)
-                    val notPresentFallbackMissing: Int by config("missing", defaultValue)
+                    val present: Int by fallbackConfig("fallback", defaultValue)
+                    val notPresentWithFallback: Int by fallbackConfig("fallback", defaultValue)
+                    val notPresentFallbackMissing: Int by fallbackConfig("missing", defaultValue)
                 }
             }
             it("uses the value provided in config if present") {

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/internal/ConfigPropertySpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/internal/ConfigPropertySpec.kt
@@ -58,8 +58,8 @@ class ConfigPropertySpec : Spek({
             val defaultValue by memoized { listOf("x") }
             val subject by memoized {
                 object : TestConfigAware("present" to "a,b,c") {
-                    val present: List<String> by configList(defaultValue)
-                    val notPresent: List<String> by configList(defaultValue)
+                    val present: List<String> by config(defaultValue)
+                    val notPresent: List<String> by config(defaultValue)
                 }
             }
             it("uses the value provided in config if present") {

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/internal/ConfigPropertySpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/internal/ConfigPropertySpec.kt
@@ -58,8 +58,8 @@ class ConfigPropertySpec : Spek({
             val defaultValue by memoized { listOf("x") }
             val subject by memoized {
                 object : TestConfigAware("present" to "a,b,c") {
-                    val present: List<String> by listConfig(defaultValue)
-                    val notPresent: List<String> by listConfig(defaultValue)
+                    val present: List<String> by configList(defaultValue)
+                    val notPresent: List<String> by configList(defaultValue)
                 }
             }
             it("uses the value provided in config if present") {
@@ -75,9 +75,9 @@ class ConfigPropertySpec : Spek({
             val fallbackValue = -1
             val subject by memoized {
                 object : TestConfigAware("present" to "$configValue", "fallback" to fallbackValue) {
-                    val present: Int by fallbackConfig("fallback", defaultValue)
-                    val notPresentWithFallback: Int by fallbackConfig("fallback", defaultValue)
-                    val notPresentFallbackMissing: Int by fallbackConfig("missing", defaultValue)
+                    val present: Int by configWithFallback("fallback", defaultValue)
+                    val notPresentWithFallback: Int by configWithFallback("fallback", defaultValue)
+                    val notPresentFallbackMissing: Int by configWithFallback("missing", defaultValue)
                 }
             }
             it("uses the value provided in config if present") {

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/ConfigurationCollector.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/ConfigurationCollector.kt
@@ -78,7 +78,7 @@ class ConfigurationCollector {
             }
         }
         if (!isInitializedWithConfigDelegate()) {
-            invalidDocumentation { "'$name' is not using the '$DELEGATE_NAME' delegate" }
+            invalidDocumentation { "'$name' is not using one of the config property delegates ($DELEGATE_NAMES)" }
         }
 
         val propertyName: String = checkNotNull(name)
@@ -113,7 +113,8 @@ class ConfigurationCollector {
     }
 
     private fun KtPropertyDelegate.getDefaultValueExpression(): KtExpression {
-        val arguments = (expression as KtCallExpression).valueArguments
+        val callExpression = expression as KtCallExpression
+        val arguments = callExpression.valueArguments
         if (arguments.size == 1) {
             return checkNotNull(arguments[0].getArgumentExpression())
         }
@@ -124,7 +125,10 @@ class ConfigurationCollector {
     }
 
     companion object {
-        private const val DELEGATE_NAME = "config"
+        private const val SIMPLE_DELEGATE_NAME = "config"
+        private const val LIST_DELEGATE_NAME = "listConfig"
+        private const val FALLBACK_DELEGATE_NAME = "fallbackConfig"
+        private val DELEGATE_NAMES = listOf(SIMPLE_DELEGATE_NAME, LIST_DELEGATE_NAME, FALLBACK_DELEGATE_NAME)
         private const val DEFAULT_VALUE_ARGUMENT_NAME = "defaultValue"
         private const val LIST_OF = "listOf"
         private const val EMPTY_LIST = "emptyList"
@@ -150,7 +154,7 @@ class ConfigurationCollector {
             findDescendantOfType { it.isListDeclaration() }
 
         private fun KtProperty.isInitializedWithConfigDelegate(): Boolean =
-            delegate?.expression?.referenceExpression()?.text == DELEGATE_NAME
+            delegate?.expression?.referenceExpression()?.text in DELEGATE_NAMES
 
         private fun KtProperty.hasSupportedType(): Boolean =
             declaredTypeOrNull in SUPPORTED_TYPES

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/ConfigurationCollector.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/ConfigurationCollector.kt
@@ -1,9 +1,9 @@
 package io.gitlab.arturbosch.detekt.generator.collection
 
-import io.gitlab.arturbosch.detekt.generator.collection.ConfigurationCollector.FallbackConfigPropertySupport.FALLBACK_DELEGATE_NAME
-import io.gitlab.arturbosch.detekt.generator.collection.ConfigurationCollector.FallbackConfigPropertySupport.getFallbackPropertyName
-import io.gitlab.arturbosch.detekt.generator.collection.ConfigurationCollector.FallbackConfigPropertySupport.isFallbackConfigDelegate
-import io.gitlab.arturbosch.detekt.generator.collection.ConfigurationCollector.FallbackConfigPropertySupport.isUsingInvalidFallbackReference
+import io.gitlab.arturbosch.detekt.generator.collection.ConfigurationCollector.ConfigWithFallbackSupport.FALLBACK_DELEGATE_NAME
+import io.gitlab.arturbosch.detekt.generator.collection.ConfigurationCollector.ConfigWithFallbackSupport.getFallbackPropertyName
+import io.gitlab.arturbosch.detekt.generator.collection.ConfigurationCollector.ConfigWithFallbackSupport.isFallbackConfigDelegate
+import io.gitlab.arturbosch.detekt.generator.collection.ConfigurationCollector.ConfigWithFallbackSupport.isUsingInvalidFallbackReference
 import io.gitlab.arturbosch.detekt.generator.collection.exception.InvalidDocumentationException
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtConstantExpression
@@ -134,8 +134,8 @@ class ConfigurationCollector {
         return checkNotNull(defaultArgument.getArgumentExpression())
     }
 
-    private object FallbackConfigPropertySupport {
-        const val FALLBACK_DELEGATE_NAME = "fallbackConfig"
+    private object ConfigWithFallbackSupport {
+        const val FALLBACK_DELEGATE_NAME = "configWithFallback"
         private const val FALLBACK_ARGUMENT_NAME = "fallbackProperty"
 
         fun KtProperty.isFallbackConfigDelegate(): Boolean =
@@ -156,7 +156,7 @@ class ConfigurationCollector {
 
     companion object {
         private const val SIMPLE_DELEGATE_NAME = "config"
-        private const val LIST_DELEGATE_NAME = "listConfig"
+        private const val LIST_DELEGATE_NAME = "configList"
         private val DELEGATE_NAMES = listOf(SIMPLE_DELEGATE_NAME, LIST_DELEGATE_NAME, FALLBACK_DELEGATE_NAME)
         private const val DEFAULT_VALUE_ARGUMENT_NAME = "defaultValue"
         private const val LIST_OF = "listOf"

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/ConfigurationCollector.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/ConfigurationCollector.kt
@@ -136,7 +136,7 @@ class ConfigurationCollector {
 
     private object ConfigWithFallbackSupport {
         const val FALLBACK_DELEGATE_NAME = "configWithFallback"
-        private const val FALLBACK_ARGUMENT_NAME = "fallbackProperty"
+        private const val FALLBACK_ARGUMENT_NAME = "fallbackPropertyName"
 
         fun KtProperty.isFallbackConfigDelegate(): Boolean =
             delegate?.expression?.referenceExpression()?.text == FALLBACK_DELEGATE_NAME

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/ConfigurationCollector.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/ConfigurationCollector.kt
@@ -156,8 +156,7 @@ class ConfigurationCollector {
 
     companion object {
         private const val SIMPLE_DELEGATE_NAME = "config"
-        private const val LIST_DELEGATE_NAME = "configList"
-        private val DELEGATE_NAMES = listOf(SIMPLE_DELEGATE_NAME, LIST_DELEGATE_NAME, FALLBACK_DELEGATE_NAME)
+        private val DELEGATE_NAMES = listOf(SIMPLE_DELEGATE_NAME, FALLBACK_DELEGATE_NAME)
         private const val DEFAULT_VALUE_ARGUMENT_NAME = "defaultValue"
         private const val LIST_OF = "listOf"
         private const val EMPTY_LIST = "emptyList"

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleCollectorSpec.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleCollectorSpec.kt
@@ -221,7 +221,7 @@ class RuleCollectorSpec : Spek({
                          */
                         class SomeRandomClass() : Rule {
                             @Configuration("description")
-                            private val config: List<String> by config(
+                            private val config: List<String> by listConfig(
                                 listOf(
                                     "a", 
                                     "b"
@@ -327,10 +327,10 @@ class RuleCollectorSpec : Spek({
                          */
                         class SomeRandomClass() : Rule {
                             @Configuration("description")
-                            private val config1: List<String> by config(DEFAULT_CONFIG_VALUE)
+                            private val config1: List<String> by listConfig(DEFAULT_CONFIG_VALUE)
 
                             @Configuration("description")
-                            private val config2: List<String> by config(listOf(DEFAULT_CONFIG_VALUE_A, "b"))
+                            private val config2: List<String> by listConfig(listOf(DEFAULT_CONFIG_VALUE_A, "b"))
 
                             companion object {
                                 private val DEFAULT_CONFIG_VALUE = listOf("a", "b")
@@ -351,10 +351,10 @@ class RuleCollectorSpec : Spek({
                          */
                         class SomeRandomClass() : Rule {
                             @Configuration("description")
-                            private val config1: List<String> by config(listOf())
+                            private val config1: List<String> by listConfig(listOf())
 
                             @Configuration("description")
-                            private val config2: List<String> by config(emptyList())
+                            private val config2: List<String> by listConfig(emptyList())
 
                             companion object {
                                 private val DEFAULT_CONFIG_VALUE_A = "a"
@@ -453,11 +453,11 @@ class RuleCollectorSpec : Spek({
                          */
                         class SomeRandomClass() : Rule {
                             @Configuration("description")
-                            private val config1: Int by config("prop", 99)
+                            private val config1: Int by fallbackConfig("prop", 99)
                             @Configuration("description")
-                            private val config2: Int by config(fallbackProperty = "prop", defaultValue = 99)
+                            private val config2: Int by fallbackConfig(fallbackProperty = "prop", defaultValue = 99)
                             @Configuration("description")
-                            private val config3: Int by config(defaultValue = 99, fallbackProperty = "prop")
+                            private val config3: Int by fallbackConfig(defaultValue = 99, fallbackProperty = "prop")
                         }                        
                     """
                         val items = subject.run(code)

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleCollectorSpec.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleCollectorSpec.kt
@@ -457,9 +457,9 @@ class RuleCollectorSpec : Spek({
                             @Configuration("description")
                             private val config1: Int by configWithFallback("prop", 99)
                             @Configuration("description")
-                            private val config2: Int by configWithFallback(fallbackProperty = "prop", defaultValue = 99)
+                            private val config2: Int by configWithFallback(fallbackPropertyName = "prop", defaultValue = 99)
                             @Configuration("description")
-                            private val config3: Int by configWithFallback(defaultValue = 99, fallbackProperty = "prop")
+                            private val config3: Int by configWithFallback(defaultValue = 99, fallbackPropertyName = "prop")
                         }                        
                     """
                         val items = subject.run(code)

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleCollectorSpec.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleCollectorSpec.kt
@@ -151,8 +151,8 @@ class RuleCollectorSpec : Spek({
             assertThat(items[0].aliases).isEqualTo("RULE, RULE2")
         }
 
-        describe("collects configuration options") {
-            describe("using annotation") {
+        context("collects configuration options") {
+            context("using annotation") {
                 it("contains no configuration options by default") {
                     val code = """
                         /**
@@ -445,9 +445,29 @@ class RuleCollectorSpec : Spek({
                     """
                     assertThatExceptionOfType(InvalidDocumentationException::class.java).isThrownBy { subject.run(code) }
                 }
+                context("fallback property") {
+                    it("extracts default value") {
+                        val code = """
+                        /**
+                         * description
+                         */
+                        class SomeRandomClass() : Rule {
+                            @Configuration("description")
+                            private val config1: Int by config("prop", 99)
+                            @Configuration("description")
+                            private val config2: Int by config(fallbackProperty = "prop", defaultValue = 99)
+                            @Configuration("description")
+                            private val config3: Int by config(defaultValue = 99, fallbackProperty = "prop")
+                        }                        
+                    """
+                        val items = subject.run(code)
+                        assertThat(items[0].configuration).hasSize(3)
+                        assertThat(items[0].configuration.map { it.defaultValue }).containsOnly("99")
+                    }
+                }
             }
 
-            describe("as part of kdoc") {
+            context("as part of kdoc") {
                 it("contains no configuration options by default") {
                     val code = """
                         /**
@@ -532,7 +552,7 @@ class RuleCollectorSpec : Spek({
             }
         }
 
-        describe("collects type resolution information") {
+        context("collects type resolution information") {
             it("has no type resolution by default") {
                 val code = """
                     /**

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleCollectorSpec.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleCollectorSpec.kt
@@ -221,7 +221,7 @@ class RuleCollectorSpec : Spek({
                          */
                         class SomeRandomClass() : Rule {
                             @Configuration("description")
-                            private val config: List<String> by configList(
+                            private val config: List<String> by config(
                                 listOf(
                                     "a", 
                                     "b"
@@ -327,10 +327,10 @@ class RuleCollectorSpec : Spek({
                          */
                         class SomeRandomClass() : Rule {
                             @Configuration("description")
-                            private val config1: List<String> by configList(DEFAULT_CONFIG_VALUE)
+                            private val config1: List<String> by config(DEFAULT_CONFIG_VALUE)
 
                             @Configuration("description")
-                            private val config2: List<String> by configList(listOf(DEFAULT_CONFIG_VALUE_A, "b"))
+                            private val config2: List<String> by config(listOf(DEFAULT_CONFIG_VALUE_A, "b"))
 
                             companion object {
                                 private val DEFAULT_CONFIG_VALUE = listOf("a", "b")
@@ -351,10 +351,10 @@ class RuleCollectorSpec : Spek({
                          */
                         class SomeRandomClass() : Rule {
                             @Configuration("description")
-                            private val config1: List<String> by configList(listOf())
+                            private val config1: List<String> by config(listOf())
 
                             @Configuration("description")
-                            private val config2: List<String> by configList(emptyList())
+                            private val config2: List<String> by config(emptyList())
 
                             companion object {
                                 private val DEFAULT_CONFIG_VALUE_A = "a"

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleCollectorSpec.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleCollectorSpec.kt
@@ -221,7 +221,7 @@ class RuleCollectorSpec : Spek({
                          */
                         class SomeRandomClass() : Rule {
                             @Configuration("description")
-                            private val config: List<String> by listConfig(
+                            private val config: List<String> by configList(
                                 listOf(
                                     "a", 
                                     "b"
@@ -327,10 +327,10 @@ class RuleCollectorSpec : Spek({
                          */
                         class SomeRandomClass() : Rule {
                             @Configuration("description")
-                            private val config1: List<String> by listConfig(DEFAULT_CONFIG_VALUE)
+                            private val config1: List<String> by configList(DEFAULT_CONFIG_VALUE)
 
                             @Configuration("description")
-                            private val config2: List<String> by listConfig(listOf(DEFAULT_CONFIG_VALUE_A, "b"))
+                            private val config2: List<String> by configList(listOf(DEFAULT_CONFIG_VALUE_A, "b"))
 
                             companion object {
                                 private val DEFAULT_CONFIG_VALUE = listOf("a", "b")
@@ -351,10 +351,10 @@ class RuleCollectorSpec : Spek({
                          */
                         class SomeRandomClass() : Rule {
                             @Configuration("description")
-                            private val config1: List<String> by listConfig(listOf())
+                            private val config1: List<String> by configList(listOf())
 
                             @Configuration("description")
-                            private val config2: List<String> by listConfig(emptyList())
+                            private val config2: List<String> by configList(emptyList())
 
                             companion object {
                                 private val DEFAULT_CONFIG_VALUE_A = "a"
@@ -455,11 +455,11 @@ class RuleCollectorSpec : Spek({
                             @Configuration("description")
                             private val prop: Int by config(1)
                             @Configuration("description")
-                            private val config1: Int by fallbackConfig("prop", 99)
+                            private val config1: Int by configWithFallback("prop", 99)
                             @Configuration("description")
-                            private val config2: Int by fallbackConfig(fallbackProperty = "prop", defaultValue = 99)
+                            private val config2: Int by configWithFallback(fallbackProperty = "prop", defaultValue = 99)
                             @Configuration("description")
-                            private val config3: Int by fallbackConfig(defaultValue = 99, fallbackProperty = "prop")
+                            private val config3: Int by configWithFallback(defaultValue = 99, fallbackProperty = "prop")
                         }                        
                     """
                         val items = subject.run(code)
@@ -475,7 +475,7 @@ class RuleCollectorSpec : Spek({
                          */
                         class SomeRandomClass() : Rule {
                             @Configuration("description")
-                            private val config: Int by fallbackConfig("prop", 99)
+                            private val config: Int by configWithFallback("prop", 99)
                         }                        
                     """
                         assertThatExceptionOfType(InvalidDocumentationException::class.java).isThrownBy {
@@ -493,7 +493,7 @@ class RuleCollectorSpec : Spek({
                         class SomeRandomClass() : Rule {
                             private val prop: Int = 1
                             @Configuration("description")
-                            private val config: Int by fallbackConfig("prop", 99)
+                            private val config: Int by configWithFallback("prop", 99)
                         }                        
                     """
                         assertThatExceptionOfType(InvalidDocumentationException::class.java).isThrownBy {

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexMethod.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexMethod.kt
@@ -12,6 +12,7 @@ import io.gitlab.arturbosch.detekt.api.ThresholdedCodeSmell
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
 import io.gitlab.arturbosch.detekt.api.internal.Configuration
 import io.gitlab.arturbosch.detekt.api.internal.config
+import io.gitlab.arturbosch.detekt.api.internal.listConfig
 import org.jetbrains.kotlin.psi.KtBlockExpression
 import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.psi.KtNamedFunction
@@ -53,7 +54,7 @@ class ComplexMethod(config: Config = Config.empty) : Rule(config) {
     private val ignoreNestingFunctions: Boolean by config(false)
 
     @Configuration("Comma separated list of function names which add complexity.")
-    private val nestingFunctions: List<String> by config(DEFAULT_NESTING_FUNCTIONS)
+    private val nestingFunctions: List<String> by listConfig(DEFAULT_NESTING_FUNCTIONS)
 
     override val issue = Issue(
         "ComplexMethod",

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexMethod.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexMethod.kt
@@ -12,7 +12,6 @@ import io.gitlab.arturbosch.detekt.api.ThresholdedCodeSmell
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
 import io.gitlab.arturbosch.detekt.api.internal.Configuration
 import io.gitlab.arturbosch.detekt.api.internal.config
-import io.gitlab.arturbosch.detekt.api.internal.configList
 import org.jetbrains.kotlin.psi.KtBlockExpression
 import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.psi.KtNamedFunction
@@ -54,7 +53,7 @@ class ComplexMethod(config: Config = Config.empty) : Rule(config) {
     private val ignoreNestingFunctions: Boolean by config(false)
 
     @Configuration("Comma separated list of function names which add complexity.")
-    private val nestingFunctions: List<String> by configList(DEFAULT_NESTING_FUNCTIONS)
+    private val nestingFunctions: List<String> by config(DEFAULT_NESTING_FUNCTIONS)
 
     override val issue = Issue(
         "ComplexMethod",

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexMethod.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexMethod.kt
@@ -12,7 +12,7 @@ import io.gitlab.arturbosch.detekt.api.ThresholdedCodeSmell
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
 import io.gitlab.arturbosch.detekt.api.internal.Configuration
 import io.gitlab.arturbosch.detekt.api.internal.config
-import io.gitlab.arturbosch.detekt.api.internal.listConfig
+import io.gitlab.arturbosch.detekt.api.internal.configList
 import org.jetbrains.kotlin.psi.KtBlockExpression
 import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.psi.KtNamedFunction
@@ -54,7 +54,7 @@ class ComplexMethod(config: Config = Config.empty) : Rule(config) {
     private val ignoreNestingFunctions: Boolean by config(false)
 
     @Configuration("Comma separated list of function names which add complexity.")
-    private val nestingFunctions: List<String> by listConfig(DEFAULT_NESTING_FUNCTIONS)
+    private val nestingFunctions: List<String> by configList(DEFAULT_NESTING_FUNCTIONS)
 
     override val issue = Issue(
         "ComplexMethod",


### PR DESCRIPTION
This PR relates to #3670 and adds support for annotated properties that have been renamed. Example:

**without annotation**
```kotlin
    private val functionThreshold: Int =
        valueOrDefault(FUNCTION_THRESHOLD, valueOrDefault(THRESHOLD, DEFAULT_FUNCTION_THRESHOLD))
```

**with annotation**
```kotlin
    private val functionThreshold: Int  by fallbackConfig(
        fallbackProperty = "threshold", 
        defaultValue = DEFAULT_FUNCTION_THRESHOLD
    )
```