### PR TITLE
NoNameShadowing: don't report when implicit 'it' parameter isn't used

### DIFF
--- a/detekt-psi-utils/api/detekt-psi-utils.api
+++ b/detekt-psi-utils/api/detekt-psi-utils.api
@@ -83,6 +83,11 @@ public final class io/gitlab/arturbosch/detekt/rules/KtCallExpressionKt {
 	public static final fun isCallingWithNonNullCheckArgument (Lorg/jetbrains/kotlin/psi/KtCallExpression;Lorg/jetbrains/kotlin/name/FqName;Lorg/jetbrains/kotlin/resolve/BindingContext;)Z
 }
 
+public final class io/gitlab/arturbosch/detekt/rules/KtLambdaExpressionKt {
+	public static final fun hasImplicitParameterReference (Lorg/jetbrains/kotlin/psi/KtLambdaExpression;Lorg/jetbrains/kotlin/descriptors/ValueParameterDescriptor;Lorg/jetbrains/kotlin/resolve/BindingContext;)Z
+	public static final fun implicitParameter (Lorg/jetbrains/kotlin/psi/KtLambdaExpression;Lorg/jetbrains/kotlin/resolve/BindingContext;)Lorg/jetbrains/kotlin/descriptors/ValueParameterDescriptor;
+}
+
 public final class io/gitlab/arturbosch/detekt/rules/KtModifierListKt {
 	public static final fun isAbstract (Lorg/jetbrains/kotlin/psi/KtModifierListOwner;)Z
 	public static final fun isActual (Lorg/jetbrains/kotlin/psi/KtModifierListOwner;)Z

--- a/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/KtLambdaExpression.kt
+++ b/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/KtLambdaExpression.kt
@@ -1,0 +1,33 @@
+package io.gitlab.arturbosch.detekt.rules
+
+import org.jetbrains.kotlin.descriptors.ValueParameterDescriptor
+import org.jetbrains.kotlin.psi.KtLambdaExpression
+import org.jetbrains.kotlin.psi.KtNameReferenceExpression
+import org.jetbrains.kotlin.psi.psiUtil.anyDescendantOfType
+import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
+import org.jetbrains.kotlin.resolve.BindingContext
+import org.jetbrains.kotlin.resolve.calls.callUtil.getResolvedCall
+
+fun KtLambdaExpression.implicitParameter(bindingContext: BindingContext): ValueParameterDescriptor? {
+    if (valueParameters.isNotEmpty()) return null
+    return bindingContext[BindingContext.FUNCTION, functionLiteral]?.valueParameters?.singleOrNull()
+}
+
+fun KtLambdaExpression.hasImplicitParameterReference(
+    implicitParameter: ValueParameterDescriptor,
+    bindingContext: BindingContext
+): Boolean {
+    return anyDescendantOfType<KtNameReferenceExpression> {
+        it.isImplicitParameterReference(this, implicitParameter, bindingContext)
+    }
+}
+
+private fun KtNameReferenceExpression.isImplicitParameterReference(
+    lambda: KtLambdaExpression,
+    implicitParameter: ValueParameterDescriptor,
+    bindingContext: BindingContext
+): Boolean {
+    return text == "it" &&
+        getStrictParentOfType<KtLambdaExpression>() == lambda &&
+        getResolvedCall(bindingContext)?.resultingDescriptor == implicitParameter
+}

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NoNameShadowingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NoNameShadowingSpec.kt
@@ -62,7 +62,7 @@ class NoNameShadowingSpec : Spek({
             assertThat(findings[0]).hasMessage("Name shadowed: it")
         }
 
-        it("report shadowing nested lambda implicit 'it' parameter") {
+        it("does not report when implicit 'it' parameter isn't used") {
             val code = """
                 fun test() {
                     listOf(1).forEach {
@@ -72,9 +72,7 @@ class NoNameShadowingSpec : Spek({
                 }
             """
             val findings = subject.compileAndLintWithContext(env, code)
-            assertThat(findings).hasSize(1)
-            assertThat(findings).hasSourceLocation(3, 27)
-            assertThat(findings[0]).hasMessage("Name shadowed: implicit lambda parameter 'it'")
+            assertThat(findings).isEmpty()
         }
 
         it("does not report not shadowing variable") {

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MultilineLambdaItParameter.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MultilineLambdaItParameter.kt
@@ -9,13 +9,10 @@ import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.rules.IT_LITERAL
-import org.jetbrains.kotlin.descriptors.ValueParameterDescriptor
+import io.gitlab.arturbosch.detekt.rules.hasImplicitParameterReference
+import io.gitlab.arturbosch.detekt.rules.implicitParameter
 import org.jetbrains.kotlin.psi.KtLambdaExpression
-import org.jetbrains.kotlin.psi.KtNameReferenceExpression
-import org.jetbrains.kotlin.psi.psiUtil.anyDescendantOfType
-import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
 import org.jetbrains.kotlin.resolve.BindingContext
-import org.jetbrains.kotlin.resolve.calls.callUtil.getResolvedCall
 
 /**
  * Lambda expressions are very useful in a lot of cases and they often include very small chunks of
@@ -112,28 +109,5 @@ class MultilineLambdaItParameter(val config: Config) : Rule(config) {
             }
             else -> { }
         }
-    }
-
-    private fun KtLambdaExpression.implicitParameter(bindingContext: BindingContext): ValueParameterDescriptor? {
-        return bindingContext[BindingContext.FUNCTION, functionLiteral]?.valueParameters?.singleOrNull()
-    }
-
-    private fun KtLambdaExpression.hasImplicitParameterReference(
-        implicitParameter: ValueParameterDescriptor,
-        bindingContext: BindingContext
-    ): Boolean {
-        return anyDescendantOfType<KtNameReferenceExpression> {
-            it.isImplicitParameterReference(this, implicitParameter, bindingContext)
-        }
-    }
-
-    private fun KtNameReferenceExpression.isImplicitParameterReference(
-        lambda: KtLambdaExpression,
-        implicitParameter: ValueParameterDescriptor,
-        bindingContext: BindingContext
-    ): Boolean {
-        return text == "it" &&
-            getStrictParentOfType<KtLambdaExpression>() == lambda &&
-            getResolvedCall(bindingContext)?.resultingDescriptor == implicitParameter
     }
 }


### PR DESCRIPTION
Fixes #3787