### PR TITLE
Publish bundled/Shadow JAR artifact to Maven repos

### DIFF
--- a/detekt-cli/build.gradle.kts
+++ b/detekt-cli/build.gradle.kts
@@ -23,6 +23,12 @@ javaComponent.withVariantsFromConfiguration(configurations["shadowRuntimeElement
     skip()
 }
 
+publishing {
+    publications.named<MavenPublication>(DETEKT_PUBLICATION) {
+        artifact(tasks.shadowJar)
+    }
+}
+
 tasks.shadowJar {
     mergeServiceFiles()
 }


### PR DESCRIPTION
This will publish the -all variant when publishing to Maven repos. It won't be added to Gradle module metadata, to avoid a repeat of #3743.

Tested locally with `gradlew publishToMavenLocal`

Fixes #3969
