### PR TITLE
Specify Java language level in module plugin

### DIFF
--- a/buildSrc/src/main/kotlin/module.gradle.kts
+++ b/buildSrc/src/main/kotlin/module.gradle.kts
@@ -73,6 +73,8 @@ dependencies {
 java {
     withSourcesJar()
     withJavadocJar()
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
 }
 
 publishing {


### PR DESCRIPTION
From https://github.com/detekt/detekt/pull/3727#issuecomment-830733869

We need to specify the Java `sourceCompatibility` and `targetCompatibility` inside the `module` plugin.
Sadly the -RC1 was build with JDK11 and and this makes it unusable for users on JRE 8

Fixes #3731