### PR TITLE
Skip publishing for detekt-cli shadowRuntimeElements variant

### DIFF
--- a/detekt-cli/build.gradle.kts
+++ b/detekt-cli/build.gradle.kts
@@ -18,6 +18,11 @@ dependencies {
     testImplementation(project(":detekt-test"))
 }
 
+val javaComponent = components["java"] as AdhocComponentWithVariants
+javaComponent.withVariantsFromConfiguration(configurations["shadowRuntimeElements"]) {
+    skip()
+}
+
 tasks.shadowJar {
     mergeServiceFiles()
 }


### PR DESCRIPTION
Fixes #3743

metadata diff comparing 1.16.0 to this branch: https://gist.github.com/3flex/9f53cba7ed55176d61fff8b6b6742e61