### PR TITLE
Remove ListAllWhenCases from changelogs

### DIFF
--- a/docs/pages/changelog 1.x.x.md
+++ b/docs/pages/changelog 1.x.x.md
@@ -292,7 +292,6 @@ You may experience some known issues when your project already uses 1.4.20
 In addition to many rule improvements, there are also new ones:
 
 - RedundantHigherOrderMapUsage
-- ListAllWhenCases
 - UseIfEmptyOrIfBlank
 
 We added documentation on how to configure [type resolution](https://detekt.github.io/detekt/type-resolution.html).  
@@ -345,7 +344,6 @@ Rule authors can use `TestConfig(Map)` or `yamlConfig(String)` from `detekt-test
 - Fix false negative in IgnoredReturnValue - [#3179](https://github.com/detekt/detekt/pull/3179)
 - Fix false positive when `to` is used to create a pair within a function - [#3178](https://github.com/detekt/detekt/pull/3178)
 - False Positive PreferToOverPairSyntax - [#3177](https://github.com/detekt/detekt/issues/3177)
-- ListAllWhenCases new rule - [#3176](https://github.com/detekt/detekt/issues/3176)
 - Suppress RedundantVisibilityModifierRule if explicit API mode enabled - [#3175](https://github.com/detekt/detekt/pull/3175)
 - Hardcode default values - [#3171](https://github.com/detekt/detekt/pull/3171)
 - False negative in IgnoredReturnValue - [#3170](https://github.com/detekt/detekt/issues/3170)


### PR DESCRIPTION
Seems like #3176 was accidentally added in the changelog for 1.15.0 as it was a issue in that milestone. I'm removing it from the changelog as we opted for #3187 instead

See #3176