### PR TITLE
Added `--auto-correct` and `--no-auto-correct` options to `Detekt` task

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -48,6 +48,7 @@ import org.gradle.api.tasks.SkipWhenEmpty
 import org.gradle.api.tasks.SourceTask
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.VerificationTask
+import org.gradle.api.tasks.options.Option
 import org.gradle.language.base.plugins.LifecycleBasePlugin
 import java.io.File
 import javax.inject.Inject
@@ -210,6 +211,16 @@ open class Detekt @Inject constructor(
     override fun setIgnoreFailures(value: Boolean) = ignoreFailuresProp.set(value)
 
     fun reports(configure: Action<DetektReports>) = configure.execute(reports)
+
+    @Option(option = "auto-correct", description = "Enables auto correct")
+    fun autoCorrect() {
+        autoCorrect = true
+    }
+
+    @Option(option = "no-auto-correct", description = "Disables auto correct")
+    fun noAutoCorrect() {
+        autoCorrect = false
+    }
 
     @TaskAction
     fun check() {


### PR DESCRIPTION
Adds Gradle's task option support for fast enabling/disabling `auto correct` feature.

The goal is to have this lightweight switch to avoid extra logic in the build script to support it.

```bash
./gradlew detetkt --auto-correct
```
or
```bash
./gradlew detetkt --no-auto-correct
```

Our use case is to have this command in our CI pipeline.
