### PR TITLE
[KMP] Fix resolution of Android test classpaths

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektAndroid.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektAndroid.kt
@@ -106,38 +106,44 @@ internal class DetektAndroid(private val project: Project) {
         ignoredVariants.contains(variant.name) ||
             ignoredBuildTypes.contains(variant.buildType.name) ||
             ignoredFlavors.contains(variant.flavorName)
-
-    private fun Project.registerAndroidDetektTask(
-        bootClasspath: FileCollection,
-        extension: DetektExtension,
-        variant: BaseVariant
-    ): TaskProvider<Detekt> =
-        registerDetektTask(DetektPlugin.DETEKT_TASK_NAME + variant.name.capitalize(), extension) {
-            setSource(variant.sourceSets.map { it.javaDirectories })
-            classpath.setFrom(variant.getCompileClasspath(null).filter { it.exists() } + bootClasspath)
-            // If a baseline file is configured as input file, it must exist to be configured, otherwise the task fails.
-            // We try to find the configured baseline or alternatively a specific variant matching this task.
-            extension.baseline?.existingVariantOrBaseFile(variant.name)?.let { baselineFile ->
-                baseline.set(layout.file(project.provider { baselineFile }))
-            }
-            reports = extension.reports
-            reports.xml.setDefaultIfUnset(File(extension.reportsDir, variant.name + ".xml"))
-            reports.html.setDefaultIfUnset(File(extension.reportsDir, variant.name + ".html"))
-            reports.txt.setDefaultIfUnset(File(extension.reportsDir, variant.name + ".txt"))
-            reports.sarif.setDefaultIfUnset(File(extension.reportsDir, variant.name + ".sarif"))
-            description = "EXPERIMENTAL: Run detekt analysis for ${variant.name} classes with type resolution"
-        }
-
-    private fun Project.registerAndroidCreateBaselineTask(
-        bootClasspath: FileCollection,
-        extension: DetektExtension,
-        variant: BaseVariant
-    ): TaskProvider<DetektCreateBaselineTask> =
-        registerCreateBaselineTask(DetektPlugin.BASELINE_TASK_NAME + variant.name.capitalize(), extension) {
-            setSource(variant.sourceSets.map { it.javaDirectories })
-            classpath.setFrom(variant.getCompileClasspath(null).filter { it.exists() } + bootClasspath)
-            val variantBaselineFile = extension.baseline?.addVariantName(variant.name)
-            baseline.set(project.layout.file(project.provider { variantBaselineFile }))
-            description = "EXPERIMENTAL: Creates detekt baseline for ${variant.name} classes with type resolution"
-        }
 }
+
+internal fun Project.registerAndroidDetektTask(
+    bootClasspath: FileCollection,
+    extension: DetektExtension,
+    variant: BaseVariant,
+    taskName: String = DetektPlugin.DETEKT_TASK_NAME + variant.name.capitalize(),
+    extraInputSource: FileCollection? = null
+): TaskProvider<Detekt> =
+    registerDetektTask(taskName, extension) {
+        setSource(variant.sourceSets.map { it.javaDirectories })
+        extraInputSource?.let { source(it) }
+        classpath.setFrom(variant.getCompileClasspath(null).filter { it.exists() } + bootClasspath)
+        // If a baseline file is configured as input file, it must exist to be configured, otherwise the task fails.
+        // We try to find the configured baseline or alternatively a specific variant matching this task.
+        extension.baseline?.existingVariantOrBaseFile(variant.name)?.let { baselineFile ->
+            baseline.set(layout.file(project.provider { baselineFile }))
+        }
+        reports = extension.reports
+        reports.xml.setDefaultIfUnset(File(extension.reportsDir, variant.name + ".xml"))
+        reports.html.setDefaultIfUnset(File(extension.reportsDir, variant.name + ".html"))
+        reports.txt.setDefaultIfUnset(File(extension.reportsDir, variant.name + ".txt"))
+        reports.sarif.setDefaultIfUnset(File(extension.reportsDir, variant.name + ".sarif"))
+        description = "EXPERIMENTAL: Run detekt analysis for ${variant.name} classes with type resolution"
+    }
+
+internal fun Project.registerAndroidCreateBaselineTask(
+    bootClasspath: FileCollection,
+    extension: DetektExtension,
+    variant: BaseVariant,
+    taskName: String = DetektPlugin.BASELINE_TASK_NAME + variant.name.capitalize(),
+    extraInputSource: FileCollection? = null
+): TaskProvider<DetektCreateBaselineTask> =
+    registerCreateBaselineTask(taskName, extension) {
+        setSource(variant.sourceSets.map { it.javaDirectories })
+        extraInputSource?.let { source(it) }
+        classpath.setFrom(variant.getCompileClasspath(null).filter { it.exists() } + bootClasspath)
+        val variantBaselineFile = extension.baseline?.addVariantName(variant.name)
+        baseline.set(project.layout.file(project.provider { variantBaselineFile }))
+        description = "EXPERIMENTAL: Creates detekt baseline for ${variant.name} classes with type resolution"
+    }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektMultiplatform.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektMultiplatform.kt
@@ -67,7 +67,7 @@ internal class DetektMultiplatform(private val project: Project) {
         // BaseVariant and other AGP apis to properly setup the classpath.
         val androidExtension = extensions.findByType(BaseExtension::class.java)
         androidExtension?.let {
-            val bootClasspath = files(androidExtension.bootClasspath)
+            val bootClasspath = files(it.bootClasspath)
             val variant = compilation.androidVariant
             val detektTaskName = DetektPlugin.DETEKT_TASK_NAME +
                 target.name.capitalize() + variant.name.capitalize()

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektMultiplatform.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektMultiplatform.kt
@@ -1,16 +1,20 @@
 package io.gitlab.arturbosch.detekt.internal
 
+import com.android.build.gradle.BaseExtension
 import io.gitlab.arturbosch.detekt.DetektPlugin
 import io.gitlab.arturbosch.detekt.extensions.DetektExtension
 import org.gradle.api.Project
 import org.gradle.api.file.FileCollection
+import org.jetbrains.kotlin.gradle.dsl.KotlinCommonOptions
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
 import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType.androidJvm
 import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType.common
 import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType.js
 import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType.jvm
 import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType.native
 import org.jetbrains.kotlin.gradle.plugin.KotlinTarget
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinJvmAndroidCompilation
 import java.io.File
 
 internal class DetektMultiplatform(private val project: Project) {
@@ -29,62 +33,121 @@ internal class DetektMultiplatform(private val project: Project) {
 
             kmpExtension.targets.all { target ->
                 target.compilations.forEach { compilation ->
-                    val taskSuffix = target.name.capitalize() + compilation.name.capitalize()
-
-                    val runWithTypeResolution = target.runWithTypeResolution
-
                     val inputSource = compilation.kotlinSourceSets
                         .map { it.kotlin.sourceDirectories }
                         .fold(evaluatedProject.files() as FileCollection) { collection, next -> collection.plus(next) }
 
-                    evaluatedProject.registerDetektTask(
-                        DetektPlugin.DETEKT_TASK_NAME + taskSuffix,
-                        extension
-                    ) {
-                        setSource(inputSource)
-                        if (runWithTypeResolution) {
-                            classpath.setFrom(inputSource, compilation.compileDependencyFiles)
-                        }
-                        // If a baseline file is configured as input file, it must exist to be configured, otherwise the task fails.
-                        // We try to find the configured baseline or alternatively a specific variant matching this task.
-                        if (runWithTypeResolution) {
-                            extension.baseline?.existingVariantOrBaseFile(compilation.name)
-                        } else {
-                            extension.baseline?.takeIf { it.exists() }
-                        }?.let { baselineFile ->
-                            baseline.set(layout.file(evaluatedProject.provider { baselineFile }))
-                        }
-                        reports = extension.reports
-                        reports.xml.setDefaultIfUnset(File(extension.reportsDir, compilation.name + ".xml"))
-                        reports.html.setDefaultIfUnset(File(extension.reportsDir, compilation.name + ".html"))
-                        reports.txt.setDefaultIfUnset(File(extension.reportsDir, compilation.name + ".txt"))
-                        reports.sarif.setDefaultIfUnset(File(extension.reportsDir, compilation.name + ".sarif"))
-                        description = "Run detekt analysis for target ${target.name} and source set ${compilation.name}"
-                        if (runWithTypeResolution) {
-                            description = "EXPERIMENTAL: $description with type resolution."
-                        }
-                    }
-
-                    evaluatedProject.registerCreateBaselineTask(
-                        DetektPlugin.BASELINE_TASK_NAME + taskSuffix, extension
-                    ) {
-                        setSource(inputSource)
-                        if (runWithTypeResolution) {
-                            classpath.setFrom(inputSource, compilation.compileDependencyFiles)
-                        }
-                        val variantBaselineFile = if (runWithTypeResolution) {
-                            extension.baseline?.addVariantName(compilation.name)
-                        } else {
-                            extension.baseline
-                        }
-                        baseline.set(evaluatedProject.layout.file(evaluatedProject.provider { variantBaselineFile }))
-
-                        description = "Creates detekt baseline for ${target.name} and source set ${compilation.name}"
-                        if (runWithTypeResolution) {
-                            description = "EXPERIMENTAL: $description with type resolution."
-                        }
+                    if (compilation is KotlinJvmAndroidCompilation) {
+                        evaluatedProject.registerMultiplatformTasksForAndroidTarget(
+                            compilation = compilation,
+                            target = target,
+                            extension = extension,
+                            inputSource = inputSource
+                        )
+                    } else {
+                        evaluatedProject.registerMultiplatformTasksForNonAndroidTarget(
+                            compilation = compilation,
+                            target = target,
+                            extension = extension,
+                            inputSource = inputSource
+                        )
                     }
                 }
+            }
+        }
+    }
+
+    private fun Project.registerMultiplatformTasksForAndroidTarget(
+        compilation: KotlinJvmAndroidCompilation,
+        target: KotlinTarget,
+        extension: DetektExtension,
+        inputSource: FileCollection
+    ) {
+        // For Android targets we delegate to DetektAndroid as we need to access
+        // BaseVariant and other AGP apis to properly setup the classpath.
+        val androidExtension = extensions.findByType(BaseExtension::class.java)
+        androidExtension?.let {
+            val bootClasspath = files(androidExtension.bootClasspath)
+            val variant = compilation.androidVariant
+            val detektTaskName = DetektPlugin.DETEKT_TASK_NAME +
+                target.name.capitalize() + variant.name.capitalize()
+            val baselineTaskName = DetektPlugin.BASELINE_TASK_NAME +
+                target.name.capitalize() + variant.name.capitalize()
+            registerAndroidDetektTask(
+                bootClasspath,
+                extension,
+                compilation.androidVariant,
+                detektTaskName,
+                inputSource
+            )
+            registerAndroidCreateBaselineTask(
+                bootClasspath,
+                extension,
+                compilation.androidVariant,
+                baselineTaskName,
+                inputSource
+            )
+        }
+    }
+
+    private fun Project.registerMultiplatformTasksForNonAndroidTarget(
+        compilation: KotlinCompilation<KotlinCommonOptions>,
+        target: KotlinTarget,
+        extension: DetektExtension,
+        inputSource: FileCollection
+    ) {
+        val taskSuffix = target.name.capitalize() + compilation.name.capitalize()
+        val runWithTypeResolution = target.runWithTypeResolution
+
+        registerDetektTask(
+            DetektPlugin.DETEKT_TASK_NAME + taskSuffix,
+            extension
+        ) {
+            setSource(inputSource)
+            if (runWithTypeResolution) {
+                classpath.setFrom(inputSource, compilation.compileDependencyFiles)
+            }
+            // If a baseline file is configured as input file, it must exist to be configured, otherwise the task fails.
+            // We try to find the configured baseline or alternatively a specific variant matching this task.
+            if (runWithTypeResolution) {
+                extension.baseline?.existingVariantOrBaseFile(compilation.name)
+            } else {
+                extension.baseline?.takeIf { it.exists() }
+            }?.let { baselineFile ->
+                baseline.set(layout.file(provider { baselineFile }))
+            }
+            reports = extension.reports
+            reports.xml.setDefaultIfUnset(File(extension.reportsDir, compilation.name + ".xml"))
+            reports.html.setDefaultIfUnset(File(extension.reportsDir, compilation.name + ".html"))
+            reports.txt.setDefaultIfUnset(File(extension.reportsDir, compilation.name + ".txt"))
+            reports.sarif.setDefaultIfUnset(File(extension.reportsDir, compilation.name + ".sarif"))
+            description =
+                "Run detekt analysis for target ${target.name} and source set ${compilation.name}"
+            if (runWithTypeResolution) {
+                description = "EXPERIMENTAL: $description with type resolution."
+            }
+        }
+
+        registerCreateBaselineTask(
+            DetektPlugin.BASELINE_TASK_NAME + taskSuffix, extension
+        ) {
+            setSource(inputSource)
+            if (runWithTypeResolution) {
+                classpath.setFrom(inputSource, compilation.compileDependencyFiles)
+            }
+            val variantBaselineFile = if (runWithTypeResolution) {
+                extension.baseline?.addVariantName(compilation.name)
+            } else {
+                extension.baseline
+            }
+            baseline.set(
+                layout.file(provider { variantBaselineFile })
+            )
+
+            description =
+                "Creates detekt baseline for ${target.name} and source set ${compilation.name}"
+            if (runWithTypeResolution) {
+                description = "EXPERIMENTAL: $description with type resolution."
             }
         }
     }

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektMultiplatformSpec.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektMultiplatformSpec.kt
@@ -143,6 +143,7 @@ class DetektMultiplatformSpec : Spek({
                         }
                         android {
                             compileSdkVersion 30
+                            sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
                             buildTypes {
                                 release {
                                 }
@@ -175,6 +176,12 @@ class DetektMultiplatformSpec : Spek({
         it("configures baseline task") {
             gradleRunner.runTasks(":shared:detektBaselineAndroidDebug")
             gradleRunner.runTasks(":shared:detektBaselineAndroidRelease")
+        }
+
+        it("configures test tasks") {
+            gradleRunner.runTasks(":shared:detektAndroidDebugAndroidTest")
+            gradleRunner.runTasks(":shared:detektAndroidDebugUnitTest")
+            gradleRunner.runTasks(":shared:detektAndroidReleaseUnitTest")
         }
 
         it("configures detekt task with type resolution") {


### PR DESCRIPTION
This PR depends on #4025

The approach used inside the KMP support for `detekt-gradle-plugin` was not working correctly for tests sourcesets of Android targets. I fixed it by delegating the creation of detekt tasks for `android()` targets to `DetektAndroid`. This will also make sure that the behavior between a pure Android project and a KMP project with an Android target is closer.

Fixes #3840

