### PR TITLE
Reformat internal detekt.yml using multi line lists

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -103,7 +103,12 @@ style:
     active: true
   ForbiddenComment:
     active: true
-    values: ['TODO:', 'FIXME:', 'STOPSHIP:', '@author', '@requiresTypeResolution']
+    values:
+      - 'TODO:'
+      - 'FIXME:'
+      - 'STOPSHIP:'
+      - '@author'
+      - '@requiresTypeResolution'
     excludes: ['**/detekt-rules-style/**/ForbiddenComment.kt']
   LibraryCodeMustSpecifyReturnType:
     active: true
@@ -114,11 +119,17 @@ style:
     excludes: ['**/test/**', '**/*Test.kt', '**/*Spec.kt']
     excludeCommentStatements: true
   MagicNumber:
+    excludes: [ '**/test/**', '**/*Test.kt', '**/*Spec.kt' ]
     ignorePropertyDeclaration: true
     ignoreAnnotation: true
     ignoreEnums: true
-    ignoreNumbers: ['-1', '0', '1', '2', '100', '1000']
-    excludes: [ '**/test/**', '**/*Test.kt', '**/*Spec.kt' ]
+    ignoreNumbers:
+      - '-1'
+      - '0'
+      - '1'
+      - '2'
+      - '100'
+      - '1000'
   NestedClassesVisibility:
     active: true
   RedundantVisibilityModifierRule:


### PR DESCRIPTION
#3827 introduced the multi line list format for all config properties. This updates the custom config accordingly.
