### PR TITLE
Update mockk to 1.12.0

### DIFF
--- a/detekt-core/build.gradle.kts
+++ b/detekt-core/build.gradle.kts
@@ -19,10 +19,4 @@ dependencies {
     testImplementation(projects.detektTest)
     testImplementation(testFixtures(projects.detektApi))
     testImplementation(libs.mockk)
-
-    constraints {
-        testImplementation("net.bytebuddy:byte-buddy:1.11.5") {
-            because("version 1.10.14 (pulled in by mockk 1.11.0) is not Java 16 compatible")
-        }
-    }
 }

--- a/detekt-metrics/build.gradle.kts
+++ b/detekt-metrics/build.gradle.kts
@@ -7,10 +7,4 @@ dependencies {
     testImplementation(projects.detektTestUtils)
     testImplementation(testFixtures(projects.detektApi))
     testImplementation(libs.mockk)
-
-    constraints {
-        testImplementation("net.bytebuddy:byte-buddy:1.11.5") {
-            because("version 1.10.14 (pulled in by mockk 1.11.0) is not Java 16 compatible")
-        }
-    }
 }

--- a/detekt-report-html/build.gradle.kts
+++ b/detekt-report-html/build.gradle.kts
@@ -12,10 +12,4 @@ dependencies {
     testImplementation(projects.detektTestUtils)
     testImplementation(testFixtures(projects.detektApi))
     testImplementation(libs.mockk)
-
-    constraints {
-        testImplementation("net.bytebuddy:byte-buddy:1.11.5") {
-            because("version 1.10.14 (pulled in by mockk 1.11.0) is not Java 16 compatible")
-        }
-    }
 }

--- a/detekt-rules-style/build.gradle.kts
+++ b/detekt-rules-style/build.gradle.kts
@@ -8,10 +8,4 @@ dependencies {
     testImplementation(projects.detektMetrics)
     testImplementation(projects.detektTest)
     testImplementation(libs.mockk)
-
-    constraints {
-        testImplementation("net.bytebuddy:byte-buddy:1.11.5") {
-            because("version 1.10.14 (pulled in by mockk 1.11.0) is not Java 16 compatible")
-        }
-    }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -42,7 +42,7 @@ spek-runner = { module = "org.spekframework.spek2:spek-runner-junit5", version.r
 sarif4k = "io.github.detekt.sarif4k:sarif4k:0.0.1"
 assertj = "org.assertj:assertj-core:3.20.2"
 reflections = "org.reflections:reflections:0.9.12"
-mockk = "io.mockk:mockk:1.11.0"
+mockk = "io.mockk:mockk:1.12.0"
 junitLauncher = "org.junit.platform:junit-platform-launcher:1.7.1"
 snakeyaml = "org.yaml:snakeyaml:1.29"
 jcommander = "com.beust:jcommander:1.81"


### PR DESCRIPTION
Mockk 1.12.x includes byte-buddy 1.11.x so we can remove to custom constraint
