### PR TITLE
Update config file due to invalid argument

### DIFF
--- a/docs/pages/configurations.md
+++ b/docs/pages/configurations.md
@@ -22,12 +22,12 @@ _Note:_ When using a custom config file, the default values are ignored unless y
 ## Rule sets and rules
 
 _detekt_ allows easily to just pick the rules you want and configure them the way you like.
-For example if you want to allow up to 20 functions inside a Kotlin file instead of the default threshold of 10, write:
+For example if you want to allow up to 20 functions inside a Kotlin file instead of the default threshold, write:
 
 ```yaml
 complexity:
   TooManyFunctions:
-    threshold: 20
+    thresholdInFiles: 20
 ```
 
 To read about all supported rule sets and rules, use the side navigation `Rule Sets`.


### PR DESCRIPTION
The rule TooManyFunctions doesn't have the threshold argument anymore.

Closes
https://github.com/detekt/detekt-intellij-plugin/issues/128
