### PR TITLE
Remove inline value class to stay compatible with Kotlin 1.4 API

### DIFF
--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ClassOrdering.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ClassOrdering.kt
@@ -105,9 +105,8 @@ private fun KtDeclaration.toSection(): Section? = when {
     else -> null // For declarations not relevant for ordering, such as nested classes.
 }
 
-@JvmInline
 @Suppress("MagicNumber")
-private value class Section(val priority: Int) : Comparable<Section> {
+private class Section(val priority: Int) : Comparable<Section> {
 
     init {
         require(priority in 0..3)


### PR DESCRIPTION
https://github.com/detekt/detekt/commit/96511d1afe4c21e690c843679c0c961bb6d15df0 was causing CI to fail on trunk, as the `@JvmInline` value class is an API in Kotlin 1.5 and we just set the API version to be Kotlin 1.4.