### PR TITLE
Fix kdoc link on blog navigation

### DIFF
--- a/docs/_data/sidebars/home_sidebar.yml
+++ b/docs/_data/sidebars/home_sidebar.yml
@@ -93,5 +93,5 @@ entries:
     output: web
     folderitems:
     - title: detekt-api
-      url: /pages/kdoc/
+      url: /pages/kdoc
       output: web

--- a/docs/_data/sidebars/home_sidebar.yml
+++ b/docs/_data/sidebars/home_sidebar.yml
@@ -93,5 +93,5 @@ entries:
     output: web
     folderitems:
     - title: detekt-api
-      url: /pages/kdoc/detekt-api/index.html
+      url: /pages/kdoc/
       output: web


### PR DESCRIPTION
https://detekt.github.io/detekt/pages/kdoc/detekt-api/index.html
The link created by dokkaJekyll is not working due to the wrong location.