### PR TITLE
Typo in Groovy merge report docs

### DIFF
--- a/docs/pages/reporting.md
+++ b/docs/pages/reporting.md
@@ -93,7 +93,7 @@ subprojects {
 
   plugins.withType(io.gitlab.arturbosch.detekt.DetektPlugin) {
     tasks.withType(io.gitlab.arturbosch.detekt.Detekt) { detektTask ->
-      finalizedBy(mergeTask)
+      finalizedBy(reportMerge)
 
       reportMerge.configure { mergeTask ->
         mergeTask.input.from(detektTask.xmlReportFile) // or detektTask.sarifReportFile


### PR DESCRIPTION
There is a typo in the script at https://github.com/detekt/detekt/blob/main/docs/pages/reporting.md#groovy-dsl

The line 
```
detektTask ->
      finalizedBy(mergeTask)
```
should be

```
detektTask ->
      finalizedBy(reportMerge)
```

`mergeTask` has not been declared yet at that point.
