### PR TITLE
Fix indent issues with continaution indent

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,6 +6,7 @@ insert_final_newline = true
 
 [*.{kt, groovy}]
 indent_style = space
+indent_size = 4
 
 [*.yml]
 indent_style = space


### PR DESCRIPTION
I don't know if I'm the only one that when there are some continuation indents in a file, if I autoformat them with IntelliJ they are indented with 8 spaces and when that code is pushed the ktlint rules complain about it.

This PR fixes that. It defines the desired indent so IntelliJ and ktlint are aligined.