### PR TITLE
Remove Error from ThrowingExceptionsWithoutMessageOrCause because it's a common name

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -234,7 +234,6 @@ exceptions:
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
     exceptions:
       - 'ArrayIndexOutOfBoundsException'
-      - 'Error'
       - 'Exception'
       - 'IllegalArgumentException'
       - 'IllegalMonitorStateException'

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionsWithoutMessageOrCause.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionsWithoutMessageOrCause.kt
@@ -52,7 +52,6 @@ class ThrowingExceptionsWithoutMessageOrCause(config: Config = Config.empty) : R
     private val exceptions: List<String> by config(
         listOf(
             "ArrayIndexOutOfBoundsException",
-            "Error",
             "Exception",
             "IllegalArgumentException",
             "IllegalMonitorStateException",


### PR DESCRIPTION
`Error` is a common name for a class. If you have a class with that name and call it's constructor without any parameter `ThrowingExceptionsWithoutMessageOrCause` catches it as a false-positive. This is just a short term fix to avoid this type of false-positives but we `ThrowingExceptionsWithoutMessageOrCause` should use Type solving to avoid all the possible false-positives.

Fix #4037