### PR TITLE
Use annotations to configure rules in detekt-rules-exceptions

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -186,7 +186,7 @@ exceptions:
   active: true
   ExceptionRaisedInUnexpectedLocation:
     active: true
-    methodNames: [toString, hashCode, equals, finalize]
+    methodNames: ['toString', 'hashCode', 'equals', 'finalize']
   InstanceOfCheckForException:
     active: false
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
@@ -203,11 +203,7 @@ exceptions:
     ignoreLabeled: false
   SwallowedException:
     active: true
-    ignoredExceptionTypes:
-     - InterruptedException
-     - NumberFormatException
-     - ParseException
-     - MalformedURLException
+    ignoredExceptionTypes: ['NumberFormatException', 'InterruptedException', 'ParseException', 'MalformedURLException']
     allowedExceptionNameRegex: '_|(ignore|expected).*'
   ThrowingExceptionFromFinally:
     active: true
@@ -216,32 +212,17 @@ exceptions:
   ThrowingExceptionsWithoutMessageOrCause:
     active: true
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
-    exceptions:
-     - IllegalArgumentException
-     - IllegalStateException
-     - IOException
+    exceptions: ['ArrayIndexOutOfBoundsException', 'Error', 'Exception', 'IllegalMonitorStateException', 'NullPointerException', 'IndexOutOfBoundsException', 'RuntimeException', 'Throwable']
   ThrowingNewInstanceOfSameException:
     active: true
   TooGenericExceptionCaught:
     active: true
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
-    exceptionNames:
-     - ArrayIndexOutOfBoundsException
-     - Error
-     - Exception
-     - IllegalMonitorStateException
-     - NullPointerException
-     - IndexOutOfBoundsException
-     - RuntimeException
-     - Throwable
+    exceptionNames: ['ArrayIndexOutOfBoundsException', 'Error', 'Exception', 'IllegalMonitorStateException', 'NullPointerException', 'IndexOutOfBoundsException', 'RuntimeException', 'Throwable']
     allowedExceptionNameRegex: '_|(ignore|expected).*'
   TooGenericExceptionThrown:
     active: true
-    exceptionNames:
-     - Error
-     - Exception
-     - Throwable
-     - RuntimeException
+    exceptionNames: ['Error', 'Exception', 'Throwable', 'RuntimeException']
 
 formatting:
   active: true

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ReturnFromFinally.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ReturnFromFinally.kt
@@ -8,7 +8,9 @@ import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
+import io.gitlab.arturbosch.detekt.api.internal.Configuration
 import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
+import io.gitlab.arturbosch.detekt.api.internal.config
 import org.jetbrains.kotlin.psi.KtBlockExpression
 import org.jetbrains.kotlin.psi.KtFinallySection
 import org.jetbrains.kotlin.psi.KtReturnExpression
@@ -38,8 +40,6 @@ import org.jetbrains.kotlin.types.KotlinType
  *
  * val a: String = try { "s" } catch (e: Exception) { "e" } finally { "f" }
  * </noncompliant>
- *
- * @configuration ignoreLabeled - ignores labeled return statements (default: `false`)
  */
 @RequiresTypeResolution
 @ActiveByDefault(since = "1.16.0")
@@ -52,7 +52,8 @@ class ReturnFromFinally(config: Config = Config.empty) : Rule(config) {
         Debt.TWENTY_MINS
     )
 
-    private val ignoreLabeled = valueOrDefault(IGNORE_LABELED, false)
+    @Configuration("ignores labeled return statements")
+    private val ignoreLabeled: Boolean by config(false)
 
     override fun visitTryExpression(expression: KtTryExpression) {
         super.visitTryExpression(expression)
@@ -104,9 +105,5 @@ class ReturnFromFinally(config: Config = Config.empty) : Rule(config) {
         if (finallyExpression.statements.isEmpty()) return false
 
         return finalExpression.getType(bindingContext) == type
-    }
-
-    companion object {
-        const val IGNORE_LABELED = "ignoreLabeled"
     }
 }

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ExceptionRaisedInUnexpectedLocationSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ExceptionRaisedInUnexpectedLocationSpec.kt
@@ -24,7 +24,7 @@ class ExceptionRaisedInUnexpectedLocationSpec : Spek({
         }
 
         it("reports the configured method") {
-            val config = TestConfig(mapOf(ExceptionRaisedInUnexpectedLocation.METHOD_NAMES to listOf("toDo", "todo2")))
+            val config = TestConfig(mapOf("methodNames" to listOf("toDo", "todo2")))
             val findings = ExceptionRaisedInUnexpectedLocation(config).compileAndLint(
                 """
             fun toDo() {
@@ -35,7 +35,7 @@ class ExceptionRaisedInUnexpectedLocationSpec : Spek({
         }
 
         it("reports the configured method with String") {
-            val config = TestConfig(mapOf(ExceptionRaisedInUnexpectedLocation.METHOD_NAMES to "toDo,todo2"))
+            val config = TestConfig(mapOf("methodNames" to "toDo,todo2"))
             val findings = ExceptionRaisedInUnexpectedLocation(config).compileAndLint(
                 """
             fun toDo() {

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ReturnFromFinallySpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ReturnFromFinallySpec.kt
@@ -101,7 +101,7 @@ class ReturnFromFinallySpec : Spek({
             }
 
             it("should not report when ignoreLabeled is true") {
-                val config = TestConfig(mapOf(ReturnFromFinally.IGNORE_LABELED to "true"))
+                val config = TestConfig(mapOf("ignoreLabeled" to "true"))
                 val findings = ReturnFromFinally(config).compileAndLintWithContext(env, code)
                 assertThat(findings).isEmpty()
             }

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedExceptionSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedExceptionSpec.kt
@@ -121,7 +121,7 @@ class SwallowedExceptionSpec : Spek({
             context("ignores given exception types config") {
 
                 val config by memoized {
-                    TestConfig(SwallowedException.IGNORED_EXCEPTION_TYPES to ignoredExceptionValue)
+                    TestConfig("ignoredExceptionTypes" to ignoredExceptionValue)
                 }
                 val rule by memoized { SwallowedException(config) }
 
@@ -151,7 +151,7 @@ class SwallowedExceptionSpec : Spek({
 
         context("ignores given exception name config") {
 
-            val config by memoized { TestConfig(mapOf(SwallowedException.ALLOWED_EXCEPTION_NAME_REGEX to "myIgnore")) }
+            val config by memoized { TestConfig(mapOf("allowedExceptionNameRegex" to "myIgnore")) }
             val rule by memoized { SwallowedException(config) }
 
             it("ignores given exception name") {
@@ -205,7 +205,7 @@ class SwallowedExceptionSpec : Spek({
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
-        SwallowedException.defaultIgnoredExceptions.forEach { exceptionName ->
+        SwallowedException.EXCEPTIONS_IGNORED_BY_DEFAULT.forEach { exceptionName ->
             it("ignores $exceptionName in the catch clause by default") {
                 val code = """
                 import java.net.MalformedURLException

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionsWithoutMessageOrCauseSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionsWithoutMessageOrCauseSpec.kt
@@ -9,7 +9,7 @@ import org.spekframework.spek2.style.specification.describe
 class ThrowingExceptionsWithoutMessageOrCauseSpec : Spek({
     val subject by memoized {
         ThrowingExceptionsWithoutMessageOrCause(
-            TestConfig(ThrowingExceptionsWithoutMessageOrCause.EXCEPTIONS to listOf("IllegalArgumentException"))
+            TestConfig("exceptions" to listOf("IllegalArgumentException"))
         )
     }
 
@@ -29,7 +29,7 @@ class ThrowingExceptionsWithoutMessageOrCauseSpec : Spek({
             }
 
             it("does not report calls to the default constructor with empty configuration") {
-                val config = TestConfig(ThrowingExceptionsWithoutMessageOrCause.EXCEPTIONS to emptyList<String>())
+                val config = TestConfig("exceptions" to emptyList<String>())
                 val findings = ThrowingExceptionsWithoutMessageOrCause(config).compileAndLint(code)
                 assertThat(findings).isEmpty()
             }

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionCaughtSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionCaughtSpec.kt
@@ -9,16 +9,19 @@ import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 import java.util.regex.PatternSyntaxException
 
+private const val CAUGHT_EXCEPTIONS_PROPERTY = "exceptionNames"
+private const val ALLOWED_EXCEPTION_NAME_REGEX = "allowedExceptionNameRegex"
+
 class TooGenericExceptionCaughtSpec : Spek({
 
     describe("a file with many caught exceptions") {
 
-        it("should find one of each kind") {
+        it("should find one of each kind of defaults") {
             val rule = TooGenericExceptionCaught(Config.empty)
 
             val findings = rule.compileAndLint(tooGenericExceptionCode)
 
-            assertThat(findings).hasSize(caughtExceptionDefaults.size)
+            assertThat(findings).hasSize(TooGenericExceptionCaught.caughtExceptionDefaults.size)
         }
     }
 
@@ -37,7 +40,7 @@ class TooGenericExceptionCaughtSpec : Spek({
         """
 
         it("should not report an ignored catch blocks because of its exception name") {
-            val config = TestConfig(mapOf(TooGenericExceptionCaught.ALLOWED_EXCEPTION_NAME_REGEX to "myIgnore"))
+            val config = TestConfig(mapOf(ALLOWED_EXCEPTION_NAME_REGEX to "myIgnore"))
             val rule = TooGenericExceptionCaught(config)
 
             val findings = rule.compileAndLint(code)
@@ -46,7 +49,7 @@ class TooGenericExceptionCaughtSpec : Spek({
         }
 
         it("should not report an ignored catch blocks because of its exception type") {
-            val config = TestConfig(mapOf(TooGenericExceptionCaught.CAUGHT_EXCEPTIONS_PROPERTY to "[MyException]"))
+            val config = TestConfig(mapOf(CAUGHT_EXCEPTIONS_PROPERTY to "[MyException]"))
             val rule = TooGenericExceptionCaught(config)
 
             val findings = rule.compileAndLint(code)
@@ -57,7 +60,7 @@ class TooGenericExceptionCaughtSpec : Spek({
         it("should not fail when disabled with invalid regex on allowed exception names") {
             val configRules = mapOf(
                 "active" to "false",
-                TooGenericExceptionCaught.ALLOWED_EXCEPTION_NAME_REGEX to "*MyException"
+                ALLOWED_EXCEPTION_NAME_REGEX to "*MyException"
             )
             val config = TestConfig(configRules)
             val rule = TooGenericExceptionCaught(config)
@@ -67,7 +70,7 @@ class TooGenericExceptionCaughtSpec : Spek({
         }
 
         it("should fail with invalid regex on allowed exception names") {
-            val config = TestConfig(mapOf(TooGenericExceptionCaught.ALLOWED_EXCEPTION_NAME_REGEX to "*Foo"))
+            val config = TestConfig(mapOf(ALLOWED_EXCEPTION_NAME_REGEX to "*Foo"))
             val rule = TooGenericExceptionCaught(config)
             assertThatExceptionOfType(PatternSyntaxException::class.java).isThrownBy {
                 rule.compileAndLint(tooGenericExceptionCode)

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionThrownSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionThrownSpec.kt
@@ -1,26 +1,37 @@
 package io.gitlab.arturbosch.detekt.rules.exceptions
 
-import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
+private const val EXCEPTION_NAMES = "exceptionNames"
+
+private val tooGenericExceptions = listOf(
+    "Error",
+    "Exception",
+    "Throwable",
+    "RuntimeException"
+)
+
 class TooGenericExceptionThrownSpec : Spek({
 
     describe("a file with many thrown exceptions") {
 
-        it("should report one for each generic throw rules") {
-            val rule = TooGenericExceptionThrown(Config.empty)
+        tooGenericExceptions.forEach { exceptionName ->
+            it("should report $exceptionName") {
+                val config = TestConfig(mapOf(EXCEPTION_NAMES to "[$exceptionName]"))
+                val rule = TooGenericExceptionCaught(config)
 
-            val findings = rule.compileAndLint(tooGenericExceptionCode)
+                val findings = rule.compileAndLint(tooGenericExceptionCode)
 
-            assertThat(findings).hasSize(thrownExceptionDefaults.size)
+                assertThat(findings).hasSize(1)
+            }
         }
 
         it("should not report thrown exceptions") {
-            val config = TestConfig(mapOf(TooGenericExceptionThrown.THROWN_EXCEPTIONS_PROPERTY to "[MyException]"))
+            val config = TestConfig(mapOf(EXCEPTION_NAMES to "['MyException', Bar]"))
             val rule = TooGenericExceptionCaught(config)
 
             val findings = rule.compileAndLint(tooGenericExceptionCode)


### PR DESCRIPTION
This belongs to #3670 and replaces all configuration kdoc tags with annotations.