### PR TITLE
Fix UnnecessaryLet false positive in inner lambdas

### DIFF
--- a/detekt-psi-utils/api/detekt-psi-utils.api
+++ b/detekt-psi-utils/api/detekt-psi-utils.api
@@ -88,6 +88,7 @@ public final class io/gitlab/arturbosch/detekt/rules/KtCallExpressionKt {
 }
 
 public final class io/gitlab/arturbosch/detekt/rules/KtLambdaExpressionKt {
+	public static final fun firstParameter (Lorg/jetbrains/kotlin/psi/KtLambdaExpression;Lorg/jetbrains/kotlin/resolve/BindingContext;)Lorg/jetbrains/kotlin/descriptors/ValueParameterDescriptor;
 	public static final fun hasImplicitParameterReference (Lorg/jetbrains/kotlin/psi/KtLambdaExpression;Lorg/jetbrains/kotlin/descriptors/ValueParameterDescriptor;Lorg/jetbrains/kotlin/resolve/BindingContext;)Z
 	public static final fun implicitParameter (Lorg/jetbrains/kotlin/psi/KtLambdaExpression;Lorg/jetbrains/kotlin/resolve/BindingContext;)Lorg/jetbrains/kotlin/descriptors/ValueParameterDescriptor;
 }

--- a/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/KtLambdaExpression.kt
+++ b/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/KtLambdaExpression.kt
@@ -8,10 +8,15 @@ import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
 import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.calls.callUtil.getResolvedCall
 
-fun KtLambdaExpression.implicitParameter(bindingContext: BindingContext): ValueParameterDescriptor? {
-    if (valueParameters.isNotEmpty()) return null
-    return bindingContext[BindingContext.FUNCTION, functionLiteral]?.valueParameters?.singleOrNull()
-}
+fun KtLambdaExpression.firstParameter(bindingContext: BindingContext) =
+    bindingContext[BindingContext.FUNCTION, functionLiteral]?.valueParameters?.singleOrNull()
+
+fun KtLambdaExpression.implicitParameter(bindingContext: BindingContext): ValueParameterDescriptor? =
+    if (valueParameters.isNotEmpty()) {
+        null
+    } else {
+        firstParameter(bindingContext)
+    }
 
 fun KtLambdaExpression.hasImplicitParameterReference(
     implicitParameter: ValueParameterDescriptor,

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLetSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLetSpec.kt
@@ -357,6 +357,24 @@ class UnnecessaryLetSpec : Spek({
                 assertThat(findings).hasSize(1)
                 assertThat(findings).allMatch { it.message == MESSAGE_USE_IF }
             }
+
+            it("does not report when an implicit parameter is used in an inner lambda") {
+                val content = """
+                    fun callMe(callback: () -> Unit) {
+                        callback()
+                    }
+                    
+                    fun test(value: Int?) {
+                        value?.let { 
+                            callMe {
+                                println(it)
+                            }
+                         }
+                    }
+                """
+                val findings = subject.compileAndLintWithContext(env, content)
+                assertThat(findings).isEmpty()
+            }
         }
     }
 })


### PR DESCRIPTION
When upgrading detekt to 1.7.1, I noticed some false positives for `UnnecessaryLet`.

For example:

```kotlin
fun callMe(callback: () -> Unit) {
    callback()
}
 
fun test(value: Int?) {
    value?.let { 
        callMe {
            println(it)
        }
     }
}
```

would be reported.

This PR should fix the issue
