### PR TITLE
Checkout files with LF line endings on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,11 +1,11 @@
-* text eol=auto
+* text eol=lf
 
 *.bat           text eol=crlf
 
 *.css           diff=css
-*.htm           eol=lf diff=html
-*.html          eol=lf diff=html
-*.md            eol=lf diff=markdown
+*.htm           diff=html
+*.html          diff=html
+*.md            diff=markdown
 
 *.jar           binary
 *.png           binary

--- a/detekt-parser/src/test/kotlin/io/github/detekt/parser/KtCompilerTest.kt
+++ b/detekt-parser/src/test/kotlin/io/github/detekt/parser/KtCompilerTest.kt
@@ -19,20 +19,38 @@ class KtCompilerTest : Spek({
         val path = resourceAsPath("/cases")
         val ktCompiler by memoized(CachingMode.SCOPE) { KtCompiler() }
 
-        it("Kotlin file has extra user data") {
-            val ktFile = ktCompiler.compile(path, path.resolve("Default.kt"))
+        it("Kotlin file with LF line separators has extra user data") {
+            val ktFile = ktCompiler.compile(path, path.resolve("DefaultLf.kt"))
 
-            assertThat(ktFile.getUserData(LINE_SEPARATOR)).isEqualTo(System.lineSeparator())
+            assertThat(ktFile.getUserData(LINE_SEPARATOR)).isEqualTo("\n")
             assertThat(ktFile.getUserData(RELATIVE_PATH))
-                .isEqualTo("Default.kt")
+                .isEqualTo("DefaultLf.kt")
             assertThat(ktFile.getUserData(BASE_PATH))
                 .endsWith("cases")
         }
 
-        it("Kotlin file does not store extra data for relative path if not provided") {
-            val ktFile = ktCompiler.compile(null, path.resolve("Default.kt"))
+        it("Kotlin file with CRLF line separators has extra user data") {
+            val ktFile = ktCompiler.compile(path, path.resolve("DefaultCrLf.kt"))
 
-            assertThat(ktFile.getUserData(LINE_SEPARATOR)).isEqualTo(System.lineSeparator())
+            assertThat(ktFile.getUserData(LINE_SEPARATOR)).isEqualTo("\r\n")
+            assertThat(ktFile.getUserData(RELATIVE_PATH))
+                .isEqualTo("DefaultCrLf.kt")
+            assertThat(ktFile.getUserData(BASE_PATH))
+                .endsWith("cases")
+        }
+
+        it("Kotlin file with LF line separators does not store extra data for relative path if not provided") {
+            val ktFile = ktCompiler.compile(null, path.resolve("DefaultLf.kt"))
+
+            assertThat(ktFile.getUserData(LINE_SEPARATOR)).isEqualTo("\n")
+            assertThat(ktFile.getUserData(RELATIVE_PATH)).isNull()
+            assertThat(ktFile.getUserData(BASE_PATH)).isNull()
+        }
+
+        it("Kotlin file with CRLF line separators does not store extra data for relative path if not provided") {
+            val ktFile = ktCompiler.compile(null, path.resolve("DefaultCrLf.kt"))
+
+            assertThat(ktFile.getUserData(LINE_SEPARATOR)).isEqualTo("\r\n")
             assertThat(ktFile.getUserData(RELATIVE_PATH)).isNull()
             assertThat(ktFile.getUserData(BASE_PATH)).isNull()
         }

--- a/detekt-parser/src/test/resources/cases/.gitattributes
+++ b/detekt-parser/src/test/resources/cases/.gitattributes
@@ -1,0 +1,2 @@
+DefaultLf.kt   text eol=lf
+DefaultCrLf.kt text eol=crlf

--- a/detekt-parser/src/test/resources/cases/DefaultCrLf.kt
+++ b/detekt-parser/src/test/resources/cases/DefaultCrLf.kt
@@ -4,4 +4,4 @@ package cases
  * A comment
  */
 @Suppress("Unused")
-class Default
+class DefaultCrLf

--- a/detekt-parser/src/test/resources/cases/DefaultLf.kt
+++ b/detekt-parser/src/test/resources/cases/DefaultLf.kt
@@ -1,0 +1,7 @@
+package cases
+
+/**
+ * A comment
+ */
+@Suppress("Unused")
+class DefaultLf


### PR DESCRIPTION
This ensures the line endings of files in git's working directory are LF on Windows, which matches behaviour on Linux & macOS.

This helps with Gradle's up-to-date checks - for example on Windows checkout the default-detekt-config.yml file is currently checked out with CRLF line endings. During the initial build the file will be rewritten by the generateDocumentation task with LF line endings, so on the next build any tasks (and their successors) that use the config file as an input will be out of date, causing many tasks to run again unnecessarily.

Two test assertions were dependent on the OS the test is running under, so those have been updated to run on files that will be checked out with CRLF and LF line endings regardless of the OS.