### PR TITLE
Allow inline comments for properties in primary constructor as documentation

### DIFF
--- a/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicProperty.kt
+++ b/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicProperty.kt
@@ -27,6 +27,7 @@ import org.jetbrains.kotlin.psi.psiUtil.isPublic
  * inline documentation (default: `false`).
  */
 class UndocumentedPublicProperty(config: Config = Config.empty) : Rule(config) {
+
     override val issue = Issue(
         javaClass.simpleName,
         Severity.Maintainability,

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicPropertySpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicPropertySpec.kt
@@ -1,6 +1,5 @@
 package io.gitlab.arturbosch.detekt.rules.documentation
 
-import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicPropertySpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicPropertySpec.kt
@@ -33,32 +33,6 @@ class UndocumentedPublicPropertySpec : Spek({
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
-        it("reports property as undocumented if only inline documentation provided") {
-            val code = """
-               class Test(
-                    /**
-                     * Some docs.
-                     */
-                    val a: Int
-               )
-            """
-            assertThat(subject.compileAndLint(code)).hasSize(1)
-        }
-
-        it("does not report constructor property if inline documentation provided and flag set") {
-            val code = """
-               class Test(
-                    /**
-                     * Some docs.
-                     */
-                    val a: Int
-               )
-            """
-            val findings = UndocumentedPublicProperty(TestConfig(mapOf(UndocumentedPublicProperty.ALLOW_INLINE_CONSTRUCTOR_PROPERTY_COMMENTS to "true"))).compileAndLint(code)
-
-            assertThat(findings).hasSize(0)
-        }
-
         it("reports undocumented public property in a primary constructor") {
             val code = "/* comment */ class Test(val a: Int)"
             assertThat(subject.compileAndLint(code)).hasSize(1)
@@ -171,7 +145,16 @@ class UndocumentedPublicPropertySpec : Spek({
                 * @property [c] int3
                 * @param d int4
                 */
-                class Test(val a: Int, val b: Int, val c: Int, val d: Int)
+                class Test(
+                    val a: Int, 
+                    val b: Int, 
+                    val c: Int, 
+                    val d: Int,
+                    /**
+                     * Some docs.
+                     */
+                    val e: Int                    
+                )
             """
             assertThat(subject.compileAndLint(code)).isEmpty()
         }

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicPropertySpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicPropertySpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.documentation
 
+import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
@@ -30,6 +31,32 @@ class UndocumentedPublicPropertySpec : Spek({
         it("reports undocumented public properties in a primary constructor") {
             val code = "class Test(val a: Int)"
             assertThat(subject.compileAndLint(code)).hasSize(1)
+        }
+
+        it("reports property as undocumented if only inline documentation provided") {
+            val code = """
+               class Test(
+                    /**
+                     * Some docs.
+                     */
+                    val a: Int
+               )
+            """
+            assertThat(subject.compileAndLint(code)).hasSize(1)
+        }
+
+        it("does not report constructor property if inline documentation provided and flag set") {
+            val code = """
+               class Test(
+                    /**
+                     * Some docs.
+                     */
+                    val a: Int
+               )
+            """
+            val findings = UndocumentedPublicProperty(TestConfig(mapOf(UndocumentedPublicProperty.ALLOW_INLINE_CONSTRUCTOR_PROPERTY_COMMENTS to "true"))).compileAndLint(code)
+
+            assertThat(findings).hasSize(0)
         }
 
         it("reports undocumented public property in a primary constructor") {


### PR DESCRIPTION
Fixes #3677

Allow inline comments for properties in primary constructor as a property documentation.

Changes:
1. ~Introduce new configuration parameter for `UndocumentedPublicProperty` that defaults to false to keep current behavior by default~ <-- decided that configuration is not needed
2. Slightly change filtering rules
3. Add tests