### PR TITLE
verify that no rule is configured with kdoc tags

### DIFF
--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/KDocTags.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/KDocTags.kt
@@ -15,6 +15,8 @@ fun KtClassOrObject.kDocSection(): KDocSection? = docComment?.getDefaultSection(
 
 fun KtClassOrObject.hasKDocTag(tagName: String) = kDocSection()?.findTagByName(tagName) != null
 
+fun KtClassOrObject.hasConfigurationKDocTag() = hasKDocTag(TAG_CONFIGURATION)
+
 private fun KDocTag.parseConfigTag(): Configuration {
     val content: String = getContent()
     val delimiterIndex = content.indexOf('-')

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleVisitor.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleVisitor.kt
@@ -83,7 +83,7 @@ internal class RuleVisitor : DetektVisitor() {
             return
         }
 
-        name = classOrObject.name?.trim() ?: error("Unable to determine rule name.")
+        name = checkNotNull(classOrObject.name?.trim()) { "Unable to determine rule name." }
 
         // Use unparsed KDoc text here to check for tabs
         // Parsed [KDocSection] element contains no tabs

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleVisitor.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleVisitor.kt
@@ -34,7 +34,6 @@ internal class RuleVisitor : DetektVisitor() {
     private var debt = ""
     private var aliases: String? = null
     private var parent = ""
-    private var configurationByKdoc = emptyList<Configuration>()
     private val configurationCollector = ConfigurationCollector()
     private val classesMap = mutableMapOf<String, Boolean>()
 
@@ -44,11 +43,6 @@ internal class RuleVisitor : DetektVisitor() {
         }
 
         val configurationByAnnotation = configurationCollector.getConfiguration()
-        if (configurationByAnnotation.isNotEmpty() && configurationByKdoc.isNotEmpty()) {
-            throw InvalidDocumentationException(
-                "Rule $name is using both annotations and kdoc to define configuration parameter."
-            )
-        }
 
         return Rule(
             name = name,
@@ -60,7 +54,7 @@ internal class RuleVisitor : DetektVisitor() {
             debt = debt,
             aliases = aliases,
             parent = parent,
-            configuration = configurationByAnnotation + configurationByKdoc,
+            configuration = configurationByAnnotation,
             autoCorrect = autoCorrect,
             requiresTypeResolution = requiresTypeResolution
         )
@@ -89,12 +83,19 @@ internal class RuleVisitor : DetektVisitor() {
             return
         }
 
-        name = classOrObject.name?.trim() ?: ""
+        name = classOrObject.name?.trim() ?: error("Unable to determine rule name.")
 
         // Use unparsed KDoc text here to check for tabs
         // Parsed [KDocSection] element contains no tabs
         if (classOrObject.docComment?.text?.contains('\t') == true) {
             throw InvalidDocumentationException("KDoc for rule $name must not contain tabs")
+        }
+
+        if (classOrObject.hasConfigurationKDocTag()) {
+            throw InvalidDocumentationException(
+                "Configuration of rule $name is invalid. Rule configuration via KDoc tag is no longer supported. " +
+                    "Use config delegate instead."
+            )
         }
 
         if (classOrObject.isAnnotatedWith(ActiveByDefault::class)) {
@@ -104,7 +105,6 @@ internal class RuleVisitor : DetektVisitor() {
 
         autoCorrect = classOrObject.isAnnotatedWith(AutoCorrectable::class)
         requiresTypeResolution = classOrObject.isAnnotatedWith(RequiresTypeResolution::class)
-        configurationByKdoc = classOrObject.parseConfigurationTags()
 
         documentationCollector.setClass(classOrObject)
     }

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleCollectorSpec.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleCollectorSpec.kt
@@ -415,15 +415,13 @@ object RuleCollectorSpec : Spek({
                     assertThat(items[0].configuration[0].deprecated).isEqualTo("use config1 instead")
                 }
 
-                it("fails if annotation and kdoc are used both to define configuration") {
+                it("fails if kdoc is used to define configuration") {
                     val code = """
                         /**
                          * description
                          * @configuration config1 - description (default: `''`)
                          */
                         class SomeRandomClass() : Rule {
-                            @Configuration("description")
-                            private val config: String by config("")
                         }                        
                     """
                     assertThatExceptionOfType(InvalidDocumentationException::class.java).isThrownBy { subject.run(code) }
@@ -652,90 +650,6 @@ object RuleCollectorSpec : Spek({
                             )
                         }
                     }
-                }
-            }
-
-            context("as part of kdoc") {
-                it("contains no configuration options by default") {
-                    val code = """
-                        /**
-                         * description
-                         */
-                        class SomeRandomClass : Rule
-                    """
-                    val items = subject.run(code)
-                    assertThat(items[0].configuration).isEmpty()
-                }
-
-                it("contains one configuration option with correct formatting") {
-                    val code = """
-                        /**
-                         * description
-                         * @configuration config - description (default: `'[A-Z$]'`)
-                         */
-                        class SomeRandomClass : Rule
-                    """
-                    val items = subject.run(code)
-                    assertThat(items[0].configuration).hasSize(1)
-                    assertThat(items[0].configuration[0].name).isEqualTo("config")
-                    assertThat(items[0].configuration[0].description).isEqualTo("description")
-                    assertThat(items[0].configuration[0].defaultValue).isEqualTo("'[A-Z$]'")
-                }
-
-                it("contains multiple configuration options") {
-                    val code = """
-                        /**
-                         * description
-                         * @configuration config - description (default: `''`)
-                         * @configuration config2 - description2 (default: `''`)
-                         */
-                        class SomeRandomClass: Rule
-                    """
-                    val items = subject.run(code)
-                    assertThat(items[0].configuration).hasSize(2)
-                }
-                it("config option doesn't have a default value") {
-                    val code = """
-                        /**
-                         * description
-                         * @configuration config - description
-                         */
-                        class SomeRandomClass : Rule
-                    """
-                    assertThatExceptionOfType(InvalidDocumentationException::class.java).isThrownBy { subject.run(code) }
-                }
-
-                it("has a blank default value") {
-                    val code = """
-                        /**
-                         * description
-                         * @configuration config - description (default: ``)
-                         */
-                        class SomeRandomClass : Rule
-                    """
-                    assertThatExceptionOfType(InvalidDocumentationException::class.java).isThrownBy { subject.run(code) }
-                }
-
-                it("has an incorrectly delimited default value") {
-                    val code = """
-                        /**
-                         * description
-                         * @configuration config - description (default: true)
-                         */
-                        class SomeRandomClass : Rule
-                    """
-                    assertThatExceptionOfType(InvalidDocumentationException::class.java).isThrownBy { subject.run(code) }
-                }
-
-                it("contains a misconfigured configuration option") {
-                    val code = """
-                        /**
-                         * description
-                         * @configuration something: description
-                         */
-                        class SomeRandomClass : Rule
-                    """
-                    assertThatExceptionOfType(InvalidDocumentationException::class.java).isThrownBy { subject.run(code) }
                 }
             }
         }


### PR DESCRIPTION
Part of the #3670 clean up. This adds verification that no rule contains a `@configuraiton` kdoc element.
