### PR TITLE
Revert annotations that are ignored by default

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -434,7 +434,8 @@ naming:
     functionPattern: '([a-z][a-zA-Z0-9]*)|(`.*`)'
     excludeClassPattern: '$^'
     ignoreOverridden: true
-    ignoreAnnotated: []
+    ignoreAnnotated:
+      - 'Composable'
   FunctionParameterNaming:
     active: true
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNaming.kt
@@ -42,7 +42,7 @@ class FunctionNaming(config: Config = Config.empty) : Rule(config) {
     private val ignoreOverridden: Boolean by config(true)
 
     @Configuration("ignore naming for functions in the context of these annotation class names")
-    private val ignoreAnnotated: List<String> by config(emptyList())
+    private val ignoreAnnotated: List<String> by config(listOf("Composable"))
 
     override fun visitNamedFunction(function: KtNamedFunction) {
         super.visitNamedFunction(function)

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNamingSpec.kt
@@ -115,19 +115,18 @@ class FunctionNamingSpec : Spek({
 
             """
 
-            it("Does not ignore annotated functions if ignoreAnnotated is empty") {
+            it("Ignores default annotated functions") {
                 assertThat(FunctionNaming().compileAndLint(code)).hasSourceLocations(
                     SourceLocation(4, 9),
-                    SourceLocation(8, 9),
-                    SourceLocation(12, 9)
+                    SourceLocation(8, 9)
                 )
             }
 
             it("Ignores annotated functions if ignoreAnnotated includes the given annotation class") {
-                val config = TestConfig(mapOf(FunctionNaming.IGNORE_ANNOTATED to listOf("Composable")))
+                val config = TestConfig(mapOf(FunctionNaming.IGNORE_ANNOTATED to listOf("Suppress")))
                 assertThat(FunctionNaming(config).compileAndLint(code)).hasSourceLocations(
                     SourceLocation(4, 9),
-                    SourceLocation(8, 9)
+                    SourceLocation(12, 9)
                 )
             }
         }


### PR DESCRIPTION
This resolves #3944 and partially reverts #3892.

While I strongly believe that detekt should not tailor the defaults for specific frameworks, I also agree with @G00fY2 and @cortinico that this change should not have been a by-product of another unrelated PR.
