### PR TITLE
Support triple quoted strings in default value of config delegate

### DIFF
--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/Annotations.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/Annotations.kt
@@ -25,9 +25,10 @@ private fun KtAnnotationEntry.firstParameterOrNull() =
         ?.text
         ?.withoutQuotes()
 
-internal fun String.withoutQuotes() = removePrefix(QUOTES)
-    .removeSuffix(QUOTES)
+internal fun String.withoutQuotes() = removeSurrounding(TRIPLE_QUOTES)
+    .removeSurrounding(SINGLE_QUOTES)
     .replace(STRING_CONCAT_REGEX, "")
 
-private const val QUOTES = "\""
+private const val SINGLE_QUOTES = "\""
+private const val TRIPLE_QUOTES = "\"\"\""
 private val STRING_CONCAT_REGEX = """["]\s*\+[\n\s]*["]""".toRegex()

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleCollectorSpec.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleCollectorSpec.kt
@@ -200,6 +200,20 @@ class RuleCollectorSpec : Spek({
                     assertThat(items[0].configuration[0].defaultValue).isEqualTo("99")
                 }
 
+                it("extracts default value when it is a multi line string") {
+                    val code = """
+                        /**
+                         * description
+                         */
+                        class SomeRandomClass() : Rule {
+                            @Configuration("description")
+                            private val config: String by config(""${"\""}abcd""${"\""})
+                        }                        
+                    """
+                    val items = subject.run(code)
+                    assertThat(items[0].configuration[0].defaultValue).isEqualTo("'abcd'")
+                }
+
                 it("extracts default value when defined with named parameter") {
                     val code = """
                         /**


### PR DESCRIPTION
This fixes the documentation generation for triple quoted default values in config delegates. This is particularly useful when it comes to regular expressions.

Previously the generated documentation for 
```kotlin
@Configuration("description")
private val prop : String by config("""([.?!][ \t\n\r\f<])|([.?!:]$)""")
```
was incorrect. It was necessary to write
```kotlin
@Configuration("description")
private val prop : String by config("([.?!][ \\t\\n\\r\\f<])|([.?!:]\$)")
```
