### PR TITLE
Update compatibility table for 1.18.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Gradle 6.1+ is the minimum requirement. However, the recommended versions togeth
 
 | Detekt Version | Gradle | Kotlin | AGP | Java Target Level | JDK Max Version |
 | -------------- | ------ | ------ | --- | ----------------- | --------------- |
-| `1.17.0` | `7.0.1` | `1.4.32` | `4.2.0` | `1.8` | `15` |
+| `1.18.0` | `7.0.1` | `1.5.21` | `4.2.0` | `1.8` | `16` |
 
 The list of [recommended versions for previous detekt version is listed here](https://detekt.github.io/detekt/compatibility.html).
 

--- a/docs/pages/compatibility.md
+++ b/docs/pages/compatibility.md
@@ -28,6 +28,7 @@ Consider **aligning** your Gradle plugin versions with the one listed below, as 
 
 | Detekt Version | Gradle Version | Kotlin Version | AGP Version | Java Target Level | JDK Version |
 | -------------- | -------------- | -------------- | ----------- | ----------------- | ----------- |
+| `1.18.0`       | `7.0.1`        | `1.5.21`       | `4.2.0`     | `1.8`             | `16`        |
 | `1.17.0`       | `7.0.1`        | `1.4.32`       | `4.2.0`     | `1.8`             | `15`        |
 | `1.16.0`       | `6.8.0`        | `1.4.21`       | `4.1.2`     | `1.8`             | `15`        |
 | `1.15.0`       | `6.8.0`        | `1.4.10`       | `4.0.1`     | `1.8`             | `15`        |


### PR DESCRIPTION
Seems like we forgot the compat table for the latest release of Detekt