### PR TITLE
Detekt gradle plugin requires Gradle 6.1 or later

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ If you want to use a SNAPSHOT version, you can find more info on [this documenta
 
 #### Requirements
 
-Gradle 5.4+ is the minimum requirement. However the recommended versions, together with the other tools recommended versions are:
+Gradle 6.1+ is the minimum requirement. However, the recommended versions together with the other tools recommended versions are:
 
 | Detekt Version | Gradle | Kotlin | AGP | Java Target Level | JDK Max Version |
 | -------------- | ------ | ------ | --- | ----------------- | --------------- |

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
@@ -4,7 +4,6 @@ import org.gradle.api.Action
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.plugins.quality.CodeQualityExtension
-import org.gradle.util.GradleVersion
 import java.io.File
 import javax.inject.Inject
 
@@ -33,14 +32,7 @@ open class DetektExtension @Inject constructor(objects: ObjectFactory) : CodeQua
         )
 
     var baseline: File? = objects.fileProperty()
-        .run {
-            if (GradleVersion.current() < GradleVersion.version("6.0")) {
-                set(File("detekt-baseline.xml"))
-                this
-            } else {
-                fileValue(File("detekt-baseline.xml"))
-            }
-        }
+        .fileValue(File("detekt-baseline.xml"))
         .get().asFile
 
     var basePath: String? = null

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektAndroidTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektAndroidTest.kt
@@ -456,7 +456,6 @@ private fun createGradleRunnerAndSetupProject(projectLayout: ProjectLayout) = Ds
                 mavenCentral()
                 google()
                 mavenLocal()
-                jcenter()
             }
         }
     """.trimIndent(),

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektJvmTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektJvmTest.kt
@@ -22,7 +22,6 @@ object DetektJvmTest : Spek({
                 repositories {
                     mavenCentral()
                     mavenLocal()
-                    jcenter()
                 }
 
                 detekt {

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektMultiplatformTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektMultiplatformTest.kt
@@ -332,7 +332,6 @@ private fun setupProject(projectLayoutAction: ProjectLayout.() -> Unit): DslGrad
                     mavenCentral()
                     google()
                     mavenLocal()
-                    jcenter()
                 }
             }
         """.trimIndent(),

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektPlainTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektPlainTest.kt
@@ -19,7 +19,6 @@ object DetektPlainTest : Spek({
 
                 repositories {
                     mavenCentral()
-                    jcenter()
                     mavenLocal()
                 }
 
@@ -50,7 +49,6 @@ object DetektPlainTest : Spek({
 
                 repositories {
                     mavenCentral()
-                    jcenter()
                     mavenLocal()
                 }
 

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/GradleVersionTest.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/GradleVersionTest.kt
@@ -10,7 +10,7 @@ import org.spekframework.spek2.style.specification.describe
 
 object GradleVersionTest : Spek({
 
-    val gradleVersion = "5.4"
+    val gradleVersion = "6.1"
 
     describe(
         "detekt plugin running on oldest supported Gradle version",

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/testkit/DslTestBuilder.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/testkit/DslTestBuilder.kt
@@ -10,7 +10,6 @@ abstract class DslTestBuilder {
         repositories {
             mavenLocal()
             mavenCentral()
-            jcenter()
         }
     """.trimIndent()
 

--- a/docs/pages/gettingstarted/gradle.md
+++ b/docs/pages/gettingstarted/gradle.md
@@ -10,7 +10,7 @@ redirect_from:
 summary:
 ---
 
-Detekt requires **Gradle 5.4** or higher. We, however, recommend using the version of Gradle that is [listed in this table](https://detekt.github.io/detekt/compatibility.html).
+Detekt requires **Gradle 6.1** or higher. We, however, recommend using the version of Gradle that is [listed in this table](https://detekt.github.io/detekt/compatibility.html).
 
 ## <a name="tasks">Available plugin tasks</a>
 


### PR DESCRIPTION
Kotlin 1.5 requires Gradle 6.1 or later so it's safe for us to require the same.

Closes #3832