### PR TITLE
Fix confusing message when breaking the MultilineLambdaItParameter rule

### DIFF
--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MultilineLambdaItParameter.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MultilineLambdaItParameter.kt
@@ -101,7 +101,7 @@ class MultilineLambdaItParameter(val config: Config) : Rule(config) {
                         CodeSmell(
                             issue,
                             Entity.from(lambdaExpression),
-                            "The implicit `it` should be used in a multiline lambda. " +
+                            "The implicit `it` should not be used in a multiline lambda. " +
                                 "Consider giving your parameter a readable and descriptive name."
                         )
                     )


### PR DESCRIPTION
Previously, this message essentially suggested doing what the offending code would already be doing, which is using the implicit `it` in a multiline lambda expression. 