### PR TITLE
Add YAML anchor/alias documentation

### DIFF
--- a/docs/pages/configurations.md
+++ b/docs/pages/configurations.md
@@ -6,7 +6,7 @@ permalink: configurations.html
 summary:
 ---
 
-_detekt_ uses a yaml style configuration file for various things:
+_detekt_ uses a [YAML style configuration](https://yaml.org/spec/1.2/spec.html) file for various things:
 
 - rule set and rule properties
 - build failure
@@ -44,6 +44,21 @@ complexity:
     ...
     excludes: ['**/internal/**']
     includes: ['**/internal/util/NeedsToBeChecked.kt']
+```
+
+In case you want to apply the same filters for different rules, you can use
+[YAML anchors and aliases](https://yaml.org/spec/1.2/spec.html#id2785586) to reapply previously defined paths.
+
+```yaml
+naming:
+  ClassNaming:
+    ...
+    excludes: &testFolders
+      - '**/test/**'
+      - '**/androidTest/**'
+  ConstructorParameterNaming:
+    ...
+    excludes: *testFolders
 ```
 
 ## Build failure


### PR DESCRIPTION
As per [the discussion on issue #3251](https://github.com/detekt/detekt/issues/3251#issuecomment-791491618), this PR adds a reference to anchor/alias documentation of YAML and gives a short example of the common use case of reusing previously defined paths in the YAML configuration documentation. 