### PR TITLE
Plugin: Fix Gradle configuration cache by not keeping classloader as a nested task field

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -196,8 +196,6 @@ open class Detekt @Inject constructor(
         group = LifecycleBasePlugin.VERIFICATION_GROUP
     }
 
-    private val invoker: DetektInvoker = DetektInvoker.create(project)
-
     @InputFiles
     @SkipWhenEmpty
     @PathSensitive(PathSensitivity.RELATIVE)
@@ -240,7 +238,7 @@ open class Detekt @Inject constructor(
         )
         arguments.addAll(convertCustomReportsToArguments())
 
-        invoker.invokeCli(
+        DetektInvoker.create(this).invokeCli(
             arguments = arguments.toList(),
             ignoreFailures = ignoreFailures,
             classpath = detektClasspath.plus(pluginClasspath),

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -21,6 +21,7 @@ import io.gitlab.arturbosch.detekt.invoke.InputArgument
 import io.gitlab.arturbosch.detekt.invoke.JvmTargetArgument
 import io.gitlab.arturbosch.detekt.invoke.LanguageVersionArgument
 import io.gitlab.arturbosch.detekt.invoke.ParallelArgument
+import io.gitlab.arturbosch.detekt.invoke.isDryRunEnabled
 import org.gradle.api.Action
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.Directory
@@ -192,6 +193,8 @@ open class Detekt @Inject constructor(
         .dir(ReportingExtension.DEFAULT_REPORTS_DIR_NAME)
         .dir("detekt")
 
+    private val isDryRun: Boolean = project.isDryRunEnabled()
+
     init {
         group = LifecycleBasePlugin.VERIFICATION_GROUP
     }
@@ -211,9 +214,7 @@ open class Detekt @Inject constructor(
     @TaskAction
     fun check() {
         if (failFastProp.getOrElse(false)) {
-            project.logger.warn(
-                "'failFast' is deprecated. Please use 'buildUponDefaultConfig' together with 'allRules'."
-            )
+            logger.warn("'failFast' is deprecated. Please use 'buildUponDefaultConfig' together with 'allRules'.")
         }
 
         val arguments = mutableListOf(
@@ -238,7 +239,7 @@ open class Detekt @Inject constructor(
         )
         arguments.addAll(convertCustomReportsToArguments())
 
-        DetektInvoker.create(this).invokeCli(
+        DetektInvoker.create(task = this, isDryRun = isDryRun).invokeCli(
             arguments = arguments.toList(),
             ignoreFailures = ignoreFailures,
             classpath = detektClasspath.plus(pluginClasspath),

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
@@ -108,12 +108,10 @@ open class DetektCreateBaselineTask : SourceTask() {
         get() = jvmTargetProp.get()
         set(value) = jvmTargetProp.set(value)
 
-    private val invoker: DetektInvoker = DetektInvoker.create(project)
-
     @TaskAction
     fun baseline() {
         if (@Suppress("DEPRECATION") failFast.getOrElse(false)) {
-            project.logger.warn(
+            logger.warn(
                 "'failFast' is deprecated. Please use 'buildUponDefaultConfig' together with 'allRules'."
             )
         }
@@ -135,7 +133,7 @@ open class DetektCreateBaselineTask : SourceTask() {
             DisableDefaultRuleSetArgument(disableDefaultRuleSets.getOrElse(false))
         )
 
-        invoker.invokeCli(
+        DetektInvoker.create(this).invokeCli(
             arguments = arguments.toList(),
             ignoreFailures = ignoreFailures.getOrElse(false),
             classpath = detektClasspath.plus(pluginClasspath),

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
@@ -15,6 +15,7 @@ import io.gitlab.arturbosch.detekt.invoke.FailFastArgument
 import io.gitlab.arturbosch.detekt.invoke.InputArgument
 import io.gitlab.arturbosch.detekt.invoke.JvmTargetArgument
 import io.gitlab.arturbosch.detekt.invoke.ParallelArgument
+import io.gitlab.arturbosch.detekt.invoke.isDryRunEnabled
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
@@ -108,12 +109,12 @@ open class DetektCreateBaselineTask : SourceTask() {
         get() = jvmTargetProp.get()
         set(value) = jvmTargetProp.set(value)
 
+    private val isDryRun: Boolean = project.isDryRunEnabled()
+
     @TaskAction
     fun baseline() {
         if (@Suppress("DEPRECATION") failFast.getOrElse(false)) {
-            logger.warn(
-                "'failFast' is deprecated. Please use 'buildUponDefaultConfig' together with 'allRules'."
-            )
+            logger.warn("'failFast' is deprecated. Please use 'buildUponDefaultConfig' together with 'allRules'.")
         }
 
         val arguments = mutableListOf(
@@ -133,7 +134,7 @@ open class DetektCreateBaselineTask : SourceTask() {
             DisableDefaultRuleSetArgument(disableDefaultRuleSets.getOrElse(false))
         )
 
-        DetektInvoker.create(this).invokeCli(
+        DetektInvoker.create(task = this, isDryRun = isDryRun).invokeCli(
             arguments = arguments.toList(),
             ignoreFailures = ignoreFailures.getOrElse(false),
             classpath = detektClasspath.plus(pluginClasspath),

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektGenerateConfigTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektGenerateConfigTask.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.DetektPlugin.Companion.CONFIG_FILE
 import io.gitlab.arturbosch.detekt.invoke.ConfigArgument
 import io.gitlab.arturbosch.detekt.invoke.DetektInvoker
 import io.gitlab.arturbosch.detekt.invoke.GenerateConfigArgument
+import io.gitlab.arturbosch.detekt.invoke.isDryRunEnabled
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.model.ObjectFactory
@@ -37,6 +38,8 @@ open class DetektGenerateConfigTask @Inject constructor(
     @get:PathSensitive(PathSensitivity.RELATIVE)
     val config: ConfigurableFileCollection = project.objects.fileCollection()
 
+    private val isDryRun: Boolean = project.isDryRunEnabled()
+
     private val defaultConfigPath = project.rootDir.toPath().resolve(CONFIG_DIR_NAME).resolve(CONFIG_FILE)
 
     @TaskAction
@@ -59,6 +62,10 @@ open class DetektGenerateConfigTask @Inject constructor(
             ConfigArgument(configurationToUse.last())
         )
 
-        DetektInvoker.create(this).invokeCli(arguments.toList(), detektClasspath, name)
+        DetektInvoker.create(task = this, isDryRun = isDryRun).invokeCli(
+            arguments = arguments.toList(),
+            classpath = detektClasspath,
+            taskName = name,
+        )
     }
 }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektGenerateConfigTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektGenerateConfigTask.kt
@@ -37,7 +37,6 @@ open class DetektGenerateConfigTask @Inject constructor(
     @get:PathSensitive(PathSensitivity.RELATIVE)
     val config: ConfigurableFileCollection = project.objects.fileCollection()
 
-    private val invoker: DetektInvoker = DetektInvoker.create(project)
     private val defaultConfigPath = project.rootDir.toPath().resolve(CONFIG_DIR_NAME).resolve(CONFIG_FILE)
 
     @TaskAction
@@ -60,6 +59,6 @@ open class DetektGenerateConfigTask @Inject constructor(
             ConfigArgument(configurationToUse.last())
         )
 
-        invoker.invokeCli(arguments.toList(), detektClasspath, name)
+        DetektInvoker.create(this).invokeCli(arguments.toList(), detektClasspath, name)
     }
 }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/DetektInvoker.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/DetektInvoker.kt
@@ -3,7 +3,7 @@ package io.gitlab.arturbosch.detekt.invoke
 import io.gitlab.arturbosch.detekt.internal.ClassLoaderCache
 import io.gitlab.arturbosch.detekt.internal.GlobalClassLoaderCache
 import org.gradle.api.GradleException
-import org.gradle.api.Project
+import org.gradle.api.Task
 import org.gradle.api.file.FileCollection
 import org.gradle.api.logging.Logger
 import java.io.PrintStream
@@ -21,14 +21,14 @@ internal interface DetektInvoker {
     companion object {
         private const val DRY_RUN_PROPERTY = "detekt-dry-run"
 
-        fun create(project: Project): DetektInvoker =
-            if (project.isDryRunEnabled()) {
-                DryRunInvoker(project.logger)
+        fun create(task: Task): DetektInvoker =
+            if (task.isDryRunEnabled()) {
+                DryRunInvoker(task.logger)
             } else {
                 DefaultCliInvoker()
             }
 
-        private fun Project.isDryRunEnabled(): Boolean {
+        private fun Task.isDryRunEnabled(): Boolean {
             return hasProperty(DRY_RUN_PROPERTY) && property(DRY_RUN_PROPERTY) == "true"
         }
     }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/DetektInvoker.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/DetektInvoker.kt
@@ -2,7 +2,6 @@ package io.gitlab.arturbosch.detekt.invoke
 
 import io.gitlab.arturbosch.detekt.internal.ClassLoaderCache
 import io.gitlab.arturbosch.detekt.internal.GlobalClassLoaderCache
-import org.codehaus.groovy.runtime.DefaultGroovyMethods.hasProperty
 import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.Task

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/DetektInvoker.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/DetektInvoker.kt
@@ -2,7 +2,9 @@ package io.gitlab.arturbosch.detekt.invoke
 
 import io.gitlab.arturbosch.detekt.internal.ClassLoaderCache
 import io.gitlab.arturbosch.detekt.internal.GlobalClassLoaderCache
+import org.codehaus.groovy.runtime.DefaultGroovyMethods.hasProperty
 import org.gradle.api.GradleException
+import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.file.FileCollection
 import org.gradle.api.logging.Logger
@@ -19,19 +21,20 @@ internal interface DetektInvoker {
     )
 
     companion object {
-        private const val DRY_RUN_PROPERTY = "detekt-dry-run"
 
-        fun create(task: Task): DetektInvoker =
-            if (task.isDryRunEnabled()) {
+        fun create(task: Task, isDryRun: Boolean): DetektInvoker =
+            if (isDryRun) {
                 DryRunInvoker(task.logger)
             } else {
                 DefaultCliInvoker()
             }
-
-        private fun Task.isDryRunEnabled(): Boolean {
-            return hasProperty(DRY_RUN_PROPERTY) && property(DRY_RUN_PROPERTY) == "true"
-        }
     }
+}
+
+private const val DRY_RUN_PROPERTY = "detekt-dry-run"
+
+internal fun Project.isDryRunEnabled(): Boolean {
+    return hasProperty(DRY_RUN_PROPERTY) && property(DRY_RUN_PROPERTY) == "true"
 }
 
 internal class DefaultCliInvoker(

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/ConfigurationCacheTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/ConfigurationCacheTest.kt
@@ -7,18 +7,23 @@ import org.spekframework.spek2.style.specification.describe
 
 object ConfigurationCacheTest : Spek({
     describe("Detekt task") {
-        it("can be loaded from the configuration cache") {
-            val gradleRunner = DslTestBuilder.kotlin()
-                .dryRun()
-                .build()
+        listOf(
+            "regular invocation" to arrayOf("detekt"),
+            "dry-run invocation" to arrayOf("detekt", "-Pdetekt-dry-run=true"),
+        ).forEach { (context, arguments) ->
+            context("given $context") {
+                it("can be loaded from the configuration cache") {
+                    val gradleRunner = DslTestBuilder.kotlin().build()
 
-            // First run primes the cache
-            gradleRunner.runTasks("--configuration-cache", "detekt")
+                    // First run primes the cache
+                    gradleRunner.runTasks("--configuration-cache", *arguments)
 
-            // Second run reuses the cache
-            val result = gradleRunner.runTasks("--configuration-cache", "detekt")
+                    // Second run reuses the cache
+                    val result = gradleRunner.runTasks("--configuration-cache", *arguments)
 
-            assertThat(result.output).contains("Reusing configuration cache.")
+                    assertThat(result.output).contains("Reusing configuration cache.")
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/detekt/detekt/issues/3563

I tried to reproduce the issue in tests, however I'm unable to trigger the `cannot serialize object of type 'java.net.URLClassLoader', a subtype of 'java.lang.ClassLoader'` error there :/ I noticed tests are passing the `dry-run` flag which calls simpler `DryRunInvoker`, but even after adding a test case with the `DefaultCliInvoker` the test still doesn't fail.  
I'd love to hear some ideas how to cover the linked scenario in tests 👀 

I verified manually on a failing project changes I'm suggesting work 🤷

