### PR TITLE
Fix crash for DontDowncastCollectionTypes on Synthetic types

### DIFF
--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DontDowncastCollectionTypes.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DontDowncastCollectionTypes.kt
@@ -67,7 +67,7 @@ class DontDowncastCollectionTypes(config: Config) : Rule(config) {
         val lhsType = left
             .getType(bindingContext)
             ?.fqNameOrNull()
-            ?.shortName()
+            ?.shortNameOrSpecial()
             ?.asString()
 
         val rhsType = right

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DontDowncastCollectionTypesSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DontDowncastCollectionTypesSpec.kt
@@ -3,6 +3,7 @@ package io.gitlab.arturbosch.detekt.rules.bugs
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.setupKotlinEnvironment
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.spekframework.spek2.Spek
@@ -174,7 +175,7 @@ class DontDowncastCollectionTypesSpec : Spek({
                 assertThat(result).isEmpty()
             }
 
-            it("detects Map type casts") {
+            it("ignores Map type casts") {
                 val code = """
                 fun main() {
                     val myMap = mutableMapOf(1 to 2)
@@ -182,6 +183,17 @@ class DontDowncastCollectionTypesSpec : Spek({
                 }
                 """
                 val result = subject.compileAndLintWithContext(env, code)
+                assertThat(result).isEmpty()
+            }
+
+            it("ignores Synthetic types") {
+                val code = """
+                import kotlinx.android.synthetic.main.tooltip_progress_bar.view.*
+                fun main() {
+                    val params = tooltip_guide.layoutParams as LayoutParams
+                }
+                """
+                val result = subject.lintWithContext(env, code)
                 assertThat(result).isEmpty()
             }
         }


### PR DESCRIPTION
This fixes a crash on `DontDowncastCollectionTypes` for Synthetic types. When resolving the left operand of a cast, the synthetic types returns `root`, causing `shortName` to crash with an `IllegalStateException`: https://github.com/JetBrains/kotlin/blob/8308f5d7d3358330af53f6f06214b9a8d00515c4/core/compiler.common/src/org/jetbrains/kotlin/name/FqNameUnsafe.java#L137-L139

I'm switching to using `shortNameOrSpecial` that has special treatment for the `root` case:
https://github.com/JetBrains/kotlin/blob/8308f5d7d3358330af53f6f06214b9a8d00515c4/core/compiler.common/src/org/jetbrains/kotlin/name/FqNameUnsafe.java#L148-L150

Fixes #3775 