### PR TITLE
[RFC] Autocorrection on native rules

### DIFF
--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/KtFileModifier.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/KtFileModifier.kt
@@ -16,14 +16,14 @@ class KtFileModifier : FileProcessListener {
 
     override fun onFinish(files: List<KtFile>, result: Detektion, bindingContext: BindingContext) {
         files.filter { it.modificationStamp > 0 }
-            .map { it.absolutePath() to it.unnormalizeContent() }
-            .forEach {
-                result.add(ModificationNotification(it.first))
-                Files.write(it.first, it.second.toByteArray())
+            .map { it.absolutePath() to it.denormalizeContent() }
+            .forEach { (path, content) ->
+                result.add(ModificationNotification(path))
+                Files.write(path, content.toByteArray())
             }
     }
 
-    private fun KtFile.unnormalizeContent(): String {
+    private fun KtFile.denormalizeContent(): String {
         val lineSeparator = getUserData(LINE_SEPARATOR)
         require(lineSeparator != null) {
             "No line separator entry for ktFile ${javaFileFacadeFqName.asString()}"

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ClassOrdering.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ClassOrdering.kt
@@ -61,59 +61,65 @@ class ClassOrdering(config: Config = Config.empty) : Rule(config) {
         Debt.FIVE_MINS
     )
 
-    private val comparator: Comparator<KtDeclaration> = Comparator { dec1: KtDeclaration, dec2: KtDeclaration ->
-        if (dec1.priority == null || dec2.priority == null) return@Comparator 0
-        compareValues(dec1.priority, dec2.priority)
-    }
-
     override fun visitClassBody(classBody: KtClassBody) {
         super.visitClassBody(classBody)
 
-        val misorders = comparator.findOutOfOrder(classBody.declarations)
-        if (misorders.isNotEmpty()) {
-            report(
-                misorders.map {
-                    CodeSmell(
-                        issue = issue,
-                        entity = Entity.from(it.first),
-                        message = "${it.first.description} should not come before ${it.second.description}",
-                        references = listOf(Entity.from(classBody))
+        var currentSection = Section(0)
+        classBody.declarations.forEach { ktDeclaration ->
+            val section = ktDeclaration.toSection()
+            when {
+                section != null && section < currentSection -> {
+                    val message =
+                        "${ktDeclaration.toDescription()} should be declared before ${currentSection.toDescription()}."
+                    report(
+                        CodeSmell(
+                            issue = issue,
+                            entity = Entity.from(ktDeclaration),
+                            message = message,
+                            references = listOf(Entity.from(classBody))
+                        )
                     )
                 }
-            )
+                section != null && section > currentSection -> currentSection = section
+            }
         }
     }
 }
 
-private fun Comparator<KtDeclaration>.findOutOfOrder(
-    declarations: List<KtDeclaration>
-): List<Pair<KtDeclaration, KtDeclaration>> =
-    declarations
-        .zipWithNext { a, b -> if (compare(a, b) > 0) Pair(a, b) else null }
-        .filterNotNull()
+private fun KtDeclaration.toDescription(): String = when {
+    this is KtProperty -> "property `$name`"
+    this is KtClassInitializer -> "initializer blocks"
+    this is KtSecondaryConstructor -> "secondary constructor"
+    this is KtNamedFunction -> "method `$name()`"
+    this is KtObjectDeclaration && isCompanion() -> "companion object"
+    else -> ""
+}
 
-private val KtDeclaration.description: String
-    get() = when (this) {
-        is KtClassInitializer -> "class initializer"
-        is KtObjectDeclaration -> if (isCompanion()) "Companion object" else ""
-        else -> "$name ($printableDeclaration)"
+@Suppress("MagicNumber")
+private fun KtDeclaration.toSection(): Section? = when {
+    this is KtProperty -> Section(0)
+    this is KtClassInitializer -> Section(0)
+    this is KtSecondaryConstructor -> Section(1)
+    this is KtNamedFunction -> Section(2)
+    this is KtObjectDeclaration && isCompanion() -> Section(3)
+    else -> null
+}
+
+@JvmInline
+@Suppress("MagicNumber", "ModifierOrder") // TODO Remove ModifierOrder once value class is supported.
+private value class Section(val priority: Int) : Comparable<Section> {
+
+    init {
+        require(priority in 0..3)
     }
 
-private val KtDeclaration.printableDeclaration: String
-    get() = when (this) {
-        is KtProperty -> "property"
-        is KtSecondaryConstructor -> "secondary constructor"
-        is KtNamedFunction -> "function"
+    fun toDescription(): String = when (priority) {
+        0 -> "property declarations and initializer blocks"
+        1 -> "secondary constructors"
+        2 -> "method declarations"
+        3 -> "companion object"
         else -> ""
     }
 
-@Suppress("MagicNumber")
-private val KtDeclaration.priority: Int?
-    get() = when (this) {
-        is KtProperty -> 0
-        is KtClassInitializer -> 0
-        is KtSecondaryConstructor -> 1
-        is KtNamedFunction -> 2
-        is KtObjectDeclaration -> if (isCompanion()) 3 else null
-        else -> null
-    }
+    override fun compareTo(other: Section): Int = priority.compareTo(other.priority)
+}

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ClassOrderingSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ClassOrderingSpec.kt
@@ -1,7 +1,12 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.github.detekt.test.utils.compileForTest
+import io.github.detekt.test.utils.readResourceContent
+import io.github.detekt.test.utils.resourceAsPath
 import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
@@ -261,6 +266,22 @@ class ClassOrderingSpec : Spek({
                 .isEqualTo("secondary constructor should be declared before companion object.")
             assertThat(findings[2].message)
                 .isEqualTo("property `y` should be declared before companion object.")
+        }
+
+        it("auto corrects all violations") {
+            val ktFile = compileForTest(resourceAsPath("ClassOrderingAutoCorrectible.kt"))
+
+            // Perform autocorrection
+            val findings = ClassOrdering(TestConfig(Config.AUTO_CORRECT_KEY to true)).lint(ktFile)
+            assertThat(findings).hasSize(4)
+
+            // Verify autocorrection output
+            val actualContent = ktFile.text
+            val expectedContent = readResourceContent("ClassOrderingAutoCorrected.kt")
+            assertThat(actualContent).isEqualToIgnoringNewLines(expectedContent)
+
+            // Ensure autocorrected code has no violation
+            assertThat(subject.lint(ktFile)).isEmpty()
         }
     }
 })

--- a/detekt-rules-style/src/test/resources/ClassOrderingAutoCorrected.kt
+++ b/detekt-rules-style/src/test/resources/ClassOrderingAutoCorrected.kt
@@ -1,0 +1,18 @@
+package cases
+
+class OutOfOrder(private val x: String) {
+
+    val y = x
+
+    init {
+        check(x == "yes")
+    }
+
+    constructor(z: Int): this(z.toString())
+
+    fun returnX() = x
+
+    companion object {
+        const val IMPORTANT_VALUE = 3
+    }
+}

--- a/detekt-rules-style/src/test/resources/ClassOrderingAutoCorrectible.kt
+++ b/detekt-rules-style/src/test/resources/ClassOrderingAutoCorrectible.kt
@@ -1,0 +1,18 @@
+package cases
+
+class OutOfOrder(private val x: String) {
+
+    companion object {
+        const val IMPORTANT_VALUE = 3
+    }
+
+    fun returnX() = x
+
+    constructor(z: Int): this(z.toString())
+
+    val y = x
+
+    init {
+        check(x == "yes")
+    }
+}

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/RuleExtensions.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/RuleExtensions.kt
@@ -37,6 +37,8 @@ fun BaseRule.lint(path: Path): List<Finding> {
     return findingsAfterVisit(ktFile)
 }
 
+fun BaseRule.lint(ktFile: KtFile): List<Finding> = findingsAfterVisit(ktFile)
+
 fun BaseRule.lintWithContext(
     environment: KotlinCoreEnvironment,
     @Language("kotlin") content: String,
@@ -74,8 +76,6 @@ private fun getContextForPaths(environment: KotlinCoreEnvironment, paths: List<K
         environment::createPackagePartProvider,
         ::FileBasedDeclarationProviderFactory
     ).bindingContext
-
-fun BaseRule.lint(ktFile: KtFile): List<Finding> = findingsAfterVisit(ktFile)
 
 private fun BaseRule.findingsAfterVisit(
     ktFile: KtFile,


### PR DESCRIPTION
## Motivation
When upgraded to Detekt 1.17 across the repo in my company, we have encountered numerous violations of `ClassOrdering` which requires manual fixing. This takes much more effort and should better be automated.

This is probably the first Detekt native rule that is auto-correctible, therefore I am posting this as a draft to collect feedback.

## Implementation

This is built on top of https://github.com/detekt/detekt/issues/3809 and should be merged.

Mutating the PSI is not as easy as it sounds according to the [IntelliJ documentation](https://plugins.jetbrains.com/docs/intellij/modifying-psi.html). This is probably why ktlint opts to mutate on ASTNode instead of PsiElement. However, in this PR, I still managed to perform modifications using only the PSI.

One tricky part is handling braces and whitespace, since `KtClassBody.declarations` and `KtClassBody.children` does not include those leaf elements.

Another tricky part is that adding PSIElement to a parent node requires its parent to be present, otherwise it will produce NPE. This is why I am copying a node and moving the children to the new node to circumvent this problem.

## Expectation
Ultimately, Detekt is a static analysis tool and is not a perfect style formatted. It is safe to assume that the autocorrected code can still violate other rules. The only guarantee which is verified by the test in this PR is that once auto-corrected, the same rule should detect no findings.