### PR TITLE
Avoid task creation in groovy example

### DIFF
--- a/docs/pages/gettingstarted/gradletask.md
+++ b/docs/pages/gettingstarted/gradletask.md
@@ -20,7 +20,7 @@ configurations {
 	detekt
 }
 
-task detekt(type: JavaExec) {
+def detektTask = tasks.register("detekt", JavaExec) {
 	main = "io.gitlab.arturbosch.detekt.cli.Main"
 	classpath = configurations.detekt
 
@@ -37,7 +37,7 @@ dependencies {
 }
 
 // Remove this line if you don't want to run detekt on every build
-check.dependsOn detekt
+check.dependsOn detektTask
 ```
 
 ###### Kotlin DSL


### PR DESCRIPTION
As per [Gradle Task Configuration Avoidance Guide](https://docs.gradle.org/current/userguide/task_configuration_avoidance.html) `TaskContainer.register` should be used in order to avoid task creation during the configuration phase.
