### PR TITLE
Avoid empty lines when running detekt with type resolution

### DIFF
--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/BindingContext.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/BindingContext.kt
@@ -23,7 +23,7 @@ internal fun generateBindingContext(
     }
 
     val analyzer = AnalyzerWithCompilerReport(
-        PrintingMessageCollector(System.err, DetektMessageRenderer, true),
+        DetektMessageCollector(CompilerMessageSeverity.ERROR),
         environment.configuration.languageVersionSettings
     )
     analyzer.analyzeAndReport(files) {
@@ -39,15 +39,16 @@ internal fun generateBindingContext(
     return analyzer.analysisResult.bindingContext
 }
 
+private class DetektMessageCollector(val minSeverity: CompilerMessageSeverity) :
+    PrintingMessageCollector(System.err, DetektMessageRenderer, false) {
+    override fun report(severity: CompilerMessageSeverity, message: String, location: CompilerMessageSourceLocation?) {
+        if (severity.ordinal <= minSeverity.ordinal) {
+            super.report(severity, message, location)
+        }
+    }
+}
+
 private object DetektMessageRenderer : PlainTextMessageRenderer() {
     override fun getName() = "detekt message renderer"
     override fun getPath(location: CompilerMessageSourceLocation) = location.path
-    override fun render(
-        severity: CompilerMessageSeverity,
-        message: String,
-        location: CompilerMessageSourceLocation?,
-    ): String {
-        if (!severity.isError) return ""
-        return super.render(severity, message, location)
-    }
 }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/BindingContext.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/BindingContext.kt
@@ -12,6 +12,7 @@ import org.jetbrains.kotlin.config.languageVersionSettings
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.lazy.declarations.FileBasedDeclarationProviderFactory
+import java.io.PrintStream
 
 internal fun generateBindingContext(
     environment: KotlinCoreEnvironment,
@@ -23,7 +24,7 @@ internal fun generateBindingContext(
     }
 
     val analyzer = AnalyzerWithCompilerReport(
-        DetektMessageCollector(CompilerMessageSeverity.ERROR),
+        DetektMessageCollector(minSeverity = CompilerMessageSeverity.ERROR),
         environment.configuration.languageVersionSettings
     )
     analyzer.analyzeAndReport(files) {
@@ -39,8 +40,11 @@ internal fun generateBindingContext(
     return analyzer.analysisResult.bindingContext
 }
 
-private class DetektMessageCollector(val minSeverity: CompilerMessageSeverity) :
-    PrintingMessageCollector(System.err, DetektMessageRenderer, false) {
+internal class DetektMessageCollector(
+    errorStream: PrintStream = System.err,
+    verbose: Boolean = false,
+    private val minSeverity: CompilerMessageSeverity = CompilerMessageSeverity.ERROR
+) : PrintingMessageCollector(errorStream, DetektMessageRenderer, verbose) {
     override fun report(severity: CompilerMessageSeverity, message: String, location: CompilerMessageSourceLocation?) {
         if (severity.ordinal <= minSeverity.ordinal) {
             super.report(severity, message, location)

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/DetektMessageCollectorSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/DetektMessageCollectorSpec.kt
@@ -1,0 +1,44 @@
+package io.gitlab.arturbosch.detekt.core
+
+import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import java.io.PrintStream
+
+internal object DetektMessageCollectorSpec : Spek({
+    describe("DetektMessageCollector") {
+        val errorStream by memoized { CollectingPrintStream() }
+        val subject by memoized {
+            DetektMessageCollector(
+                errorStream = errorStream,
+                minSeverity = CompilerMessageSeverity.INFO
+            )
+        }
+
+        describe("message with min severity") {
+            beforeEachTest { subject.report(CompilerMessageSeverity.INFO, "message", null) }
+            it("prints the message") {
+                assertThat(errorStream.messages).containsExactly("info: message")
+            }
+        }
+        describe("message with higher severity than the min severity") {
+            beforeEachTest { subject.report(CompilerMessageSeverity.WARNING, "message", null) }
+            it("prints the message") {
+                assertThat(errorStream.messages).containsExactly("warning: message")
+            }
+        }
+        describe("message with lower severity than the min severity") {
+            beforeEachTest { subject.report(CompilerMessageSeverity.LOGGING, "message", null) }
+            it("ignores the message") {
+                assertThat(errorStream.messages).isEmpty()
+            }
+        }
+    }
+})
+
+private class CollectingPrintStream(val messages: MutableList<String> = mutableListOf()) : PrintStream(System.err) {
+    override fun println(message: String) {
+        messages.add(message)
+    }
+}


### PR DESCRIPTION
This relates to #3684 and solves the issue of empty lines when running detekt with type resolution.
