### PR TITLE
ImplicitUnitReturnType: don't report when expression body is 'Unit'

### DIFF
--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ImplicitUnitReturnTypeSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ImplicitUnitReturnTypeSpec.kt
@@ -57,5 +57,13 @@ class ImplicitUnitReturnTypeSpec : Spek({
 
             assertThat(findings).isEmpty()
         }
+
+        it("does not report for Unit expression") {
+            val code = """
+                fun foo() = Unit
+            """
+            val findings = rule.compileAndLintWithContext(env, code)
+            assertThat(findings).isEmpty()
+        }
     }
 })


### PR DESCRIPTION
Fixes #4004