### PR TITLE
Set apiVersion to 1.4

### DIFF
--- a/buildSrc/src/main/kotlin/module.gradle.kts
+++ b/buildSrc/src/main/kotlin/module.gradle.kts
@@ -84,6 +84,7 @@ tasks.withType<KotlinCompile>().configureEach {
     kotlinOptions {
         jvmTarget = Versions.JVM_TARGET
         languageVersion = "1.5"
+        apiVersion = "1.4"
         freeCompilerArgs = listOf(
             "-progressive",
             "-Xopt-in=kotlin.RequiresOptIn"

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Rule.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Rule.kt
@@ -72,7 +72,7 @@ abstract class Rule(
     private fun computeSeverity(): SeverityLevel {
         val configValue: String = valueOrNull(SEVERITY_KEY)
             ?: ruleSetConfig.valueOrDefault(SEVERITY_KEY, "warning")
-        return enumValueOf(configValue.uppercase(Locale.US))
+        return enumValueOf(configValue.toUpperCase(Locale.US))
     }
 
     /**

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/DetektPrinter.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/DetektPrinter.kt
@@ -25,7 +25,7 @@ class DetektPrinter(private val arguments: GeneratorArgs) {
         check(ruleSet.length > 1) { "Rule set name must be not empty or less than two symbols." }
         return """
             |---
-            |title: ${ruleSet[0].uppercase()}${ruleSet.substring(1)} Rule Set
+            |title: ${ruleSet[0].toUpperCase()}${ruleSet.substring(1)} Rule Set
             |sidebar: home_sidebar
             |keywords: rules, $ruleSet
             |permalink: $ruleSet.html

--- a/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/RuleDescriptors.kt
+++ b/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/RuleDescriptors.kt
@@ -37,8 +37,8 @@ private fun MultiRule.toDescriptors(ruleSetId: RuleSetId): List<ReportingDescrip
     this.rules.map { it.toDescriptor(ruleSetId) }
 
 private fun Rule.toDescriptor(ruleSetId: RuleSetId): ReportingDescriptor {
-    val formattedRuleSetId = ruleSetId.lowercase(Locale.US)
-    val formattedRuleId = ruleId.lowercase(Locale.US)
+    val formattedRuleSetId = ruleSetId.toLowerCase(Locale.US)
+    val formattedRuleId = ruleId.toLowerCase(Locale.US)
 
     return ReportingDescriptor(
         id = "detekt.$ruleSetId.$ruleId",

--- a/detekt-report-xml/src/main/kotlin/io/github/detekt/report/xml/XmlEscape.kt
+++ b/detekt-report-xml/src/main/kotlin/io/github/detekt/report/xml/XmlEscape.kt
@@ -277,7 +277,7 @@ private object Xml10EscapeSymbolsInitializer {
     }
 
     private operator fun ByteArray.set(c: Char, value: Byte) {
-        set(c.code, value)
+        set(c.toInt(), value)
     }
 
     /**

--- a/detekt-report-xml/src/main/kotlin/io/github/detekt/report/xml/XmlOutputReport.kt
+++ b/detekt-report-xml/src/main/kotlin/io/github/detekt/report/xml/XmlOutputReport.kt
@@ -17,7 +17,7 @@ class XmlOutputReport : OutputReport() {
     override val name = "Checkstyle XML report"
 
     private val Finding.severityLabel: String
-        get() = severity.name.lowercase(Locale.US)
+        get() = severity.name.toLowerCase(Locale.US)
 
     override fun render(detektion: Detektion): String {
         val smells = detektion.findings.flatMap { it.value }

--- a/detekt-report-xml/src/test/kotlin/io/github/detekt/report/xml/XmlOutputFormatSpec.kt
+++ b/detekt-report-xml/src/test/kotlin/io/github/detekt/report/xml/XmlOutputFormatSpec.kt
@@ -185,7 +185,7 @@ class XmlOutputFormatSpec : Spek({
 
             SeverityLevel.values().forEach { severity ->
 
-                val xmlSeverity = severity.name.lowercase(Locale.US)
+                val xmlSeverity = severity.name.toLowerCase(Locale.US)
 
                 it("renders detektion with severity [$severity] as XML with severity [$xmlSeverity]") {
                     val finding = object : CodeSmell(

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumber.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumber.kt
@@ -180,7 +180,7 @@ class MagicNumber(config: Config = Config.empty) : Rule(config) {
 
     private fun normalizeForParsingAsDouble(text: String): String {
         return text.trim()
-            .lowercase(Locale.US)
+            .toLowerCase(Locale.US)
             .replace("_", "")
             .removeSuffix("l")
             .removeSuffix("d")

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiterals.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiterals.kt
@@ -98,7 +98,7 @@ class UnderscoresInNumericLiterals(config: Config = Config.empty) : Rule(config)
 
     private fun normalizeForMatching(text: String): String {
         return text.trim()
-            .lowercase(Locale.US)
+            .toLowerCase(Locale.US)
             .removeSuffix("l")
             .removeSuffix("d")
             .removeSuffix("f")


### PR DESCRIPTION
This sets the `apiVersion` to `1.4` and forces us to use only stdlib methods that were included in the 1.4 version.

Given that the usage of the 1.5 APIs is limited, I believe we can support this.

Fixes #3849