### PR TITLE
Prepare Detekt 1.18.1

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,6 +1,6 @@
 object Versions {
 
-    const val DETEKT: String = "1.18.0"
+    const val DETEKT: String = "1.18.1"
     const val SNAPSHOT_NAME: String = "main"
     const val JVM_TARGET: String = "1.8"
 

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -123,7 +123,7 @@ potential-bugs:
   DontDowncastCollectionTypes:
     active: true
   DoubleMutabilityForCollection:
-    active: true
+    active: false
   ExitOutsideMain:
     active: false
   HasPlatformType:

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Context.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Context.kt
@@ -50,7 +50,7 @@ open class DefaultContext : Context {
     override val findings: List<Finding>
         get() = _findings.toList()
 
-    private var _findings: MutableList<Finding> = mutableListOf()
+    private val _findings: MutableList<Finding> = mutableListOf()
 
     /**
      * Reports a single code smell finding.
@@ -66,6 +66,6 @@ open class DefaultContext : Context {
     }
 
     final override fun clearFindings() {
-        _findings = mutableListOf()
+        _findings.clear()
     }
 }

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/MultiRule.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/MultiRule.kt
@@ -17,6 +17,9 @@ abstract class MultiRule : BaseRule() {
 
     override fun preVisit(root: KtFile) {
         activeRules = rules.filterTo(HashSet(rules.size)) { it.visitCondition(root) }
+        activeRules.forEach { singleRule ->
+            singleRule.bindingContext = this.bindingContext
+        }
     }
 
     override fun postVisit(root: KtFile) {

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/ValidatableConfiguration.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/ValidatableConfiguration.kt
@@ -17,6 +17,9 @@ interface ValidatableConfiguration {
  * in the configuration and we want to validate the config by default.
  */
 val DEFAULT_PROPERTY_EXCLUDES = setOf(
+    ".*>excludes",
+    ".*>includes",
+    ".*>active",
     ".*>.*>excludes",
     ".*>.*>includes",
     ".*>.*>active",

--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -234,7 +234,6 @@ exceptions:
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
     exceptions:
       - 'ArrayIndexOutOfBoundsException'
-      - 'Error'
       - 'Exception'
       - 'IllegalArgumentException'
       - 'IllegalMonitorStateException'

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/ConfigValidationSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/ConfigValidationSpec.kt
@@ -22,7 +22,7 @@ internal class ConfigValidationSpec : Spek({
             assertThat(result).isEmpty()
         }
 
-        it("passes for properties which may appear on rules but may be not present in default config") {
+        it("passes for properties which may appear on rules and rule sets but may be not present in default config") {
             val result = validateConfig(
                 yamlConfig("config_validation/default-excluded-properties.yml"),
                 baseline

--- a/detekt-core/src/test/resources/config_validation/default-excluded-properties.yml
+++ b/detekt-core/src/test/resources/config_validation/default-excluded-properties.yml
@@ -1,4 +1,7 @@
 style:
+  active: true
+  excludes: []
+  includes: []
   MagicNumber:
     active: true
     autoCorrect: true

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/AvoidReferentialEquality.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/AvoidReferentialEquality.kt
@@ -37,7 +37,7 @@ import org.jetbrains.kotlin.resolve.calls.callUtil.getType
 class AvoidReferentialEquality(config: Config) : Rule(config) {
 
     override val issue = Issue(
-        "ReferentialEquality",
+        "AvoidReferentialEquality",
         Severity.Warning,
         "Avoid using referential equality checks",
         Debt.FIVE_MINS

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DoubleMutabilityForCollection.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DoubleMutabilityForCollection.kt
@@ -40,7 +40,7 @@ import org.jetbrains.kotlin.resolve.BindingContext
 class DoubleMutabilityForCollection(config: Config = Config.empty) : Rule(config) {
 
     override val issue: Issue = Issue(
-        "DoubleMutabilityInCollection",
+        "DoubleMutabilityForCollection",
         Severity.CodeSmell,
         "Using var with mutable collections leads to double mutability. " +
             "Consider using val or immutable collection types.",

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionsWithoutMessageOrCause.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionsWithoutMessageOrCause.kt
@@ -52,7 +52,6 @@ class ThrowingExceptionsWithoutMessageOrCause(config: Config = Config.empty) : R
     private val exceptions: List<String> by config(
         listOf(
             "ArrayIndexOutOfBoundsException",
-            "Error",
             "Exception",
             "IllegalArgumentException",
             "IllegalMonitorStateException",

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIsNullOrEmpty.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIsNullOrEmpty.kt
@@ -89,7 +89,7 @@ class UseIsNullOrEmpty(config: Config = Config.empty) : Rule(config) {
     }
 
     private fun KtDotQualifiedExpression.sizeCheckedExpression(): KtSimpleNameExpression? {
-        if (!selectorExpression.isCalling(isEmptyFunctions)) return null
+        if (!selectorExpression.isCalling(emptyCheckFunctions)) return null
         return receiverExpression.safeAs<KtSimpleNameExpression>()?.takeIf { it.isCollectionOrArrayOrString() }
     }
 
@@ -168,7 +168,7 @@ class UseIsNullOrEmpty(config: Config = Config.empty) : Rule(config) {
 
         private val stringClass = StandardNames.FqNames.string.toSafe()
 
-        private val isEmptyFunctions = collectionClasses.map { FqName("$it.isEmpty") } +
+        private val emptyCheckFunctions = collectionClasses.map { FqName("$it.isEmpty") } +
             listOf("kotlin.collections.isEmpty", "kotlin.text.isEmpty").map(::FqName)
 
         private val countFunctions = listOf("kotlin.collections.count", "kotlin.text.count").map(::FqName)

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -117,4 +117,4 @@ description: "Meet detekt, a static code analysis tool for Kotlin."
 url: https://detekt.github.io
 baseurl: /detekt
 
-detekt_version: 1.18.0
+detekt_version: 1.18.1

--- a/docs/pages/changelog 1.x.x.md
+++ b/docs/pages/changelog 1.x.x.md
@@ -6,6 +6,19 @@ permalink: changelog.html
 toc: true
 ---
 
+#### 1.18.1 - 2021-08-30    
+
+This is a point release for Detekt `1.18.0` containing bugfixes for problems that got discovered just after the release.
+
+##### Notable Changes
+
+- MultiRule should pass correctly the BindingContext - [#4071](https://github.com/detekt/detekt/pull/4071) 
+- Allow active, excludes and includes in the rule-set configuration - [#4045](https://github.com/detekt/detekt/pull/4045)
+- Remove Error from ThrowingExceptionsWithoutMessageOrCause because is a common name - [#4046](https://github.com/detekt/detekt/pull/4046)
+- Fix issue IDs for ReferentialEquality and DoubleMutability - [#4040](https://github.com/detekt/detekt/pull/4040)
+
+See all issues at: [1.18.1](https://github.com/detekt/detekt/milestone/84)
+
 #### 1.18.0 - 2021-08-12
 
 We're more than excited to introduce you a next stable release of Detekt: `1.18.0` 🎉

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ spek = "2.0.15"
 
 [libraries]
 binaryCompatibilityValidator-gradle = "org.jetbrains.kotlinx:binary-compatibility-validator:0.4.0"
-detekt-gradle = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.18.0"
+detekt-gradle = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.18.1"
 githubRelease-gradle = "com.github.breadmoirai:github-release:2.2.12"
 gradleVersions-gradle = "com.github.ben-manes:gradle-versions-plugin:0.28.0"
 nexusStaging-gradle = "io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.22.0"


### PR DESCRIPTION
This is the branch for a point release of Detekt `1.18.1`.

I've picked the following PRs:

- Allow active, excludes and includes in the rule-set configuration - [#4045](https://github.com/detekt/detekt/pull/4045)
- Remove Error from ThrowingExceptionsWithoutMessageOrCause because is a common name - [#4046](https://github.com/detekt/detekt/pull/4046)
- Fix issue IDs for ReferentialEquality and DoubleMutability - [#4040](https://github.com/detekt/detekt/pull/4040)

Please let me know if you think there is more to be picked up 👍 