### PR TITLE
Sort config lists

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -92,15 +92,15 @@ complexity:
     ignoreSimpleWhenEntries: false
     ignoreNestingFunctions: false
     nestingFunctions:
-      - 'run'
-      - 'let'
-      - 'apply'
-      - 'with'
       - 'also'
-      - 'use'
+      - 'apply'
       - 'forEach'
       - 'isNotNull'
       - 'ifNull'
+      - 'let'
+      - 'run'
+      - 'use'
+      - 'with'
   LabeledExpression:
     active: false
     ignoredLabels: []
@@ -199,10 +199,10 @@ exceptions:
   ExceptionRaisedInUnexpectedLocation:
     active: true
     methodNames:
-      - 'toString'
-      - 'hashCode'
       - 'equals'
       - 'finalize'
+      - 'hashCode'
+      - 'toString'
   InstanceOfCheckForException:
     active: false
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
@@ -220,10 +220,10 @@ exceptions:
   SwallowedException:
     active: true
     ignoredExceptionTypes:
-      - 'NumberFormatException'
       - 'InterruptedException'
-      - 'ParseException'
       - 'MalformedURLException'
+      - 'NumberFormatException'
+      - 'ParseException'
     allowedExceptionNameRegex: '_|(ignore|expected).*'
   ThrowingExceptionFromFinally:
     active: true
@@ -239,8 +239,8 @@ exceptions:
       - 'IllegalArgumentException'
       - 'IllegalMonitorStateException'
       - 'IllegalStateException'
-      - 'NullPointerException'
       - 'IndexOutOfBoundsException'
+      - 'NullPointerException'
       - 'RuntimeException'
       - 'Throwable'
   ThrowingNewInstanceOfSameException:
@@ -253,8 +253,8 @@ exceptions:
       - 'Error'
       - 'Exception'
       - 'IllegalMonitorStateException'
-      - 'NullPointerException'
       - 'IndexOutOfBoundsException'
+      - 'NullPointerException'
       - 'RuntimeException'
       - 'Throwable'
     allowedExceptionNameRegex: '_|(ignore|expected).*'
@@ -263,8 +263,8 @@ exceptions:
     exceptionNames:
       - 'Error'
       - 'Exception'
-      - 'Throwable'
       - 'RuntimeException'
+      - 'Throwable'
 
 formatting:
   active: true
@@ -538,8 +538,8 @@ potential-bugs:
     active: false
     restrictToAnnotatedMethods: true
     returnValueAnnotations:
-      - '*.CheckReturnValue'
       - '*.CheckResult'
+      - '*.CheckReturnValue'
     ignoreReturnValueAnnotations:
       - '*.CanIgnoreReturnValue'
   ImplicitDefaultLocale:
@@ -616,9 +616,9 @@ style:
   ForbiddenComment:
     active: true
     values:
-      - 'TODO:'
       - 'FIXME:'
       - 'STOPSHIP:'
+      - 'TODO:'
     allowedPatterns: ''
   ForbiddenImport:
     active: false
@@ -627,8 +627,8 @@ style:
   ForbiddenMethodCall:
     active: false
     methods:
-      - 'kotlin.io.println'
       - 'kotlin.io.print'
+      - 'kotlin.io.println'
   ForbiddenPublicDataClass:
     active: true
     excludes: ['**']

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexMethod.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexMethod.kt
@@ -101,15 +101,15 @@ class ComplexMethod(config: Config = Config.empty) : Rule(config) {
 
     companion object {
         val DEFAULT_NESTING_FUNCTIONS = listOf(
-            "run",
-            "let",
-            "apply",
-            "with",
             "also",
-            "use",
+            "apply",
             "forEach",
             "isNotNull",
-            "ifNull"
+            "ifNull",
+            "let",
+            "run",
+            "use",
+            "with",
         )
     }
 }

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValue.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValue.kt
@@ -49,7 +49,7 @@ class IgnoredReturnValue(config: Config = Config.empty) : Rule(config) {
     private val restrictToAnnotatedMethods: Boolean by config(defaultValue = true)
 
     @Configuration("List of glob patterns to be used as inspection annotation")
-    private val returnValueAnnotations: List<Regex> by config(listOf("*.CheckReturnValue", "*.CheckResult")) {
+    private val returnValueAnnotations: List<Regex> by config(listOf("*.CheckResult", "*.CheckReturnValue")) {
         it.map(String::simplePatternToRegex)
     }
 

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ExceptionRaisedInUnexpectedLocation.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ExceptionRaisedInUnexpectedLocation.kt
@@ -41,7 +41,14 @@ class ExceptionRaisedInUnexpectedLocation(config: Config = Config.empty) : Rule(
     )
 
     @Configuration("methods which should not throw exceptions")
-    private val methodNames: List<String> by config(listOf("toString", "hashCode", "equals", "finalize"))
+    private val methodNames: List<String> by config(
+        listOf(
+            "equals",
+            "finalize",
+            "hashCode",
+            "toString",
+        )
+    )
 
     override fun visitNamedFunction(function: KtNamedFunction) {
         if (isPotentialMethod(function) && hasThrowExpression(function.bodyExpression)) {

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedException.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedException.kt
@@ -165,10 +165,10 @@ class SwallowedException(config: Config = Config.empty) : Rule(config) {
 
     companion object {
         internal val EXCEPTIONS_IGNORED_BY_DEFAULT = listOf(
-            "NumberFormatException",
             "InterruptedException",
+            "MalformedURLException",
+            "NumberFormatException",
             "ParseException",
-            "MalformedURLException"
         )
     }
 }

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionsWithoutMessageOrCause.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionsWithoutMessageOrCause.kt
@@ -57,10 +57,10 @@ class ThrowingExceptionsWithoutMessageOrCause(config: Config = Config.empty) : R
             "IllegalArgumentException",
             "IllegalMonitorStateException",
             "IllegalStateException",
-            "NullPointerException",
             "IndexOutOfBoundsException",
+            "NullPointerException",
             "RuntimeException",
-            "Throwable"
+            "Throwable",
         )
     )
 

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionCaught.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionCaught.kt
@@ -73,10 +73,10 @@ class TooGenericExceptionCaught(config: Config) : Rule(config) {
             "Error",
             "Exception",
             "IllegalMonitorStateException",
-            "NullPointerException",
             "IndexOutOfBoundsException",
+            "NullPointerException",
             "RuntimeException",
-            "Throwable"
+            "Throwable",
         )
     }
 }

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionThrown.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionThrown.kt
@@ -50,8 +50,8 @@ class TooGenericExceptionThrown(config: Config) : Rule(config) {
         listOf(
             "Error",
             "Exception",
+            "RuntimeException",
             "Throwable",
-            "RuntimeException"
         )
     ) { it.toSet() }
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenComment.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenComment.kt
@@ -38,7 +38,7 @@ class ForbiddenComment(config: Config = Config.empty) : Rule(config) {
     )
 
     @Configuration("forbidden comment strings")
-    private val values: List<String> by config(listOf("TODO:", "FIXME:", "STOPSHIP:"))
+    private val values: List<String> by config(listOf("FIXME:", "STOPSHIP:", "TODO:"))
 
     @Configuration("ignores comments which match the specified regular expression. For example `Ticket|Task`.")
     private val allowedPatterns: Regex by config("", String::toRegex)

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCall.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCall.kt
@@ -54,8 +54,8 @@ class ForbiddenMethodCall(config: Config = Config.empty) : Rule(config) {
     )
     private val methods: List<Pair<String, List<String>?>> by config(
         listOf(
+            "kotlin.io.print",
             "kotlin.io.println",
-            "kotlin.io.print"
         )
     ) { it.map(::extractMethodNameAndParams) }
 


### PR DESCRIPTION
In this release we are already changing our default config yaml. For that reason I think that we could use it to sort the list configurations to follow an alphabetic order. I sorted all of them but I'm not sure if it have sense to do it with all of them because maybe there is another "more logical order". These are the rules that maybe a "more logical order" can exist:

- ComplexMethod (keep all the [scope functions](https://kotlinlang.org/docs/scope-functions.html#function-selection) together)
- ExceptionRaisedInUnexpectedLocation (order them for "more common")
- ForbiddenComment (order them for "more common")