### PR TITLE
Enable more rules for detekt code base

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -104,10 +104,20 @@ formatting:
   SpacingBetweenDeclarationsWithComments:
     active: true
 
+naming:
+  InvalidPackageDeclaration:
+    active: true
+  NonBooleanPropertyPrefixedWithIs:
+    active: true
+  VariableMaxLength:
+    active: true
+  VariableMinLength:
+    active: true
+
 potential-bugs:
   UnsafeCast:
     active: true
-    excludes: ['**/test/**', '**/*.Test.kt', '**/*.Spec.kt']
+    excludes: [ '**/test/**', '**/*.Test.kt', '**/*.Spec.kt' ]
   UselessPostfixExpression:
     active: true
   IgnoredReturnValue:

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -206,6 +206,20 @@ style:
     excludeGuardClauses: true
   SpacingBetweenPackageAndImports:
     active: true
+  TrailingWhitespace:
+    active: true
+  UnderscoresInNumericLiterals:
+    active: true
+  UnnecessaryAnnotationUseSiteTarget:
+    active: true
+  UnnecessaryFilter:
+    active: true
+  UnnecessaryLet:
+    active: true
+  UntilInsteadOfRangeTo:
+    active: true
+  UnusedImports:
+    active: true
   UnusedPrivateMember:
     active: true
     allowedNames: '(_|ignored|expected)'

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -144,6 +144,14 @@ style:
     active: true
   CollapsibleIfStatements:
     active: true
+  DestructuringDeclarationWithTooManyEntries:
+    active: true
+  EqualsOnSignatureLine:
+    active: true
+  ExplicitCollectionElementAccessMethod:
+    active: true
+  ExplicitItLambdaParameter:
+    active: true
   ForbiddenComment:
     active: true
     values:
@@ -153,10 +161,16 @@ style:
       - '@author'
       - '@requiresTypeResolution'
     excludes: ['**/detekt-rules-style/**/ForbiddenComment.kt']
+  ForbiddenVoid:
+    active: true
   LibraryCodeMustSpecifyReturnType:
     active: true
     excludes: ['**/*.kt']
     includes: ['**/detekt-api/src/main/**/api/*.kt']
+  MandatoryBracesIfStatements:
+    active: true
+  MandatoryBracesLoops:
+    active: true
   MaxLineLength:
     active: true
     excludes: ['**/test/**', '**/*Test.kt', '**/*Spec.kt']

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -231,8 +231,6 @@ style:
     active: true
   UseIfEmptyOrIfBlank:
     active: true
-#  UseIfInsteadOfWhen:
-#    active: true
   UseIsNullOrEmpty:
     active: true
   UseOrEmpty:

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -115,12 +115,28 @@ naming:
     active: true
 
 potential-bugs:
+  DontDowncastCollectionTypes:
+    active: true
+  DoubleMutabilityForCollection:
+    active: true
+  ExitOutsideMain:
+    active: false
+  HasPlatformType:
+    active: true
+  IgnoredReturnValue:
+    active: true
+  ImplicitUnitReturnType:
+    active: true
+  MapGetWithNotNullAssertionOperator:
+    active: true
+  UnconditionalJumpStatementInLoop:
+    active: true
+  UnreachableCatchBlock:
+    active: true
   UnsafeCast:
     active: true
     excludes: [ '**/test/**', '**/*.Test.kt', '**/*.Spec.kt' ]
   UselessPostfixExpression:
-    active: true
-  IgnoredReturnValue:
     active: true
 
 style:

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -107,6 +107,7 @@ formatting:
 naming:
   InvalidPackageDeclaration:
     active: true
+    excludes: ['**/buildSrc/**/*.kt']
   NonBooleanPropertyPrefixedWithIs:
     active: true
   VariableMaxLength:

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -135,7 +135,7 @@ potential-bugs:
     active: true
   UnsafeCast:
     active: true
-    excludes: [ '**/test/**', '**/*.Test.kt', '**/*.Spec.kt' ]
+    excludes: ['**/test/**', '**/*.Test.kt', '**/*.Spec.kt']
   UselessPostfixExpression:
     active: true
 
@@ -160,15 +160,15 @@ style:
       - 'STOPSHIP:'
       - '@author'
       - '@requiresTypeResolution'
-    excludes: [ '**/detekt-rules-style/**/ForbiddenComment.kt' ]
+    excludes: ['**/detekt-rules-style/**/ForbiddenComment.kt']
   ForbiddenVoid:
     active: true
   LibraryCodeMustSpecifyReturnType:
     active: true
-    excludes: [ '**/*.kt' ]
-    includes: [ '**/detekt-api/src/main/**/api/*.kt' ]
+    excludes: ['**/*.kt']
+    includes: ['**/detekt-api/src/main/**/api/*.kt']
   MagicNumber:
-    excludes: [ '**/test/**', '**/*Test.kt', '**/*Spec.kt' ]
+    excludes: ['**/test/**', '**/*Test.kt', '**/*Spec.kt']
     ignorePropertyDeclaration: true
     ignoreAnnotation: true
     ignoreEnums: true
@@ -185,7 +185,7 @@ style:
     active: true
   MaxLineLength:
     active: true
-    excludes: [ '**/test/**', '**/*Test.kt', '**/*Spec.kt' ]
+    excludes: ['**/test/**', '**/*Test.kt', '**/*Spec.kt']
     excludeCommentStatements: true
   NoTabs:
     active: true
@@ -225,3 +225,20 @@ style:
     allowedNames: '(_|ignored|expected)'
   UseCheckOrError:
     active: true
+  UseDataClass:
+    active: true
+  UseEmptyCounterpart:
+    active: true
+  UseIfEmptyOrIfBlank:
+    active: true
+#  UseIfInsteadOfWhen:
+#    active: true
+  UseIsNullOrEmpty:
+    active: true
+  UseOrEmpty:
+    active: true
+  UseRequire:
+    active: true
+  UseRequireNotNull:
+    active: true
+

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -44,6 +44,17 @@ complexity:
   MethodOverloading:
     active: true
 
+coroutines:
+  active: true
+  GlobalCoroutineUsage:
+    active: true
+  RedundantSuspendModifier:
+    active: true
+  SleepInsteadOfDelay:
+    active: true
+  SuspendFunWithFlowReturnType:
+    active: true
+
 exceptions:
   NotImplementedDeclaration:
     active: true

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -60,11 +60,15 @@ exceptions:
     active: true
   InstanceOfCheckForException:
     active: true
+  ObjectExtendsThrowable:
+    active: true
   RethrowCaughtException:
     active: true
   ReturnFromFinally:
     active: true
   ThrowingExceptionFromFinally:
+    active: true
+  ThrowingExceptionInMain:
     active: true
   ThrowingExceptionsWithoutMessageOrCause:
     active: true

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -107,7 +107,7 @@ formatting:
 naming:
   InvalidPackageDeclaration:
     active: true
-    excludes: ['**/buildSrc/**/*.kt']
+    excludes: ['**/buildSrc/**/*.kt', '**/*.kts']
   NonBooleanPropertyPrefixedWithIs:
     active: true
   VariableMaxLength:

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -160,21 +160,13 @@ style:
       - 'STOPSHIP:'
       - '@author'
       - '@requiresTypeResolution'
-    excludes: ['**/detekt-rules-style/**/ForbiddenComment.kt']
+    excludes: [ '**/detekt-rules-style/**/ForbiddenComment.kt' ]
   ForbiddenVoid:
     active: true
   LibraryCodeMustSpecifyReturnType:
     active: true
-    excludes: ['**/*.kt']
-    includes: ['**/detekt-api/src/main/**/api/*.kt']
-  MandatoryBracesIfStatements:
-    active: true
-  MandatoryBracesLoops:
-    active: true
-  MaxLineLength:
-    active: true
-    excludes: ['**/test/**', '**/*Test.kt', '**/*Spec.kt']
-    excludeCommentStatements: true
+    excludes: [ '**/*.kt' ]
+    includes: [ '**/detekt-api/src/main/**/api/*.kt' ]
   MagicNumber:
     excludes: [ '**/test/**', '**/*Test.kt', '**/*Spec.kt' ]
     ignorePropertyDeclaration: true
@@ -187,7 +179,25 @@ style:
       - '2'
       - '100'
       - '1000'
+  MandatoryBracesIfStatements:
+    active: true
+  MandatoryBracesLoops:
+    active: true
+  MaxLineLength:
+    active: true
+    excludes: [ '**/test/**', '**/*Test.kt', '**/*Spec.kt' ]
+    excludeCommentStatements: true
+  NoTabs:
+    active: true
   NestedClassesVisibility:
+    active: true
+  ObjectLiteralToLambda:
+    active: true
+  PreferToOverPairSyntax:
+    active: true
+  RedundantExplicitType:
+    active: true
+  RedundantHigherOrderMapUsage:
     active: true
   RedundantVisibilityModifierRule:
     active: true

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/AnnotationExcluder.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/AnnotationExcluder.kt
@@ -20,7 +20,7 @@ class AnnotationExcluder(
             .mapNotNull { it.importedFqName?.asString() }
             .map { it.substringAfterLast('.') to it }
             .toMap()
-    } ?: emptyMap()
+    }.orEmpty()
 
     constructor(root: KtFile, excludes: SplitPattern) : this(root, excludes.mapAll { it })
 

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/CodeSmell.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/CodeSmell.kt
@@ -14,8 +14,8 @@ open class CodeSmell(
     final override val issue: Issue,
     override val entity: Entity,
     override val message: String,
-    override val metrics: List<Metric> = listOf(),
-    override val references: List<Entity> = listOf()
+    override val metrics: List<Metric> = emptyList(),
+    override val references: List<Entity> = emptyList()
 ) : Finding {
 
     internal var internalSeverity: SeverityLevel = SeverityLevel.WARNING
@@ -38,7 +38,7 @@ open class CodeSmell(
             "id='$id')"
     }
 
-    override fun messageOrDescription(): String = if (message.isEmpty()) issue.description else message
+    override fun messageOrDescription(): String = message.ifEmpty { issue.description }
 }
 
 /**
@@ -50,8 +50,8 @@ open class CorrectableCodeSmell(
     issue: Issue,
     entity: Entity,
     message: String,
-    metrics: List<Metric> = listOf(),
-    references: List<Entity> = listOf(),
+    metrics: List<Metric> = emptyList(),
+    references: List<Entity> = emptyList(),
     val autoCorrectEnabled: Boolean
 ) : CodeSmell(
     issue,
@@ -100,5 +100,5 @@ open class ThresholdedCodeSmell(
 
     override fun compact(): String = "$id - $metric - ${entity.compact()}"
 
-    override fun messageOrDescription(): String = if (message.isEmpty()) issue.description else message
+    override fun messageOrDescription(): String = message.ifEmpty { issue.description }
 }

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/Signatures.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/Signatures.kt
@@ -29,8 +29,7 @@ internal fun PsiElement.searchName(): String {
  * Example: KtFile with name /full/path/to/Test.kt will have its name formatted to be simply Test.kt
  */
 private fun String.formatElementName(): String =
-    if (contains(File.separatorChar)) substringAfterLast(File.separatorChar)
-    else this
+    if (contains(File.separatorChar)) substringAfterLast(File.separatorChar) else this
 
 /*
  * KtCompiler wrongly used Path.filename as the name for a KtFile instead of the whole path.

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/Signatures.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/Signatures.kt
@@ -63,7 +63,7 @@ internal fun PsiElement.buildFullSignature(): String {
 }
 
 private fun PsiElement.extractClassName() =
-    this.getNonStrictParentOfType<KtClassOrObject>()?.nameAsSafeName?.asString() ?: ""
+    this.getNonStrictParentOfType<KtClassOrObject>()?.nameAsSafeName?.asString().orEmpty()
 
 private fun PsiElement.searchSignature(): String {
     return when (this) {
@@ -86,7 +86,7 @@ private fun buildClassSignature(classOrObject: KtClassOrObject): String {
     }
     val extendedEntries = classOrObject.superTypeListEntries
     if (extendedEntries.isNotEmpty()) baseName += " : "
-    extendedEntries.forEach { baseName += it.typeAsUserType?.referencedName ?: "" }
+    extendedEntries.forEach { baseName += it.typeAsUserType?.referencedName.orEmpty() }
     return baseName
 }
 

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/Suppressions.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/Suppressions.kt
@@ -43,7 +43,9 @@ private val suppressionAnnotations = setOf("Suppress", "SuppressWarnings")
  */
 fun KtAnnotated.isSuppressedBy(id: RuleId, aliases: Set<String>, ruleSetId: RuleSetId? = null): Boolean {
     val acceptedSuppressionIds = mutableSetOf(id, "ALL", "all", "All")
-    ruleSetId?.let { acceptedSuppressionIds.addAll(listOf(ruleSetId, "$ruleSetId.$id", "$ruleSetId:$id")) }
+    if (ruleSetId != null) {
+        acceptedSuppressionIds.addAll(listOf(ruleSetId, "$ruleSetId.$id", "$ruleSetId:$id"))
+    }
     acceptedSuppressionIds.addAll(aliases)
     return annotationEntries
         .find { it.typeReference?.text in suppressionAnnotations }

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/AnnotationExcluderSpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/AnnotationExcluderSpec.kt
@@ -38,7 +38,7 @@ class AnnotationExcluderSpec : Spek({
         }
 
         it("should not exclude when no annotations should be excluded") {
-            val excluder = AnnotationExcluder(file, listOf())
+            val excluder = AnnotationExcluder(file, emptyList())
             assertThat(excluder.shouldExclude(listOf(jvmFieldAnnotation))).isFalse()
         }
 

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/ConfigPropertySpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/ConfigPropertySpec.kt
@@ -255,6 +255,7 @@ class ConfigPropertySpec : Spek({
             }
             context("empty list of strings") {
                 val subject by memoized {
+                    @Suppress("UseEmptyCounterpart")
                     object : TestConfigAware() {
                         val defaultValue: List<String> = emptyList()
                         val prop1: List<Int> by config(defaultValue) { it.map(String::toInt) }

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt
@@ -205,7 +205,7 @@ class CliArgs {
     }
 
     val reportPaths: List<ReportPath> by lazy {
-        reports?.map { ReportPath.from(it) } ?: emptyList()
+        reports?.map(ReportPath::from).orEmpty()
     }
 
     companion object {

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Spec.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Spec.kt
@@ -44,8 +44,8 @@ internal fun CliArgs.createSpec(output: Appendable, error: Appendable): Processi
             shouldValidateBeforeAnalysis = false
             knownPatterns = emptyList()
             // ^^ cli does not have these properties yet; specified in yaml config for now
-            configPaths = config?.let { MultipleExistingPathConverter().convert(it) } ?: emptyList()
-            resources = configResource?.let { MultipleClasspathResourceConverter().convert(it) } ?: emptyList()
+            configPaths = config?.let { MultipleExistingPathConverter().convert(it) }.orEmpty()
+            resources = configResource?.let { MultipleClasspathResourceConverter().convert(it) }.orEmpty()
         }
 
         execution {
@@ -55,7 +55,7 @@ internal fun CliArgs.createSpec(output: Appendable, error: Appendable): Processi
 
         extensions {
             disableDefaultRuleSets = args.disableDefaultRuleSets
-            fromPaths { args.plugins?.let { MultipleExistingPathConverter().convert(it) } ?: emptyList() }
+            fromPaths { args.plugins?.let { MultipleExistingPathConverter().convert(it) }.orEmpty() }
         }
 
         reports {
@@ -76,7 +76,7 @@ private fun asPatterns(rawValue: String?): List<String> =
     rawValue?.trim()
         ?.commaSeparatedPattern(",", ";")
         ?.toList()
-        ?: emptyList()
+        .orEmpty()
 
 private fun CliArgs.toRunPolicy(): RulesSpec.RunPolicy {
     val parts = runRule?.split(":") ?: return RulesSpec.RunPolicy.NoRestrictions

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgsSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgsSpec.kt
@@ -18,7 +18,7 @@ internal class CliArgsSpec : Spek({
     describe("Parsing the input path") {
 
         it("the current working directory is used if parameter is not set") {
-            val cli = parseArguments(arrayOf())
+            val cli = parseArguments(emptyArray())
             assertThat(cli.inputPaths).hasSize(1)
             assertThat(cli.inputPaths.first()).isEqualTo(Paths.get(System.getProperty("user.dir")))
         }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/KtFileModifier.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/KtFileModifier.kt
@@ -25,7 +25,7 @@ class KtFileModifier : FileProcessListener {
 
     private fun KtFile.unnormalizeContent(): String {
         val lineSeparator = getUserData(LINE_SEPARATOR)
-        require(lineSeparator != null) {
+        requireNotNull(lineSeparator) {
             "No line separator entry for ktFile ${javaFileFacadeFqName.asString()}"
         }
         return StringUtilRt.convertLineSeparators(text, lineSeparator)

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/YamlConfig.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/YamlConfig.kt
@@ -20,7 +20,7 @@ class YamlConfig internal constructor(
 ) : Config, ValidatableConfiguration {
 
     override fun subConfig(key: String): Config {
-        val subProperties = properties.getOrElse(key) { mapOf<String, Any>() }
+        val subProperties = properties.getOrElse(key) { emptyMap<String, Any>() }
         return YamlConfig(
             subProperties as Map<String, Any>,
             if (parentPath == null) key else "$parentPath $CONFIG_SEPARATOR $key"

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/OutputFacade.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/OutputFacade.kt
@@ -15,7 +15,7 @@ class OutputFacade(
     private var reports: Map<String, ReportsSpec.Report> =
         settings.getOrNull<Collection<ReportsSpec.Report>>(DETEKT_OUTPUT_REPORT_PATHS_KEY)
             ?.associateBy { it.type }
-            ?: emptyMap()
+            .orEmpty()
 
     fun run(result: Detektion) {
         // Always run output reports first.

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/rules/RuleSets.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/rules/RuleSets.kt
@@ -28,9 +28,9 @@ fun RuleSet.visitFile(
     file: KtFile,
     bindingContext: BindingContext = BindingContext.EMPTY
 ): List<Finding> =
-    rules.flatMap {
-        it.visitFile(file, bindingContext)
-        it.findings
+    rules.flatMap { rule ->
+        rule.visitFile(file, bindingContext)
+        rule.findings
     }
 
 fun associateRuleIdsToRuleSetIds(ruleSets: Sequence<RuleSet>): Map<RuleId, RuleSetId> {

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/settings/EnvironmentAware.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/settings/EnvironmentAware.kt
@@ -44,7 +44,7 @@ internal class EnvironmentFacade(
 }
 
 internal fun CompilerSpec.classpathEntries(): List<String> =
-    classpath?.split(File.pathSeparator) ?: emptyList()
+    classpath?.split(File.pathSeparator).orEmpty()
 
 internal fun CompilerSpec.parseLanguageVersion(): LanguageVersion? {
     fun parse(value: String): LanguageVersion {

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/tooling/Lifecycle.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/tooling/Lifecycle.kt
@@ -54,7 +54,7 @@ internal interface Lifecycle {
     }
 }
 
-internal class DefaultLifecycle(
+internal data class DefaultLifecycle(
     override val settings: ProcessingSettings,
     override val parsingStrategy: ParsingStrategy,
     override val bindingProvider: (files: List<KtFile>) -> BindingContext =

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/KT.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/KT.kt
@@ -23,7 +23,7 @@ class TestProvider(override val ruleSetId: String = "Test") : RuleSetProvider {
 
 class TestProvider2(override val ruleSetId: String = "Test2") : RuleSetProvider {
     override fun instance(config: Config): RuleSet {
-        return RuleSet("Test", listOf())
+        return RuleSet("Test", emptyList())
     }
 }
 

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/ProcessingSettingsFactory.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/ProcessingSettingsFactory.kt
@@ -48,7 +48,7 @@ fun createNullLoggingSpec(init: (ProcessingSpecBuilder.() -> Unit)? = null): Pro
 class DirectExecutor : AbstractExecutorService() {
 
     override fun execute(command: Runnable): Unit = command.run()
-    override fun shutdown() = Unit
+    override fun shutdown(): Unit = Unit
     override fun shutdownNow(): MutableList<Runnable> = mutableListOf()
     override fun isShutdown(): Boolean = true
     override fun isTerminated(): Boolean = true

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/ProcessingSettingsFactory.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/ProcessingSettingsFactory.kt
@@ -20,7 +20,7 @@ fun createProcessingSettings(
     reportPaths: Collection<ReportsSpec.Report> = emptyList(),
     spec: ProcessingSpec = createNullLoggingSpec {
         project {
-            inputPaths = inputPath?.let(::listOf) ?: emptyList()
+            inputPaths = inputPath?.let(::listOf).orEmpty()
         }
     }
 ) = ProcessingSettings(spec, config).apply {

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/IssueExtensionSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/IssueExtensionSpec.kt
@@ -15,8 +15,8 @@ class IssueExtensionSpec : Spek({
 
     val issues by memoized {
         mapOf(
-            Pair("Ruleset1", listOf(createFinding(), createCorrectableFinding())),
-            Pair("Ruleset2", listOf(createFinding()))
+            "Ruleset1" to listOf(createFinding(), createCorrectableFinding()),
+            "Ruleset2" to listOf(createFinding())
         )
     }
 

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/YamlConfigSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/YamlConfigSpec.kt
@@ -23,10 +23,10 @@ class YamlConfigSpec : Spek({
 
         it("should create a sub config") {
             val subConfig = config.subConfig("style")
-            assertThat(subConfig.valueOrDefault("WildcardImport", mapOf<String, Any>())).isNotEmpty
-            assertThat(subConfig.valueOrDefault("WildcardImport", mapOf<String, Any>())["active"].toString()).isEqualTo("true")
-            assertThat(subConfig.valueOrDefault("WildcardImport", mapOf<String, Any>())["active"] as Boolean).isTrue()
-            assertThat(subConfig.valueOrDefault("NotFound", mapOf<String, Any>())).isEmpty()
+            assertThat(subConfig.valueOrDefault("WildcardImport", emptyMap<String, Any>())).isNotEmpty
+            assertThat(subConfig.valueOrDefault("WildcardImport", emptyMap<String, Any>())["active"].toString()).isEqualTo("true")
+            assertThat(subConfig.valueOrDefault("WildcardImport", emptyMap<String, Any>())["active"] as Boolean).isTrue()
+            assertThat(subConfig.valueOrDefault("NotFound", emptyMap<String, Any>())).isEmpty()
             assertThat(subConfig.valueOrDefault("NotFound", "")).isEmpty()
         }
 

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/OutputFacadeSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/OutputFacadeSpec.kt
@@ -19,7 +19,7 @@ internal class OutputFacadeSpec : Spek({
     test("Running the output facade with multiple reports") {
         val printStream = StringPrintStream()
         val inputPath: Path = resourceAsPath("/cases")
-        val defaultResult = DetektResult(mapOf(Pair("Key", listOf(createFinding()))))
+        val defaultResult = DetektResult(mapOf("Key" to listOf(createFinding())))
         val plainOutputPath = createTempFileForTest("detekt", ".txt")
         val htmlOutputPath = createTempFileForTest("detekt", ".html")
         val xmlOutputPath = createTempFileForTest("detekt", ".xml")

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/ComplexityReportSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/ComplexityReportSpec.kt
@@ -37,7 +37,7 @@ internal class ComplexityReportSpec : Spek({
     }
 })
 
-private fun createDetektion(): Detektion = DetektResult(mapOf(Pair("Key", listOf(createFinding()))))
+private fun createDetektion(): Detektion = DetektResult(mapOf("Key" to listOf(createFinding())))
 
 private fun addData(detektion: Detektion) {
     detektion.addData(complexityKey, 2)

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/FileBasedFindingsReportSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/FileBasedFindingsReportSpec.kt
@@ -23,17 +23,13 @@ class FileBasedFindingsReportSpec : Spek({
                 val expectedContent = readResourceContent("/reporting/grouped-findings-report.txt")
                 val detektion = object : TestDetektion() {
                     override val findings: Map<String, List<Finding>> = mapOf(
-                        Pair(
-                            "Ruleset1",
-                            listOf(
-                                createFinding(fileName = "File1.kt"),
-                                createFinding(fileName = "File2.kt")
-                            )
+                        "Ruleset1" to listOf(
+                            createFinding(fileName = "File1.kt"),
+                            createFinding(fileName = "File2.kt")
                         ),
-                        Pair("EmptyRuleset", emptyList()),
-                        Pair(
-                            "Ruleset2",
-                            listOf(createFinding(fileName = "File1.kt"))
+                        "EmptyRuleset" to emptyList(),
+                        "Ruleset2" to listOf(
+                            createFinding(fileName = "File1.kt")
                         )
                     )
                 }
@@ -52,7 +48,7 @@ class FileBasedFindingsReportSpec : Spek({
         it("reports no findings when no rule set contains smells") {
             val detektion = object : TestDetektion() {
                 override val findings: Map<String, List<Finding>> = mapOf(
-                    Pair("EmptySmells", emptyList())
+                    "EmptySmells" to emptyList()
                 )
             }
             assertThat(subject.render(detektion)).isNull()

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/FindingsReportSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/FindingsReportSpec.kt
@@ -22,9 +22,9 @@ class FindingsReportSpec : Spek({
             val detektion by memoized {
                 object : TestDetektion() {
                     override val findings: Map<String, List<Finding>> = mapOf(
-                        Pair("Ruleset1", listOf(createFinding(), createFinding())),
-                        Pair("EmptyRuleset", emptyList()),
-                        Pair("Ruleset2", listOf(createFinding()))
+                        "Ruleset1" to listOf(createFinding(), createFinding()),
+                        "EmptyRuleset" to emptyList(),
+                        "Ruleset2" to listOf(createFinding())
                     )
                 }
             }
@@ -52,7 +52,7 @@ class FindingsReportSpec : Spek({
         it("reports no findings with rule set containing no smells") {
             val detektion = object : TestDetektion() {
                 override val findings: Map<String, List<Finding>> = mapOf(
-                    Pair("Ruleset", emptyList())
+                    "Ruleset" to emptyList()
                 )
             }
             assertThat(subject.render(detektion)).isNull()

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/rules/MultiRuleSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/rules/MultiRuleSpec.kt
@@ -86,7 +86,9 @@ private class TestMultiRule(config: Config) : MultiRule() {
 @Suppress("detekt.UnnecessaryAbstractClass") // uses inherited members
 private abstract class AbstractRule(config: Config) : Rule(config) {
     override val issue: Issue = Issue(javaClass.simpleName, Severity.Minor, "", Debt.TWENTY_MINS)
-    override fun visitKtFile(file: KtFile) = report(CodeSmell(issue, Entity.from(file), message = ""))
+    override fun visitKtFile(file: KtFile) {
+        report(CodeSmell(issue, Entity.from(file), message = ""))
+    }
 }
 
 private class TestRuleOne(config: Config) : AbstractRule(config)

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingRule.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingRule.kt
@@ -55,7 +55,7 @@ abstract class FormattingRule(config: Config) : Rule(config) {
         val editorConfigProperties = overrideEditorConfigProperties()
 
         if (!editorConfigProperties.isNullOrEmpty()) {
-            val userData = (root.node.getUserData(KtLint.EDITOR_CONFIG_PROPERTIES_USER_DATA_KEY) ?: emptyMap())
+            val userData = (root.node.getUserData(KtLint.EDITOR_CONFIG_PROPERTIES_USER_DATA_KEY).orEmpty())
                 .toMutableMap()
             editorConfigProperties.forEach { (editorConfigProperty, defaultValue) ->
                 userData[editorConfigProperty.type.name] = Property.builder()
@@ -92,7 +92,7 @@ abstract class FormattingRule(config: Config) : Rule(config) {
             val packageName = root.packageFqName.asString()
                 .takeIf { it.isNotEmpty() }
                 ?.plus(".")
-                ?: ""
+                .orEmpty()
             val entity = Entity("", "$packageName${root.fileName}:$line", location, root)
             report(CorrectableCodeSmell(issue, entity, message, autoCorrectEnabled = autoCorrect))
         }

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/DocumentationCollector.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/DocumentationCollector.kt
@@ -14,7 +14,7 @@ class DocumentationCollector {
         private set
 
     fun setClass(classOrObject: KtClassOrObject) {
-        name = classOrObject.name?.trim() ?: ""
+        name = classOrObject.name?.trim().orEmpty()
         classOrObject.kDocSection()
             ?.getContent()
             ?.trim()

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/KDocTags.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/KDocTags.kt
@@ -9,7 +9,7 @@ fun KtClassOrObject.parseConfigurationTags() =
     kDocSection()?.findTagsByName(TAG_CONFIGURATION)
         ?.filter { it.isValidConfigurationTag() }
         ?.map { it.parseConfigTag() }
-        ?: emptyList()
+        .orEmpty()
 
 fun KtClassOrObject.kDocSection(): KDocSection? = docComment?.getDefaultSection()
 
@@ -24,7 +24,8 @@ private fun KDocTag.parseConfigTag(): Configuration {
     val defaultValue = configurationDefaultValueRegex.find(content)
         ?.groupValues
         ?.get(1)
-        ?.trim() ?: ""
+        ?.trim()
+        .orEmpty()
     val deprecatedMessage = configurationDeprecatedRegex.find(content)
         ?.groupValues
         ?.get(1)

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/MultiRuleCollector.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/MultiRuleCollector.kt
@@ -15,13 +15,13 @@ import org.jetbrains.kotlin.psi.psiUtil.referenceExpression
 
 data class MultiRule(
     val name: String,
-    val rules: List<String> = listOf()
+    val rules: List<String> = emptyList()
 ) {
 
     operator fun contains(ruleName: String) = ruleName in this.rules
 }
 
-private val multiRule = io.gitlab.arturbosch.detekt.api.MultiRule::class.simpleName ?: ""
+private val multiRule = io.gitlab.arturbosch.detekt.api.MultiRule::class.simpleName.orEmpty()
 
 class MultiRuleCollector : Collector<MultiRule> {
     override val items = mutableListOf<MultiRule>()
@@ -80,7 +80,7 @@ class MultiRuleVisitor : DetektVisitor() {
             return
         }
 
-        name = classOrObject.name?.trim() ?: ""
+        name = classOrObject.name?.trim().orEmpty()
     }
 
     override fun visitProperty(property: KtProperty) {
@@ -115,14 +115,14 @@ class RuleListVisitor : DetektVisitor() {
         ruleNames.addAll(
             argumentExpressions
                 .filterIsInstance<KtCallExpression>()
-                .map { it.calleeExpression?.text ?: "" }
+                .map { it.calleeExpression?.text.orEmpty() }
         )
 
         // Reference Expression = variable we need to search for
         ruleProperties.addAll(
             argumentExpressions
                 .filterIsInstance<KtReferenceExpression>()
-                .map { it.text ?: "" }
+                .map { it.text.orEmpty() }
         )
     }
 }

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/Rule.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/Rule.kt
@@ -10,7 +10,7 @@ data class Rule(
     var debt: String,
     var aliases: String?,
     val parent: String,
-    val configuration: List<Configuration> = listOf(),
+    val configuration: List<Configuration> = emptyList(),
     val autoCorrect: Boolean = false,
     var inMultiRule: String? = null,
     val requiresTypeResolution: Boolean = false

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleSetProviderCollector.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleSetProviderCollector.kt
@@ -18,8 +18,8 @@ data class RuleSetProvider(
     val name: String,
     val description: String,
     val defaultActivationStatus: DefaultActivationStatus,
-    val rules: List<String> = listOf(),
-    val configuration: List<Configuration> = listOf()
+    val rules: List<String> = emptyList(),
+    val configuration: List<Configuration> = emptyList()
 )
 
 class RuleSetProviderCollector : Collector<RuleSetProvider> {
@@ -64,13 +64,13 @@ class RuleSetProviderVisitor : DetektVisitor() {
         val superTypes = list.entries
             ?.map { it.typeAsUserType?.referencedName }
             ?.toSet()
-            ?: emptySet()
+            .orEmpty()
         containsRuleSetProvider = SUPPORTED_PROVIDERS.any { it in superTypes }
         super.visitSuperTypeList(list)
     }
 
     override fun visitClassOrObject(classOrObject: KtClassOrObject) {
-        description = classOrObject.docComment?.getDefaultSection()?.getContent()?.trim() ?: ""
+        description = classOrObject.docComment?.getDefaultSection()?.getContent()?.trim().orEmpty()
         if (classOrObject.isAnnotatedWith(ActiveByDefault::class)) {
             defaultActivationStatus = Active(since = classOrObject.firstAnnotationParameter(ActiveByDefault::class))
         }
@@ -84,7 +84,7 @@ class RuleSetProviderVisitor : DetektVisitor() {
             name = (property.initializer as? KtStringTemplateExpression)?.entries?.get(0)?.text
                 ?: throw InvalidDocumentationException(
                     "RuleSetProvider class " +
-                        "${property.containingClass()?.name ?: ""} doesn't provide list of rules."
+                        "${property.containingClass()?.name.orEmpty()} doesn't provide list of rules."
                 )
         }
     }
@@ -102,7 +102,7 @@ class RuleSetProviderVisitor : DetektVisitor() {
                 ?.valueArguments
                 ?.mapNotNull { it.getArgumentExpression() }
                 ?.mapNotNull { it.referenceExpression()?.text }
-                ?: emptyList()
+                .orEmpty()
 
             ruleNames.addAll(ruleArgumentNames)
         }

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleVisitor.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleVisitor.kt
@@ -69,7 +69,7 @@ internal class RuleVisitor : DetektVisitor() {
         val className = containingClass?.name
         if (containingClass != null && className != null && !classesMap.containsKey(className)) {
             classesMap[className] = isRule
-            parent = containingClass.getSuperNames().firstOrNull { ruleClasses.contains(it) } ?: ""
+            parent = containingClass.getSuperNames().firstOrNull { ruleClasses.contains(it) }.orEmpty()
             extractIssueSeverityAndDebt(containingClass)
             extractAliases(containingClass)
         }
@@ -138,7 +138,7 @@ internal class RuleVisitor : DetektVisitor() {
                 .singleOrNull { it.name == "issue" }
                 ?.initializer as? KtCallExpression
             )
-            ?.valueArguments ?: emptyList()
+            ?.valueArguments.orEmpty()
 
         if (arguments.size >= ISSUE_ARGUMENT_SIZE) {
             severity = getArgument(arguments[1], "Severity")

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/out/Markdown.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/out/Markdown.kt
@@ -22,16 +22,16 @@ inline fun markdown(content: MarkdownContent.() -> Unit): String {
     }
 }
 
-inline fun MarkdownContent.markdown(markdown: () -> String) = append(markdown())
-inline fun MarkdownContent.paragraph(content: () -> String) = append("${content()}\n")
+inline fun MarkdownContent.markdown(markdown: () -> String): Unit = append(markdown())
+inline fun MarkdownContent.paragraph(content: () -> String): Unit = append("${content()}\n")
 
 inline fun MarkdownContent.bold(content: () -> String) = "**${content()}**"
 inline fun MarkdownContent.crossOut(code: () -> String) = "~~${code()}~~"
 
-inline fun MarkdownContent.h1(heading: () -> String) = append("# ${heading()}\n")
-inline fun MarkdownContent.h2(heading: () -> String) = append("## ${heading()}\n")
-inline fun MarkdownContent.h3(heading: () -> String) = append("### ${heading()}\n")
-inline fun MarkdownContent.h4(heading: () -> String) = append("#### ${heading()}\n")
+inline fun MarkdownContent.h1(heading: () -> String): Unit = append("# ${heading()}\n")
+inline fun MarkdownContent.h2(heading: () -> String): Unit = append("## ${heading()}\n")
+inline fun MarkdownContent.h3(heading: () -> String): Unit = append("### ${heading()}\n")
+inline fun MarkdownContent.h4(heading: () -> String): Unit = append("#### ${heading()}\n")
 
 inline fun MarkdownContent.orderedList(sectionList: () -> List<String>) {
     for (i in sectionList().indices) {
@@ -44,7 +44,7 @@ inline fun MarkdownContent.code(code: () -> String) = "``${code()}``"
 
 inline fun MarkdownContent.codeBlock(syntax: String = "kotlin", code: () -> String) = "```$syntax\n${code()}\n```"
 
-fun MarkdownContent.emptyLine() = append("")
+fun MarkdownContent.emptyLine(): Unit = append("")
 
 inline fun MarkdownContent.list(listContent: MarkdownList.() -> Unit) {
     return MarkdownList().let { list ->
@@ -55,5 +55,5 @@ inline fun MarkdownContent.list(listContent: MarkdownList.() -> Unit) {
     }
 }
 
-inline fun MarkdownList.item(item: () -> String) = append("* ${item()}\n")
-inline fun MarkdownList.description(description: () -> String) = append("  ${description()}\n")
+inline fun MarkdownList.item(item: () -> String): Unit = append("* ${item()}\n")
+inline fun MarkdownList.description(description: () -> String): Unit = append("  ${description()}\n")

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/out/Yaml.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/out/Yaml.kt
@@ -61,7 +61,7 @@ fun YamlNode.list(name: String, list: List<String>) {
     }
 }
 
-inline fun YamlNode.yaml(yaml: () -> String) = append(yaml())
+inline fun YamlNode.yaml(yaml: () -> String): Unit = append(yaml())
 
 private fun String.quotedForList(): String {
     return when {

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/rulesetpage/Exclusion.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/rulesetpage/Exclusion.kt
@@ -14,7 +14,7 @@ val exclusions = arrayOf(TestExclusions, KotlinScriptExclusions, LibraryExclusio
 abstract class Exclusions {
 
     abstract val pattern: String
-    open val ruleSets: Set<String> = setOf()
+    open val ruleSets: Set<String> = emptySet()
     abstract val rules: Set<String>
 
     fun isExcluded(rule: Rule) = rule.name in rules || rule.inMultiRule in rules
@@ -24,7 +24,7 @@ private object TestExclusions : Exclusions() {
 
     override val pattern =
         "['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']"
-    override val ruleSets = emptySet<String>()
+    override val ruleSets: Set<String> = emptySet()
     override val rules = setOf(
         "NamingRules",
         "WildcardImport",

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/rulesetpage/RuleSetPagePrinter.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/rulesetpage/RuleSetPagePrinter.kt
@@ -43,7 +43,7 @@ object RuleSetPagePrinter : DocumentationPrinter<RuleSetPage> {
 
             paragraph {
                 "${bold { "Active by default" }}: ${if (rule.defaultActivationStatus.active) "Yes" else "No"}" +
-                    ((rule.defaultActivationStatus as? Active)?.let { " - Since v${it.since}" } ?: "")
+                    ((rule.defaultActivationStatus as? Active)?.let { " - Since v${it.since}" }.orEmpty())
             }
 
             if (rule.requiresTypeResolution) {

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -207,9 +207,13 @@ open class Detekt @Inject constructor(
     @Input
     override fun getIgnoreFailures(): Boolean = ignoreFailuresProp.getOrElse(false)
 
-    override fun setIgnoreFailures(value: Boolean) = ignoreFailuresProp.set(value)
+    override fun setIgnoreFailures(value: Boolean) {
+        ignoreFailuresProp.set(value)
+    }
 
-    fun reports(configure: Action<DetektReports>) = configure.execute(reports)
+    fun reports(configure: Action<DetektReports>) {
+        configure.execute(reports)
+    }
 
     @TaskAction
     fun check() {

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/KotlinExtension.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/KotlinExtension.kt
@@ -9,5 +9,6 @@ import org.gradle.api.Project
     """Either apply detekt plugin to root project or follow this advice:
 https://docs.gradle.org/current/userguide/kotlin_dsl.html#sec:multi_project_builds_applying_plugins"""
 )
-fun Project.detekt(configure: DetektExtension.() -> Unit) =
+fun Project.detekt(configure: DetektExtension.() -> Unit) {
     extensions.configure(DetektExtension::class.java, configure)
+}

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
@@ -78,7 +78,9 @@ open class DetektExtension @Inject constructor(objects: ObjectFactory) : CodeQua
      */
     var ignoredFlavors: List<String> = emptyList()
 
-    fun reports(configure: Action<DetektReports>) = configure.execute(reports)
+    fun reports(configure: Action<DetektReports>) {
+        configure.execute(reports)
+    }
 
     companion object {
         const val DEFAULT_SRC_DIR_JAVA = "src/main/java"

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektReport.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektReport.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.extensions
 
 import java.io.File
 
-class DetektReport(val type: DetektReportType) {
+data class DetektReport(val type: DetektReportType) {
 
     var enabled: Boolean? = null
 

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektReports.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektReports.kt
@@ -20,19 +20,19 @@ class DetektReports {
 
     val custom = mutableListOf<CustomDetektReport>()
 
-    fun xml(configure: DetektReport.() -> Unit) = xml.configure()
+    fun xml(configure: DetektReport.() -> Unit): Unit = xml.configure()
     fun xml(closure: Closure<*>): DetektReport = ConfigureUtil.configure(closure, xml)
 
-    fun html(configure: DetektReport.() -> Unit) = html.configure()
+    fun html(configure: DetektReport.() -> Unit): Unit = html.configure()
     fun html(closure: Closure<*>): DetektReport = ConfigureUtil.configure(closure, html)
 
-    fun txt(configure: DetektReport.() -> Unit) = txt.configure()
+    fun txt(configure: DetektReport.() -> Unit): Unit = txt.configure()
     fun txt(closure: Closure<*>): DetektReport = ConfigureUtil.configure(closure, txt)
 
-    fun sarif(configure: DetektReport.() -> Unit) = sarif.configure()
+    fun sarif(configure: DetektReport.() -> Unit): Unit = sarif.configure()
     fun sarif(closure: Closure<*>): DetektReport = ConfigureUtil.configure(closure, sarif)
 
-    fun custom(configure: CustomDetektReport.() -> Unit) = createAndAddCustomReport().configure()
+    fun custom(configure: CustomDetektReport.() -> Unit): Unit = createAndAddCustomReport().configure()
     fun custom(closure: Closure<*>): CustomDetektReport = ConfigureUtil.configure(closure, createAndAddCustomReport())
 
     private fun createAndAddCustomReport() = CustomDetektReport().apply { custom.add(this) }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektAndroid.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektAndroid.kt
@@ -68,7 +68,7 @@ internal class DetektAndroid(private val project: Project) {
         // so we catch them all by looking for this one
         project.afterEvaluate {
             val baseExtension = project.extensions.findByType(BaseExtension::class.java)
-            baseExtension?.let {
+            if (baseExtension != null) {
                 val bootClasspath = project.files(baseExtension.bootClasspath)
                 baseExtension.variants
                     ?.matching { !extension.matchesIgnoredConfiguration(it) }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektAndroid.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektAndroid.kt
@@ -61,8 +61,7 @@ internal class DetektAndroid(private val project: Project) {
         }
 
     private val BaseVariant.testVariants: List<BaseVariant>
-        get() = if (this is TestedVariant) listOfNotNull(testVariant, unitTestVariant)
-        else emptyList()
+        get() = if (this is TestedVariant) listOfNotNull(testVariant, unitTestVariant) else emptyList()
 
     fun registerTasks(extension: DetektExtension) {
         // There is not a single Android plugin, but each registers an extension based on BaseExtension,

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/CliArgument.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/CliArgument.kt
@@ -51,20 +51,20 @@ internal data class ClasspathArgument(val fileCollection: FileCollection) : CliA
 }
 
 internal data class LanguageVersionArgument(val languageVersion: String?) : CliArgument() {
-    override fun toArgument() = languageVersion?.let { listOf(LANGUAGE_VERSION_PARAMETER, it) } ?: emptyList()
+    override fun toArgument() = languageVersion?.let { listOf(LANGUAGE_VERSION_PARAMETER, it) }.orEmpty()
 }
 
 internal data class JvmTargetArgument(val jvmTarget: String?) : CliArgument() {
-    override fun toArgument() = jvmTarget?.let { listOf(JVM_TARGET_PARAMETER, it) } ?: emptyList()
+    override fun toArgument() = jvmTarget?.let { listOf(JVM_TARGET_PARAMETER, it) }.orEmpty()
 }
 
 internal data class BaselineArgument(val baseline: RegularFile?) : CliArgument() {
-    override fun toArgument() = baseline?.let { listOf(BASELINE_PARAMETER, it.asFile.absolutePath) } ?: emptyList()
+    override fun toArgument() = baseline?.let { listOf(BASELINE_PARAMETER, it.asFile.absolutePath) }.orEmpty()
 }
 
 internal data class DefaultReportArgument(val type: DetektReportType, val file: RegularFile?) : CliArgument() {
     override fun toArgument() =
-        file?.let { listOf(REPORT_PARAMETER, "${type.reportId}:${it.asFile.absoluteFile}") } ?: emptyList()
+        file?.let { listOf(REPORT_PARAMETER, "${type.reportId}:${it.asFile.absoluteFile}") }.orEmpty()
 }
 
 internal data class CustomReportArgument(val reportId: String, val file: RegularFile) : CliArgument() {
@@ -72,7 +72,7 @@ internal data class CustomReportArgument(val reportId: String, val file: Regular
 }
 
 internal data class BasePathArgument(val basePath: String?) : CliArgument() {
-    override fun toArgument() = basePath?.let { listOf(BASE_PATH_PARAMETER, it) } ?: emptyList()
+    override fun toArgument() = basePath?.let { listOf(BASE_PATH_PARAMETER, it) }.orEmpty()
 }
 
 internal data class ConfigArgument(val files: Collection<File>) : CliArgument() {

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/invoke/DefaultCliInvokerSpec.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/invoke/DefaultCliInvokerSpec.kt
@@ -14,7 +14,7 @@ internal class DefaultCliInvokerSpec : Spek({
 
         assertThatCode {
             DefaultCliInvoker(stubbedCache)
-                .invokeCli(listOf(), TestFileCollection(), "detekt", ignoreFailures = false)
+                .invokeCli(emptyList(), TestFileCollection(), "detekt", ignoreFailures = false)
         }.isInstanceOf(GradleException::class.java)
             .hasMessageContaining("testing reflection wrapper...")
     }

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/testkit/DslGradleRunner.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/testkit/DslGradleRunner.kt
@@ -4,7 +4,7 @@ import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
 import java.io.File
 import java.nio.file.Files
-import java.util.*
+import java.util.UUID
 
 @Suppress("TooManyFunctions", "ClassOrdering")
 class DslGradleRunner @Suppress("LongParameterList") constructor(
@@ -73,7 +73,7 @@ class DslGradleRunner @Suppress("LongParameterList") constructor(
         }
 
         projectLayout.submodules.forEach { submodule ->
-            submodule.writeModuleFile(buildFileName, submodule.buildFileContent ?: "")
+            submodule.writeModuleFile(buildFileName, submodule.buildFileContent.orEmpty())
             submodule.baselineFiles.forEach { file -> submodule.writeModuleFile(file, baselineContent) }
             submodule.srcDirs.forEachIndexed { srcDirIdx, moduleSourceDir ->
                 repeat(submodule.numberOfSourceFilesPerSourceDir) {

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/testkit/DslGradleRunner.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/testkit/DslGradleRunner.kt
@@ -4,7 +4,7 @@ import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
 import java.io.File
 import java.nio.file.Files
-import java.util.UUID
+import java.util.*
 
 @Suppress("TooManyFunctions", "ClassOrdering")
 class DslGradleRunner @Suppress("LongParameterList") constructor(
@@ -55,7 +55,9 @@ class DslGradleRunner @Suppress("LongParameterList") constructor(
     fun setupProject() {
         writeProjectFile(buildFileName, mainBuildFileContent)
         writeProjectFile(SETTINGS_FILENAME, settingsContent)
-        configFileOrNone?.let { writeProjectFile(configFileOrNone, configFileContent) }
+        if (configFileOrNone != null) {
+            writeProjectFile(configFileOrNone, configFileContent)
+        }
         baselineFiles.forEach { file -> writeProjectFile(file, baselineContent) }
         projectLayout.srcDirs.forEachIndexed { srcDirIdx, sourceDir ->
             repeat(projectLayout.numberOfSourceFilesInRootPerSourceDir) { srcFileIndex ->
@@ -126,7 +128,7 @@ class DslGradleRunner @Suppress("LongParameterList") constructor(
             withProjectDir(rootDir)
             withPluginClasspath()
             withArguments(args)
-            gradleVersionOrNone?.let { withGradleVersion(gradleVersionOrNone) }
+            gradleVersionOrNone?.let(::withGradleVersion)
         }
     }
 

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/testkit/DslTestBuilder.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/testkit/DslTestBuilder.kt
@@ -60,7 +60,7 @@ abstract class DslTestBuilder {
             gradleBuildName,
             mainBuildFileContent,
             configFile,
-            baselineFile?.let { listOf(it) } ?: emptyList(),
+            baselineFile?.let(::listOf).orEmpty(),
             gradleVersion,
             dryRun
         )

--- a/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/ComplexityMetric.kt
+++ b/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/ComplexityMetric.kt
@@ -7,6 +7,7 @@ import io.github.detekt.metrics.processors.logicalLinesKey
 import io.github.detekt.metrics.processors.sourceLinesKey
 import io.gitlab.arturbosch.detekt.api.Detektion
 
+@Suppress("UseDataClass")
 class ComplexityMetric(detektion: Detektion) {
 
     val mcc = detektion.getData(complexityKey)

--- a/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/ComplexityMetric.kt
+++ b/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/ComplexityMetric.kt
@@ -6,15 +6,28 @@ import io.github.detekt.metrics.processors.linesKey
 import io.github.detekt.metrics.processors.logicalLinesKey
 import io.github.detekt.metrics.processors.sourceLinesKey
 import io.gitlab.arturbosch.detekt.api.Detektion
+import io.gitlab.arturbosch.detekt.api.Finding
+import io.gitlab.arturbosch.detekt.api.RuleSetId
 
-@Suppress("UseDataClass")
-class ComplexityMetric(detektion: Detektion) {
-
-    val mcc = detektion.getData(complexityKey)
-    val cognitiveComplexity = detektion.getData(CognitiveComplexity.KEY)
-    val loc = detektion.getData(linesKey)
-    val sloc = detektion.getData(sourceLinesKey)
-    val lloc = detektion.getData(logicalLinesKey)
-    val cloc = detektion.getData(commentLinesKey)
-    val findings = detektion.findings.entries
+data class ComplexityMetric(
+    val mcc: Int?,
+    val cognitiveComplexity: Int?,
+    val loc: Int?,
+    val sloc: Int?,
+    val lloc: Int?,
+    val cloc: Int?,
+    val findings: Set<Map.Entry<RuleSetId, List<Finding>>>
+) {
+    companion object {
+        fun create(detektion: Detektion): ComplexityMetric =
+            ComplexityMetric(
+                mcc = detektion.getData(complexityKey),
+                cognitiveComplexity = detektion.getData(CognitiveComplexity.KEY),
+                loc = detektion.getData(linesKey),
+                sloc = detektion.getData(sourceLinesKey),
+                lloc = detektion.getData(logicalLinesKey),
+                cloc = detektion.getData(commentLinesKey),
+                findings = detektion.findings.entries
+            )
+    }
 }

--- a/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/ComplexityReportGenerator.kt
+++ b/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/ComplexityReportGenerator.kt
@@ -47,6 +47,6 @@ class ComplexityReportGenerator(private val complexityMetric: ComplexityMetric) 
 
     companion object Factory {
         fun create(detektion: Detektion): ComplexityReportGenerator =
-            ComplexityReportGenerator(ComplexityMetric(detektion))
+            ComplexityReportGenerator(ComplexityMetric.create(detektion))
     }
 }

--- a/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/CyclomaticComplexity.kt
+++ b/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/CyclomaticComplexity.kt
@@ -24,7 +24,7 @@ import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
 @Suppress("TooManyFunctions")
 class CyclomaticComplexity(private val config: Config) : DetektVisitor() {
 
-    class Config(
+    data class Config(
         var ignoreSimpleWhenEntries: Boolean = false,
         var ignoreNestingFunctions: Boolean = false,
         var nestingFunctions: Set<String> = DEFAULT_NESTING_FUNCTIONS

--- a/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/CyclomaticComplexity.kt
+++ b/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/CyclomaticComplexity.kt
@@ -94,7 +94,7 @@ class CyclomaticComplexity(private val config: Config) : DetektVisitor() {
     override fun visitCallExpression(expression: KtCallExpression) {
         if (!config.ignoreNestingFunctions && expression.isUsedForNesting()) {
             val lambdaExpression = expression.lambdaArguments.firstOrNull()?.getLambdaExpression()
-            lambdaExpression?.bodyExpression?.let {
+            if (lambdaExpression?.bodyExpression != null) {
                 complexity++
             }
         }

--- a/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/processors/ProjectSLOCProcessor.kt
+++ b/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/processors/ProjectSLOCProcessor.kt
@@ -25,8 +25,7 @@ class SLOCVisitor : DetektVisitor() {
         fun count(lines: List<String>): Int {
             return lines
                 .map { it.trim() }
-                .filter { trim -> trim.isNotEmpty() && !comments.any { trim.startsWith(it) } }
-                .size
+                .count { trim -> trim.isNotEmpty() && !comments.any { trim.startsWith(it) } }
         }
     }
 }

--- a/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/ComplexityReportGeneratorSpec.kt
+++ b/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/ComplexityReportGeneratorSpec.kt
@@ -87,7 +87,5 @@ private fun TestDetektion.withTestData(): TestDetektion {
 }
 
 private fun generateComplexityReport(detektion: Detektion): List<String>? {
-    val complexityMetric = ComplexityMetric(detektion)
-    val generator = ComplexityReportGenerator(complexityMetric)
-    return generator.generate()
+    return ComplexityReportGenerator.create(detektion).generate()
 }

--- a/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/CyclomaticComplexitySpec.kt
+++ b/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/CyclomaticComplexitySpec.kt
@@ -90,7 +90,7 @@ class CyclomaticComplexitySpec : Spek({
         it("does not count when forEach is not specified") {
             assertThat(
                 CyclomaticComplexity.calculate(code) {
-                    nestingFunctions = setOf()
+                    nestingFunctions = emptySet()
                 }
             ).isEqualTo(defaultFunctionComplexity)
         }

--- a/detekt-psi-utils/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/MethodSignatureSpec.kt
+++ b/detekt-psi-utils/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/MethodSignatureSpec.kt
@@ -49,7 +49,7 @@ class MethodSignatureSpec : Spek({
     }
 })
 
-private class TestCase(
+private data class TestCase(
     val testDescription: String,
     val methodSignature: String,
     val expectedMethodName: String,

--- a/detekt-report-html/src/main/kotlin/io/github/detekt/report/html/HtmlOutputReport.kt
+++ b/detekt-report-html/src/main/kotlin/io/github/detekt/report/html/HtmlOutputReport.kt
@@ -150,7 +150,7 @@ class HtmlOutputReport : OutputReport() {
     }
 
     private fun getComplexityMetrics(detektion: Detektion): List<String> {
-        return ComplexityReportGenerator.create(detektion).generate() ?: emptyList()
+        return ComplexityReportGenerator.create(detektion).generate().orEmpty()
     }
 }
 

--- a/detekt-report-html/src/test/kotlin/io/github/detekt/report/html/HtmlOutputReportSpec.kt
+++ b/detekt-report-html/src/test/kotlin/io/github/detekt/report/html/HtmlOutputReportSpec.kt
@@ -112,7 +112,7 @@ class HtmlOutputReportSpec : Spek({
         it("renders a metric report correctly") {
             val detektion = object : TestDetektion() {
                 override val metrics: Collection<ProjectMetric> = listOf(
-                    ProjectMetric("M1", 10000),
+                    ProjectMetric("M1", 10_000),
                     ProjectMetric("M2", 2)
                 )
             }

--- a/detekt-report-html/src/test/kotlin/io/github/detekt/report/html/HtmlOutputReportSpec.kt
+++ b/detekt-report-html/src/test/kotlin/io/github/detekt/report/html/HtmlOutputReportSpec.kt
@@ -64,7 +64,7 @@ class HtmlOutputReportSpec : Spek({
         it("contains no findings") {
             val detektion = object : TestDetektion() {
                 override val findings: Map<String, List<Finding>> = mapOf(
-                    Pair("EmptyRuleset", emptyList())
+                    "EmptyRuleset" to emptyList()
                 )
             }
             val result = htmlReport.render(detektion)

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LabeledExpression.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LabeledExpression.kt
@@ -69,7 +69,7 @@ class LabeledExpression(config: Config = Config.empty) : Rule(config) {
     )
 
     @Configuration("allows to provide a list of label names which should be ignored by this rule")
-    private val ignoredLabels: List<String> by config(listOf<String>()) { list ->
+    private val ignoredLabels: List<String> by config(emptyList<String>()) { list ->
         list.map { it.removePrefix("*").removeSuffix("*") }
     }
 

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongMethod.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongMethod.kt
@@ -58,8 +58,7 @@ class LongMethod(config: Config = Config.empty) : Rule(config) {
         val functionToLines = HashMap<KtNamedFunction, Int>()
         functionToLinesCache.map { (function, lines) ->
             val isNested = function.getStrictParentOfType<KtNamedFunction>() != null
-            if (isNested) functionToLines[function] = functionToBodyLinesCache[function] ?: 0
-            else functionToLines[function] = lines
+            functionToLines[function] = if (isNested) functionToBodyLinesCache[function] ?: 0 else lines
         }
         for ((function, lines) in functionToLines) {
             if (lines >= threshold) {

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterList.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterList.kt
@@ -134,7 +134,7 @@ class LongParameterList(config: Config = Config.empty) : Rule(config) {
     private fun KtParameterList.parameterCount(): Int {
         val preFilteredParameters = parameters.filter { !it.isIgnored() }
         return if (ignoreDefaultParameters) {
-            preFilteredParameters.filter { !it.hasDefaultValue() }.size
+            preFilteredParameters.count { !it.hasDefaultValue() }
         } else {
             preFilteredParameters.size
         }

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterList.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterList.kt
@@ -68,7 +68,7 @@ class LongParameterList(config: Config = Config.empty) : Rule(config) {
             "the most common cases are for dependency injection where constructors are annotated with `@Inject` " +
             "or parameters are annotated with `@Value` and should not be counted for the rule to trigger"
     )
-    private val ignoreAnnotated: List<String> by config(listOf<String>()) { list ->
+    private val ignoreAnnotated: List<String> by config(emptyList<String>()) { list ->
         list.map { it.removePrefix("*").removeSuffix("*") }
     }
 

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedBlockDepth.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedBlockDepth.kt
@@ -116,7 +116,7 @@ class NestedBlockDepth(config: Config = Config.empty) : Rule(config) {
         private fun insideLambdaDo(lambdaArguments: List<KtLambdaArgument>, function: () -> Unit) {
             if (lambdaArguments.isNotEmpty()) {
                 val lambdaArgument = lambdaArguments[0]
-                lambdaArgument.getLambdaExpression()?.bodyExpression?.let {
+                if (lambdaArgument.getLambdaExpression()?.bodyExpression != null) {
                     function()
                 }
             }

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/TooManyFunctions.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/TooManyFunctions.kt
@@ -155,8 +155,7 @@ class TooManyFunctions(config: Config = Config.empty) : Rule(config) {
         ?.run {
             declarations
                 .filterIsInstance<KtNamedFunction>()
-                .filter { !isIgnoredFunction(it) }
-                .size
+                .count { !isIgnoredFunction(it) }
         } ?: 0
 
     private fun isIgnoredFunction(function: KtNamedFunction): Boolean = when {

--- a/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/RedundantSuspendModifier.kt
+++ b/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/RedundantSuspendModifier.kt
@@ -82,8 +82,11 @@ class RedundantSuspendModifier(config: Config) : Rule(config) {
             is KtOperationReferenceExpression, is KtForExpression, is KtProperty, is KtNameReferenceExpression -> true
             else -> {
                 val parent = parent
-                if (parent is KtCallExpression && parent.calleeExpression == this) true
-                else this is KtCallExpression && this.calleeExpression is KtCallExpression
+                if (parent is KtCallExpression && parent.calleeExpression == this) {
+                    true
+                } else {
+                    this is KtCallExpression && this.calleeExpression is KtCallExpression
+                }
             }
         }
     }
@@ -116,8 +119,9 @@ class RedundantSuspendModifier(config: Config) : Rule(config) {
             }
             else -> {
                 val resolvedCall = getResolvedCall(bindingContext)
-                if ((resolvedCall?.resultingDescriptor as? FunctionDescriptor)?.isSuspend == true) true
-                else {
+                if ((resolvedCall?.resultingDescriptor as? FunctionDescriptor)?.isSuspend == true) {
+                    true
+                } else {
                     val propertyDescriptor = resolvedCall?.resultingDescriptor as? PropertyDescriptor
                     val s = propertyDescriptor?.fqNameSafe?.asString()
                     s?.startsWith("kotlin.coroutines.") == true && s.endsWith(".coroutineContext")

--- a/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/RedundantSuspendModifier.kt
+++ b/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/RedundantSuspendModifier.kt
@@ -107,7 +107,7 @@ class RedundantSuspendModifier(config: Config) : Rule(config) {
                 if (hasDelegateExpression()) {
                     val variableDescriptor =
                         bindingContext[DECLARATION_TO_DESCRIPTOR, this] as? VariableDescriptorWithAccessors
-                    val accessors = variableDescriptor?.accessors ?: emptyList()
+                    val accessors = variableDescriptor?.accessors.orEmpty()
                     accessors.any { accessor ->
                         val delegatedFunctionDescriptor =
                             bindingContext[DELEGATED_PROPERTY_RESOLVED_CALL, accessor]?.resultingDescriptor

--- a/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/LicenceHeaderLoaderExtension.kt
+++ b/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/LicenceHeaderLoaderExtension.kt
@@ -57,6 +57,7 @@ class LicenceHeaderLoaderExtension : FileProcessListener {
                 """.trimIndent()
             }
 
+            @Suppress("UnnecessaryLet")
             return Files.newBufferedReader(templateFile)
                 .use(BufferedReader::readText)
                 .let(StringUtilRt::convertLineSeparators)

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCast.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCast.kt
@@ -55,7 +55,7 @@ class UnsafeCast(config: Config = Config.empty) : Rule(config) {
                 CodeSmell(
                     issue,
                     Entity.from(expression),
-                    "${expression.left.text} cast to ${expression.right?.text ?: ""} cannot succeed."
+                    "${expression.left.text} cast to ${expression.right?.text.orEmpty()} cannot succeed."
                 )
             )
         }

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UselessPostfixExpression.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UselessPostfixExpression.kt
@@ -62,7 +62,7 @@ class UselessPostfixExpression(config: Config = Config.empty) : Rule(config) {
         Debt.TWENTY_MINS
     )
 
-    var properties = setOf<String?>()
+    var properties: Set<String?> = emptySet()
 
     override fun visitClass(klass: KtClass) {
         properties = klass.getProperties()

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ForbiddenClassName.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ForbiddenClassName.kt
@@ -26,7 +26,7 @@ class ForbiddenClassName(config: Config = Config.empty) : Rule(config) {
     )
 
     @Configuration("forbidden class names")
-    private val forbiddenName: List<String> by config(listOf<String>()) { names ->
+    private val forbiddenName: List<String> by config(emptyList<String>()) { names ->
         names.map { it.removePrefix("*").removeSuffix("*") }
     }
 

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingRules.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingRules.kt
@@ -60,7 +60,7 @@ class NamingRules(config: Config = Config.empty) : MultiRule() {
         if (declaration.nameAsSafeName.isSpecial) {
             return
         }
-        declaration.nameIdentifier?.parent?.javaClass?.let {
+        if (declaration.nameIdentifier?.parent?.javaClass != null) {
             when (declaration) {
                 is KtProperty -> handleProperty(declaration)
                 is KtNamedFunction -> handleFunction(declaration)

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenImport.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenImport.kt
@@ -44,7 +44,7 @@ class ForbiddenImport(config: Config = Config.empty) : Rule(config) {
     override fun visitImportDirective(importDirective: KtImportDirective) {
         super.visitImportDirective(importDirective)
 
-        val import = importDirective.importedFqName?.asString() ?: ""
+        val import = importDirective.importedFqName?.asString().orEmpty()
         if (imports.any { it.matches(import) } || containsForbiddenPattern(import)) {
             report(
                 CodeSmell(

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCall.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCall.kt
@@ -100,7 +100,7 @@ class ForbiddenMethodCall(config: Config = Config.empty) : Rule(config) {
                             CodeSmell(
                                 issue,
                                 Entity.from(expression),
-                                "The method ${it.first}(${expectedParamTypes?.joinToString() ?: ""}) " +
+                                "The method ${it.first}(${expectedParamTypes?.joinToString().orEmpty()}) " +
                                     "has been forbidden in the Detekt config."
                             )
                         )

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCount.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCount.kt
@@ -102,7 +102,7 @@ class ReturnCount(config: Config = Config.empty) : Rule(config) {
         val statements = if (excludeGuardClauses) {
             function.yieldStatementsSkippingGuardClauses<KtReturnExpression>()
         } else {
-            function.bodyBlockExpression?.statements?.asSequence() ?: emptySequence()
+            function.bodyBlockExpression?.statements?.asSequence().orEmpty()
         }
 
         return statements.flatMap { it.collectDescendantsOfType<KtReturnExpression>().asSequence() }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCount.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCount.kt
@@ -107,8 +107,7 @@ class ReturnCount(config: Config = Config.empty) : Rule(config) {
 
         return statements.flatMap { it.collectDescendantsOfType<KtReturnExpression>().asSequence() }
             .filterNot { it.isExcluded() }
-            .filter { it.getParentOfType<KtNamedFunction>(true) == function }
-            .count()
+            .count { it.getParentOfType<KtNamedFunction>(true) == function }
     }
 
     private fun KtReturnExpression.isNamedReturnFromLambda(): Boolean {

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ThrowsCount.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ThrowsCount.kt
@@ -61,7 +61,7 @@ class ThrowsCount(config: Config = Config.empty) : Rule(config) {
             val statements = if (excludeGuardClauses) {
                 function.yieldStatementsSkippingGuardClauses<KtThrowExpression>()
             } else {
-                function.bodyBlockExpression?.statements?.asSequence() ?: emptySequence()
+                function.bodyBlockExpression?.statements?.asSequence().orEmpty()
             }
 
             val countOfThrows = statements

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UtilityClassWithPublicConstructor.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UtilityClassWithPublicConstructor.kt
@@ -104,7 +104,7 @@ class UtilityClassWithPublicConstructor(config: Config = Config.empty) : Rule(co
     }
 
     private fun hasOnlyUtilityClassMembers(declarations: List<KtDeclaration>?): Boolean {
-        if (declarations == null || declarations.isEmpty()) {
+        if (declarations.isNullOrEmpty()) {
             return false
         }
         var containsCompanionObject = false

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ObjectLiteralToLambdaSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ObjectLiteralToLambdaSpec.kt
@@ -480,9 +480,9 @@ class ObjectLiteralToLambdaSpec : Spek({
         context("Edge case") {
             // https://github.com/detekt/detekt/pull/3599#issuecomment-806389701
             it(
-                """Anonymous objects are always newly created, 
-                |but lambdas are singletons, 
-                |so they have the same reference.""".trimMargin()
+                """Anonymous objects are always newly created,
+                | but lambdas are singletons, 
+                | so they have the same reference.""".trimMargin()
             ) {
                 val code = """
                 fun interface Sam {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/VarCouldBeValSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/VarCouldBeValSpec.kt
@@ -2,7 +2,6 @@ package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.rules.setupKotlinEnvironment
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
-import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.spekframework.spek2.Spek

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/MandatoryBracesLoopsSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/MandatoryBracesLoopsSpec.kt
@@ -310,7 +310,7 @@ class MandatoryBracesLoopsSpec : Spek({
         }
 
         it("does not report nested loops with braces") {
-            val code = """		
+            val code = """
             fun test() {		
                 do {		
                     while (true) {		
@@ -324,7 +324,7 @@ class MandatoryBracesLoopsSpec : Spek({
         }
 
         it("does not report nested loops on single line") {
-            val code = """		
+            val code = """
             fun test() {		
                 var i = 0
                 do do i += 1 while(i < 5) while (i < 5)	
@@ -335,7 +335,7 @@ class MandatoryBracesLoopsSpec : Spek({
         }
 
         it("reports in nested loop outer") {
-            val code = """		
+            val code = """
             fun test() {		
                 do 		
                     do {		

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/LicenceHeaderLoaderExtensionSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/LicenceHeaderLoaderExtensionSpec.kt
@@ -24,7 +24,7 @@ class LicenceHeaderLoaderExtensionSpec : Spek({
                     override val outputChannel: PrintStream = NullPrintStream()
                     override val errorChannel: PrintStream = NullPrintStream()
                     override val properties: Map<String, Any?> = HashMap()
-                    override fun register(key: String, value: Any) = Unit
+                    override fun register(key: String, value: Any): Unit = Unit
                 })
             }.doesNotThrowAnyException()
         }

--- a/detekt-sample-extensions/src/test/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/processors/QualifiedNameProcessorSpec.kt
+++ b/detekt-sample-extensions/src/test/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/processors/QualifiedNameProcessorSpec.kt
@@ -34,9 +34,9 @@ class QualifiedNameProcessorSpec : Spek({
 
 private val result = object : Detektion {
 
-    override val findings: Map<String, List<Finding>> = mapOf()
-    override val notifications: Collection<Notification> = listOf()
-    override val metrics: Collection<ProjectMetric> = listOf()
+    override val findings: Map<String, List<Finding>> = emptyMap()
+    override val notifications: Collection<Notification> = emptyList()
+    override val metrics: Collection<ProjectMetric> = emptyList()
 
     private var userData = KeyFMap.EMPTY_MAP
     override fun <V> getData(key: Key<V>): V? = userData.get(key)

--- a/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/KotlinCoreEnvironmentWrapper.kt
+++ b/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/KotlinCoreEnvironmentWrapper.kt
@@ -28,6 +28,6 @@ class KotlinCoreEnvironmentWrapper(
  *
  * @param additionalRootPaths the optional JVM classpath roots list.
  */
-fun createEnvironment(additionalRootPaths: List<File> = listOf()): KotlinCoreEnvironmentWrapper = KtTestCompiler.createEnvironment(additionalRootPaths)
+fun createEnvironment(additionalRootPaths: List<File> = emptyList()): KotlinCoreEnvironmentWrapper = KtTestCompiler.createEnvironment(additionalRootPaths)
 
 fun createPsiFactory(): KtPsiFactory = KtPsiFactory(KtTestCompiler.project(), false)

--- a/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/KtTestCompiler.kt
+++ b/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/KtTestCompiler.kt
@@ -37,7 +37,7 @@ internal object KtTestCompiler : KtCompiler() {
      * Not sure why but this function only works from this context.
      * Somehow the Kotlin language was not yet initialized.
      */
-    fun createEnvironment(additionalRootPaths: List<File> = listOf()): KotlinCoreEnvironmentWrapper {
+    fun createEnvironment(additionalRootPaths: List<File> = emptyList()): KotlinCoreEnvironmentWrapper {
         val configuration = CompilerConfiguration()
         configuration.put(CommonConfigurationKeys.MODULE_NAME, "test_module")
         configuration.put(CLIConfigurationKeys.MESSAGE_COLLECTOR_KEY, MessageCollector.NONE)

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/TestConfig.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/TestConfig.kt
@@ -28,8 +28,7 @@ open class TestConfig(
     }
 
     override fun <T : Any> valueOrNull(key: String): T? =
-        if (key == Config.ACTIVE_KEY) (values[Config.ACTIVE_KEY] ?: true) as T?
-        else values[key] as? T
+        if (key == Config.ACTIVE_KEY) (values[Config.ACTIVE_KEY] ?: true) as T? else values[key] as? T
 
     private fun tryParseBasedOnDefaultRespectingCollections(result: String, defaultResult: Any): Any =
         when (defaultResult) {

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/ThresholdedCodeSmellAssert.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/ThresholdedCodeSmellAssert.kt
@@ -17,7 +17,7 @@ class ThresholdedCodeSmellAssert(actual: ThresholdedCodeSmell?) :
         ThresholdedCodeSmellAssert::class.java
     ) {
 
-    fun withValue(expected: Int) = hasValue(expected).let { this }
+    fun withValue(expected: Int) = apply { hasValue(expected) }
 
     fun hasValue(expected: Int) {
         isNotNull
@@ -28,7 +28,7 @@ class ThresholdedCodeSmellAssert(actual: ThresholdedCodeSmell?) :
         }
     }
 
-    fun withThreshold(expected: Int) = hasThreshold(expected).let { this }
+    fun withThreshold(expected: Int) = apply { hasThreshold(expected) }
 
     fun hasThreshold(expected: Int) {
         isNotNull

--- a/detekt-tooling/src/test/kotlin/io/github/detekt/tooling/api/PluginsSpec.kt
+++ b/detekt-tooling/src/test/kotlin/io/github/detekt/tooling/api/PluginsSpec.kt
@@ -14,7 +14,7 @@ internal class PluginsSpec : Spek({
         it("throws when both sources are supplied via dsl") {
             assertThatCode {
                 ExtensionsSpecBuilder().apply {
-                    fromPaths { listOf() }
+                    fromPaths { emptyList() }
                     fromClassloader { javaClass.classLoader }
                 }.build()
             }.isInstanceOf(IllegalArgumentException::class.java)
@@ -22,13 +22,13 @@ internal class PluginsSpec : Spek({
             assertThatCode {
                 ExtensionsSpecBuilder().apply {
                     fromClassloader { javaClass.classLoader }
-                    fromPaths { listOf() }
+                    fromPaths { emptyList() }
                 }.build()
             }.isInstanceOf(IllegalArgumentException::class.java)
         }
 
         it("throws when both sources are supplied via internal helper class") {
-            assertThatCode { PluginsHolder(listOf(), javaClass.classLoader) }
+            assertThatCode { PluginsHolder(emptyList(), javaClass.classLoader) }
                 .isInstanceOf(IllegalArgumentException::class.java)
         }
 


### PR DESCRIPTION
There are quite a few rule that are deactivated by default and therefor are not checked when running checking the detekt code base.  I think it is very helpful to at least run those that are not controversial.

Looking back I should have probably created multiple PR for this. Sorry about that.

There are still some rules I would like to enable but that would blow up the change set even more. So there will be more PR unless you think there is no need for that.