### PR TITLE
Use annotations to configure rules in rules-naming

### DIFF
--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ClassNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ClassNaming.kt
@@ -5,17 +5,16 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.LazyRegex
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
+import io.gitlab.arturbosch.detekt.api.internal.Configuration
+import io.gitlab.arturbosch.detekt.api.internal.config
 import io.gitlab.arturbosch.detekt.rules.identifierName
 import org.jetbrains.kotlin.psi.KtClassOrObject
 
 /**
  * Reports when class or object names which do not follow the specified naming convention are used.
- *
- * @configuration classPattern - naming pattern (default: `'[A-Z][a-zA-Z0-9]*'`)
  */
 @ActiveByDefault(since = "1.0.0")
 class ClassNaming(config: Config = Config.empty) : Rule(config) {
@@ -29,7 +28,8 @@ class ClassNaming(config: Config = Config.empty) : Rule(config) {
         debt = Debt.FIVE_MINS
     )
 
-    private val classPattern by LazyRegex(CLASS_PATTERN, "[A-Z][a-zA-Z0-9]*")
+    @Configuration("naming pattern")
+    private val classPattern: Regex by config("[A-Z][a-zA-Z0-9]*") { it.toRegex() }
 
     override fun visitClassOrObject(classOrObject: KtClassOrObject) {
         if (!classOrObject.identifierName().matches(classPattern)) {

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ConstructorParameterNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ConstructorParameterNaming.kt
@@ -5,10 +5,11 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.LazyRegex
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
+import io.gitlab.arturbosch.detekt.api.internal.Configuration
+import io.gitlab.arturbosch.detekt.api.internal.config
 import io.gitlab.arturbosch.detekt.rules.identifierName
 import io.gitlab.arturbosch.detekt.rules.isOverride
 import io.gitlab.arturbosch.detekt.rules.naming.util.isContainingExcludedClassOrObject
@@ -17,11 +18,6 @@ import org.jetbrains.kotlin.psi.psiUtil.isPrivate
 
 /**
  * Reports constructor parameter names which do not follow the specified naming convention are used.
- *
- * @configuration parameterPattern - naming pattern (default: `'[a-z][A-Za-z0-9]*'`)
- * @configuration privateParameterPattern - naming pattern (default: `'[a-z][A-Za-z0-9]*'`)
- * @configuration excludeClassPattern - ignores variables in classes which match this regex (default: `'$^'`)
- * @configuration ignoreOverridden - ignores constructor properties that have the override modifier (default: `true`)
  */
 @ActiveByDefault(since = "1.0.0")
 class ConstructorParameterNaming(config: Config = Config.empty) : Rule(config) {
@@ -33,10 +29,17 @@ class ConstructorParameterNaming(config: Config = Config.empty) : Rule(config) {
         debt = Debt.FIVE_MINS
     )
 
-    private val parameterPattern by LazyRegex(PARAMETER_PATTERN, "[a-z][A-Za-z\\d]*")
-    private val privateParameterPattern by LazyRegex(PRIVATE_PARAMETER_PATTERN, "[a-z][A-Za-z\\d]*")
-    private val excludeClassPattern by LazyRegex(EXCLUDE_CLASS_PATTERN, "$^")
-    private val ignoreOverridden = valueOrDefault(IGNORE_OVERRIDDEN, true)
+    @Configuration("naming pattern")
+    private val parameterPattern: Regex by config("[a-z][A-Za-z0-9]*") { it.toRegex() }
+
+    @Configuration("naming pattern")
+    private val privateParameterPattern: Regex by config("[a-z][A-Za-z0-9]*") { it.toRegex() }
+
+    @Configuration("ignores variables in classes which match this regex")
+    private val excludeClassPattern: Regex by config("$^") { it.toRegex() }
+
+    @Configuration("ignores constructor properties that have the override modifier")
+    private val ignoreOverridden: Boolean by config(true)
 
     override fun visitParameter(parameter: KtParameter) {
         if (parameter.isContainingExcludedClassOrObject(excludeClassPattern) || isIgnoreOverridden(parameter)) {
@@ -69,11 +72,4 @@ class ConstructorParameterNaming(config: Config = Config.empty) : Rule(config) {
     }
 
     private fun isIgnoreOverridden(parameter: KtParameter) = ignoreOverridden && parameter.isOverride()
-
-    companion object {
-        const val PARAMETER_PATTERN = "parameterPattern"
-        const val PRIVATE_PARAMETER_PATTERN = "privateParameterPattern"
-        const val EXCLUDE_CLASS_PATTERN = "excludeClassPattern"
-        const val IGNORE_OVERRIDDEN = "ignoreOverridden"
-    }
 }

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/EnumNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/EnumNaming.kt
@@ -5,17 +5,16 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.LazyRegex
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
+import io.gitlab.arturbosch.detekt.api.internal.Configuration
+import io.gitlab.arturbosch.detekt.api.internal.config
 import io.gitlab.arturbosch.detekt.rules.identifierName
 import org.jetbrains.kotlin.psi.KtEnumEntry
 
 /**
  * Reports when enum names which do not follow the specified naming convention are used.
- *
- * @configuration enumEntryPattern - naming pattern (default: `'[A-Z][_a-zA-Z0-9]*'`)
  */
 @ActiveByDefault(since = "1.0.0")
 class EnumNaming(config: Config = Config.empty) : Rule(config) {
@@ -27,7 +26,8 @@ class EnumNaming(config: Config = Config.empty) : Rule(config) {
         debt = Debt.FIVE_MINS
     )
 
-    private val enumEntryPattern by LazyRegex(ENUM_PATTERN, "[A-Z][_a-zA-Z0-9]*")
+    @Configuration("naming pattern")
+    private val enumEntryPattern: Regex by config("[A-Z][_a-zA-Z0-9]*") { it.toRegex() }
 
     override fun visitEnumEntry(enumEntry: KtEnumEntry) {
         if (!enumEntry.identifierName().matches(enumEntryPattern)) {

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ForbiddenClassName.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ForbiddenClassName.kt
@@ -7,15 +7,14 @@ import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
-import io.gitlab.arturbosch.detekt.api.internal.valueOrDefaultCommaSeparated
+import io.gitlab.arturbosch.detekt.api.internal.Configuration
+import io.gitlab.arturbosch.detekt.api.internal.config
 import org.jetbrains.kotlin.psi.KtClassOrObject
 
 /**
  * Reports class names which are forbidden per configuration.
  * By default this rule does not report any classes.
  * Examples for forbidden names might be too generic class names like `...Manager`.
- *
- * @configuration forbiddenName - forbidden class names (default: `[]`)
  */
 class ForbiddenClassName(config: Config = Config.empty) : Rule(config) {
 
@@ -25,12 +24,15 @@ class ForbiddenClassName(config: Config = Config.empty) : Rule(config) {
         "Forbidden class name as per configuration detected.",
         Debt.FIVE_MINS
     )
-    private val forbiddenNames = valueOrDefaultCommaSeparated(FORBIDDEN_NAME, emptyList())
-        .map { it.removePrefix("*").removeSuffix("*") }
+
+    @Configuration("forbidden class names")
+    private val forbiddenName: List<String> by config(listOf<String>()) { names ->
+        names.map { it.removeSurrounding("*") }
+    }
 
     override fun visitClassOrObject(classOrObject: KtClassOrObject) {
         val name = classOrObject.name
-        val forbiddenEntries = name?.let { forbiddenNames.filter { name.contains(it, ignoreCase = true) } }
+        val forbiddenEntries = name?.let { forbiddenName.filter { name.contains(it, ignoreCase = true) } }
 
         if (forbiddenEntries?.isNotEmpty() == true) {
             var message = "Class name $name is forbidden as it contains:"

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ForbiddenClassName.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ForbiddenClassName.kt
@@ -27,7 +27,7 @@ class ForbiddenClassName(config: Config = Config.empty) : Rule(config) {
 
     @Configuration("forbidden class names")
     private val forbiddenName: List<String> by config(listOf<String>()) { names ->
-        names.map { it.removeSurrounding("*") }
+        names.map { it.removePrefix("*").removeSuffix("*") }
     }
 
     override fun visitClassOrObject(classOrObject: KtClassOrObject) {

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionMaxLength.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionMaxLength.kt
@@ -7,13 +7,13 @@ import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.internal.Configuration
+import io.gitlab.arturbosch.detekt.api.internal.config
 import io.gitlab.arturbosch.detekt.rules.identifierName
 import org.jetbrains.kotlin.psi.KtNamedFunction
 
 /**
  * Reports when very long function names are used.
- *
- * @configuration maximumFunctionNameLength - maximum name length (default: `30`)
  */
 class FunctionMaxLength(config: Config = Config.empty) : Rule(config) {
 
@@ -24,8 +24,8 @@ class FunctionMaxLength(config: Config = Config.empty) : Rule(config) {
         debt = Debt.FIVE_MINS
     )
 
-    private val maximumFunctionNameLength =
-        valueOrDefault(MAXIMUM_FUNCTION_NAME_LENGTH, DEFAULT_MAXIMUM_FUNCTION_NAME_LENGTH)
+    @Configuration("maximum name length")
+    private val maximumFunctionNameLength: Int by config(30)
 
     override fun visitNamedFunction(function: KtNamedFunction) {
         if (function.identifierName().length > maximumFunctionNameLength) {
@@ -41,6 +41,5 @@ class FunctionMaxLength(config: Config = Config.empty) : Rule(config) {
 
     companion object {
         const val MAXIMUM_FUNCTION_NAME_LENGTH = "maximumFunctionNameLength"
-        private const val DEFAULT_MAXIMUM_FUNCTION_NAME_LENGTH = 30
     }
 }

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionMinLength.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionMinLength.kt
@@ -7,13 +7,13 @@ import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.internal.Configuration
+import io.gitlab.arturbosch.detekt.api.internal.config
 import io.gitlab.arturbosch.detekt.rules.identifierName
 import org.jetbrains.kotlin.psi.KtNamedFunction
 
 /**
  * Reports when very short function names are used.
- *
- * @configuration minimumFunctionNameLength - minimum name length (default: `3`)
  */
 class FunctionMinLength(config: Config = Config.empty) : Rule(config) {
 
@@ -24,8 +24,8 @@ class FunctionMinLength(config: Config = Config.empty) : Rule(config) {
         debt = Debt.FIVE_MINS
     )
 
-    private val minimumFunctionNameLength =
-        valueOrDefault(MINIMUM_FUNCTION_NAME_LENGTH, DEFAULT_MINIMUM_FUNCTION_NAME_LENGTH)
+    @Configuration("minimum name length")
+    private val minimumFunctionNameLength: Int by config(3)
 
     override fun visitNamedFunction(function: KtNamedFunction) {
         if (function.identifierName().length < minimumFunctionNameLength) {
@@ -37,10 +37,5 @@ class FunctionMinLength(config: Config = Config.empty) : Rule(config) {
                 )
             )
         }
-    }
-
-    companion object {
-        const val MINIMUM_FUNCTION_NAME_LENGTH = "minimumFunctionNameLength"
-        private const val DEFAULT_MINIMUM_FUNCTION_NAME_LENGTH = 3
     }
 }

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/InvalidPackageDeclaration.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/InvalidPackageDeclaration.kt
@@ -8,14 +8,14 @@ import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.internal.Configuration
+import io.gitlab.arturbosch.detekt.api.internal.config
 import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtPackageDirective
 
 /**
  * Reports when the package declaration is missing or the file location does not match the declared package.
- *
- * @configuration rootPackage - if specified this part of the package structure is ignored (default: `''`)
  */
 class InvalidPackageDeclaration(config: Config = Config.empty) : Rule(config) {
 
@@ -26,7 +26,8 @@ class InvalidPackageDeclaration(config: Config = Config.empty) : Rule(config) {
         debt = Debt.FIVE_MINS
     )
 
-    private val rootPackage: String = valueOrDefault(ROOT_PACKAGE, "")
+    @Configuration("if specified this part of the package structure is ignored")
+    private val rootPackage: String by config("")
 
     private var packageDeclaration: KtPackageDirective? = null
 
@@ -66,8 +67,4 @@ class InvalidPackageDeclaration(config: Config = Config.empty) : Rule(config) {
     private fun <T> Iterable<T>.toNormalizedForm() = joinToString("|")
 
     private fun packageNameToNormalizedForm(packageName: String) = packageName.split('.').toNormalizedForm()
-
-    companion object {
-        const val ROOT_PACKAGE = "rootPackage"
-    }
 }

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MatchingDeclarationName.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MatchingDeclarationName.kt
@@ -9,6 +9,8 @@ import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
+import io.gitlab.arturbosch.detekt.api.internal.Configuration
+import io.gitlab.arturbosch.detekt.api.internal.config
 import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtTypeAlias
@@ -44,8 +46,6 @@ import org.jetbrains.kotlin.psi.psiUtil.isPrivate
  * fun Bar.toFoo(): Foo = ...
  *
  * </compliant>
- *
- * @configuration mustBeFirst - name should only be checked if the file starts with a class or object (default: `true`)
  */
 @ActiveByDefault(since = "1.0.0")
 class MatchingDeclarationName(config: Config = Config.empty) : Rule(config) {
@@ -58,7 +58,8 @@ class MatchingDeclarationName(config: Config = Config.empty) : Rule(config) {
         Debt.FIVE_MINS
     )
 
-    private val mustBeFirst = valueOrDefault(MUST_BE_FIRST, true)
+    @Configuration("name should only be checked if the file starts with a class or object")
+    private val mustBeFirst: Boolean by config(true)
 
     override fun visitKtFile(file: KtFile) {
         val declarations = file.declarations
@@ -91,5 +92,3 @@ class MatchingDeclarationName(config: Config = Config.empty) : Rule(config) {
         }
     }
 }
-
-const val MUST_BE_FIRST = "mustBeFirst"

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MemberNameEqualsClassName.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MemberNameEqualsClassName.kt
@@ -8,6 +8,9 @@ import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
+import io.gitlab.arturbosch.detekt.api.internal.Configuration
+import io.gitlab.arturbosch.detekt.api.internal.config
+import io.gitlab.arturbosch.detekt.api.internal.configWithFallback
 import io.gitlab.arturbosch.detekt.rules.isOverride
 import org.jetbrains.kotlin.descriptors.DeclarationDescriptor
 import org.jetbrains.kotlin.descriptors.FunctionDescriptor
@@ -50,10 +53,6 @@ import org.jetbrains.kotlin.resolve.BindingContext
  *     }
  * }
  * </compliant>
- *
- * @configuration ignoreOverriddenFunction - if overridden functions and properties should be ignored (default: `true`)
- * (deprecated: "Use `ignoreOverridden` instead")
- * @configuration ignoreOverridden - if overridden functions and properties should be ignored (default: `true`)
  */
 @ActiveByDefault(since = "1.2.0")
 class MemberNameEqualsClassName(config: Config = Config.empty) : Rule(config) {
@@ -70,7 +69,13 @@ class MemberNameEqualsClassName(config: Config = Config.empty) : Rule(config) {
     private val objectMessage = "A member is named after the object. " +
         "This might result in confusion. Please rename the member."
 
-    private val ignoreOverridden = valueOrDefault(IGNORE_OVERRIDDEN, valueOrDefault(IGNORE_OVERRIDDEN_FUNCTION, true))
+    @Suppress("unused")
+    @Configuration("if overridden functions and properties should be ignored")
+    @Deprecated("Use `ignoreOverridden` instead")
+    private val ignoreOverriddenFunction: Boolean by config(true)
+
+    @Configuration("if overridden functions and properties should be ignored")
+    private val ignoreOverridden: Boolean by configWithFallback("ignoreOverriddenFunction", true)
 
     override fun visitClass(klass: KtClass) {
         if (!klass.isInterface()) {
@@ -123,10 +128,5 @@ class MemberNameEqualsClassName(config: Config = Config.empty) : Rule(config) {
         } else {
             bindingContext[BindingContext.DECLARATION_TO_DESCRIPTOR, this]
         }
-    }
-
-    companion object {
-        const val IGNORE_OVERRIDDEN_FUNCTION = "ignoreOverriddenFunction"
-        const val IGNORE_OVERRIDDEN = "ignoreOverridden"
     }
 }

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNaming.kt
@@ -5,10 +5,11 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.LazyRegex
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
+import io.gitlab.arturbosch.detekt.api.internal.Configuration
+import io.gitlab.arturbosch.detekt.api.internal.config
 import io.gitlab.arturbosch.detekt.rules.identifierName
 import io.gitlab.arturbosch.detekt.rules.isConstant
 import org.jetbrains.kotlin.psi.KtProperty
@@ -16,10 +17,6 @@ import org.jetbrains.kotlin.psi.psiUtil.isPrivate
 
 /**
  * Reports when property names inside objects which do not follow the specified naming convention are used.
- *
- * @configuration constantPattern - naming pattern (default: `'[A-Za-z][_A-Za-z0-9]*'`)
- * @configuration propertyPattern - naming pattern (default: `'[A-Za-z][_A-Za-z0-9]*'`)
- * @configuration privatePropertyPattern - naming pattern (default: `'(_)?[A-Za-z][_A-Za-z0-9]*'`)
  */
 @ActiveByDefault(since = "1.0.0")
 class ObjectPropertyNaming(config: Config = Config.empty) : Rule(config) {
@@ -31,9 +28,14 @@ class ObjectPropertyNaming(config: Config = Config.empty) : Rule(config) {
         debt = Debt.FIVE_MINS
     )
 
-    private val constantPattern by LazyRegex(CONSTANT_PATTERN, "[A-Za-z][_A-Za-z0-9]*")
-    private val propertyPattern by LazyRegex(PROPERTY_PATTERN, "[A-Za-z][_A-Za-z0-9]*")
-    private val privatePropertyPattern by LazyRegex(PRIVATE_PROPERTY_PATTERN, "(_)?[A-Za-z][_A-Za-z0-9]*")
+    @Configuration("naming pattern")
+    private val constantPattern: Regex by config("[A-Za-z][_A-Za-z0-9]*") { it.toRegex() }
+
+    @Configuration("naming pattern")
+    private val propertyPattern: Regex by config("[A-Za-z][_A-Za-z0-9]*") { it.toRegex() }
+
+    @Configuration("naming pattern")
+    private val privatePropertyPattern: Regex by config("(_)?[A-Za-z][_A-Za-z0-9]*") { it.toRegex() }
 
     override fun visitProperty(property: KtProperty) {
         if (property.isLocal) {
@@ -71,11 +73,5 @@ class ObjectPropertyNaming(config: Config = Config.empty) : Rule(config) {
                 message = message
             )
         )
-    }
-
-    companion object {
-        const val CONSTANT_PATTERN = "constantPattern"
-        const val PROPERTY_PATTERN = "propertyPattern"
-        const val PRIVATE_PROPERTY_PATTERN = "privatePropertyPattern"
     }
 }

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/PackageNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/PackageNaming.kt
@@ -5,16 +5,15 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.LazyRegex
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
+import io.gitlab.arturbosch.detekt.api.internal.Configuration
+import io.gitlab.arturbosch.detekt.api.internal.config
 import org.jetbrains.kotlin.psi.KtPackageDirective
 
 /**
  * Reports when package names which do not follow the specified naming convention are used.
- *
- * @configuration packagePattern - naming pattern (default: `'[a-z]+(\.[a-z][A-Za-z0-9]*)*'`)
  */
 @ActiveByDefault(since = "1.0.0")
 class PackageNaming(config: Config = Config.empty) : Rule(config) {
@@ -28,7 +27,8 @@ class PackageNaming(config: Config = Config.empty) : Rule(config) {
         debt = Debt.FIVE_MINS
     )
 
-    private val packagePattern by LazyRegex(PACKAGE_PATTERN, "[a-z]+(\\.[a-z][A-Za-z0-9]*)*")
+    @Configuration("naming pattern")
+    private val packagePattern: Regex by config("""[a-z]+(\.[a-z][A-Za-z0-9]*)*""") { it.toRegex() }
 
     override fun visitPackageDirective(directive: KtPackageDirective) {
         val name = directive.qualifiedName

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/TopLevelPropertyNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/TopLevelPropertyNaming.kt
@@ -5,10 +5,11 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.LazyRegex
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
+import io.gitlab.arturbosch.detekt.api.internal.Configuration
+import io.gitlab.arturbosch.detekt.api.internal.config
 import io.gitlab.arturbosch.detekt.rules.identifierName
 import io.gitlab.arturbosch.detekt.rules.isConstant
 import org.jetbrains.kotlin.psi.KtProperty
@@ -16,10 +17,6 @@ import org.jetbrains.kotlin.psi.psiUtil.isPrivate
 
 /**
  * Reports when top level constant names which do not follow the specified naming convention are used.
- *
- * @configuration constantPattern - naming pattern (default: `'[A-Z][_A-Z0-9]*'`)
- * @configuration propertyPattern - naming pattern (default: `'[A-Za-z][_A-Za-z0-9]*'`)
- * @configuration privatePropertyPattern - naming pattern (default: `'_?[A-Za-z][_A-Za-z0-9]*'`)
  */
 @ActiveByDefault(since = "1.0.0")
 class TopLevelPropertyNaming(config: Config = Config.empty) : Rule(config) {
@@ -31,9 +28,14 @@ class TopLevelPropertyNaming(config: Config = Config.empty) : Rule(config) {
         debt = Debt.FIVE_MINS
     )
 
-    private val constantPattern by LazyRegex(CONSTANT_PATTERN, "[A-Z][_A-Z0-9]*")
-    private val propertyPattern by LazyRegex(PROPERTY_PATTERN, "[A-Za-z][_A-Za-z0-9]*")
-    private val privatePropertyPattern by LazyRegex(PRIVATE_PROPERTY_PATTERN, "_?[A-Za-z][_A-Za-z0-9]*")
+    @Configuration("naming pattern")
+    private val constantPattern: Regex by config("[A-Z][_A-Z0-9]*") { it.toRegex() }
+
+    @Configuration("naming pattern")
+    private val propertyPattern: Regex by config("[A-Za-z][_A-Za-z0-9]*") { it.toRegex() }
+
+    @Configuration("naming pattern")
+    private val privatePropertyPattern: Regex by config("_?[A-Za-z][_A-Za-z0-9]*") { it.toRegex() }
 
     override fun visitProperty(property: KtProperty) {
         if (property.isConstant()) {
@@ -71,7 +73,5 @@ class TopLevelPropertyNaming(config: Config = Config.empty) : Rule(config) {
 
     companion object {
         const val CONSTANT_PATTERN = "constantPattern"
-        const val PROPERTY_PATTERN = "propertyPattern"
-        const val PRIVATE_PROPERTY_PATTERN = "privatePropertyPattern"
     }
 }

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableMaxLength.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableMaxLength.kt
@@ -7,13 +7,13 @@ import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.internal.Configuration
+import io.gitlab.arturbosch.detekt.api.internal.config
 import io.gitlab.arturbosch.detekt.rules.identifierName
 import org.jetbrains.kotlin.psi.KtProperty
 
 /**
  * Reports when very long variable names are used.
- *
- * @configuration maximumVariableNameLength - maximum name length (default: `64`)
  */
 class VariableMaxLength(config: Config = Config.empty) : Rule(config) {
 
@@ -24,8 +24,8 @@ class VariableMaxLength(config: Config = Config.empty) : Rule(config) {
         debt = Debt.FIVE_MINS
     )
 
-    private val maximumVariableNameLength =
-        valueOrDefault(MAXIMUM_VARIABLE_NAME_LENGTH, DEFAULT_MAXIMUM_VARIABLE_NAME_LENGTH)
+    @Configuration("maximum name length")
+    private val maximumVariableNameLength: Int by config(DEFAULT_MAXIMUM_VARIABLE_NAME_LENGTH)
 
     override fun visitProperty(property: KtProperty) {
         if (property.identifierName().length > maximumVariableNameLength) {
@@ -40,7 +40,6 @@ class VariableMaxLength(config: Config = Config.empty) : Rule(config) {
     }
 
     companion object {
-        const val MAXIMUM_VARIABLE_NAME_LENGTH = "maximumVariableNameLength"
         private const val DEFAULT_MAXIMUM_VARIABLE_NAME_LENGTH = 64
     }
 }

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableMinLength.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableMinLength.kt
@@ -7,14 +7,14 @@ import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.internal.Configuration
+import io.gitlab.arturbosch.detekt.api.internal.config
 import io.gitlab.arturbosch.detekt.rules.identifierName
 import org.jetbrains.kotlin.psi.KtProperty
 import org.jetbrains.kotlin.resolve.calls.util.isSingleUnderscore
 
 /**
  * Reports when very short variable names are used.
- *
- * @configuration minimumVariableNameLength - maximum name length (default: `1`)
  */
 class VariableMinLength(config: Config = Config.empty) : Rule(config) {
 
@@ -25,8 +25,8 @@ class VariableMinLength(config: Config = Config.empty) : Rule(config) {
         debt = Debt.FIVE_MINS
     )
 
-    private val minimumVariableNameLength =
-        valueOrDefault(MINIMUM_VARIABLE_NAME_LENGTH, DEFAULT_MINIMUM_VARIABLE_NAME_LENGTH)
+    @Configuration("minimum name length")
+    private val minimumVariableNameLength: Int by config(DEFAULT_MINIMUM_VARIABLE_NAME_LENGTH)
 
     override fun visitProperty(property: KtProperty) {
         if (property.isSingleUnderscore) {

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ConstructorParameterNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ConstructorParameterNamingSpec.kt
@@ -34,7 +34,7 @@ class ConstructorParameterNamingSpec : Spek({
             assertThat(ConstructorParameterNaming().compileAndLint(code)).hasSize(5)
         }
 
-        it("should find a violation in the correct text locaction") {
+        it("should find a violation in the correct text location") {
             val code = """
                 class C(val PARAM: String)
             """

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ForbiddenClassNameSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ForbiddenClassNameSpec.kt
@@ -43,5 +43,17 @@ class ForbiddenClassNameSpec : Spek({
             )
                 .hasSize(2)
         }
+
+        it("should report classes with forbidden names using config string using wildcards") {
+            val code = """
+                class TestManager {} // violation
+                class TestProvider {} // violation
+                class TestHolder"""
+            assertThat(
+                ForbiddenClassName(TestConfig(mapOf(FORBIDDEN_NAME to "*Manager*, *Provider*")))
+                    .compileAndLint(code)
+            )
+                .hasSize(2)
+        }
     }
 })

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionParameterNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionParameterNamingSpec.kt
@@ -6,7 +6,10 @@ import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
-class FunctionParameterNamingSpec : Spek({
+private const val EXCLUDE_CLASS_PATTERN = "excludeClassPattern"
+private const val IGNORE_OVERRIDDEN = "ignoreOverridden"
+
+object FunctionParameterNamingSpec : Spek({
 
     describe("parameters in a function of a class") {
 
@@ -36,7 +39,7 @@ class FunctionParameterNamingSpec : Spek({
                 }
                 interface I { fun someStuff(`object`: String) }
             """
-            val config = TestConfig(mapOf(FunctionParameterNaming.IGNORE_OVERRIDDEN to "false"))
+            val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to "false"))
             assertThat(FunctionParameterNaming(config).compileAndLint(code)).hasSize(2)
         }
 
@@ -52,7 +55,7 @@ class FunctionParameterNamingSpec : Spek({
 
     describe("parameters in a function of an excluded class") {
 
-        val config by memoized { TestConfig(mapOf(FunctionParameterNaming.EXCLUDE_CLASS_PATTERN to "Excluded")) }
+        val config by memoized { TestConfig(mapOf(EXCLUDE_CLASS_PATTERN to "Excluded")) }
 
         it("should not detect function parameter") {
             val code = """

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/InvalidPackageDeclarationSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/InvalidPackageDeclarationSpec.kt
@@ -1,7 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.naming
 
 import io.github.detekt.test.utils.compileContentForTest
-import io.gitlab.arturbosch.detekt.rules.naming.InvalidPackageDeclaration.Companion.ROOT_PACKAGE
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lint
@@ -9,6 +8,8 @@ import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 import java.nio.file.FileSystems
 import java.nio.file.Paths
+
+private const val ROOT_PACKAGE = "rootPackage"
 
 internal class InvalidPackageDeclarationSpec : Spek({
 

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MemberNameEqualsClassNameSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MemberNameEqualsClassNameSpec.kt
@@ -10,6 +10,8 @@ import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
+private const val IGNORE_OVERRIDDEN = "ignoreOverridden"
+
 class MemberNameEqualsClassNameSpec : Spek({
     setupKotlinEnvironment()
 
@@ -21,7 +23,7 @@ class MemberNameEqualsClassNameSpec : Spek({
         val noIgnoreOverridden by memoized {
             TestConfig(
                 mapOf(
-                    MemberNameEqualsClassName.IGNORE_OVERRIDDEN_FUNCTION to "false"
+                    IGNORE_OVERRIDDEN to "false"
                 )
             )
         }

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNamingSpec.kt
@@ -6,6 +6,10 @@ import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
+private const val CONSTANT_PATTERN = "constantPattern"
+private const val PROPERTY_PATTERN = "propertyPattern"
+private const val PRIVATE_PROPERTY_PATTERN = "privatePropertyPattern"
+
 class ObjectPropertyNamingSpec : Spek({
 
     describe("constants in object declarations") {
@@ -164,8 +168,8 @@ class ObjectPropertyNamingSpec : Spek({
         val config by memoized {
             TestConfig(
                 mapOf(
-                    ObjectPropertyNaming.CONSTANT_PATTERN to "_[A-Za-z]*",
-                    ObjectPropertyNaming.PRIVATE_PROPERTY_PATTERN to ".*"
+                    CONSTANT_PATTERN to "_[A-Za-z]*",
+                    PRIVATE_PROPERTY_PATTERN to ".*"
                 )
             )
         }
@@ -196,7 +200,7 @@ class ObjectPropertyNamingSpec : Spek({
         it("should not detect local properties") {
             val config = TestConfig(
                 mapOf(
-                    ObjectPropertyNaming.PROPERTY_PATTERN to "valid"
+                    PROPERTY_PATTERN to "valid"
                 )
             )
             val subject = ObjectPropertyNaming(config)


### PR DESCRIPTION
This belongs to #3670 and replaces all configuration kdoc tags in `rules-naming` with annotations. 