### PR TITLE
Use annotation to configure rules in rules-documentation

### DIFF
--- a/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/AbsentOrWrongFileLicense.kt
+++ b/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/AbsentOrWrongFileLicense.kt
@@ -28,11 +28,13 @@ class AbsentOrWrongFileLicense(config: Config = Config.empty) : Rule(config) {
         debt = Debt.FIVE_MINS
     )
 
+    @Suppress("unused")
     @Configuration("path to file with license header template resolved relatively to config file")
-    val licenseTemplateFile: String by config(DEFAULT_LICENSE_TEMPLATE_FILE)
+    private val licenseTemplateFile: String by config(DEFAULT_LICENSE_TEMPLATE_FILE)
 
+    @Suppress("unused")
     @Configuration("whether or not the license header template is a regex template")
-    val licenseTemplateIsRegex: Boolean by config(DEFAULT_LICENSE_TEMPLATE_IS_REGEX)
+    private val licenseTemplateIsRegex: Boolean by config(DEFAULT_LICENSE_TEMPLATE_IS_REGEX)
 
     override fun visitCondition(root: KtFile): Boolean =
         super.visitCondition(root) && (root.hasLicenseHeader() || root.hasLicenseHeaderRegex())

--- a/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/AbsentOrWrongFileLicense.kt
+++ b/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/AbsentOrWrongFileLicense.kt
@@ -7,6 +7,8 @@ import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.internal.Configuration
+import io.gitlab.arturbosch.detekt.api.internal.config
 import org.jetbrains.kotlin.psi.KtFile
 
 /**
@@ -16,11 +18,6 @@ import org.jetbrains.kotlin.psi.KtFile
  * `licenseTemplateFile` configuration option. If `licenseTemplateIsRegex = true` the rule matches the header with
  * a regular expression produced from the passed template license file (defined via `licenseTemplateFile` configuration
  * option).
- *
- * @configuration licenseTemplateFile - path to file with license header template resolved relatively to config file
- * (default: `'license.template'`)
- * @configuration licenseTemplateIsRegex - whether or not the license header template is a regex template
- * (default: `false`)
  */
 class AbsentOrWrongFileLicense(config: Config = Config.empty) : Rule(config) {
 
@@ -30,6 +27,12 @@ class AbsentOrWrongFileLicense(config: Config = Config.empty) : Rule(config) {
         description = "License text is absent or incorrect in the file.",
         debt = Debt.FIVE_MINS
     )
+
+    @Configuration("path to file with license header template resolved relatively to config file")
+    val licenseTemplateFile: String by config(DEFAULT_LICENSE_TEMPLATE_FILE)
+
+    @Configuration("whether or not the license header template is a regex template")
+    val licenseTemplateIsRegex: Boolean by config(DEFAULT_LICENSE_TEMPLATE_IS_REGEX)
 
     override fun visitCondition(root: KtFile): Boolean =
         super.visitCondition(root) && (root.hasLicenseHeader() || root.hasLicenseHeaderRegex())

--- a/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/EndOfSentenceFormat.kt
+++ b/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/EndOfSentenceFormat.kt
@@ -7,15 +7,14 @@ import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.internal.Configuration
+import io.gitlab.arturbosch.detekt.api.internal.config
 import io.gitlab.arturbosch.detekt.rules.lastArgumentMatchesUrl
 import org.jetbrains.kotlin.psi.KtDeclaration
 
 /**
  * This rule validates the end of the first sentence of a KDoc comment.
  * It should end with proper punctuation or with a correct URL.
- *
- * @configuration endOfSentenceFormat - regular expression which should match the end of the first sentence in the KDoc
- * (default: `'([.?!][ \t\n\r\f<])|([.?!:]$)'`)
  */
 @Suppress("MemberNameEqualsClassName")
 class EndOfSentenceFormat(config: Config = Config.empty) : Rule(config) {
@@ -27,8 +26,9 @@ class EndOfSentenceFormat(config: Config = Config.empty) : Rule(config) {
         Debt.FIVE_MINS
     )
 
-    private val endOfSentenceFormat =
-        Regex(valueOrDefault(END_OF_SENTENCE_FORMAT, "([.?!][ \\t\\n\\r\\f<])|([.?!:]\$)"))
+    @Configuration("regular expression which should match the end of the first sentence in the KDoc")
+    private val endOfSentenceFormat: Regex by config("""([.?!][ \t\n\r\f<])|([.?!:]$)""") { it.toRegex() }
+
     private val htmlTag = Regex("<.+>")
 
     override fun visitDeclaration(dcl: KtDeclaration) {

--- a/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicClass.kt
+++ b/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicClass.kt
@@ -7,6 +7,8 @@ import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.internal.Configuration
+import io.gitlab.arturbosch.detekt.api.internal.config
 import io.gitlab.arturbosch.detekt.rules.isPublicInherited
 import io.gitlab.arturbosch.detekt.rules.isPublicNotOverridden
 import org.jetbrains.kotlin.psi.KtClass
@@ -20,11 +22,6 @@ import org.jetbrains.kotlin.psi.KtObjectDeclaration
  *
  * By default this rule also searches for nested and inner classes and objects. This default behavior can be changed
  * with the configuration options of this rule.
- *
- * @configuration searchInNestedClass - if nested classes should be searched (default: `true`)
- * @configuration searchInInnerClass - if inner classes should be searched (default: `true`)
- * @configuration searchInInnerObject - if inner objects should be searched (default: `true`)
- * @configuration searchInInnerInterface - if inner interfaces should be searched (default: `true`)
  */
 class UndocumentedPublicClass(config: Config = Config.empty) : Rule(config) {
 
@@ -35,10 +32,17 @@ class UndocumentedPublicClass(config: Config = Config.empty) : Rule(config) {
         Debt.TWENTY_MINS
     )
 
-    private val searchInNestedClass = valueOrDefault(SEARCH_IN_NESTED_CLASS, true)
-    private val searchInInnerClass = valueOrDefault(SEARCH_IN_INNER_CLASS, true)
-    private val searchInInnerObject = valueOrDefault(SEARCH_IN_INNER_OBJECT, true)
-    private val searchInInnerInterface = valueOrDefault(SEARCH_IN_INNER_INTERFACE, true)
+    @Configuration("if nested classes should be searched")
+    private val searchInNestedClass: Boolean by config(true)
+
+    @Configuration("if inner classes should be searched")
+    private val searchInInnerClass: Boolean by config(true)
+
+    @Configuration("if inner objects should be searched")
+    private val searchInInnerObject: Boolean by config(true)
+
+    @Configuration("if inner interfaces should be searched")
+    private val searchInInnerInterface: Boolean by config(true)
 
     override fun visitClass(klass: KtClass) {
         if (requiresDocumentation(klass)) {
@@ -89,11 +93,4 @@ class UndocumentedPublicClass(config: Config = Config.empty) : Rule(config) {
     private fun KtClass.isInnerInterface() = !isTopLevel() && isInterface() && searchInInnerInterface
 
     private fun KtClassOrObject.notEnumEntry() = this !is KtEnumEntry
-
-    companion object {
-        const val SEARCH_IN_NESTED_CLASS = "searchInNestedClass"
-        const val SEARCH_IN_INNER_CLASS = "searchInInnerClass"
-        const val SEARCH_IN_INNER_OBJECT = "searchInInnerObject"
-        const val SEARCH_IN_INNER_INTERFACE = "searchInInnerInterface"
-    }
 }

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicClassSpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicClassSpec.kt
@@ -6,6 +6,11 @@ import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
+private const val SEARCH_IN_NESTED_CLASS = "searchInNestedClass"
+private const val SEARCH_IN_INNER_CLASS = "searchInInnerClass"
+private const val SEARCH_IN_INNER_OBJECT = "searchInInnerObject"
+private const val SEARCH_IN_INNER_INTERFACE = "searchInInnerInterface"
+
 class UndocumentedPublicClassSpec : Spek({
     val subject by memoized { UndocumentedPublicClass() }
 
@@ -85,22 +90,28 @@ class UndocumentedPublicClassSpec : Spek({
         }
 
         it("should not report inner classes when turned off") {
-            val findings = UndocumentedPublicClass(TestConfig(mapOf(UndocumentedPublicClass.SEARCH_IN_INNER_CLASS to "false"))).compileAndLint(inner)
+            val findings =
+                UndocumentedPublicClass(TestConfig(mapOf(SEARCH_IN_INNER_CLASS to "false"))).compileAndLint(inner)
             assertThat(findings).isEmpty()
         }
 
         it("should not report inner objects when turned off") {
-            val findings = UndocumentedPublicClass(TestConfig(mapOf(UndocumentedPublicClass.SEARCH_IN_INNER_OBJECT to "false"))).compileAndLint(innerObject)
+            val findings =
+                UndocumentedPublicClass(TestConfig(mapOf(SEARCH_IN_INNER_OBJECT to "false"))).compileAndLint(innerObject)
             assertThat(findings).isEmpty()
         }
 
         it("should not report inner interfaces when turned off") {
-            val findings = UndocumentedPublicClass(TestConfig(mapOf(UndocumentedPublicClass.SEARCH_IN_INNER_INTERFACE to "false"))).compileAndLint(innerInterface)
+            val findings =
+                UndocumentedPublicClass(TestConfig(mapOf(SEARCH_IN_INNER_INTERFACE to "false"))).compileAndLint(
+                    innerInterface
+                )
             assertThat(findings).isEmpty()
         }
 
         it("should not report nested classes when turned off") {
-            val findings = UndocumentedPublicClass(TestConfig(mapOf(UndocumentedPublicClass.SEARCH_IN_NESTED_CLASS to "false"))).compileAndLint(nested)
+            val findings =
+                UndocumentedPublicClass(TestConfig(mapOf(SEARCH_IN_NESTED_CLASS to "false"))).compileAndLint(nested)
             assertThat(findings).isEmpty()
         }
 


### PR DESCRIPTION
This belongs to #3670 and replaces all configuration kdoc tags in rules-documentation with annotations.