### PR TITLE
Always run warningsAsErrors on CI

### DIFF
--- a/buildSrc/src/main/kotlin/module.gradle.kts
+++ b/buildSrc/src/main/kotlin/module.gradle.kts
@@ -55,7 +55,7 @@ tasks.withType<KotlinCompile>().configureEach {
             "-Xopt-in=kotlin.RequiresOptIn"
         )
         // Usage: <code>./gradlew build -PwarningsAsErrors=true</code>.
-        allWarningsAsErrors = project.findProperty("warningsAsErrors") == "true"
+        allWarningsAsErrors = project.findProperty("warningsAsErrors") == "true" || System.getenv("CI") == "true"
     }
 }
 


### PR DESCRIPTION
Merging #3724 I introduced a regresion disabled what I enabled at #3646

Anywy I found that my previous approuch wasn't good enought because `warningsAsErrors` mess up with the gradle cache so we want to have a consistent value for `warningsAsErrors` in all out CI. For this reason I change this in the gradle files instead of adding the flag in the workflows.

~(I'm adding a stub commit to ensure that this do what it's meant to do)~ Done, and it works like a charm.