### PR TITLE
(Try to) improve CI build reliability

### DIFF
--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -23,16 +23,6 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
-
-      # Let's cleanup the gradle cache folders to make sure
-      # we don't accidentally cache stale files.
-    - name: Cleanup Gradle Folders
-      shell: bash
-      run: |
-        rm -rf ~/.gradle/caches/ && \
-        rm -rf ~/.gradle/wrapper/
-
-
     - name: Cache Gradle Folders
       uses: actions/cache@v2
       with:
@@ -44,22 +34,17 @@ jobs:
           cache-gradle-${{ matrix.os }}-${{ matrix.jdk }}-
           cache-gradle-${{ matrix.os }}-
           cache-gradle-
-
-
     - name: Setup Java
       uses: actions/setup-java@v2
       with:
         java-version: ${{ matrix.jdk }}
         distribution: 'adopt'
-
-
     - name: Build detekt
       run: ./gradlew build moveJarForIntegrationTest -x detekt
     - name: Run detekt-cli --help
       run: java -jar ./build/detekt-cli-all.jar --help
     - name: Run detekt-cli with argsfile
       run: java -jar ./build/detekt-cli-all.jar "@./config/detekt/argsfile"
-
 
   verify-generated-config-file:
     if: ${{ !contains(github.event.head_commit.message, 'ci skip') }}
@@ -88,7 +73,6 @@ jobs:
         distribution: 'adopt'
     - name: Verify Generated Detekt Config File
       run: ./gradlew verifyGeneratorOutput
-
 
   compile-test-snippets:
     if: ${{ !contains(github.event.head_commit.message, 'ci skip') }}

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/GradleVersionTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/GradleVersionTest.kt
@@ -5,34 +5,29 @@ import io.gitlab.arturbosch.detekt.testkit.DslTestBuilder.Companion.kotlin
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.TaskOutcome
 import org.spekframework.spek2.Spek
+import org.spekframework.spek2.dsl.Skip
 import org.spekframework.spek2.style.specification.describe
 
 object GradleVersionTest : Spek({
 
-    val testedGradleVersions = getGradleVersionsUnderTest()
+    val gradleVersion = "5.4"
 
-    describe("detekt plugin running on different Gradle versions") {
+    describe(
+        "detekt plugin running on oldest supported Gradle version",
+        skip = if (getJdkVersion() < 13) Skip.No else Skip.Yes("Gradle $gradleVersion unsupported on this Java version")
+    ) {
         listOf(groovy().dryRun(), kotlin().dryRun()).forEach { builder ->
             describe("using ${builder.gradleBuildName}") {
-                testedGradleVersions.forEach { gradleVersion ->
-                    it("runs on version $gradleVersion of Gradle") {
-                        val gradleRunner = builder.withGradleVersion(gradleVersion).build()
-                        gradleRunner.runDetektTaskAndCheckResult { result ->
-                            assertThat(result.task(":detekt")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
-                        }
+                it("runs on version $gradleVersion of Gradle") {
+                    val gradleRunner = builder.withGradleVersion(gradleVersion).build()
+                    gradleRunner.runDetektTaskAndCheckResult { result ->
+                        assertThat(result.task(":detekt")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
                     }
                 }
             }
         }
     }
 })
-
-private fun getGradleVersionsUnderTest() =
-    if (getJdkVersion() < 13) {
-        listOf("5.4", "6.7")
-    } else {
-        listOf("6.7")
-    }
 
 private fun getJdkVersion(): Int {
     val version = System.getProperty("java.version")

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,5 +2,4 @@ kotlin.code.style=official
 systemProp.sonar.host.url=http://localhost:9000
 systemProp.file.encoding=UTF-8
 org.gradle.parallel=true
-org.gradle.workers.max=4
 org.gradle.caching=true


### PR DESCRIPTION
These changes should all help, or at least not make things any worse, by:
* reducing work done (by dropping one of the multi-Gradle version tests)
* ~~reducing memory use (by not allocation 2GB heap for each Gradle integration test - 512MB is the default, and unless there are OOM errors there shouldn't be any need to increase this)~~
* reducing CPU contention during heavy load during the build (by reducing max worker count from 4 to # of CPUs, which is 2 on Windows & Linux CI runners and 3 on macOS)