### PR TITLE
Ignore gradle plugin in codecov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -10,3 +10,6 @@ coverage:
         target: 80%
         # Only post a patch status to pull requests
         only_pulls: true
+
+ignore:
+  - "detekt-gradle-plugin/"

--- a/.github/workflows/codecoverage.yaml
+++ b/.github/workflows/codecoverage.yaml
@@ -25,7 +25,7 @@ jobs:
           java-version: 11
 
       - name: Generate Coverage Report
-        run: ./gradlew jacocoTestReport --no-build-cache
+        run: ./gradlew jacocoTestReport --no-build-cache -x :detekt-gradle-plugin:test
 
       - name: Publish Coverage
         if: success()


### PR DESCRIPTION
The code coverage reports from codecov about our gradle plugin aren't correct. For that reason it's better to ignore them so we don't get that noise in our PRs.

Following this documentation: https://docs.codecov.io/docs/ignoring-paths