### PR TITLE
Use @Configuration for rules-errorprone

### DIFF
--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValue.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValue.kt
@@ -7,8 +7,9 @@ import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.internal.Configuration
 import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
-import io.gitlab.arturbosch.detekt.api.internal.valueOrDefaultCommaSeparated
+import io.gitlab.arturbosch.detekt.api.internal.config
 import io.gitlab.arturbosch.detekt.api.simplePatternToRegex
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.resolve.BindingContext
@@ -32,10 +33,6 @@ import org.jetbrains.kotlin.types.typeUtil.isUnit
  *     if (42 == returnsValue()) {}
  *     val x = returnsValue()
  * </compliant>
- *
- * @configuration restrictToAnnotatedMethods - if the rule should check only annotated methods. (default: `true`)
- * @configuration returnValueAnnotations - List of glob patterns to be used as inspection annotation (default: `['*.CheckReturnValue', '*.CheckResult']`)
- *
  */
 @RequiresTypeResolution
 class IgnoredReturnValue(config: Config = Config.empty) : Rule(config) {
@@ -47,17 +44,13 @@ class IgnoredReturnValue(config: Config = Config.empty) : Rule(config) {
         Debt.TWENTY_MINS
     )
 
-    private val annotationsRegexes = valueOrDefaultCommaSeparated(
-        RETURN_VALUE_ANNOTATIONS,
-        DEFAULT_RETURN_VALUE_ANNOTATIONS
-    )
-        .distinct()
-        .map { it.simplePatternToRegex() }
+    @Configuration("List of glob patterns to be used as inspection annotation")
+    private val returnValueAnnotations: List<Regex> by config(listOf("*.CheckReturnValue", "*.CheckResult")) {
+        it.map(String::simplePatternToRegex)
+    }
 
-    private val restrictToAnnotatedMethods: Boolean = valueOrDefault(
-        RESTRICT_TO_ANNOTATED_METHODS,
-        DEFAULT_RESTRICT_TO_ANNOTATED_METHODS
-    )
+    @Configuration("if the rule should check only annotated methods")
+    private val restrictToAnnotatedMethods: Boolean by config(defaultValue = true)
 
     @Suppress("ReturnCount")
     override fun visitCallExpression(expression: KtCallExpression) {
@@ -70,7 +63,7 @@ class IgnoredReturnValue(config: Config = Config.empty) : Rule(config) {
         if (resultingDescriptor.returnType?.isUnit() == true) return
         if (restrictToAnnotatedMethods) {
             val annotations = resultingDescriptor.annotations.mapNotNull { it.fqName?.asString() }
-            if (annotations.none { annotation -> annotationsRegexes.any { it.matches(annotation) } }) {
+            if (annotations.none { annotation -> returnValueAnnotations.any { it.matches(annotation) } }) {
                 return
             }
         }
@@ -83,12 +76,5 @@ class IgnoredReturnValue(config: Config = Config.empty) : Rule(config) {
                 message = "The call $messageText is returning a value that is ignored."
             )
         )
-    }
-
-    companion object {
-        const val RESTRICT_TO_ANNOTATED_METHODS = "restrictToAnnotatedMethods"
-        const val DEFAULT_RESTRICT_TO_ANNOTATED_METHODS = true
-        const val RETURN_VALUE_ANNOTATIONS = "returnValueAnnotations"
-        val DEFAULT_RETURN_VALUE_ANNOTATIONS = listOf("*.CheckReturnValue", "*.CheckResult")
     }
 }

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValue.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValue.kt
@@ -44,13 +44,13 @@ class IgnoredReturnValue(config: Config = Config.empty) : Rule(config) {
         Debt.TWENTY_MINS
     )
 
+    @Configuration("if the rule should check only annotated methods")
+    private val restrictToAnnotatedMethods: Boolean by config(defaultValue = true)
+
     @Configuration("List of glob patterns to be used as inspection annotation")
     private val returnValueAnnotations: List<Regex> by config(listOf("*.CheckReturnValue", "*.CheckResult")) {
         it.map(String::simplePatternToRegex)
     }
-
-    @Configuration("if the rule should check only annotated methods")
-    private val restrictToAnnotatedMethods: Boolean by config(defaultValue = true)
 
     @Suppress("ReturnCount")
     override fun visitCallExpression(expression: KtCallExpression) {

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ImplicitUnitReturnType.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ImplicitUnitReturnType.kt
@@ -7,7 +7,9 @@ import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.internal.Configuration
 import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
+import io.gitlab.arturbosch.detekt.api.internal.config
 import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.calls.callUtil.getResolvedCall
@@ -17,9 +19,6 @@ import org.jetbrains.kotlin.resolve.calls.callUtil.getResolvedCall
  * Changing the type of the expression accidentally, changes the functions return type.
  * This may lead to backward incompatibility.
  * Use a block statement to make clear this function will never return a value.
- *
- * @configuration allowExplicitReturnType - if functions with explicit 'Unit' return type should be allowed
- * (default: `true`)
  *
  * <noncompliant>
  * fun errorProneUnit() = println("Hello Unit")
@@ -52,7 +51,8 @@ class ImplicitUnitReturnType(config: Config) : Rule(config) {
         Debt.FIVE_MINS
     )
 
-    private val allowExplicitReturnType = valueOrDefault(ALLOW_EXPLICIT_RETURN_TYPE, true)
+    @Configuration("if functions with explicit 'Unit' return type should be allowed")
+    private val allowExplicitReturnType: Boolean by config(true)
 
     override fun visitNamedFunction(function: KtNamedFunction) {
         super.visitNamedFunction(function)
@@ -90,9 +90,5 @@ class ImplicitUnitReturnType(config: Config) : Rule(config) {
             ?.resultingDescriptor
             ?.returnType
         return returnType?.toString() == "Unit"
-    }
-
-    companion object {
-        const val ALLOW_EXPLICIT_RETURN_TYPE = "allowExplicitReturnType"
     }
 }

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/LateinitUsage.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/LateinitUsage.kt
@@ -6,10 +6,10 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.LazyRegex
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
-import io.gitlab.arturbosch.detekt.api.internal.valueOrDefaultCommaSeparated
+import io.gitlab.arturbosch.detekt.api.internal.Configuration
+import io.gitlab.arturbosch.detekt.api.internal.config
 import io.gitlab.arturbosch.detekt.rules.isLateinit
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtProperty
@@ -27,10 +27,6 @@ import org.jetbrains.kotlin.psi.psiUtil.containingClass
  *     @JvmField @SinceKotlin("1.0.0") lateinit var i2: Int
  * }
  * </noncompliant>
- *
- * @configuration excludeAnnotatedProperties - Allows you to provide a list of annotations that disable
- * this check. (default: `[]`)
- * @configuration ignoreOnClassesPattern - Allows you to disable the rule for a list of classes (default: `''`)
  */
 class LateinitUsage(config: Config = Config.empty) : Rule(config) {
 
@@ -42,10 +38,13 @@ class LateinitUsage(config: Config = Config.empty) : Rule(config) {
         Debt.TWENTY_MINS
     )
 
-    private val excludeAnnotatedProperties = valueOrDefaultCommaSeparated(EXCLUDE_ANNOTATED_PROPERTIES, emptyList())
-        .map { it.removePrefix("*").removeSuffix("*") }
+    @Configuration("Allows you to provide a list of annotations that disable")
+    private val excludeAnnotatedProperties: List<String> by config(emptyList<String>()) { list ->
+        list.map { it.removePrefix("*").removeSuffix("*") }
+    }
 
-    private val ignoreOnClassesPattern by LazyRegex(key = IGNORE_ON_CLASSES_PATTERN, default = "")
+    @Configuration("Allows you to disable the rule for a list of classes")
+    private val ignoreOnClassesPattern: Regex by config("''", String::toRegex)
 
     private var properties = mutableListOf<KtProperty>()
 
@@ -67,10 +66,5 @@ class LateinitUsage(config: Config = Config.empty) : Rule(config) {
             .forEach {
                 report(CodeSmell(issue, Entity.from(it), "Usages of lateinit should be avoided."))
             }
-    }
-
-    companion object {
-        const val EXCLUDE_ANNOTATED_PROPERTIES = "excludeAnnotatedProperties"
-        const val IGNORE_ON_CLASSES_PATTERN = "ignoreOnClassesPattern"
     }
 }

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/LateinitUsage.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/LateinitUsage.kt
@@ -44,7 +44,7 @@ class LateinitUsage(config: Config = Config.empty) : Rule(config) {
     }
 
     @Configuration("Allows you to disable the rule for a list of classes")
-    private val ignoreOnClassesPattern: Regex by config("''", String::toRegex)
+    private val ignoreOnClassesPattern: Regex by config("", String::toRegex)
 
     private var properties = mutableListOf<KtProperty>()
 

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/LateinitUsage.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/LateinitUsage.kt
@@ -38,7 +38,7 @@ class LateinitUsage(config: Config = Config.empty) : Rule(config) {
         Debt.TWENTY_MINS
     )
 
-    @Configuration("Allows you to provide a list of annotations that disable")
+    @Configuration("Allows you to provide a list of annotations that disable this check.")
     private val excludeAnnotatedProperties: List<String> by config(emptyList<String>()) { list ->
         list.map { it.removePrefix("*").removeSuffix("*") }
     }

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingWhenCase.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingWhenCase.kt
@@ -8,7 +8,9 @@ import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
+import io.gitlab.arturbosch.detekt.api.internal.Configuration
 import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
+import io.gitlab.arturbosch.detekt.api.internal.config
 import org.jetbrains.kotlin.cfg.WhenChecker
 import org.jetbrains.kotlin.cfg.WhenMissingCase
 import org.jetbrains.kotlin.psi.KtWhenExpression
@@ -64,7 +66,6 @@ import org.jetbrains.kotlin.resolve.calls.callUtil.getType
  *     }
  * }
  * </compliant>
- * @configuration allowElseExpression - whether `else` can be treated as a valid case for enums and sealed classes (default: `true`)
  */
 @ActiveByDefault(since = "1.2.0")
 @RequiresTypeResolution
@@ -77,7 +78,8 @@ class MissingWhenCase(config: Config = Config.empty) : Rule(config) {
         Debt.TWENTY_MINS
     )
 
-    private val allowElseExpression = valueOrDefault(ALLOW_ELSE_EXPRESSION, true)
+    @Configuration("whether `else` can be treated as a valid case for enums and sealed classes")
+    private val allowElseExpression: Boolean by config(true)
 
     override fun visitWhenExpression(expression: KtWhenExpression) {
         super.visitWhenExpression(expression)
@@ -110,9 +112,5 @@ class MissingWhenCase(config: Config = Config.empty) : Rule(config) {
             }
             report(CodeSmell(issue, Entity.from(expression), message))
         }
-    }
-
-    companion object {
-        const val ALLOW_ELSE_EXPRESSION = "allowElseExpression"
     }
 }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValueSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValueSpec.kt
@@ -593,7 +593,7 @@ object IgnoredReturnValueSpec : Spek({
     describe("custom annotation config") {
         val subject by memoized {
             IgnoredReturnValue(
-                TestConfig(mapOf(IgnoredReturnValue.RETURN_VALUE_ANNOTATIONS to listOf("*.CustomReturn")))
+                TestConfig(mapOf("returnValueAnnotations" to listOf("*.CustomReturn")))
             )
         }
 
@@ -652,7 +652,7 @@ object IgnoredReturnValueSpec : Spek({
 
     describe("restrict to annotated methods config") {
         val subject by memoized {
-            IgnoredReturnValue(TestConfig(mapOf(IgnoredReturnValue.RESTRICT_TO_ANNOTATED_METHODS to false)))
+            IgnoredReturnValue(TestConfig(mapOf("restrictToAnnotatedMethods" to false)))
         }
 
         it("reports when a function is annotated with a custom annotation") {

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ImplicitUnitReturnTypeSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ImplicitUnitReturnTypeSpec.kt
@@ -1,7 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.bugs
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.rules.bugs.ImplicitUnitReturnType.Companion.ALLOW_EXPLICIT_RETURN_TYPE
 import io.gitlab.arturbosch.detekt.rules.setupKotlinEnvironment
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
@@ -41,7 +40,7 @@ class ImplicitUnitReturnTypeSpec : Spek({
         it("reports explicit Unit return type if configured") {
             val code = """fun safeButStillReported(): Unit = println("Hello Unit")"""
 
-            val findings = ImplicitUnitReturnType(TestConfig(ALLOW_EXPLICIT_RETURN_TYPE to "false"))
+            val findings = ImplicitUnitReturnType(TestConfig("allowExplicitReturnType" to "false"))
                 .compileAndLintWithContext(env, code)
 
             assertThat(findings).hasSize(1)

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/LateinitUsageSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/LateinitUsageSpec.kt
@@ -26,61 +26,64 @@ class LateinitUsageSpec : Spek({
         }
 
         it("should only report lateinit property with no @SinceKotlin annotation") {
-            val findings = LateinitUsage(TestConfig(mapOf(LateinitUsage.EXCLUDE_ANNOTATED_PROPERTIES to listOf("SinceKotlin")))).compileAndLint(code)
+            val findings = LateinitUsage(TestConfig(mapOf(EXCLUDE_ANNOTATED_PROPERTIES to listOf("SinceKotlin")))).compileAndLint(code)
             assertThat(findings).hasSize(1)
         }
 
         it("should only report lateinit properties not matching kotlin.*") {
-            val findings = LateinitUsage(TestConfig(mapOf(LateinitUsage.EXCLUDE_ANNOTATED_PROPERTIES to listOf("kotlin.*")))).compileAndLint(code)
+            val findings = LateinitUsage(TestConfig(mapOf(EXCLUDE_ANNOTATED_PROPERTIES to listOf("kotlin.*")))).compileAndLint(code)
             assertThat(findings).hasSize(1)
         }
 
         it("should only report lateinit properties matching kotlin.") {
-            val findings = LateinitUsage(TestConfig(mapOf(LateinitUsage.EXCLUDE_ANNOTATED_PROPERTIES to listOf("kotlin.")))).compileAndLint(code)
+            val findings = LateinitUsage(TestConfig(mapOf(EXCLUDE_ANNOTATED_PROPERTIES to listOf("kotlin.")))).compileAndLint(code)
             assertThat(findings).hasSize(1)
         }
 
         it("should only report lateinit properties matching kotlin.SinceKotlin") {
-            val config = TestConfig(mapOf(LateinitUsage.EXCLUDE_ANNOTATED_PROPERTIES to listOf("kotlin.SinceKotlin")))
+            val config = TestConfig(mapOf(EXCLUDE_ANNOTATED_PROPERTIES to listOf("kotlin.SinceKotlin")))
             val findings = LateinitUsage(config).compileAndLint(code)
             assertThat(findings).hasSize(1)
         }
 
         it("should only report lateinit property with no @SinceKotlin annotation with config string") {
-            val findings = LateinitUsage(TestConfig(mapOf(LateinitUsage.EXCLUDE_ANNOTATED_PROPERTIES to "SinceKotlin"))).compileAndLint(code)
+            val findings = LateinitUsage(TestConfig(mapOf(EXCLUDE_ANNOTATED_PROPERTIES to "SinceKotlin"))).compileAndLint(code)
             assertThat(findings).hasSize(1)
         }
 
         it("should only report lateinit property with no @SinceKotlin annotation containing whitespaces with config string") {
-            val findings = LateinitUsage(TestConfig(mapOf(LateinitUsage.EXCLUDE_ANNOTATED_PROPERTIES to " SinceKotlin "))).compileAndLint(code)
+            val findings = LateinitUsage(TestConfig(mapOf(EXCLUDE_ANNOTATED_PROPERTIES to " SinceKotlin "))).compileAndLint(code)
             assertThat(findings).hasSize(1)
         }
 
         it("should report lateinit properties not matching the exclude pattern") {
-            val findings = LateinitUsage(TestConfig(mapOf(LateinitUsage.EXCLUDE_ANNOTATED_PROPERTIES to "IgnoreThis"))).compileAndLint(code)
+            val findings = LateinitUsage(TestConfig(mapOf(EXCLUDE_ANNOTATED_PROPERTIES to "IgnoreThis"))).compileAndLint(code)
             assertThat(findings).hasSize(2)
         }
 
         it("should report lateinit properties when ignoreOnClassesPattern does not match") {
-            val findings = LateinitUsage(TestConfig(mapOf(LateinitUsage.IGNORE_ON_CLASSES_PATTERN to "[\\w]+Test1234"))).compileAndLint(code)
+            val findings = LateinitUsage(TestConfig(mapOf(IGNORE_ON_CLASSES_PATTERN to "[\\w]+Test1234"))).compileAndLint(code)
             assertThat(findings).hasSize(2)
         }
 
         it("should not report lateinit properties when ignoreOnClassesPattern does match") {
-            val findings = LateinitUsage(TestConfig(mapOf(LateinitUsage.IGNORE_ON_CLASSES_PATTERN to "[\\w]+Test"))).compileAndLint(code)
+            val findings = LateinitUsage(TestConfig(mapOf(IGNORE_ON_CLASSES_PATTERN to "[\\w]+Test"))).compileAndLint(code)
             assertThat(findings).isEmpty()
         }
 
         it("should fail when enabled with faulty regex pattern") {
             assertThatExceptionOfType(PatternSyntaxException::class.java).isThrownBy {
-                LateinitUsage(TestConfig(mapOf(LateinitUsage.IGNORE_ON_CLASSES_PATTERN to "*Test"))).compileAndLint(code)
+                LateinitUsage(TestConfig(mapOf(IGNORE_ON_CLASSES_PATTERN to "*Test"))).compileAndLint(code)
             }
         }
 
         it("should not fail when disabled with faulty regex pattern") {
-            val configValues = mapOf("active" to "false", LateinitUsage.IGNORE_ON_CLASSES_PATTERN to "*Test")
+            val configValues = mapOf("active" to "false", IGNORE_ON_CLASSES_PATTERN to "*Test")
             val findings = LateinitUsage(TestConfig(configValues)).compileAndLint(code)
             assertThat(findings).isEmpty()
         }
     }
 })
+
+private const val EXCLUDE_ANNOTATED_PROPERTIES = "excludeAnnotatedProperties"
+private const val IGNORE_ON_CLASSES_PATTERN = "ignoreOnClassesPattern"

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingWhenCaseSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingWhenCaseSpec.kt
@@ -284,7 +284,7 @@ object MissingWhenCaseSpec : Spek({
     describe("MissingWhenCase rule when else expression is not considered") {
         val subject by memoized {
             MissingWhenCase(
-                TestConfig(mapOf(MissingWhenCase.ALLOW_ELSE_EXPRESSION to false))
+                TestConfig(mapOf("allowElseExpression" to false))
             )
         }
 


### PR DESCRIPTION
This belongs to #3670 and replaces all configuration kdoc tags in detekt-rules-errorprone with annotation.