### PR TITLE
Fix exclusion pattern for InvalidPackageDeclaration

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -406,7 +406,7 @@ naming:
     ignoreOverridden: true
   InvalidPackageDeclaration:
     active: false
-    excludes: ['*.kts']
+    excludes: ['**/*.kts']
     rootPackage: ''
   MatchingDeclarationName:
     active: true

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/rulesetpage/Exclusion.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/rulesetpage/Exclusion.kt
@@ -46,7 +46,7 @@ private object TestExclusions : Exclusions() {
 
 private object KotlinScriptExclusions : Exclusions() {
 
-    override val pattern = "['*.kts']"
+    override val pattern = "['**/*.kts']"
     override val rules = setOf("InvalidPackageDeclaration")
 }
 


### PR DESCRIPTION
Related to #3900
The exclusion pattern for `InvalidPackageDeclaration` is wrong and should be fixed to `'**/*.kts'`