### PR TITLE
Increase memory available to gradle integration test daemon

### DIFF
--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/testkit/DslGradleRunner.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/testkit/DslGradleRunner.kt
@@ -116,6 +116,7 @@ class DslGradleRunner @Suppress("LongParameterList") constructor(
             add("--info")
             add("--build-cache")
             add("-Dorg.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m")
+            add("--no-daemon")
             if (dryRun) {
                 add("-Pdetekt-dry-run=true")
             }

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/testkit/DslGradleRunner.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/testkit/DslGradleRunner.kt
@@ -115,8 +115,7 @@ class DslGradleRunner @Suppress("LongParameterList") constructor(
             add("--stacktrace")
             add("--info")
             add("--build-cache")
-            add("-Dorg.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m")
-            add("--no-daemon")
+            add("-Dorg.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=1g")
             if (dryRun) {
                 add("-Pdetekt-dry-run=true")
             }

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,3 @@ systemProp.sonar.host.url=http://localhost:9000
 systemProp.file.encoding=UTF-8
 org.gradle.parallel=true
 org.gradle.caching=true
-org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,3 +3,4 @@ systemProp.sonar.host.url=http://localhost:9000
 systemProp.file.encoding=UTF-8
 org.gradle.parallel=true
 org.gradle.caching=true
+org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m


### PR DESCRIPTION
Trying to figure out why there is a OutOfMemoryError on the CI