### PR TITLE
MultiRule should pass correctly the BindingContext

### DIFF
--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/MultiRule.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/MultiRule.kt
@@ -17,6 +17,9 @@ abstract class MultiRule : BaseRule() {
 
     override fun preVisit(root: KtFile) {
         activeRules = rules.filterTo(HashSet(rules.size)) { it.visitCondition(root) }
+        activeRules.forEach { singleRule ->
+            singleRule.bindingContext = this.bindingContext
+        }
     }
 
     override fun postVisit(root: KtFile) {

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIsNullOrEmpty.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIsNullOrEmpty.kt
@@ -89,7 +89,7 @@ class UseIsNullOrEmpty(config: Config = Config.empty) : Rule(config) {
     }
 
     private fun KtDotQualifiedExpression.sizeCheckedExpression(): KtSimpleNameExpression? {
-        if (!selectorExpression.isCalling(isEmptyFunctions)) return null
+        if (!selectorExpression.isCalling(emptyCheckFunctions)) return null
         return receiverExpression.safeAs<KtSimpleNameExpression>()?.takeIf { it.isCollectionOrArrayOrString() }
     }
 
@@ -168,7 +168,7 @@ class UseIsNullOrEmpty(config: Config = Config.empty) : Rule(config) {
 
         private val stringClass = StandardNames.FqNames.string.toSafe()
 
-        private val isEmptyFunctions = collectionClasses.map { FqName("$it.isEmpty") } +
+        private val emptyCheckFunctions = collectionClasses.map { FqName("$it.isEmpty") } +
             listOf("kotlin.collections.isEmpty", "kotlin.text.isEmpty").map(::FqName)
 
         private val countFunctions = listOf("kotlin.collections.count", "kotlin.text.count").map(::FqName)


### PR DESCRIPTION
Fixes #4058

The rule `BooleanPropertyNaming` that was recently added relies on Type Resolution. That rule was plugged inside a `MultiRule` instead of a classical `RuleSetProvider`.

Given that rules rely on inheritance to access a `BindingContext`, the `MultiRule` should pass over the `BindingContext` to the rules he's managing.

The result was that `BooleanPropertyNaming` was effectively not running at all. This PR is fixing it.
