### PR TITLE
Improve LongParameterList rule by supporting ignoring annotated parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ If you contributed to detekt but your name is not in the list, please feel free 
 - [Vinicius Montes Munhoz](https://github.com/vfmunhoz) - Documentation improvement
 - [Eliezer Graber](https://github.com/eygraber) - Rule fix: ModifierOrder
 - [Dominik Labuda](https://github.com/Dominick1993) - Gradle plugin improvement
+- [Andre Paz](https://github.com/andrepaz) - Rule improvement: LongParameterList
 
 ### Mentions
 

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterList.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterList.kt
@@ -63,9 +63,10 @@ class LongParameterList(config: Config = Config.empty) : Rule(config) {
     private val ignoreDataClasses: Boolean by config(defaultValue = true)
 
     @Configuration(
-        "ignore long parameters list for constructors or functions in the " +
-            "context of these annotation class names; (e.g. ['Inject', 'Module', 'Suppress']); " +
-            "the most common case is for dependency injection where constructors are annotated with `@Inject`."
+        "ignore long parameters list for constructors, functions or their parameters in the " +
+            "context of these annotation class names; (e.g. ['Inject', 'Module', 'Suppress', 'Value']); " +
+            "the most common cases are for dependency injection where constructors are annotated with `@Inject` " +
+            "or parameters are annotated with `@Value` and should not be counted for the rule to trigger"
     )
     private val ignoreAnnotated: List<String> by config(listOf<String>()) { list ->
         list.map { it.removePrefix("*").removeSuffix("*") }

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterList.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterList.kt
@@ -131,10 +131,11 @@ class LongParameterList(config: Config = Config.empty) : Rule(config) {
     }
 
     private fun KtParameterList.parameterCount(): Int {
+        val preFilteredParameters = parameters.filter { !it.isIgnored() }
         return if (ignoreDefaultParameters) {
-            parameters.filter { !it.hasDefaultValue() }.size
+            preFilteredParameters.filter { !it.hasDefaultValue() }.size
         } else {
-            parameters.size
+            preFilteredParameters.size
         }
     }
 

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterListSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterListSpec.kt
@@ -102,7 +102,8 @@ class LongParameterListSpec : Spek({
                         "ignoreAnnotated" to listOf(
                             "Generated",
                             "kotlin.Deprecated",
-                            "kotlin.jvm.JvmName"
+                            "kotlin.jvm.JvmName",
+                            "kotlin.Suppress"
                         ),
                         "functionThreshold" to 1,
                         "constructorThreshold" to 1
@@ -160,14 +161,34 @@ class LongParameterListSpec : Spek({
                 assertThat(rule.compileAndLint(code)).isEmpty()
             }
 
+            it("reports long parameter list for constructors if constructor parameters are annotated with annotation that is not ignored") {
+                val code = """
+                    @Target(AnnotationTarget.VALUE_PARAMETER)
+                    annotation class CustomAnnotation
+
+                    class Data constructor(@CustomAnnotation val a: Int)
+                """
+                assertThat(rule.compileAndLint(code)).hasSize(1)
+            }
+
+            it("reports long parameter list for functions if enough function parameters are annotated with annotation that is not ignored") {
+                val code = """
+                    @Target(AnnotationTarget.VALUE_PARAMETER)
+                    annotation class CustomAnnotation
+
+                    class Data { fun foo(@CustomAnnotation a: Int) {} }
+                """
+                assertThat(rule.compileAndLint(code)).hasSize(1)
+            }
+
             it("does not report long parameter list for constructors if enough constructor parameters are annotated with ignored annotation") {
-                val code = "class Data constructor(@kotlin.Deprecated(message = \"\") val a: Int)"
+                val code = "class Data constructor(@kotlin.Suppress(\"\") val a: Int)"
                 assertThat(rule.compileAndLint(code)).isEmpty()
             }
 
             it("does not report long parameter list for functions if enough function parameters are annotated with ignored annotation") {
                 val code = """class Data {
-                    fun foo(@kotlin.Deprecated(message = "") a: Int) {} }
+                    fun foo(@kotlin.Suppress("") a: Int) {} }
                 """
                 assertThat(rule.compileAndLint(code)).isEmpty()
             }

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterListSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterListSpec.kt
@@ -159,6 +159,18 @@ class LongParameterListSpec : Spek({
                 """
                 assertThat(rule.compileAndLint(code)).isEmpty()
             }
+
+            it("does not report long parameter list for constructors if enough constructor parameters are annotated with ignored annotation") {
+                val code = "class Data constructor(@kotlin.Deprecated(message = \"\") val a: Int)"
+                assertThat(rule.compileAndLint(code)).isEmpty()
+            }
+
+            it("does not report long parameter list for functions if enough function parameters are annotated with ignored annotation") {
+                val code = """class Data {
+                    fun foo(@kotlin.Deprecated(message = "") a: Int) {} }
+                """
+                assertThat(rule.compileAndLint(code)).isEmpty()
+            }
         }
     }
 })


### PR DESCRIPTION
Add support for ignoring annotated parameters in constructors and functions in addition to the other forms of ignoring already supported by the LongParameterList rule.

It should be useful for annotations such as Spring's @Value that mark something that usually doesn't actually add a dependency, just a custom form of configuration (similar to what a parameter with a default value would do) for a function or class and as such might not violate the Single Responsibility Principle as stated by the rule's own documentation of its motivation.

Users should be able to decide if annotated parameters should count or not, just as they can choose or not to ignore parameters with a default value.