### PR TITLE
Update to setup-java@v2

### DIFF
--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -47,9 +47,10 @@ jobs:
 
 
     - name: Setup Java
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v2
       with:
         java-version: ${{ matrix.jdk }}
+        distribution: 'adopt'
 
 
     - name: Build detekt
@@ -74,16 +75,17 @@ jobs:
         path: |
           ~/.gradle/caches/
           ~/.gradle/wrapper/
-        key: cache-gradle-ubuntu-latest-14-verifygenerator-${{ hashFiles('detekt-bom/build.gradle.kts') }}
+        key: cache-gradle-ubuntu-latest-11-verifygenerator-${{ hashFiles('detekt-bom/build.gradle.kts') }}
         restore-keys: |
-          cache-gradle-ubuntu-latest-14-verifygenerator-
-          cache-gradle-ubuntu-latest-14-
+          cache-gradle-ubuntu-latest-11-verifygenerator-
+          cache-gradle-ubuntu-latest-11-
           cache-gradle-ubuntu-latest-
           cache-gradle-
     - name: Setup Java
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v2
       with:
-        java-version: 14
+        java-version: 11
+        distribution: 'adopt'
     - name: Verify Generated Detekt Config File
       run: ./gradlew verifyGeneratorOutput --stacktrace
 
@@ -102,15 +104,16 @@ jobs:
           path: |
             ~/.gradle/caches/
             ~/.gradle/wrapper/
-          key: cache-gradle-ubuntu-latest-14-compiletestsnippets-${{ hashFiles('detekt-bom/build.gradle.kts') }}
+          key: cache-gradle-ubuntu-latest-11-compiletestsnippets-${{ hashFiles('detekt-bom/build.gradle.kts') }}
           restore-keys: |
-            cache-gradle-ubuntu-latest-14-compiletestsnippets-
-            cache-gradle-ubuntu-latest-14-
+            cache-gradle-ubuntu-latest-11-compiletestsnippets-
+            cache-gradle-ubuntu-latest-11-
             cache-gradle-ubuntu-latest-
             cache-gradle-
       - name: Setup Java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
-          java-version: 15
+          java-version: 11
+          distribution: 'adopt'
       - name: Build and compile test snippets
         run: ./gradlew test -x ":detekt-gradle-plugin:test" -Pcompile-test-snippets=true --stacktrace


### PR DESCRIPTION
* Use AdoptJDK distribution which is the distribution cached on runners
* Use LTS version of Java for generated config file verification & test snippet compilation tasks