### PR TITLE
Fix java.lang.ClassCastException is reading default yaml config

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -92,15 +92,15 @@ complexity:
     ignoreSimpleWhenEntries: false
     ignoreNestingFunctions: false
     nestingFunctions:
-      - run
-      - let
-      - apply
-      - with
-      - also
-      - use
-      - forEach
-      - isNotNull
-      - ifNull
+      - 'run'
+      - 'let'
+      - 'apply'
+      - 'with'
+      - 'also'
+      - 'use'
+      - 'forEach'
+      - 'isNotNull'
+      - 'ifNull'
   LabeledExpression:
     active: false
     ignoredLabels: []
@@ -199,10 +199,10 @@ exceptions:
   ExceptionRaisedInUnexpectedLocation:
     active: true
     methodNames:
-      - toString
-      - hashCode
-      - equals
-      - finalize
+      - 'toString'
+      - 'hashCode'
+      - 'equals'
+      - 'finalize'
   InstanceOfCheckForException:
     active: false
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
@@ -220,10 +220,10 @@ exceptions:
   SwallowedException:
     active: true
     ignoredExceptionTypes:
-      - NumberFormatException
-      - InterruptedException
-      - ParseException
-      - MalformedURLException
+      - 'NumberFormatException'
+      - 'InterruptedException'
+      - 'ParseException'
+      - 'MalformedURLException'
     allowedExceptionNameRegex: '_|(ignore|expected).*'
   ThrowingExceptionFromFinally:
     active: true
@@ -233,36 +233,36 @@ exceptions:
     active: true
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
     exceptions:
-      - ArrayIndexOutOfBoundsException
-      - Error
-      - Exception
-      - IllegalMonitorStateException
-      - NullPointerException
-      - IndexOutOfBoundsException
-      - RuntimeException
-      - Throwable
+      - 'ArrayIndexOutOfBoundsException'
+      - 'Error'
+      - 'Exception'
+      - 'IllegalMonitorStateException'
+      - 'NullPointerException'
+      - 'IndexOutOfBoundsException'
+      - 'RuntimeException'
+      - 'Throwable'
   ThrowingNewInstanceOfSameException:
     active: true
   TooGenericExceptionCaught:
     active: true
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
     exceptionNames:
-      - ArrayIndexOutOfBoundsException
-      - Error
-      - Exception
-      - IllegalMonitorStateException
-      - NullPointerException
-      - IndexOutOfBoundsException
-      - RuntimeException
-      - Throwable
+      - 'ArrayIndexOutOfBoundsException'
+      - 'Error'
+      - 'Exception'
+      - 'IllegalMonitorStateException'
+      - 'NullPointerException'
+      - 'IndexOutOfBoundsException'
+      - 'RuntimeException'
+      - 'Throwable'
     allowedExceptionNameRegex: '_|(ignore|expected).*'
   TooGenericExceptionThrown:
     active: true
     exceptionNames:
-      - Error
-      - Exception
-      - Throwable
-      - RuntimeException
+      - 'Error'
+      - 'Exception'
+      - 'Throwable'
+      - 'RuntimeException'
 
 formatting:
   active: true
@@ -614,8 +614,8 @@ style:
   ForbiddenMethodCall:
     active: false
     methods:
-      - kotlin.io.println
-      - kotlin.io.print
+      - 'kotlin.io.println'
+      - 'kotlin.io.print'
   ForbiddenPublicDataClass:
     active: true
     excludes: ['**']
@@ -632,7 +632,7 @@ style:
     ignoreActualFunction: true
     excludedFunctions: ''
     excludeAnnotatedFunction:
-      - dagger.Provides
+      - 'dagger.Provides'
   LibraryCodeMustSpecifyReturnType:
     active: true
     excludes: ['**']
@@ -646,10 +646,10 @@ style:
     active: true
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
     ignoreNumbers:
-      - -1
-      - 0
-      - 1
-      - 2
+      - '-1'
+      - '0'
+      - '1'
+      - '2'
     ignoreHashCodeFunction: true
     ignorePropertyDeclaration: false
     ignoreLocalVariableDeclaration: false
@@ -725,7 +725,7 @@ style:
   UnnecessaryAbstractClass:
     active: true
     excludeAnnotatedClasses:
-      - dagger.Module
+      - 'dagger.Module'
   UnnecessaryAnnotationUseSiteTarget:
     active: false
   UnnecessaryApply:

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/out/Yaml.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/out/Yaml.kt
@@ -68,7 +68,6 @@ private fun String.quotedForList(): String {
         isBlank() -> quoted()
         startsWith(SINGLE_QUOTE) && endsWith(SINGLE_QUOTE)
             || startsWith(DOUBLE_QUOTE) && endsWith(DOUBLE_QUOTE) -> this
-        matches(NO_QUOTES_REQUIRED) -> this
         else -> quoted()
     }
 }
@@ -78,4 +77,3 @@ private fun String.quoted() = "'$this'"
 private const val SINGLE_INDENT = "  "
 private const val SINGLE_QUOTE = "'"
 private const val DOUBLE_QUOTE = "\""
-private val NO_QUOTES_REQUIRED = Regex("""[.\w\s-]+""")

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/out/YamlSpec.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/out/YamlSpec.kt
@@ -19,7 +19,7 @@ object YamlSpec : Spek({
             val given = listOf("value")
             val result = yaml { list("key", given) }
             val expected = """key:
-                |  - value
+                |  - 'value'
             """.trimMargin()
             assertThat(result).isEqualTo(expected)
         }
@@ -28,8 +28,8 @@ object YamlSpec : Spek({
             val given = listOf("value 1", "value 2")
             val result = yaml { list("key", given) }
             val expected = """key:
-                |  - value 1
-                |  - value 2
+                |  - 'value 1'
+                |  - 'value 2'
             """.trimMargin()
             assertThat(result).isEqualTo(expected)
         }

--- a/detekt-generator/src/test/resources/RuleSetConfig.yml
+++ b/detekt-generator/src/test/resources/RuleSetConfig.yml
@@ -2,18 +2,18 @@ style:
   active: true
   rulesetconfig1: true
   rulesetconfig2:
-    - foo
-    - bar
+    - 'foo'
+    - 'bar'
   rulesetconfig3:
-    - first
+    - 'first'
     - 'se*cond'
   WildcardImport:
     active: true
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
     conf1: foo
     conf3:
-      - a
-      - b
+      - 'a'
+      - 'b'
     conf5: 120
   EqualsNull:
     active: false


### PR DESCRIPTION
## Stacktrace
```
Caused by: java.lang.ClassCastException: java.lang.Integer cannot be cast to java.lang.String
	at io.gitlab.arturbosch.detekt.rules.style.MagicNumber$ignoreNumbers$2.invoke(MagicNumber.kt:259)
	at io.gitlab.arturbosch.detekt.rules.style.MagicNumber$ignoreNumbers$2.invoke(MagicNumber.kt:86)
	at io.gitlab.arturbosch.detekt.api.internal.TransformedConfigProperty.doGetValue(ConfigProperty.kt:87)
	at io.gitlab.arturbosch.detekt.api.internal.MemoizedConfigProperty.getValue(ConfigProperty.kt:64)
	at io.gitlab.arturbosch.detekt.api.internal.MemoizedConfigProperty.getValue(ConfigProperty.kt:60)
	at io.gitlab.arturbosch.detekt.rules.style.MagicNumber.getIgnoreNumbers(MagicNumber.kt:86)
	at io.gitlab.arturbosch.detekt.rules.style.MagicNumber.visitConstantExpression(MagicNumber.kt:138)
```

## Root cause
With https://github.com/detekt/detekt/pull/3827/, each line in a multi-line YAML array can be unquoted, such as
```
    ignoreNumbers:
      - -1
      - 0
      - 1
      - 2
```
This will lead to YAML config being parsed as `List<Int>`, but `MagicNumber.ignoreValues()` still have a default value of `List<String>`, causing the exception.

## Fix
The pessimistic fix is to always print quotes in multi-line YAML array.

## Testing
Since Gradle integration tests are only testing against latest published version, I have verified the fix through:
```
./gradlew :detekt-generator:generateDocumentation
./gradlew publishToMavenLocal
./gradlew :detekt-gradle-plugin:test
`
