### PR TITLE
Add support for transformer function in config property delegate

### DIFF
--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/internal/ConfigPropertySpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/internal/ConfigPropertySpec.kt
@@ -256,6 +256,21 @@ class ConfigPropertySpec : Spek({
                     assertThat(subject.notPresent).isEqualTo(99)
                 }
             }
+            context("empty list of strings") {
+                val subject by memoized {
+                    object : TestConfigAware() {
+                        val defaultValue: List<String> = emptyList()
+                        val prop1: List<Int> by config(defaultValue) { it.map(String::toInt) }
+                        val prop2: List<Int> by config(listOf<String>()) { it.map(String::toInt) }
+                    }
+                }
+                it("can be defined as variable") {
+                    assertThat(subject.prop1).isEmpty()
+                }
+                it("can be defined using listOf<String>()") {
+                    assertThat(subject.prop2).isEmpty()
+                }
+            }
             context("memoization") {
                 val subject by memoized {
                     object : TestConfigAware() {

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/internal/ConfigPropertySpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/internal/ConfigPropertySpec.kt
@@ -8,151 +8,324 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
-
-private val A_REGEX = Regex("a-z")
-private val A_LIST_OF_INTS = listOf(1)
+import java.util.concurrent.atomic.AtomicInteger
 
 class ConfigPropertySpec : Spek({
 
     describe("Config property delegate") {
-        context("string property") {
-            val configValue = "value"
-            val defaultValue = "default"
-            val subject by memoized {
-                object : TestConfigAware("present" to configValue) {
-                    val present: String by config(defaultValue)
-                    val notPresent: String by config(defaultValue)
+        context("simple property") {
+            context("String property") {
+                val configValue = "value"
+                val defaultValue = "default"
+                val subject by memoized {
+                    object : TestConfigAware("present" to configValue) {
+                        val present: String by config(defaultValue)
+                        val notPresent: String by config(defaultValue)
+                    }
+                }
+                it("uses the value provided in config if present") {
+                    assertThat(subject.present).isEqualTo(configValue)
+                }
+                it("uses the default value if not present") {
+                    assertThat(subject.notPresent).isEqualTo(defaultValue)
                 }
             }
-            it("uses the value provided in config if present") {
-                assertThat(subject.present).isEqualTo(configValue)
+            context("Int property") {
+                val configValue = 99
+                val defaultValue = -1
+
+                context("defined as number") {
+                    val subject by memoized {
+                        object : TestConfigAware("present" to configValue) {
+                            val present: Int by config(defaultValue)
+                            val notPresent: Int by config(defaultValue)
+                        }
+                    }
+                    it("uses the value provided in config if present") {
+                        assertThat(subject.present).isEqualTo(configValue)
+                    }
+                    it("uses the default value if not present") {
+                        assertThat(subject.notPresent).isEqualTo(defaultValue)
+                    }
+                }
+                context("defined as string") {
+                    val subject by memoized {
+                        object : TestConfigAware("present" to "$configValue") {
+                            val present: Int by config(defaultValue)
+                        }
+                    }
+                    it("uses the value provided in config if present") {
+                        assertThat(subject.present).isEqualTo(configValue)
+                    }
+                }
             }
-            it("uses the default value if not present") {
-                assertThat(subject.notPresent).isEqualTo(defaultValue)
+            context("Boolean property") {
+                val configValue by memoized { false }
+                val defaultValue by memoized { true }
+
+                context("defined as Boolean") {
+                    val subject by memoized {
+                        object : TestConfigAware("present" to configValue) {
+                            val present: Boolean by config(defaultValue)
+                            val notPresent: Boolean by config(defaultValue)
+                        }
+                    }
+                    it("uses the value provided in config if present") {
+                        assertThat(subject.present).isEqualTo(configValue)
+                    }
+                    it("uses the default value if not present") {
+                        assertThat(subject.notPresent).isEqualTo(defaultValue)
+                    }
+                }
+                context("defined as string") {
+                    val subject by memoized {
+                        object : TestConfigAware("present" to "$configValue") {
+                            val present: Boolean by config(defaultValue)
+                        }
+                    }
+                    it("uses the value provided in config if present") {
+                        assertThat(subject.present).isEqualTo(configValue)
+                    }
+                }
+            }
+            context("List property") {
+                val defaultValue by memoized { listOf("x") }
+                context("defined as list") {
+                    val subject by memoized {
+                        object : TestConfigAware("present" to "a,b,c") {
+                            val present: List<String> by config(defaultValue)
+                            val notPresent: List<String> by config(defaultValue)
+                        }
+                    }
+                    it("uses the value provided in config if present") {
+                        assertThat(subject.present).isEqualTo(listOf("a", "b", "c"))
+                    }
+                    it("uses the default value if not present") {
+                        assertThat(subject.notPresent).isEqualTo(defaultValue)
+                    }
+                }
+                context("defined as comma separated string") {
+                    val subject by memoized {
+                        object : TestConfigAware("present" to "a,b,c") {
+                            val present: List<String> by config(defaultValue)
+                            val notPresent: List<String> by config(defaultValue)
+                        }
+                    }
+                    it("uses the value provided in config if present") {
+                        assertThat(subject.present).isEqualTo(listOf("a", "b", "c"))
+                    }
+                    it("uses the default value if not present") {
+                        assertThat(subject.notPresent).isEqualTo(defaultValue)
+                    }
+                }
             }
         }
-        context("Int property") {
-            val configValue = 99
-            val defaultValue = -1
-            val subject by memoized {
-                object : TestConfigAware("present" to configValue) {
-                    val present: Int by config(defaultValue)
-                    val notPresent: Int by config(defaultValue)
+        context("invalid type") {
+            context("Long") {
+                val defaultValue by memoized { 1L }
+                val subject by memoized {
+                    object : TestConfigAware() {
+                        val prop: Long by config(defaultValue)
+                    }
+                }
+                it("throws") {
+                    assertThatThrownBy { subject.prop }
+                        .isInstanceOf(IllegalStateException::class.java)
+                        .hasMessageContaining("is not supported")
                 }
             }
-            it("uses the value provided in config if present") {
-                assertThat(subject.present).isEqualTo(configValue)
+            context("Regex") {
+                val defaultValue by memoized { Regex("a") }
+                val subject by memoized {
+                    object : TestConfigAware() {
+                        val prop: Regex by config(defaultValue)
+                    }
+                }
+                it("throws") {
+                    assertThatThrownBy { subject.prop }
+                        .isInstanceOf(IllegalStateException::class.java)
+                        .hasMessageContaining("is not supported")
+                }
             }
-            it("uses the default value if not present") {
-                assertThat(subject.notPresent).isEqualTo(defaultValue)
+            context("Set") {
+                val defaultValue by memoized { setOf("a") }
+                val subject by memoized {
+                    object : TestConfigAware() {
+                        val prop: Set<String> by config(defaultValue)
+                    }
+                }
+                it("throws") {
+                    assertThatThrownBy { subject.prop }
+                        .isInstanceOf(IllegalStateException::class.java)
+                        .hasMessageContaining("is not supported")
+                }
+            }
+            context("List of Int") {
+                val defaultValue by memoized { listOf(1) }
+                val subject by memoized {
+                    object : TestConfigAware() {
+                        val prop: List<Int> by config(defaultValue)
+                    }
+                }
+                it("throws") {
+                    assertThatThrownBy { subject.prop }
+                        .isInstanceOf(IllegalStateException::class.java)
+                        .hasMessageContaining("lists of strings are supported")
+                }
             }
         }
-        context("Int property defined as string") {
-            val configValue = 99
-            val subject by memoized {
-                object : TestConfigAware("present" to "$configValue") {
-                    val present: Int by config(-1)
+
+        context("transform") {
+            context("primitive") {
+                context("String property is transformed to regex") {
+                    val defaultValue = ".*"
+                    val configValue = "[a-z]+"
+                    val subject by memoized {
+                        object : TestConfigAware("present" to configValue) {
+                            val present: Regex by config(defaultValue) { it.toRegex() }
+                            val notPresent: Regex by config(defaultValue) { it.toRegex() }
+                        }
+                    }
+                    it("applies the mapping function to the configured value") {
+                        assertThat(subject.present.matches("abc")).isTrue
+                        assertThat(subject.present.matches("123")).isFalse()
+                    }
+                    it("applies the mapping function to the default") {
+                        assertThat(subject.notPresent.matches("abc")).isTrue
+                        assertThat(subject.notPresent.matches("123")).isTrue
+                    }
+                }
+                context("Int property is transformed to String") {
+                    val configValue = 99
+                    val defaultValue = -1
+                    val subject by memoized {
+                        object : TestConfigAware("present" to configValue) {
+                            val present: String by config(defaultValue) { it.toString() }
+                            val notPresent: String by config(defaultValue) { it.toString() }
+                        }
+                    }
+                    it("applies the mapping function to the configured value") {
+                        assertThat(subject.present).isEqualTo("$configValue")
+                    }
+                    it("applies the mapping function to the default") {
+                        assertThat(subject.notPresent).isEqualTo("$defaultValue")
+                    }
+                }
+                context("Boolean property is transformed to String") {
+                    val configValue by memoized { true }
+                    val defaultValue by memoized { false }
+                    val subject by memoized {
+                        object : TestConfigAware("present" to configValue) {
+                            val present: String by config(defaultValue) { it.toString() }
+                            val notPresent: String by config(defaultValue) { it.toString() }
+                        }
+                    }
+                    it("applies the mapping function to the configured value") {
+                        assertThat(subject.present).isEqualTo("$configValue")
+                    }
+                    it("applies the mapping function to the default") {
+                        assertThat(subject.notPresent).isEqualTo("$defaultValue")
+                    }
+                }
+                context("Boolean property is transformed to String with function reference") {
+                    val defaultValue by memoized { false }
+                    val subject by memoized {
+                        object : TestConfigAware() {
+                            val prop1: String by config(defaultValue, Boolean::toString)
+                            val prop2: String by config(transformer = Boolean::toString, defaultValue = defaultValue)
+                        }
+                    }
+                    it("transforms properties") {
+                        assertThat(subject.prop1).isEqualTo("$defaultValue")
+                        assertThat(subject.prop2).isEqualTo("$defaultValue")
+                    }
                 }
             }
-            it("uses the value provided in config if present") {
-                assertThat(subject.present).isEqualTo(configValue)
+            context("list of strings") {
+                val defaultValue by memoized { listOf("99") }
+                val subject by memoized {
+                    object : TestConfigAware("present" to "1,2,3") {
+                        val present: Int by config(defaultValue) { it.sumBy(String::toInt) }
+                        val notPresent: Int by config(defaultValue) { it.sumBy(String::toInt) }
+                    }
+                }
+                it("applies transformer to list configured") {
+                    assertThat(subject.present).isEqualTo(6)
+                }
+                it("applies transformer to default list") {
+                    assertThat(subject.notPresent).isEqualTo(99)
+                }
+            }
+            context("memoization") {
+                val subject by memoized {
+                    object : TestConfigAware() {
+                        val counter = AtomicInteger(0)
+                        val prop: String by config(1) {
+                            counter.getAndIncrement()
+                            it.toString()
+                        }
+
+                        fun useProperty(): String {
+                            return "something with $prop"
+                        }
+                    }
+                }
+                it("transformer is called only once") {
+                    repeat(5) {
+                        assertThat(subject.useProperty()).isEqualTo("something with 1")
+                    }
+                    assertThat(subject.counter.get()).isEqualTo(1)
+                }
             }
         }
-        context("Boolean property") {
-            val subject by memoized {
-                object : TestConfigAware("present" to false) {
-                    val present: Boolean by config(true)
-                    val notPresent: Boolean by config(true)
+        context("configWithFallback") {
+            context("primitive") {
+                val configValue = 99
+                val defaultValue = 0
+                val fallbackValue = -1
+                val subject by memoized {
+                    object : TestConfigAware("present" to "$configValue", "fallback" to fallbackValue) {
+                        val present: Int by configWithFallback("fallback", defaultValue)
+                        val notPresentWithFallback: Int by configWithFallback("fallback", defaultValue)
+                        val notPresentFallbackMissing: Int by configWithFallback("missing", defaultValue)
+                    }
+                }
+                it("uses the value provided in config if present") {
+                    assertThat(subject.present).isEqualTo(configValue)
+                }
+                it("uses the value from fallback property if value is missing and fallback exists") {
+                    assertThat(subject.notPresentWithFallback).isEqualTo(fallbackValue)
+                }
+                it("uses the default value if not present") {
+                    assertThat(subject.notPresentFallbackMissing).isEqualTo(defaultValue)
                 }
             }
-            it("uses the value provided in config if present") {
-                assertThat(subject.present).isEqualTo(false)
-            }
-            it("uses the default value if not present") {
-                assertThat(subject.notPresent).isEqualTo(true)
-            }
-        }
-        context("Boolean property defined as string") {
-            val subject by memoized {
-                object : TestConfigAware("present" to "false") {
-                    val present: Boolean by config(true)
-                    val notPresent: Boolean by config(true)
+            context("with transformation") {
+                val configValue = 99
+                val defaultValue = 0
+                val fallbackValue = -1
+                val subject by memoized {
+                    object : TestConfigAware("present" to configValue, "fallback" to fallbackValue) {
+                        val present: String by configWithFallback("fallback", defaultValue) { v ->
+                            v.toString()
+                        }
+                        val notPresentWithFallback: String by configWithFallback("fallback", defaultValue) { v ->
+                            v.toString()
+                        }
+                        val notPresentFallbackMissing: String by configWithFallback("missing", defaultValue) { v ->
+                            v.toString()
+                        }
+                    }
                 }
-            }
-            it("uses the value provided in config if present") {
-                assertThat(subject.present).isEqualTo(false)
-            }
-            it("uses the default value if not present") {
-                assertThat(subject.notPresent).isEqualTo(true)
-            }
-        }
-        context("String list property") {
-            val defaultValue by memoized { listOf("x") }
-            val subject by memoized {
-                object : TestConfigAware("present" to listOf("a", "b", "c")) {
-                    val present: List<String> by config(defaultValue)
-                    val notPresent: List<String> by config(defaultValue)
+                it("uses the value provided in config if present") {
+                    assertThat(subject.present).isEqualTo("$configValue")
                 }
-            }
-            it("uses the value provided in config if present") {
-                assertThat(subject.present).isEqualTo(listOf("a", "b", "c"))
-            }
-            it("uses the default value if not present") {
-                assertThat(subject.notPresent).isEqualTo(defaultValue)
-            }
-        }
-        context("String list property defined as comma separated string") {
-            val defaultValue by memoized { listOf("x") }
-            val subject by memoized {
-                object : TestConfigAware("present" to "a,b,c") {
-                    val present: List<String> by config(defaultValue)
-                    val notPresent: List<String> by config(defaultValue)
+                it("uses the value from fallback property if value is missing and fallback exists") {
+                    assertThat(subject.notPresentWithFallback).isEqualTo("$fallbackValue")
                 }
-            }
-            it("uses the value provided in config if present") {
-                assertThat(subject.present).isEqualTo(listOf("a", "b", "c"))
-            }
-            it("uses the default value if not present") {
-                assertThat(subject.notPresent).isEqualTo(defaultValue)
-            }
-        }
-        context("Int property with fallback") {
-            val configValue = 99
-            val defaultValue = 0
-            val fallbackValue = -1
-            val subject by memoized {
-                object : TestConfigAware("present" to "$configValue", "fallback" to fallbackValue) {
-                    val present: Int by configWithFallback("fallback", defaultValue)
-                    val notPresentWithFallback: Int by configWithFallback("fallback", defaultValue)
-                    val notPresentFallbackMissing: Int by configWithFallback("missing", defaultValue)
+                it("uses the default value if not present") {
+                    assertThat(subject.notPresentFallbackMissing).isEqualTo("$defaultValue")
                 }
-            }
-            it("uses the value provided in config if present") {
-                assertThat(subject.present).isEqualTo(configValue)
-            }
-            it("uses the value from fallback property if value is missing and fallback exists") {
-                assertThat(subject.notPresentWithFallback).isEqualTo(fallbackValue)
-            }
-            it("uses the default value if not present") {
-                assertThat(subject.notPresentFallbackMissing).isEqualTo(defaultValue)
-            }
-        }
-        context("Invalid property type") {
-            val subject by memoized {
-                object : TestConfigAware() {
-                    val regexProp: Regex by config(A_REGEX)
-                    val listProp: List<Int> by config(A_LIST_OF_INTS)
-                }
-            }
-            it("fails when invalid regex property is accessed") {
-                assertThatThrownBy { subject.regexProp }
-                    .isInstanceOf(IllegalStateException::class.java)
-                    .hasMessageContaining("kotlin.text.Regex is not supported")
-            }
-            it("fails when invalid list property is accessed") {
-                assertThatThrownBy { subject.listProp }
-                    .isInstanceOf(IllegalStateException::class.java)
-                    .hasMessageContaining("Only lists of strings are supported")
             }
         }
     }

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleCollectorSpec.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleCollectorSpec.kt
@@ -369,9 +369,27 @@ object RuleCollectorSpec : Spek({
 
                             @Configuration("description")
                             private val config2: List<String> by config(emptyList())
+                        }                        
+                    """
+                    val items = subject.run(code)
+                    assertThat(items[0].configuration[0].defaultValue).isEqualTo("[]")
+                    assertThat(items[0].configuration[1].defaultValue).isEqualTo("[]")
+                }
+
+                it("extracts emptyList default value of transformed list") {
+                    val code = """
+                        /**
+                         * description
+                         */
+                        class SomeRandomClass() : Rule {
+                            @Configuration("description")
+                            private val config1: List<Int> by config(listOf<String>()) { it.map(String::toInt) }
+
+                            @Configuration("description")
+                            private val config2: List<Int> by config(DEFAULT_CONFIG_VALUE) { it.map(String::toInt) }
 
                             companion object {
-                                private val DEFAULT_CONFIG_VALUE_A = "a"
+                                private val DEFAULT_CONFIG_VALUE: List<String> = emptyList()
                             }
                         }                        
                     """

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexMethod.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexMethod.kt
@@ -53,7 +53,7 @@ class ComplexMethod(config: Config = Config.empty) : Rule(config) {
     private val ignoreNestingFunctions: Boolean by config(false)
 
     @Configuration("Comma separated list of function names which add complexity.")
-    private val nestingFunctions: List<String> by config(DEFAULT_NESTING_FUNCTIONS)
+    private val nestingFunctions: Set<String> by config(DEFAULT_NESTING_FUNCTIONS) { it.toSet() }
 
     override val issue = Issue(
         "ComplexMethod",
@@ -61,8 +61,6 @@ class ComplexMethod(config: Config = Config.empty) : Rule(config) {
         "Prefer splitting up complex methods into smaller, easier to understand methods.",
         Debt.TWENTY_MINS
     )
-
-    private val nestingFunctionsAsSet: Set<String> = nestingFunctions.toSet()
 
     override fun visitNamedFunction(function: KtNamedFunction) {
         if (ignoreSingleWhenExpression && hasSingleWhenExpression(function.bodyExpression)) {
@@ -72,7 +70,7 @@ class ComplexMethod(config: Config = Config.empty) : Rule(config) {
         val complexity = CyclomaticComplexity.calculate(function) {
             this.ignoreSimpleWhenEntries = this@ComplexMethod.ignoreSimpleWhenEntries
             this.ignoreNestingFunctions = this@ComplexMethod.ignoreNestingFunctions
-            this.nestingFunctions = this@ComplexMethod.nestingFunctionsAsSet
+            this.nestingFunctions = this@ComplexMethod.nestingFunctions
         }
 
         if (complexity >= threshold) {


### PR DESCRIPTION
This relates to [a comment](https://github.com/detekt/detekt/issues/3670#issuecomment-817337889) by @BraisGabin in #3670 addressing situations in which the configured values must be transformed.

This PR:
* allows config values to be converted into anything else using a transformer function (by lambda or method reference)
* adds memoization  to all config values (similar to LazyRegex)
* increases test coverage for ConfigurationCollector and ConfigProperty
* removes Long from supported config types as it is not supported by BaseConfig 

**Examples:**
```kotlin
val aSet: Set<String> by config(listOf("a", "b")) { it.toSet() }

val aRegex: Regex by config("[0-9]*", String::toRegex)
    
val anotherRegex: Regex by configWithFallback("fallback", "[0-9]*") { it.toRegex() }
```
This would also resolve #3672