### PR TITLE
 MultilineLambdaItParameter: don't report when lambda has no implicit parameter references

### DIFF
--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MultilineLambdaItParameter.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MultilineLambdaItParameter.kt
@@ -9,8 +9,13 @@ import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.rules.IT_LITERAL
+import org.jetbrains.kotlin.descriptors.ValueParameterDescriptor
 import org.jetbrains.kotlin.psi.KtLambdaExpression
+import org.jetbrains.kotlin.psi.KtNameReferenceExpression
+import org.jetbrains.kotlin.psi.psiUtil.anyDescendantOfType
+import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
 import org.jetbrains.kotlin.resolve.BindingContext
+import org.jetbrains.kotlin.resolve.calls.callUtil.getResolvedCall
 
 /**
  * Lambda expressions are very useful in a lot of cases and they often include very small chunks of
@@ -91,7 +96,10 @@ class MultilineLambdaItParameter(val config: Config) : Rule(config) {
                 )
             // Implicit `it`
             parameterNames.isEmpty() -> {
-                if (lambdaExpression.hasImplicitParameter(bindingContext)) {
+                val implicitParameter = lambdaExpression.implicitParameter(bindingContext)
+                if (implicitParameter != null &&
+                    lambdaExpression.hasImplicitParameterReference(implicitParameter, bindingContext)
+                ) {
                     report(
                         CodeSmell(
                             issue,
@@ -106,7 +114,26 @@ class MultilineLambdaItParameter(val config: Config) : Rule(config) {
         }
     }
 
-    private fun KtLambdaExpression.hasImplicitParameter(bindingContext: BindingContext): Boolean {
-        return (bindingContext[BindingContext.FUNCTION, functionLiteral]?.valueParameters?.singleOrNull()) != null
+    private fun KtLambdaExpression.implicitParameter(bindingContext: BindingContext): ValueParameterDescriptor? {
+        return bindingContext[BindingContext.FUNCTION, functionLiteral]?.valueParameters?.singleOrNull()
+    }
+
+    private fun KtLambdaExpression.hasImplicitParameterReference(
+        implicitParameter: ValueParameterDescriptor,
+        bindingContext: BindingContext
+    ): Boolean {
+        return anyDescendantOfType<KtNameReferenceExpression> {
+            it.isImplicitParameterReference(this, implicitParameter, bindingContext)
+        }
+    }
+
+    private fun KtNameReferenceExpression.isImplicitParameterReference(
+        lambda: KtLambdaExpression,
+        implicitParameter: ValueParameterDescriptor,
+        bindingContext: BindingContext
+    ): Boolean {
+        return text == "it" &&
+            getStrictParentOfType<KtLambdaExpression>() == lambda &&
+            getResolvedCall(bindingContext)?.resultingDescriptor == implicitParameter
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MultilineLambdaItParameterSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MultilineLambdaItParameterSpec.kt
@@ -58,6 +58,8 @@ class MultilineLambdaItParameterSpec : Spek({
                     foo {
                         println(1)
                         println(2)
+                        val it = 3
+                        println(it)
                     }
                 }"""
                 val findings = subject.compileAndLintWithContext(env, code)

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MultilineLambdaItParameterSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MultilineLambdaItParameterSpec.kt
@@ -50,6 +50,19 @@ class MultilineLambdaItParameterSpec : Spek({
                 val findings = subject.compileAndLintWithContext(env, code)
                 assertThat(findings).isEmpty()
             }
+
+            it("does not report when lambda has no implicit parameter references") {
+                val code = """
+                fun foo(f: (Int) -> Unit) {}
+                fun main() {
+                    foo {
+                        println(1)
+                        println(2)
+                    }
+                }"""
+                val findings = subject.compileAndLintWithContext(env, code)
+                assertThat(findings).isEmpty()
+            }
         }
 
         context("single parameter, multiline lambda with a single statement") {


### PR DESCRIPTION
Fixes #3570