### PR TITLE
Properly populate versions.properties

### DIFF
--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -71,17 +71,9 @@ pluginBundle {
 }
 
 tasks.processResources {
-    filter<org.apache.tools.ant.filters.ReplaceTokens>(
-        "tokens" to mapOf(
-            "detektVersion" to project.version as String
-        )
-    )
+    expand(mutableMapOf("detektVersion" to project.version))
 }
 
 tasks.processTestResources {
-    filter<org.apache.tools.ant.filters.ReplaceTokens>(
-        "tokens" to mapOf(
-            "detektVersion" to project.version as String
-        )
-    )
+    expand(mutableMapOf("detektVersion" to project.version))
 }

--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -70,10 +70,19 @@ pluginBundle {
     }
 }
 
-tasks.processResources {
-    expand(mutableMapOf("detektVersion" to project.version))
-}
+tasks {
+    val writeDetektVersionProperties by registering(WriteProperties::class) {
+        description = "Write the properties file with the Detekt version to be used by the plugin"
+        encoding = "UTF-8"
+        outputFile = file("${buildDir}/versions.properties")
+        property("detektVersion", project.version)
+    }
 
-tasks.processTestResources {
-    expand(mutableMapOf("detektVersion" to project.version))
+    processResources {
+        from(writeDetektVersionProperties)
+    }
+
+    processTestResources {
+        from(writeDetektVersionProperties)
+    }
 }

--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -74,7 +74,7 @@ tasks {
     val writeDetektVersionProperties by registering(WriteProperties::class) {
         description = "Write the properties file with the Detekt version to be used by the plugin"
         encoding = "UTF-8"
-        outputFile = file("${buildDir}/versions.properties")
+        outputFile = file("$buildDir/versions.properties")
         property("detektVersion", project.version)
     }
 

--- a/detekt-gradle-plugin/src/main/resources/versions.properties
+++ b/detekt-gradle-plugin/src/main/resources/versions.properties
@@ -1,1 +1,0 @@
-detektVersion=$detektVersion

--- a/detekt-gradle-plugin/src/main/resources/versions.properties
+++ b/detekt-gradle-plugin/src/main/resources/versions.properties
@@ -1,1 +1,1 @@
-detektVersion=@detektVersion@
+detektVersion=$detektVersion

--- a/detekt-gradle-plugin/src/test/resources/versions.properties
+++ b/detekt-gradle-plugin/src/test/resources/versions.properties
@@ -1,1 +1,0 @@
-detektVersion=$detektVersion

--- a/detekt-gradle-plugin/src/test/resources/versions.properties
+++ b/detekt-gradle-plugin/src/test/resources/versions.properties
@@ -1,1 +1,1 @@
-detektVersion=@detektVersion@
+detektVersion=$detektVersion


### PR DESCRIPTION
Detekt 1.17.0-RC1 was bundled with a `versions.properties` that contains just `1.17.0`.
This PR fixes this problem using the `expand()` function of CopySpec. I'm not sure how to write a test for this, but I verified on my Maven Local and the file is populated correctly with `1.17.0-RC1`

Fixes #3729 