### PR TITLE
Use annotation to confugure rules in rules-empty

### DIFF
--- a/detekt-rules-empty/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyCatchBlock.kt
+++ b/detekt-rules-empty/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyCatchBlock.kt
@@ -1,9 +1,9 @@
 package io.gitlab.arturbosch.detekt.rules.empty
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.LazyRegex
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
-import io.gitlab.arturbosch.detekt.rules.ALLOWED_EXCEPTION_NAME
+import io.gitlab.arturbosch.detekt.api.internal.Configuration
+import io.gitlab.arturbosch.detekt.api.internal.config
 import io.gitlab.arturbosch.detekt.rules.isAllowedExceptionName
 import org.jetbrains.kotlin.psi.KtCatchClause
 
@@ -11,9 +11,6 @@ import org.jetbrains.kotlin.psi.KtCatchClause
  * Reports empty `catch` blocks. Empty catch blocks indicate that an exception is ignored and not handled.
  * In case exceptions are ignored intentionally, this should be made explicit
  * by using the specified names in the `allowedExceptionNameRegex`.
- *
- * @configuration allowedExceptionNameRegex - ignores exception types which match this regex
- * (default: `'_|(ignore|expected).*'`)
  */
 @ActiveByDefault(since = "1.0.0")
 class EmptyCatchBlock(config: Config) : EmptyRule(
@@ -26,7 +23,8 @@ class EmptyCatchBlock(config: Config) : EmptyRule(
         "name the exception according to one of the exemptions as per the configuration of this rule."
 ) {
 
-    private val allowedExceptionNameRegex by LazyRegex(ALLOWED_EXCEPTION_NAME_REGEX, ALLOWED_EXCEPTION_NAME)
+    @Configuration("ignores exception types which match this regex")
+    private val allowedExceptionNameRegex: Regex by config("_|(ignore|expected).*") { it.toRegex() }
 
     override fun visitCatchSection(catchClause: KtCatchClause) {
         super.visitCatchSection(catchClause)
@@ -34,9 +32,5 @@ class EmptyCatchBlock(config: Config) : EmptyRule(
             return
         }
         catchClause.catchBody?.addFindingIfBlockExprIsEmpty()
-    }
-
-    companion object {
-        const val ALLOWED_EXCEPTION_NAME_REGEX = "allowedExceptionNameRegex"
     }
 }

--- a/detekt-rules-empty/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyFunctionBlock.kt
+++ b/detekt-rules-empty/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyFunctionBlock.kt
@@ -2,6 +2,9 @@ package io.gitlab.arturbosch.detekt.rules.empty
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
+import io.gitlab.arturbosch.detekt.api.internal.Configuration
+import io.gitlab.arturbosch.detekt.api.internal.config
+import io.gitlab.arturbosch.detekt.api.internal.configWithFallback
 import io.gitlab.arturbosch.detekt.rules.isOpen
 import io.gitlab.arturbosch.detekt.rules.isOverride
 import org.jetbrains.kotlin.psi.KtClass
@@ -15,16 +18,17 @@ import org.jetbrains.kotlin.psi.psiUtil.getParentOfType
  *
  * Set the [ignoreOverridden] parameter to `true` to exclude all functions which are overriding other
  * functions from the superclass or from an interface (i.e., functions declared with the override modifier).
- *
- * @configuration ignoreOverriddenFunctions - Excludes all the overridden functions (default: `false`)
- * (deprecated: "Use `ignoreOverridden` instead")
- * @configuration ignoreOverridden - Excludes all the overridden functions (default: `false`)
  */
 @ActiveByDefault(since = "1.0.0")
 class EmptyFunctionBlock(config: Config) : EmptyRule(config) {
 
-    private val ignoreOverridden =
-        valueOrDefault(IGNORE_OVERRIDDEN, valueOrDefault(IGNORE_OVERRIDDEN_FUNCTIONS, false))
+    @Suppress("unused")
+    @Configuration("Excludes all the overridden functions")
+    @Deprecated("Use `ignoreOverridden` instead")
+    private val ignoreOverriddenFunctions: Boolean by config(false)
+
+    @Configuration("Excludes all the overridden functions")
+    private val ignoreOverridden: Boolean by configWithFallback("ignoreOverriddenFunctions", false)
 
     override fun visitNamedFunction(function: KtNamedFunction) {
         super.visitNamedFunction(function)
@@ -45,9 +49,4 @@ class EmptyFunctionBlock(config: Config) : EmptyRule(config) {
 
     private fun KtNamedFunction.isDefaultFunction() =
         getParentOfType<KtClass>(true)?.isInterface() == true && hasBody()
-
-    companion object {
-        const val IGNORE_OVERRIDDEN_FUNCTIONS = "ignoreOverriddenFunctions"
-        const val IGNORE_OVERRIDDEN = "ignoreOverridden"
-    }
 }

--- a/detekt-rules-empty/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyCodeSpec.kt
+++ b/detekt-rules-empty/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyCodeSpec.kt
@@ -13,6 +13,8 @@ import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 import java.util.regex.PatternSyntaxException
 
+private const val ALLOWED_EXCEPTION_NAME_REGEX = "allowedExceptionNameRegex"
+
 class EmptyCodeSpec : Spek({
 
     val regexTestingCode = """
@@ -59,7 +61,7 @@ class EmptyCodeSpec : Spek({
                 } catch (foo: Exception) {
                 }
             }"""
-            val config = TestConfig(mapOf(EmptyCatchBlock.ALLOWED_EXCEPTION_NAME_REGEX to "foo"))
+            val config = TestConfig(mapOf(ALLOWED_EXCEPTION_NAME_REGEX to "foo"))
             assertThat(EmptyCatchBlock(config).compileAndLint(code)).isEmpty()
         }
 
@@ -126,14 +128,14 @@ class EmptyCodeSpec : Spek({
         it("doesNotFailWithInvalidRegexWhenDisabled") {
             val configValues = mapOf(
                 "active" to "false",
-                EmptyCatchBlock.ALLOWED_EXCEPTION_NAME_REGEX to "*foo"
+                ALLOWED_EXCEPTION_NAME_REGEX to "*foo"
             )
             val config = TestConfig(configValues)
             assertThat(EmptyCatchBlock(config).compileAndLint(regexTestingCode)).isEmpty()
         }
 
         it("doesFailWithInvalidRegex") {
-            val configValues = mapOf(EmptyCatchBlock.ALLOWED_EXCEPTION_NAME_REGEX to "*foo")
+            val configValues = mapOf(ALLOWED_EXCEPTION_NAME_REGEX to "*foo")
             val config = TestConfig(configValues)
             assertThatExceptionOfType(PatternSyntaxException::class.java).isThrownBy {
                 EmptyCatchBlock(config).compileAndLint(regexTestingCode)

--- a/detekt-rules-empty/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyFunctionBlockSpec.kt
+++ b/detekt-rules-empty/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyFunctionBlockSpec.kt
@@ -7,6 +7,9 @@ import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
+private const val IGNORE_OVERRIDDEN_FUNCTIONS = "ignoreOverriddenFunctions"
+private const val IGNORE_OVERRIDDEN = "ignoreOverridden"
+
 class EmptyFunctionBlockSpec : Spek({
 
     val subject by memoized { EmptyFunctionBlock(Config.empty) }
@@ -75,7 +78,7 @@ class EmptyFunctionBlockSpec : Spek({
             }
 
             it("should not flag overridden functions") {
-                val config = TestConfig(mapOf(EmptyFunctionBlock.IGNORE_OVERRIDDEN_FUNCTIONS to "true"))
+                val config = TestConfig(mapOf(IGNORE_OVERRIDDEN_FUNCTIONS to "true"))
                 assertThat(EmptyFunctionBlock(config).compileAndLint(code)).hasSourceLocation(1, 13)
             }
         }
@@ -103,7 +106,7 @@ class EmptyFunctionBlockSpec : Spek({
             }
 
             it("should not flag overridden functions with ignoreOverridden") {
-                val config = TestConfig(mapOf(EmptyFunctionBlock.IGNORE_OVERRIDDEN to "true"))
+                val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to "true"))
                 assertThat(EmptyFunctionBlock(config).compileAndLint(code)).isEmpty()
             }
         }


### PR DESCRIPTION
This belongs to #3670 and replaces all configuration kdoc tags in rules-empty with annotations.