### PR TITLE
mark configWithFallback as unstable

### DIFF
--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/ConfigProperty.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/ConfigProperty.kt
@@ -43,6 +43,7 @@ fun <T : Any, U : Any> config(
  * @param defaultValue the value that the property evaluates to when there is no key with the name of the property in
  * the config. Although [T] is defined as [Any], only [String], [Int], [Boolean] and [List<String>] are supported.
  */
+@UnstableApi("fallback property handling is still under discussion")
 fun <T : Any> configWithFallback(
     fallbackPropertyName: String,
     defaultValue: T
@@ -64,6 +65,7 @@ fun <T : Any> configWithFallback(
  * @param transformer a function that transforms the value from the configuration (or the default) into its final
  * value.
  */
+@UnstableApi("fallback property handling is still under discussion")
 fun <T : Any, U : Any> configWithFallback(
     fallbackPropertyName: String,
     defaultValue: T,

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/ConfigPropertySpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/ConfigPropertySpec.kt
@@ -290,6 +290,7 @@ class ConfigPropertySpec : Spek({
                 }
             }
         }
+        @OptIn(UnstableApi::class)
         context("configWithFallback") {
             context("primitive") {
                 val configValue = 99

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterList.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterList.kt
@@ -9,6 +9,7 @@ import io.gitlab.arturbosch.detekt.api.Metric
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.ThresholdedCodeSmell
+import io.gitlab.arturbosch.detekt.api.UnstableApi
 import io.gitlab.arturbosch.detekt.api.config
 import io.gitlab.arturbosch.detekt.api.configWithFallback
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
@@ -44,12 +45,14 @@ class LongParameterList(config: Config = Config.empty) : Rule(config) {
     @Configuration("number of parameters required to trigger the rule")
     private val threshold: Int by config(DEFAULT_FUNCTION_THRESHOLD)
 
+    @OptIn(UnstableApi::class)
     @Configuration("number of function parameters required to trigger the rule")
     private val functionThreshold: Int by configWithFallback(
         fallbackPropertyName = "threshold",
         defaultValue = DEFAULT_FUNCTION_THRESHOLD
     )
 
+    @OptIn(UnstableApi::class)
     @Configuration("number of constructor parameters required to trigger the rule")
     private val constructorThreshold: Int by configWithFallback(
         fallbackPropertyName = "threshold",

--- a/detekt-rules-empty/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyFunctionBlock.kt
+++ b/detekt-rules-empty/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyFunctionBlock.kt
@@ -1,6 +1,7 @@
 package io.gitlab.arturbosch.detekt.rules.empty
 
 import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.UnstableApi
 import io.gitlab.arturbosch.detekt.api.config
 import io.gitlab.arturbosch.detekt.api.configWithFallback
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
@@ -27,6 +28,7 @@ class EmptyFunctionBlock(config: Config) : EmptyRule(config) {
     @Deprecated("Use `ignoreOverridden` instead")
     private val ignoreOverriddenFunctions: Boolean by config(false)
 
+    @OptIn(UnstableApi::class)
     @Configuration("Excludes all the overridden functions")
     private val ignoreOverridden: Boolean by configWithFallback("ignoreOverriddenFunctions", false)
 

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionParameterNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionParameterNaming.kt
@@ -7,6 +7,7 @@ import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.UnstableApi
 import io.gitlab.arturbosch.detekt.api.config
 import io.gitlab.arturbosch.detekt.api.configWithFallback
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
@@ -40,6 +41,7 @@ class FunctionParameterNaming(config: Config = Config.empty) : Rule(config) {
     @Deprecated("Use `ignoreOverridden` instead")
     private val ignoreOverriddenFunctions: Boolean by config(true)
 
+    @OptIn(UnstableApi::class)
     @Configuration("ignores overridden functions with parameters not matching the pattern")
     private val ignoreOverridden: Boolean by configWithFallback("ignoreOverriddenFunctions", true)
 

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MemberNameEqualsClassName.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MemberNameEqualsClassName.kt
@@ -7,6 +7,7 @@ import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.UnstableApi
 import io.gitlab.arturbosch.detekt.api.config
 import io.gitlab.arturbosch.detekt.api.configWithFallback
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
@@ -72,6 +73,7 @@ class MemberNameEqualsClassName(config: Config = Config.empty) : Rule(config) {
     @Deprecated("Use `ignoreOverridden` instead")
     private val ignoreOverriddenFunction: Boolean by config(true)
 
+    @OptIn(UnstableApi::class)
     @Configuration("if overridden functions and properties should be ignored")
     private val ignoreOverridden: Boolean by configWithFallback("ignoreOverriddenFunction", true)
 


### PR DESCRIPTION
Since the api change in #3982 is still under discussion this will allow a 1.1.18 relase without breaking compatibility in 1.1.19.
