### PR TITLE
Remove --stacktrace now that we have scan

### DIFF
--- a/.github/workflows/deploy-snapshot.yaml
+++ b/.github/workflows/deploy-snapshot.yaml
@@ -31,7 +31,7 @@ jobs:
         java-version: 8
 
     - name: Build detekt
-      run: ./gradlew build --build-cache --stacktrace
+      run: ./gradlew build --build-cache
 
     - name: Deploy Snapshot
       env:

--- a/.github/workflows/detekt-with-type-resolution.yaml
+++ b/.github/workflows/detekt-with-type-resolution.yaml
@@ -34,7 +34,7 @@ jobs:
           java-version: 11
 
       - name: Package executable jar
-        run: ./gradlew jar shadowJar moveJarForIntegrationTest --stacktrace
+        run: ./gradlew jar shadowJar moveJarForIntegrationTest
 
       - name: Run detekt-cli with argsfile
         run: java -jar ./build/detekt-cli-all.jar "@./config/detekt/argsfile"
@@ -71,4 +71,4 @@ jobs:
         java-version: 11
 
     - name: Run analysis
-      run: ./gradlew detektMain detektTest --build-cache --stacktrace
+      run: ./gradlew detektMain detektTest

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -54,7 +54,7 @@ jobs:
 
 
     - name: Build detekt
-      run: ./gradlew build moveJarForIntegrationTest -x detekt -PwarningsAsErrors=true --stacktrace
+      run: ./gradlew build moveJarForIntegrationTest -x detekt
     - name: Run detekt-cli --help
       run: java -jar ./build/detekt-cli-all.jar --help
     - name: Run detekt-cli with argsfile
@@ -87,7 +87,7 @@ jobs:
         java-version: 11
         distribution: 'adopt'
     - name: Verify Generated Detekt Config File
-      run: ./gradlew verifyGeneratorOutput --stacktrace
+      run: ./gradlew verifyGeneratorOutput
 
 
   compile-test-snippets:
@@ -116,4 +116,4 @@ jobs:
           java-version: 11
           distribution: 'adopt'
       - name: Build and compile test snippets
-        run: ./gradlew test -x ":detekt-gradle-plugin:test" -Pcompile-test-snippets=true --stacktrace
+        run: ./gradlew test -x ":detekt-gradle-plugin:test" -Pcompile-test-snippets=true


### PR DESCRIPTION
This PR reverts #3604 now that we have #3710

`--stacktrace` is quite noisy and it makes difficult to find which test failed.