### PR TITLE
Setup FOSSA

### DIFF
--- a/.github/workflows/fossascan.yaml
+++ b/.github/workflows/fossascan.yaml
@@ -1,0 +1,26 @@
+name: FOSSA License Scan
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  fossa-scan:
+    runs-on: ubuntu-latest
+    env:
+      GRADLE_OPTS: -Dorg.gradle.daemon=false
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+
+      - name: Setup Java
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
+      - name: Run FOSSA Scan
+        uses: fossas/fossa-action@v1
+        if: ${{ github.repository == 'detekt/detekt'}}
+        with:
+          api-key: ${{ secrets.FOSSA_API_KEY }}


### PR DESCRIPTION
I'm delegating the FOSSA Setup to a Github Actions workflow.
This will work on post-merge to `main`.

Once this gets merged, I'll update the FOSSA Badge on the README as the one we have right now is pointing to a project that has 0 dependencies: https://app.fossa.io/projects/git%2Bgithub.com%2Farturbosch%2Fdetekt/refs/branch/master/091dc917cd3bac0b8a47793ab63e2216be2252e2/preview