### PR TITLE
Revert "Noisy gradle (#3655)"

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
@@ -106,6 +106,8 @@ class DetektPlugin : Plugin<Project> {
         const val BASELINE_TASK_NAME = "detektBaseline"
         const val DETEKT_EXTENSION = "detekt"
         private const val GENERATE_CONFIG = "detektGenerateConfig"
+        internal val defaultExcludes = listOf("build/")
+        internal val defaultIncludes = listOf("**/*.kt", "**/*.kts")
         internal const val CONFIG_DIR_NAME = "config/detekt"
         internal const val CONFIG_FILE = "detekt.yml"
 

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektPlain.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektPlain.kt
@@ -20,6 +20,8 @@ internal class DetektPlain(private val project: Project) {
                 baseline.set(project.layout.file(project.provider { baselineFile }))
             }
             setSource(existingInputDirectoriesProvider(project, extension))
+            setIncludes(DetektPlugin.defaultIncludes)
+            setExcludes(DetektPlugin.defaultExcludes)
             reportsDir.set(project.provider { extension.customReportsDir })
             reports = extension.reports
         }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/SharedTasks.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/SharedTasks.kt
@@ -24,8 +24,6 @@ internal fun Project.registerDetektTask(
         it.ignoreFailuresProp.set(project.provider { extension.ignoreFailures })
         it.basePathProp.set(extension.basePath)
         it.allRulesProp.set(provider { extension.allRules })
-        it.setIncludes(DEFAULT_INCLUDES)
-        it.setExcludes(DEFAULT_EXCLUDES)
         configuration(it)
     }
 
@@ -52,6 +50,3 @@ internal fun DetektReport.setDefaultIfUnset(default: File) {
         destination = default
     }
 }
-
-private val DEFAULT_EXCLUDES = listOf("build/")
-private val DEFAULT_INCLUDES = listOf("**/*.kt", "**/*.kts")

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektAndroidTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektAndroidTest.kt
@@ -2,7 +2,6 @@ package io.gitlab.arturbosch.detekt
 
 import io.gitlab.arturbosch.detekt.testkit.DslGradleRunner
 import io.gitlab.arturbosch.detekt.testkit.ProjectLayout
-import io.gitlab.arturbosch.detekt.testkit.createJavaClass
 import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.dsl.Skip
@@ -39,7 +38,6 @@ object DetektAndroidTest : Spek({
             }
             val gradleRunner = createGradleRunnerAndSetupProject(projectLayout)
             gradleRunner.writeProjectFile("app/src/main/AndroidManifest.xml", MANIFEST_CONTENT)
-            gradleRunner.createJavaClassAtSubmodule("AJavaClass")
 
             it("task :app:detektMain") {
                 gradleRunner.runTasksAndCheckResult(":app:detektMain") { buildResult ->
@@ -48,7 +46,6 @@ object DetektAndroidTest : Spek({
                     assertThat(buildResult.output).contains("--report xml:")
                     assertThat(buildResult.output).contains("--report sarif:")
                     assertThat(buildResult.output).doesNotContain("--report txt:")
-                    assertThat(buildResult.output).doesNotContain("AJavaClass.java")
                     assertThat(buildResult.tasks.map { it.path }).containsAll(
                         listOf(
                             ":app:detektMain",
@@ -66,7 +63,6 @@ object DetektAndroidTest : Spek({
                     assertThat(buildResult.output).contains("--report xml:")
                     assertThat(buildResult.output).contains("--report sarif:")
                     assertThat(buildResult.output).doesNotContain("--report txt:")
-                    assertThat(buildResult.output).doesNotContain("AJavaClassTest.java")
                     assertThat(buildResult.tasks.map { it.path }).containsAll(
                         listOf(
                             ":app:detektDebugUnitTest",
@@ -83,8 +79,6 @@ object DetektAndroidTest : Spek({
                     assertThat(buildResult.output).contains("--report xml:")
                     assertThat(buildResult.output).contains("--report sarif:")
                     assertThat(buildResult.output).doesNotContain("--report txt:")
-                    assertThat(buildResult.output).doesNotContain("AJavaClass.java")
-                    assertThat(buildResult.output).doesNotContain("AJavaClassTest.java")
                 }
             }
         }
@@ -148,7 +142,6 @@ object DetektAndroidTest : Spek({
             }
             val gradleRunner = createGradleRunnerAndSetupProject(projectLayout)
             gradleRunner.writeProjectFile("lib/src/main/AndroidManifest.xml", MANIFEST_CONTENT)
-            gradleRunner.createJavaClassAtSubmodule("AJavaClass")
 
             it("task :lib:detektMain") {
                 gradleRunner.runTasksAndCheckResult(":lib:detektMain") { buildResult ->
@@ -157,7 +150,6 @@ object DetektAndroidTest : Spek({
                     assertThat(buildResult.output).contains("--report xml:")
                     assertThat(buildResult.output).contains("--report sarif:")
                     assertThat(buildResult.output).doesNotContain("--report txt:")
-                    assertThat(buildResult.output).doesNotContain("AJavaClass.java")
                     assertThat(buildResult.tasks.map { it.path }).containsAll(
                         listOf(
                             ":lib:detektMain",
@@ -175,7 +167,6 @@ object DetektAndroidTest : Spek({
                     assertThat(buildResult.output).contains("--report xml:")
                     assertThat(buildResult.output).contains("--report sarif:")
                     assertThat(buildResult.output).doesNotContain("--report txt:")
-                    assertThat(buildResult.output).doesNotContain("AJavaClassTest.java")
                     assertThat(buildResult.tasks.map { it.path }).containsAll(
                         listOf(
                             ":lib:detektDebugUnitTest",
@@ -192,8 +183,6 @@ object DetektAndroidTest : Spek({
                     assertThat(buildResult.output).contains("--report xml:")
                     assertThat(buildResult.output).contains("--report sarif:")
                     assertThat(buildResult.output).doesNotContain("--report txt:")
-                    assertThat(buildResult.output).doesNotContain("AJavaClass.java")
-                    assertThat(buildResult.output).doesNotContain("AJavaClassTest.java")
                 }
             }
         }
@@ -467,7 +456,3 @@ private fun createGradleRunnerAndSetupProject(projectLayout: ProjectLayout) = Ds
     """.trimIndent(),
     dryRun = true
 ).also { it.setupProject() }
-
-private fun DslGradleRunner.createJavaClassAtSubmodule(name: String) {
-    createJavaClass(projectLayout.submodules.first(), name)
-}

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektJvmTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektJvmTest.kt
@@ -2,7 +2,6 @@ package io.gitlab.arturbosch.detekt
 
 import io.gitlab.arturbosch.detekt.testkit.DslGradleRunner
 import io.gitlab.arturbosch.detekt.testkit.ProjectLayout
-import io.gitlab.arturbosch.detekt.testkit.createJavaClass
 import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
@@ -35,7 +34,6 @@ object DetektJvmTest : Spek({
             dryRun = true
         )
         gradleRunner.setupProject()
-        gradleRunner.createJavaClass("AJavaClass")
 
         it("configures detekt type resolution task main") {
             gradleRunner.runTasksAndCheckResult(":detektMain") { buildResult ->
@@ -44,7 +42,6 @@ object DetektJvmTest : Spek({
                 assertThat(buildResult.output).contains("--report sarif:")
                 assertThat(buildResult.output).doesNotContain("--report txt:")
                 assertThat(buildResult.output).contains("--classpath")
-                assertThat(buildResult.output).doesNotContain("AJavaClass.java")
             }
         }
 
@@ -55,7 +52,6 @@ object DetektJvmTest : Spek({
                 assertThat(buildResult.output).contains("--report sarif:")
                 assertThat(buildResult.output).doesNotContain("--report txt:")
                 assertThat(buildResult.output).contains("--classpath")
-                assertThat(buildResult.output).doesNotContain("AJavaClassTest.java")
             }
         }
     }

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektPlainTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektPlainTest.kt
@@ -2,7 +2,6 @@ package io.gitlab.arturbosch.detekt
 
 import io.gitlab.arturbosch.detekt.testkit.DslGradleRunner
 import io.gitlab.arturbosch.detekt.testkit.ProjectLayout
-import io.gitlab.arturbosch.detekt.testkit.createJavaClass
 import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
@@ -65,7 +64,6 @@ object DetektPlainTest : Spek({
             dryRun = true
         )
         gradleRunner.setupProject()
-        gradleRunner.createJavaClass("AJavaClass")
 
         it("configures detekt plain task") {
             gradleRunner.runTasksAndCheckResult(":detekt") { buildResult ->
@@ -74,8 +72,6 @@ object DetektPlainTest : Spek({
                 assertThat(buildResult.output).contains("--report sarif:")
                 assertThat(buildResult.output).doesNotContain("--report txt:")
                 assertThat(buildResult.output).doesNotContain("--classpath")
-                assertThat(buildResult.output).doesNotContain("AJavaClass.java")
-                assertThat(buildResult.output).doesNotContain("AJavaClassTest.java")
             }
         }
     }

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskDslTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskDslTest.kt
@@ -143,10 +143,7 @@ internal object DetektTaskDslTest : Spek({
                         |}
                         """
 
-                        val projectLayout = ProjectLayout(
-                            numberOfSourceFilesInRootPerSourceDir = 1,
-                            srcDirs = listOf(customSrc1, customSrc2)
-                        )
+                        val projectLayout = ProjectLayout(1, srcDirs = listOf(customSrc1, customSrc2))
                         gradleRunner = builder
                             .withProjectLayout(projectLayout)
                             .withDetektConfig(config)
@@ -157,7 +154,7 @@ internal object DetektTaskDslTest : Spek({
                     it("sets input parameter to absolute filenames of all source files") {
                         val file1 = gradleRunner.projectFile("$customSrc1/My0Root0Class.kt")
                         val file2 = gradleRunner.projectFile("$customSrc2/My1Root0Class.kt")
-                        val expectedInputParam = "--input $file1,$file2 "
+                        val expectedInputParam = "--input $file1,$file2"
                         assertThat(result.output).contains(expectedInputParam)
                     }
 

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/testkit/DslGradleRunner.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/testkit/DslGradleRunner.kt
@@ -97,8 +97,6 @@ class DslGradleRunner @Suppress("LongParameterList") constructor(
         writeKtFile(File(rootDir, srcDir), className)
     }
 
-    fun Submodule.projectFile(path: String): File = File(moduleRoot, path).canonicalFile
-
     private fun writeKtFile(dir: File, className: String, withCodeSmell: Boolean = false) {
         dir.mkdirs()
         File(dir, "$className.kt").writeText(ktFileContent(className, withCodeSmell))
@@ -158,22 +156,4 @@ class DslGradleRunner @Suppress("LongParameterList") constructor(
         const val SETTINGS_FILENAME = "settings.gradle"
         private const val DETEKT_TASK = "detekt"
     }
-}
-
-fun DslGradleRunner.createJavaClass(name: String) {
-    projectFile("${projectLayout.srcDirs.first { it.contains("main") }}/$name.java")
-        .apply { createNewFile() }
-        .writeText("public class $name {}")
-    projectFile("${projectLayout.srcDirs.first { it.contains("test") }}/${name}Test.java")
-        .apply { createNewFile() }
-        .writeText("public class ${name}Test {}")
-}
-
-fun DslGradleRunner.createJavaClass(submodule: Submodule, name: String) {
-    submodule.projectFile("${submodule.srcDirs.first { it.contains("main") }}/$name.java")
-        .apply { createNewFile() }
-        .writeText("public class $name {}")
-    submodule.projectFile("${submodule.srcDirs.first { it.contains("test") }}/${name}Test.java")
-        .apply { createNewFile() }
-        .writeText("public class ${name}Test {}")
 }


### PR DESCRIPTION
I don't know exactly why but we should provide the java files as input to the cli to make it work properly. I'll check exactyl why and I'll find another way to fix the issue that #3655 wanted to fix.

Closes #3791