### PR TITLE
Update ktlint to 0.42.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 dokka = "1.4.32"
 jacoco = "0.8.7"
 kotlin = "1.5.21"
-ktlint = "0.41.0"
+ktlint = "0.42.0"
 spek = "2.0.15"
 
 [libraries]


### PR DESCRIPTION
This PR updates ktlint to [0.42.0](https://github.com/pinterest/ktlint/releases/tag/0.42.0).

Looks like 0.42.0 is mainly a bugfix release (beside the SARIF output support). So I don't see any necessary changes beside bumping the version number.
