### PR TITLE
Fix issue IDs for ReferentialEquality and DoubleMutability

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -123,7 +123,7 @@ potential-bugs:
   DontDowncastCollectionTypes:
     active: true
   DoubleMutabilityForCollection:
-    active: true
+    active: false
   ExitOutsideMain:
     active: false
   HasPlatformType:

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Context.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Context.kt
@@ -50,7 +50,7 @@ open class DefaultContext : Context {
     override val findings: List<Finding>
         get() = _findings.toList()
 
-    private var _findings: MutableList<Finding> = mutableListOf()
+    private val _findings: MutableList<Finding> = mutableListOf()
 
     /**
      * Reports a single code smell finding.
@@ -66,6 +66,6 @@ open class DefaultContext : Context {
     }
 
     final override fun clearFindings() {
-        _findings = mutableListOf()
+        _findings.clear()
     }
 }

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/AvoidReferentialEquality.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/AvoidReferentialEquality.kt
@@ -37,7 +37,7 @@ import org.jetbrains.kotlin.resolve.calls.callUtil.getType
 class AvoidReferentialEquality(config: Config) : Rule(config) {
 
     override val issue = Issue(
-        "ReferentialEquality",
+        "AvoidReferentialEquality",
         Severity.Warning,
         "Avoid using referential equality checks",
         Debt.FIVE_MINS

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DoubleMutabilityForCollection.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DoubleMutabilityForCollection.kt
@@ -40,7 +40,7 @@ import org.jetbrains.kotlin.resolve.BindingContext
 class DoubleMutabilityForCollection(config: Config = Config.empty) : Rule(config) {
 
     override val issue: Issue = Issue(
-        "DoubleMutabilityInCollection",
+        "DoubleMutabilityForCollection",
         Severity.CodeSmell,
         "Using var with mutable collections leads to double mutability. " +
             "Consider using val or immutable collection types.",


### PR DESCRIPTION
Trying to fix for https://github.com/detekt/detekt/issues/4039
I think the issue ID created does not match the configuration and hence does not affect it the same way as expected.

**Disabling the DoubleMutabilityForCollection rule** as it seems the project has quite a few of said issues
