### PR TITLE
Rename property in gradle plugin extension from input to source

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
@@ -22,6 +22,7 @@ open class DetektExtension @Inject constructor(objects: ObjectFactory) : CodeQua
 
     val reports = DetektReports()
 
+    @Deprecated(message = "Use source instead.", replaceWith = ReplaceWith("source"))
     var input: ConfigurableFileCollection by this::source
 
     var source: ConfigurableFileCollection = objects.fileCollection()

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
@@ -12,7 +12,6 @@ open class DetektExtension @Inject constructor(objects: ObjectFactory) : CodeQua
     var ignoreFailures: Boolean
         @JvmName("ignoreFailures_")
         get() = isIgnoreFailures
-
         @JvmName("ignoreFailures_")
         set(value) {
             isIgnoreFailures = value
@@ -23,7 +22,9 @@ open class DetektExtension @Inject constructor(objects: ObjectFactory) : CodeQua
 
     val reports = DetektReports()
 
-    var input: ConfigurableFileCollection = objects.fileCollection()
+    var input: ConfigurableFileCollection by this::source
+
+    var source: ConfigurableFileCollection = objects.fileCollection()
         .from(
             DEFAULT_SRC_DIR_JAVA,
             DEFAULT_TEST_SRC_DIR_JAVA,

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
@@ -12,6 +12,7 @@ open class DetektExtension @Inject constructor(objects: ObjectFactory) : CodeQua
     var ignoreFailures: Boolean
         @JvmName("ignoreFailures_")
         get() = isIgnoreFailures
+
         @JvmName("ignoreFailures_")
         set(value) {
             isIgnoreFailures = value
@@ -22,8 +23,12 @@ open class DetektExtension @Inject constructor(objects: ObjectFactory) : CodeQua
 
     val reports = DetektReports()
 
-    @Deprecated(message = "Use source instead.", replaceWith = ReplaceWith("source"))
-    var input: ConfigurableFileCollection by this::source
+    @Deprecated(message = "Please use the source property instead.", replaceWith = ReplaceWith("source"))
+    var input: ConfigurableFileCollection
+        get() = source
+        set(value) {
+            source = value
+        }
 
     var source: ConfigurableFileCollection = objects.fileCollection()
         .from(

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektPlain.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektPlain.kt
@@ -41,5 +41,5 @@ internal class DetektPlain(private val project: Project) {
     private fun existingInputDirectoriesProvider(
         project: Project,
         extension: DetektExtension
-    ): Provider<FileCollection> = project.provider { extension.input.filter { it.exists() } }
+    ): Provider<FileCollection> = project.provider { extension.source.filter { it.exists() } }
 }

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskDslSpec.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskDslSpec.kt
@@ -131,7 +131,7 @@ internal object DetektTaskDslSpec : Spek({
                     }
                 }
 
-                describe("with custom input directories") {
+                describe("[deprecated] with custom input directories using input") {
                     val customSrc1 = "gensrc/kotlin"
                     val customSrc2 = "src/main/kotlin"
 
@@ -140,6 +140,38 @@ internal object DetektTaskDslSpec : Spek({
                         val config = """
                         |detekt {
                         |    input = files("$customSrc1", "$customSrc2", "folder_that_does_not_exist")
+                        |}
+                        """
+
+                        val projectLayout = ProjectLayout(1, srcDirs = listOf(customSrc1, customSrc2))
+                        gradleRunner = builder
+                            .withProjectLayout(projectLayout)
+                            .withDetektConfig(config)
+                            .build()
+                        result = gradleRunner.runDetektTask()
+                    }
+
+                    it("sets input parameter to absolute filenames of all source files") {
+                        val file1 = gradleRunner.projectFile("$customSrc1/My0Root0Class.kt")
+                        val file2 = gradleRunner.projectFile("$customSrc2/My1Root0Class.kt")
+                        val expectedInputParam = "--input $file1,$file2"
+                        assertThat(result.output).contains(expectedInputParam)
+                    }
+
+                    it("ignores input directories that do not exist") {
+                        assertThat(result.output).doesNotContain("folder_that_does_not_exist")
+                    }
+                }
+
+                describe("with custom input directories") {
+                    val customSrc1 = "gensrc/kotlin"
+                    val customSrc2 = "src/main/kotlin"
+
+                    beforeGroup {
+
+                        val config = """
+                        |detekt {
+                        |    source = files("$customSrc1", "$customSrc2", "folder_that_does_not_exist")
                         |}
                         """
 

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskMultiModuleIntegrationSpec.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskMultiModuleIntegrationSpec.kt
@@ -191,7 +191,7 @@ internal class DetektTaskMultiModuleIntegrationSpec : Spek({
 
                     val detektConfig: String = """
                         |detekt {
-                        |    input = files(
+                        |    source = files(
                         |       "${"$"}projectDir/src",
                         |       "${"$"}projectDir/child1/src",
                         |       "${"$"}projectDir/child2/src"

--- a/docs/_posts/2019-03-03-configure-detekt-on-root-project.md
+++ b/docs/_posts/2019-03-03-configure-detekt-on-root-project.md
@@ -41,7 +41,7 @@ repositories {
 }
 
 detekt {
-    input = files(rootProject.rootDir)
+    source = files(rootProject.rootDir)
     buildUponDefaultConfig = true
 }
 ```

--- a/docs/pages/gettingstarted/gradle.md
+++ b/docs/pages/gettingstarted/gradle.md
@@ -191,7 +191,7 @@ detekt {
     
     // The directories where detekt looks for source files. 
     // Defaults to `files("src/main/java", "src/test/java", "src/main/kotlin", "src/test/kotlin")`.
-    source = files(
+    input = files(
         "src/main/kotlin",
         "gensrc/main/kotlin"
     )
@@ -277,7 +277,7 @@ detekt {
     
     // The directories where detekt looks for source files. 
     // Defaults to `files("src/main/java", "src/test/java", "src/main/kotlin", "src/test/kotlin")`.
-    source = files("src/main/java", "src/main/kotlin")     
+    input = files("src/main/java", "src/main/kotlin")     
     
     // Builds the AST in parallel. Rules are always executed in parallel. 
     // Can lead to speedups in larger projects. `false` by default.

--- a/docs/pages/gettingstarted/gradle.md
+++ b/docs/pages/gettingstarted/gradle.md
@@ -191,7 +191,7 @@ detekt {
     
     // The directories where detekt looks for source files. 
     // Defaults to `files("src/main/java", "src/test/java", "src/main/kotlin", "src/test/kotlin")`.
-    input = files(
+    source = files(
         "src/main/kotlin",
         "gensrc/main/kotlin"
     )
@@ -277,7 +277,7 @@ detekt {
     
     // The directories where detekt looks for source files. 
     // Defaults to `files("src/main/java", "src/test/java", "src/main/kotlin", "src/test/kotlin")`.
-    input = files("src/main/java", "src/main/kotlin")     
+    source = files("src/main/java", "src/main/kotlin")     
     
     // Builds the AST in parallel. Rules are always executed in parallel. 
     // Can lead to speedups in larger projects. `false` by default.


### PR DESCRIPTION
This closes #3918 

Since switching to  `org.gradle.api.tasks.SourceTask`, there is a difference how users would specify the input to be checked using the detekt extension vs. creating a custom task which seemed to have confused users.

```groovy
detekt {
    input = files(
        "src/main/kotlin",
        "gensrc/main/kotlin"
    )
}
```

vs.

```groovy
tasks.register(name: myDetekt, type: io.gitlab.arturbosch.detekt.Detekt) {
   source = files("src/main/kotlin", "src/test/kotlin")
}
```