### PR TITLE
Re-enable warnings as errors for the gradle plugin module

### DIFF
--- a/buildSrc/src/main/kotlin/module.gradle.kts
+++ b/buildSrc/src/main/kotlin/module.gradle.kts
@@ -90,12 +90,7 @@ tasks.withType<KotlinCompile>().configureEach {
             "-Xopt-in=kotlin.RequiresOptIn"
         )
         // Usage: <code>./gradlew build -PwarningsAsErrors=true</code>.
-        // Note: currently there are warnings for detekt-gradle-plugin that seemingly can't be fixed
-        //       until Gradle releases an update (https://github.com/gradle/gradle/issues/16345)
-        allWarningsAsErrors = when (project.name) {
-            "detekt-gradle-plugin" -> false
-            else -> (project.findProperty("warningsAsErrors") == "true" || System.getenv("CI") == "true")
-        }
+        allWarningsAsErrors = (project.findProperty("warningsAsErrors") == "true" || System.getenv("CI") == "true")
     }
 }
 


### PR DESCRIPTION
Blocked by https://github.com/gradle/gradle/issues/16345
