### PR TITLE
Remove custom assertions that check kdoc of rules

### DIFF
--- a/detekt-core/build.gradle.kts
+++ b/detekt-core/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
     implementation(projects.detektReportSarif)
 
     testRuntimeOnly(projects.detektRules)
+    testRuntimeOnly(projects.detektFormatting)
     testImplementation(projects.detektTest)
     testImplementation(testFixtures(projects.detektApi))
     testImplementation(libs.mockk)

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/ConfigAssert.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/ConfigAssert.kt
@@ -17,15 +17,19 @@ class ConfigAssert(
     private val allowedOptions = setOf(
         Config.ACTIVE_KEY,
         Config.EXCLUDES_KEY,
-        Config.INCLUDES_KEY
+        Config.INCLUDES_KEY,
+        Config.AUTO_CORRECT_KEY,
+        "android"
     )
 
     fun assert() {
         val ymlDeclarations = getYmlRuleConfig().properties.filter { it.key !in allowedOptions }
         assertThat(ymlDeclarations).isNotEmpty
+
         val ruleClasses = getRuleClasses()
-        assertThat(ruleClasses).isNotEmpty
-        assertThat(ruleClasses).hasSize(ymlDeclarations.size)
+        val foundRulesClassNames = ruleClasses.map { it.simpleName }
+        val ruleNamesInConfig = ymlDeclarations.keys
+        assertThat(foundRulesClassNames).containsExactlyInAnyOrderElementsOf(ruleNamesInConfig)
 
         checkRules(ruleClasses, ymlDeclarations)
     }

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/ConfigAssert.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/ConfigAssert.kt
@@ -2,13 +2,11 @@ package io.gitlab.arturbosch.detekt.core
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Rule
-import io.gitlab.arturbosch.detekt.api.internal.Configuration
 import io.gitlab.arturbosch.detekt.core.config.DefaultConfig
 import io.gitlab.arturbosch.detekt.core.config.YamlConfig
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.fail
 import org.reflections.Reflections
-import java.lang.reflect.Field
 import java.lang.reflect.Modifier
 
 class ConfigAssert(
@@ -38,32 +36,8 @@ class ConfigAssert(
             if (ymlDeclaration.keys.size != 1) {
                 fail<String>("${ruleClass.simpleName} rule is not correctly defined in ${DefaultConfig.RESOURCE_NAME}")
             }
-
-            @Suppress("UNCHECKED_CAST")
-            val options = ymlDeclaration.iterator().next().value as HashMap<String, *>
-            checkOptions(options, ruleClass)
         }
     }
-
-    private fun checkOptions(ymlOptions: HashMap<String, *>, ruleClass: Class<out Rule>) {
-        if (ruleClass.isConfiguredWithAnnotations()) return
-
-        val configFields = ruleClass.declaredFields.filter { isPublicStaticFinal(it) && it.name != "Companion" }
-        var filter = ymlOptions.filterKeys { it !in allowedOptions }
-        if (filter.containsKey(THRESHOLD)) {
-            assertThat(ruleClass.superclass.simpleName).isEqualTo(THRESHOLD_RULE)
-            filter = filter.filterKeys { it != THRESHOLD }
-        }
-        for (ymlOption in filter) {
-            val configField = configFields.singleOrNull { ymlOption.key == it.get(null) }
-            if (configField == null) {
-                fail<String>("${ymlOption.key} option for ${ruleClass.simpleName} rule is not correctly defined")
-            }
-        }
-    }
-
-    private fun Class<out Rule>.isConfiguredWithAnnotations(): Boolean =
-        declaredMethods.any { it.isAnnotationPresent(Configuration::class.java) }
 
     private fun getYmlRuleConfig() = config.subConfig(name) as? YamlConfig
         ?: error("yaml config expected but got ${config.javaClass}")
@@ -73,12 +47,4 @@ class ConfigAssert(
             .getSubTypesOf(Rule::class.java)
             .filter { !Modifier.isAbstract(it.modifiers) }
     }
-
-    private fun isPublicStaticFinal(it: Field): Boolean {
-        val modifiers = it.modifiers
-        return Modifier.isStatic(modifiers) && Modifier.isPublic(modifiers) && Modifier.isFinal(modifiers)
-    }
 }
-
-private const val THRESHOLD_RULE = "ThresholdRule"
-private const val THRESHOLD = "threshold"

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/DetektYmlConfigSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/DetektYmlConfigSpec.kt
@@ -1,6 +1,8 @@
 package io.gitlab.arturbosch.detekt.core
 
 import io.gitlab.arturbosch.detekt.core.config.DefaultConfig
+import io.gitlab.arturbosch.detekt.core.config.YamlConfig
+import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
@@ -10,76 +12,53 @@ class DetektYmlConfigSpec : Spek({
 
         val config by memoized { DefaultConfig.newInstance() }
 
-        it("complexitySection") {
-            ConfigAssert(
-                config,
-                "complexity",
-                "io.gitlab.arturbosch.detekt.rules.complexity"
-            ).assert()
+        ruleSetsNamesToPackage.forEach { (name, packageName) ->
+            it("$name section") {
+                ConfigAssert(config, name, packageName).assert()
+            }
         }
 
-        it("coroutinesSection") {
-            ConfigAssert(
-                config,
-                "coroutines",
-                "io.gitlab.arturbosch.detekt.rules.coroutines"
-            ).assert()
+        it("is backed by a yaml file") {
+            assertThat(config).isInstanceOf(YamlConfig::class.java)
         }
 
-        it("documentationSection") {
-            ConfigAssert(
-                config,
-                "comments",
-                "io.gitlab.arturbosch.detekt.rules.documentation"
-            ).assert()
+        it("contains all general config keys") {
+            val yamlConfig = config as YamlConfig
+
+            val topLevelConfigKeys = yamlConfig.properties.keys
+
+            assertThat(topLevelConfigKeys).containsAll(generalConfigKeys)
         }
 
-        it("emptyBlocksSection") {
-            ConfigAssert(
-                config,
-                "empty-blocks",
-                "io.gitlab.arturbosch.detekt.rules.empty"
-            ).assert()
-        }
+        it("is completely checked") {
+            val yamlConfig = config as YamlConfig
+            val checkedRuleSetNames = ruleSetsNamesToPackage.map { it.first }
 
-        it("exceptionsSection") {
-            ConfigAssert(
-                config,
-                "exceptions",
-                "io.gitlab.arturbosch.detekt.rules.exceptions"
-            ).assert()
-        }
+            val topLevelConfigKeys = yamlConfig.properties.keys
 
-        it("namingSection") {
-            ConfigAssert(
-                config,
-                "naming",
-                "io.gitlab.arturbosch.detekt.rules.naming"
-            ).assert()
-        }
-
-        it("performanceSection") {
-            ConfigAssert(
-                config,
-                "performance",
-                "io.gitlab.arturbosch.detekt.rules.performance"
-            ).assert()
-        }
-
-        it("potentialBugsSection") {
-            ConfigAssert(
-                config,
-                "potential-bugs",
-                "io.gitlab.arturbosch.detekt.rules.bugs"
-            ).assert()
-        }
-
-        it("styleSection") {
-            ConfigAssert(
-                config,
-                "style",
-                "io.gitlab.arturbosch.detekt.rules.style"
-            ).assert()
+            assertThat(topLevelConfigKeys - generalConfigKeys)
+                .containsExactlyInAnyOrderElementsOf(checkedRuleSetNames)
         }
     }
 })
+
+private val ruleSetsNamesToPackage: List<Pair<String, String>> = listOf(
+    "complexity" to "io.gitlab.arturbosch.detekt.rules.complexity",
+    "coroutines" to "io.gitlab.arturbosch.detekt.rules.coroutines",
+    "comments" to "io.gitlab.arturbosch.detekt.rules.documentation",
+    "empty-blocks" to "io.gitlab.arturbosch.detekt.rules.empty",
+    "exceptions" to "io.gitlab.arturbosch.detekt.rules.exceptions",
+    "formatting" to "io.gitlab.arturbosch.detekt.formatting",
+    "naming" to "io.gitlab.arturbosch.detekt.rules.naming",
+    "performance" to "io.gitlab.arturbosch.detekt.rules.performance",
+    "potential-bugs" to "io.gitlab.arturbosch.detekt.rules.bugs",
+    "style" to "io.gitlab.arturbosch.detekt.rules.style",
+)
+
+private val generalConfigKeys = listOf(
+    "build",
+    "config",
+    "processors",
+    "console-reports",
+    "output-reports"
+)

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/DetektYmlConfigSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/DetektYmlConfigSpec.kt
@@ -18,6 +18,14 @@ class DetektYmlConfigSpec : Spek({
             ).assert()
         }
 
+        it("coroutinesSection") {
+            ConfigAssert(
+                config,
+                "coroutines",
+                "io.gitlab.arturbosch.detekt.rules.coroutines"
+            ).assert()
+        }
+
         it("documentationSection") {
             ConfigAssert(
                 config,
@@ -39,6 +47,14 @@ class DetektYmlConfigSpec : Spek({
                 config,
                 "exceptions",
                 "io.gitlab.arturbosch.detekt.rules.exceptions"
+            ).assert()
+        }
+
+        it("namingSection") {
+            ConfigAssert(
+                config,
+                "naming",
+                "io.gitlab.arturbosch.detekt.rules.naming"
             ).assert()
         }
 


### PR DESCRIPTION
This is part of the #3670 cleanup. 

- removes checks that are no longer necessary after switching to annotations
- add missing rule sets to checks
- add dependency to formatting rules to be able to check those
- test rule configs more generically

