### PR TITLE
Set the org.gradle.dependency.bundling attribute to external

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
@@ -7,6 +7,7 @@ import io.gitlab.arturbosch.detekt.internal.DetektMultiplatform
 import io.gitlab.arturbosch.detekt.internal.DetektPlain
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.attributes.Bundling
 import org.gradle.api.plugins.ReportingBasePlugin
 import org.gradle.api.reporting.ReportingExtension
 import java.util.Properties
@@ -77,6 +78,12 @@ class DetektPlugin : Plugin<Project> {
             configuration.isVisible = false
             configuration.isTransitive = true
             configuration.description = "The $CONFIGURATION_DETEKT dependencies to be used for this project."
+
+            // We set the org.gradle.dependency.bundling attribute to "external"
+            configuration.attributes.attribute(
+                Bundling.BUNDLING_ATTRIBUTE,
+                project.objects.named(Bundling::class.java, Bundling.EXTERNAL)
+            )
 
             configuration.defaultDependencies { dependencySet ->
                 val version = extension.toolVersion ?: loadDetektVersion(DetektPlugin::class.java.classLoader)


### PR DESCRIPTION
This fixes the failures on the PR https://github.com/detekt/detekt/pull/3727/ such as:

```
    > Could not resolve all files for configuration ':child1:detekt'.
       > Could not resolve io.gitlab.arturbosch.detekt:detekt-cli:1.17.0-RC2.
         Required by:
             project :child1
          > Cannot choose between the following variants of io.gitlab.arturbosch.detekt:detekt-cli:1.17.0-RC2:
              - runtimeElements
              - shadowRuntimeElements
            All of them match the consumer attributes:
              - Variant 'runtimeElements' capability io.gitlab.arturbosch.detekt:detekt-cli:1.17.0-RC2:
                  - Unmatched attributes:
                      - Provides org.gradle.category 'library' but the consumer didn't ask for it
                      - Provides org.gradle.dependency.bundling 'external' but the consumer didn't ask for it
                      - Provides org.gradle.jvm.version '8' but the consumer didn't ask for it
                      - Provides org.gradle.libraryelements 'jar' but the consumer didn't ask for it
                      - Provides org.gradle.status 'release' but the consumer didn't ask for it
                      - Provides org.gradle.usage 'java-runtime' but the consumer didn't ask for it
                      - Provides org.jetbrains.kotlin.localToProject 'public' but the consumer didn't ask for it
                      - Provides org.jetbrains.kotlin.platform.type 'jvm' but the consumer didn't ask for it
              - Variant 'shadowRuntimeElements' capability io.gitlab.arturbosch.detekt:detekt-cli:1.17.0-RC2:
                  - Unmatched attributes:
                      - Provides org.gradle.category 'library' but the consumer didn't ask for it
                      - Provides org.gradle.dependency.bundling 'shadowed' but the consumer didn't ask for it
                      - Provides org.gradle.libraryelements 'jar' but the consumer didn't ask for it
                      - Provides org.gradle.status 'release' but the consumer didn't ask for it
                      - Provides org.gradle.usage 'java-runtime' but the consumer didn't ask for it
                      -
```
