### PR TITLE
plugin: Simpler classLoader caching (#3248)

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ If you contributed to detekt but your name is not in the list, please feel free 
 - [Paya Do](https://github.com/payathedo) - Designer for Detekt's logo
 - [zmunm](https://github.com/zmunm) - New rule: ObjectLiteralToLambda
 - [Eliezer Graber](https://github.com/eygraber) - Rule fix: ModifierOrder
+- [Dominik Labuda](https://github.com/Dominick1993) - Gradle plugin improvement
 
 ### Mentions
 

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/ClassLoaderCache.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/ClassLoaderCache.kt
@@ -1,9 +1,8 @@
 package io.gitlab.arturbosch.detekt.internal
 
-import org.codehaus.groovy.runtime.DefaultGroovyMethodsSupport
 import org.gradle.api.file.FileCollection
-import java.io.File
 import java.net.URLClassLoader
+import java.util.concurrent.ConcurrentHashMap
 
 fun interface ClassLoaderCache {
 
@@ -12,40 +11,18 @@ fun interface ClassLoaderCache {
 
 internal class DefaultClassLoaderCache : ClassLoaderCache {
 
-    private var loaderAndClasspathFiles: Pair<URLClassLoader, Set<File>>? = null
+    private val classpathFilesHashWithLoaders = ConcurrentHashMap<Int, URLClassLoader>()
 
     override fun getOrCreate(classpath: FileCollection): URLClassLoader {
         val classpathFiles = classpath.files
-        synchronized(this) {
-            val lastLoader = loaderAndClasspathFiles?.first
-            val lastClasspathFiles = loaderAndClasspathFiles?.second
-
-            if (lastClasspathFiles == null) {
-                cache(classpathFiles)
-            } else if (hasClasspathChanged(lastClasspathFiles, classpathFiles)) {
-                DefaultGroovyMethodsSupport.closeQuietly(lastLoader)
-                cache(classpathFiles)
-            }
-
-            return loaderAndClasspathFiles?.first ?: error("Cached or newly created detekt classloader expected.")
+        val classpathHashCode = HashSet(classpathFiles).hashCode()
+        return classpathFilesHashWithLoaders.getOrPut(classpathHashCode) {
+            URLClassLoader(
+                classpathFiles.map { it.toURI().toURL() }.toTypedArray(),
+                null /* isolate detekt environment */
+            )
         }
-    }
-
-    private fun cache(classpathFiles: Set<File>) {
-        loaderAndClasspathFiles = URLClassLoader(
-            classpathFiles.map { it.toURI().toURL() }.toTypedArray(),
-            null /* isolate detekt environment */
-        ) to classpathFiles
     }
 }
 
 object GlobalClassLoaderCache : ClassLoaderCache by DefaultClassLoaderCache()
-
-internal fun hasClasspathChanged(lastClasspathFiles: Set<File>, currentClasspathFiles: Set<File>): Boolean {
-    if (lastClasspathFiles.size != currentClasspathFiles.size) {
-        return true
-    }
-    return lastClasspathFiles.sorted()
-        .zip(currentClasspathFiles.sorted())
-        .any { (last, current) -> last != current || last.lastModified() != current.lastModified() }
-}


### PR DESCRIPTION
Previous caching mechanism didn't work properly when multiple projects
were running detekt task in parallel and differed in classpath. Due to
the broken locking mechanism the classpath files would not match the
content in the classloader.

The new implementation uses ConcurrentHashMap which handles locking by
itself and allows us to store classloader for any combination of files.
