### PR TITLE
Remove annotations from LateinitUsage noncompliant block

### DIFF
--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/LateinitUsage.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/LateinitUsage.kt
@@ -23,8 +23,8 @@ import org.jetbrains.kotlin.psi.psiUtil.containingClass
  *
  * <noncompliant>
  * class Foo {
- *     @JvmField lateinit var i1: Int
- *     @JvmField @SinceKotlin("1.0.0") lateinit var i2: Int
+ *     private lateinit var i1: Int
+ *     lateinit var i2: Int
  * }
  * </noncompliant>
  */


### PR DESCRIPTION
Those annotations were missileading. This rule is not related with any of those annotations.