### PR TITLE
Update the implementation of ClassOrdering to handle false negatives

### DIFF
--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ClassOrdering.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ClassOrdering.kt
@@ -61,59 +61,65 @@ class ClassOrdering(config: Config = Config.empty) : Rule(config) {
         Debt.FIVE_MINS
     )
 
-    private val comparator: Comparator<KtDeclaration> = Comparator { dec1: KtDeclaration, dec2: KtDeclaration ->
-        if (dec1.priority == null || dec2.priority == null) return@Comparator 0
-        compareValues(dec1.priority, dec2.priority)
-    }
-
     override fun visitClassBody(classBody: KtClassBody) {
         super.visitClassBody(classBody)
 
-        val misorders = comparator.findOutOfOrder(classBody.declarations)
-        if (misorders.isNotEmpty()) {
-            report(
-                misorders.map {
-                    CodeSmell(
-                        issue = issue,
-                        entity = Entity.from(it.first),
-                        message = "${it.first.description} should not come before ${it.second.description}",
-                        references = listOf(Entity.from(classBody))
+        var currentSection = Section(0)
+        classBody.declarations.forEach { ktDeclaration ->
+            val section = ktDeclaration.toSection()
+            when {
+                section != null && section < currentSection -> {
+                    val message =
+                        "${ktDeclaration.toDescription()} should be declared before ${currentSection.toDescription()}."
+                    report(
+                        CodeSmell(
+                            issue = issue,
+                            entity = Entity.from(ktDeclaration),
+                            message = message,
+                            references = listOf(Entity.from(classBody))
+                        )
                     )
                 }
-            )
+                section != null && section > currentSection -> currentSection = section
+            }
         }
     }
 }
 
-private fun Comparator<KtDeclaration>.findOutOfOrder(
-    declarations: List<KtDeclaration>
-): List<Pair<KtDeclaration, KtDeclaration>> =
-    declarations
-        .zipWithNext { a, b -> if (compare(a, b) > 0) Pair(a, b) else null }
-        .filterNotNull()
+private fun KtDeclaration.toDescription(): String = when {
+    this is KtProperty -> "property `$name`"
+    this is KtClassInitializer -> "initializer blocks"
+    this is KtSecondaryConstructor -> "secondary constructor"
+    this is KtNamedFunction -> "method `$name()`"
+    this is KtObjectDeclaration && isCompanion() -> "companion object"
+    else -> ""
+}
 
-private val KtDeclaration.description: String
-    get() = when (this) {
-        is KtClassInitializer -> "class initializer"
-        is KtObjectDeclaration -> if (isCompanion()) "Companion object" else ""
-        else -> "$name ($printableDeclaration)"
+@Suppress("MagicNumber")
+private fun KtDeclaration.toSection(): Section? = when {
+    this is KtProperty -> Section(0)
+    this is KtClassInitializer -> Section(0)
+    this is KtSecondaryConstructor -> Section(1)
+    this is KtNamedFunction -> Section(2)
+    this is KtObjectDeclaration && isCompanion() -> Section(3)
+    else -> null
+}
+
+@JvmInline
+@Suppress("MagicNumber", "ModifierOrder") // TODO Remove ModifierOrder once value class is supported.
+private value class Section(val priority: Int) : Comparable<Section> {
+
+    init {
+        require(priority in 0..3)
     }
 
-private val KtDeclaration.printableDeclaration: String
-    get() = when (this) {
-        is KtProperty -> "property"
-        is KtSecondaryConstructor -> "secondary constructor"
-        is KtNamedFunction -> "function"
+    fun toDescription(): String = when (priority) {
+        0 -> "property declarations and initializer blocks"
+        1 -> "secondary constructors"
+        2 -> "method declarations"
+        3 -> "companion object"
         else -> ""
     }
 
-@Suppress("MagicNumber")
-private val KtDeclaration.priority: Int?
-    get() = when (this) {
-        is KtProperty -> 0
-        is KtClassInitializer -> 0
-        is KtSecondaryConstructor -> 1
-        is KtNamedFunction -> 2
-        is KtObjectDeclaration -> if (isCompanion()) 3 else null
-        else -> null
-    }
+    override fun compareTo(other: Section): Int = priority.compareTo(other.priority)
+}

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ClassOrdering.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ClassOrdering.kt
@@ -65,10 +65,10 @@ class ClassOrdering(config: Config = Config.empty) : Rule(config) {
         super.visitClassBody(classBody)
 
         var currentSection = Section(0)
-        classBody.declarations.forEach { ktDeclaration ->
-            val section = ktDeclaration.toSection()
+        for (ktDeclaration in classBody.declarations) {
+            val section = ktDeclaration.toSection() ?: continue
             when {
-                section != null && section < currentSection -> {
+                section < currentSection -> {
                     val message =
                         "${ktDeclaration.toDescription()} should be declared before ${currentSection.toDescription()}."
                     report(
@@ -80,7 +80,7 @@ class ClassOrdering(config: Config = Config.empty) : Rule(config) {
                         )
                     )
                 }
-                section != null && section > currentSection -> currentSection = section
+                section > currentSection -> currentSection = section
             }
         }
     }
@@ -102,11 +102,11 @@ private fun KtDeclaration.toSection(): Section? = when {
     this is KtSecondaryConstructor -> Section(1)
     this is KtNamedFunction -> Section(2)
     this is KtObjectDeclaration && isCompanion() -> Section(3)
-    else -> null
+    else -> null // For declarations not relevant for ordering, such as nested classes.
 }
 
 @JvmInline
-@Suppress("MagicNumber", "ModifierOrder") // TODO Remove ModifierOrder once value class is supported.
+@Suppress("MagicNumber")
 private value class Section(val priority: Int) : Comparable<Section> {
 
     init {


### PR DESCRIPTION
Resolves #3809.

With this new implementation, one noticeable changes are that the number of violations is going to be increased:
For example, in a class layout like

```
class MyClass {
    val a: Int
    fun b(): String
    val c: Int
    val d: Int
    val e: Int
    val f: Int
}
```
Previous the violation will be reported only the boundary (a <-> b, b <-> c), now it will be reported on (c, d, e, f).
If the increase in the violations is a concern, we can implement grouping logic to reduce the number of violations.