### PR TITLE
Property apply test excludes for comments

### DIFF
--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/rulesetpage/Exclusion.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/rulesetpage/Exclusion.kt
@@ -24,7 +24,7 @@ private object TestExclusions : Exclusions() {
 
     override val pattern =
         "['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']"
-    override val ruleSets = setOf("comments")
+    override val ruleSets = emptySet<String>()
     override val rules = setOf(
         "NamingRules",
         "WildcardImport",
@@ -37,7 +37,10 @@ private object TestExclusions : Exclusions() {
         "FunctionMaxLength",
         "TooGenericExceptionCaught",
         "InstanceOfCheckForException",
-        "ThrowingExceptionsWithoutMessageOrCause"
+        "ThrowingExceptionsWithoutMessageOrCause",
+        "UndocumentedPublicClass",
+        "UndocumentedPublicFunction",
+        "UndocumentedPublicProperty"
     )
 }
 


### PR DESCRIPTION
Closes #3812 

My original PR #3801 was wrong. The correct way to apply excludes is to list them inside the `Exclusion.kt` file.