### PR TITLE
Check bindingContext only once

### DIFF
--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MemberNameEqualsClassName.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MemberNameEqualsClassName.kt
@@ -12,12 +12,10 @@ import io.gitlab.arturbosch.detekt.api.internal.Configuration
 import io.gitlab.arturbosch.detekt.api.internal.config
 import io.gitlab.arturbosch.detekt.api.internal.configWithFallback
 import io.gitlab.arturbosch.detekt.rules.isOverride
-import org.jetbrains.kotlin.descriptors.DeclarationDescriptor
 import org.jetbrains.kotlin.descriptors.FunctionDescriptor
 import org.jetbrains.kotlin.psi.KtBlockExpression
 import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtClassOrObject
-import org.jetbrains.kotlin.psi.KtDeclaration
 import org.jetbrains.kotlin.psi.KtNamedDeclaration
 import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.KtObjectDeclaration
@@ -115,8 +113,8 @@ class MemberNameEqualsClassName(config: Config = Config.empty) : Rule(config) {
                 refName == klass.name
             }
             function.bodyExpression !is KtBlockExpression && bindingContext != BindingContext.EMPTY -> {
-                val functionDescriptor = bindingContext[BindingContext.DECLARATION_TO_DESCRIPTOR, function]
-                        as? FunctionDescriptor
+                val functionDescriptor =
+                    bindingContext[BindingContext.DECLARATION_TO_DESCRIPTOR, function] as? FunctionDescriptor
                 val classDescriptor = bindingContext[BindingContext.DECLARATION_TO_DESCRIPTOR, klass]
                 functionDescriptor?.returnType?.constructor?.declarationDescriptor == classDescriptor
             }

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MemberNameEqualsClassName.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MemberNameEqualsClassName.kt
@@ -114,19 +114,13 @@ class MemberNameEqualsClassName(config: Config = Config.empty) : Rule(config) {
                 val refName = (typeReference.typeElement as? KtUserType)?.referencedName ?: typeReference.text
                 refName == klass.name
             }
-            function.bodyExpression !is KtBlockExpression -> {
-                val functionDescriptor = function.descriptor() as? FunctionDescriptor
-                functionDescriptor?.returnType?.constructor?.declarationDescriptor == klass.descriptor()
+            function.bodyExpression !is KtBlockExpression && bindingContext != BindingContext.EMPTY -> {
+                val functionDescriptor = bindingContext[BindingContext.DECLARATION_TO_DESCRIPTOR, function]
+                        as? FunctionDescriptor
+                val classDescriptor = bindingContext[BindingContext.DECLARATION_TO_DESCRIPTOR, klass]
+                functionDescriptor?.returnType?.constructor?.declarationDescriptor == classDescriptor
             }
             else -> false
-        }
-    }
-
-    private fun KtDeclaration.descriptor(): DeclarationDescriptor? {
-        return if (bindingContext == BindingContext.EMPTY) {
-            null
-        } else {
-            bindingContext[BindingContext.DECLARATION_TO_DESCRIPTOR, this]
         }
     }
 }


### PR DESCRIPTION
This change simplifies the MemberNameEqualsClassName rule.
For a class/function pair the bindingContext check happens once.