### PR TITLE
Change `@autocorrect` from tag to annotation

### DIFF
--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/AutoCorrectable.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/AutoCorrectable.kt
@@ -8,7 +8,7 @@ package io.gitlab.arturbosch.detekt.api.internal
 @Retention(AnnotationRetention.SOURCE)
 annotation class AutoCorrectable(
     /**
-     *  The Detekt version the rule was auto-correctable in the following format: <major>.<minor>.<patch>,
+     *  The Detekt version since the rule is auto-correctable in the following format: <major>.<minor>.<patch>,
      *  where major, minor and patch are non-negative integer numbers.
      */
     val since: String

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/AutoCorrectable.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/AutoCorrectable.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.api.internal
 
 /**
  * Annotated [io.gitlab.arturbosch.detekt.api.Rule] or [io.gitlab.arturbosch.detekt.api.RuleSetProvider]
- * is auto correctable.
+ * is auto-correctable.
  */
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.SOURCE)

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/AutoCorrectable.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/AutoCorrectable.kt
@@ -1,0 +1,15 @@
+package io.gitlab.arturbosch.detekt.api.internal
+
+/**
+ * Annotated [io.gitlab.arturbosch.detekt.api.Rule] or [io.gitlab.arturbosch.detekt.api.RuleSetProvider]
+ * is auto correctable.
+ */
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.SOURCE)
+annotation class AutoCorrectable(
+    /**
+     *  The Detekt version the rule was auto-correctable in the following format: <major>.<minor>.<patch>,
+     *  where major, minor and patch are non-negative integer numbers.
+     */
+    val since: String
+)

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/AnnotationOnSeparateLine.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/AnnotationOnSeparateLine.kt
@@ -2,13 +2,13 @@ package io.gitlab.arturbosch.detekt.formatting.wrappers
 
 import com.pinterest.ktlint.ruleset.experimental.AnnotationRule
 import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
  * See <a href="https://ktlint.github.io">ktlint-website</a> for documentation.
- *
- * @autoCorrect since v1.0.0
  */
+@AutoCorrectable(since = "1.0.0")
 class AnnotationOnSeparateLine(config: Config) : FormattingRule(config) {
 
     override val wrapping = AnnotationRule()

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/AnnotationSpacing.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/AnnotationSpacing.kt
@@ -2,13 +2,13 @@ package io.gitlab.arturbosch.detekt.formatting.wrappers
 
 import com.pinterest.ktlint.ruleset.experimental.AnnotationSpacingRule
 import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
  * See <a href="https://ktlint.github.io">ktlint-website</a> for documentation.
- *
- * @autoCorrect since v1.0.0
  */
+@AutoCorrectable(since = "1.0.0")
 class AnnotationSpacing(config: Config) : FormattingRule(config) {
 
     override val wrapping = AnnotationSpacingRule()

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/ArgumentListWrapping.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/ArgumentListWrapping.kt
@@ -2,6 +2,7 @@ package io.gitlab.arturbosch.detekt.formatting.wrappers
 
 import com.pinterest.ktlint.ruleset.experimental.ArgumentListWrappingRule
 import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.ANDROID_MAX_LINE_LENGTH
 import io.gitlab.arturbosch.detekt.formatting.DEFAULT_IDEA_LINE_LENGTH
 import io.gitlab.arturbosch.detekt.formatting.DEFAULT_INDENT
@@ -14,9 +15,8 @@ import io.gitlab.arturbosch.detekt.formatting.MAX_LINE_LENGTH_KEY
  *
  * @configuration indentSize - indentation size (default: `4`)
  * @configuration maxLineLength - maximum line length (default: `120`)
- *
- * @autoCorrect since v1.0.0
  */
+@AutoCorrectable(since = "1.0.0")
 class ArgumentListWrapping(config: Config) : FormattingRule(config) {
 
     override val wrapping = ArgumentListWrappingRule()

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/ChainWrapping.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/ChainWrapping.kt
@@ -3,14 +3,14 @@ package io.gitlab.arturbosch.detekt.formatting.wrappers
 import com.pinterest.ktlint.ruleset.standard.ChainWrappingRule
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
+import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
  * See <a href="https://ktlint.github.io">ktlint-website</a> for documentation.
- *
- * @autoCorrect since v1.0.0
  */
 @ActiveByDefault(since = "1.0.0")
+@AutoCorrectable(since = "1.0.0")
 class ChainWrapping(config: Config) : FormattingRule(config) {
 
     override val wrapping = ChainWrappingRule()

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/CommentSpacing.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/CommentSpacing.kt
@@ -3,14 +3,14 @@ package io.gitlab.arturbosch.detekt.formatting.wrappers
 import com.pinterest.ktlint.ruleset.standard.CommentSpacingRule
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
+import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
  * See <a href="https://ktlint.github.io">ktlint-website</a> for documentation.
- *
- * @autoCorrect since v1.0.0
  */
 @ActiveByDefault(since = "1.0.0")
+@AutoCorrectable(since = "1.0.0")
 class CommentSpacing(config: Config) : FormattingRule(config) {
 
     override val wrapping = CommentSpacingRule()

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/EnumEntryNameCase.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/EnumEntryNameCase.kt
@@ -2,13 +2,13 @@ package io.gitlab.arturbosch.detekt.formatting.wrappers
 
 import com.pinterest.ktlint.ruleset.experimental.EnumEntryNameCaseRule
 import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
  * See <a href="https://ktlint.github.io">ktlint-website</a> for documentation.
- *
- * @autoCorrect since v1.4.0
  */
+@AutoCorrectable(since = "1.4.0")
 class EnumEntryNameCase(config: Config) : FormattingRule(config) {
 
     override val wrapping = EnumEntryNameCaseRule()

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/FinalNewline.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/FinalNewline.kt
@@ -5,17 +5,17 @@ import com.pinterest.ktlint.core.api.UsesEditorConfigProperties
 import com.pinterest.ktlint.ruleset.standard.FinalNewlineRule
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
+import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
  * See <a href="https://ktlint.github.io">ktlint-website</a> for documentation.
  *
  * @configuration insertFinalNewLine - report absence or presence of a newline (default: `true`)
- *
- * @autoCorrect since v1.0.0
  */
 @OptIn(FeatureInAlphaState::class)
 @ActiveByDefault(since = "1.0.0")
+@AutoCorrectable(since = "1.0.0")
 class FinalNewline(config: Config) : FormattingRule(config) {
 
     override val wrapping = FinalNewlineRule()

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/ImportOrdering.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/ImportOrdering.kt
@@ -4,6 +4,7 @@ import com.pinterest.ktlint.core.api.FeatureInAlphaState
 import com.pinterest.ktlint.core.api.UsesEditorConfigProperties
 import com.pinterest.ktlint.ruleset.standard.ImportOrderingRule
 import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
@@ -13,10 +14,9 @@ import io.gitlab.arturbosch.detekt.formatting.FormattingRule
  * https://github.com/pinterest/ktlint/blob/a6ca5b2edf95cc70a138a9470cfb6c4fd5d9d3ce/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/ImportOrderingRule.kt
  *
  * @configuration layout - the import ordering layout; (default: `'*,java.**,javax.**,kotlin.**,^'`)
- *
- * @autoCorrect since v1.0.0
  */
 @OptIn(FeatureInAlphaState::class)
+@AutoCorrectable(since = "1.0.0")
 class ImportOrdering(config: Config) : FormattingRule(config) {
 
     override val wrapping = ImportOrderingRule()

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/Indentation.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/Indentation.kt
@@ -2,6 +2,7 @@ package io.gitlab.arturbosch.detekt.formatting.wrappers
 
 import com.pinterest.ktlint.ruleset.standard.IndentationRule
 import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.CONTINUATION_INDENT_SIZE_KEY
 import io.gitlab.arturbosch.detekt.formatting.DEFAULT_CONTINUATION_INDENT
 import io.gitlab.arturbosch.detekt.formatting.DEFAULT_INDENT
@@ -13,9 +14,8 @@ import io.gitlab.arturbosch.detekt.formatting.INDENT_SIZE_KEY
  *
  * @configuration indentSize - indentation size (default: `4`)
  * @configuration continuationIndentSize - continuation indentation size (default: `4`)
- *
- * @autoCorrect since v1.0.0
  */
+@AutoCorrectable(since = "1.0.0")
 class Indentation(config: Config) : FormattingRule(config) {
 
     override val wrapping = IndentationRule()

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/ModifierOrdering.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/ModifierOrdering.kt
@@ -3,14 +3,14 @@ package io.gitlab.arturbosch.detekt.formatting.wrappers
 import com.pinterest.ktlint.ruleset.standard.ModifierOrderRule
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
+import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
  * See <a href="https://ktlint.github.io/#rule-modifier-order">ktlint-website</a> for documentation.
- *
- * @autoCorrect since v1.0.0
  */
 @ActiveByDefault(since = "1.0.0")
+@AutoCorrectable(since = "1.0.0")
 class ModifierOrdering(config: Config) : FormattingRule(config) {
 
     override val wrapping = ModifierOrderRule()

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/MultiLineIfElse.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/MultiLineIfElse.kt
@@ -3,14 +3,14 @@ package io.gitlab.arturbosch.detekt.formatting.wrappers
 import com.pinterest.ktlint.ruleset.experimental.MultiLineIfElseRule
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
+import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
  * See <a href="https://ktlint.github.io/#rule-modifier-order">ktlint-website</a> for documentation.
- *
- * @autoCorrect since v1.0.0
  */
 @ActiveByDefault(since = "1.0.0")
+@AutoCorrectable(since = "1.0.0")
 class MultiLineIfElse(config: Config) : FormattingRule(config) {
 
     override val wrapping = MultiLineIfElseRule()

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/NoBlankLineBeforeRbrace.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/NoBlankLineBeforeRbrace.kt
@@ -3,14 +3,14 @@ package io.gitlab.arturbosch.detekt.formatting.wrappers
 import com.pinterest.ktlint.ruleset.standard.NoBlankLineBeforeRbraceRule
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
+import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
  * See <a href="https://ktlint.github.io">ktlint-website</a> for documentation.
- *
- * @autoCorrect since v1.0.0
  */
 @ActiveByDefault(since = "1.0.0")
+@AutoCorrectable(since = "1.0.0")
 class NoBlankLineBeforeRbrace(config: Config) : FormattingRule(config) {
 
     override val wrapping = NoBlankLineBeforeRbraceRule()

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/NoConsecutiveBlankLines.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/NoConsecutiveBlankLines.kt
@@ -3,14 +3,14 @@ package io.gitlab.arturbosch.detekt.formatting.wrappers
 import com.pinterest.ktlint.ruleset.standard.NoConsecutiveBlankLinesRule
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
+import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
  * See <a href="https://ktlint.github.io/#rule-blank">ktlint-website</a> for documentation.
- *
- * @autoCorrect since v1.0.0
  */
 @ActiveByDefault(since = "1.0.0")
+@AutoCorrectable(since = "1.0.0")
 class NoConsecutiveBlankLines(config: Config) : FormattingRule(config) {
 
     override val wrapping = NoConsecutiveBlankLinesRule()

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/NoEmptyClassBody.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/NoEmptyClassBody.kt
@@ -3,14 +3,14 @@ package io.gitlab.arturbosch.detekt.formatting.wrappers
 import com.pinterest.ktlint.ruleset.standard.NoEmptyClassBodyRule
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
+import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
  * See <a href="https://ktlint.github.io/#rule-empty-class-body">ktlint-website</a> for documentation.
- *
- * @autoCorrect since v1.0.0
  */
 @ActiveByDefault(since = "1.0.0")
+@AutoCorrectable(since = "1.0.0")
 class NoEmptyClassBody(config: Config) : FormattingRule(config) {
 
     override val wrapping = NoEmptyClassBodyRule()

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/NoEmptyFirstLineInMethodBlock.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/NoEmptyFirstLineInMethodBlock.kt
@@ -2,13 +2,13 @@ package io.gitlab.arturbosch.detekt.formatting.wrappers
 
 import com.pinterest.ktlint.ruleset.experimental.NoEmptyFirstLineInMethodBlockRule
 import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
  * See <a href="https://ktlint.github.io">ktlint-website</a> for documentation.
- *
- * @autoCorrect since v1.4.0
  */
+@AutoCorrectable(since = "1.4.0")
 class NoEmptyFirstLineInMethodBlock(config: Config) : FormattingRule(config) {
 
     override val wrapping = NoEmptyFirstLineInMethodBlockRule()

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/NoLineBreakAfterElse.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/NoLineBreakAfterElse.kt
@@ -3,14 +3,14 @@ package io.gitlab.arturbosch.detekt.formatting.wrappers
 import com.pinterest.ktlint.ruleset.standard.NoLineBreakAfterElseRule
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
+import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
  * See <a href="https://ktlint.github.io">ktlint-website</a> for documentation.
- *
- * @autoCorrect since v1.0.0
  */
 @ActiveByDefault(since = "1.0.0")
+@AutoCorrectable(since = "1.0.0")
 class NoLineBreakAfterElse(config: Config) : FormattingRule(config) {
 
     override val wrapping = NoLineBreakAfterElseRule()

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/NoLineBreakBeforeAssignment.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/NoLineBreakBeforeAssignment.kt
@@ -3,14 +3,14 @@ package io.gitlab.arturbosch.detekt.formatting.wrappers
 import com.pinterest.ktlint.ruleset.standard.NoLineBreakBeforeAssignmentRule
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
+import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
  * See <a href="https://ktlint.github.io">ktlint-website</a> for documentation.
- *
- * @autoCorrect since v1.0.0
  */
 @ActiveByDefault(since = "1.0.0")
+@AutoCorrectable(since = "1.0.0")
 class NoLineBreakBeforeAssignment(config: Config) : FormattingRule(config) {
 
     override val wrapping = NoLineBreakBeforeAssignmentRule()

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/NoMultipleSpaces.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/NoMultipleSpaces.kt
@@ -3,14 +3,14 @@ package io.gitlab.arturbosch.detekt.formatting.wrappers
 import com.pinterest.ktlint.ruleset.standard.NoMultipleSpacesRule
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
+import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
  * See <a href="https://ktlint.github.io">ktlint-website</a> for documentation.
- *
- * @autoCorrect since v1.0.0
  */
 @ActiveByDefault(since = "1.0.0")
+@AutoCorrectable(since = "1.0.0")
 class NoMultipleSpaces(config: Config) : FormattingRule(config) {
 
     override val wrapping = NoMultipleSpacesRule()

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/NoSemicolons.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/NoSemicolons.kt
@@ -3,14 +3,14 @@ package io.gitlab.arturbosch.detekt.formatting.wrappers
 import com.pinterest.ktlint.ruleset.standard.NoSemicolonsRule
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
+import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
  * See <a href="https://ktlint.github.io/#rule-semi">ktlint-website</a> for documentation.
- *
- * @autoCorrect since v1.0.0
  */
 @ActiveByDefault(since = "1.0.0")
+@AutoCorrectable(since = "1.0.0")
 class NoSemicolons(config: Config) : FormattingRule(config) {
 
     override val wrapping = NoSemicolonsRule()

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/NoTrailingSpaces.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/NoTrailingSpaces.kt
@@ -3,14 +3,14 @@ package io.gitlab.arturbosch.detekt.formatting.wrappers
 import com.pinterest.ktlint.ruleset.standard.NoTrailingSpacesRule
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
+import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
  * See <a href="https://ktlint.github.io/#rule-trailing-whitespaces">ktlint-website</a> for documentation.
- *
- * @autoCorrect since v1.0.0
  */
 @ActiveByDefault(since = "1.0.0")
+@AutoCorrectable(since = "1.0.0")
 class NoTrailingSpaces(config: Config) : FormattingRule(config) {
 
     override val wrapping = NoTrailingSpacesRule()

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/NoUnitReturn.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/NoUnitReturn.kt
@@ -3,14 +3,14 @@ package io.gitlab.arturbosch.detekt.formatting.wrappers
 import com.pinterest.ktlint.ruleset.standard.NoUnitReturnRule
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
+import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
  * See <a href="https://ktlint.github.io/#rule-unit-return">ktlint-website</a> for documentation.
- *
- * @autoCorrect since v1.0.0
  */
 @ActiveByDefault(since = "1.0.0")
+@AutoCorrectable(since = "1.0.0")
 class NoUnitReturn(config: Config) : FormattingRule(config) {
 
     override val wrapping = NoUnitReturnRule()

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/NoUnusedImports.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/NoUnusedImports.kt
@@ -3,14 +3,14 @@ package io.gitlab.arturbosch.detekt.formatting.wrappers
 import com.pinterest.ktlint.ruleset.standard.NoUnusedImportsRule
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
+import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
  * See <a href="https://ktlint.github.io">ktlint-website</a> for documentation.
- *
- * @autoCorrect since v1.0.0
  */
 @ActiveByDefault(since = "1.0.0")
+@AutoCorrectable(since = "1.0.0")
 class NoUnusedImports(config: Config) : FormattingRule(config) {
 
     override val wrapping = NoUnusedImportsRule()

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/PackageName.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/PackageName.kt
@@ -3,14 +3,14 @@ package io.gitlab.arturbosch.detekt.formatting.wrappers
 import com.pinterest.ktlint.ruleset.experimental.PackageNameRule
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
+import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
  * See <a href="https://ktlint.github.io">ktlint-website</a> for documentation.
- *
- * @autoCorrect since v1.0.0
  */
 @ActiveByDefault(since = "1.0.0")
+@AutoCorrectable(since = "1.0.0")
 class PackageName(config: Config) : FormattingRule(config) {
 
     override val wrapping = PackageNameRule()

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/ParameterListWrapping.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/ParameterListWrapping.kt
@@ -3,6 +3,7 @@ package io.gitlab.arturbosch.detekt.formatting.wrappers
 import com.pinterest.ktlint.ruleset.standard.ParameterListWrappingRule
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
+import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.ANDROID_MAX_LINE_LENGTH
 import io.gitlab.arturbosch.detekt.formatting.DEFAULT_IDEA_LINE_LENGTH
 import io.gitlab.arturbosch.detekt.formatting.DEFAULT_INDENT
@@ -15,10 +16,9 @@ import io.gitlab.arturbosch.detekt.formatting.MAX_LINE_LENGTH_KEY
  *
  * @configuration indentSize - indentation size (default: `4`)
  * @configuration maxLineLength - maximum line length (default: `120`)
- *
- * @autoCorrect since v1.0.0
  */
 @ActiveByDefault(since = "1.0.0")
+@AutoCorrectable(since = "1.0.0")
 class ParameterListWrapping(config: Config) : FormattingRule(config) {
 
     override val wrapping = ParameterListWrappingRule()

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingAroundAngleBrackets.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingAroundAngleBrackets.kt
@@ -2,13 +2,13 @@ package io.gitlab.arturbosch.detekt.formatting.wrappers
 
 import com.pinterest.ktlint.ruleset.experimental.SpacingAroundAngleBracketsRule
 import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
  * See <a href="https://ktlint.github.io/#rule-spacing">ktlint-website</a> for documentation.
- *
- * @autoCorrect since v1.16.0
  */
+@AutoCorrectable(since = "1.16.0")
 class SpacingAroundAngleBrackets(config: Config) : FormattingRule(config) {
 
     override val wrapping = SpacingAroundAngleBracketsRule()

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingAroundColon.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingAroundColon.kt
@@ -3,14 +3,14 @@ package io.gitlab.arturbosch.detekt.formatting.wrappers
 import com.pinterest.ktlint.ruleset.standard.SpacingAroundColonRule
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
+import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
  * See <a href="https://ktlint.github.io/#rule-spacing">ktlint-website</a> for documentation.
- *
- * @autoCorrect since v1.0.0
  */
 @ActiveByDefault(since = "1.0.0")
+@AutoCorrectable(since = "1.0.0")
 class SpacingAroundColon(config: Config) : FormattingRule(config) {
 
     override val wrapping = SpacingAroundColonRule()

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingAroundComma.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingAroundComma.kt
@@ -3,14 +3,14 @@ package io.gitlab.arturbosch.detekt.formatting.wrappers
 import com.pinterest.ktlint.ruleset.standard.SpacingAroundCommaRule
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
+import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
  * See <a href="https://ktlint.github.io/#rule-spacing">ktlint-website</a> for documentation.
- *
- * @autoCorrect since v1.0.0
  */
 @ActiveByDefault(since = "1.0.0")
+@AutoCorrectable(since = "1.0.0")
 class SpacingAroundComma(config: Config) : FormattingRule(config) {
 
     override val wrapping = SpacingAroundCommaRule()

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingAroundCurly.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingAroundCurly.kt
@@ -3,14 +3,14 @@ package io.gitlab.arturbosch.detekt.formatting.wrappers
 import com.pinterest.ktlint.ruleset.standard.SpacingAroundCurlyRule
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
+import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
  * See <a href="https://ktlint.github.io/#rule-spacing">ktlint-website</a> for documentation.
- *
- * @autoCorrect since v1.0.0
  */
 @ActiveByDefault(since = "1.0.0")
+@AutoCorrectable(since = "1.0.0")
 class SpacingAroundCurly(config: Config) : FormattingRule(config) {
 
     override val wrapping = SpacingAroundCurlyRule()

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingAroundDot.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingAroundDot.kt
@@ -3,14 +3,14 @@ package io.gitlab.arturbosch.detekt.formatting.wrappers
 import com.pinterest.ktlint.ruleset.standard.SpacingAroundDotRule
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
+import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
  * See <a href="https://ktlint.github.io/#rule-spacing">ktlint-website</a> for documentation.
- *
- * @autoCorrect since v1.0.0
  */
 @ActiveByDefault(since = "1.0.0")
+@AutoCorrectable(since = "1.0.0")
 class SpacingAroundDot(config: Config) : FormattingRule(config) {
 
     override val wrapping = SpacingAroundDotRule()

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingAroundDoubleColon.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingAroundDoubleColon.kt
@@ -2,13 +2,13 @@ package io.gitlab.arturbosch.detekt.formatting.wrappers
 
 import com.pinterest.ktlint.ruleset.experimental.SpacingAroundDoubleColonRule
 import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
  * See <a href="https://ktlint.github.io/#rule-spacing">ktlint-website</a> for documentation.
- *
- * @autoCorrect since v1.10.0
  */
+@AutoCorrectable(since = "1.10.0")
 class SpacingAroundDoubleColon(config: Config) : FormattingRule(config) {
 
     override val wrapping = SpacingAroundDoubleColonRule()

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingAroundKeyword.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingAroundKeyword.kt
@@ -3,14 +3,14 @@ package io.gitlab.arturbosch.detekt.formatting.wrappers
 import com.pinterest.ktlint.ruleset.standard.SpacingAroundKeywordRule
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
+import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
  * See <a href="https://ktlint.github.io/#rule-spacing">ktlint-website</a> for documentation.
- *
- * @autoCorrect since v1.0.0
  */
 @ActiveByDefault(since = "1.0.0")
+@AutoCorrectable(since = "1.0.0")
 class SpacingAroundKeyword(config: Config) : FormattingRule(config) {
 
     override val wrapping = SpacingAroundKeywordRule()

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingAroundOperators.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingAroundOperators.kt
@@ -3,14 +3,14 @@ package io.gitlab.arturbosch.detekt.formatting.wrappers
 import com.pinterest.ktlint.ruleset.standard.SpacingAroundOperatorsRule
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
+import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
  * See <a href="https://ktlint.github.io/#rule-spacing">ktlint-website</a> for documentation.
- *
- * @autoCorrect since v1.0.0
  */
 @ActiveByDefault(since = "1.0.0")
+@AutoCorrectable(since = "1.0.0")
 class SpacingAroundOperators(config: Config) : FormattingRule(config) {
 
     override val wrapping = SpacingAroundOperatorsRule()

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingAroundParens.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingAroundParens.kt
@@ -3,14 +3,14 @@ package io.gitlab.arturbosch.detekt.formatting.wrappers
 import com.pinterest.ktlint.ruleset.standard.SpacingAroundParensRule
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
+import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
  * See <a href="https://ktlint.github.io/#rule-spacing">ktlint-website</a> for documentation.
- *
- * @autoCorrect since v1.0.0
  */
 @ActiveByDefault(since = "1.0.0")
+@AutoCorrectable(since = "1.0.0")
 class SpacingAroundParens(config: Config) : FormattingRule(config) {
 
     override val wrapping = SpacingAroundParensRule()

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingAroundRangeOperator.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingAroundRangeOperator.kt
@@ -3,14 +3,14 @@ package io.gitlab.arturbosch.detekt.formatting.wrappers
 import com.pinterest.ktlint.ruleset.standard.SpacingAroundRangeOperatorRule
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
+import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
  * See <a href="https://ktlint.github.io/#rule-spacing">ktlint-website</a> for documentation.
- *
- * @autoCorrect since v1.0.0
  */
 @ActiveByDefault(since = "1.0.0")
+@AutoCorrectable(since = "1.0.0")
 class SpacingAroundRangeOperator(config: Config) : FormattingRule(config) {
 
     override val wrapping = SpacingAroundRangeOperatorRule()

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingAroundUnaryOperator.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingAroundUnaryOperator.kt
@@ -2,13 +2,13 @@ package io.gitlab.arturbosch.detekt.formatting.wrappers
 
 import com.pinterest.ktlint.ruleset.experimental.SpacingAroundUnaryOperatorRule
 import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
  * See <a href="https://ktlint.github.io/#rule-spacing">ktlint-website</a> for documentation.
- *
- * @autoCorrect since v1.16.0
  */
+@AutoCorrectable(since = "1.16.0")
 class SpacingAroundUnaryOperator(config: Config) : FormattingRule(config) {
 
     override val wrapping = SpacingAroundUnaryOperatorRule()

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingBetweenDeclarationsWithAnnotations.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingBetweenDeclarationsWithAnnotations.kt
@@ -2,13 +2,13 @@ package io.gitlab.arturbosch.detekt.formatting.wrappers
 
 import com.pinterest.ktlint.ruleset.experimental.SpacingBetweenDeclarationsWithAnnotationsRule
 import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
  * See <a href="https://ktlint.github.io/#rule-spacing">ktlint-website</a> for documentation.
- *
- * @autoCorrect since v1.10.0
  */
+@AutoCorrectable(since = "1.10.0")
 class SpacingBetweenDeclarationsWithAnnotations(config: Config) : FormattingRule(config) {
 
     override val wrapping = SpacingBetweenDeclarationsWithAnnotationsRule()

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingBetweenDeclarationsWithComments.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingBetweenDeclarationsWithComments.kt
@@ -2,13 +2,13 @@ package io.gitlab.arturbosch.detekt.formatting.wrappers
 
 import com.pinterest.ktlint.ruleset.experimental.SpacingBetweenDeclarationsWithCommentsRule
 import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
  * See <a href="https://ktlint.github.io/#rule-spacing">ktlint-website</a> for documentation.
- *
- * @autoCorrect since v1.10.0
  */
+@AutoCorrectable(since = "1.10.0")
 class SpacingBetweenDeclarationsWithComments(config: Config) : FormattingRule(config) {
 
     override val wrapping = SpacingBetweenDeclarationsWithCommentsRule()

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/StringTemplate.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/StringTemplate.kt
@@ -3,14 +3,14 @@ package io.gitlab.arturbosch.detekt.formatting.wrappers
 import com.pinterest.ktlint.ruleset.standard.StringTemplateRule
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
+import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
  * See <a href="https://ktlint.github.io/#rule-string-template">ktlint-website</a> for documentation.
- *
- * @autoCorrect since v1.0.0
  */
 @ActiveByDefault(since = "1.0.0")
+@AutoCorrectable(since = "1.0.0")
 class StringTemplate(config: Config) : FormattingRule(config) {
 
     override val wrapping = StringTemplateRule()

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleVisitor.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleVisitor.kt
@@ -4,6 +4,7 @@ import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.DetektVisitor
 import io.gitlab.arturbosch.detekt.api.ThresholdRule
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
+import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 import io.gitlab.arturbosch.detekt.generator.collection.exception.InvalidAliasesDeclaration
@@ -101,7 +102,7 @@ internal class RuleVisitor : DetektVisitor() {
             defaultActivationStatus = Active(since = activeByDefaultSinceValue)
         }
 
-        autoCorrect = classOrObject.hasKDocTag(TAG_AUTO_CORRECT)
+        autoCorrect = classOrObject.isAnnotatedWith(AutoCorrectable::class)
         requiresTypeResolution = classOrObject.isAnnotatedWith(RequiresTypeResolution::class)
         configurationByKdoc = classOrObject.parseConfigurationTags()
 
@@ -168,8 +169,6 @@ internal class RuleVisitor : DetektVisitor() {
             ThresholdRule::class.simpleName,
             EmptyRule::class.simpleName
         )
-
-        private const val TAG_AUTO_CORRECT = "autoCorrect"
 
         private const val ISSUE_ARGUMENT_SIZE = 4
         private const val DEBT_ARGUMENT_INDEX = 3

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleCollectorSpec.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleCollectorSpec.kt
@@ -123,12 +123,13 @@ object RuleCollectorSpec : Spek({
             assertThatExceptionOfType(InvalidDocumentationException::class.java).isThrownBy { subject.run(code) }
         }
 
-        it("is auto-correctable tag is present") {
+        it("is auto-correctable") {
             val code = """
                 /**
                  * description
-                 * @autoCorrect
+                 *
                  */
+                @AutoCorrectable(since = "1.0.0")
                 class SomeRandomClass : Rule
             """
             val items = subject.run(code)


### PR DESCRIPTION
Continuing #3562, this PR moves `@autocorrect` from tag to a Kotlin annotation class.

Note: This PR is not intend for improving the functionality, such as displaying the autocorrectable status, along with the since field, in our docs.