### PR TITLE
Revert "Bump Kotlin to v1.5.20"

### DIFF
--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingWhenCase.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingWhenCase.kt
@@ -12,7 +12,7 @@ import io.gitlab.arturbosch.detekt.api.internal.Configuration
 import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.internal.config
 import org.jetbrains.kotlin.cfg.WhenChecker
-import org.jetbrains.kotlin.diagnostics.WhenMissingCase
+import org.jetbrains.kotlin.cfg.WhenMissingCase
 import org.jetbrains.kotlin.psi.KtWhenExpression
 import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.bindingContextUtil.isUsedAsExpression

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 dokka = "1.4.32"
 jacoco = "0.8.7"
-kotlin = "1.5.20"
+kotlin = "1.5.10"
 ktlint = "0.41.0"
 spek = "2.0.15"
 


### PR DESCRIPTION
This PR reverts detekt/detekt#3921

See my comment here: https://github.com/detekt/detekt/pull/3921#issuecomment-875909469

> Since this is blocking the release process, I'd suggest we:
> 1.   Revert this PR
> 2.   Craft a 1.18.0-RC without this PR
> 3.   Wait for 1.5.21 to release the 1.18.0 stable
