### PR TITLE
Use @Configuration in detekt-rules-style

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -681,6 +681,7 @@ style:
   ThrowsCount:
     active: true
     max: 2
+    excludeGuardClauses: false
   TrailingWhitespace:
     active: false
   UnderscoresInNumericLiterals:

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/ConfigurationCollector.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/ConfigurationCollector.kt
@@ -161,7 +161,8 @@ class ConfigurationCollector {
 
         private const val TYPE_STRING = "String"
         private const val TYPE_REGEX = "Regex"
-        private val TYPES_THAT_NEED_QUOTATION_FOR_DEFAULT = listOf(TYPE_STRING, TYPE_REGEX)
+        private const val TYPE_SPLIT_PATTERN = "SplitPattern"
+        private val TYPES_THAT_NEED_QUOTATION_FOR_DEFAULT = listOf(TYPE_STRING, TYPE_REGEX, TYPE_SPLIT_PATTERN)
 
         private val KtPropertyDelegate.property: KtProperty
             get() = parent as KtProperty

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/DataClassContainsFunctions.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/DataClassContainsFunctions.kt
@@ -8,6 +8,8 @@ import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.SplitPattern
+import io.gitlab.arturbosch.detekt.api.internal.Configuration
+import io.gitlab.arturbosch.detekt.api.internal.config
 import io.gitlab.arturbosch.detekt.rules.isOverride
 import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtNamedFunction
@@ -24,8 +26,6 @@ import org.jetbrains.kotlin.psi.KtNamedFunction
  *     fun foo() { }
  * }
  * </noncompliant>
- *
- * @configuration conversionFunctionPrefix - allowed conversion function names (default: `'to'`)
  */
 class DataClassContainsFunctions(config: Config = Config.empty) : Rule(config) {
 
@@ -37,7 +37,8 @@ class DataClassContainsFunctions(config: Config = Config.empty) : Rule(config) {
         Debt.TWENTY_MINS
     )
 
-    private val conversionFunctionPrefix = SplitPattern(valueOrDefault(CONVERSION_FUNCTION_PREFIX, "to"))
+    @Configuration("allowed conversion function names")
+    private val conversionFunctionPrefix: SplitPattern by config("to") { SplitPattern(it) }
 
     override fun visitClass(klass: KtClass) {
         if (klass.isData()) {
@@ -59,9 +60,5 @@ class DataClassContainsFunctions(config: Config = Config.empty) : Rule(config) {
                 )
             )
         }
-    }
-
-    companion object {
-        const val CONVERSION_FUNCTION_PREFIX = "conversionFunctionPrefix"
     }
 }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/DestructuringDeclarationWithTooManyEntries.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/DestructuringDeclarationWithTooManyEntries.kt
@@ -7,6 +7,8 @@ import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.internal.Configuration
+import io.gitlab.arturbosch.detekt.api.internal.config
 import org.jetbrains.kotlin.psi.KtDestructuringDeclaration
 
 /**
@@ -22,8 +24,6 @@ import org.jetbrains.kotlin.psi.KtDestructuringDeclaration
  * data class FewerElements(val a: Int, val b: Int, val c: Int)
  * val (a, b, c) = TooManyElements(1, 2, 3)
  * </compliant>
- *
- * @configuration maxDestructuringEntries - maximum allowed elements in a destructuring declaration (default: `3`)
  */
 class DestructuringDeclarationWithTooManyEntries(config: Config = Config.empty) : Rule(config) {
     override val issue = Issue(
@@ -34,16 +34,13 @@ class DestructuringDeclarationWithTooManyEntries(config: Config = Config.empty) 
         Debt.TEN_MINS
     )
 
-    private val maxDestructuringEntries = valueOrDefault(MAX_DESTRUCTURING_ENTRIES, 3)
+    @Configuration("maximum allowed elements in a destructuring declaration")
+    private val maxDestructuringEntries: Int by config(3)
 
     override fun visitDestructuringDeclaration(destructuringDeclaration: KtDestructuringDeclaration) {
         if (destructuringDeclaration.entries.size > maxDestructuringEntries) {
             report(CodeSmell(issue, Entity.from(destructuringDeclaration), issue.description))
         }
         super.visitDestructuringDeclaration(destructuringDeclaration)
-    }
-
-    companion object {
-        const val MAX_DESTRUCTURING_ENTRIES = "maxDestructuringEntries"
     }
 }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExpressionBodySyntax.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExpressionBodySyntax.kt
@@ -7,6 +7,8 @@ import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.internal.Configuration
+import io.gitlab.arturbosch.detekt.api.internal.config
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtBinaryExpression
 import org.jetbrains.kotlin.psi.KtBlockExpression
@@ -35,8 +37,6 @@ import org.jetbrains.kotlin.psi.psiUtil.anyDescendantOfType
  *             .stuffStuff()
  * }
  * </compliant>
- *
- * @configuration includeLineWrapping - include return statements with line wraps in it (default: `false`)
  */
 class ExpressionBodySyntax(config: Config = Config.empty) : Rule(config) {
 
@@ -48,7 +48,8 @@ class ExpressionBodySyntax(config: Config = Config.empty) : Rule(config) {
         Debt.FIVE_MINS
     )
 
-    private val includeLineWrapping = valueOrDefault(INCLUDE_LINE_WRAPPING, false)
+    @Configuration("include return statements with line wraps in it")
+    private val includeLineWrapping: Boolean by config(false)
 
     override fun visitNamedFunction(function: KtNamedFunction) {
         val stmt = function.bodyExpression
@@ -68,8 +69,4 @@ class ExpressionBodySyntax(config: Config = Config.empty) : Rule(config) {
 
     private fun isLineWrapped(expression: KtExpression): Boolean =
         expression.children.any { it.text.contains('\n') }
-
-    companion object {
-        const val INCLUDE_LINE_WRAPPING = "includeLineWrapping"
-    }
 }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenComment.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenComment.kt
@@ -5,11 +5,11 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.LazyRegex
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
-import io.gitlab.arturbosch.detekt.api.internal.valueOrDefaultCommaSeparated
+import io.gitlab.arturbosch.detekt.api.internal.Configuration
+import io.gitlab.arturbosch.detekt.api.internal.config
 import org.jetbrains.kotlin.com.intellij.psi.PsiComment
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.kdoc.psi.impl.KDocSection
@@ -26,10 +26,6 @@ import org.jetbrains.kotlin.psi.psiUtil.collectDescendantsOfType
  * fun foo() { }
  * // STOPSHIP:
  * </noncompliant>
- *
- * @configuration values - forbidden comment strings (default: `['TODO:', 'FIXME:', 'STOPSHIP:']`)
- * @configuration allowedPatterns - ignores comments which match the specified regular expression.
- * For example `Ticket|Task`. (default: `''`)
  */
 @ActiveByDefault(since = "1.0.0")
 class ForbiddenComment(config: Config = Config.empty) : Rule(config) {
@@ -41,9 +37,11 @@ class ForbiddenComment(config: Config = Config.empty) : Rule(config) {
         Debt.TEN_MINS
     )
 
-    private val values: List<String> = valueOrDefaultCommaSeparated(VALUES, listOf("TODO:", "FIXME:", "STOPSHIP:"))
+    @Configuration("forbidden comment strings")
+    private val values: List<String> by config(listOf("TODO:", "FIXME:", "STOPSHIP:"))
 
-    private val allowedPatterns: Regex by LazyRegex(ALLOWED_PATTERNS, "")
+    @Configuration("ignores comments which match the specified regular expression. For example `Ticket|Task`.")
+    private val allowedPatterns: Regex by config("", String::toRegex)
 
     override fun visitComment(comment: PsiComment) {
         super.visitComment(comment)
@@ -74,10 +72,5 @@ class ForbiddenComment(config: Config = Config.empty) : Rule(config) {
                 )
             }
         }
-    }
-
-    companion object {
-        const val VALUES = "values"
-        const val ALLOWED_PATTERNS = "allowedPatterns"
     }
 }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCall.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCall.kt
@@ -52,14 +52,12 @@ class ForbiddenMethodCall(config: Config = Config.empty) : Rule(config) {
             "(i.e. `java.time.LocalDate(java.time.Clock)`) which would report only call " +
             "with this concrete signature."
     )
-    private val methods: List<String> by config(
+    private val methods: List<Pair<String, List<String>?>> by config(
         listOf(
             "kotlin.io.println",
             "kotlin.io.print"
         )
-    )
-
-    private val forbiddenMethods = methods.map { extractMethodNameAndParams(it) }
+    ) { it.map(::extractMethodNameAndParams) }
 
     override fun visitCallExpression(expression: KtCallExpression) {
         super.visitCallExpression(expression)
@@ -90,7 +88,7 @@ class ForbiddenMethodCall(config: Config = Config.empty) : Rule(config) {
             .map { it.type.fqNameOrNull()?.asString() }
 
         if (methodName != null) {
-            forbiddenMethods
+            methods
                 .filter { methodName == it.first }
                 .forEach {
                     val expectedParamTypes = it.second

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/FunctionOnlyReturningConstant.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/FunctionOnlyReturningConstant.kt
@@ -10,7 +10,8 @@ import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.SplitPattern
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
-import io.gitlab.arturbosch.detekt.api.internal.valueOrDefaultCommaSeparated
+import io.gitlab.arturbosch.detekt.api.internal.Configuration
+import io.gitlab.arturbosch.detekt.api.internal.config
 import io.gitlab.arturbosch.detekt.rules.isActual
 import io.gitlab.arturbosch.detekt.rules.isOpen
 import io.gitlab.arturbosch.detekt.rules.isOverride
@@ -33,12 +34,6 @@ import org.jetbrains.kotlin.psi.psiUtil.containingClass
  * <compliant>
  * const val constantString = "1"
  * </compliant>
- *
- * @configuration ignoreOverridableFunction - if overriden functions should be ignored (default: `true`)
- * @configuration ignoreActualFunction - if actual functions should be ignored (default: `true`)
- * @configuration excludedFunctions - excluded functions (default: `'describeContents'`)
- * @configuration excludeAnnotatedFunction - allows to provide a list of annotations that disable this check
- * (default: `['dagger.Provides']`)
  */
 @ActiveByDefault(since = "1.2.0")
 class FunctionOnlyReturningConstant(config: Config = Config.empty) : Rule(config) {
@@ -51,18 +46,24 @@ class FunctionOnlyReturningConstant(config: Config = Config.empty) : Rule(config
         Debt.TEN_MINS
     )
 
-    private val ignoreOverridableFunction = valueOrDefault(IGNORE_OVERRIDABLE_FUNCTION, true)
-    private val ignoreActualFunction = valueOrDefault(IGNORE_ACTUAL_FUNCTION, true)
-    private val excludedFunctions = SplitPattern(valueOrDefault(EXCLUDED_FUNCTIONS, "describeContents"))
-    private val excludeAnnotatedFunctions = valueOrDefaultCommaSeparated(
-        EXCLUDE_ANNOTATED_FUNCTION,
-        listOf("dagger.Provides")
-    )
-        .map { it.removePrefix("*").removeSuffix("*") }
+    @Configuration("if overriden functions should be ignored")
+    private val ignoreOverridableFunction: Boolean by config(true)
+
+    @Configuration("if actual functions should be ignored")
+    private val ignoreActualFunction: Boolean by config(true)
+
+    @Configuration("excluded functions")
+    private val excludedFunctions: SplitPattern by config("describeContents") { SplitPattern(it) }
+
+    @Configuration("allows to provide a list of annotations that disable this check")
+    private val excludeAnnotatedFunction: List<String> by config(listOf("dagger.Provides")) { functions ->
+        functions.map { it.removeSurrounding("*") }
+    }
+
     private lateinit var annotationExcluder: AnnotationExcluder
 
     override fun visit(root: KtFile) {
-        annotationExcluder = AnnotationExcluder(root, excludeAnnotatedFunctions)
+        annotationExcluder = AnnotationExcluder(root, excludeAnnotatedFunction)
         super.visit(root)
     }
 
@@ -120,12 +121,5 @@ class FunctionOnlyReturningConstant(config: Config = Config.empty) : Rule(config
     private fun returnsConstant(function: KtNamedFunction): Boolean {
         val returnExpression = function.bodyExpression?.children?.singleOrNull() as? KtReturnExpression
         return isConstantExpression(returnExpression?.returnedExpression)
-    }
-
-    companion object {
-        const val IGNORE_OVERRIDABLE_FUNCTION = "ignoreOverridableFunction"
-        const val IGNORE_ACTUAL_FUNCTION = "ignoreActualFunction"
-        const val EXCLUDED_FUNCTIONS = "excludedFunctions"
-        const val EXCLUDE_ANNOTATED_FUNCTION = "excludeAnnotatedFunction"
     }
 }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/FunctionOnlyReturningConstant.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/FunctionOnlyReturningConstant.kt
@@ -53,7 +53,7 @@ class FunctionOnlyReturningConstant(config: Config = Config.empty) : Rule(config
     private val ignoreActualFunction: Boolean by config(true)
 
     @Configuration("excluded functions")
-    private val excludedFunctions: SplitPattern by config("describeContents") { SplitPattern(it) }
+    private val excludedFunctions: SplitPattern by config("") { SplitPattern(it) }
 
     @Configuration("allows to provide a list of annotations that disable this check")
     private val excludeAnnotatedFunction: List<String> by config(listOf("dagger.Provides")) { functions ->

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/FunctionOnlyReturningConstant.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/FunctionOnlyReturningConstant.kt
@@ -57,7 +57,7 @@ class FunctionOnlyReturningConstant(config: Config = Config.empty) : Rule(config
 
     @Configuration("allows to provide a list of annotations that disable this check")
     private val excludeAnnotatedFunction: List<String> by config(listOf("dagger.Provides")) { functions ->
-        functions.map { it.removeSurrounding("*") }
+        functions.map { it.removePrefix("*").removeSuffix("*") }
     }
 
     private lateinit var annotationExcluder: AnnotationExcluder

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/LoopWithTooManyJumpStatements.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/LoopWithTooManyJumpStatements.kt
@@ -9,6 +9,8 @@ import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
+import io.gitlab.arturbosch.detekt.api.internal.Configuration
+import io.gitlab.arturbosch.detekt.api.internal.config
 import org.jetbrains.kotlin.psi.KtBreakExpression
 import org.jetbrains.kotlin.psi.KtContinueExpression
 import org.jetbrains.kotlin.psi.KtElement
@@ -29,8 +31,6 @@ import org.jetbrains.kotlin.psi.KtLoopExpression
  *     }
  * }
  * </noncompliant>
- *
- * @configuration maxJumpCount - maximum allowed jumps in a loop (default: `1`)
  */
 @ActiveByDefault(since = "1.2.0")
 class LoopWithTooManyJumpStatements(config: Config = Config.empty) : Rule(config) {
@@ -43,7 +43,8 @@ class LoopWithTooManyJumpStatements(config: Config = Config.empty) : Rule(config
         Debt.TEN_MINS
     )
 
-    private val maxJumpCount = valueOrDefault(MAX_JUMP_COUNT, 1)
+    @Configuration("maximum allowed jumps in a loop")
+    private val maxJumpCount: Int by config(1)
 
     override fun visitLoopExpression(loopExpression: KtLoopExpression) {
         if (countBreakAndReturnStatements(loopExpression.body) > maxJumpCount) {
@@ -68,9 +69,5 @@ class LoopWithTooManyJumpStatements(config: Config = Config.empty) : Rule(config
             }
         })
         return count
-    }
-
-    companion object {
-        const val MAX_JUMP_COUNT = "maxJumpCount"
     }
 }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumber.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumber.kt
@@ -8,7 +8,8 @@ import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
-import io.gitlab.arturbosch.detekt.api.internal.valueOrDefaultCommaSeparated
+import io.gitlab.arturbosch.detekt.api.internal.Configuration
+import io.gitlab.arturbosch.detekt.api.internal.config
 import io.gitlab.arturbosch.detekt.rules.isConstant
 import io.gitlab.arturbosch.detekt.rules.isHashCodeFunction
 import io.gitlab.arturbosch.detekt.rules.isPartOf
@@ -66,26 +67,6 @@ import java.util.Locale
  *     }
  * }
  * </compliant>
- *
- * @configuration ignoreNumbers - numbers which do not count as magic numbers (default: `['-1', '0', '1', '2']`)
- * @configuration ignoreHashCodeFunction - whether magic numbers in hashCode functions should be ignored
- * (default: `true`)
- * @configuration ignorePropertyDeclaration - whether magic numbers in property declarations should be ignored
- * (default: `false`)
- * @configuration ignoreLocalVariableDeclaration - whether magic numbers in local variable declarations should be
- * ignored (default: `false`)
- * @configuration ignoreConstantDeclaration - whether magic numbers in constant declarations should be ignored
- * (default: `true`)
- * @configuration ignoreCompanionObjectPropertyDeclaration - whether magic numbers in companion object
- * declarations should be ignored (default: `true`)
- * @configuration ignoreAnnotation - whether magic numbers in annotations should be ignored
- * (default: `false`)
- * @configuration ignoreNamedArgument - whether magic numbers in named arguments should be ignored
- * (default: `true`)
- * @configuration ignoreEnums - whether magic numbers in enums should be ignored (default: `false`)
- * @configuration ignoreRanges - whether magic numbers in ranges should be ignored (default: `false`)
- * @configuration ignoreExtensionFunctions - whether magic numbers as subject of an extension function should be ignored
- * (default: `true`)
  */
 @Suppress("TooManyFunctions")
 @ActiveByDefault(since = "1.0.0")
@@ -101,21 +82,40 @@ class MagicNumber(config: Config = Config.empty) : Rule(config) {
         Debt.TEN_MINS
     )
 
-    private val ignoredNumbers = valueOrDefaultCommaSeparated(IGNORE_NUMBERS, listOf("-1", "0", "1", "2"))
-        .map { parseAsDouble(it) }
-        .sorted()
+    @Configuration("numbers which do not count as magic numbers")
+    private val ignoreNumbers: List<Double> by config(listOf("-1", "0", "1", "2")) { numbers ->
+        numbers.map(this::parseAsDouble).sorted()
+    }
 
-    private val ignoreAnnotation = valueOrDefault(IGNORE_ANNOTATION, false)
-    private val ignoreHashCodeFunction = valueOrDefault(IGNORE_HASH_CODE, true)
-    private val ignorePropertyDeclaration = valueOrDefault(IGNORE_PROPERTY_DECLARATION, false)
-    private val ignoreLocalVariables = valueOrDefault(IGNORE_LOCAL_VARIABLES, false)
-    private val ignoreNamedArgument = valueOrDefault(IGNORE_NAMED_ARGUMENT, false)
-    private val ignoreEnums = valueOrDefault(IGNORE_ENUMS, false)
-    private val ignoreConstantDeclaration = valueOrDefault(IGNORE_CONSTANT_DECLARATION, true)
-    private val ignoreCompanionObjectPropertyDeclaration =
-        valueOrDefault(IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION, true)
-    private val ignoreRanges = valueOrDefault(IGNORE_RANGES, false)
-    private val ignoreExtensionFunctions = valueOrDefault(IGNORE_EXTENSION_FUNCTIONS, true)
+    @Configuration("whether magic numbers in hashCode functions should be ignored")
+    private val ignoreHashCodeFunction: Boolean by config(true)
+
+    @Configuration("whether magic numbers in property declarations should be ignored")
+    private val ignorePropertyDeclaration: Boolean by config(false)
+
+    @Configuration("whether magic numbers in local variable declarations should be ignored")
+    private val ignoreLocalVariableDeclaration: Boolean by config(false)
+
+    @Configuration("whether magic numbers in constant declarations should be ignored")
+    private val ignoreConstantDeclaration: Boolean by config(true)
+
+    @Configuration("whether magic numbers in companion object declarations should be ignored")
+    private val ignoreCompanionObjectPropertyDeclaration: Boolean by config(true)
+
+    @Configuration("whether magic numbers in annotations should be ignored")
+    private val ignoreAnnotation: Boolean by config(false)
+
+    @Configuration("whether magic numbers in named arguments should be ignored")
+    private val ignoreNamedArgument: Boolean by config(true)
+
+    @Configuration("whether magic numbers in enums should be ignored")
+    private val ignoreEnums: Boolean by config(false)
+
+    @Configuration("whether magic numbers in ranges should be ignored")
+    private val ignoreRanges: Boolean by config(false)
+
+    @Configuration("whether magic numbers as subject of an extension function should be ignored")
+    private val ignoreExtensionFunctions: Boolean by config(true)
 
     override fun visitConstantExpression(expression: KtConstantExpression) {
         val elementType = expression.elementType
@@ -135,7 +135,7 @@ class MagicNumber(config: Config = Config.empty) : Rule(config) {
         }
 
         val number = parseAsDoubleOrNull(rawNumber)
-        if (number != null && !ignoredNumbers.contains(number)) {
+        if (number != null && !ignoreNumbers.contains(number)) {
             report(
                 CodeSmell(
                     issue,
@@ -149,7 +149,7 @@ class MagicNumber(config: Config = Config.empty) : Rule(config) {
 
     private fun isIgnoredByConfig(expression: KtConstantExpression) = when {
         ignorePropertyDeclaration && expression.isProperty() -> true
-        ignoreLocalVariables && expression.isLocalProperty() -> true
+        ignoreLocalVariableDeclaration && expression.isLocalProperty() -> true
         ignoreConstantDeclaration && expression.isConstantProperty() -> true
         ignoreCompanionObjectPropertyDeclaration && expression.isCompanionObjectProperty() -> true
         ignoreAnnotation && expression.isPartOf<KtAnnotationEntry>() -> true
@@ -249,18 +249,6 @@ class MagicNumber(config: Config = Config.empty) : Rule(config) {
         (firstChild as? KtOperationReferenceExpression)?.operationSignTokenType == KtTokens.MINUS
 
     companion object {
-        const val IGNORE_NUMBERS = "ignoreNumbers"
-        const val IGNORE_HASH_CODE = "ignoreHashCodeFunction"
-        const val IGNORE_PROPERTY_DECLARATION = "ignorePropertyDeclaration"
-        const val IGNORE_LOCAL_VARIABLES = "ignoreLocalVariableDeclaration"
-        const val IGNORE_CONSTANT_DECLARATION = "ignoreConstantDeclaration"
-        const val IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION = "ignoreCompanionObjectPropertyDeclaration"
-        const val IGNORE_ANNOTATION = "ignoreAnnotation"
-        const val IGNORE_NAMED_ARGUMENT = "ignoreNamedArgument"
-        const val IGNORE_ENUMS = "ignoreEnums"
-        const val IGNORE_RANGES = "ignoreRanges"
-        const val IGNORE_EXTENSION_FUNCTIONS = "ignoreExtensionFunctions"
-
         private const val HEX_RADIX = 16
         private const val BINARY_RADIX = 2
     }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLength.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLength.kt
@@ -8,6 +8,8 @@ import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
+import io.gitlab.arturbosch.detekt.api.internal.Configuration
+import io.gitlab.arturbosch.detekt.api.internal.config
 import io.gitlab.arturbosch.detekt.rules.lastArgumentMatchesUrl
 
 /**
@@ -15,11 +17,6 @@ import io.gitlab.arturbosch.detekt.rules.lastArgumentMatchesUrl
  *
  * Long lines might be hard to read on smaller screens or printouts. Additionally having a maximum line length
  * in the codebase will help make the code more uniform.
- *
- * @configuration maxLineLength - maximum line length (default: `120`)
- * @configuration excludePackageStatements - if package statements should be ignored (default: `true`)
- * @configuration excludeImportStatements - if import statements should be ignored (default: `true`)
- * @configuration excludeCommentStatements - if comment statements should be ignored (default: `false`)
  */
 @ActiveByDefault(since = "1.0.0")
 class MaxLineLength(config: Config = Config.empty) : Rule(config) {
@@ -31,14 +28,17 @@ class MaxLineLength(config: Config = Config.empty) : Rule(config) {
         Debt.FIVE_MINS
     )
 
-    private val lengthThreshold: Int =
-        valueOrDefault(MAX_LINE_LENGTH, DEFAULT_IDEA_LINE_LENGTH)
-    private val excludePackageStatements: Boolean =
-        valueOrDefault(EXCLUDE_PACKAGE_STATEMENTS, true)
-    private val excludeImportStatements: Boolean =
-        valueOrDefault(EXCLUDE_IMPORT_STATEMENTS, true)
-    private val excludeCommentStatements: Boolean =
-        valueOrDefault(EXCLUDE_COMMENT_STATEMENTS, false)
+    @Configuration("maximum line length")
+    private val maxLineLength: Int by config(DEFAULT_IDEA_LINE_LENGTH)
+
+    @Configuration("if package statements should be ignored")
+    private val excludePackageStatements: Boolean by config(true)
+
+    @Configuration("if import statements should be ignored")
+    private val excludeImportStatements: Boolean by config(true)
+
+    @Configuration("if comment statements should be ignored")
+    private val excludeCommentStatements: Boolean by config(false)
 
     fun visit(element: KtFileContent) {
         var offset = 0
@@ -62,7 +62,7 @@ class MaxLineLength(config: Config = Config.empty) : Rule(config) {
 
     private fun isValidLine(line: String): Boolean {
         val isUrl = line.lastArgumentMatchesUrl()
-        return line.length <= lengthThreshold || isIgnoredStatement(line) || isUrl
+        return line.length <= maxLineLength || isIgnoredStatement(line) || isUrl
     }
 
     private fun isIgnoredStatement(line: String): Boolean {
@@ -92,10 +92,6 @@ class MaxLineLength(config: Config = Config.empty) : Rule(config) {
     }
 
     companion object {
-        const val MAX_LINE_LENGTH = "maxLineLength"
         const val DEFAULT_IDEA_LINE_LENGTH = 120
-        const val EXCLUDE_PACKAGE_STATEMENTS = "excludePackageStatements"
-        const val EXCLUDE_IMPORT_STATEMENTS = "excludeImportStatements"
-        const val EXCLUDE_COMMENT_STATEMENTS = "excludeCommentStatements"
     }
 }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLength.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLength.kt
@@ -93,6 +93,6 @@ class MaxLineLength(config: Config = Config.empty) : Rule(config) {
     }
 
     companion object {
-        const val DEFAULT_IDEA_LINE_LENGTH = 120
+        private const val DEFAULT_IDEA_LINE_LENGTH = 120
     }
 }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLength.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLength.kt
@@ -28,6 +28,7 @@ class MaxLineLength(config: Config = Config.empty) : Rule(config) {
         Debt.FIVE_MINS
     )
 
+    @Suppress("MemberNameEqualsClassName")
     @Configuration("maximum line length")
     private val maxLineLength: Int by config(DEFAULT_IDEA_LINE_LENGTH)
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ThrowsCount.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ThrowsCount.kt
@@ -8,6 +8,8 @@ import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
+import io.gitlab.arturbosch.detekt.api.internal.Configuration
+import io.gitlab.arturbosch.detekt.api.internal.config
 import io.gitlab.arturbosch.detekt.rules.isOverride
 import io.gitlab.arturbosch.detekt.rules.yieldStatementsSkippingGuardClauses
 import org.jetbrains.kotlin.psi.KtNamedFunction
@@ -36,8 +38,6 @@ import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
  *     }
  * }
  * </compliant>
- *
- * @configuration max - maximum amount of throw statements in a method (default: `2`)
  */
 @ActiveByDefault(since = "1.0.0")
 class ThrowsCount(config: Config = Config.empty) : Rule(config) {
@@ -49,8 +49,11 @@ class ThrowsCount(config: Config = Config.empty) : Rule(config) {
         Debt.TEN_MINS
     )
 
-    private val max = valueOrDefault(MAX, 2)
-    private val excludeGuardClauses = valueOrDefault(EXCLUDE_GUARD_CLAUSES, false)
+    @Configuration("maximum amount of throw statements in a method")
+    private val max: Int by config(2)
+
+    @Configuration("if set to true, guard clauses do not count towards the allowed throws count")
+    private val excludeGuardClauses: Boolean by config(false)
 
     override fun visitNamedFunction(function: KtNamedFunction) {
         super.visitNamedFunction(function)
@@ -80,10 +83,5 @@ class ThrowsCount(config: Config = Config.empty) : Rule(config) {
                 )
             }
         }
-    }
-
-    companion object {
-        const val MAX = "max"
-        const val EXCLUDE_GUARD_CLAUSES = "excludeGuardClauses"
     }
 }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiterals.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiterals.kt
@@ -7,6 +7,8 @@ import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.internal.Configuration
+import io.gitlab.arturbosch.detekt.api.internal.config
 import org.jetbrains.kotlin.psi.KtConstantExpression
 import org.jetbrains.kotlin.psi.KtObjectDeclaration
 import org.jetbrains.kotlin.psi.KtPrefixExpression
@@ -31,9 +33,6 @@ import java.util.Locale
  *     const val DEFAULT_AMOUNT = 1_000_000
  * }
  * </compliant>
- *
- * @configuration acceptableDecimalLength - Length under which decimal base 10 literals are not required to have
- * underscores (default: `5`)
  */
 class UnderscoresInNumericLiterals(config: Config = Config.empty) : Rule(config) {
 
@@ -46,9 +45,8 @@ class UnderscoresInNumericLiterals(config: Config = Config.empty) : Rule(config)
         Debt.FIVE_MINS
     )
 
-    private val underscoreNumberRegex = Regex("[0-9]{1,3}(_[0-9]{3})*")
-
-    private val acceptableDecimalLength = valueOrDefault(ACCEPTABLE_DECIMAL_LENGTH, DEFAULT_ACCEPTABLE_DECIMAL_LENGTH)
+    @Configuration("Length under which decimal base 10 literals are not required to have underscores")
+    private val acceptableDecimalLength: Int by config(DEFAULT_ACCEPTABLE_DECIMAL_LENGTH)
 
     override fun visitConstantExpression(expression: KtConstantExpression) {
         val normalizedText = normalizeForMatching(expression.text)
@@ -65,7 +63,7 @@ class UnderscoresInNumericLiterals(config: Config = Config.empty) : Rule(config)
     }
 
     private fun reportIfInvalidUnderscorePattern(expression: KtConstantExpression, numberString: String) {
-        if (!numberString.matches(underscoreNumberRegex)) {
+        if (!numberString.matches(UNDERSCORE_NUMBER_REGEX)) {
             report(
                 CodeSmell(
                     issue,
@@ -107,8 +105,7 @@ class UnderscoresInNumericLiterals(config: Config = Config.empty) : Rule(config)
     }
 
     companion object {
-        const val ACCEPTABLE_DECIMAL_LENGTH = "acceptableDecimalLength"
-
+        private val UNDERSCORE_NUMBER_REGEX = Regex("[0-9]{1,3}(_[0-9]{3})*")
         private const val HEX_PREFIX = "0x"
         private const val BIN_PREFIX = "0b"
         private const val SERIALIZABLE = "Serializable"

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAbstractClass.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAbstractClass.kt
@@ -62,7 +62,7 @@ class UnnecessaryAbstractClass(config: Config = Config.empty) : Rule(config) {
 
     @Configuration("Allows you to provide a list of annotations that disable this check.")
     private val excludeAnnotatedClasses: List<String> by config(listOf("dagger.Module")) { classes ->
-        classes.map { it.removeSurrounding("*") }
+        classes.map { it.removePrefix("*").removeSuffix("*") }
     }
 
     private lateinit var annotationExcluder: AnnotationExcluder

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAbstractClass.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAbstractClass.kt
@@ -10,7 +10,8 @@ import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
-import io.gitlab.arturbosch.detekt.api.internal.valueOrDefaultCommaSeparated
+import io.gitlab.arturbosch.detekt.api.internal.Configuration
+import io.gitlab.arturbosch.detekt.api.internal.config
 import io.gitlab.arturbosch.detekt.rules.isAbstract
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.descriptors.ClassDescriptor
@@ -42,9 +43,6 @@ import org.jetbrains.kotlin.resolve.BindingContext
  *     fun f() { }
  * }
  * </noncompliant>
- *
- * @configuration excludeAnnotatedClasses - Allows you to provide a list of annotations that disable
- * this check. (default: `['dagger.Module']`)
  */
 @ActiveByDefault(since = "1.2.0")
 class UnnecessaryAbstractClass(config: Config = Config.empty) : Rule(config) {
@@ -62,11 +60,11 @@ class UnnecessaryAbstractClass(config: Config = Config.empty) : Rule(config) {
             Debt.FIVE_MINS
         )
 
-    private val excludeAnnotatedClasses = valueOrDefaultCommaSeparated(
-        EXCLUDE_ANNOTATED_CLASSES,
-        listOf("dagger.Module")
-    )
-        .map { it.removePrefix("*").removeSuffix("*") }
+    @Configuration("Allows you to provide a list of annotations that disable this check.")
+    private val excludeAnnotatedClasses: List<String> by config(listOf("dagger.Module")) { classes ->
+        classes.map { it.removeSurrounding("*") }
+    }
+
     private lateinit var annotationExcluder: AnnotationExcluder
 
     override fun visitKtFile(file: KtFile) {
@@ -130,9 +128,5 @@ class UnnecessaryAbstractClass(config: Config = Config.empty) : Rule(config) {
                 }
             }
         }
-    }
-
-    companion object {
-        const val EXCLUDE_ANNOTATED_CLASSES = "excludeAnnotatedClasses"
     }
 }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
@@ -6,10 +6,11 @@ import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.DetektVisitor
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.LazyRegex
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
+import io.gitlab.arturbosch.detekt.api.internal.Configuration
+import io.gitlab.arturbosch.detekt.api.internal.config
 import io.gitlab.arturbosch.detekt.rules.isAbstract
 import io.gitlab.arturbosch.detekt.rules.isActual
 import io.gitlab.arturbosch.detekt.rules.isExpect
@@ -49,9 +50,6 @@ import org.jetbrains.kotlin.util.OperatorNameConventions
  * Reports unused private properties, function parameters and functions.
  * If these private elements are unused they should be removed. Otherwise this dead code
  * can lead to confusion and potential bugs.
- *
- * @configuration allowedNames - unused private member names matching this regex are ignored
- * (default: `'(_|ignored|expected|serialVersionUID)'`)
  */
 @ActiveByDefault(since = "1.16.0")
 class UnusedPrivateMember(config: Config = Config.empty) : Rule(config) {
@@ -65,7 +63,8 @@ class UnusedPrivateMember(config: Config = Config.empty) : Rule(config) {
         Debt.FIVE_MINS
     )
 
-    private val allowedNames by LazyRegex(ALLOWED_NAMES_PATTERN, "(_|ignored|expected|serialVersionUID)")
+    @Configuration("unused private member names matching this regex are ignored")
+    private val allowedNames: Regex by config("(_|ignored|expected|serialVersionUID)", String::toRegex)
 
     override fun visit(root: KtFile) {
         super.visit(root)
@@ -77,10 +76,6 @@ class UnusedPrivateMember(config: Config = Config.empty) : Rule(config) {
     private fun KtFile.acceptUnusedMemberVisitor(visitor: UnusedMemberVisitor) {
         accept(visitor)
         visitor.getUnusedReports(issue).forEach { report(it) }
-    }
-
-    companion object {
-        const val ALLOWED_NAMES_PATTERN = "allowedNames"
     }
 }
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/WildcardImport.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/WildcardImport.kt
@@ -60,7 +60,7 @@ class WildcardImport(config: Config = Config.empty) : Rule(config) {
             "kotlinx.android.synthetic.*"
         )
     ) { imports ->
-        imports.map { it.removeSurrounding("*") }
+        imports.map { it.removePrefix("*").removeSuffix("*") }
     }
 
     override fun visitImportDirective(importDirective: KtImportDirective) {

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/WildcardImport.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/WildcardImport.kt
@@ -8,7 +8,8 @@ import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
-import io.gitlab.arturbosch.detekt.api.internal.valueOrDefaultCommaSeparated
+import io.gitlab.arturbosch.detekt.api.internal.Configuration
+import io.gitlab.arturbosch.detekt.api.internal.config
 import org.jetbrains.kotlin.psi.KtImportDirective
 
 /**
@@ -38,9 +39,6 @@ import org.jetbrains.kotlin.psi.KtImportDirective
  *     val element2 = DetektElement2()
  * }
  * </compliant>
- *
- * @configuration excludeImports - Define a list of package names that should be allowed to be imported
- * with wildcard imports. (default: `['java.util.*', 'kotlinx.android.synthetic.*']`)
  */
 @ActiveByDefault(since = "1.0.0")
 class WildcardImport(config: Config = Config.empty) : Rule(config) {
@@ -55,11 +53,15 @@ class WildcardImport(config: Config = Config.empty) : Rule(config) {
         Debt.FIVE_MINS
     )
 
-    private val excludedImports = valueOrDefaultCommaSeparated(
-        EXCLUDED_IMPORTS,
-        listOf("java.util.*", "kotlinx.android.synthetic.*")
-    )
-        .map { it.removePrefix("*").removeSuffix("*") }
+    @Configuration("Define a list of package names that should be allowed to be imported with wildcard imports.")
+    private val excludeImports: List<String> by config(
+        listOf(
+            "java.util.*",
+            "kotlinx.android.synthetic.*"
+        )
+    ) { imports ->
+        imports.map { it.removeSurrounding("*") }
+    }
 
     override fun visitImportDirective(importDirective: KtImportDirective) {
         val import = importDirective.importPath?.pathStr
@@ -68,7 +70,7 @@ class WildcardImport(config: Config = Config.empty) : Rule(config) {
                 return
             }
 
-            if (excludedImports.any { import.contains(it, ignoreCase = true) }) {
+            if (excludeImports.any { import.contains(it, ignoreCase = true) }) {
                 return
             }
             report(
@@ -80,9 +82,5 @@ class WildcardImport(config: Config = Config.empty) : Rule(config) {
                 )
             )
         }
-    }
-
-    companion object {
-        const val EXCLUDED_IMPORTS = "excludeImports"
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/DataClassContainsFunctionsSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/DataClassContainsFunctionsSpec.kt
@@ -6,6 +6,8 @@ import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
+private const val CONVERSION_FUNCTION_PREFIX = "conversionFunctionPrefix"
+
 class DataClassContainsFunctionsSpec : Spek({
     val subject by memoized { DataClassContainsFunctions() }
 
@@ -27,7 +29,7 @@ class DataClassContainsFunctionsSpec : Spek({
             }
 
             it("reports valid data class w/o conversion function") {
-                val config = TestConfig(mapOf(DataClassContainsFunctions.CONVERSION_FUNCTION_PREFIX to ""))
+                val config = TestConfig(mapOf(CONVERSION_FUNCTION_PREFIX to ""))
                 val rule = DataClassContainsFunctions(config)
                 assertThat(rule.compileAndLint(code)).hasSize(2)
             }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/DestructuringDeclarationWithTooManyEntriesSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/DestructuringDeclarationWithTooManyEntriesSpec.kt
@@ -6,6 +6,8 @@ import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
+private const val MAX_DESTRUCTURING_ENTRIES = "maxDestructuringEntries"
+
 class DestructuringDeclarationWithTooManyEntriesSpec : Spek({
     val subject by memoized { DestructuringDeclarationWithTooManyEntries() }
 
@@ -80,7 +82,7 @@ class DestructuringDeclarationWithTooManyEntriesSpec : Spek({
 
             val configuredRule by memoized {
                 DestructuringDeclarationWithTooManyEntries(
-                    TestConfig(mapOf(DestructuringDeclarationWithTooManyEntries.MAX_DESTRUCTURING_ENTRIES to "2"))
+                    TestConfig(mapOf(MAX_DESTRUCTURING_ENTRIES to "2"))
                 )
             }
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExpressionBodySyntaxSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExpressionBodySyntaxSpec.kt
@@ -7,6 +7,8 @@ import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
+private const val INCLUDE_LINE_WRAPPING = "includeLineWrapping"
+
 class ExpressionBodySyntaxSpec : Spek({
     val subject by memoized { ExpressionBodySyntax(Config.empty) }
 
@@ -95,7 +97,7 @@ class ExpressionBodySyntaxSpec : Spek({
             }
 
             it("reports with includeLineWrapping = true configuration") {
-                val config = TestConfig(mapOf(ExpressionBodySyntax.INCLUDE_LINE_WRAPPING to "true"))
+                val config = TestConfig(mapOf(INCLUDE_LINE_WRAPPING to "true"))
                 assertThat(ExpressionBodySyntax(config).compileAndLint(code)).hasSize(1)
             }
         }
@@ -115,7 +117,7 @@ class ExpressionBodySyntaxSpec : Spek({
             }
 
             it("reports with includeLineWrapping = true configuration") {
-                val config = TestConfig(mapOf(ExpressionBodySyntax.INCLUDE_LINE_WRAPPING to "true"))
+                val config = TestConfig(mapOf(INCLUDE_LINE_WRAPPING to "true"))
                 assertThat(ExpressionBodySyntax(config).compileAndLint(code)).hasSize(1)
             }
         }
@@ -134,7 +136,7 @@ class ExpressionBodySyntaxSpec : Spek({
             }
 
             it("reports with includeLineWrapping = true configuration") {
-                val config = TestConfig(mapOf(ExpressionBodySyntax.INCLUDE_LINE_WRAPPING to "true"))
+                val config = TestConfig(mapOf(INCLUDE_LINE_WRAPPING to "true"))
                 assertThat(ExpressionBodySyntax(config).compileAndLint(code)).hasSize(1)
             }
         }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenCommentSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenCommentSpec.kt
@@ -6,6 +6,9 @@ import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
+private const val VALUES = "values"
+private const val ALLOWED_PATTERNS = "allowedPatterns"
+
 class ForbiddenCommentSpec : Spek({
 
     val todoColon = "// TODO: I need to fix this."
@@ -80,8 +83,8 @@ class ForbiddenCommentSpec : Spek({
         context("custom default values are configured") {
 
             listOf(
-                TestConfig(mapOf(ForbiddenComment.VALUES to "Banana")),
-                TestConfig(mapOf(ForbiddenComment.VALUES to listOf("Banana")))
+                TestConfig(mapOf(VALUES to "Banana")),
+                TestConfig(mapOf(VALUES to listOf("Banana")))
             )
                 .forEach { config ->
                     val banana = "// Banana."
@@ -107,7 +110,7 @@ class ForbiddenCommentSpec : Spek({
                     }
 
                     it("should report Banana usages regardless of case sensitive") {
-                        val forbiddenComment = ForbiddenComment(TestConfig(mapOf(ForbiddenComment.VALUES to "bAnAnA")))
+                        val forbiddenComment = ForbiddenComment(TestConfig(mapOf(VALUES to "bAnAnA")))
                         val findings = forbiddenComment.compileAndLint(banana)
                         assertThat(findings).hasSize(1)
                     }
@@ -119,8 +122,8 @@ class ForbiddenCommentSpec : Spek({
             val patternsConfig by memoized {
                 TestConfig(
                     mapOf(
-                        ForbiddenComment.VALUES to "Comment",
-                        ForbiddenComment.ALLOWED_PATTERNS to "Ticket|Task"
+                        VALUES to "Comment",
+                        ALLOWED_PATTERNS to "Ticket|Task"
                     )
                 )
             }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenImportSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenImportSpec.kt
@@ -6,6 +6,9 @@ import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
+private const val IMPORTS = "imports"
+private const val FORBIDDEN_PATTERNS = "forbiddenPatterns"
+
 class ForbiddenImportSpec : Spek({
     describe("ForbiddenImport rule") {
         val code = """
@@ -25,29 +28,29 @@ class ForbiddenImportSpec : Spek({
         }
 
         it("should report nothing when imports are blank") {
-            val findings = ForbiddenImport(TestConfig(mapOf(ForbiddenImport.IMPORTS to "  "))).lint(code)
+            val findings = ForbiddenImport(TestConfig(mapOf(IMPORTS to "  "))).lint(code)
             assertThat(findings).isEmpty()
         }
 
         it("should report nothing when imports do not match") {
-            val findings = ForbiddenImport(TestConfig(mapOf(ForbiddenImport.IMPORTS to "org.*"))).lint(code)
+            val findings = ForbiddenImport(TestConfig(mapOf(IMPORTS to "org.*"))).lint(code)
             assertThat(findings).isEmpty()
         }
 
         it("should report kotlin.* when imports are kotlin.*") {
-            val findings = ForbiddenImport(TestConfig(mapOf(ForbiddenImport.IMPORTS to "kotlin.*"))).lint(code)
+            val findings = ForbiddenImport(TestConfig(mapOf(IMPORTS to "kotlin.*"))).lint(code)
             assertThat(findings).hasSize(2)
         }
 
         it("should report kotlin.SinceKotlin when specified via fully qualified name") {
             val findings =
-                ForbiddenImport(TestConfig(mapOf(ForbiddenImport.IMPORTS to "kotlin.SinceKotlin"))).lint(code)
+                ForbiddenImport(TestConfig(mapOf(IMPORTS to "kotlin.SinceKotlin"))).lint(code)
             assertThat(findings).hasSize(1)
         }
 
         it("should report kotlin.SinceKotlin and kotlin.jvm.JvmField when specified via fully qualified names") {
             val findings =
-                ForbiddenImport(TestConfig(mapOf(ForbiddenImport.IMPORTS to "kotlin.SinceKotlin,kotlin.jvm.JvmField"))).lint(
+                ForbiddenImport(TestConfig(mapOf(IMPORTS to "kotlin.SinceKotlin,kotlin.jvm.JvmField"))).lint(
                     code
                 )
             assertThat(findings).hasSize(2)
@@ -58,7 +61,7 @@ class ForbiddenImportSpec : Spek({
                 ForbiddenImport(
                     TestConfig(
                         mapOf(
-                            ForbiddenImport.IMPORTS to listOf("kotlin.SinceKotlin", "kotlin.jvm.JvmField")
+                            IMPORTS to listOf("kotlin.SinceKotlin", "kotlin.jvm.JvmField")
                         )
                     )
                 ).lint(code)
@@ -66,30 +69,30 @@ class ForbiddenImportSpec : Spek({
         }
 
         it("should report kotlin.SinceKotlin when specified via kotlin.Since*") {
-            val findings = ForbiddenImport(TestConfig(mapOf(ForbiddenImport.IMPORTS to "kotlin.Since*"))).lint(code)
+            val findings = ForbiddenImport(TestConfig(mapOf(IMPORTS to "kotlin.Since*"))).lint(code)
             assertThat(findings).hasSize(1)
         }
 
         it("should report all of com.example.R.string, net.example.R.dimen, and net.example.R.dimension") {
-            val findings = ForbiddenImport(TestConfig(mapOf(ForbiddenImport.IMPORTS to "*.R.*"))).lint(code)
+            val findings = ForbiddenImport(TestConfig(mapOf(IMPORTS to "*.R.*"))).lint(code)
             assertThat(findings).hasSize(3)
         }
 
         it("should report net.example.R.dimen but not net.example.R.dimension") {
             val findings =
-                ForbiddenImport(TestConfig(mapOf(ForbiddenImport.IMPORTS to "net.example.R.dimen"))).lint(code)
+                ForbiddenImport(TestConfig(mapOf(IMPORTS to "net.example.R.dimen"))).lint(code)
             assertThat(findings).hasSize(1)
         }
 
         it("should not report import when it does not match any pattern") {
             val findings =
-                ForbiddenImport(TestConfig(mapOf(ForbiddenImport.FORBIDDEN_PATTERNS to "nets.*R"))).lint(code)
+                ForbiddenImport(TestConfig(mapOf(FORBIDDEN_PATTERNS to "nets.*R"))).lint(code)
             assertThat(findings).isEmpty()
         }
 
         it("should report import when it matches the forbidden pattern") {
             val findings =
-                ForbiddenImport(TestConfig(mapOf(ForbiddenImport.FORBIDDEN_PATTERNS to "net.*R|com.*expiremental"))).lint(code)
+                ForbiddenImport(TestConfig(mapOf(FORBIDDEN_PATTERNS to "net.*R|com.*expiremental"))).lint(code)
             assertThat(findings).hasSize(2)
         }
     }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCallSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCallSpec.kt
@@ -9,6 +9,8 @@ import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
+private const val METHODS = "methods"
+
 class ForbiddenMethodCallSpec : Spek({
     setupKotlinEnvironment()
 
@@ -39,7 +41,7 @@ class ForbiddenMethodCallSpec : Spek({
             }
             """
             val findings =
-                ForbiddenMethodCall(TestConfig(mapOf(ForbiddenMethodCall.METHODS to "  "))).compileAndLintWithContext(
+                ForbiddenMethodCall(TestConfig(mapOf(METHODS to "  "))).compileAndLintWithContext(
                     env,
                     code
                 )
@@ -54,7 +56,7 @@ class ForbiddenMethodCallSpec : Spek({
             }
             """
             val findings = ForbiddenMethodCall(
-                TestConfig(mapOf(ForbiddenMethodCall.METHODS to listOf("java.lang.System.gc")))
+                TestConfig(mapOf(METHODS to listOf("java.lang.System.gc")))
             ).compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
@@ -66,7 +68,7 @@ class ForbiddenMethodCallSpec : Spek({
             }
             """
             val findings = ForbiddenMethodCall(
-                TestConfig(mapOf(ForbiddenMethodCall.METHODS to listOf("java.io.PrintStream.println")))
+                TestConfig(mapOf(METHODS to listOf("java.io.PrintStream.println")))
             ).compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasTextLocations(38 to 54)
@@ -80,7 +82,7 @@ class ForbiddenMethodCallSpec : Spek({
             }
             """
             val findings = ForbiddenMethodCall(
-                TestConfig(mapOf(ForbiddenMethodCall.METHODS to listOf("java.io.PrintStream.println")))
+                TestConfig(mapOf(METHODS to listOf("java.io.PrintStream.println")))
             ).compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasTextLocations(49 to 65)
@@ -97,7 +99,7 @@ class ForbiddenMethodCallSpec : Spek({
             val findings = ForbiddenMethodCall(
                 TestConfig(
                     mapOf(
-                        ForbiddenMethodCall.METHODS to listOf(
+                        METHODS to listOf(
                             "java.io.PrintStream.println",
                             "java.lang.System.gc"
                         )
@@ -117,7 +119,7 @@ class ForbiddenMethodCallSpec : Spek({
             }
             """
             val findings = ForbiddenMethodCall(
-                TestConfig(mapOf(ForbiddenMethodCall.METHODS to "java.io.PrintStream.println, java.lang.System.gc"))
+                TestConfig(mapOf(METHODS to "java.io.PrintStream.println, java.lang.System.gc"))
             ).compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(2)
             assertThat(findings).hasTextLocations(48 to 64, 76 to 80)
@@ -130,7 +132,7 @@ class ForbiddenMethodCallSpec : Spek({
                 }
             """
             val findings = ForbiddenMethodCall(
-                TestConfig(mapOf(ForbiddenMethodCall.METHODS to listOf("java.math.BigDecimal.equals")))
+                TestConfig(mapOf(METHODS to listOf("java.math.BigDecimal.equals")))
             ).compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
@@ -143,7 +145,7 @@ class ForbiddenMethodCallSpec : Spek({
                 }
             """
             val findings = ForbiddenMethodCall(
-                TestConfig(mapOf(ForbiddenMethodCall.METHODS to listOf("kotlin.Int.inc")))
+                TestConfig(mapOf(METHODS to listOf("kotlin.Int.inc")))
             ).compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
@@ -156,7 +158,7 @@ class ForbiddenMethodCallSpec : Spek({
                 }
             """
             val findings = ForbiddenMethodCall(
-                TestConfig(mapOf(ForbiddenMethodCall.METHODS to listOf("kotlin.Int.dec")))
+                TestConfig(mapOf(METHODS to listOf("kotlin.Int.dec")))
             ).compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
@@ -172,7 +174,7 @@ class ForbiddenMethodCallSpec : Spek({
                 }
             """
             val findings = ForbiddenMethodCall(
-                TestConfig(mapOf(ForbiddenMethodCall.METHODS to listOf("java.time.LocalDate.now")))
+                TestConfig(mapOf(METHODS to listOf("java.time.LocalDate.now")))
             ).compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(2)
         }
@@ -188,7 +190,7 @@ class ForbiddenMethodCallSpec : Spek({
                 }
             """
             val findings = ForbiddenMethodCall(
-                TestConfig(mapOf(ForbiddenMethodCall.METHODS to listOf("java.time.LocalDate.now()")))
+                TestConfig(mapOf(METHODS to listOf("java.time.LocalDate.now()")))
             ).compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasSourceLocation(5, 26)
@@ -205,7 +207,7 @@ class ForbiddenMethodCallSpec : Spek({
                 }
             """
             val findings = ForbiddenMethodCall(
-                TestConfig(mapOf(ForbiddenMethodCall.METHODS to listOf("java.time.LocalDate.now(java.time.Clock)")))
+                TestConfig(mapOf(METHODS to listOf("java.time.LocalDate.now(java.time.Clock)")))
             ).compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasSourceLocation(6, 27)
@@ -219,7 +221,7 @@ class ForbiddenMethodCallSpec : Spek({
                 }
             """
             val findings = ForbiddenMethodCall(
-                TestConfig(mapOf(ForbiddenMethodCall.METHODS to listOf("java.time.LocalDate.of(kotlin.Int, kotlin.Int, kotlin.Int)")))
+                TestConfig(mapOf(METHODS to listOf("java.time.LocalDate.of(kotlin.Int, kotlin.Int, kotlin.Int)")))
             ).compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasSourceLocation(3, 26)
@@ -233,7 +235,7 @@ class ForbiddenMethodCallSpec : Spek({
                 }
             """
             val findings = ForbiddenMethodCall(
-                TestConfig(mapOf(ForbiddenMethodCall.METHODS to listOf("java.time.LocalDate.of(kotlin.Int,kotlin.Int,kotlin.Int)")))
+                TestConfig(mapOf(METHODS to listOf("java.time.LocalDate.of(kotlin.Int,kotlin.Int,kotlin.Int)")))
             ).compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasSourceLocation(3, 26)
@@ -250,7 +252,7 @@ class ForbiddenMethodCallSpec : Spek({
                 }
             """
             val findings = ForbiddenMethodCall(
-                TestConfig(mapOf(ForbiddenMethodCall.METHODS to listOf("io.gitlab.arturbosch.detekt.rules.style.`some, test`()")))
+                TestConfig(mapOf(METHODS to listOf("io.gitlab.arturbosch.detekt.rules.style.`some, test`()")))
             ).compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasSourceLocation(6, 13)
@@ -269,7 +271,7 @@ class ForbiddenMethodCallSpec : Spek({
             val findings = ForbiddenMethodCall(
                 TestConfig(
                     mapOf(
-                        ForbiddenMethodCall.METHODS to
+                        METHODS to
                             listOf("io.gitlab.arturbosch.detekt.rules.style.defaultParamsMethod(kotlin.String,kotlin.Int)")
                     )
                 )

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenVoidSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenVoidSpec.kt
@@ -10,6 +10,9 @@ import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
+private const val IGNORE_OVERRIDDEN = "ignoreOverridden"
+private const val IGNORE_USAGE_IN_GENERICS = "ignoreUsageInGenerics"
+
 class ForbiddenVoidSpec : Spek({
     setupKotlinEnvironment()
 
@@ -59,7 +62,7 @@ class ForbiddenVoidSpec : Spek({
 
         describe("ignoreOverridden is enabled") {
 
-            val config by memoized { TestConfig(mapOf(ForbiddenVoid.IGNORE_OVERRIDDEN to "true")) }
+            val config by memoized { TestConfig(mapOf(IGNORE_OVERRIDDEN to "true")) }
 
             it("should not report Void in overriding function declarations") {
                 val code = """
@@ -130,7 +133,7 @@ class ForbiddenVoidSpec : Spek({
 
         describe("ignoreUsageInGenerics is enabled") {
 
-            val config by memoized { TestConfig(mapOf(ForbiddenVoid.IGNORE_USAGE_IN_GENERICS to "true")) }
+            val config by memoized { TestConfig(mapOf(IGNORE_USAGE_IN_GENERICS to "true")) }
 
             it("should not report Void in generic type declaration") {
                 val code = """

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/FunctionOnlyReturningConstantSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/FunctionOnlyReturningConstantSpec.kt
@@ -8,6 +8,11 @@ import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
+private const val IGNORE_OVERRIDABLE_FUNCTION = "ignoreOverridableFunction"
+private const val IGNORE_ACTUAL_FUNCTION = "ignoreActualFunction"
+private const val EXCLUDED_FUNCTIONS = "excludedFunctions"
+private const val EXCLUDE_ANNOTATED_FUNCTION = "excludeAnnotatedFunction"
+
 class FunctionOnlyReturningConstantSpec : Spek({
     val subject by memoized { FunctionOnlyReturningConstant() }
 
@@ -20,7 +25,7 @@ class FunctionOnlyReturningConstantSpec : Spek({
         }
 
         it("reports overridden functions which return constants") {
-            val config = TestConfig(mapOf(FunctionOnlyReturningConstant.IGNORE_OVERRIDABLE_FUNCTION to "false"))
+            val config = TestConfig(mapOf(IGNORE_OVERRIDABLE_FUNCTION to "false"))
             val rule = FunctionOnlyReturningConstant(config)
             assertThat(rule.lint(path)).hasSize(9)
         }
@@ -36,14 +41,14 @@ class FunctionOnlyReturningConstantSpec : Spek({
         }
 
         it("reports actual functions which return constants") {
-            val config = TestConfig(mapOf(FunctionOnlyReturningConstant.IGNORE_ACTUAL_FUNCTION to "false"))
+            val config = TestConfig(mapOf(IGNORE_ACTUAL_FUNCTION to "false"))
             val rule = FunctionOnlyReturningConstant(config)
             assertThat(rule.lint(actualFunctionCode)).hasSize(1)
         }
 
         it("does not report excluded function which returns a constant") {
             val code = "fun f() = 1"
-            val config = TestConfig(mapOf(FunctionOnlyReturningConstant.EXCLUDED_FUNCTIONS to "f"))
+            val config = TestConfig(mapOf(EXCLUDED_FUNCTIONS to "f"))
             val rule = FunctionOnlyReturningConstant(config)
             assertThat(rule.compileAndLint(code)).isEmpty()
         }
@@ -59,8 +64,8 @@ class FunctionOnlyReturningConstantSpec : Spek({
         """
 
         listOf(
-            TestConfig(mapOf(FunctionOnlyReturningConstant.EXCLUDE_ANNOTATED_FUNCTION to "kotlin.SinceKotlin")),
-            TestConfig(mapOf(FunctionOnlyReturningConstant.EXCLUDE_ANNOTATED_FUNCTION to listOf("kotlin.SinceKotlin")))
+            TestConfig(mapOf(EXCLUDE_ANNOTATED_FUNCTION to "kotlin.SinceKotlin")),
+            TestConfig(mapOf(EXCLUDE_ANNOTATED_FUNCTION to listOf("kotlin.SinceKotlin")))
         ).forEach { config ->
             it("does not report excluded annotated function which returns a constant") {
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/LoopWithTooManyJumpStatementsSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/LoopWithTooManyJumpStatementsSpec.kt
@@ -7,6 +7,8 @@ import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
+private const val MAX_JUMP_COUNT = "maxJumpCount"
+
 class LoopWithTooManyJumpStatementsSpec : Spek({
     val subject by memoized { LoopWithTooManyJumpStatements() }
 
@@ -19,7 +21,7 @@ class LoopWithTooManyJumpStatementsSpec : Spek({
         }
 
         it("does not report when max count configuration is set to 2") {
-            val config = TestConfig(mapOf(LoopWithTooManyJumpStatements.MAX_JUMP_COUNT to "2"))
+            val config = TestConfig(mapOf(MAX_JUMP_COUNT to "2"))
             val findings = LoopWithTooManyJumpStatements(config).lint(path)
             assertThat(findings).isEmpty()
         }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumberSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumberSpec.kt
@@ -2,7 +2,6 @@ package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.test.TestConfig
-import io.gitlab.arturbosch.detekt.test.assert
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import io.gitlab.arturbosch.detekt.test.lint
@@ -399,6 +398,7 @@ class MagicNumberSpec : Spek({
                     mapOf(
                         IGNORE_PROPERTY_DECLARATION to "false",
                         IGNORE_ANNOTATION to "false",
+                        IGNORE_NAMED_ARGUMENT to "false",
                         IGNORE_HASH_CODE to "false",
                         IGNORE_CONSTANT_DECLARATION to "false",
                         IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "false"
@@ -552,30 +552,32 @@ class MagicNumberSpec : Spek({
                 var model = Model(someVal = $numberString)
             """
 
-                it("should not ignore int by default") {
-                    assertThat(MagicNumber().lint(code("53"))).hasSize(1)
+                it("should not ignore int") {
+                    val rule = MagicNumber(TestConfig(mapOf(IGNORE_NAMED_ARGUMENT to "false")))
+                    assertThat(rule.lint(code("53"))).hasSize(1)
                 }
 
-                it("should not ignore float by default") {
-                    assertThat(MagicNumber().lint(code("53f"))).hasSize(1)
+                it("should not ignore float") {
+                    val rule = MagicNumber(TestConfig(mapOf(IGNORE_NAMED_ARGUMENT to "false")))
+                    assertThat(rule.lint(code("53f"))).hasSize(1)
                 }
 
-                it("should not ignore binary by default") {
-                    assertThat(MagicNumber().lint(code("0b01001"))).hasSize(1)
+                it("should not ignore binary") {
+                    val rule = MagicNumber(TestConfig(mapOf(IGNORE_NAMED_ARGUMENT to "false")))
+                    assertThat(rule.lint(code("0b01001"))).hasSize(1)
                 }
 
                 it("should ignore integer with underscores") {
-                    assertThat(MagicNumber().lint(code("101_000"))).hasSize(1)
+                    val rule = MagicNumber(TestConfig(mapOf(IGNORE_NAMED_ARGUMENT to "false")))
+                    assertThat(rule.lint(code("101_000"))).hasSize(1)
                 }
 
-                it("should ignore numbers when 'ignoreNamedArgument' is set to true") {
-                    val rule = MagicNumber(TestConfig(mapOf(IGNORE_NAMED_ARGUMENT to "true")))
-                    assertThat(rule.lint(code("53"))).isEmpty()
+                it("should ignore numbers by default") {
+                    assertThat(MagicNumber().lint(code("53"))).isEmpty()
                 }
 
-                it("should ignore numbers when 'ignoreNamedArgument' is set to true and value is negative") {
-                    val rule = MagicNumber(TestConfig(mapOf(IGNORE_NAMED_ARGUMENT to "true")))
-                    assertThat(rule.lint(code("-53"))).isEmpty()
+                it("should ignore negative numbers by default") {
+                    assertThat(MagicNumber().lint(code("-53"))).isEmpty()
                 }
 
                 it("should ignore named arguments in inheritance - #992") {
@@ -584,17 +586,13 @@ class MagicNumberSpec : Spek({
 
                     object B : A(n = 5)
                 """
-                    val rule = MagicNumber(TestConfig(mapOf(IGNORE_NAMED_ARGUMENT to "true")))
-                    assertThat(rule.compileAndLint(code)).isEmpty()
+                    assertThat(MagicNumber().compileAndLint(code)).isEmpty()
                 }
 
                 it("should ignore named arguments in parameter annotations - #1115") {
                     val code =
                         "@JvmStatic fun setCustomDimension(@IntRange(from = 0, to = 19) index: Int, value: String?) {}"
-                    MagicNumber(TestConfig(mapOf(IGNORE_NAMED_ARGUMENT to "true")))
-                        .lint(code)
-                        .assert()
-                        .isEmpty()
+                    assertThat(MagicNumber().lint(code)).isEmpty()
                 }
             }
 
@@ -609,9 +607,8 @@ class MagicNumberSpec : Spek({
                 var model = Model($numberString)
             """
 
-                it("should detect the argument") {
-                    val rule = MagicNumber(TestConfig(mapOf(IGNORE_NAMED_ARGUMENT to "true")))
-                    assertThat(rule.lint(code("53"))).hasSize(1)
+                it("should detect the argument by default") {
+                    assertThat(MagicNumber().lint(code("53"))).hasSize(1)
                 }
             }
 
@@ -619,7 +616,7 @@ class MagicNumberSpec : Spek({
                 fun code(number: Number) = """
                 fun tested(someVal: Int, other: String = "default")
 
-                tested(someVal = $number)
+                vaö t = tested(someVal = $number)
             """
                 it("should ignore int by default") {
                     assertThat(MagicNumber().lint(code(53))).isEmpty()
@@ -659,11 +656,19 @@ class MagicNumberSpec : Spek({
                     EXTRA_LARGE(id = 5)
                 }
             """
-                it("should be reported by default") {
-                    assertThat(MagicNumber().lint(code)).hasSize(1)
+                it("should be reported") {
+                    val rule = MagicNumber(TestConfig(mapOf(IGNORE_NAMED_ARGUMENT to "false")))
+                    assertThat(rule.lint(code)).hasSize(1)
                 }
                 it("numbers when 'ignoreEnums' is set to true") {
-                    val rule = MagicNumber(TestConfig(mapOf(IGNORE_ENUMS to "true")))
+                    val rule = MagicNumber(
+                        TestConfig(
+                            mapOf(
+                                IGNORE_NAMED_ARGUMENT to "false",
+                                IGNORE_ENUMS to "true"
+                            )
+                        )
+                    )
                     assertThat(rule.lint(code)).isEmpty()
                 }
             }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumberSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumberSpec.kt
@@ -1,7 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.api.SourceLocation
-import io.gitlab.arturbosch.detekt.rules.style.MagicNumber.Companion.IGNORE_NUMBERS
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assert
 import io.gitlab.arturbosch.detekt.test.assertThat
@@ -10,6 +9,18 @@ import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
+
+private const val IGNORE_NUMBERS = "ignoreNumbers"
+private const val IGNORE_HASH_CODE = "ignoreHashCodeFunction"
+private const val IGNORE_PROPERTY_DECLARATION = "ignorePropertyDeclaration"
+private const val IGNORE_LOCAL_VARIABLES = "ignoreLocalVariableDeclaration"
+private const val IGNORE_CONSTANT_DECLARATION = "ignoreConstantDeclaration"
+private const val IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION = "ignoreCompanionObjectPropertyDeclaration"
+private const val IGNORE_ANNOTATION = "ignoreAnnotation"
+private const val IGNORE_NAMED_ARGUMENT = "ignoreNamedArgument"
+private const val IGNORE_ENUMS = "ignoreEnums"
+private const val IGNORE_RANGES = "ignoreRanges"
+private const val IGNORE_EXTENSION_FUNCTIONS = "ignoreExtensionFunctions"
 
 class MagicNumberSpec : Spek({
 
@@ -353,7 +364,7 @@ class MagicNumberSpec : Spek({
 
             it("throws a NumberFormatException") {
                 assertThatExceptionOfType(NumberFormatException::class.java).isThrownBy {
-                    MagicNumber(TestConfig(mapOf(IGNORE_NUMBERS to listOf("banana"))))
+                    MagicNumber(TestConfig(mapOf(IGNORE_NUMBERS to listOf("banana")))).compileAndLint("val i = 0")
                 }
             }
         }
@@ -386,11 +397,11 @@ class MagicNumberSpec : Spek({
             it("should report all without ignore flags") {
                 val config = TestConfig(
                     mapOf(
-                        MagicNumber.IGNORE_PROPERTY_DECLARATION to "false",
-                        MagicNumber.IGNORE_ANNOTATION to "false",
-                        MagicNumber.IGNORE_HASH_CODE to "false",
-                        MagicNumber.IGNORE_CONSTANT_DECLARATION to "false",
-                        MagicNumber.IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "false"
+                        IGNORE_PROPERTY_DECLARATION to "false",
+                        IGNORE_ANNOTATION to "false",
+                        IGNORE_HASH_CODE to "false",
+                        IGNORE_CONSTANT_DECLARATION to "false",
+                        IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "false"
                     )
                 )
 
@@ -409,11 +420,11 @@ class MagicNumberSpec : Spek({
             it("should not report any issues with all ignore flags") {
                 val config = TestConfig(
                     mapOf(
-                        MagicNumber.IGNORE_PROPERTY_DECLARATION to "true",
-                        MagicNumber.IGNORE_ANNOTATION to "true",
-                        MagicNumber.IGNORE_HASH_CODE to "true",
-                        MagicNumber.IGNORE_CONSTANT_DECLARATION to "true",
-                        MagicNumber.IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "true"
+                        IGNORE_PROPERTY_DECLARATION to "true",
+                        IGNORE_ANNOTATION to "true",
+                        IGNORE_HASH_CODE to "true",
+                        IGNORE_CONSTANT_DECLARATION to "true",
+                        IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "true"
                     )
                 )
 
@@ -441,9 +452,9 @@ class MagicNumberSpec : Spek({
             it("should not report any issues when ignoring properties but not constants nor companion objects") {
                 val config = TestConfig(
                     mapOf(
-                        MagicNumber.IGNORE_PROPERTY_DECLARATION to "true",
-                        MagicNumber.IGNORE_CONSTANT_DECLARATION to "false",
-                        MagicNumber.IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "false"
+                        IGNORE_PROPERTY_DECLARATION to "true",
+                        IGNORE_CONSTANT_DECLARATION to "false",
+                        IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "false"
                     )
                 )
 
@@ -454,9 +465,9 @@ class MagicNumberSpec : Spek({
             it("should not report any issues when ignoring properties and constants but not companion objects") {
                 val config = TestConfig(
                     mapOf(
-                        MagicNumber.IGNORE_PROPERTY_DECLARATION to "true",
-                        MagicNumber.IGNORE_CONSTANT_DECLARATION to "true",
-                        MagicNumber.IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "false"
+                        IGNORE_PROPERTY_DECLARATION to "true",
+                        IGNORE_CONSTANT_DECLARATION to "true",
+                        IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "false"
                     )
                 )
 
@@ -467,9 +478,9 @@ class MagicNumberSpec : Spek({
             it("should not report any issues when ignoring properties, constants and companion objects") {
                 val config = TestConfig(
                     mapOf(
-                        MagicNumber.IGNORE_PROPERTY_DECLARATION to "true",
-                        MagicNumber.IGNORE_CONSTANT_DECLARATION to "true",
-                        MagicNumber.IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "true"
+                        IGNORE_PROPERTY_DECLARATION to "true",
+                        IGNORE_CONSTANT_DECLARATION to "true",
+                        IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "true"
                     )
                 )
 
@@ -480,9 +491,9 @@ class MagicNumberSpec : Spek({
             it("should not report any issues when ignoring companion objects but not properties and constants") {
                 val config = TestConfig(
                     mapOf(
-                        MagicNumber.IGNORE_PROPERTY_DECLARATION to "false",
-                        MagicNumber.IGNORE_CONSTANT_DECLARATION to "false",
-                        MagicNumber.IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "true"
+                        IGNORE_PROPERTY_DECLARATION to "false",
+                        IGNORE_CONSTANT_DECLARATION to "false",
+                        IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "true"
                     )
                 )
 
@@ -493,9 +504,9 @@ class MagicNumberSpec : Spek({
             it("should report property when ignoring constants but not properties and companion objects") {
                 val config = TestConfig(
                     mapOf(
-                        MagicNumber.IGNORE_PROPERTY_DECLARATION to "false",
-                        MagicNumber.IGNORE_CONSTANT_DECLARATION to "true",
-                        MagicNumber.IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "false"
+                        IGNORE_PROPERTY_DECLARATION to "false",
+                        IGNORE_CONSTANT_DECLARATION to "true",
+                        IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "false"
                     )
                 )
 
@@ -506,9 +517,9 @@ class MagicNumberSpec : Spek({
             it("should report property and constant when not ignoring properties, constants nor companion objects") {
                 val config = TestConfig(
                     mapOf(
-                        MagicNumber.IGNORE_PROPERTY_DECLARATION to "false",
-                        MagicNumber.IGNORE_CONSTANT_DECLARATION to "false",
-                        MagicNumber.IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "false"
+                        IGNORE_PROPERTY_DECLARATION to "false",
+                        IGNORE_CONSTANT_DECLARATION to "false",
+                        IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "false"
                     )
                 )
 
@@ -558,12 +569,12 @@ class MagicNumberSpec : Spek({
                 }
 
                 it("should ignore numbers when 'ignoreNamedArgument' is set to true") {
-                    val rule = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NAMED_ARGUMENT to "true")))
+                    val rule = MagicNumber(TestConfig(mapOf(IGNORE_NAMED_ARGUMENT to "true")))
                     assertThat(rule.lint(code("53"))).isEmpty()
                 }
 
                 it("should ignore numbers when 'ignoreNamedArgument' is set to true and value is negative") {
-                    val rule = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NAMED_ARGUMENT to "true")))
+                    val rule = MagicNumber(TestConfig(mapOf(IGNORE_NAMED_ARGUMENT to "true")))
                     assertThat(rule.lint(code("-53"))).isEmpty()
                 }
 
@@ -573,14 +584,14 @@ class MagicNumberSpec : Spek({
 
                     object B : A(n = 5)
                 """
-                    val rule = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NAMED_ARGUMENT to "true")))
+                    val rule = MagicNumber(TestConfig(mapOf(IGNORE_NAMED_ARGUMENT to "true")))
                     assertThat(rule.compileAndLint(code)).isEmpty()
                 }
 
                 it("should ignore named arguments in parameter annotations - #1115") {
                     val code =
                         "@JvmStatic fun setCustomDimension(@IntRange(from = 0, to = 19) index: Int, value: String?) {}"
-                    MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NAMED_ARGUMENT to "true")))
+                    MagicNumber(TestConfig(mapOf(IGNORE_NAMED_ARGUMENT to "true")))
                         .lint(code)
                         .assert()
                         .isEmpty()
@@ -599,7 +610,7 @@ class MagicNumberSpec : Spek({
             """
 
                 it("should detect the argument") {
-                    val rule = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_NAMED_ARGUMENT to "true")))
+                    val rule = MagicNumber(TestConfig(mapOf(IGNORE_NAMED_ARGUMENT to "true")))
                     assertThat(rule.lint(code("53"))).hasSize(1)
                 }
             }
@@ -637,7 +648,7 @@ class MagicNumberSpec : Spek({
                     assertThat(MagicNumber().lint(code)).hasSize(1)
                 }
                 it("numbers when 'ignoreEnums' is set to true") {
-                    val rule = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_ENUMS to "true")))
+                    val rule = MagicNumber(TestConfig(mapOf(IGNORE_ENUMS to "true")))
                     assertThat(rule.lint(code)).isEmpty()
                 }
             }
@@ -652,7 +663,7 @@ class MagicNumberSpec : Spek({
                     assertThat(MagicNumber().lint(code)).hasSize(1)
                 }
                 it("numbers when 'ignoreEnums' is set to true") {
-                    val rule = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_ENUMS to "true")))
+                    val rule = MagicNumber(TestConfig(mapOf(IGNORE_ENUMS to "true")))
                     assertThat(rule.lint(code)).isEmpty()
                 }
             }
@@ -724,23 +735,23 @@ class MagicNumberSpec : Spek({
                 }
                 it("'$codeWithMagicNumberInRange' reports a code smell if ranges are not ignored") {
                     val code = codeWithMagicNumberInRange
-                    assertThat(MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_RANGES to "false"))).lint(code))
+                    assertThat(MagicNumber(TestConfig(mapOf(IGNORE_RANGES to "false"))).lint(code))
                         .hasSize(1)
                 }
                 it("'$codeWithMagicNumberInRange' reports no finding if ranges are ignored") {
                     val code = codeWithMagicNumberInRange
-                    assertThat(MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_RANGES to "true"))).lint(code))
+                    assertThat(MagicNumber(TestConfig(mapOf(IGNORE_RANGES to "true"))).lint(code))
                         .isEmpty()
                 }
             }
 
             it("reports a finding for a parenthesized number if ranges are ignored") {
                 val code = "val foo : Int = (127)"
-                assertThat(MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_RANGES to "true"))).lint(code)).hasSize(1)
+                assertThat(MagicNumber(TestConfig(mapOf(IGNORE_RANGES to "true"))).lint(code)).hasSize(1)
             }
             it("reports a finding for an addition if ranges are ignored") {
                 val code = "val foo : Int = 1 + 27"
-                assertThat(MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_RANGES to "true"))).lint(code)).hasSize(1)
+                assertThat(MagicNumber(TestConfig(mapOf(IGNORE_RANGES to "true"))).lint(code)).hasSize(1)
             }
         }
 
@@ -749,12 +760,12 @@ class MagicNumberSpec : Spek({
             val code = """fun f() { val a = 3; }"""
 
             it("reports 3 due to the assignment to a local variable") {
-                val rule = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_LOCAL_VARIABLES to "false")))
+                val rule = MagicNumber(TestConfig(mapOf(IGNORE_LOCAL_VARIABLES to "false")))
                 assertThat(rule.compileAndLint(code)).hasSize(1)
             }
 
             it("should not report 3 due to the ignored local variable config") {
-                val rule = MagicNumber(TestConfig(mapOf(MagicNumber.IGNORE_LOCAL_VARIABLES to "true")))
+                val rule = MagicNumber(TestConfig(mapOf(IGNORE_LOCAL_VARIABLES to "true")))
                 assertThat(rule.compileAndLint(code)).isEmpty()
             }
         }
@@ -765,8 +776,8 @@ class MagicNumberSpec : Spek({
                 MagicNumber(
                     TestConfig(
                         mapOf(
-                            MagicNumber.IGNORE_LOCAL_VARIABLES to "true",
-                            MagicNumber.IGNORE_NAMED_ARGUMENT to "true"
+                            IGNORE_LOCAL_VARIABLES to "true",
+                            IGNORE_NAMED_ARGUMENT to "true"
                         )
                     )
                 )
@@ -791,7 +802,7 @@ class MagicNumberSpec : Spek({
                 MagicNumber(
                     TestConfig(
                         mapOf(
-                            MagicNumber.IGNORE_EXTENSION_FUNCTIONS to "true"
+                            IGNORE_EXTENSION_FUNCTIONS to "true"
                         )
                     )
                 )

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLengthSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLengthSpec.kt
@@ -9,6 +9,11 @@ import io.gitlab.arturbosch.detekt.test.assertThat
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
+private const val MAX_LINE_LENGTH = "maxLineLength"
+private const val EXCLUDE_PACKAGE_STATEMENTS = "excludePackageStatements"
+private const val EXCLUDE_IMPORT_STATEMENTS = "excludeImportStatements"
+private const val EXCLUDE_COMMENT_STATEMENTS = "excludeCommentStatements"
+
 class MaxLineLengthSpec : Spek({
 
     describe("MaxLineLength rule") {
@@ -20,7 +25,7 @@ class MaxLineLengthSpec : Spek({
             val fileContent by memoized { KtFileContent(file, lines) }
 
             it("should report no errors when maxLineLength is set to 200") {
-                val rule = MaxLineLength(TestConfig(mapOf(MaxLineLength.MAX_LINE_LENGTH to "200")))
+                val rule = MaxLineLength(TestConfig(mapOf(MAX_LINE_LENGTH to "200")))
 
                 rule.visit(fileContent)
                 assertThat(rule.findings).isEmpty()
@@ -66,7 +71,7 @@ class MaxLineLengthSpec : Spek({
                 val rule = MaxLineLength(
                     TestConfig(
                         mapOf(
-                            MaxLineLength.MAX_LINE_LENGTH to "60"
+                            MAX_LINE_LENGTH to "60"
                         )
                     )
                 )
@@ -79,9 +84,9 @@ class MaxLineLengthSpec : Spek({
                 val rule = MaxLineLength(
                     TestConfig(
                         mapOf(
-                            MaxLineLength.MAX_LINE_LENGTH to "60",
-                            MaxLineLength.EXCLUDE_PACKAGE_STATEMENTS to "false",
-                            MaxLineLength.EXCLUDE_IMPORT_STATEMENTS to "false"
+                            MAX_LINE_LENGTH to "60",
+                            EXCLUDE_PACKAGE_STATEMENTS to "false",
+                            EXCLUDE_IMPORT_STATEMENTS to "false"
                         )
                     )
                 )
@@ -94,9 +99,9 @@ class MaxLineLengthSpec : Spek({
                 val rule = MaxLineLength(
                     TestConfig(
                         mapOf(
-                            MaxLineLength.MAX_LINE_LENGTH to "60",
-                            MaxLineLength.EXCLUDE_PACKAGE_STATEMENTS to "true",
-                            MaxLineLength.EXCLUDE_IMPORT_STATEMENTS to "true"
+                            MAX_LINE_LENGTH to "60",
+                            EXCLUDE_PACKAGE_STATEMENTS to "true",
+                            EXCLUDE_IMPORT_STATEMENTS to "true"
                         )
                     )
                 )
@@ -116,7 +121,7 @@ class MaxLineLengthSpec : Spek({
                 val rule = MaxLineLength(
                     TestConfig(
                         mapOf(
-                            MaxLineLength.MAX_LINE_LENGTH to "60"
+                            MAX_LINE_LENGTH to "60"
                         )
                     )
                 )
@@ -129,10 +134,10 @@ class MaxLineLengthSpec : Spek({
                 val rule = MaxLineLength(
                     TestConfig(
                         mapOf(
-                            MaxLineLength.MAX_LINE_LENGTH to "60",
-                            MaxLineLength.EXCLUDE_PACKAGE_STATEMENTS to "false",
-                            MaxLineLength.EXCLUDE_IMPORT_STATEMENTS to "false",
-                            MaxLineLength.EXCLUDE_COMMENT_STATEMENTS to "false"
+                            MAX_LINE_LENGTH to "60",
+                            EXCLUDE_PACKAGE_STATEMENTS to "false",
+                            EXCLUDE_IMPORT_STATEMENTS to "false",
+                            EXCLUDE_COMMENT_STATEMENTS to "false"
                         )
                     )
                 )
@@ -145,8 +150,8 @@ class MaxLineLengthSpec : Spek({
                 val rule = MaxLineLength(
                     TestConfig(
                         mapOf(
-                            MaxLineLength.MAX_LINE_LENGTH to "60",
-                            MaxLineLength.EXCLUDE_COMMENT_STATEMENTS to "true"
+                            MAX_LINE_LENGTH to "60",
+                            EXCLUDE_COMMENT_STATEMENTS to "true"
                         )
                     )
                 )
@@ -175,7 +180,7 @@ class MaxLineLengthSpec : Spek({
                 val rule = MaxLineLength(
                     TestConfig(
                         mapOf(
-                            MaxLineLength.MAX_LINE_LENGTH to "60"
+                            MAX_LINE_LENGTH to "60"
                         )
                     )
                 )
@@ -188,9 +193,9 @@ class MaxLineLengthSpec : Spek({
                 val rule = MaxLineLength(
                     TestConfig(
                         mapOf(
-                            MaxLineLength.MAX_LINE_LENGTH to "60",
-                            MaxLineLength.EXCLUDE_PACKAGE_STATEMENTS to "false",
-                            MaxLineLength.EXCLUDE_IMPORT_STATEMENTS to "false"
+                            MAX_LINE_LENGTH to "60",
+                            EXCLUDE_PACKAGE_STATEMENTS to "false",
+                            EXCLUDE_IMPORT_STATEMENTS to "false"
                         )
                     )
                 )
@@ -203,9 +208,9 @@ class MaxLineLengthSpec : Spek({
                 val rule = MaxLineLength(
                     TestConfig(
                         mapOf(
-                            MaxLineLength.MAX_LINE_LENGTH to "60",
-                            MaxLineLength.EXCLUDE_PACKAGE_STATEMENTS to "true",
-                            MaxLineLength.EXCLUDE_IMPORT_STATEMENTS to "true"
+                            MAX_LINE_LENGTH to "60",
+                            EXCLUDE_PACKAGE_STATEMENTS to "true",
+                            EXCLUDE_IMPORT_STATEMENTS to "true"
                         )
                     )
                 )
@@ -218,9 +223,9 @@ class MaxLineLengthSpec : Spek({
                 val rule = MaxLineLength(
                     TestConfig(
                         mapOf(
-                            MaxLineLength.MAX_LINE_LENGTH to "60",
-                            MaxLineLength.EXCLUDE_PACKAGE_STATEMENTS to "true",
-                            MaxLineLength.EXCLUDE_IMPORT_STATEMENTS to "true"
+                            MAX_LINE_LENGTH to "60",
+                            EXCLUDE_PACKAGE_STATEMENTS to "true",
+                            EXCLUDE_IMPORT_STATEMENTS to "true"
                         )
                     )
                 )

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCountSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCountSpec.kt
@@ -8,6 +8,12 @@ import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
+private const val MAX = "max"
+private const val EXCLUDED_FUNCTIONS = "excludedFunctions"
+private const val EXCLUDE_LABELED = "excludeLabeled"
+private const val EXCLUDE_RETURN_FROM_LAMBDA = "excludeReturnFromLambda"
+private const val EXCLUDE_GUARD_CLAUSES = "excludeGuardClauses"
+
 class ReturnCountSpec : Spek({
 
     describe("ReturnCount rule") {
@@ -45,7 +51,7 @@ class ReturnCountSpec : Spek({
         """
 
             it("should not get flagged for if condition guard clauses") {
-                val findings = ReturnCount(TestConfig(mapOf(ReturnCount.EXCLUDE_GUARD_CLAUSES to "true")))
+                val findings = ReturnCount(TestConfig(mapOf(EXCLUDE_GUARD_CLAUSES to "true")))
                     .compileAndLint(code)
                 assertThat(findings).isEmpty()
             }
@@ -67,13 +73,13 @@ class ReturnCountSpec : Spek({
         """
 
             it("should not get flagged for if condition guard clauses") {
-                val findings = ReturnCount(TestConfig(mapOf(ReturnCount.EXCLUDE_GUARD_CLAUSES to "true")))
+                val findings = ReturnCount(TestConfig(mapOf(EXCLUDE_GUARD_CLAUSES to "true")))
                     .compileAndLint(code)
                 assertThat(findings).isEmpty()
             }
 
             it("should get flagged without guard clauses") {
-                val findings = ReturnCount(TestConfig(mapOf(ReturnCount.EXCLUDE_GUARD_CLAUSES to "false")))
+                val findings = ReturnCount(TestConfig(mapOf(EXCLUDE_GUARD_CLAUSES to "false")))
                     .compileAndLint(code)
                 assertThat(findings).hasSize(1)
             }
@@ -99,7 +105,7 @@ class ReturnCountSpec : Spek({
         """
 
             it("should report a too-complicated if statement for being a guard clause, with EXCLUDE_GUARD_CLAUSES on") {
-                val findings = ReturnCount(TestConfig(mapOf(ReturnCount.EXCLUDE_GUARD_CLAUSES to "true")))
+                val findings = ReturnCount(TestConfig(mapOf(EXCLUDE_GUARD_CLAUSES to "true")))
                     .compileAndLint(code)
                 assertThat(findings).hasSize(1)
             }
@@ -118,7 +124,7 @@ class ReturnCountSpec : Spek({
         """
 
             it("should not get flagged for ELVIS operator guard clauses") {
-                val findings = ReturnCount(TestConfig(mapOf(ReturnCount.EXCLUDE_GUARD_CLAUSES to "true")))
+                val findings = ReturnCount(TestConfig(mapOf(EXCLUDE_GUARD_CLAUSES to "true")))
                     .compileAndLint(code)
                 assertThat(findings).isEmpty()
             }
@@ -137,7 +143,7 @@ class ReturnCountSpec : Spek({
         """
 
             it("should get flagged for an if condition guard clause which is not the first statement") {
-                val findings = ReturnCount(TestConfig(mapOf(ReturnCount.EXCLUDE_GUARD_CLAUSES to "true")))
+                val findings = ReturnCount(TestConfig(mapOf(EXCLUDE_GUARD_CLAUSES to "true")))
                     .compileAndLint(code)
                 assertThat(findings).hasSize(1)
             }
@@ -156,7 +162,7 @@ class ReturnCountSpec : Spek({
         """
 
             it("should get flagged for an ELVIS guard clause which is not the first statement") {
-                val findings = ReturnCount(TestConfig(mapOf(ReturnCount.EXCLUDE_GUARD_CLAUSES to "true")))
+                val findings = ReturnCount(TestConfig(mapOf(EXCLUDE_GUARD_CLAUSES to "true")))
                     .compileAndLint(code)
                 assertThat(findings).hasSize(1)
             }
@@ -180,7 +186,7 @@ class ReturnCountSpec : Spek({
             it("should not count all four guard clauses") {
                 val findings = ReturnCount(
                     TestConfig(
-                        ReturnCount.EXCLUDE_GUARD_CLAUSES to "true"
+                        EXCLUDE_GUARD_CLAUSES to "true"
                     )
                 ).compileAndLint(code)
                 assertThat(findings).isEmpty()
@@ -189,7 +195,7 @@ class ReturnCountSpec : Spek({
             it("should count all four guard clauses") {
                 val findings = ReturnCount(
                     TestConfig(
-                        ReturnCount.EXCLUDE_GUARD_CLAUSES to "false"
+                        EXCLUDE_GUARD_CLAUSES to "false"
                     )
                 ).compileAndLint(code)
                 assertThat(findings).hasSize(1)
@@ -214,12 +220,12 @@ class ReturnCountSpec : Spek({
             }
 
             it("should not get flagged when max value is 3") {
-                val findings = ReturnCount(TestConfig(mapOf(ReturnCount.MAX to "3"))).compileAndLint(code)
+                val findings = ReturnCount(TestConfig(mapOf(MAX to "3"))).compileAndLint(code)
                 assertThat(findings).isEmpty()
             }
 
             it("should get flagged when max value is 1") {
-                val findings = ReturnCount(TestConfig(mapOf(ReturnCount.MAX to "1"))).compileAndLint(code)
+                val findings = ReturnCount(TestConfig(mapOf(MAX to "1"))).compileAndLint(code)
                 assertThat(findings).hasSize(1)
             }
         }
@@ -241,12 +247,12 @@ class ReturnCountSpec : Spek({
             }
 
             it("should not get flagged when max value is 2") {
-                val findings = ReturnCount(TestConfig(mapOf(ReturnCount.MAX to "2"))).compileAndLint(code)
+                val findings = ReturnCount(TestConfig(mapOf(MAX to "2"))).compileAndLint(code)
                 assertThat(findings).isEmpty()
             }
 
             it("should get flagged when max value is 1") {
-                val findings = ReturnCount(TestConfig(mapOf(ReturnCount.MAX to "1"))).compileAndLint(code)
+                val findings = ReturnCount(TestConfig(mapOf(MAX to "1"))).compileAndLint(code)
                 assertThat(findings).hasSize(1)
             }
         }
@@ -267,8 +273,8 @@ class ReturnCountSpec : Spek({
                 val findings = ReturnCount(
                     TestConfig(
                         mapOf(
-                            ReturnCount.MAX to "2",
-                            ReturnCount.EXCLUDED_FUNCTIONS to "test"
+                            MAX to "2",
+                            EXCLUDED_FUNCTIONS to "test"
                         )
                     )
                 ).compileAndLint(code)
@@ -310,8 +316,8 @@ class ReturnCountSpec : Spek({
                 val findings = ReturnCount(
                     TestConfig(
                         mapOf(
-                            ReturnCount.MAX to "2",
-                            ReturnCount.EXCLUDED_FUNCTIONS to "test1,test2"
+                            MAX to "2",
+                            EXCLUDED_FUNCTIONS to "test1,test2"
                         )
                     )
                 ).compileAndLint(code)
@@ -340,7 +346,7 @@ class ReturnCountSpec : Spek({
         """
 
             it("should not get flag when returns is in inner object") {
-                val findings = ReturnCount(TestConfig(mapOf(ReturnCount.MAX to "2"))).compileAndLint(code)
+                val findings = ReturnCount(TestConfig(mapOf(MAX to "2"))).compileAndLint(code)
                 assertThat(findings).isEmpty()
             }
         }
@@ -375,7 +381,7 @@ class ReturnCountSpec : Spek({
         """
 
             it("should not get flag when returns is in inner object") {
-                val findings = ReturnCount(TestConfig(mapOf(ReturnCount.MAX to "2"))).compileAndLint(code)
+                val findings = ReturnCount(TestConfig(mapOf(MAX to "2"))).compileAndLint(code)
                 assertThat(findings).isEmpty()
             }
         }
@@ -412,7 +418,7 @@ class ReturnCountSpec : Spek({
         """
 
             it("should get flagged when returns is in inner object") {
-                val findings = ReturnCount(TestConfig(mapOf(ReturnCount.MAX to "2"))).compileAndLint(code)
+                val findings = ReturnCount(TestConfig(mapOf(MAX to "2"))).compileAndLint(code)
                 assertThat(findings).hasSize(1)
             }
         }
@@ -436,7 +442,7 @@ class ReturnCountSpec : Spek({
 
             it("should count labeled returns from lambda when activated") {
                 val findings = ReturnCount(
-                    TestConfig(mapOf(ReturnCount.EXCLUDE_RETURN_FROM_LAMBDA to "false"))
+                    TestConfig(mapOf(EXCLUDE_RETURN_FROM_LAMBDA to "false"))
                 ).lint(code)
                 assertThat(findings).hasSize(1)
             }
@@ -445,8 +451,8 @@ class ReturnCountSpec : Spek({
                 val findings = ReturnCount(
                     TestConfig(
                         mapOf(
-                            ReturnCount.EXCLUDE_LABELED to "true",
-                            ReturnCount.EXCLUDE_RETURN_FROM_LAMBDA to "false"
+                            EXCLUDE_LABELED to "true",
+                            EXCLUDE_RETURN_FROM_LAMBDA to "false"
                         )
                     )
                 ).lint(code)

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ThrowsCountSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ThrowsCountSpec.kt
@@ -7,6 +7,9 @@ import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
+private const val MAX = "max"
+private const val EXCLUDE_GUARD_CLAUSES = "excludeGuardClauses"
+
 class ThrowsCountSpec : Spek({
 
     describe("ThrowsCount rule") {
@@ -115,13 +118,13 @@ class ThrowsCountSpec : Spek({
             """
 
             it("does not report when max parameter is 3") {
-                val config = TestConfig(mapOf(ThrowsCount.MAX to "3"))
+                val config = TestConfig(mapOf(MAX to "3"))
                 val subject = ThrowsCount(config)
                 assertThat(subject.lint(code)).isEmpty()
             }
 
             it("reports violation when max parameter is 2") {
-                val config = TestConfig(mapOf(ThrowsCount.MAX to "2"))
+                val config = TestConfig(mapOf(MAX to "2"))
                 val subject = ThrowsCount(config)
                 assertThat(subject.lint(code)).hasSize(1)
             }
@@ -140,13 +143,13 @@ class ThrowsCountSpec : Spek({
             """
 
             it("should not report violation with EXCLUDE_GUARD_CLAUSES as true") {
-                val config = TestConfig(mapOf(ThrowsCount.EXCLUDE_GUARD_CLAUSES to "true"))
+                val config = TestConfig(mapOf(EXCLUDE_GUARD_CLAUSES to "true"))
                 val subject = ThrowsCount(config)
                 assertThat(subject.lint(codeWithGuardClause)).isEmpty()
             }
 
             it("should report violation with EXCLUDE_GUARD_CLAUSES as false") {
-                val config = TestConfig(mapOf(ThrowsCount.EXCLUDE_GUARD_CLAUSES to "false"))
+                val config = TestConfig(mapOf(EXCLUDE_GUARD_CLAUSES to "false"))
                 val subject = ThrowsCount(config)
                 assertThat(subject.lint(codeWithGuardClause)).hasSize(1)
             }
@@ -165,13 +168,13 @@ class ThrowsCountSpec : Spek({
             """
 
             it("should not report violation with EXCLUDE_GUARD_CLAUSES as true") {
-                val config = TestConfig(mapOf(ThrowsCount.EXCLUDE_GUARD_CLAUSES to "true"))
+                val config = TestConfig(mapOf(EXCLUDE_GUARD_CLAUSES to "true"))
                 val subject = ThrowsCount(config)
                 assertThat(subject.lint(codeWithGuardClause)).isEmpty()
             }
 
             it("should report violation with EXCLUDE_GUARD_CLAUSES as false") {
-                val config = TestConfig(mapOf(ThrowsCount.EXCLUDE_GUARD_CLAUSES to "false"))
+                val config = TestConfig(mapOf(EXCLUDE_GUARD_CLAUSES to "false"))
                 val subject = ThrowsCount(config)
                 assertThat(subject.lint(codeWithGuardClause)).hasSize(1)
             }
@@ -197,7 +200,7 @@ class ThrowsCountSpec : Spek({
             """
 
             it("should report violation even with EXCLUDE_GUARD_CLAUSES as true") {
-                val config = TestConfig(mapOf(ThrowsCount.EXCLUDE_GUARD_CLAUSES to "true"))
+                val config = TestConfig(mapOf(EXCLUDE_GUARD_CLAUSES to "true"))
                 val subject = ThrowsCount(config)
                 assertThat(subject.lint(codeWithIfCondition)).hasSize(1)
             }
@@ -216,7 +219,7 @@ class ThrowsCountSpec : Spek({
             """
 
             it("should report the violation even with EXCLUDE_GUARD_CLAUSES as true") {
-                val config = TestConfig(mapOf(ThrowsCount.EXCLUDE_GUARD_CLAUSES to "true"))
+                val config = TestConfig(mapOf(EXCLUDE_GUARD_CLAUSES to "true"))
                 val subject = ThrowsCount(config)
                 assertThat(subject.lint(codeWithIfCondition)).hasSize(1)
             }
@@ -234,7 +237,7 @@ class ThrowsCountSpec : Spek({
             """
 
             it("should report the violation even with EXCLUDE_GUARD_CLAUSES as true") {
-                val config = TestConfig(mapOf(ThrowsCount.EXCLUDE_GUARD_CLAUSES to "true"))
+                val config = TestConfig(mapOf(EXCLUDE_GUARD_CLAUSES to "true"))
                 val subject = ThrowsCount(config)
                 assertThat(subject.lint(codeWithIfCondition)).hasSize(1)
             }
@@ -256,13 +259,13 @@ class ThrowsCountSpec : Spek({
             """
 
             it("should not report violation with EXCLUDE_GUARD_CLAUSES as true") {
-                val config = TestConfig(mapOf(ThrowsCount.EXCLUDE_GUARD_CLAUSES to "true"))
+                val config = TestConfig(mapOf(EXCLUDE_GUARD_CLAUSES to "true"))
                 val subject = ThrowsCount(config)
                 assertThat(subject.lint(codeWithMultipleGuardClauses)).isEmpty()
             }
 
             it("should report violation with EXCLUDE_GUARD_CLAUSES as false") {
-                val config = TestConfig(mapOf(ThrowsCount.EXCLUDE_GUARD_CLAUSES to "false"))
+                val config = TestConfig(mapOf(EXCLUDE_GUARD_CLAUSES to "false"))
                 val subject = ThrowsCount(config)
                 assertThat(subject.lint(codeWithMultipleGuardClauses)).hasSize(1)
             }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiteralsSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiteralsSpec.kt
@@ -7,6 +7,8 @@ import io.gitlab.arturbosch.detekt.test.lint
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
+private const val ACCEPTABLE_DECIMAL_LENGTH = "acceptableDecimalLength"
+
 class UnderscoresInNumericLiteralsSpec : Spek({
 
     describe("an Int of 1000") {
@@ -19,7 +21,7 @@ class UnderscoresInNumericLiteralsSpec : Spek({
 
         it("should be reported if acceptableDecimalLength is 4") {
             val findings = UnderscoresInNumericLiterals(
-                TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "4"))
+                TestConfig(mapOf(ACCEPTABLE_DECIMAL_LENGTH to "4"))
             ).compileAndLint(code)
             assertThat(findings).isNotEmpty
         }
@@ -44,7 +46,7 @@ class UnderscoresInNumericLiteralsSpec : Spek({
 
         it("should not be reported if acceptableDecimalLength is 8") {
             val findings = UnderscoresInNumericLiterals(
-                TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "8"))
+                TestConfig(mapOf(ACCEPTABLE_DECIMAL_LENGTH to "8"))
             ).compileAndLint(code)
             assertThat(findings).isEmpty()
         }
@@ -60,7 +62,7 @@ class UnderscoresInNumericLiteralsSpec : Spek({
 
         it("should be reported if acceptableDecimalLength is 4") {
             val findings = UnderscoresInNumericLiterals(
-                TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "4"))
+                TestConfig(mapOf(ACCEPTABLE_DECIMAL_LENGTH to "4"))
             ).compileAndLint(code)
             assertThat(findings).isNotEmpty
         }
@@ -76,7 +78,7 @@ class UnderscoresInNumericLiteralsSpec : Spek({
 
         it("should be reported if acceptableDecimalLength is 4") {
             val findings = UnderscoresInNumericLiterals(
-                TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "4"))
+                TestConfig(mapOf(ACCEPTABLE_DECIMAL_LENGTH to "4"))
             ).compileAndLint(code)
             assertThat(findings).isNotEmpty
         }
@@ -101,7 +103,7 @@ class UnderscoresInNumericLiteralsSpec : Spek({
 
         it("should not be reported if ignored acceptableDecimalLength is 8") {
             val findings = UnderscoresInNumericLiterals(
-                TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "8"))
+                TestConfig(mapOf(ACCEPTABLE_DECIMAL_LENGTH to "8"))
             ).compileAndLint(code)
             assertThat(findings).isEmpty()
         }
@@ -126,7 +128,7 @@ class UnderscoresInNumericLiteralsSpec : Spek({
 
         it("should be reported if acceptableDecimalLength is 4") {
             val findings = UnderscoresInNumericLiterals(
-                TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "4"))
+                TestConfig(mapOf(ACCEPTABLE_DECIMAL_LENGTH to "4"))
             ).compileAndLint(code)
             assertThat(findings).isNotEmpty
         }
@@ -160,7 +162,7 @@ class UnderscoresInNumericLiteralsSpec : Spek({
 
         it("should still be reported even if acceptableDecimalLength is 7") {
             val findings = UnderscoresInNumericLiterals(
-                TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "7"))
+                TestConfig(mapOf(ACCEPTABLE_DECIMAL_LENGTH to "7"))
             ).compileAndLint(code)
             assertThat(findings).isNotEmpty
         }
@@ -300,7 +302,7 @@ class UnderscoresInNumericLiteralsSpec : Spek({
 
         it("should not be reported if acceptableDecimalLength is 6") {
             val findings = UnderscoresInNumericLiterals(
-                TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "6"))
+                TestConfig(mapOf(ACCEPTABLE_DECIMAL_LENGTH to "6"))
             ).compileAndLint(code)
             assertThat(findings).isEmpty()
         }
@@ -329,7 +331,7 @@ class UnderscoresInNumericLiteralsSpec : Spek({
 
         it("should be reported if acceptableDecimalLength is 4") {
             val findings = UnderscoresInNumericLiterals(
-                TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "4"))
+                TestConfig(mapOf(ACCEPTABLE_DECIMAL_LENGTH to "4"))
             ).compileAndLint(code)
             assertThat(findings).isNotEmpty
         }
@@ -345,7 +347,7 @@ class UnderscoresInNumericLiteralsSpec : Spek({
 
         it("should not be reported if acceptableDecimalLength is 8") {
             val findings = UnderscoresInNumericLiterals(
-                TestConfig(mapOf(UnderscoresInNumericLiterals.ACCEPTABLE_DECIMAL_LENGTH to "8"))
+                TestConfig(mapOf(ACCEPTABLE_DECIMAL_LENGTH to "8"))
             ).compileAndLint(code)
             assertThat(findings).isEmpty()
         }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAbstractClassSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAbstractClassSpec.kt
@@ -9,6 +9,8 @@ import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
+private const val EXCLUDE_ANNOTATED_CLASSES = "excludeAnnotatedClasses"
+
 class UnnecessaryAbstractClassSpec : Spek({
     setupKotlinEnvironment()
 
@@ -17,7 +19,7 @@ class UnnecessaryAbstractClassSpec : Spek({
         UnnecessaryAbstractClass(
             TestConfig(
                 mapOf(
-                    UnnecessaryAbstractClass.EXCLUDE_ANNOTATED_CLASSES to listOf("Deprecated")
+                    EXCLUDE_ANNOTATED_CLASSES to listOf("Deprecated")
                 )
             )
         )

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMemberSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMemberSpec.kt
@@ -13,6 +13,8 @@ import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 import java.util.regex.PatternSyntaxException
 
+private const val ALLOWED_NAMES_PATTERN = "allowedNames"
+
 class UnusedPrivateMemberSpec : Spek({
     setupKotlinEnvironment()
 
@@ -247,14 +249,14 @@ class UnusedPrivateMemberSpec : Spek({
         it("does not fail when disabled with invalid regex") {
             val configRules = mapOf(
                 "active" to "false",
-                UnusedPrivateMember.ALLOWED_NAMES_PATTERN to "*foo"
+                ALLOWED_NAMES_PATTERN to "*foo"
             )
             val config = TestConfig(configRules)
             assertThat(UnusedPrivateMember(config).lint(regexTestingCode)).isEmpty()
         }
 
         it("does fail when enabled with invalid regex") {
-            val configRules = mapOf(UnusedPrivateMember.ALLOWED_NAMES_PATTERN to "*foo")
+            val configRules = mapOf(ALLOWED_NAMES_PATTERN to "*foo")
             val config = TestConfig(configRules)
             assertThatExceptionOfType(PatternSyntaxException::class.java)
                 .isThrownBy { UnusedPrivateMember(config).lint(regexTestingCode) }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseDataClassSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseDataClassSpec.kt
@@ -11,6 +11,9 @@ import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
+private const val ALLOW_VARS = "allowVars"
+private const val EXCLUDE_ANNOTATED_CLASSES = "excludeAnnotatedClasses"
+
 class UseDataClassSpec : Spek({
     setupKotlinEnvironment()
 
@@ -284,7 +287,7 @@ class UseDataClassSpec : Spek({
 
             it("does not report class with mutable constructor parameter") {
                 val code = """class DataClassCandidateWithVar(var i: Int)"""
-                val config = TestConfig(mapOf(UseDataClass.ALLOW_VARS to "true"))
+                val config = TestConfig(mapOf(ALLOW_VARS to "true"))
                 assertThat(UseDataClass(config).compileAndLint(code)).isEmpty()
             }
 
@@ -294,7 +297,7 @@ class UseDataClassSpec : Spek({
                         var i2: Int = 0
                     }
                 """
-                val config = TestConfig(mapOf(UseDataClass.ALLOW_VARS to "true"))
+                val config = TestConfig(mapOf(ALLOW_VARS to "true"))
                 assertThat(UseDataClass(config).compileAndLint(code)).isEmpty()
             }
 
@@ -304,7 +307,7 @@ class UseDataClassSpec : Spek({
                         var i2: Int = 0
                     }
                 """
-                val config = TestConfig(mapOf(UseDataClass.ALLOW_VARS to "true"))
+                val config = TestConfig(mapOf(ALLOW_VARS to "true"))
                 assertThat(UseDataClass(config).compileAndLint(code)).isEmpty()
             }
 
@@ -314,7 +317,7 @@ class UseDataClassSpec : Spek({
                         val i2: Int = 0
                     }
                 """
-                val config = TestConfig(mapOf(UseDataClass.ALLOW_VARS to "true"))
+                val config = TestConfig(mapOf(ALLOW_VARS to "true"))
                 assertThat(UseDataClass(config).compileAndLint(code)).isEmpty()
             }
         }
@@ -330,7 +333,7 @@ class UseDataClassSpec : Spek({
                 @SinceKotlin("1.0.0")
                 class AnnotatedClass(val i: Int) {}
                 """
-            val config = TestConfig(mapOf(UseDataClass.EXCLUDE_ANNOTATED_CLASSES to "kotlin.*"))
+            val config = TestConfig(mapOf(EXCLUDE_ANNOTATED_CLASSES to "kotlin.*"))
             assertThat(UseDataClass(config).compileAndLint(code)).isEmpty()
         }
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/WildcardImportSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/WildcardImportSpec.kt
@@ -1,13 +1,14 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.rules.style.WildcardImport.Companion.EXCLUDED_IMPORTS
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
+
+private const val EXCLUDED_IMPORTS = "excludeImports"
 
 class WildcardImportSpec : Spek({
 
@@ -44,14 +45,24 @@ class WildcardImportSpec : Spek({
             }
 
             it("should not report excluded wildcard imports when multiple are excluded") {
-                val rule = WildcardImport(TestConfig(mapOf(EXCLUDED_IMPORTS to listOf("org.spekframework.*", "io.gitlab.arturbosch.detekt"))))
+                val rule = WildcardImport(
+                    TestConfig(
+                        mapOf(
+                            EXCLUDED_IMPORTS to listOf(
+                                "org.spekframework.*",
+                                "io.gitlab.arturbosch.detekt"
+                            )
+                        )
+                    )
+                )
 
                 val findings = rule.compileAndLint(code)
                 assertThat(findings).isEmpty()
             }
 
             it("should not report excluded wildcard imports when multiple are excluded using config string") {
-                val rule = WildcardImport(TestConfig(mapOf(EXCLUDED_IMPORTS to "org.spekframework.*, io.gitlab.arturbosch.detekt")))
+                val rule =
+                    WildcardImport(TestConfig(mapOf(EXCLUDED_IMPORTS to "org.spekframework.*, io.gitlab.arturbosch.detekt")))
 
                 val findings = rule.compileAndLint(code)
                 assertThat(findings).isEmpty()


### PR DESCRIPTION
This belongs to #3670 and replaces all configuration kdoc tags in detekt-rules-style.
