### PR TITLE
Remove deprecated Gradle config option

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -2,10 +2,6 @@ plugins {
     `kotlin-dsl`
 }
 
-kotlinDslPluginOptions {
-    experimentalWarning.set(false)
-}
-
 repositories {
     mavenLocal() // used to publish and test local gradle plugin changes
     mavenCentral()


### PR DESCRIPTION
Flag has no effect since `kotlin-dsl` no longer relies on experimental features.