### PR TITLE
UndocumentedPublicProperty and UndocumentedPublicFunction should include objects

### DIFF
--- a/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicFunction.kt
+++ b/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicFunction.kt
@@ -9,7 +9,7 @@ import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.rules.isPublicNotOverridden
 import org.jetbrains.kotlin.psi.KtNamedFunction
-import org.jetbrains.kotlin.psi.psiUtil.containingClass
+import org.jetbrains.kotlin.psi.psiUtil.containingClassOrObject
 import org.jetbrains.kotlin.psi.psiUtil.isPublic
 
 /**
@@ -41,5 +41,5 @@ class UndocumentedPublicFunction(config: Config = Config.empty) : Rule(config) {
     }
 
     private fun KtNamedFunction.shouldBeDocumented() =
-        (isTopLevel || containingClass()?.isPublic == true) && isPublicNotOverridden()
+        (isTopLevel || containingClassOrObject?.isPublic == true) && isPublicNotOverridden()
 }

--- a/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicProperty.kt
+++ b/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicProperty.kt
@@ -13,7 +13,6 @@ import org.jetbrains.kotlin.psi.KtNamedDeclaration
 import org.jetbrains.kotlin.psi.KtParameter
 import org.jetbrains.kotlin.psi.KtPrimaryConstructor
 import org.jetbrains.kotlin.psi.KtProperty
-import org.jetbrains.kotlin.psi.psiUtil.containingClass
 import org.jetbrains.kotlin.psi.psiUtil.containingClassOrObject
 import org.jetbrains.kotlin.psi.psiUtil.isPublic
 
@@ -61,7 +60,7 @@ class UndocumentedPublicProperty(config: Config = Config.empty) : Rule(config) {
     private fun KtProperty.shouldBeDocumented() =
         docComment == null && isTopLevelOrInPublicClass() && isPublicNotOverridden()
 
-    private fun KtProperty.isTopLevelOrInPublicClass() = isTopLevel || containingClass()?.isPublic == true
+    private fun KtProperty.isTopLevelOrInPublicClass() = isTopLevel || containingClassOrObject?.isPublic == true
 
     private fun report(property: KtNamedDeclaration) {
         report(

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicFunctionSpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicFunctionSpec.kt
@@ -17,6 +17,26 @@ class UndocumentedPublicFunctionSpec : Spek({
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
+        it("reports undocumented public function in object") {
+            val code = """
+                object Test {
+                    fun noComment1() {}
+                }
+            """
+            assertThat(subject.compileAndLint(code)).hasSize(1)
+        }
+
+        it("reports undocumented public function in nested object") {
+            val code = """
+                class Test {
+                    object Test2 {
+                        fun noComment1() {}
+                    }
+                }
+            """
+            assertThat(subject.compileAndLint(code)).hasSize(1)
+        }
+
         it("reports undocumented public functions in companion object") {
             val code = """
                 class Test {
@@ -90,6 +110,15 @@ class UndocumentedPublicFunctionSpec : Spek({
 					public fun nope2() {}
 				}
 			"""
+            assertThat(subject.compileAndLint(code)).isEmpty()
+        }
+
+        it("does not report public functions in private object") {
+            val code = """
+                private object Test {
+                    fun noComment1() {}
+                }
+            """
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
     }

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicFunctionSpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicFunctionSpec.kt
@@ -49,6 +49,15 @@ class UndocumentedPublicFunctionSpec : Spek({
             assertThat(subject.compileAndLint(code)).hasSize(2)
         }
 
+        it("reports undocumented public function in an interface") {
+            val code = """
+                interface Test {
+                    fun noComment1()
+                }
+            """
+            assertThat(subject.compileAndLint(code)).hasSize(1)
+        }
+
         it("does not report documented public function") {
             val code = """
                 /**

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicPropertySpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicPropertySpec.kt
@@ -15,6 +15,26 @@ class UndocumentedPublicPropertySpec : Spek({
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
+        it("reports undocumented public property in objects") {
+            val code = """
+                object Test {
+                    val a = 1
+                }
+            """
+            assertThat(subject.compileAndLint(code)).hasSize(1)
+        }
+
+        it("reports undocumented public property in nested objects") {
+            val code = """
+                class Test {
+                    object NestedTest {
+                        val a = 1 
+                    }
+                }
+            """
+            assertThat(subject.compileAndLint(code)).hasSize(1)
+        }
+
         it("reports undocumented public properties in companion object") {
             val code = """
                 class Test {
@@ -158,6 +178,15 @@ class UndocumentedPublicPropertySpec : Spek({
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
+        it("does not report undocumented public properties in private object") {
+            val code = """
+                private object Test {
+                    val a = 1
+                }
+            """
+            assertThat(subject.compileAndLint(code)).isEmpty()
+        }
+
         describe("public properties in nested classes") {
 
             it("reports undocumented public properties in nested classes") {
@@ -186,7 +215,7 @@ class UndocumentedPublicPropertySpec : Spek({
                 assertThat(subject.compileAndLint(code)).hasSize(1)
             }
 
-            it("reports undocumented public properties inside objects") {
+            it("reports undocumented public properties in classes nested in objects") {
                 val code = """
                 object Outer {
                     class Inner {
@@ -242,7 +271,7 @@ class UndocumentedPublicPropertySpec : Spek({
                 assertThat(subject.compileAndLint(code)).hasSize(2)
             }
 
-            it("reports undocumented public properties inside objects") {
+            it("reports undocumented public properties in classes nested in objects") {
                 val code = """
                 object Outer {
                     class Inner(val a: Int)

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicPropertySpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicPropertySpec.kt
@@ -50,7 +50,7 @@ class UndocumentedPublicPropertySpec : Spek({
         it("reports undocumented public property in an interface") {
             val code = """
                 interface Test {
-                    val a = 1 
+                    val a: Int
                 }
             """
             assertThat(subject.compileAndLint(code)).hasSize(1)

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicPropertySpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicPropertySpec.kt
@@ -47,6 +47,15 @@ class UndocumentedPublicPropertySpec : Spek({
             assertThat(subject.compileAndLint(code)).hasSize(2)
         }
 
+        it("reports undocumented public property in an interface") {
+            val code = """
+                interface Test {
+                    val a = 1 
+                }
+            """
+            assertThat(subject.compileAndLint(code)).hasSize(1)
+        }
+
         it("reports undocumented public properties in a primary constructor") {
             val code = "class Test(val a: Int)"
             assertThat(subject.compileAndLint(code)).hasSize(1)


### PR DESCRIPTION
# Summary
Given an `object` with an undocumented public function or property, I would expect the `UndocumentedPublicFunction` rule or `UndocumentedPublicProperty` rule to fail the build. However, the behavior of the rules is inconsistent in regards to `objects`.

The following code is failed when the rules are enabled and an object is nested in a class, as expected:
```kotlin
class Test {
  object InnerObject {
    // Fails, expected
    fun noComment1() {}
    // Fails, expected
    val a = 1
  }
}
```

However, if the object is promoted to a top level object, then the rules will not fail the function or property.
```kotlin
object Test {
  // Passes, unexpected
  fun noComment1() {}
  // Passes, unexpected
  val a = 1
}
```

## Changes
I discovered that the `containingClass()` function used in both rules to determine if the function or property is part of a public class returns null if the function or property is in an `object`. We can change this behavior to check if the `object` is public or not by replacing the usage of `containingClass()` with `containingClassOrObject`. In this way, we can treat an undocumented function or property in an `object` the same as one in a regular `class`.

I changed both `UndocumentedPublicFunction` and `UndocumentedPublicProperty` to utilize `containingClassOrObject` instead of `containingClass()`. I also added test cases for public and private `object` cases as well as a nested `object` test case. For the test cases I added to the `UndocumentedPublicPropertySpec`, I renamed two of the existing test cases with ambiguous names to avoid confusion with the test cases I added.