### PR TITLE
Convert DetektJvmSpec to use ProjectBuilder

### DIFF
--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -16,11 +16,13 @@ dependencies {
     implementation(libs.sarif4k)
     compileOnly(libs.android.gradle)
     compileOnly(libs.kotlin.gradle)
+    compileOnly(gradleKotlinDsl())
 
     testImplementation(projects.detektTestUtils)
     testImplementation(libs.kotlin.gradle)
     testImplementation(libs.bundles.testImplementation)
     testRuntimeOnly(libs.spek.runner)
+    testImplementation(gradleKotlinDsl())
     intTest(libs.kotlin.gradle)
     intTest(libs.android.gradle)
 }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -199,6 +199,29 @@ open class Detekt @Inject constructor(
         group = LifecycleBasePlugin.VERIFICATION_GROUP
     }
 
+    @get:Internal
+    internal val arguments
+        get() = mutableListOf(
+            InputArgument(source),
+            ClasspathArgument(classpath),
+            LanguageVersionArgument(languageVersionProp.orNull),
+            JvmTargetArgument(jvmTargetProp.orNull),
+            ConfigArgument(config),
+            BaselineArgument(baseline.orNull),
+            DefaultReportArgument(DetektReportType.XML, xmlReportFile.orNull),
+            DefaultReportArgument(DetektReportType.HTML, htmlReportFile.orNull),
+            DefaultReportArgument(DetektReportType.TXT, txtReportFile.orNull),
+            DefaultReportArgument(DetektReportType.SARIF, sarifReportFile.orNull),
+            DebugArgument(debugProp.getOrElse(false)),
+            ParallelArgument(parallelProp.getOrElse(false)),
+            BuildUponDefaultConfigArgument(buildUponDefaultConfigProp.getOrElse(false)),
+            FailFastArgument(failFastProp.getOrElse(false)),
+            AllRulesArgument(allRulesProp.getOrElse(false)),
+            AutoCorrectArgument(autoCorrectProp.getOrElse(false)),
+            BasePathArgument(basePathProp.orNull),
+            DisableDefaultRuleSetArgument(disableDefaultRuleSetsProp.getOrElse(false))
+        ) + convertCustomReportsToArguments()
+
     @InputFiles
     @SkipWhenEmpty
     @PathSensitive(PathSensitivity.RELATIVE)
@@ -220,28 +243,6 @@ open class Detekt @Inject constructor(
         if (failFastProp.getOrElse(false)) {
             logger.warn("'failFast' is deprecated. Please use 'buildUponDefaultConfig' together with 'allRules'.")
         }
-
-        val arguments = mutableListOf(
-            InputArgument(source),
-            ClasspathArgument(classpath),
-            LanguageVersionArgument(languageVersionProp.orNull),
-            JvmTargetArgument(jvmTargetProp.orNull),
-            ConfigArgument(config),
-            BaselineArgument(baseline.orNull),
-            DefaultReportArgument(DetektReportType.XML, xmlReportFile.orNull),
-            DefaultReportArgument(DetektReportType.HTML, htmlReportFile.orNull),
-            DefaultReportArgument(DetektReportType.TXT, txtReportFile.orNull),
-            DefaultReportArgument(DetektReportType.SARIF, sarifReportFile.orNull),
-            DebugArgument(debugProp.getOrElse(false)),
-            ParallelArgument(parallelProp.getOrElse(false)),
-            BuildUponDefaultConfigArgument(buildUponDefaultConfigProp.getOrElse(false)),
-            FailFastArgument(failFastProp.getOrElse(false)),
-            AllRulesArgument(allRulesProp.getOrElse(false)),
-            AutoCorrectArgument(autoCorrectProp.getOrElse(false)),
-            BasePathArgument(basePathProp.orNull),
-            DisableDefaultRuleSetArgument(disableDefaultRuleSetsProp.getOrElse(false))
-        )
-        arguments.addAll(convertCustomReportsToArguments())
 
         DetektInvoker.create(task = this, isDryRun = isDryRun).invokeCli(
             arguments = arguments.toList(),

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektJvmSpec.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektJvmSpec.kt
@@ -3,6 +3,7 @@ package io.gitlab.arturbosch.detekt
 import io.gitlab.arturbosch.detekt.invoke.CliArgument
 import io.gitlab.arturbosch.detekt.testkit.DslGradleRunner
 import io.gitlab.arturbosch.detekt.testkit.ProjectLayout
+import io.gitlab.arturbosch.detekt.testkit.triggerEvaluation
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.repositories
@@ -37,7 +38,7 @@ object DetektJvmSpec : Spek({
             it("configures detekt type resolution task main") {
                 val project = gradleRunner.buildProject()
 
-                project.getTasksByName("detektMain", true) // trigger project evaluation
+                project.triggerEvaluation()
 
                 val detektTask = project.tasks.getByPath("detektMain") as Detekt
                 val argumentString = detektTask.arguments.flatMap(CliArgument::toArgument).joinToString(" ")
@@ -52,7 +53,7 @@ object DetektJvmSpec : Spek({
             it("configures detekt type resolution task test") {
                 val project = gradleRunner.buildProject()
 
-                project.getTasksByName("detektTest", true) // trigger project evaluation
+                project.triggerEvaluation()
 
                 val detektTask = project.tasks.getByPath("detektTest") as Detekt
                 val argumentString = detektTask.arguments.flatMap(CliArgument::toArgument).joinToString(" ")

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektJvmSpec.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektJvmSpec.kt
@@ -1,8 +1,12 @@
 package io.gitlab.arturbosch.detekt
 
+import io.gitlab.arturbosch.detekt.invoke.CliArgument
 import io.gitlab.arturbosch.detekt.testkit.DslGradleRunner
 import io.gitlab.arturbosch.detekt.testkit.ProjectLayout
 import org.assertj.core.api.Assertions.assertThat
+import org.gradle.kotlin.dsl.apply
+import org.gradle.kotlin.dsl.repositories
+import org.jetbrains.kotlin.gradle.plugin.KotlinPluginWrapper
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
@@ -14,45 +18,50 @@ object DetektJvmSpec : Spek({
                 projectLayout = ProjectLayout(numberOfSourceFilesInRootPerSourceDir = 1),
                 buildFileName = "build.gradle",
                 baselineFiles = listOf("detekt-baseline.xml", "detekt-baseline-main.xml", "detekt-baseline-test.xml"),
-                mainBuildFileContent = """
-                    plugins {
-                        id "org.jetbrains.kotlin.jvm"
-                        id "io.gitlab.arturbosch.detekt"
-                    }
-
+                projectScript = {
+                    apply<KotlinPluginWrapper>()
+                    apply<DetektPlugin>()
                     repositories {
                         mavenCentral()
                         mavenLocal()
                     }
-
-                    tasks.withType(io.gitlab.arturbosch.detekt.Detekt).configureEach {
-                        reports {
-                            txt.enabled = false
+                    tasks.withType(Detekt::class.java).configureEach {
+                        it.reports { reports ->
+                            reports.txt.required.set(false)
                         }
                     }
-                """.trimIndent(),
-                dryRun = true
+                },
             )
             gradleRunner.setupProject()
 
             it("configures detekt type resolution task main") {
-                gradleRunner.runTasksAndCheckResult(":detektMain") { buildResult ->
-                    assertThat(buildResult.output).containsPattern("""--baseline \S*[/\\]detekt-baseline-main.xml """)
-                    assertThat(buildResult.output).contains("--report xml:")
-                    assertThat(buildResult.output).contains("--report sarif:")
-                    assertThat(buildResult.output).doesNotContain("--report txt:")
-                    assertThat(buildResult.output).contains("--classpath")
-                }
+                val project = gradleRunner.buildProject()
+
+                project.getTasksByName("detektMain", true) // trigger project evaluation
+
+                val detektTask = project.tasks.getByPath("detektMain") as Detekt
+                val argumentString = detektTask.arguments.flatMap(CliArgument::toArgument).joinToString(" ")
+
+                assertThat(argumentString).containsPattern("""--baseline \S*[/\\]detekt-baseline-main.xml """)
+                assertThat(argumentString).contains("--report xml:")
+                assertThat(argumentString).contains("--report sarif:")
+                assertThat(argumentString).doesNotContain("--report txt:")
+                assertThat(argumentString).contains("--classpath")
             }
 
             it("configures detekt type resolution task test") {
-                gradleRunner.runTasksAndCheckResult(":detektTest") { buildResult ->
-                    assertThat(buildResult.output).containsPattern("""--baseline \S*[/\\]detekt-baseline-test.xml """)
-                    assertThat(buildResult.output).contains("--report xml:")
-                    assertThat(buildResult.output).contains("--report sarif:")
-                    assertThat(buildResult.output).doesNotContain("--report txt:")
-                    assertThat(buildResult.output).contains("--classpath")
-                }
+                val project = gradleRunner.buildProject()
+
+                project.getTasksByName("detektTest", true) // trigger project evaluation
+
+                val detektTask = project.tasks.getByPath("detektTest") as Detekt
+                val argumentString = detektTask.arguments.flatMap(CliArgument::toArgument).joinToString(" ")
+
+                assertThat(argumentString).containsPattern("""--baseline \S*[/\\]detekt-baseline-test.xml """)
+                assertThat(argumentString).contains("--report xml:")
+                assertThat(argumentString).contains("--report sarif:")
+                assertThat(argumentString).doesNotContain("--report txt:")
+                assertThat(argumentString).contains("--classpath")
             }
         }
 

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/testkit/DslGradleRunner.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/testkit/DslGradleRunner.kt
@@ -165,3 +165,5 @@ class DslGradleRunner @Suppress("LongParameterList") constructor(
         private const val DETEKT_TASK = "detekt"
     }
 }
+
+fun Project.triggerEvaluation() { this.getTasksByName("tasks", true) }

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/testkit/DslGradleRunner.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/testkit/DslGradleRunner.kt
@@ -1,5 +1,7 @@
 package io.gitlab.arturbosch.detekt.testkit
 
+import org.gradle.api.Project
+import org.gradle.testfixtures.ProjectBuilder
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
 import java.io.File
@@ -10,11 +12,12 @@ import java.util.UUID
 class DslGradleRunner @Suppress("LongParameterList") constructor(
     val projectLayout: ProjectLayout,
     val buildFileName: String,
-    val mainBuildFileContent: String,
+    val mainBuildFileContent: String = "",
     val configFileOrNone: String? = null,
     val baselineFiles: List<String> = emptyList(),
     val gradleVersionOrNone: String? = null,
-    val dryRun: Boolean = false
+    val dryRun: Boolean = false,
+    val projectScript: Project.() -> Unit = {},
 ) {
 
     private val rootDir: File = Files.createTempDirectory("applyPlugin").toFile().apply { deleteOnExit() }
@@ -108,6 +111,11 @@ class DslGradleRunner @Suppress("LongParameterList") constructor(
 
     private val Submodule.moduleRoot: File
         get() = File(rootDir, name).apply { mkdirs() }
+
+    fun buildProject(): Project = ProjectBuilder.builder()
+        .withProjectDir(rootDir)
+        .build()
+        .apply(projectScript)
 
     @OptIn(ExperimentalStdlibApi::class)
     private fun buildGradleRunner(tasks: List<String>): GradleRunner {


### PR DESCRIPTION
See #3778. This reduced execution of the DetektJvmSpec test by about 25% on my machine.