### PR TITLE
Invalidate GitHub Actions cache when dependencies change

### DIFF
--- a/.github/workflows/deploy-snapshot.yaml
+++ b/.github/workflows/deploy-snapshot.yaml
@@ -21,7 +21,7 @@ jobs:
         path: |
           ~/.gradle/caches/
           ~/.gradle/wrapper/
-        key: cache-gradle-${{ hashFiles('detekt-bom/build.gradle.kts') }}
+        key: cache-gradle-${{ hashFiles('gradle/libs.versions.toml') }}
         restore-keys: |
           cache-gradle-
 

--- a/.github/workflows/deploy-snapshot.yaml
+++ b/.github/workflows/deploy-snapshot.yaml
@@ -22,8 +22,6 @@ jobs:
           ~/.gradle/caches/
           ~/.gradle/wrapper/
         key: cache-gradle-${{ hashFiles('gradle/libs.versions.toml') }}
-        restore-keys: |
-          cache-gradle-
 
     - name: Setup Java
       uses: actions/setup-java@v1

--- a/.github/workflows/deploy-website.yaml
+++ b/.github/workflows/deploy-website.yaml
@@ -22,8 +22,6 @@ jobs:
             ~/.gradle/caches/
             ~/.gradle/wrapper/
           key: cache-gradle-${{ hashFiles('gradle/libs.versions.toml') }}
-          restore-keys: |
-            cache-gradle-
 
       - name: Setup Java
         uses: actions/setup-java@v1

--- a/.github/workflows/deploy-website.yaml
+++ b/.github/workflows/deploy-website.yaml
@@ -21,7 +21,7 @@ jobs:
           path: |
             ~/.gradle/caches/
             ~/.gradle/wrapper/
-          key: cache-gradle-${{ hashFiles('detekt-bom/build.gradle.kts') }}
+          key: cache-gradle-${{ hashFiles('gradle/libs.versions.toml') }}
           restore-keys: |
             cache-gradle-
 

--- a/.github/workflows/detekt-with-type-resolution.yaml
+++ b/.github/workflows/detekt-with-type-resolution.yaml
@@ -25,8 +25,6 @@ jobs:
             ~/.gradle/caches/
             ~/.gradle/wrapper/
           key: cache-gradle-${{ hashFiles('gradle/libs.versions.toml') }}
-          restore-keys: |
-            cache-gradle-
 
       - name: Setup Java
         uses: actions/setup-java@v1
@@ -62,8 +60,6 @@ jobs:
           ~/.gradle/caches/
           ~/.gradle/wrapper/
         key: cache-gradle-${{ hashFiles('gradle/libs.versions.toml') }}
-        restore-keys: |
-          cache-gradle-
 
     - name: Setup Java
       uses: actions/setup-java@v1

--- a/.github/workflows/detekt-with-type-resolution.yaml
+++ b/.github/workflows/detekt-with-type-resolution.yaml
@@ -24,7 +24,7 @@ jobs:
           path: |
             ~/.gradle/caches/
             ~/.gradle/wrapper/
-          key: cache-gradle-${{ hashFiles('detekt-bom/build.gradle.kts') }}
+          key: cache-gradle-${{ hashFiles('gradle/libs.versions.toml') }}
           restore-keys: |
             cache-gradle-
 
@@ -61,7 +61,7 @@ jobs:
         path: |
           ~/.gradle/caches/
           ~/.gradle/wrapper/
-        key: cache-gradle-${{ hashFiles('detekt-bom/build.gradle.kts') }}
+        key: cache-gradle-${{ hashFiles('gradle/libs.versions.toml') }}
         restore-keys: |
           cache-gradle-
 

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -29,7 +29,7 @@ jobs:
         path: |
           ~/.gradle/caches/
           ~/.gradle/wrapper/
-        key: cache-gradle-${{ matrix.os }}-${{ matrix.jdk }}-${{ hashFiles('detekt-bom/build.gradle.kts') }}
+        key: cache-gradle-${{ matrix.os }}-${{ matrix.jdk }}-${{ hashFiles('gradle/libs.versions.toml') }}
         restore-keys: |
           cache-gradle-${{ matrix.os }}-${{ matrix.jdk }}-
           cache-gradle-${{ matrix.os }}-
@@ -65,7 +65,7 @@ jobs:
         path: |
           ~/.gradle/caches/
           ~/.gradle/wrapper/
-        key: cache-gradle-ubuntu-latest-11-verifygenerator-${{ hashFiles('detekt-bom/build.gradle.kts') }}
+        key: cache-gradle-ubuntu-latest-11-verifygenerator-${{ hashFiles('gradle/libs.versions.toml') }}
         restore-keys: |
           cache-gradle-ubuntu-latest-11-verifygenerator-
           cache-gradle-ubuntu-latest-11-
@@ -93,7 +93,7 @@ jobs:
           path: |
             ~/.gradle/caches/
             ~/.gradle/wrapper/
-          key: cache-gradle-ubuntu-latest-11-compiletestsnippets-${{ hashFiles('detekt-bom/build.gradle.kts') }}
+          key: cache-gradle-ubuntu-latest-11-compiletestsnippets-${{ hashFiles('gradle/libs.versions.toml') }}
           restore-keys: |
             cache-gradle-ubuntu-latest-11-compiletestsnippets-
             cache-gradle-ubuntu-latest-11-

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -30,10 +30,6 @@ jobs:
           ~/.gradle/caches/
           ~/.gradle/wrapper/
         key: cache-gradle-${{ matrix.os }}-${{ matrix.jdk }}-${{ hashFiles('gradle/libs.versions.toml') }}
-        restore-keys: |
-          cache-gradle-${{ matrix.os }}-${{ matrix.jdk }}-
-          cache-gradle-${{ matrix.os }}-
-          cache-gradle-
     - name: Setup Java
       uses: actions/setup-java@v2
       with:
@@ -66,11 +62,6 @@ jobs:
           ~/.gradle/caches/
           ~/.gradle/wrapper/
         key: cache-gradle-ubuntu-latest-11-verifygenerator-${{ hashFiles('gradle/libs.versions.toml') }}
-        restore-keys: |
-          cache-gradle-ubuntu-latest-11-verifygenerator-
-          cache-gradle-ubuntu-latest-11-
-          cache-gradle-ubuntu-latest-
-          cache-gradle-
     - name: Setup Java
       uses: actions/setup-java@v2
       with:
@@ -94,11 +85,6 @@ jobs:
             ~/.gradle/caches/
             ~/.gradle/wrapper/
           key: cache-gradle-ubuntu-latest-11-compiletestsnippets-${{ hashFiles('gradle/libs.versions.toml') }}
-          restore-keys: |
-            cache-gradle-ubuntu-latest-11-compiletestsnippets-
-            cache-gradle-ubuntu-latest-11-
-            cache-gradle-ubuntu-latest-
-            cache-gradle-
       - name: Setup Java
         uses: actions/setup-java@v2
         with:


### PR DESCRIPTION
With https://github.com/detekt/detekt/pull/3741 the majority of Gradle dependencies moved from the BOM to `libs.versions.toml`. This means one of the inputs to the GitHub Actions cache keys would very rarely change, meaning the cache wouldn't be invalidated in some circumstances.

This also removes the restore keys. The reason is when there's a cache hit on one of the restore keys the cache isn't updated - this means that in the worst case a cache hit may happen on e.g. `cache-gradle-` which could be from any OS, JDK version or an old set of dependencies, which means the cached build cache and dependencies would not be usable in the Gradle build. This change should mean more frequent cache hits in Actions as well as Gradle's build cache.