### PR TITLE
Change default baseline file name from baseline.xml to detekt-baseline.xml

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
@@ -35,10 +35,10 @@ open class DetektExtension @Inject constructor(objects: ObjectFactory) : CodeQua
     var baseline: File? = objects.fileProperty()
         .run {
             if (GradleVersion.current() < GradleVersion.version("6.0")) {
-                set(File("baseline.xml"))
+                set(File("detekt-baseline.xml"))
                 this
             } else {
-                fileValue(File("baseline.xml"))
+                fileValue(File("detekt-baseline.xml"))
             }
         }
         .get().asFile

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/CreateBaselineTaskDslTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/CreateBaselineTaskDslTest.kt
@@ -32,12 +32,11 @@ internal class CreateBaselineTaskDslTest : Spek({
                     gradleRunner.runTasksAndCheckResult("detektBaseline") { result ->
                         assertThat(result.task(":detektBaseline")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
                         assertThat(projectFile(baselineFilename)).exists()
+                        assertThat(projectFile(DEFAULT_BASELINE_FILENAME)).doesNotExist()
                     }
                 }
 
                 it("can be executed when baseline file is not specified") {
-                    val baselineFilename = "baseline.xml"
-
                     val detektConfig = """
                         |detekt {
                         |}
@@ -54,13 +53,11 @@ internal class CreateBaselineTaskDslTest : Spek({
 
                     gradleRunner.runTasksAndCheckResult("detektBaseline") { result ->
                         assertThat(result.task(":detektBaseline")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
-                        assertThat(projectFile(baselineFilename)).exists()
+                        assertThat(projectFile(DEFAULT_BASELINE_FILENAME)).exists()
                     }
                 }
 
                 it("can not be executed when baseline file is specified null") {
-                    val baselineFilename = "baseline.xml"
-
                     val detektConfig = """
                         |detekt {
                         |   baseline = null
@@ -78,10 +75,12 @@ internal class CreateBaselineTaskDslTest : Spek({
 
                     gradleRunner.runTasksAndExpectFailure("detektBaseline") { result ->
                         assertThat(result.output).contains("property 'baseline' doesn't have a configured value")
-                        assertThat(projectFile(baselineFilename)).doesNotExist()
+                        assertThat(projectFile(DEFAULT_BASELINE_FILENAME)).doesNotExist()
                     }
                 }
             }
         }
     }
 })
+
+private const val DEFAULT_BASELINE_FILENAME = "detekt-baseline.xml"

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektAndroidTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektAndroidTest.kt
@@ -28,12 +28,12 @@ object DetektAndroidTest : Spek({
                     """.trimIndent(),
                     srcDirs = listOf("src/main/java", "src/debug/java", "src/test/java", "src/androidTest/java"),
                     baselineFiles = listOf(
-                        "baseline.xml",
-                        "baseline-release.xml",
-                        "baseline-debug.xml",
-                        "baseline-releaseUnitTest.xml",
-                        "baseline-debugUnitTest.xml",
-                        "baseline-debugAndroidTest.xml"
+                        "detekt-baseline.xml",
+                        "detekt-baseline-release.xml",
+                        "detekt-baseline-debug.xml",
+                        "detekt-baseline-releaseUnitTest.xml",
+                        "detekt-baseline-debugUnitTest.xml",
+                        "detekt-baseline-debugAndroidTest.xml"
                     )
                 )
             }
@@ -43,8 +43,8 @@ object DetektAndroidTest : Spek({
 
             it("task :app:detektMain") {
                 gradleRunner.runTasksAndCheckResult(":app:detektMain") { buildResult ->
-                    assertThat(buildResult.output).containsPattern("""--baseline \S*[/\\]baseline-release.xml """)
-                    assertThat(buildResult.output).containsPattern("""--baseline \S*[/\\]baseline-debug.xml """)
+                    assertThat(buildResult.output).containsPattern("""--baseline \S*[/\\]detekt-baseline-release.xml """)
+                    assertThat(buildResult.output).containsPattern("""--baseline \S*[/\\]detekt-baseline-debug.xml """)
                     assertThat(buildResult.output).contains("--report xml:")
                     assertThat(buildResult.output).contains("--report sarif:")
                     assertThat(buildResult.output).doesNotContain("--report txt:")
@@ -60,9 +60,9 @@ object DetektAndroidTest : Spek({
 
             it("task :app:detektTest") {
                 gradleRunner.runTasksAndCheckResult(":app:detektTest") { buildResult ->
-                    assertThat(buildResult.output).containsPattern("""--baseline \S*[/\\]baseline-releaseUnitTest.xml """)
-                    assertThat(buildResult.output).containsPattern("""--baseline \S*[/\\]baseline-debugUnitTest.xml """)
-                    assertThat(buildResult.output).containsPattern("""--baseline \S*[/\\]baseline-debugAndroidTest.xml """)
+                    assertThat(buildResult.output).containsPattern("""--baseline \S*[/\\]detekt-baseline-releaseUnitTest.xml """)
+                    assertThat(buildResult.output).containsPattern("""--baseline \S*[/\\]detekt-baseline-debugUnitTest.xml """)
+                    assertThat(buildResult.output).containsPattern("""--baseline \S*[/\\]detekt-baseline-debugAndroidTest.xml """)
                     assertThat(buildResult.output).contains("--report xml:")
                     assertThat(buildResult.output).contains("--report sarif:")
                     assertThat(buildResult.output).doesNotContain("--report txt:")
@@ -78,7 +78,7 @@ object DetektAndroidTest : Spek({
 
             it("task :app:check") {
                 gradleRunner.runTasksAndCheckResult(":app:check") { buildResult ->
-                    assertThat(buildResult.output).containsPattern("""--baseline \S*[/\\]baseline.xml """)
+                    assertThat(buildResult.output).containsPattern("""--baseline \S*[/\\]detekt-baseline.xml """)
                     assertThat(buildResult.task(":app:detekt")).isNotNull
                     assertThat(buildResult.output).contains("--report xml:")
                     assertThat(buildResult.output).contains("--report sarif:")
@@ -137,12 +137,12 @@ object DetektAndroidTest : Spek({
                     """.trimIndent(),
                     srcDirs = listOf("src/main/java", "src/debug/java", "src/test/java", "src/androidTest/java"),
                     baselineFiles = listOf(
-                        "baseline.xml",
-                        "baseline-release.xml",
-                        "baseline-debug.xml",
-                        "baseline-releaseUnitTest.xml",
-                        "baseline-debugUnitTest.xml",
-                        "baseline-debugAndroidTest.xml"
+                        "detekt-baseline.xml",
+                        "detekt-baseline-release.xml",
+                        "detekt-baseline-debug.xml",
+                        "detekt-baseline-releaseUnitTest.xml",
+                        "detekt-baseline-debugUnitTest.xml",
+                        "detekt-baseline-debugAndroidTest.xml"
                     )
                 )
             }
@@ -152,8 +152,8 @@ object DetektAndroidTest : Spek({
 
             it("task :lib:detektMain") {
                 gradleRunner.runTasksAndCheckResult(":lib:detektMain") { buildResult ->
-                    assertThat(buildResult.output).containsPattern("""--baseline \S*[/\\]baseline-release.xml """)
-                    assertThat(buildResult.output).containsPattern("""--baseline \S*[/\\]baseline-debug.xml """)
+                    assertThat(buildResult.output).containsPattern("""--baseline \S*[/\\]detekt-baseline-release.xml """)
+                    assertThat(buildResult.output).containsPattern("""--baseline \S*[/\\]detekt-baseline-debug.xml """)
                     assertThat(buildResult.output).contains("--report xml:")
                     assertThat(buildResult.output).contains("--report sarif:")
                     assertThat(buildResult.output).doesNotContain("--report txt:")
@@ -169,9 +169,9 @@ object DetektAndroidTest : Spek({
 
             it("task :lib:detektTest") {
                 gradleRunner.runTasksAndCheckResult(":lib:detektTest") { buildResult ->
-                    assertThat(buildResult.output).containsPattern("""--baseline \S*[/\\]baseline-releaseUnitTest.xml """)
-                    assertThat(buildResult.output).containsPattern("""--baseline \S*[/\\]baseline-debugUnitTest.xml """)
-                    assertThat(buildResult.output).containsPattern("""--baseline \S*[/\\]baseline-debugAndroidTest.xml """)
+                    assertThat(buildResult.output).containsPattern("""--baseline \S*[/\\]detekt-baseline-releaseUnitTest.xml """)
+                    assertThat(buildResult.output).containsPattern("""--baseline \S*[/\\]detekt-baseline-debugUnitTest.xml """)
+                    assertThat(buildResult.output).containsPattern("""--baseline \S*[/\\]detekt-baseline-debugAndroidTest.xml """)
                     assertThat(buildResult.output).contains("--report xml:")
                     assertThat(buildResult.output).contains("--report sarif:")
                     assertThat(buildResult.output).doesNotContain("--report txt:")
@@ -187,7 +187,7 @@ object DetektAndroidTest : Spek({
 
             it(":lib:check") {
                 gradleRunner.runTasksAndCheckResult(":lib:check") { buildResult ->
-                    assertThat(buildResult.output).containsPattern("""--baseline \S*[/\\]baseline.xml """)
+                    assertThat(buildResult.output).containsPattern("""--baseline \S*[/\\]detekt-baseline.xml """)
                     assertThat(buildResult.task(":lib:detekt")).isNotNull
                     assertThat(buildResult.output).contains("--report xml:")
                     assertThat(buildResult.output).contains("--report sarif:")

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektJvmTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektJvmTest.kt
@@ -13,7 +13,7 @@ object DetektJvmTest : Spek({
         val gradleRunner = DslGradleRunner(
             projectLayout = ProjectLayout(numberOfSourceFilesInRootPerSourceDir = 1),
             buildFileName = "build.gradle",
-            baselineFiles = listOf("baseline.xml", "baseline-main.xml", "baseline-test.xml"),
+            baselineFiles = listOf("detekt-baseline.xml", "detekt-baseline-main.xml", "detekt-baseline-test.xml"),
             mainBuildFileContent = """
                 plugins {
                     id "org.jetbrains.kotlin.jvm"
@@ -39,7 +39,7 @@ object DetektJvmTest : Spek({
 
         it("configures detekt type resolution task main") {
             gradleRunner.runTasksAndCheckResult(":detektMain") { buildResult ->
-                assertThat(buildResult.output).containsPattern("""--baseline \S*[/\\]baseline-main.xml """)
+                assertThat(buildResult.output).containsPattern("""--baseline \S*[/\\]detekt-baseline-main.xml """)
                 assertThat(buildResult.output).contains("--report xml:")
                 assertThat(buildResult.output).contains("--report sarif:")
                 assertThat(buildResult.output).doesNotContain("--report txt:")
@@ -50,7 +50,7 @@ object DetektJvmTest : Spek({
 
         it("configures detekt type resolution task test") {
             gradleRunner.runTasksAndCheckResult(":detektTest") { buildResult ->
-                assertThat(buildResult.output).containsPattern("""--baseline \S*[/\\]baseline-test.xml """)
+                assertThat(buildResult.output).containsPattern("""--baseline \S*[/\\]detekt-baseline-test.xml """)
                 assertThat(buildResult.output).contains("--report xml:")
                 assertThat(buildResult.output).contains("--report sarif:")
                 assertThat(buildResult.output).doesNotContain("--report txt:")

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektMultiplatformTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektMultiplatformTest.kt
@@ -26,7 +26,7 @@ class DetektMultiplatformTest : Spek({
                     $DETEKT_BLOCK
                 """.trimIndent(),
                 srcDirs = listOf("src/commonMain/kotlin", "src/commonTest/kotlin"),
-                baselineFiles = listOf("baseline.xml", "baseline-metadataMain.xml")
+                baselineFiles = listOf("detekt-baseline.xml", "detekt-baseline-metadataMain.xml")
             )
         }
 
@@ -36,7 +36,7 @@ class DetektMultiplatformTest : Spek({
 
         it("configures detekt task without type resolution") {
             gradleRunner.runTasksAndCheckResult(":shared:detektMetadataMain") {
-                assertThat(it.output).containsPattern("""--baseline \S*[/\\]baseline.xml """)
+                assertThat(it.output).containsPattern("""--baseline \S*[/\\]detekt-baseline.xml """)
                 assertDetektWithoutClasspath(it)
             }
         }
@@ -100,7 +100,7 @@ class DetektMultiplatformTest : Spek({
                     "src/jvmBackendMain/kotlin",
                     "src/jvmEmbeddedMain/kotlin",
                 ),
-                baselineFiles = listOf("baseline.xml", "baseline-main.xml")
+                baselineFiles = listOf("detekt-baseline.xml", "detekt-baseline-main.xml")
             )
         }
 
@@ -113,14 +113,14 @@ class DetektMultiplatformTest : Spek({
 
         it("configures detekt task with type resolution backend") {
             gradleRunner.runTasksAndCheckResult(":shared:detektJvmBackendMain") {
-                assertThat(it.output).containsPattern("""--baseline \S*[/\\]baseline-main.xml """)
+                assertThat(it.output).containsPattern("""--baseline \S*[/\\]detekt-baseline-main.xml """)
                 assertDetektWithClasspath(it)
             }
         }
 
         it("configures detekt task with type resolution embedded") {
             gradleRunner.runTasksAndCheckResult(":shared:detektJvmEmbeddedMain") {
-                assertThat(it.output).containsPattern("""--baseline \S*[/\\]baseline-main.xml """)
+                assertThat(it.output).containsPattern("""--baseline \S*[/\\]detekt-baseline-main.xml """)
                 assertDetektWithClasspath(it)
             }
         }
@@ -172,7 +172,11 @@ class DetektMultiplatformTest : Spek({
                     "src/commonMain/kotlin",
                     "src/commonTest/kotlin"
                 ),
-                baselineFiles = listOf("baseline.xml", "baseline-debug.xml", "baseline-release.xml")
+                baselineFiles = listOf(
+                    "detekt-baseline.xml",
+                    "detekt-baseline-debug.xml",
+                    "detekt-baseline-release.xml"
+                )
             )
         }
 
@@ -187,11 +191,11 @@ class DetektMultiplatformTest : Spek({
 
         it("configures detekt task with type resolution") {
             gradleRunner.runTasksAndCheckResult(":shared:detektAndroidDebug") {
-                assertThat(it.output).containsPattern("""--baseline \S*[/\\]baseline-debug.xml """)
+                assertThat(it.output).containsPattern("""--baseline \S*[/\\]detekt-baseline-debug.xml """)
                 assertDetektWithClasspath(it)
             }
             gradleRunner.runTasksAndCheckResult(":shared:detektAndroidRelease") {
-                assertThat(it.output).containsPattern("""--baseline \S*[/\\]baseline-release.xml """)
+                assertThat(it.output).containsPattern("""--baseline \S*[/\\]detekt-baseline-release.xml """)
                 assertDetektWithClasspath(it)
             }
         }
@@ -224,7 +228,7 @@ class DetektMultiplatformTest : Spek({
                     "src/jsMain/kotlin",
                     "src/jsTest/kotlin",
                 ),
-                baselineFiles = listOf("baseline.xml")
+                baselineFiles = listOf("detekt-baseline.xml")
             )
         }
 
@@ -235,11 +239,11 @@ class DetektMultiplatformTest : Spek({
 
         it("configures detekt task without type resolution") {
             gradleRunner.runTasksAndCheckResult(":shared:detektJsMain") {
-                assertThat(it.output).containsPattern("""--baseline \S*[/\\]baseline.xml """)
+                assertThat(it.output).containsPattern("""--baseline \S*[/\\]detekt-baseline.xml """)
                 assertDetektWithoutClasspath(it)
             }
             gradleRunner.runTasksAndCheckResult(":shared:detektJsTest") {
-                assertThat(it.output).containsPattern("""--baseline \S*[/\\]baseline.xml """)
+                assertThat(it.output).containsPattern("""--baseline \S*[/\\]detekt-baseline.xml """)
                 assertDetektWithoutClasspath(it)
             }
         }
@@ -277,7 +281,7 @@ class DetektMultiplatformTest : Spek({
                     "src/iosX64Test/kotlin",
                     "src/iosMain/kotlin",
                 ),
-                baselineFiles = listOf("baseline.xml")
+                baselineFiles = listOf("detekt-baseline.xml")
             )
         }
 
@@ -290,19 +294,19 @@ class DetektMultiplatformTest : Spek({
 
         it("configures detekt task without type resolution") {
             gradleRunner.runTasksAndCheckResult(":shared:detektIosArm64Main") {
-                assertThat(it.output).containsPattern("""--baseline \S*[/\\]baseline.xml """)
+                assertThat(it.output).containsPattern("""--baseline \S*[/\\]detekt-baseline.xml """)
                 assertDetektWithoutClasspath(it)
             }
             gradleRunner.runTasksAndCheckResult(":shared:detektIosArm64Test") {
-                assertThat(it.output).containsPattern("""--baseline \S*[/\\]baseline.xml """)
+                assertThat(it.output).containsPattern("""--baseline \S*[/\\]detekt-baseline.xml """)
                 assertDetektWithoutClasspath(it)
             }
             gradleRunner.runTasksAndCheckResult(":shared:detektIosX64Main") {
-                assertThat(it.output).containsPattern("""--baseline \S*[/\\]baseline.xml """)
+                assertThat(it.output).containsPattern("""--baseline \S*[/\\]detekt-baseline.xml """)
                 assertDetektWithoutClasspath(it)
             }
             gradleRunner.runTasksAndCheckResult(":shared:detektIosX64Test") {
-                assertThat(it.output).containsPattern("""--baseline \S*[/\\]baseline.xml """)
+                assertThat(it.output).containsPattern("""--baseline \S*[/\\]detekt-baseline.xml """)
                 assertDetektWithoutClasspath(it)
             }
         }
@@ -359,7 +363,6 @@ private val KMM_PLUGIN_BLOCK = """
 
 private val DETEKT_BLOCK = """
     detekt {
-        baseline = file("${"$"}projectDir/baseline.xml")
         reports.txt.enabled = false
     }
 """.trimIndent()

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektPlainTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektPlainTest.kt
@@ -42,7 +42,7 @@ object DetektPlainTest : Spek({
         val gradleRunner = DslGradleRunner(
             projectLayout = ProjectLayout(numberOfSourceFilesInRootPerSourceDir = 1),
             buildFileName = "build.gradle",
-            baselineFiles = listOf("baseline.xml"),
+            baselineFiles = listOf("detekt-baseline.xml"),
             mainBuildFileContent = """
                 plugins {
                     id "org.jetbrains.kotlin.jvm"
@@ -69,7 +69,7 @@ object DetektPlainTest : Spek({
 
         it("configures detekt plain task") {
             gradleRunner.runTasksAndCheckResult(":detekt") { buildResult ->
-                assertThat(buildResult.output).containsPattern("""--baseline \S*[/\\]baseline.xml """)
+                assertThat(buildResult.output).containsPattern("""--baseline \S*[/\\]detekt-baseline.xml """)
                 assertThat(buildResult.output).contains("--report xml:")
                 assertThat(buildResult.output).contains("--report sarif:")
                 assertThat(buildResult.output).doesNotContain("--report txt:")


### PR DESCRIPTION
Fixes #3737

`baseline.xml` is too generic as a file name. We should define that this file comes from detekt to work nice with other tools.