### PR TITLE
Update Kotlin to 1.5

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,6 +9,9 @@ plugins {
     detekt
     id("com.github.ben-manes.versions")
     id("org.sonarqube")
+
+    // remove once Kotlin 1.5.10 is released (https://youtrack.jetbrains.com/issue/KT-46368)
+    id("dev.zacsweers.kgp-150-leak-patcher") version "1.1.0"
 }
 
 allprojects {

--- a/buildSrc/src/main/kotlin/module.gradle.kts
+++ b/buildSrc/src/main/kotlin/module.gradle.kts
@@ -55,7 +55,12 @@ tasks.withType<KotlinCompile>().configureEach {
             "-Xopt-in=kotlin.RequiresOptIn"
         )
         // Usage: <code>./gradlew build -PwarningsAsErrors=true</code>.
-        allWarningsAsErrors = project.findProperty("warningsAsErrors") == "true" || System.getenv("CI") == "true"
+        // Note: currently there are warnings for detekt-gradle-plugin that seemingly can't be fixed
+        //       until Gradle releases an update (https://github.com/gradle/gradle/issues/16345)
+        allWarningsAsErrors = when (project.name) {
+            "detekt-gradle-plugin" -> false
+            else -> (project.findProperty("warningsAsErrors") == "true" || System.getenv("CI") == "true")
+        }
     }
 }
 

--- a/buildSrc/src/main/kotlin/module.gradle.kts
+++ b/buildSrc/src/main/kotlin/module.gradle.kts
@@ -49,7 +49,7 @@ tasks.withType<Test>().configureEach {
 tasks.withType<KotlinCompile>().configureEach {
     kotlinOptions {
         jvmTarget = Versions.JVM_TARGET
-        languageVersion = "1.4"
+        languageVersion = "1.5"
         freeCompilerArgs = listOf(
             "-progressive",
             "-Xopt-in=kotlin.RequiresOptIn"

--- a/detekt-api/api/detekt-api.api
+++ b/detekt-api/api/detekt-api.api
@@ -13,6 +13,7 @@ public class io/gitlab/arturbosch/detekt/api/CodeSmell : io/gitlab/arturbosch/de
 	public fun getEntity ()Lio/gitlab/arturbosch/detekt/api/Entity;
 	public fun getFile ()Ljava/lang/String;
 	public fun getId ()Ljava/lang/String;
+	public final fun getInternalSeverity$detekt_api ()Lio/gitlab/arturbosch/detekt/api/SeverityLevel;
 	public final fun getIssue ()Lio/gitlab/arturbosch/detekt/api/Issue;
 	public fun getLocation ()Lio/gitlab/arturbosch/detekt/api/Location;
 	public fun getMessage ()Ljava/lang/String;
@@ -23,6 +24,7 @@ public class io/gitlab/arturbosch/detekt/api/CodeSmell : io/gitlab/arturbosch/de
 	public fun getStartPosition ()Lio/gitlab/arturbosch/detekt/api/SourceLocation;
 	public fun messageOrDescription ()Ljava/lang/String;
 	public fun metricByType (Ljava/lang/String;)Lio/gitlab/arturbosch/detekt/api/Metric;
+	public final fun setInternalSeverity$detekt_api (Lio/gitlab/arturbosch/detekt/api/SeverityLevel;)V
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -435,6 +437,10 @@ public abstract interface class io/gitlab/arturbosch/detekt/api/PropertiesAware 
 	public abstract fun register (Ljava/lang/String;Ljava/lang/Object;)V
 }
 
+public final class io/gitlab/arturbosch/detekt/api/PropertiesAwareKt {
+	public static final synthetic fun getOrNull (Lio/gitlab/arturbosch/detekt/api/PropertiesAware;Ljava/lang/String;)Ljava/lang/Object;
+}
+
 public abstract interface class io/gitlab/arturbosch/detekt/api/ReportingExtension : io/gitlab/arturbosch/detekt/api/Extension {
 	public abstract fun onFinalResult (Lio/gitlab/arturbosch/detekt/api/Detektion;)V
 	public abstract fun onRawResult (Lio/gitlab/arturbosch/detekt/api/Detektion;)V
@@ -464,6 +470,7 @@ public abstract class io/gitlab/arturbosch/detekt/api/Rule : io/gitlab/arturbosc
 	public fun getParentPath ()Ljava/lang/String;
 	public final fun getRuleId ()Ljava/lang/String;
 	public fun getRuleSetConfig ()Lio/gitlab/arturbosch/detekt/api/Config;
+	public final fun getRuleSetId$detekt_api ()Ljava/lang/String;
 	public final fun report (Lio/gitlab/arturbosch/detekt/api/Finding;)V
 	public final fun report (Ljava/util/List;)V
 	public fun subConfig (Ljava/lang/String;)Lio/gitlab/arturbosch/detekt/api/Config;
@@ -471,6 +478,9 @@ public abstract class io/gitlab/arturbosch/detekt/api/Rule : io/gitlab/arturbosc
 	public fun valueOrNull (Ljava/lang/String;)Ljava/lang/Object;
 	public fun visitCondition (Lorg/jetbrains/kotlin/psi/KtFile;)Z
 	public fun withAutoCorrect (Lkotlin/jvm/functions/Function0;)V
+}
+
+public final class io/gitlab/arturbosch/detekt/api/RuleKt {
 }
 
 public final class io/gitlab/arturbosch/detekt/api/RuleSet {
@@ -481,6 +491,9 @@ public final class io/gitlab/arturbosch/detekt/api/RuleSet {
 	public final fun getPathFilters ()Lio/gitlab/arturbosch/detekt/api/internal/PathFilters;
 	public final fun getRules ()Ljava/util/List;
 	public final fun setPathFilters (Lio/gitlab/arturbosch/detekt/api/internal/PathFilters;)V
+}
+
+public final class io/gitlab/arturbosch/detekt/api/RuleSetKt {
 }
 
 public abstract interface class io/gitlab/arturbosch/detekt/api/RuleSetProvider {

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Rule.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Rule.kt
@@ -72,7 +72,7 @@ abstract class Rule(
     private fun computeSeverity(): SeverityLevel {
         val configValue: String = valueOrNull(SEVERITY_KEY)
             ?: ruleSetConfig.valueOrDefault(SEVERITY_KEY, "warning")
-        return enumValueOf(configValue.toUpperCase(Locale.US))
+        return enumValueOf(configValue.uppercase(Locale.US))
     }
 
     /**

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/internal/ConfigPropertySpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/internal/ConfigPropertySpec.kt
@@ -245,8 +245,8 @@ class ConfigPropertySpec : Spek({
                 val defaultValue by memoized { listOf("99") }
                 val subject by memoized {
                     object : TestConfigAware("present" to "1,2,3") {
-                        val present: Int by config(defaultValue) { it.sumBy(String::toInt) }
-                        val notPresent: Int by config(defaultValue) { it.sumBy(String::toInt) }
+                        val present: Int by config(defaultValue) { it.sumOf(String::toInt) }
+                        val notPresent: Int by config(defaultValue) { it.sumOf(String::toInt) }
                     }
                 }
                 it("applies transformer to list configured") {

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/IssueExtension.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/IssueExtension.kt
@@ -31,7 +31,7 @@ internal fun Detektion.getOrComputeWeightedAmountOfIssues(config: Config): Int {
         )
     }
 
-    val amount = smells.sumBy { it.weighted() }
+    val amount = smells.sumOf { it.weighted() }
     this.addData(WEIGHTED_ISSUES_COUNT_KEY, amount)
     return amount
 }

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/DetektPrinter.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/DetektPrinter.kt
@@ -25,7 +25,7 @@ class DetektPrinter(private val arguments: GeneratorArgs) {
         check(ruleSet.length > 1) { "Rule set name must be not empty or less than two symbols." }
         return """
             |---
-            |title: ${ruleSet[0].toUpperCase()}${ruleSet.substring(1)} Rule Set
+            |title: ${ruleSet[0].uppercase()}${ruleSet.substring(1)} Rule Set
             |sidebar: home_sidebar
             |keywords: rules, $ruleSet
             |permalink: $ruleSet.html

--- a/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/ComplexityReportGenerator.kt
+++ b/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/ComplexityReportGenerator.kt
@@ -36,7 +36,7 @@ class ComplexityReportGenerator(private val complexityMetric: ComplexityMetric) 
             complexityMetric.lloc == null || complexityMetric.lloc == 0 -> true
             complexityMetric.sloc == null || complexityMetric.sloc == 0 -> true
             else -> {
-                numberOfSmells = complexityMetric.findings.sumBy { it.value.size }
+                numberOfSmells = complexityMetric.findings.sumOf { it.value.size }
                 smellPerThousandLines = numberOfSmells * 1000 / complexityMetric.lloc
                 mccPerThousandLines = requireNotNull(complexityMetric.mcc) * 1000 / complexityMetric.lloc
                 commentSourceRatio = requireNotNull(complexityMetric.cloc) * 100 / complexityMetric.sloc

--- a/detekt-psi-utils/api/detekt-psi-utils.api
+++ b/detekt-psi-utils/api/detekt-psi-utils.api
@@ -45,7 +45,9 @@ public final class io/gitlab/arturbosch/detekt/rules/AllowedExceptionNamePattern
 
 public final class io/gitlab/arturbosch/detekt/rules/GuardClausesKt {
 	public static final fun isElvisOperatorGuardClause (Lorg/jetbrains/kotlin/psi/KtExpression;)Z
+	public static final synthetic fun isGuardClause (Lorg/jetbrains/kotlin/psi/KtExpression;)Z
 	public static final fun isIfConditionGuardClause (Lorg/jetbrains/kotlin/psi/KtExpression;Lorg/jetbrains/kotlin/psi/KtExpression;)Z
+	public static final synthetic fun yieldStatementsSkippingGuardClauses (Lorg/jetbrains/kotlin/psi/KtNamedFunction;)Lkotlin/sequences/Sequence;
 }
 
 public final class io/gitlab/arturbosch/detekt/rules/IdentifierNameKt {
@@ -53,6 +55,7 @@ public final class io/gitlab/arturbosch/detekt/rules/IdentifierNameKt {
 }
 
 public final class io/gitlab/arturbosch/detekt/rules/IsPartOfUtilsKt {
+	public static final synthetic fun isPartOf (Lorg/jetbrains/kotlin/com/intellij/psi/PsiElement;)Z
 	public static final fun isPartOfString (Lorg/jetbrains/kotlin/com/intellij/psi/PsiElement;)Z
 }
 
@@ -63,6 +66,7 @@ public final class io/gitlab/arturbosch/detekt/rules/JunkKt {
 	public static final fun hasCommentInside (Lorg/jetbrains/kotlin/psi/KtClassOrObject;)Z
 	public static final fun isUsedForNesting (Lorg/jetbrains/kotlin/psi/KtCallExpression;)Z
 	public static final fun receiverIsUsed (Lorg/jetbrains/kotlin/psi/KtCallExpression;Lorg/jetbrains/kotlin/resolve/BindingContext;)Z
+	public static final synthetic fun safeAs (Ljava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class io/gitlab/arturbosch/detekt/rules/KeywordsKt {
@@ -123,12 +127,15 @@ public final class io/gitlab/arturbosch/detekt/rules/StringExtensionsKt {
 public final class io/gitlab/arturbosch/detekt/rules/ThrowExtensionsKt {
 	public static final fun getArguments (Lorg/jetbrains/kotlin/psi/KtThrowExpression;)Ljava/util/List;
 	public static final fun isEnclosedByConditionalStatement (Lorg/jetbrains/kotlin/psi/KtThrowExpression;)Z
+	public static final synthetic fun isExceptionOfType (Lorg/jetbrains/kotlin/psi/KtThrowExpression;)Z
 	public static final fun isIllegalArgumentException (Lorg/jetbrains/kotlin/psi/KtThrowExpression;)Z
 	public static final fun isIllegalStateException (Lorg/jetbrains/kotlin/psi/KtThrowExpression;)Z
 }
 
 public final class io/gitlab/arturbosch/detekt/rules/TraversingKt {
 	public static final fun isPublicInherited (Lorg/jetbrains/kotlin/psi/KtNamedDeclaration;)Z
+	public static final synthetic fun parentsOfTypeUntil (Lorg/jetbrains/kotlin/psi/KtElement;Z)Lkotlin/sequences/Sequence;
+	public static synthetic fun parentsOfTypeUntil$default (Lorg/jetbrains/kotlin/psi/KtElement;ZILjava/lang/Object;)Lkotlin/sequences/Sequence;
 }
 
 public final class io/gitlab/arturbosch/detekt/rules/TypeUtilsKt {

--- a/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/RuleDescriptors.kt
+++ b/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/RuleDescriptors.kt
@@ -37,8 +37,8 @@ private fun MultiRule.toDescriptors(ruleSetId: RuleSetId): List<ReportingDescrip
     this.rules.map { it.toDescriptor(ruleSetId) }
 
 private fun Rule.toDescriptor(ruleSetId: RuleSetId): ReportingDescriptor {
-    val formattedRuleSetId = ruleSetId.toLowerCase(Locale.US)
-    val formattedRuleId = ruleId.toLowerCase(Locale.US)
+    val formattedRuleSetId = ruleSetId.lowercase(Locale.US)
+    val formattedRuleId = ruleId.lowercase(Locale.US)
 
     return ReportingDescriptor(
         id = "detekt.$ruleSetId.$ruleId",

--- a/detekt-report-xml/src/main/kotlin/io/github/detekt/report/xml/XmlEscape.kt
+++ b/detekt-report-xml/src/main/kotlin/io/github/detekt/report/xml/XmlEscape.kt
@@ -277,7 +277,7 @@ private object Xml10EscapeSymbolsInitializer {
     }
 
     private operator fun ByteArray.set(c: Char, value: Byte) {
-        set(c.toInt(), value)
+        set(c.code, value)
     }
 
     /**

--- a/detekt-report-xml/src/main/kotlin/io/github/detekt/report/xml/XmlOutputReport.kt
+++ b/detekt-report-xml/src/main/kotlin/io/github/detekt/report/xml/XmlOutputReport.kt
@@ -17,7 +17,7 @@ class XmlOutputReport : OutputReport() {
     override val name = "Checkstyle XML report"
 
     private val Finding.severityLabel: String
-        get() = severity.name.toLowerCase(Locale.US)
+        get() = severity.name.lowercase(Locale.US)
 
     override fun render(detektion: Detektion): String {
         val smells = detektion.findings.flatMap { it.value }

--- a/detekt-report-xml/src/test/kotlin/io/github/detekt/report/xml/XmlOutputFormatSpec.kt
+++ b/detekt-report-xml/src/test/kotlin/io/github/detekt/report/xml/XmlOutputFormatSpec.kt
@@ -185,7 +185,7 @@ class XmlOutputFormatSpec : Spek({
 
             SeverityLevel.values().forEach { severity ->
 
-                val xmlSeverity = severity.name.toLowerCase(Locale.US)
+                val xmlSeverity = severity.name.lowercase(Locale.US)
 
                 it("renders detektion with severity [$severity] as XML with severity [$xmlSeverity]") {
                     val finding = object : CodeSmell(

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumber.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumber.kt
@@ -180,7 +180,7 @@ class MagicNumber(config: Config = Config.empty) : Rule(config) {
 
     private fun normalizeForParsingAsDouble(text: String): String {
         return text.trim()
-            .toLowerCase(Locale.US)
+            .lowercase(Locale.US)
             .replace("_", "")
             .removeSuffix("l")
             .removeSuffix("d")

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiterals.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiterals.kt
@@ -100,7 +100,7 @@ class UnderscoresInNumericLiterals(config: Config = Config.empty) : Rule(config)
 
     private fun normalizeForMatching(text: String): String {
         return text.trim()
-            .toLowerCase(Locale.US)
+            .lowercase(Locale.US)
             .removeSuffix("l")
             .removeSuffix("d")
             .removeSuffix("f")

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLet.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLet.kt
@@ -128,7 +128,7 @@ private fun KtLambdaExpression.countReferences(): Int {
     val bodyExpression = bodyExpression ?: return 0
     val destructuringDeclaration = firstParameter?.destructuringDeclaration
     return if (destructuringDeclaration != null) {
-        destructuringDeclaration.entries.sumBy { bodyExpression.countVarRefs(it.nameAsSafeName.asString(), this) }
+        destructuringDeclaration.entries.sumOf { bodyExpression.countVarRefs(it.nameAsSafeName.asString(), this) }
     } else {
         val parameterName = firstParameter?.nameAsSafeName?.asString() ?: IT_LITERAL
         bodyExpression.countVarRefs(parameterName, this)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 dokka = "1.4.32"
 jacoco = "0.8.7"
-kotlin = "1.4.32"
+kotlin = "1.5.0"
 ktlint = "0.41.0"
 spek = "2.0.15"
 
@@ -25,7 +25,7 @@ kotlin-scriptingCompilerEmbeddable = { module = "org.jetbrains.kotlin:kotlin-scr
 kotlin-stdlibJdk8 = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlin" }
 
 kotlinx-html = "org.jetbrains.kotlinx:kotlinx-html-jvm:0.7.3"
-kotlinx-coroutines = "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.1"
+kotlinx-coroutines = "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.0"
 
 android-gradlePlugin = "com.android.tools.build:gradle:4.2.0"
 


### PR DESCRIPTION
Looks like if `kotlinOptions.apiVersion` is not set to `"1.5"` the IDE won't resolve any of the new APIs. I'm assuming that's only needed until the IDE plugin is released.