### PR TITLE
Prepare Detekt 1.17.1

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,6 +1,6 @@
 object Versions {
 
-    const val DETEKT: String = "1.17.0"
+    const val DETEKT: String = "1.17.1"
     const val SNAPSHOT_NAME: String = "main"
     const val JVM_TARGET: String = "1.8"
 

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
@@ -106,6 +106,8 @@ class DetektPlugin : Plugin<Project> {
         const val BASELINE_TASK_NAME = "detektBaseline"
         const val DETEKT_EXTENSION = "detekt"
         private const val GENERATE_CONFIG = "detektGenerateConfig"
+        internal val defaultExcludes = listOf("build/")
+        internal val defaultIncludes = listOf("**/*.kt", "**/*.kts")
         internal const val CONFIG_DIR_NAME = "config/detekt"
         internal const val CONFIG_FILE = "detekt.yml"
 

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektPlain.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektPlain.kt
@@ -20,6 +20,8 @@ internal class DetektPlain(private val project: Project) {
                 baseline.set(project.layout.file(project.provider { baselineFile }))
             }
             setSource(existingInputDirectoriesProvider(project, extension))
+            setIncludes(DetektPlugin.defaultIncludes)
+            setExcludes(DetektPlugin.defaultExcludes)
             reportsDir.set(project.provider { extension.customReportsDir })
             reports = extension.reports
         }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/SharedTasks.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/SharedTasks.kt
@@ -24,8 +24,6 @@ internal fun Project.registerDetektTask(
         it.ignoreFailuresProp.set(project.provider { extension.ignoreFailures })
         it.basePathProp.set(extension.basePath)
         it.allRulesProp.set(provider { extension.allRules })
-        it.setIncludes(DEFAULT_INCLUDES)
-        it.setExcludes(DEFAULT_EXCLUDES)
         configuration(it)
     }
 
@@ -52,6 +50,3 @@ internal fun DetektReport.setDefaultIfUnset(default: File) {
         destination = default
     }
 }
-
-private val DEFAULT_EXCLUDES = listOf("build/")
-private val DEFAULT_INCLUDES = listOf("**/*.kt", "**/*.kts")

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektAndroidTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektAndroidTest.kt
@@ -2,7 +2,6 @@ package io.gitlab.arturbosch.detekt
 
 import io.gitlab.arturbosch.detekt.testkit.DslGradleRunner
 import io.gitlab.arturbosch.detekt.testkit.ProjectLayout
-import io.gitlab.arturbosch.detekt.testkit.createJavaClass
 import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.dsl.Skip
@@ -39,7 +38,6 @@ object DetektAndroidTest : Spek({
             }
             val gradleRunner = createGradleRunnerAndSetupProject(projectLayout)
             gradleRunner.writeProjectFile("app/src/main/AndroidManifest.xml", MANIFEST_CONTENT)
-            gradleRunner.createJavaClassAtSubmodule("AJavaClass")
 
             it("task :app:detektMain") {
                 gradleRunner.runTasksAndCheckResult(":app:detektMain") { buildResult ->
@@ -48,7 +46,6 @@ object DetektAndroidTest : Spek({
                     assertThat(buildResult.output).contains("--report xml:")
                     assertThat(buildResult.output).contains("--report sarif:")
                     assertThat(buildResult.output).doesNotContain("--report txt:")
-                    assertThat(buildResult.output).doesNotContain("AJavaClass.java")
                     assertThat(buildResult.tasks.map { it.path }).containsAll(
                         listOf(
                             ":app:detektMain",
@@ -66,7 +63,6 @@ object DetektAndroidTest : Spek({
                     assertThat(buildResult.output).contains("--report xml:")
                     assertThat(buildResult.output).contains("--report sarif:")
                     assertThat(buildResult.output).doesNotContain("--report txt:")
-                    assertThat(buildResult.output).doesNotContain("AJavaClassTest.java")
                     assertThat(buildResult.tasks.map { it.path }).containsAll(
                         listOf(
                             ":app:detektDebugUnitTest",
@@ -83,8 +79,6 @@ object DetektAndroidTest : Spek({
                     assertThat(buildResult.output).contains("--report xml:")
                     assertThat(buildResult.output).contains("--report sarif:")
                     assertThat(buildResult.output).doesNotContain("--report txt:")
-                    assertThat(buildResult.output).doesNotContain("AJavaClass.java")
-                    assertThat(buildResult.output).doesNotContain("AJavaClassTest.java")
                 }
             }
         }
@@ -148,7 +142,6 @@ object DetektAndroidTest : Spek({
             }
             val gradleRunner = createGradleRunnerAndSetupProject(projectLayout)
             gradleRunner.writeProjectFile("lib/src/main/AndroidManifest.xml", MANIFEST_CONTENT)
-            gradleRunner.createJavaClassAtSubmodule("AJavaClass")
 
             it("task :lib:detektMain") {
                 gradleRunner.runTasksAndCheckResult(":lib:detektMain") { buildResult ->
@@ -157,7 +150,6 @@ object DetektAndroidTest : Spek({
                     assertThat(buildResult.output).contains("--report xml:")
                     assertThat(buildResult.output).contains("--report sarif:")
                     assertThat(buildResult.output).doesNotContain("--report txt:")
-                    assertThat(buildResult.output).doesNotContain("AJavaClass.java")
                     assertThat(buildResult.tasks.map { it.path }).containsAll(
                         listOf(
                             ":lib:detektMain",
@@ -175,7 +167,6 @@ object DetektAndroidTest : Spek({
                     assertThat(buildResult.output).contains("--report xml:")
                     assertThat(buildResult.output).contains("--report sarif:")
                     assertThat(buildResult.output).doesNotContain("--report txt:")
-                    assertThat(buildResult.output).doesNotContain("AJavaClassTest.java")
                     assertThat(buildResult.tasks.map { it.path }).containsAll(
                         listOf(
                             ":lib:detektDebugUnitTest",
@@ -192,8 +183,6 @@ object DetektAndroidTest : Spek({
                     assertThat(buildResult.output).contains("--report xml:")
                     assertThat(buildResult.output).contains("--report sarif:")
                     assertThat(buildResult.output).doesNotContain("--report txt:")
-                    assertThat(buildResult.output).doesNotContain("AJavaClass.java")
-                    assertThat(buildResult.output).doesNotContain("AJavaClassTest.java")
                 }
             }
         }
@@ -467,7 +456,3 @@ private fun createGradleRunnerAndSetupProject(projectLayout: ProjectLayout) = Ds
     """.trimIndent(),
     dryRun = true
 ).also { it.setupProject() }
-
-private fun DslGradleRunner.createJavaClassAtSubmodule(name: String) {
-    createJavaClass(projectLayout.submodules.first(), name)
-}

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektJvmTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektJvmTest.kt
@@ -2,7 +2,6 @@ package io.gitlab.arturbosch.detekt
 
 import io.gitlab.arturbosch.detekt.testkit.DslGradleRunner
 import io.gitlab.arturbosch.detekt.testkit.ProjectLayout
-import io.gitlab.arturbosch.detekt.testkit.createJavaClass
 import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
@@ -35,7 +34,6 @@ object DetektJvmTest : Spek({
             dryRun = true
         )
         gradleRunner.setupProject()
-        gradleRunner.createJavaClass("AJavaClass")
 
         it("configures detekt type resolution task main") {
             gradleRunner.runTasksAndCheckResult(":detektMain") { buildResult ->
@@ -44,7 +42,6 @@ object DetektJvmTest : Spek({
                 assertThat(buildResult.output).contains("--report sarif:")
                 assertThat(buildResult.output).doesNotContain("--report txt:")
                 assertThat(buildResult.output).contains("--classpath")
-                assertThat(buildResult.output).doesNotContain("AJavaClass.java")
             }
         }
 
@@ -55,7 +52,6 @@ object DetektJvmTest : Spek({
                 assertThat(buildResult.output).contains("--report sarif:")
                 assertThat(buildResult.output).doesNotContain("--report txt:")
                 assertThat(buildResult.output).contains("--classpath")
-                assertThat(buildResult.output).doesNotContain("AJavaClassTest.java")
             }
         }
     }

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektPlainTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektPlainTest.kt
@@ -2,7 +2,6 @@ package io.gitlab.arturbosch.detekt
 
 import io.gitlab.arturbosch.detekt.testkit.DslGradleRunner
 import io.gitlab.arturbosch.detekt.testkit.ProjectLayout
-import io.gitlab.arturbosch.detekt.testkit.createJavaClass
 import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
@@ -65,7 +64,6 @@ object DetektPlainTest : Spek({
             dryRun = true
         )
         gradleRunner.setupProject()
-        gradleRunner.createJavaClass("AJavaClass")
 
         it("configures detekt plain task") {
             gradleRunner.runTasksAndCheckResult(":detekt") { buildResult ->
@@ -74,8 +72,6 @@ object DetektPlainTest : Spek({
                 assertThat(buildResult.output).contains("--report sarif:")
                 assertThat(buildResult.output).doesNotContain("--report txt:")
                 assertThat(buildResult.output).doesNotContain("--classpath")
-                assertThat(buildResult.output).doesNotContain("AJavaClass.java")
-                assertThat(buildResult.output).doesNotContain("AJavaClassTest.java")
             }
         }
     }

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskDslTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskDslTest.kt
@@ -143,10 +143,7 @@ internal object DetektTaskDslTest : Spek({
                         |}
                         """
 
-                        val projectLayout = ProjectLayout(
-                            numberOfSourceFilesInRootPerSourceDir = 1,
-                            srcDirs = listOf(customSrc1, customSrc2)
-                        )
+                        val projectLayout = ProjectLayout(1, srcDirs = listOf(customSrc1, customSrc2))
                         gradleRunner = builder
                             .withProjectLayout(projectLayout)
                             .withDetektConfig(config)
@@ -157,7 +154,7 @@ internal object DetektTaskDslTest : Spek({
                     it("sets input parameter to absolute filenames of all source files") {
                         val file1 = gradleRunner.projectFile("$customSrc1/My0Root0Class.kt")
                         val file2 = gradleRunner.projectFile("$customSrc2/My1Root0Class.kt")
-                        val expectedInputParam = "--input $file1,$file2 "
+                        val expectedInputParam = "--input $file1,$file2"
                         assertThat(result.output).contains(expectedInputParam)
                     }
 

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/testkit/DslGradleRunner.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/testkit/DslGradleRunner.kt
@@ -97,8 +97,6 @@ class DslGradleRunner @Suppress("LongParameterList") constructor(
         writeKtFile(File(rootDir, srcDir), className)
     }
 
-    fun Submodule.projectFile(path: String): File = File(moduleRoot, path).canonicalFile
-
     private fun writeKtFile(dir: File, className: String, withCodeSmell: Boolean = false) {
         dir.mkdirs()
         File(dir, "$className.kt").writeText(ktFileContent(className, withCodeSmell))
@@ -158,22 +156,4 @@ class DslGradleRunner @Suppress("LongParameterList") constructor(
         const val SETTINGS_FILENAME = "settings.gradle"
         private const val DETEKT_TASK = "detekt"
     }
-}
-
-fun DslGradleRunner.createJavaClass(name: String) {
-    projectFile("${projectLayout.srcDirs.first { it.contains("main") }}/$name.java")
-        .apply { createNewFile() }
-        .writeText("public class $name {}")
-    projectFile("${projectLayout.srcDirs.first { it.contains("test") }}/${name}Test.java")
-        .apply { createNewFile() }
-        .writeText("public class ${name}Test {}")
-}
-
-fun DslGradleRunner.createJavaClass(submodule: Submodule, name: String) {
-    submodule.projectFile("${submodule.srcDirs.first { it.contains("main") }}/$name.java")
-        .apply { createNewFile() }
-        .writeText("public class $name {}")
-    submodule.projectFile("${submodule.srcDirs.first { it.contains("test") }}/${name}Test.java")
-        .apply { createNewFile() }
-        .writeText("public class ${name}Test {}")
 }

--- a/detekt-psi-utils/api/detekt-psi-utils.api
+++ b/detekt-psi-utils/api/detekt-psi-utils.api
@@ -83,6 +83,11 @@ public final class io/gitlab/arturbosch/detekt/rules/KtCallExpressionKt {
 	public static final fun isCallingWithNonNullCheckArgument (Lorg/jetbrains/kotlin/psi/KtCallExpression;Lorg/jetbrains/kotlin/name/FqName;Lorg/jetbrains/kotlin/resolve/BindingContext;)Z
 }
 
+public final class io/gitlab/arturbosch/detekt/rules/KtLambdaExpressionKt {
+	public static final fun hasImplicitParameterReference (Lorg/jetbrains/kotlin/psi/KtLambdaExpression;Lorg/jetbrains/kotlin/descriptors/ValueParameterDescriptor;Lorg/jetbrains/kotlin/resolve/BindingContext;)Z
+	public static final fun implicitParameter (Lorg/jetbrains/kotlin/psi/KtLambdaExpression;Lorg/jetbrains/kotlin/resolve/BindingContext;)Lorg/jetbrains/kotlin/descriptors/ValueParameterDescriptor;
+}
+
 public final class io/gitlab/arturbosch/detekt/rules/KtModifierListKt {
 	public static final fun isAbstract (Lorg/jetbrains/kotlin/psi/KtModifierListOwner;)Z
 	public static final fun isActual (Lorg/jetbrains/kotlin/psi/KtModifierListOwner;)Z

--- a/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/KtLambdaExpression.kt
+++ b/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/KtLambdaExpression.kt
@@ -1,0 +1,33 @@
+package io.gitlab.arturbosch.detekt.rules
+
+import org.jetbrains.kotlin.descriptors.ValueParameterDescriptor
+import org.jetbrains.kotlin.psi.KtLambdaExpression
+import org.jetbrains.kotlin.psi.KtNameReferenceExpression
+import org.jetbrains.kotlin.psi.psiUtil.anyDescendantOfType
+import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
+import org.jetbrains.kotlin.resolve.BindingContext
+import org.jetbrains.kotlin.resolve.calls.callUtil.getResolvedCall
+
+fun KtLambdaExpression.implicitParameter(bindingContext: BindingContext): ValueParameterDescriptor? {
+    if (valueParameters.isNotEmpty()) return null
+    return bindingContext[BindingContext.FUNCTION, functionLiteral]?.valueParameters?.singleOrNull()
+}
+
+fun KtLambdaExpression.hasImplicitParameterReference(
+    implicitParameter: ValueParameterDescriptor,
+    bindingContext: BindingContext
+): Boolean {
+    return anyDescendantOfType<KtNameReferenceExpression> {
+        it.isImplicitParameterReference(this, implicitParameter, bindingContext)
+    }
+}
+
+private fun KtNameReferenceExpression.isImplicitParameterReference(
+    lambda: KtLambdaExpression,
+    implicitParameter: ValueParameterDescriptor,
+    bindingContext: BindingContext
+): Boolean {
+    return text == "it" &&
+        getStrictParentOfType<KtLambdaExpression>() == lambda &&
+        getResolvedCall(bindingContext)?.resultingDescriptor == implicitParameter
+}

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NoNameShadowingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NoNameShadowingSpec.kt
@@ -62,7 +62,7 @@ class NoNameShadowingSpec : Spek({
             assertThat(findings[0]).hasMessage("Name shadowed: it")
         }
 
-        it("report shadowing nested lambda implicit 'it' parameter") {
+        it("does not report when implicit 'it' parameter isn't used") {
             val code = """
                 fun test() {
                     listOf(1).forEach {
@@ -72,9 +72,7 @@ class NoNameShadowingSpec : Spek({
                 }
             """
             val findings = subject.compileAndLintWithContext(env, code)
-            assertThat(findings).hasSize(1)
-            assertThat(findings).hasSourceLocation(3, 27)
-            assertThat(findings[0]).hasMessage("Name shadowed: implicit lambda parameter 'it'")
+            assertThat(findings).isEmpty()
         }
 
         it("does not report not shadowing variable") {

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MultilineLambdaItParameter.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MultilineLambdaItParameter.kt
@@ -9,13 +9,10 @@ import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.rules.IT_LITERAL
-import org.jetbrains.kotlin.descriptors.ValueParameterDescriptor
+import io.gitlab.arturbosch.detekt.rules.hasImplicitParameterReference
+import io.gitlab.arturbosch.detekt.rules.implicitParameter
 import org.jetbrains.kotlin.psi.KtLambdaExpression
-import org.jetbrains.kotlin.psi.KtNameReferenceExpression
-import org.jetbrains.kotlin.psi.psiUtil.anyDescendantOfType
-import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
 import org.jetbrains.kotlin.resolve.BindingContext
-import org.jetbrains.kotlin.resolve.calls.callUtil.getResolvedCall
 
 /**
  * Lambda expressions are very useful in a lot of cases and they often include very small chunks of
@@ -112,28 +109,5 @@ class MultilineLambdaItParameter(val config: Config) : Rule(config) {
             }
             else -> { }
         }
-    }
-
-    private fun KtLambdaExpression.implicitParameter(bindingContext: BindingContext): ValueParameterDescriptor? {
-        return bindingContext[BindingContext.FUNCTION, functionLiteral]?.valueParameters?.singleOrNull()
-    }
-
-    private fun KtLambdaExpression.hasImplicitParameterReference(
-        implicitParameter: ValueParameterDescriptor,
-        bindingContext: BindingContext
-    ): Boolean {
-        return anyDescendantOfType<KtNameReferenceExpression> {
-            it.isImplicitParameterReference(this, implicitParameter, bindingContext)
-        }
-    }
-
-    private fun KtNameReferenceExpression.isImplicitParameterReference(
-        lambda: KtLambdaExpression,
-        implicitParameter: ValueParameterDescriptor,
-        bindingContext: BindingContext
-    ): Boolean {
-        return text == "it" &&
-            getStrictParentOfType<KtLambdaExpression>() == lambda &&
-            getResolvedCall(bindingContext)?.resultingDescriptor == implicitParameter
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLetSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLetSpec.kt
@@ -344,6 +344,19 @@ class UnnecessaryLetSpec : Spek({
                 assertThat(findings).hasSize(1)
                 assertThat(findings).allMatch { it.message == MESSAGE_USE_IF }
             }
+
+            it("reports when implicit parameter isn't used") {
+                val content = """
+                    fun test(value: Int?) {
+                        value?.let {
+                          listOf(1).map { it }
+                        }
+                    }
+                """
+                val findings = subject.compileAndLintWithContext(env, content)
+                assertThat(findings).hasSize(1)
+                assertThat(findings).allMatch { it.message == MESSAGE_USE_IF }
+            }
         }
     }
 })

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -117,4 +117,4 @@ description: "Meet detekt, a static code analysis tool for Kotlin."
 url: https://detekt.github.io
 baseurl: /detekt
 
-detekt_version: 1.17.0
+detekt_version: 1.17.1

--- a/docs/pages/changelog 1.x.x.md
+++ b/docs/pages/changelog 1.x.x.md
@@ -6,6 +6,22 @@ permalink: changelog.html
 toc: true
 ---
 
+#### 1.17.1 - 2021-05-19
+
+##### Notable Changes
+
+This is a patch release for Detekt `1.17.0` including fixes that we considered worth a point release. 
+
+Specifically, we're reverting a change on our Gradle Plugin. The original change [#3655](https://github.com/detekt/detekt/pull/3655) resulted in several false positives when using rules with Type Resolution on Java/Kotlin mixed codebases.
+
+Moreover we included a couple of false positive fixes for `NoNameShadowing` and `UnnecessaryLet`
+
+##### Changelog
+
+- Revert "Noisy gradle (#3655)" - [#3792](https://github.com/detekt/detekt/pull/3792)
+- NoNameShadowing: don't report when implicit 'it' parameter isn't used - [#3793](https://github.com/detekt/detekt/pull/3793)
+- UnnecessaryLet: report when implicit parameter isn't used - [#3794](https://github.com/detekt/detekt/pull/3794)
+
 #### 1.17.0 - 2021-05-15
 
 ##### Notable Changes

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ spek = "2.0.15"
 
 [libraries]
 binaryCompatibilityValidator-gradlePlugin = "org.jetbrains.kotlinx:binary-compatibility-validator:0.4.0"
-detekt-gradlePlugin = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.17.0"
+detekt-gradlePlugin = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.17.1"
 githubRelease-gradlePlugin = "com.github.breadmoirai:github-release:2.2.12"
 gradleVersions-gradlePlugin = "com.github.ben-manes:gradle-versions-plugin:0.28.0"
 nexusStaging-gradlePlugin = "io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.22.0"


### PR DESCRIPTION
This PR contains the release branch for Detekt `1.17.1`.
I'm pushing the `release/1.17.1` branch to detekt/detekt so others can track it as well.

The CI will fail as the artifacts haven't been published yet.
I'm waiting for a positive review before publishing the assets 👍 

I've included #3792 #3793 #3794 only as discussed

The branch was created from: `git checkout -b release/1.17.1 6a92af522c67b9f3aa9d5965423f00009b2a6cb6`