### PR TITLE
Upload any heap dumps produced during CI build

### DIFF
--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -41,6 +41,11 @@ jobs:
         distribution: 'adopt'
     - name: Build detekt
       run: ./gradlew build moveJarForIntegrationTest -x detekt
+    - uses: actions/upload-artifact@v2
+      with:
+        name: heap-dump
+        path: '**.hprof'
+        if-no-files-found: ignore
     - name: Run detekt-cli --help
       run: java -jar ./build/detekt-cli-all.jar --help
     - name: Run detekt-cli with argsfile


### PR DESCRIPTION
This may allow us to investigate build failures due to out of memory conditions.

One possible cause: https://github.com/Kotlin/dokka/issues/1405