### PR TITLE
Fix TextLocation of Indentation rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ If you contributed to detekt but your name is not in the list, please feel free 
 - [Dominik Labuda](https://github.com/Dominick1993) - Gradle plugin improvement
 - [Andre Paz](https://github.com/andrepaz) - Rule improvement: LongParameterList
 - [Alina Rakhimova](https://github.com/AlinaRakhimova) - New rule: BooleanPropertyNaming
+- [Vladislav Yundin](https://github.com/Yundin) - Rule fix: Indentation
 
 ### Mentions
 

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingRule.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingRule.kt
@@ -81,7 +81,7 @@ abstract class FormattingRule(config: Config) : Rule(config) {
             val (line, column) = positionByOffset(offset)
             val location = Location(
                 SourceLocation(line, column),
-                TextLocation(node.startOffset, node.psi.endOffset),
+                getTextLocationForViolation(node, offset),
                 root.toFilePath()
             )
 
@@ -97,6 +97,9 @@ abstract class FormattingRule(config: Config) : Rule(config) {
             report(CorrectableCodeSmell(issue, entity, message, autoCorrectEnabled = autoCorrect))
         }
     }
+
+    open fun getTextLocationForViolation(node: ASTNode, offset: Int) =
+        TextLocation(node.startOffset, node.psi.endOffset)
 
     private fun ruleShouldOnlyRunOnFileNode(node: ASTNode) =
         wrapping is com.pinterest.ktlint.core.Rule.Modifier.RestrictToRoot && node !is FileASTNode

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/Indentation.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/Indentation.kt
@@ -2,12 +2,14 @@ package io.gitlab.arturbosch.detekt.formatting.wrappers
 
 import com.pinterest.ktlint.ruleset.standard.IndentationRule
 import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.TextLocation
 import io.gitlab.arturbosch.detekt.api.config
 import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.api.internal.Configuration
 import io.gitlab.arturbosch.detekt.formatting.CONTINUATION_INDENT_SIZE_KEY
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 import io.gitlab.arturbosch.detekt.formatting.INDENT_SIZE_KEY
+import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 
 /**
  * See <a href="https://ktlint.github.io/#rule-indentation">ktlint-website</a> for documentation.
@@ -28,4 +30,14 @@ class Indentation(config: Config) : FormattingRule(config) {
         INDENT_SIZE_KEY to indentSize,
         CONTINUATION_INDENT_SIZE_KEY to continuationIndentSize
     )
+
+    /**
+     * [wrapping] is working with file's [node] and we don't want to highlight the whole file
+     */
+    override fun getTextLocationForViolation(node: ASTNode, offset: Int): TextLocation {
+        val relativeEnd = node.text
+            .drop(offset)
+            .indexOfFirst { !it.isWhitespace() }
+        return TextLocation(offset, offset + relativeEnd)
+    }
 }

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/IndentationSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/IndentationSpec.kt
@@ -3,6 +3,7 @@ package io.gitlab.arturbosch.detekt.formatting
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.formatting.wrappers.Indentation
 import io.gitlab.arturbosch.detekt.test.TestConfig
+import io.gitlab.arturbosch.detekt.test.assert
 import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
@@ -17,8 +18,17 @@ class IndentationSpec : Spek({
 
             val code = "fun main() {\n println()\n}"
 
-            it("reports wrong indentation level") {
-                assertThat(subject.lint(code)).hasSize(1)
+            describe("indentation level config of default") {
+
+                it("reports wrong indentation level") {
+                    assertThat(subject.lint(code)).hasSize(1)
+                }
+
+                it("places finding location to the indentation") {
+                    subject.lint(code).assert()
+                        .hasSourceLocation(2, 1)
+                        .hasTextLocations(13 to 14)
+                }
             }
 
             it("does not report when using an indentation level config of 1") {


### PR DESCRIPTION
Although Indentation applies to the whole file, it's a local rule. Start of the real location reported by ktlint's offset. And I assume that the end location should be on first non-whitespace character.
This cause detekt plugin to highlight the whole file and html output to highlight everything to the end of snippet.

Relevant issue: https://github.com/detekt/detekt-intellij-plugin/issues/131