### PR TITLE
GitHub Actions cache fixes

### DIFF
--- a/.github/workflows/codecoverage.yaml
+++ b/.github/workflows/codecoverage.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Generate Coverage Report
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: jacocoMergedReport
+          arguments: --configuration-cache jacocoMergedReport
 
       - name: Publish Coverage
         if: success()

--- a/.github/workflows/codecoverage.yaml
+++ b/.github/workflows/codecoverage.yaml
@@ -25,7 +25,9 @@ jobs:
           distribution: 'temurin'
 
       - name: Generate Coverage Report
-        run: ./gradlew jacocoMergedReport
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: jacocoMergedReport
 
       - name: Publish Coverage
         if: success()

--- a/.github/workflows/codecoverage.yaml
+++ b/.github/workflows/codecoverage.yaml
@@ -12,8 +12,6 @@ jobs:
   publish-code-coverage:
     if: ${{ !contains(github.event.head_commit.message, 'coverage skip') }}
     runs-on: ubuntu-latest
-    env:
-      GRADLE_OPTS: -Dorg.gradle.daemon=false
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2

--- a/.github/workflows/deploy-snapshot.yaml
+++ b/.github/workflows/deploy-snapshot.yaml
@@ -15,16 +15,6 @@ jobs:
     - name: Checkout Repo
       uses: actions/checkout@v2
 
-    - name: Cache Gradle Folders
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.gradle/caches/
-          ~/.gradle/wrapper/
-        key: cache-gradle-${{ hashFiles('gradle/libs.versions.toml') }}
-        restore-keys: |
-          cache-gradle-
-
     - name: Setup Java
       uses: actions/setup-java@v2
       with:
@@ -32,11 +22,15 @@ jobs:
         distribution: 'temurin'
 
     - name: Build detekt
-      run: ./gradlew build
+      uses: gradle/gradle-build-action@v2
+      with:
+        arguments: build
 
     - name: Deploy Snapshot
+      uses: gradle/gradle-build-action@v2
       env:
         MAVEN_CENTRAL_USER: ${{ secrets.MAVEN_CENTRAL_USER }}
         MAVEN_CENTRAL_PW: ${{ secrets.MAVEN_CENTRAL_PW }}
-      run: ./gradlew publishAllPublicationsToSonatypeSnapshotRepository -Dsnapshot=true --stacktrace
+      with:
+        arguments: publishAllPublicationsToSonatypeSnapshotRepository -Dsnapshot=true --stacktrace
       if: ${{ github.repository == 'detekt/detekt'}}

--- a/.github/workflows/deploy-snapshot.yaml
+++ b/.github/workflows/deploy-snapshot.yaml
@@ -9,8 +9,6 @@ jobs:
   gradle:
     runs-on: ubuntu-latest
     if: ${{ !contains(github.event.head_commit.message, 'ci skip') }}
-    env:
-      GRADLE_OPTS: -Dorg.gradle.daemon=false
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2

--- a/.github/workflows/deploy-website.yaml
+++ b/.github/workflows/deploy-website.yaml
@@ -15,16 +15,6 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v2
 
-      - name: Cache Gradle Folders
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches/
-            ~/.gradle/wrapper/
-          key: cache-gradle-${{ hashFiles('gradle/libs.versions.toml') }}
-          restore-keys: |
-            cache-gradle-
-
       - name: Setup Java
         uses: actions/setup-java@v2
         with:
@@ -32,7 +22,9 @@ jobs:
           distribution: 'temurin'
 
       - name: Build Detekt Documentation
-        run: ./gradlew :detekt-generator:generateDocumentation
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: :detekt-generator:generateDocumentation
 
       - name: Upload Generated Rules documentation
         uses: actions/upload-artifact@v2

--- a/.github/workflows/deploy-website.yaml
+++ b/.github/workflows/deploy-website.yaml
@@ -8,9 +8,6 @@ on:
 jobs:
   build-detekt-docs:
     runs-on: ubuntu-latest
-    env:
-      GRADLE_OPTS: -Dorg.gradle.daemon=false
-
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2

--- a/.github/workflows/detekt-with-type-resolution.yaml
+++ b/.github/workflows/detekt-with-type-resolution.yaml
@@ -18,16 +18,6 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v2
 
-      - name: Cache Gradle Folders
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches/
-            ~/.gradle/wrapper/
-          key: cache-gradle-${{ hashFiles('gradle/libs.versions.toml') }}
-          restore-keys: |
-            cache-gradle-
-
       - name: Setup Java
         uses: actions/setup-java@v2
         with:
@@ -35,7 +25,9 @@ jobs:
           distribution: 'temurin'
 
       - name: Run detekt-cli with argsfile
-        run: ./gradlew :detekt-cli:runWithArgsFile
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: :detekt-cli:runWithArgsFile
 
       - name: Upload SARIF to Github using the upload-sarif action
         uses: github/codeql-action/upload-sarif@v1
@@ -53,19 +45,12 @@ jobs:
     - name: Checkout Repo
       uses: actions/checkout@v2
 
-    - name: Cache Gradle Folders
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.gradle/caches/
-          ~/.gradle/wrapper/
-        key: cache-gradle-${{ hashFiles('gradle/libs.versions.toml') }}
-        restore-keys: |
-          cache-gradle-
     - name: Setup Java
       uses: actions/setup-java@v2
       with:
         java-version: 11
         distribution: 'temurin'
     - name: Run analysis
-      run: ./gradlew detektMain detektTest
+      uses: gradle/gradle-build-action@v2
+      with:
+        arguments: detektMain detektTest

--- a/.github/workflows/detekt-with-type-resolution.yaml
+++ b/.github/workflows/detekt-with-type-resolution.yaml
@@ -12,8 +12,6 @@ jobs:
   plain:
     runs-on: ubuntu-latest
     if: ${{ !contains(github.event.head_commit.message, 'ci skip') }}
-    env:
-      GRADLE_OPTS: -Dorg.gradle.daemon=false
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
@@ -39,8 +37,6 @@ jobs:
   gradle:
     runs-on: ubuntu-latest
     if: ${{ !contains(github.event.head_commit.message, 'ci skip') }}
-    env:
-      GRADLE_OPTS: -Dorg.gradle.daemon=false
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2

--- a/.github/workflows/detekt-with-type-resolution.yaml
+++ b/.github/workflows/detekt-with-type-resolution.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Run detekt-cli with argsfile
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: :detekt-cli:runWithArgsFile
+          arguments: --configuration-cache :detekt-cli:runWithArgsFile
 
       - name: Upload SARIF to Github using the upload-sarif action
         uses: github/codeql-action/upload-sarif@v1
@@ -49,4 +49,4 @@ jobs:
     - name: Run analysis
       uses: gradle/gradle-build-action@v2
       with:
-        arguments: detektMain detektTest
+        arguments: --configuration-cache detektMain detektTest

--- a/.github/workflows/fossascan.yaml
+++ b/.github/workflows/fossascan.yaml
@@ -9,8 +9,6 @@ jobs:
   fossa-scan:
     if: ${{ github.repository == 'detekt/detekt' }}
     runs-on: ubuntu-latest
-    env:
-      GRADLE_OPTS: -Dorg.gradle.daemon=false
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -22,33 +22,28 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
-    - name: Cache Gradle Folders
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.gradle/caches/
-          ~/.gradle/wrapper/
-        key: cache-gradle-${{ matrix.os }}-${{ matrix.jdk }}-${{ hashFiles('gradle/libs.versions.toml') }}
-        restore-keys: |
-          cache-gradle-${{ matrix.os }}-${{ matrix.jdk }}-
-          cache-gradle-${{ matrix.os }}-
-          cache-gradle-
     - name: Setup Java
       uses: actions/setup-java@v2
       with:
         java-version: ${{ matrix.jdk }}
         distribution: 'temurin'
     - name: Build detekt
-      run: ./gradlew build -x detekt
+      uses: gradle/gradle-build-action@v2
+      with:
+        arguments: build -x detekt
     - uses: actions/upload-artifact@v2
       with:
         name: heap-dump
         path: '**.hprof'
         if-no-files-found: ignore
     - name: Run detekt-cli --help
-      run: ./gradlew :detekt-cli:runWithHelpFlag
+      uses: gradle/gradle-build-action@v2
+      with:
+        arguments: :detekt-cli:runWithHelpFlag
     - name: Run detekt-cli with argsfile
-      run: ./gradlew :detekt-cli:runWithArgsFile
+      uses: gradle/gradle-build-action@v2
+      with:
+        arguments: :detekt-cli:runWithArgsFile
 
   verify-generated-config-file:
     if: ${{ !contains(github.event.head_commit.message, 'ci skip') }}
@@ -58,25 +53,15 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
-    - name: Cache Gradle Folders
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.gradle/caches/
-          ~/.gradle/wrapper/
-        key: cache-gradle-ubuntu-latest-11-verifygenerator-${{ hashFiles('gradle/libs.versions.toml') }}
-        restore-keys: |
-          cache-gradle-ubuntu-latest-11-verifygenerator-
-          cache-gradle-ubuntu-latest-11-
-          cache-gradle-ubuntu-latest-
-          cache-gradle-
     - name: Setup Java
       uses: actions/setup-java@v2
       with:
         java-version: 11
         distribution: 'temurin'
     - name: Verify Generated Detekt Config File
-      run: ./gradlew verifyGeneratorOutput
+      uses: gradle/gradle-build-action@v2
+      with:
+        arguments: verifyGeneratorOutput
 
   compile-test-snippets:
     if: ${{ !contains(github.event.head_commit.message, 'ci skip') }}
@@ -86,22 +71,12 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
-      - name: Cache Gradle Folders
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches/
-            ~/.gradle/wrapper/
-          key: cache-gradle-ubuntu-latest-11-compiletestsnippets-${{ hashFiles('gradle/libs.versions.toml') }}
-          restore-keys: |
-            cache-gradle-ubuntu-latest-11-compiletestsnippets-
-            cache-gradle-ubuntu-latest-11-
-            cache-gradle-ubuntu-latest-
-            cache-gradle-
       - name: Setup Java
         uses: actions/setup-java@v2
         with:
           java-version: 11
           distribution: 'temurin'
       - name: Build and compile test snippets
-        run: ./gradlew test -x ":detekt-gradle-plugin:test" -Pcompile-test-snippets=true
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: test -x ":detekt-gradle-plugin:test" -Pcompile-test-snippets=true

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -37,11 +37,11 @@ jobs:
     - name: Run detekt-cli --help
       uses: gradle/gradle-build-action@v2
       with:
-        arguments: :detekt-cli:runWithHelpFlag
+        arguments: --configuration-cache :detekt-cli:runWithHelpFlag
     - name: Run detekt-cli with argsfile
       uses: gradle/gradle-build-action@v2
       with:
-        arguments: :detekt-cli:runWithArgsFile
+        arguments: --configuration-cache :detekt-cli:runWithArgsFile
 
   verify-generated-config-file:
     if: ${{ !contains(github.event.head_commit.message, 'ci skip') }}
@@ -73,4 +73,4 @@ jobs:
       - name: Build and compile test snippets
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: test -x ":detekt-gradle-plugin:test" -Pcompile-test-snippets=true
+          arguments: --configuration-cache test -x :detekt-gradle-plugin:test -Pcompile-test-snippets=true

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -17,8 +17,6 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         jdk: [8, 11, 17]
     runs-on: ${{ matrix.os }}
-    env:
-      GRADLE_OPTS: -Dorg.gradle.daemon=false
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
@@ -48,8 +46,6 @@ jobs:
   verify-generated-config-file:
     if: ${{ !contains(github.event.head_commit.message, 'ci skip') }}
     runs-on: ubuntu-latest
-    env:
-      GRADLE_OPTS: -Dorg.gradle.daemon=false
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
@@ -66,8 +62,6 @@ jobs:
   compile-test-snippets:
     if: ${{ !contains(github.event.head_commit.message, 'ci skip') }}
     runs-on: ubuntu-latest
-    env:
-      GRADLE_OPTS: -Dorg.gradle.daemon=false
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2


### PR DESCRIPTION
Summary of changes:
* Runs Gradle tasks with gradle-build-action@v2. This handles running Gradle tasks and caching various outputs. v2 is in beta, but once it's stable it will be supported by Gradle and recommended as the canonical way to run Gradle tasks on GitHub Actions.
* Enable Gradle's configuration cache for jobs that support it, which will reduce the job's execution time

Blocked until [gradle-build-action](https://github.com/gradle/gradle-build-action) v2 goes into production release as the configuration syntax could potentially change.