### PR TITLE
Update documentation renaming input to source in gradle extension

### DIFF
--- a/docs/pages/gettingstarted/gradle.md
+++ b/docs/pages/gettingstarted/gradle.md
@@ -191,7 +191,7 @@ detekt {
     
     // The directories where detekt looks for source files. 
     // Defaults to `files("src/main/java", "src/test/java", "src/main/kotlin", "src/test/kotlin")`.
-    input = files(
+    source = files(
         "src/main/kotlin",
         "gensrc/main/kotlin"
     )
@@ -277,7 +277,7 @@ detekt {
     
     // The directories where detekt looks for source files. 
     // Defaults to `files("src/main/java", "src/test/java", "src/main/kotlin", "src/test/kotlin")`.
-    input = files("src/main/java", "src/main/kotlin")     
+    source = files("src/main/java", "src/main/kotlin")     
     
     // Builds the AST in parallel. Rules are always executed in parallel. 
     // Can lead to speedups in larger projects. `false` by default.


### PR DESCRIPTION
This updates the documentation matching the changes from #3951. This should only be merged after #3918 has been released.