### PR TITLE
Fix broken `applySelfAnalysisVersion` task

### DIFF
--- a/buildSrc/src/main/kotlin/releasing.gradle.kts
+++ b/buildSrc/src/main/kotlin/releasing.gradle.kts
@@ -59,9 +59,9 @@ tasks {
 
     register<UpdateVersionInFileTask>("applySelfAnalysisVersion") {
         fileToUpdate.set(file("${rootProject.rootDir}/gradle/libs.versions.toml"))
-        linePartToFind.set("detekt-gradlePlugin = \"io.gitlab.arturbosch.detekt:detekt-gradle-plugin")
+        linePartToFind.set("detekt-gradle = \"io.gitlab.arturbosch.detekt:detekt-gradle-plugin")
         lineTransformation.set(
-            "detekt-gradlePlugin = \"io.gitlab.arturbosch.detekt:" +
+            "detekt-gradle = \"io.gitlab.arturbosch.detekt:" +
                 "detekt-gradle-plugin:${Versions.DETEKT}\""
         )
     }


### PR DESCRIPTION
The recent update to Gradle 7.2 broke this task that is using during release. I'm fixing it here.
