### PR TITLE
UnnecessaryLet: report when implicit parameter isn't used

### DIFF
--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLetSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLetSpec.kt
@@ -344,6 +344,19 @@ class UnnecessaryLetSpec : Spek({
                 assertThat(findings).hasSize(1)
                 assertThat(findings).allMatch { it.message == MESSAGE_USE_IF }
             }
+
+            it("reports when implicit parameter isn't used") {
+                val content = """
+                    fun test(value: Int?) {
+                        value?.let {
+                          listOf(1).map { it }
+                        }
+                    }
+                """
+                val findings = subject.compileAndLintWithContext(env, content)
+                assertThat(findings).hasSize(1)
+                assertThat(findings).allMatch { it.message == MESSAGE_USE_IF }
+            }
         }
     }
 })


### PR DESCRIPTION
Fixes #3786