### PR TITLE
ClassNaming: Don't treat Kotlin syntax ` as part of class name

### DIFF
--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ClassNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ClassNaming.kt
@@ -32,7 +32,7 @@ class ClassNaming(config: Config = Config.empty) : Rule(config) {
     private val classPattern: Regex by config("[A-Z][a-zA-Z0-9]*") { it.toRegex() }
 
     override fun visitClassOrObject(classOrObject: KtClassOrObject) {
-        if (!classOrObject.identifierName().matches(classPattern)) {
+        if (!classOrObject.identifierName().removeSurrounding("`").matches(classPattern)) {
             report(
                 CodeSmell(
                     issue,

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ClassNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ClassNamingSpec.kt
@@ -26,6 +26,14 @@ class ClassNamingSpec : Spek({
             assertThat(ClassNaming().compileAndLint(code)).isEmpty()
         }
 
+        it("should detect no violations with class using backticks") {
+            val code = """
+                class `NamingConventions`
+            """
+
+            assertThat(ClassNaming().compileAndLint(code)).isEmpty()
+        }
+
         it("should detect because it have a _") {
             val code = """
                 class _NamingConventions

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ClassNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ClassNamingSpec.kt
@@ -9,39 +9,49 @@ class ClassNamingSpec : Spek({
 
     describe("different naming conventions inside classes") {
 
-        it("should detect no violations") {
-            val findings = ClassNaming().compileAndLint(
-                """
-                    class MyClassWithNumbers5
+        it("should detect no violations class with numbers") {
+            val code = """
+                class MyClassWithNumbers5
+            """
 
-                    class NamingConventions {
-                    }
-                """
-            )
-            assertThat(findings).isEmpty()
+            assertThat(ClassNaming().compileAndLint(code)).isEmpty()
         }
 
-        it("should find two violations") {
-            val findings = ClassNaming().compileAndLint(
-                """
-                    class _NamingConventions
+        it("should detect no violations") {
+            val code = """
+                class NamingConventions {
+                }
+            """
 
-                    class namingConventions {}
-                """
-            )
-            assertThat(findings).hasSize(2)
-            assertThat(findings).hasTextLocations(6 to 24, 32 to 49)
+            assertThat(ClassNaming().compileAndLint(code)).isEmpty()
+        }
+
+        it("should detect because it have a _") {
+            val code = """
+                class _NamingConventions
+            """
+
+            assertThat(ClassNaming().compileAndLint(code))
+                .hasSize(1)
+                .hasTextLocations(6 to 24)
+        }
+
+        it("should detect because it have starts with lowercase") {
+            val code = """
+                class namingConventions {}
+            """
+
+            assertThat(ClassNaming().compileAndLint(code))
+                .hasSize(1)
+                .hasTextLocations(6 to 23)
         }
 
         it("should ignore the issue by alias suppression") {
-            assertThat(
-                ClassNaming().compileAndLint(
-                    """
-                    @Suppress("ClassName")
-                    class namingConventions {}
-                """
-                )
-            ).isEmpty()
+            val code = """
+                @Suppress("ClassName")
+                class namingConventions {}
+            """
+            assertThat(ClassNaming().compileAndLint(code)).isEmpty()
         }
     }
 })


### PR DESCRIPTION
This tries to fix #2656. But I find this a bit controversial:

Pros:

- It's true that `` ` ``  is not part of the name of a class (or any other entity in the code).

Cons:

- `FunctionNaming` is using this "error" to provide the feature that only allows any type of function name if it uses backticks. That's like that because in the tests we want to allow that kind of naming in the functions.

I vote to merge because I think that the one that is wrong is `FunctionNaming`. But fixing `FuctionNaming` is not easy. A way to fix it would be to allow multiple instances of the same rule with different configurations. This way we could have an instance that checks FunctionNaming in production code and another for test code.

Maybe a solution is to exclude `FunctionNaming` from test source sets and don't allow backtick at all.