### PR TITLE
enable PreferToOverPairSyntax rule for detekt code base

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -173,7 +173,7 @@ style:
     excludes: ['**/*.kt']
     includes: ['**/detekt-api/src/main/**/api/*.kt']
   MagicNumber:
-    excludes: [ '**/test/**', '**/*Test.kt', '**/*Spec.kt' ]
+    excludes: ['**/test/**', '**/*Test.kt', '**/*Spec.kt']
     ignorePropertyDeclaration: true
     ignoreAnnotation: true
     ignoreEnums: true
@@ -188,7 +188,7 @@ style:
     active: true
   MaxLineLength:
     active: true
-    excludes: [ '**/test/**', '**/*Test.kt', '**/*Spec.kt' ]
+    excludes: ['**/test/**', '**/*Test.kt', '**/*Spec.kt']
     excludeCommentStatements: true
   NestedClassesVisibility:
     active: true

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -188,11 +188,13 @@ style:
     active: true
   MaxLineLength:
     active: true
-    excludes: ['**/test/**', '**/*Test.kt', '**/*Spec.kt']
+    excludes: [ '**/test/**', '**/*Test.kt', '**/*Spec.kt' ]
     excludeCommentStatements: true
   NestedClassesVisibility:
     active: true
   ObjectLiteralToLambda:
+    active: true
+  PreferToOverPairSyntax:
     active: true
   RedundantExplicitType:
     active: true

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/IssueExtensionSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/IssueExtensionSpec.kt
@@ -15,8 +15,8 @@ class IssueExtensionSpec : Spek({
 
     val issues by memoized {
         mapOf(
-            Pair("Ruleset1", listOf(createFinding(), createCorrectableFinding())),
-            Pair("Ruleset2", listOf(createFinding()))
+            "Ruleset1" to listOf(createFinding(), createCorrectableFinding()),
+            "Ruleset2" to listOf(createFinding())
         )
     }
 

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/OutputFacadeSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/OutputFacadeSpec.kt
@@ -19,7 +19,7 @@ internal class OutputFacadeSpec : Spek({
     test("Running the output facade with multiple reports") {
         val printStream = StringPrintStream()
         val inputPath: Path = resourceAsPath("/cases")
-        val defaultResult = DetektResult(mapOf(Pair("Key", listOf(createFinding()))))
+        val defaultResult = DetektResult(mapOf("Key" to listOf(createFinding())))
         val plainOutputPath = createTempFileForTest("detekt", ".txt")
         val htmlOutputPath = createTempFileForTest("detekt", ".html")
         val xmlOutputPath = createTempFileForTest("detekt", ".xml")

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/ComplexityReportSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/ComplexityReportSpec.kt
@@ -37,7 +37,7 @@ internal class ComplexityReportSpec : Spek({
     }
 })
 
-private fun createDetektion(): Detektion = DetektResult(mapOf(Pair("Key", listOf(createFinding()))))
+private fun createDetektion(): Detektion = DetektResult(mapOf("Key" to listOf(createFinding())))
 
 private fun addData(detektion: Detektion) {
     detektion.addData(complexityKey, 2)

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/FileBasedFindingsReportSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/FileBasedFindingsReportSpec.kt
@@ -23,18 +23,12 @@ class FileBasedFindingsReportSpec : Spek({
                 val expectedContent = readResourceContent("/reporting/grouped-findings-report.txt")
                 val detektion = object : TestDetektion() {
                     override val findings: Map<String, List<Finding>> = mapOf(
-                        Pair(
-                            "Ruleset1",
-                            listOf(
-                                createFinding(fileName = "File1.kt"),
-                                createFinding(fileName = "File2.kt")
-                            )
+                        "Ruleset1" to listOf(
+                            createFinding(fileName = "File1.kt"),
+                            createFinding(fileName = "File2.kt")
                         ),
-                        Pair("EmptyRuleset", emptyList()),
-                        Pair(
-                            "Ruleset2",
-                            listOf(createFinding(fileName = "File1.kt"))
-                        )
+                        "EmptyRuleset" to emptyList(),
+                        "Ruleset2" to listOf(createFinding(fileName = "File1.kt"))
                     )
                 }
 
@@ -52,7 +46,7 @@ class FileBasedFindingsReportSpec : Spek({
         it("reports no findings when no rule set contains smells") {
             val detektion = object : TestDetektion() {
                 override val findings: Map<String, List<Finding>> = mapOf(
-                    Pair("EmptySmells", emptyList())
+                    "EmptySmells" to emptyList()
                 )
             }
             assertThat(subject.render(detektion)).isNull()

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/FindingsReportSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/FindingsReportSpec.kt
@@ -22,9 +22,9 @@ class FindingsReportSpec : Spek({
             val detektion by memoized {
                 object : TestDetektion() {
                     override val findings: Map<String, List<Finding>> = mapOf(
-                        Pair("Ruleset1", listOf(createFinding(), createFinding())),
-                        Pair("EmptyRuleset", emptyList()),
-                        Pair("Ruleset2", listOf(createFinding()))
+                        "Ruleset1" to listOf(createFinding(), createFinding()),
+                        "EmptyRuleset" to emptyList(),
+                        "Ruleset2" to listOf(createFinding())
                     )
                 }
             }
@@ -52,7 +52,7 @@ class FindingsReportSpec : Spek({
         it("reports no findings with rule set containing no smells") {
             val detektion = object : TestDetektion() {
                 override val findings: Map<String, List<Finding>> = mapOf(
-                    Pair("Ruleset", emptyList())
+                    "Ruleset" to emptyList()
                 )
             }
             assertThat(subject.render(detektion)).isNull()

--- a/detekt-report-html/src/test/kotlin/io/github/detekt/report/html/HtmlOutputReportSpec.kt
+++ b/detekt-report-html/src/test/kotlin/io/github/detekt/report/html/HtmlOutputReportSpec.kt
@@ -64,7 +64,7 @@ class HtmlOutputReportSpec : Spek({
         it("contains no findings") {
             val detektion = object : TestDetektion() {
                 override val findings: Map<String, List<Finding>> = mapOf(
-                    Pair("EmptyRuleset", emptyList())
+                    "EmptyRuleset" to emptyList()
                 )
             }
             val result = htmlReport.render(detektion)


### PR DESCRIPTION
I hope this is not too annoying ;) Just a few left
