### PR TITLE
Kotlin 1.5.10

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,9 +7,6 @@ plugins {
     detekt
     id("com.github.ben-manes.versions")
     id("org.sonarqube")
-
-    // remove once Kotlin 1.5.10 is released (https://youtrack.jetbrains.com/issue/KT-46368)
-    id("dev.zacsweers.kgp-150-leak-patcher") version "1.1.0"
 }
 
 allprojects {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 dokka = "1.4.32"
 jacoco = "0.8.7"
-kotlin = "1.5.0"
+kotlin = "1.5.10"
 ktlint = "0.41.0"
 spek = "2.0.15"
 


### PR DESCRIPTION
https://github.com/JetBrains/kotlin/releases/tag/v1.5.10

Memory leak issue ([KT-46368](https://youtrack.jetbrains.com/issue/KT-46368)) marked as fixed in the release notes.