### PR TITLE
Update docs to use configuration avoidance API

### DIFF
--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskDslSpec.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskDslSpec.kt
@@ -85,7 +85,7 @@ internal object DetektTaskDslSpec : Spek({
                 }
 
                 describe("with custom baseline file") {
-                    val baselineFilename = "detekt-baseline.xml"
+                    val baselineFilename = "custom-baseline.xml"
 
                     beforeGroup {
 

--- a/docs/pages/gettingstarted/gradle.md
+++ b/docs/pages/gettingstarted/gradle.md
@@ -360,7 +360,9 @@ More information on type resolution are available on the [type resolution](type-
 #### Groovy DSL
 
 ```groovy
-tasks.detekt.jvmTarget = "1.8"
+tasks.withType(io.gitlab.arturbosch.detekt.Detekt).configureEach {
+    jvmTarget = "1.8"
+}
 ```
 
 #### Kotlin DSL


### PR DESCRIPTION
Fixes #3985.

Additionally, updated the integration test to configure baseline with something that is not the default value as https://github.com/detekt/detekt/blob/main/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt#L42