### PR TITLE
Allow active, excludes and includes in the rule-set configuration

### DIFF
--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/ValidatableConfiguration.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/ValidatableConfiguration.kt
@@ -17,6 +17,9 @@ interface ValidatableConfiguration {
  * in the configuration and we want to validate the config by default.
  */
 val DEFAULT_PROPERTY_EXCLUDES = setOf(
+    ".*>excludes",
+    ".*>includes",
+    ".*>active",
     ".*>.*>excludes",
     ".*>.*>includes",
     ".*>.*>active",

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/ConfigValidationSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/ConfigValidationSpec.kt
@@ -22,7 +22,7 @@ internal class ConfigValidationSpec : Spek({
             assertThat(result).isEmpty()
         }
 
-        it("passes for properties which may appear on rules but may be not present in default config") {
+        it("passes for properties which may appear on rules and rule sets but may be not present in default config") {
             val result = validateConfig(
                 yamlConfig("config_validation/default-excluded-properties.yml"),
                 baseline

--- a/detekt-core/src/test/resources/config_validation/default-excluded-properties.yml
+++ b/detekt-core/src/test/resources/config_validation/default-excluded-properties.yml
@@ -1,4 +1,7 @@
 style:
+  active: true
+  excludes: []
+  includes: []
   MagicNumber:
     active: true
     autoCorrect: true


### PR DESCRIPTION
in 1.17.1 the rule set `comments` had the `excludes` flag on it. But we removed it from there and lowered to some of their rules. Now, the old configurations of our users are complainig about it. This bug was there for long time but no one notices until now.

Fix #4038