### PR TITLE
Allow else when {...} in MandatoryBracesIfStatements rule

### DIFF
--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/MandatoryBracesIfStatements.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/MandatoryBracesIfStatements.kt
@@ -10,6 +10,8 @@ import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.psi.KtBlockExpression
 import org.jetbrains.kotlin.psi.KtIfExpression
+import org.jetbrains.kotlin.psi.KtWhenCondition
+import org.jetbrains.kotlin.psi.KtWhenExpression
 import org.jetbrains.kotlin.psi.psiUtil.siblings
 
 private const val DESCRIPTION = "Multi-line if statement was found that does not have braces. " +
@@ -56,5 +58,6 @@ class MandatoryBracesIfStatements(config: Config = Config.empty) : Rule(config) 
     private fun KtIfExpression.isNotBlockOrIfExpression(): Boolean =
         this.`else` != null &&
             this.`else` !is KtIfExpression &&
-            this.`else` !is KtBlockExpression
+            this.`else` !is KtBlockExpression &&
+            this.`else` !is KtWhenExpression
 }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/MandatoryBracesIfStatements.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/MandatoryBracesIfStatements.kt
@@ -10,7 +10,6 @@ import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.psi.KtBlockExpression
 import org.jetbrains.kotlin.psi.KtIfExpression
-import org.jetbrains.kotlin.psi.KtWhenCondition
 import org.jetbrains.kotlin.psi.KtWhenExpression
 import org.jetbrains.kotlin.psi.psiUtil.siblings
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/MandatoryBracesIfStatementsSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/MandatoryBracesIfStatementsSpec.kt
@@ -180,4 +180,21 @@ class MandatoryBracesIfStatementsSpec : Spek({
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
     }
+
+    describe("multi-line when following an else statement without requiring braces") {
+
+        it("does not report multi-line when") {
+            val code = """
+                fun f(i: Int) {
+                	if (true) {
+                        println()
+                    } else when(i) {
+                        1 -> println(1)
+                        else -> println()
+                    }
+                }
+            """
+            assertThat(subject.compileAndLint(code)).isEmpty()
+        }
+    }
 })


### PR DESCRIPTION
This allows multi-line when statements following an else without requiring braces.

Fixes #3708