### PR TITLE
Deprecate DefaultContext

### DIFF
--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Context.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Context.kt
@@ -42,6 +42,7 @@ interface Context {
 /**
  * Default [Context] implementation.
  */
+@Deprecated("You should not use this class directly. Use or extend Context instead.")
 open class DefaultContext : Context {
 
     /**

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Rule.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Rule.kt
@@ -2,6 +2,7 @@ package io.gitlab.arturbosch.detekt.api
 
 import io.gitlab.arturbosch.detekt.api.Config.Companion.SEVERITY_KEY
 import io.gitlab.arturbosch.detekt.api.internal.BaseRule
+import io.gitlab.arturbosch.detekt.api.internal.DefaultContext
 import io.gitlab.arturbosch.detekt.api.internal.PathFilters
 import io.gitlab.arturbosch.detekt.api.internal.createPathFilters
 import io.gitlab.arturbosch.detekt.api.internal.isSuppressedBy

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/BaseRule.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/BaseRule.kt
@@ -2,7 +2,6 @@ package io.gitlab.arturbosch.detekt.api.internal
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Context
-import io.gitlab.arturbosch.detekt.api.DefaultContext
 import io.gitlab.arturbosch.detekt.api.DetektVisitor
 import io.gitlab.arturbosch.detekt.api.MultiRule
 import io.gitlab.arturbosch.detekt.api.Rule

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/DefaultContext.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/DefaultContext.kt
@@ -1,0 +1,36 @@
+package io.gitlab.arturbosch.detekt.api.internal
+
+import io.gitlab.arturbosch.detekt.api.Context
+import io.gitlab.arturbosch.detekt.api.Finding
+import io.gitlab.arturbosch.detekt.api.RuleSetId
+
+/**
+ * Default [Context] implementation.
+ */
+internal class DefaultContext : Context {
+
+    /**
+     * Returns a copy of violations for this rule.
+     */
+    override val findings: List<Finding>
+        get() = _findings.toList()
+
+    private val _findings: MutableList<Finding> = mutableListOf()
+
+    /**
+     * Reports a single code smell finding.
+     *
+     * Before adding a finding, it is checked if it is not suppressed
+     * by @Suppress or @SuppressWarnings annotations.
+     */
+    override fun report(finding: Finding, aliases: Set<String>, ruleSetId: RuleSetId?) {
+        val ktElement = finding.entity.ktElement
+        if (ktElement == null || !ktElement.isSuppressedBy(finding.id, aliases, ruleSetId)) {
+            _findings.add(finding)
+        }
+    }
+
+    override fun clearFindings() {
+        _findings.clear()
+    }
+}


### PR DESCRIPTION
I just copy&paste the `DefaultContext` class in api.internal so we can use it and I deprecated the "public" one. We don't need to expose this. If someone wants to change the behaviour can implement `Context` directly.