### PR TITLE
 UnderscoresInNumericLiterals acceptableDecimalLength is off by one

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -731,7 +731,7 @@ style:
     active: false
   UnderscoresInNumericLiterals:
     active: false
-    acceptableDecimalLength: 5
+    acceptableLength: 4
   UnnecessaryAbstractClass:
     active: true
     excludeAnnotatedClasses: []

--- a/detekt-core/src/main/resources/deprecation.properties
+++ b/detekt-core/src/main/resources/deprecation.properties
@@ -2,3 +2,4 @@ complexity>LongParameterList>threshold=Use `functionThreshold` and `constructorT
 empty-blocks>EmptyFunctionBlock>ignoreOverriddenFunctions=Use `ignoreOverridden` instead
 naming>FunctionParameterNaming>ignoreOverriddenFunctions=Use `ignoreOverridden` instead
 naming>MemberNameEqualsClassName>ignoreOverriddenFunction=Use `ignoreOverridden` instead
+style>UnderscoresInNumericLiterals>acceptableDecimalLength=Use `acceptableLength` instead

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiterals.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiterals.kt
@@ -17,21 +17,17 @@ import org.jetbrains.kotlin.psi.psiUtil.containingClassOrObject
 import java.util.Locale
 
 /**
- * This rule detects and reports decimal base 10 numeric literals above a certain length that should be underscore
+ * This rule detects and reports base 10 numbers above a certain length that should be underscore
  * separated for readability. Underscores that do not make groups of 3 digits are also reported even if their length is
  * under the `acceptableDecimalLength`. For `Serializable` classes or objects, the field `serialVersionUID` is
- * explicitly ignored. For floats and doubles, anything to the right of the decimal is ignored.
+ * explicitly ignored. For floats and doubles, anything to the right of the decimal point is ignored.
  *
  * <noncompliant>
- * object Money {
- *     const val DEFAULT_AMOUNT = 1000000
- * }
+ * const val DEFAULT_AMOUNT = 1000000
  * </noncompliant>
  *
  * <compliant>
- * object Money {
- *     const val DEFAULT_AMOUNT = 1_000_000
- * }
+ * const val DEFAULT_AMOUNT = 1_000_000
  * </compliant>
  */
 class UnderscoresInNumericLiterals(config: Config = Config.empty) : Rule(config) {
@@ -39,13 +35,13 @@ class UnderscoresInNumericLiterals(config: Config = Config.empty) : Rule(config)
     override val issue = Issue(
         javaClass.simpleName,
         Severity.Style,
-        "Report missing or invalid underscores in decimal base 10 numeric literals. Numeric literals " +
+        "Report missing or invalid underscores in base 10 numbers. Numeric literals " +
             "should be underscore separated to increase readability. Underscores that do not make groups of " +
             "3 digits are also reported.",
         Debt.FIVE_MINS
     )
 
-    @Configuration("Length under which decimal base 10 literals are not required to have underscores")
+    @Configuration("Length under which base 10 numbers are not required to have underscores")
     private val acceptableDecimalLength: Int by config(DEFAULT_ACCEPTABLE_DECIMAL_LENGTH)
 
     override fun visitConstantExpression(expression: KtConstantExpression) {
@@ -57,7 +53,7 @@ class UnderscoresInNumericLiterals(config: Config = Config.empty) : Rule(config)
 
         val numberString = normalizedText.split('.').first()
 
-        if (numberString.length >= acceptableDecimalLength || numberString.contains('_')) {
+        if (numberString.length > acceptableDecimalLength || numberString.contains('_')) {
             reportIfInvalidUnderscorePattern(expression, numberString)
         }
     }
@@ -68,8 +64,7 @@ class UnderscoresInNumericLiterals(config: Config = Config.empty) : Rule(config)
                 CodeSmell(
                     issue,
                     Entity.from(expression),
-                    "This numeric literal should be separated " +
-                        "by underscores in order to increase readability."
+                    "This number should be separated by underscores in order to increase readability."
                 )
             )
         }
@@ -98,7 +93,7 @@ class UnderscoresInNumericLiterals(config: Config = Config.empty) : Rule(config)
 
     private fun normalizeForMatching(text: String): String {
         return text.trim()
-            .toLowerCase(Locale.US)
+            .toLowerCase(Locale.ROOT)
             .removeSuffix("l")
             .removeSuffix("d")
             .removeSuffix("f")

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiterals.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiterals.kt
@@ -7,7 +7,9 @@ import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.UnstableApi
 import io.gitlab.arturbosch.detekt.api.config
+import io.gitlab.arturbosch.detekt.api.configWithFallback
 import io.gitlab.arturbosch.detekt.api.internal.Configuration
 import org.jetbrains.kotlin.psi.KtConstantExpression
 import org.jetbrains.kotlin.psi.KtObjectDeclaration
@@ -19,7 +21,7 @@ import java.util.Locale
 /**
  * This rule detects and reports base 10 numbers above a certain length that should be underscore
  * separated for readability. Underscores that do not make groups of 3 digits are also reported even if their length is
- * under the `acceptableDecimalLength`. For `Serializable` classes or objects, the field `serialVersionUID` is
+ * under the `acceptableLength`. For `Serializable` classes or objects, the field `serialVersionUID` is
  * explicitly ignored. For floats and doubles, anything to the right of the decimal point is ignored.
  *
  * <noncompliant>
@@ -42,7 +44,13 @@ class UnderscoresInNumericLiterals(config: Config = Config.empty) : Rule(config)
     )
 
     @Configuration("Length under which base 10 numbers are not required to have underscores")
-    private val acceptableDecimalLength: Int by config(DEFAULT_ACCEPTABLE_DECIMAL_LENGTH)
+    @Deprecated("Use `acceptableLength` instead")
+    private val acceptableDecimalLength: Int by config(5) { it - 1 }
+
+    @Suppress("DEPRECATION")
+    @OptIn(UnstableApi::class)
+    @Configuration("Maximum number of digits that a number can have and not use underscores")
+    private val acceptableLength: Int by configWithFallback(::acceptableDecimalLength, 4)
 
     override fun visitConstantExpression(expression: KtConstantExpression) {
         val normalizedText = normalizeForMatching(expression.text)
@@ -53,7 +61,7 @@ class UnderscoresInNumericLiterals(config: Config = Config.empty) : Rule(config)
 
         val numberString = normalizedText.split('.').first()
 
-        if (numberString.length > acceptableDecimalLength || numberString.contains('_')) {
+        if (numberString.length > acceptableLength || numberString.contains('_')) {
             reportIfInvalidUnderscorePattern(expression, numberString)
         }
     }
@@ -105,6 +113,5 @@ class UnderscoresInNumericLiterals(config: Config = Config.empty) : Rule(config)
         private const val BIN_PREFIX = "0b"
         private const val SERIALIZABLE = "Serializable"
         private const val SERIAL_UID_PROPERTY_NAME = "serialVersionUID"
-        private const val DEFAULT_ACCEPTABLE_DECIMAL_LENGTH = 5
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiteralsSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiteralsSpec.kt
@@ -8,6 +8,7 @@ import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
 private const val ACCEPTABLE_DECIMAL_LENGTH = "acceptableDecimalLength"
+private const val ACCEPTABLE_LENGTH = "acceptableLength"
 
 class UnderscoresInNumericLiteralsSpec : Spek({
 
@@ -19,7 +20,14 @@ class UnderscoresInNumericLiteralsSpec : Spek({
             assertThat(findings).isEmpty()
         }
 
-        it("should be reported if acceptableDecimalLength is 4") {
+        it("should be reported if acceptableLength is 3") {
+            val findings = UnderscoresInNumericLiterals(
+                TestConfig(mapOf(ACCEPTABLE_LENGTH to "3"))
+            ).compileAndLint(code)
+            assertThat(findings).isNotEmpty
+        }
+
+        it("should be reported if deprecated acceptableDecimalLength is 4") {
             val findings = UnderscoresInNumericLiterals(
                 TestConfig(mapOf(ACCEPTABLE_DECIMAL_LENGTH to "4"))
             ).compileAndLint(code)
@@ -44,9 +52,9 @@ class UnderscoresInNumericLiteralsSpec : Spek({
             assertThat(findings).isNotEmpty
         }
 
-        it("should not be reported if acceptableDecimalLength is 8") {
+        it("should not be reported if acceptableLength is 7") {
             val findings = UnderscoresInNumericLiterals(
-                TestConfig(mapOf(ACCEPTABLE_DECIMAL_LENGTH to "8"))
+                TestConfig(mapOf(ACCEPTABLE_LENGTH to "7"))
             ).compileAndLint(code)
             assertThat(findings).isEmpty()
         }
@@ -60,9 +68,9 @@ class UnderscoresInNumericLiteralsSpec : Spek({
             assertThat(findings).isEmpty()
         }
 
-        it("should be reported if acceptableDecimalLength is 4") {
+        it("should be reported if acceptableLength is 3") {
             val findings = UnderscoresInNumericLiterals(
-                TestConfig(mapOf(ACCEPTABLE_DECIMAL_LENGTH to "4"))
+                TestConfig(mapOf(ACCEPTABLE_LENGTH to "3"))
             ).compileAndLint(code)
             assertThat(findings).isNotEmpty
         }
@@ -76,9 +84,9 @@ class UnderscoresInNumericLiteralsSpec : Spek({
             assertThat(findings).isEmpty()
         }
 
-        it("should be reported if acceptableDecimalLength is 4") {
+        it("should be reported if acceptableLength is 3") {
             val findings = UnderscoresInNumericLiterals(
-                TestConfig(mapOf(ACCEPTABLE_DECIMAL_LENGTH to "4"))
+                TestConfig(mapOf(ACCEPTABLE_LENGTH to "3"))
             ).compileAndLint(code)
             assertThat(findings).isNotEmpty
         }
@@ -101,9 +109,9 @@ class UnderscoresInNumericLiteralsSpec : Spek({
             assertThat(findings).isNotEmpty
         }
 
-        it("should not be reported if ignored acceptableDecimalLength is 8") {
+        it("should not be reported if ignored acceptableLength is 7") {
             val findings = UnderscoresInNumericLiterals(
-                TestConfig(mapOf(ACCEPTABLE_DECIMAL_LENGTH to "8"))
+                TestConfig(mapOf(ACCEPTABLE_LENGTH to "7"))
             ).compileAndLint(code)
             assertThat(findings).isEmpty()
         }
@@ -126,9 +134,9 @@ class UnderscoresInNumericLiteralsSpec : Spek({
             assertThat(findings).isEmpty()
         }
 
-        it("should be reported if acceptableDecimalLength is 4") {
+        it("should be reported if acceptableLength is 3") {
             val findings = UnderscoresInNumericLiterals(
-                TestConfig(mapOf(ACCEPTABLE_DECIMAL_LENGTH to "4"))
+                TestConfig(mapOf(ACCEPTABLE_LENGTH to "3"))
             ).compileAndLint(code)
             assertThat(findings).isNotEmpty
         }
@@ -160,9 +168,9 @@ class UnderscoresInNumericLiteralsSpec : Spek({
             assertThat(findings).isNotEmpty
         }
 
-        it("should still be reported even if acceptableDecimalLength is 7") {
+        it("should still be reported even if acceptableLength is 6") {
             val findings = UnderscoresInNumericLiterals(
-                TestConfig(mapOf(ACCEPTABLE_DECIMAL_LENGTH to "7"))
+                TestConfig(mapOf(ACCEPTABLE_LENGTH to "6"))
             ).compileAndLint(code)
             assertThat(findings).isNotEmpty
         }
@@ -300,9 +308,9 @@ class UnderscoresInNumericLiteralsSpec : Spek({
             assertThat(findings).isNotEmpty
         }
 
-        it("should not be reported if acceptableDecimalLength is 6") {
+        it("should not be reported if acceptableLength is 5") {
             val findings = UnderscoresInNumericLiterals(
-                TestConfig(mapOf(ACCEPTABLE_DECIMAL_LENGTH to "6"))
+                TestConfig(mapOf(ACCEPTABLE_LENGTH to "5"))
             ).compileAndLint(code)
             assertThat(findings).isEmpty()
         }
@@ -329,9 +337,9 @@ class UnderscoresInNumericLiteralsSpec : Spek({
     describe("a Double of 3000.1415926535897932385") {
         val code = "val myDouble = 3000.1415926535897932385"
 
-        it("should be reported if acceptableDecimalLength is 4") {
+        it("should be reported if acceptableLength is 3") {
             val findings = UnderscoresInNumericLiterals(
-                TestConfig(mapOf(ACCEPTABLE_DECIMAL_LENGTH to "4"))
+                TestConfig(mapOf(ACCEPTABLE_LENGTH to "3"))
             ).compileAndLint(code)
             assertThat(findings).isNotEmpty
         }
@@ -345,9 +353,9 @@ class UnderscoresInNumericLiteralsSpec : Spek({
             assertThat(findings).isNotEmpty
         }
 
-        it("should not be reported if acceptableDecimalLength is 8") {
+        it("should not be reported if acceptableLength is 7") {
             val findings = UnderscoresInNumericLiterals(
-                TestConfig(mapOf(ACCEPTABLE_DECIMAL_LENGTH to "8"))
+                TestConfig(mapOf(ACCEPTABLE_LENGTH to "7"))
             ).compileAndLint(code)
             assertThat(findings).isEmpty()
         }


### PR DESCRIPTION
This rule was using the word "decimal" everywhere. It's correct to call a base 10 number "decimal" but it is saying the same thing twice. And the problem with "decimal" is that it have a lot of meanings so it can be missleading. For that reason I changed the documentation a bit removing the word "decimal" (first commit).

After that the only point where "decimal" was used is in the configuration so to avoid the breaking change and because it also improves "readability" I renamed "acceptableDecimalLength" to "acceptableLenght". All this rule is about base 10 numbers so there's is no need to point that out in the configuration too.

But this is a Draft an it's not a ready to merge PR because I found a missing feature in our new configuration system:

```
private val acceptableLength: Int by configWithFallback("acceptableDecimalLength", 4)
```

We can't use the value of `acceptableDecimalLength` as the value of `acceptableLenght` because it would be off by one. Should we care about this? We were talking about adding a "breaking change" to fix this so, maybe, we should not care.

Fix #3860