### PR TITLE
Fix #3893 by only calling super.visit once

### DIFF
--- a/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/DeprecatedBlockTag.kt
+++ b/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/DeprecatedBlockTag.kt
@@ -49,10 +49,6 @@ class DeprecatedBlockTag(config: Config = Config.empty) : Rule(config) {
 
     override fun visitDeclaration(dcl: KtDeclaration) {
         super.visitDeclaration(dcl)
-        verify(dcl)
-    }
-
-    fun verify(dcl: KtDeclaration) {
         dcl.docComment?.getAllSections()?.forEach { section ->
             section.findTagsByName("deprecated").forEach { tag ->
                 report(

--- a/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/EndOfSentenceFormat.kt
+++ b/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/EndOfSentenceFormat.kt
@@ -33,11 +33,7 @@ class EndOfSentenceFormat(config: Config = Config.empty) : Rule(config) {
 
     override fun visitDeclaration(dcl: KtDeclaration) {
         super.visitDeclaration(dcl)
-        verify(dcl)
-    }
-
-    fun verify(declaration: KtDeclaration) {
-        declaration.docComment?.let {
+        dcl.docComment?.let {
             val text = it.getDefaultSection().getContent()
             if (text.isEmpty() || text.startsWithHtmlTag()) {
                 return
@@ -46,7 +42,7 @@ class EndOfSentenceFormat(config: Config = Config.empty) : Rule(config) {
                 report(
                     CodeSmell(
                         issue,
-                        Entity.from(declaration),
+                        Entity.from(dcl),
                         "The first sentence of this KDoc does not end with the correct punctuation."
                     )
                 )

--- a/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/KDocStyle.kt
+++ b/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/KDocStyle.kt
@@ -15,8 +15,7 @@ class KDocStyle(config: Config = Config.empty) : MultiRule() {
     )
 
     override fun visitDeclaration(dcl: KtDeclaration) {
-        super.visitDeclaration(dcl)
-        deprecatedBlockTag.verify(dcl)
-        endOfSentenceFormat.verify(dcl)
+        deprecatedBlockTag.visitDeclaration(dcl)
+        endOfSentenceFormat.visitDeclaration(dcl)
     }
 }

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/EndOfSentenceFormatSpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/EndOfSentenceFormatSpec.kt
@@ -21,9 +21,9 @@ class EndOfSentenceFormatSpec : Spek({
 
         it("reports invalid KDoc endings on objects") {
             val code = """
-            /** Some doc */
-            object Test {
-            }
+                /** Some doc */
+                fun f(x: Int, y: Int, z: Int) = 
+                    if (x == 0) y + z else x + y
             """
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/EndOfSentenceFormatSpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/EndOfSentenceFormatSpec.kt
@@ -19,7 +19,7 @@ class EndOfSentenceFormatSpec : Spek({
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
-        it("reports invalid KDoc endings on objects") {
+        it("reports invalid KDoc endings on function with expression body") {
             val code = """
                 /** Some doc */
                 fun f(x: Int, y: Int, z: Int) = 

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/KDocStyleSpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/KDocStyleSpec.kt
@@ -1,0 +1,22 @@
+package io.gitlab.arturbosch.detekt.rules.documentation
+
+import io.gitlab.arturbosch.detekt.test.compileAndLint
+import org.assertj.core.api.Assertions.assertThat
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+class KDocStyleSpec : Spek({
+    val subject by memoized { KDocStyle() }
+
+    describe("check referenced multi rule to only lint errors once per case") {
+
+        it("does only lint once") {
+            val code = """
+            /** Some doc */
+            class Test {
+            }
+            """
+            assertThat(subject.compileAndLint(code)).hasSize(1)
+        }
+    }
+})


### PR DESCRIPTION
In #3660 the EndOfSentenceFormat rule got refactored.
The rule is called by the MultiRule 'KDocStyle'.
Both the called and calling visitor function execute a super.visit().
This can cause problems.
Hence, super.visit only called once with the changes made.

Suspicion:
Multiple KtDeclaration super.visit calls cause the crash in #3893.

