### PR TITLE
Upscale JVM settings

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,3 +3,4 @@ systemProp.sonar.host.url=http://localhost:9000
 systemProp.file.encoding=UTF-8
 org.gradle.parallel=true
 org.gradle.caching=true
+org.gradle.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=512m


### PR DESCRIPTION
There are recent instances of out out memory error, such as:
- https://github.com/detekt/detekt/runs/3367423257
- https://github.com/detekt/detekt/runs/3340966297

This PR doubles the default configuration for building the project.
As the default JVM arguments from Gradle is `Xmx512m "-XX:MaxMetaspaceSize=256m"` (https://docs.gradle.org/current/userguide/build_environment.html#sec:configuring_jvm_memory)

There is not an easy way to verify that this will work (Unless we kick-off hundreds of github action jobs to verify the volume of OOM build errors is reduced). But I would believe this is a reasonable first step.