### PR TITLE
VarCouldBeVal: don't report assigned property that is defined in anonymous object

### DIFF
--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/VarCouldBeVal.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/VarCouldBeVal.kt
@@ -9,16 +9,18 @@ import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
-import org.jetbrains.kotlin.com.intellij.psi.PsiElement
+import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtBinaryExpression
-import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
+import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.psi.KtNamedDeclaration
 import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.KtProperty
-import org.jetbrains.kotlin.psi.KtThisExpression
+import org.jetbrains.kotlin.psi.KtQualifiedExpression
 import org.jetbrains.kotlin.psi.KtUnaryExpression
 import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
+import org.jetbrains.kotlin.resolve.BindingContext
+import org.jetbrains.kotlin.resolve.calls.callUtil.getResolvedCall
 
 private val unaryAssignmentOperators = setOf(KtTokens.MINUSMINUS, KtTokens.PLUSPLUS)
 
@@ -41,6 +43,7 @@ private val unaryAssignmentOperators = setOf(KtTokens.MINUSMINUS, KtTokens.PLUSP
  * </compliant>
  */
 @ActiveByDefault(since = "1.16.0")
+@RequiresTypeResolution
 class VarCouldBeVal(config: Config = Config.empty) : Rule(config) {
 
     override val defaultRuleIdAliases: Set<String> = setOf("CanBeVal")
@@ -53,11 +56,11 @@ class VarCouldBeVal(config: Config = Config.empty) : Rule(config) {
     )
 
     override fun visitNamedFunction(function: KtNamedFunction) {
-        if (function.isSomehowNested()) {
+        if (bindingContext == BindingContext.EMPTY || function.isSomehowNested()) {
             return
         }
 
-        val assignmentVisitor = AssignmentVisitor()
+        val assignmentVisitor = AssignmentVisitor(bindingContext)
         function.accept(assignmentVisitor)
 
         assignmentVisitor.getNonReAssignedDeclarations().forEach {
@@ -69,71 +72,54 @@ class VarCouldBeVal(config: Config = Config.empty) : Rule(config) {
     private fun KtNamedFunction.isSomehowNested() =
         getStrictParentOfType<KtNamedFunction>() != null
 
-    private class AssignmentVisitor : DetektVisitor() {
+    private class AssignmentVisitor(private val bindingContext: BindingContext) : DetektVisitor() {
 
         private val declarations = mutableSetOf<KtNamedDeclaration>()
-
-        // an easy way to find declarations when walking up the contexts of an assignment
-        private val contextsByDeclarationName = mutableMapOf<String, MutableSet<PsiElement>>()
-        private val assignments = mutableMapOf<String, MutableSet<PsiElement>>()
+        private val assignments = mutableMapOf<String, MutableSet<KtExpression>>()
 
         fun getNonReAssignedDeclarations(): List<KtNamedDeclaration> {
-            return declarations.filter { declaration ->
-                assignments[declaration.nameAsSafeName.identifier]
-                    ?.let { declaration.parent !in it }
-                    ?: true
+            return declarations.filterNot { it.hasAssignments() }
+        }
+
+        private fun KtNamedDeclaration.hasAssignments(): Boolean {
+            val declarationName = nameAsSafeName.toString()
+            val assignments = assignments[declarationName]
+            if (assignments.isNullOrEmpty()) return false
+            val declarationDescriptor = bindingContext[BindingContext.DECLARATION_TO_DESCRIPTOR, this]
+            return assignments.any {
+                it.getResolvedCall(bindingContext)?.resultingDescriptor == declarationDescriptor
             }
         }
 
         override fun visitProperty(property: KtProperty) {
             if (property.isVar) {
                 declarations.add(property)
-                val identifier = property.nameAsSafeName.identifier
-                val contextsForName = contextsByDeclarationName.getOrPut(identifier) { mutableSetOf() }
-                contextsForName.add(property.parent)
             }
             super.visitProperty(property)
         }
 
         override fun visitUnaryExpression(expression: KtUnaryExpression) {
             if (expression.operationToken in unaryAssignmentOperators) {
-                expression.baseExpression?.run {
-                    visitAssignment(text, expression.parent)
-                }
+                visitAssignment(expression.baseExpression)
             }
             super.visitUnaryExpression(expression)
         }
 
         override fun visitBinaryExpression(expression: KtBinaryExpression) {
             if (expression.operationToken in KtTokens.ALL_ASSIGNMENTS) {
-                val assignedName = extractAssignedName(expression)
-                if (assignedName != null) {
-                    visitAssignment(assignedName, expression.parent)
-                }
+                visitAssignment(expression.left)
             }
             super.visitBinaryExpression(expression)
         }
 
-        private fun extractAssignedName(expression: KtBinaryExpression): String? {
-            val leftSide = expression.left
-            if (leftSide is KtDotQualifiedExpression &&
-                leftSide.receiverExpression is KtThisExpression
-            ) {
-                return leftSide.selectorExpression?.text
-            }
-            return leftSide?.text
-        }
-
-        private fun visitAssignment(assignedName: String, context: PsiElement) {
-            val potentialContexts = contextsByDeclarationName[assignedName]
-            if (potentialContexts != null) {
-                val actualContextChain = generateSequence(context) { it.parent }
-                val actualContext = actualContextChain.firstOrNull { it in potentialContexts }
-                if (actualContext != null) {
-                    val nameAssignments = assignments.getOrPut(assignedName) { mutableSetOf() }
-                    nameAssignments.add(actualContext)
-                }
-            }
+        private fun visitAssignment(assignedExpression: KtExpression?) {
+            if (assignedExpression == null) return
+            val name = if (assignedExpression is KtQualifiedExpression) {
+                assignedExpression.selectorExpression
+            } else {
+                assignedExpression
+            }?.text ?: return
+            assignments.getOrPut(name) { mutableSetOf() }.add(assignedExpression)
         }
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/VarCouldBeValSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/VarCouldBeValSpec.kt
@@ -85,7 +85,7 @@ class VarCouldBeValSpec : Spek({
             val code = """
             fun test() {
                 var a = 1
-                something(a)
+                println(a)
             }
             """
             val findings = subject.compileAndLintWithContext(env, code)

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/VarCouldBeValSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/VarCouldBeValSpec.kt
@@ -178,5 +178,22 @@ class VarCouldBeValSpec : Spek({
             """
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
+
+        it("should not report assigned properties that have accessors") {
+            val code = """
+                interface I {
+                    var optionEnabled: Boolean
+                }
+                fun test(i: Int) {
+                    val o = object: I {
+                        override var optionEnabled: Boolean = false
+                            get() = i == 1
+                            set(value) { field = i != 1 && value }
+                    }
+                    o.optionEnabled = false
+                }
+           """
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        }
     }
 })


### PR DESCRIPTION
Fixes #3805