### PR TITLE
Revert "Android: add javac intermediates to classpath (#3867)"

### DIFF
--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektAndroidSpec.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektAndroidSpec.kt
@@ -378,43 +378,6 @@ object DetektAndroidSpec : Spek({
                 }
             }
         }
-
-        describe("android tasks have javac intermediates on classpath") {
-            val projectLayout = ProjectLayout(
-                numberOfSourceFilesInRootPerSourceDir = 0,
-            ).apply {
-                addSubmodule(
-                    name = "app",
-                    numberOfSourceFilesPerSourceDir = 0,
-                    numberOfCodeSmells = 0,
-                    buildFileContent = """
-                        $APP_PLUGIN_BLOCK
-                        $ANDROID_BLOCK_WITH_VIEW_BINDING
-                        $DETEKT_BLOCK
-                    """.trimIndent(),
-                    srcDirs = listOf("src/main/java"),
-                )
-            }
-            val gradleRunner = createGradleRunnerAndSetupProject(projectLayout, dryRun = false)
-
-            gradleRunner.projectFile("app/src/main/java").mkdirs()
-            gradleRunner.projectFile("app/src/main/res/layout").mkdirs()
-            gradleRunner.writeProjectFile("app/src/main/AndroidManifest.xml", MANIFEST_CONTENT)
-            gradleRunner.writeProjectFile("app/src/main/res/layout/activity_sample.xml", SAMPLE_ACTIVITY_LAYOUT)
-            gradleRunner.writeProjectFile("app/src/main/java/SampleActivity.kt", SAMPLE_ACTIVITY_USING_VIEW_BINDING)
-
-            it("task :app:detektMain has javac intermediates on the classpath") {
-                gradleRunner.runTasksAndCheckResult(":app:detektMain") { buildResult ->
-                    assertThat(buildResult.output).doesNotContain("error: unresolved reference: databinding")
-                }
-            }
-
-            it("task :app:detektTest has javac intermediates on the classpath") {
-                gradleRunner.runTasksAndCheckResult(":app:detektTest") { buildResult ->
-                    assertThat(buildResult.output).doesNotContain("error: unresolved reference: databinding")
-                }
-            }
-        }
     }
 })
 
@@ -476,19 +439,6 @@ private val ANDROID_BLOCK_WITH_FLAVOR = """
     }
 """.trimIndent()
 
-private val ANDROID_BLOCK_WITH_VIEW_BINDING = """
-    android {
-        compileSdkVersion = 30
-        defaultConfig {
-            applicationId = "io.gitlab.arturbosch.detekt.app"
-            minSdkVersion = 24
-        }
-        buildFeatures {
-            viewBinding = true
-        }
-    }
-""".trimIndent()
-
 private val DETEKT_BLOCK = """
     detekt {
         reports {
@@ -497,39 +447,7 @@ private val DETEKT_BLOCK = """
     }
 """.trimIndent()
 
-private val SAMPLE_ACTIVITY_LAYOUT = """
-    <?xml version="1.0" encoding="utf-8"?>
-    <View
-        xmlns:android="http://schemas.android.com/apk/res/android"
-        android:id="@+id/sample_view"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        />
-""".trimIndent()
-
-private val SAMPLE_ACTIVITY_USING_VIEW_BINDING = """
-    package io.gitlab.arturbosch.detekt.app
-    
-    import android.app.Activity
-    import android.os.Bundle
-    import android.view.LayoutInflater
-    import io.gitlab.arturbosch.detekt.app.databinding.ActivitySampleBinding
-    
-    class SampleActivity : Activity() {
-    
-        private lateinit var binding: ActivitySampleBinding
-    
-        override fun onCreate(savedInstanceState: Bundle?) {
-            binding = ActivitySampleBinding.inflate(LayoutInflater.from(this))
-            setContentView(binding.root)
-        }
-    }
-""".trimIndent() + "\n" // new line at end of file rule
-
-private fun createGradleRunnerAndSetupProject(
-    projectLayout: ProjectLayout,
-    dryRun: Boolean = true,
-) = DslGradleRunner(
+private fun createGradleRunnerAndSetupProject(projectLayout: ProjectLayout) = DslGradleRunner(
     projectLayout = projectLayout,
     buildFileName = "build.gradle",
     mainBuildFileContent = """
@@ -541,5 +459,5 @@ private fun createGradleRunnerAndSetupProject(
             }
         }
     """.trimIndent(),
-    dryRun = dryRun,
+    dryRun = true
 ).also { it.setupProject() }


### PR DESCRIPTION
Resolves #3952.

## Intention
`detektIntermediatesJavacJar` has the input path as `intermediates/javac/${variant.name}/classes`, which may trigger unnecessary tasks to execute.

## Tests
Ran `detektBaselineMain detektBaselineTest` and verified that `assembleDebug` or `assembleRelease` are not run.
https://scans.gradle.com/s/q3mpjdwkffxaa/timeline.

## Future
Reverting the change for the time being. 
- We should rethink the implementation of working with AGP 7.0 https://developer.android.com/studio/releases/gradle-plugin-roadmap
- We should focus on improving detekt compiler plugin for it to be fully productionalized.