### PR TITLE
Fix broken verifyGeneratorOutput task

### DIFF
--- a/detekt-generator/build.gradle.kts
+++ b/detekt-generator/build.gradle.kts
@@ -69,10 +69,13 @@ val verifyGeneratorOutput by tasks.registering(Exec::class) {
     commandLine = listOf("git", "diff", defaultConfigFile)
     standardOutput = configDiff
 
-    if (configDiff.toString().isNotEmpty()) {
-        throw GradleException(
-            "The default-detekt-config.yml is not up-to-date. " +
-                "You can execute the generateDocumentation Gradle task to update it and commit the changed files."
-        )
+    doLast {
+        if (configDiff.toString().isNotEmpty()) {
+            throw GradleException(
+                "The default-detekt-config.yml is not up-to-date. " +
+                    "You can execute the generateDocumentation Gradle task " +
+                    "to update it and commit the changed files."
+            )
+        }
     }
 }


### PR DESCRIPTION
From @marschwar comments here: https://github.com/detekt/detekt/pull/4013#issuecomment-894679951
I'm fixing the `verifyGeneratorOutput` task that was running but always returning green.