### PR TITLE
enable coroutine rules for detekt code base

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -44,6 +44,17 @@ complexity:
   MethodOverloading:
     active: true
 
+coroutines:
+  active: true
+  GlobalCoroutineUsage:
+    active: true
+  RedundantSuspendModifier:
+    active: true
+  SleepInsteadOfDelay:
+    active: true
+  SuspendFunWithFlowReturnType:
+    active: true
+
 exceptions:
   NotImplementedDeclaration:
     active: true


### PR DESCRIPTION
This relates to #3993 and enables all rules from the coroutine rule set for the detekt code base.