### PR TITLE
Don't generate coverage reports for Gradle plugin

### DIFF
--- a/.github/workflows/codecoverage.yaml
+++ b/.github/workflows/codecoverage.yaml
@@ -25,7 +25,7 @@ jobs:
           java-version: 11
 
       - name: Generate Coverage Report
-        run: ./gradlew jacocoMergedReport --no-build-cache -x :detekt-gradle-plugin:test
+        run: ./gradlew jacocoMergedReport --no-build-cache
 
       - name: Publish Coverage
         if: success()

--- a/code-coverage-report/build.gradle.kts
+++ b/code-coverage-report/build.gradle.kts
@@ -12,7 +12,6 @@ dependencies {
     implementation(projects.detektCore)
     implementation(projects.detektFormatting)
     implementation(projects.detektGenerator)
-    implementation(projects.detektGradlePlugin)
     implementation(projects.detektMetrics)
     implementation(projects.detektParser)
     implementation(projects.detektPsiUtils)


### PR DESCRIPTION
This should fix the code coverage workflow.

Because the gradle plugin test task was excluded with `-x` in the workflow, but the new code-coverage-report build file tried merging the test results from that task, the workflow failed because the test hadn't been run.