### PR TITLE
include `file://` in compact version of Location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,8 @@ local.properties
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+# heap dump in case of out of memory
+*.hprof
 
 ### LaTeX ###
 *.acn

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Location.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Location.kt
@@ -52,7 +52,7 @@ data class Location @Deprecated("Consider relative path by passing a [FilePath]"
         file: String
     ) : this(source, text, file)
 
-    override fun compact(): String = "${filePath.absolutePath}:$source"
+    override fun compact(): String = "file://${filePath.absolutePath}:$source"
 
     companion object {
         /**

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/EntitySpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/EntitySpec.kt
@@ -53,7 +53,7 @@ class EntitySpec : Spek({
                 val memberFunction = functions.first { it.name == "memberFun" }
 
                 assertThat(Entity.atName(memberFunction).compact())
-                    .isEqualTo("[memberFun] at $path:5:17")
+                    .isEqualTo("[memberFun] at file://$path:5:17")
             }
         }
 
@@ -65,7 +65,7 @@ class EntitySpec : Spek({
             }
 
             it("includes class name in entity compact") {
-                assertThat(Entity.atName(clazz).compact()).isEqualTo("[C] at $path:3:7")
+                assertThat(Entity.atName(clazz).compact()).isEqualTo("[C] at file://$path:3:7")
             }
         }
 
@@ -77,7 +77,7 @@ class EntitySpec : Spek({
             }
 
             it("includes file name in entity compact") {
-                val expectedResult = "[Test.kt] at $path:1:1"
+                val expectedResult = "[Test.kt] at file://$path:1:1"
 
                 assertThat(Entity.from(code).compact()).isEqualTo(expectedResult)
                 assertThat(Entity.atPackageOrFirstDecl(code).compact()).isEqualTo(expectedResult)

--- a/detekt-core/src/test/resources/reporting/findings-report.txt
+++ b/detekt-core/src/test/resources/reporting/findings-report.txt
@@ -1,7 +1,7 @@
 Ruleset1 - 10min debt
-	TestSmell - [TestEntity] at TestFile.kt:1:1
-	TestSmell - [TestEntity] at TestFile.kt:1:1
+	TestSmell - [TestEntity] at file://TestFile.kt:1:1
+	TestSmell - [TestEntity] at file://TestFile.kt:1:1
 Ruleset2 - 5min debt
-	TestSmell - [TestEntity] at TestFile.kt:1:1
+	TestSmell - [TestEntity] at file://TestFile.kt:1:1
 
 Overall debt: 15min

--- a/detekt-core/src/test/resources/reporting/grouped-findings-report.txt
+++ b/detekt-core/src/test/resources/reporting/grouped-findings-report.txt
@@ -1,7 +1,7 @@
 File1.kt - 10min debt
-	TestSmell - [TestEntity] at File1.kt:1:1
-	TestSmell - [TestEntity] at File1.kt:1:1
+	TestSmell - [TestEntity] at file://File1.kt:1:1
+	TestSmell - [TestEntity] at file://File1.kt:1:1
 File2.kt - 5min debt
-	TestSmell - [TestEntity] at File2.kt:1:1
+	TestSmell - [TestEntity] at file://File2.kt:1:1
 
 Overall debt: 15min

--- a/detekt-report-txt/src/test/kotlin/io/github/detekt/report/txt/TxtOutputReportSpec.kt
+++ b/detekt-report-txt/src/test/kotlin/io/github/detekt/report/txt/TxtOutputReportSpec.kt
@@ -20,7 +20,7 @@ class TxtOutputReportSpec : Spek({
         it("renders one") {
             val report = TxtOutputReport()
             val detektion = TestDetektion(createFinding())
-            val renderedText = "TestSmell - [TestEntity] at TestFile.kt:1:1 - Signature=TestEntitySignature\n"
+            val renderedText = "TestSmell - [TestEntity] at file://TestFile.kt:1:1 - Signature=TestEntitySignature\n"
             assertThat(report.render(detektion)).isEqualTo(renderedText)
         }
 
@@ -32,9 +32,9 @@ class TxtOutputReportSpec : Spek({
                 createFinding(ruleName = "TestSmellC")
             )
             val renderedText = """
-                TestSmellA - [TestEntity] at TestFile.kt:1:1 - Signature=TestEntitySignature
-                TestSmellB - [TestEntity] at TestFile.kt:1:1 - Signature=TestEntitySignature
-                TestSmellC - [TestEntity] at TestFile.kt:1:1 - Signature=TestEntitySignature
+                TestSmellA - [TestEntity] at file://TestFile.kt:1:1 - Signature=TestEntitySignature
+                TestSmellB - [TestEntity] at file://TestFile.kt:1:1 - Signature=TestEntitySignature
+                TestSmellC - [TestEntity] at file://TestFile.kt:1:1 - Signature=TestEntitySignature
 
             """.trimIndent()
             assertThat(report.render(detektion)).isEqualTo(renderedText)


### PR DESCRIPTION
As you can see in the changes, it looks like there are cases where file:// does not make sense. Not all paths are absolute paths. My guess is that we are dealing with test-data here which does not resemble the real world scenario and in real world they would all be absolute paths. If this is the case then I suggest to change this to set the expectations straight -- otherwise I can check if the path starts with / or [A-Z]:

Would fix 4041