### PR TITLE
Remove library specific configurations

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -439,8 +439,7 @@ naming:
     functionPattern: '([a-z][a-zA-Z0-9]*)|(`.*`)'
     excludeClassPattern: '$^'
     ignoreOverridden: true
-    ignoreAnnotated:
-      - 'Composable'
+    ignoreAnnotated: []
   FunctionParameterNaming:
     active: true
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
@@ -643,8 +642,7 @@ style:
     ignoreOverridableFunction: true
     ignoreActualFunction: true
     excludedFunctions: ''
-    excludeAnnotatedFunction:
-      - 'dagger.Provides'
+    excludeAnnotatedFunction: []
   LibraryCodeMustSpecifyReturnType:
     active: true
     excludes: ['**']
@@ -736,8 +734,7 @@ style:
     acceptableDecimalLength: 5
   UnnecessaryAbstractClass:
     active: true
-    excludeAnnotatedClasses:
-      - 'dagger.Module'
+    excludeAnnotatedClasses: []
   UnnecessaryAnnotationUseSiteTarget:
     active: false
   UnnecessaryApply:
@@ -794,4 +791,3 @@ style:
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
     excludeImports:
       - 'java.util.*'
-      - 'kotlinx.android.synthetic.*'

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNaming.kt
@@ -42,7 +42,7 @@ class FunctionNaming(config: Config = Config.empty) : Rule(config) {
     private val ignoreOverridden: Boolean by config(true)
 
     @Configuration("ignore naming for functions in the context of these annotation class names")
-    private val ignoreAnnotated: List<String> by config(listOf("Composable"))
+    private val ignoreAnnotated: List<String> by config(emptyList())
 
     override fun visitNamedFunction(function: KtNamedFunction) {
         super.visitNamedFunction(function)

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNamingSpec.kt
@@ -122,13 +122,6 @@ class FunctionNamingSpec : Spek({
 
             """
 
-            it("Ignores default annotated functions") {
-                assertThat(FunctionNaming().compileAndLint(code)).hasSourceLocations(
-                    SourceLocation(4, 9),
-                    SourceLocation(8, 9)
-                )
-            }
-
             it("Ignores annotated functions if ignoreAnnotated includes the given annotation class") {
                 val config = TestConfig(mapOf(FunctionNaming.IGNORE_ANNOTATED to listOf("Suppress")))
                 assertThat(FunctionNaming(config).compileAndLint(code)).hasSourceLocations(

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/FunctionOnlyReturningConstant.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/FunctionOnlyReturningConstant.kt
@@ -56,7 +56,7 @@ class FunctionOnlyReturningConstant(config: Config = Config.empty) : Rule(config
     private val excludedFunctions: SplitPattern by config("") { SplitPattern(it) }
 
     @Configuration("allows to provide a list of annotations that disable this check")
-    private val excludeAnnotatedFunction: List<String> by config(listOf("dagger.Provides")) { functions ->
+    private val excludeAnnotatedFunction: List<String> by config(emptyList<String>()) { functions ->
         functions.map { it.removePrefix("*").removeSuffix("*") }
     }
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAbstractClass.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAbstractClass.kt
@@ -61,7 +61,7 @@ class UnnecessaryAbstractClass(config: Config = Config.empty) : Rule(config) {
         )
 
     @Configuration("Allows you to provide a list of annotations that disable this check.")
-    private val excludeAnnotatedClasses: List<String> by config(listOf("dagger.Module")) { classes ->
+    private val excludeAnnotatedClasses: List<String> by config(emptyList<String>()) { classes ->
         classes.map { it.removePrefix("*").removeSuffix("*") }
     }
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/WildcardImport.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/WildcardImport.kt
@@ -54,12 +54,7 @@ class WildcardImport(config: Config = Config.empty) : Rule(config) {
     )
 
     @Configuration("Define a list of package names that should be allowed to be imported with wildcard imports.")
-    private val excludeImports: List<String> by config(
-        listOf(
-            "java.util.*",
-            "kotlinx.android.synthetic.*"
-        )
-    ) { imports ->
+    private val excludeImports: List<String> by config(listOf("java.util.*")) { imports ->
         imports.map { it.removePrefix("*").removeSuffix("*") }
     }
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/WildcardImportSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/WildcardImportSpec.kt
@@ -78,7 +78,6 @@ class WildcardImportSpec : Spek({
             it("ignores the default values") {
                 val code2 = """
                     import java.util.*
-                    import kotlinx.android.synthetic.*
                 """
 
                 val findings = WildcardImport().lint(code2)


### PR DESCRIPTION
We don't want to have library specific configurations in the default configuration of detekt. There are far too much libraries out there for us to keep their configuration. For historical reasons we had 4 configurations that were "violating" this rule. This PR fixes that.

Related: #3894, #3041, #2747, #3944