### PR TITLE
Allow factory function names - fix #1639

### DIFF
--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNaming.kt
@@ -54,7 +54,7 @@ class FunctionNaming(config: Config = Config.empty) : Rule(config) {
         val functionName = function.nameIdentifier?.text ?: return
         if (!function.isContainingExcludedClassOrObject(excludeClassPattern) &&
             !functionName.matches(functionPattern) &&
-            functionName != function.typeReference?.name
+            functionName != function.typeReference?.text
         ) {
             report(
                 CodeSmell(

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNamingSpec.kt
@@ -68,7 +68,7 @@ class FunctionNamingSpec : Spek({
             fun Foo(): Foo = FooImpl()
         """
             val config = TestConfig(mapOf(FunctionNaming.IGNORE_OVERRIDDEN to "false"))
-            assertThat(FunctionNaming(config).compileAndLint(code))
+            assertThat(FunctionNaming(config).compileAndLint(code)).isEmpty()
         }
 
         it("flags functions with bad names inside overridden functions by default") {


### PR DESCRIPTION
The PR #1668 tried to fix this issue but it seems that it forgot to add the `.isEmpty()` so it wasn't actually fixed.

I would like the review of @schalkms because it was the one tring to fixing this so I can be missing something.