### PR TITLE
Android: add javac intermediates to classpath

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektAndroid.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektAndroid.kt
@@ -134,9 +134,7 @@ internal class DetektAndroid(private val project: Project) {
             classpath.apply {
                 setFrom(variant.getCompileClasspath(null).filter { it.exists() })
                 from(bootClasspath)
-                from(intermediatesJavaCJar.map { task ->
-                    task.destinationDirectory.asFileTree.matching { it.include("*.jar") }
-                })
+                from(intermediatesJavaCJar.map { it.destinationDirectory.asFileTree })
             }
             dependsOn(intermediatesJavaCJar)
             // If a baseline file is configured as input file, it must exist to be configured, otherwise the task fails.
@@ -163,9 +161,7 @@ internal class DetektAndroid(private val project: Project) {
             classpath.apply {
                 setFrom(variant.getCompileClasspath(null).filter { it.exists() })
                 from(bootClasspath)
-                from(intermediatesJavaCJar.map { task ->
-                    task.destinationDirectory.asFileTree.matching { it.include("*.jar") }
-                })
+                from(intermediatesJavaCJar.map { it.destinationDirectory.asFileTree })
             }
             dependsOn(intermediatesJavaCJar)
             val variantBaselineFile = extension.baseline?.addVariantName(variant.name)


### PR DESCRIPTION
This adds the classes from `build/intermediates/javac` to the classpath used to compile the code, in order for the compiler to be able to resolve references to Java code (included that which is generated). This resolves issues such as #3488 among probably others.

A test is included which enables `viewBinding` on a sample project and verifies that the Detekt invocation doesn't produce any errors about unresolved references to the generated classes.

Downside: invoking Detekt (with type resolution) now depends on the full assembly of the variant. Before (I think?) this was not a requirement. This is a bit of a trade-off, although in practice I don't think it makes too much of a difference considering the "expensive" type resolution tasks are typically run on CI (we configure Detekt in this way already in a fairly large codebase and haven't found it to be especially burdensome). It would be possible to make this an opt-in option if needed though. 🙃