### PR TITLE
Upgrade to AGP 4.2.0

### DIFF
--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -21,17 +21,6 @@ dependencies {
     testImplementation(libs.kotlin.gradlePlugin)
     intTest(libs.kotlin.gradlePlugin)
     intTest(libs.android.gradlePlugin)
-
-    constraints {
-        implementation(libs.kotlin.reflect) {
-            because(
-                """Android Gradle Plugin 4.1.1 depends on Kotlin 1.3.72 but we should not mix 1.3 and 1.4.
-                This constraint should be lifted on Android Gradle Plugin 4.2.0. See
-                https://dl.google.com/android/maven2/com/android/tools/build/gradle/4.2.0-beta02/gradle-4.2.0-beta02.pom
-            """
-            )
-        }
-    }
 }
 
 gradlePlugin {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,7 +19,6 @@ sonarqube-gradlePlugin = "org.sonarsource.scanner.gradle:sonarqube-gradle-plugin
 kotlin-compilerEmbeddable = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable", version.ref = "kotlin" }
 kotlin-gradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 kotlin-gradlePluginApi = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin-api", version.ref = "kotlin" }
-kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
 kotlin-scriptRuntime = { module = "org.jetbrains.kotlin:kotlin-script-runtime", version.ref = "kotlin" }
 kotlin-scriptUtil = { module = "org.jetbrains.kotlin:kotlin-script-util", version.ref = "kotlin" }
 kotlin-scriptingCompilerEmbeddable = { module = "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable", version.ref = "kotlin" }
@@ -28,7 +27,7 @@ kotlin-stdlibJdk8 = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", versio
 kotlinx-html = "org.jetbrains.kotlinx:kotlinx-html-jvm:0.7.3"
 kotlinx-coroutines = "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.1"
 
-android-gradlePlugin = "com.android.tools.build:gradle:4.1.3"
+android-gradlePlugin = "com.android.tools.build:gradle:4.2.0"
 
 ktlint-core = { module = "com.pinterest.ktlint:ktlint-core", version.ref = "ktlint" }
 ktlint-rulesetStandard = { module = "com.pinterest.ktlint:ktlint-ruleset-standard", version.ref = "ktlint" }


### PR DESCRIPTION
Verified in a test project that we are no longer mixing Kotlin 1.3 with 1.4. Buildscan: https://scans.gradle.com/s/3owvdxjm5onxo/