### PR TITLE
Fix generation issues around (deprecated) list properties

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -583,7 +583,7 @@ style:
     active: true
     ignoreOverridableFunction: true
     ignoreActualFunction: true
-    excludedFunctions: 'describeContents'
+    excludedFunctions: ''
     excludeAnnotatedFunction: ['dagger.Provides']
   LibraryCodeMustSpecifyReturnType:
     active: true

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/Configuration.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/Configuration.kt
@@ -5,4 +5,6 @@ data class Configuration(
     val description: String,
     val defaultValue: String,
     val deprecated: String?
-)
+) {
+    fun isDeprecated() = deprecated != null
+}

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/out/Yaml.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/out/Yaml.kt
@@ -16,7 +16,7 @@ sealed class YML(open val indent: Int = 0, open var content: String = "") {
     private fun getIndent(): String {
         var spaces = ""
         indent times {
-            spaces += "  "
+            spaces += SINGLE_INDENT
         }
         return spaces
     }
@@ -57,8 +57,10 @@ inline fun YamlNode.keyValue(comment: String = "", keyValue: () -> Pair<String, 
 fun YamlNode.list(name: String, list: List<String>) {
     append("$name:")
     list.forEach {
-        append(" - $it")
+        append("$SINGLE_INDENT- $it")
     }
 }
 
 inline fun YamlNode.yaml(yaml: () -> String) = append(yaml())
+
+private const val SINGLE_INDENT = "  "

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/rulesetpage/ConfigPrinter.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/rulesetpage/ConfigPrinter.kt
@@ -52,14 +52,7 @@ object ConfigPrinter : DocumentationPrinter<List<RuleSetPage>> {
                     if (ruleExclusion != null) {
                         keyValue { Config.EXCLUDES_KEY to ruleExclusion.pattern }
                     }
-                    rule.configuration
-                        .forEach { configuration ->
-                            if (configuration.defaultValue.isYamlList()) {
-                                list(configuration.name, configuration.defaultValue.toList())
-                            } else if (configuration.deprecated == null) {
-                                keyValue { configuration.name to configuration.defaultValue }
-                            }
-                        }
+                    rule.configuration.forEach { printConfiguration(it) }
                 }
             }
             emptyLine()

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/rulesetpage/ConfigPrinter.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/rulesetpage/ConfigPrinter.kt
@@ -1,6 +1,7 @@
 package io.gitlab.arturbosch.detekt.generator.printer.rulesetpage
 
 import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.generator.collection.Configuration
 import io.gitlab.arturbosch.detekt.generator.collection.Rule
 import io.gitlab.arturbosch.detekt.generator.collection.RuleSetProvider
 import io.gitlab.arturbosch.detekt.generator.out.YamlNode
@@ -38,14 +39,9 @@ object ConfigPrinter : DocumentationPrinter<List<RuleSetPage>> {
             if (ruleSetExclusion != null) {
                 keyValue { Config.EXCLUDES_KEY to ruleSetExclusion.pattern }
             }
-            ruleSet.configuration
-                .forEach { configuration ->
-                    if (configuration.defaultValue.isYamlList()) {
-                        list(configuration.name, configuration.defaultValue.toList())
-                    } else {
-                        keyValue { configuration.name to configuration.defaultValue }
-                    }
-                }
+
+            ruleSet.configuration.forEach { printConfiguration(it) }
+
             rules.forEach { rule ->
                 node(rule.name) {
                     keyValue { Config.ACTIVE_KEY to "${rule.defaultActivationStatus.active}" }
@@ -67,6 +63,16 @@ object ConfigPrinter : DocumentationPrinter<List<RuleSetPage>> {
                 }
             }
             emptyLine()
+        }
+    }
+
+    private fun YamlNode.printConfiguration(configuration: Configuration) {
+        if (configuration.isDeprecated()) return
+
+        if (configuration.defaultValue.isYamlList()) {
+            list(configuration.name, configuration.defaultValue.toList())
+        } else {
+            keyValue { configuration.name to configuration.defaultValue }
         }
     }
 

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/rulesetpage/RuleSetPagePrinter.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/rulesetpage/RuleSetPagePrinter.kt
@@ -68,17 +68,16 @@ object RuleSetPagePrinter : DocumentationPrinter<RuleSetPage> {
                 h4 { "Configuration options:" }
                 list {
                     rule.configuration.forEach {
-                        if (it.deprecated != null) {
+                        val defaultValues = it.defaultValue.lines()
+                        val defaultValuesString = defaultValues.joinToString { value ->
+                            value.trim().removePrefix("- ")
+                        }
+                        if (it.isDeprecated()) {
                             item {
-                                crossOut { code { it.name } } + " (default: ${code { it.defaultValue }})"
+                                crossOut { code { it.name } } + " (default: ${code { defaultValuesString }})"
                             }
                             description { "${bold { "Deprecated" }}: ${it.deprecated}" }
                         } else {
-                            val defaultValues = it.defaultValue.lines()
-                            val defaultValuesString = defaultValues.joinToString {
-                                value ->
-                                value.trim().removePrefix("- ")
-                            }
                             item { "${code { it.name }} (default: ${code { defaultValuesString }})" }
                         }
                         description { it.description }

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/printer/ConfigPrinterSpec.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/printer/ConfigPrinterSpec.kt
@@ -10,17 +10,34 @@ import org.spekframework.spek2.style.specification.describe
 class ConfigPrinterSpec : Spek({
 
     describe("Config printer") {
+        val ruleSetPage by memoized { createRuleSetPage() }
+        val yamlString by memoized { ConfigPrinter.print(listOf(ruleSetPage)) }
 
-        it("prints the correct yaml format") {
-            val ruleSetList = listOf(createRuleSetPage())
+        it("prints the rule set in the correct yaml format") {
             val expectedRulePart = readResourceContent("RuleSetConfig.yml")
 
-            val yamlString = ConfigPrinter.print(ruleSetList)
-
             assertThat(yamlString).contains(expectedRulePart)
+        }
+        it("prints default build configuration") {
+            assertThat(yamlString).contains("build:")
+        }
+        it("prints default config configuration") {
+            assertThat(yamlString).contains("config:")
+        }
+        it("prints default processor configuration") {
+            assertThat(yamlString).contains("processors:")
+        }
+        it("prints default report configuration") {
             assertThat(yamlString).contains("output-reports:")
             assertThat(yamlString).contains("console-reports:")
-            assertThat(yamlString).contains("processors:")
+        }
+        it("omits deprecated ruleset properties") {
+            assertThat(yamlString).doesNotContain("deprecatedSimpleConfig")
+            assertThat(yamlString).doesNotContain("deprecatedListConfig")
+        }
+        it("omits deprecated rule properties") {
+            assertThat(yamlString).doesNotContain("conf2")
+            assertThat(yamlString).doesNotContain("conf4")
         }
     }
 })

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/util/RuleSetPageCreator.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/util/RuleSetPageCreator.kt
@@ -26,6 +26,18 @@ internal fun createRuleSetPage(): RuleSetPage {
                     name = "rulesetconfig2",
                     description = "description rulesetconfig2",
                     defaultValue = "['foo', 'bar']",
+                    deprecated = null
+                ),
+                Configuration(
+                    name = "deprecatedSimpleConfig",
+                    description = "description deprecatedSimpleConfig",
+                    defaultValue = "true",
+                    deprecated = "is deprecated"
+                ),
+                Configuration(
+                    name = "deprecatedListConfig",
+                    description = "description deprecatedListConfig",
+                    defaultValue = "['foo', 'bar']",
                     deprecated = "is deprecated"
                 )
             )

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/util/RuleSetPageCreator.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/util/RuleSetPageCreator.kt
@@ -60,6 +60,7 @@ internal fun createRules(): List<Rule> {
             Configuration("conf1", "a config option", "foo", null),
             Configuration("conf2", "deprecated config", "false", "use conf1 instead"),
             Configuration("conf3", "list config", "- a\n- b", null),
+            Configuration("conf4", "deprecated list config", "- a\n- b", "use conf3 instead"),
         )
     )
     val rule2 = Rule(

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/util/RuleSetPageCreator.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/util/RuleSetPageCreator.kt
@@ -25,7 +25,7 @@ internal fun createRuleSetPage(): RuleSetPage {
                 Configuration(
                     name = "rulesetconfig2",
                     description = "description rulesetconfig2",
-                    defaultValue = "['foo', 'bar']",
+                    defaultValue = "- foo\n- bar",
                     deprecated = null
                 ),
                 Configuration(
@@ -37,7 +37,7 @@ internal fun createRuleSetPage(): RuleSetPage {
                 Configuration(
                     name = "deprecatedListConfig",
                     description = "description deprecatedListConfig",
-                    defaultValue = "['foo', 'bar']",
+                    defaultValue = "- foo\n- bar",
                     deprecated = "is deprecated"
                 )
             )
@@ -59,8 +59,8 @@ internal fun createRules(): List<Rule> {
         configuration = listOf(
             Configuration("conf1", "a config option", "foo", null),
             Configuration("conf2", "deprecated config", "false", "use conf1 instead"),
-            Configuration("conf3", "list config", "- a\n- b", null),
-            Configuration("conf4", "deprecated list config", "- a\n- b", "use conf3 instead"),
+            Configuration("conf3", "list config", "['a', 'b']", null),
+            Configuration("conf4", "deprecated list config", "['a', 'b']", "use conf3 instead"),
         )
     )
     val rule2 = Rule(

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/util/RuleSetPageCreator.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/util/RuleSetPageCreator.kt
@@ -59,7 +59,7 @@ internal fun createRules(): List<Rule> {
         configuration = listOf(
             Configuration("conf1", "a config option", "foo", null),
             Configuration("conf2", "deprecated config", "false", "use conf1 instead"),
-            Configuration("conf3", "list config", "['a', 'b']", null),
+            Configuration("conf3", "list config", "- a\n- b", null),
         )
     )
     val rule2 = Rule(

--- a/detekt-generator/src/test/resources/RuleSet.md
+++ b/detekt-generator/src/test/resources/RuleSet.md
@@ -26,8 +26,7 @@ a wildcard import
 
   list config
 
-* ~~``conf4``~~ (default: ``- a
-- b``)
+* ~~``conf4``~~ (default: ``a, b``)
 
   **Deprecated**: use conf3 instead
 

--- a/detekt-generator/src/test/resources/RuleSet.md
+++ b/detekt-generator/src/test/resources/RuleSet.md
@@ -22,11 +22,11 @@ a wildcard import
 
   deprecated config
 
-* ``conf3`` (default: ``a, b``)
+* ``conf3`` (default: ``['a', 'b']``)
 
   list config
 
-* ~~``conf4``~~ (default: ``a, b``)
+* ~~``conf4``~~ (default: ``['a', 'b']``)
 
   **Deprecated**: use conf3 instead
 

--- a/detekt-generator/src/test/resources/RuleSet.md
+++ b/detekt-generator/src/test/resources/RuleSet.md
@@ -22,7 +22,7 @@ a wildcard import
 
   deprecated config
 
-* ``conf3`` (default: ``['a', 'b']``)
+* ``conf3`` (default: ``a, b``)
 
   list config
 

--- a/detekt-generator/src/test/resources/RuleSet.md
+++ b/detekt-generator/src/test/resources/RuleSet.md
@@ -26,6 +26,13 @@ a wildcard import
 
   list config
 
+* ~~``conf4``~~ (default: ``- a
+- b``)
+
+  **Deprecated**: use conf3 instead
+
+  deprecated list config
+
 #### Noncompliant Code:
 
 ```kotlin

--- a/detekt-generator/src/test/resources/RuleSetConfig.yml
+++ b/detekt-generator/src/test/resources/RuleSetConfig.yml
@@ -6,7 +6,9 @@ style:
     active: true
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
     conf1: foo
-    conf3: ['a', 'b']
+    conf3:
+     - a
+     - b
   EqualsNull:
     active: false
   NoUnitKeyword:

--- a/detekt-generator/src/test/resources/RuleSetConfig.yml
+++ b/detekt-generator/src/test/resources/RuleSetConfig.yml
@@ -1,14 +1,14 @@
 style:
   active: true
   rulesetconfig1: true
-  rulesetconfig2: ['foo', 'bar']
+  rulesetconfig2:
+    - foo
+    - bar
   WildcardImport:
     active: true
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
     conf1: foo
-    conf3:
-      - a
-      - b
+    conf3: ['a', 'b']
   EqualsNull:
     active: false
   NoUnitKeyword:

--- a/detekt-generator/src/test/resources/RuleSetConfig.yml
+++ b/detekt-generator/src/test/resources/RuleSetConfig.yml
@@ -9,6 +9,9 @@ style:
     conf3:
      - a
      - b
+    conf4:
+     - a
+     - b
   EqualsNull:
     active: false
   NoUnitKeyword:

--- a/detekt-generator/src/test/resources/RuleSetConfig.yml
+++ b/detekt-generator/src/test/resources/RuleSetConfig.yml
@@ -9,9 +9,6 @@ style:
     conf3:
      - a
      - b
-    conf4:
-     - a
-     - b
   EqualsNull:
     active: false
   NoUnitKeyword:

--- a/detekt-generator/src/test/resources/RuleSetConfig.yml
+++ b/detekt-generator/src/test/resources/RuleSetConfig.yml
@@ -7,8 +7,8 @@ style:
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
     conf1: foo
     conf3:
-     - a
-     - b
+      - a
+      - b
   EqualsNull:
     active: false
   NoUnitKeyword:


### PR DESCRIPTION
This fixes #3806 plus a few more minor issues along the way

- deprecated ruleset config options are ignored for config file generation
- fix output of deprecated default value when it is a list
- omit deprecated list property from config
- fix indentation of yml list to 2 spaces
