### PR TITLE
Allow passing extra flags to Kotlin compiler environment

### DIFF
--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt
@@ -200,6 +200,9 @@ class CliArgs {
     )
     var showVersion: Boolean = false
 
+    @Parameter(description = "Options to pass to the Kotlin compiler.", hidden = true)
+    var freeCompilerArgs: MutableList<String> = mutableListOf()
+
     val inputPaths: List<Path> by lazy {
         MultipleExistingPathConverter().convert(input ?: System.getProperty("user.dir"))
     }

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Spec.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Spec.kt
@@ -68,6 +68,7 @@ internal fun CliArgs.createSpec(output: Appendable, error: Appendable): Processi
             jvmTarget = args.jvmTarget.description
             languageVersion = args.languageVersion?.versionString
             classpath = args.classpath?.trim()
+            freeCompilerArgs = args.freeCompilerArgs
         }
     }
 }

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgsSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgsSpec.kt
@@ -88,11 +88,6 @@ internal class CliArgsSpec : Spek({
             assertThatExceptionOfType(HelpRequest::class.java)
                 .isThrownBy { parseArguments(arrayOf("--help")) }
         }
-
-        it("throws HandledArgumentViolation on wrong options") {
-            assertThatExceptionOfType(HandledArgumentViolation::class.java)
-                .isThrownBy { parseArguments(arrayOf("--unknown-to-us-all")) }
-        }
     }
 
     describe("--all-rules and --fail-fast lead to all rules being activated") {

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/settings/EnvironmentAware.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/settings/EnvironmentAware.kt
@@ -6,6 +6,7 @@ import io.github.detekt.tooling.api.spec.CompilerSpec
 import io.github.detekt.tooling.api.spec.ProjectSpec
 import org.jetbrains.kotlin.cli.common.arguments.K2JVMCompilerArguments
 import org.jetbrains.kotlin.cli.common.arguments.parseCommandLineArguments
+import org.jetbrains.kotlin.cli.common.arguments.validateArguments
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.jetbrains.kotlin.com.intellij.openapi.Disposable
 import org.jetbrains.kotlin.com.intellij.openapi.util.Disposer
@@ -35,6 +36,8 @@ internal class EnvironmentFacade(
         val compilerArguments = K2JVMCompilerArguments().apply {
             parseCommandLineArguments(compilerSpec.freeCompilerArgs, this)
         }
+
+        validateArguments(compilerArguments.errors)?.let { throw IllegalStateException(it) }
 
         val compilerConfiguration = createCompilerConfiguration(
             projectSpec.inputPaths.toList(),

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/settings/EnvironmentAware.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/settings/EnvironmentAware.kt
@@ -4,6 +4,8 @@ import io.github.detekt.parser.createCompilerConfiguration
 import io.github.detekt.parser.createKotlinCoreEnvironment
 import io.github.detekt.tooling.api.spec.CompilerSpec
 import io.github.detekt.tooling.api.spec.ProjectSpec
+import org.jetbrains.kotlin.cli.common.arguments.K2JVMCompilerArguments
+import org.jetbrains.kotlin.cli.common.arguments.parseCommandLineArguments
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.jetbrains.kotlin.com.intellij.openapi.Disposable
 import org.jetbrains.kotlin.com.intellij.openapi.util.Disposer
@@ -29,6 +31,10 @@ internal class EnvironmentFacade(
     override val classpath: List<String> = compilerSpec.classpathEntries()
 
     override val environment: KotlinCoreEnvironment by lazy {
+        val compilerArguments = K2JVMCompilerArguments().apply {
+            parseCommandLineArguments(compilerSpec.freeCompilerArgs, this)
+        }
+
         val compilerConfiguration = createCompilerConfiguration(
             projectSpec.inputPaths.toList(),
             classpath,

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/settings/EnvironmentAware.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/settings/EnvironmentAware.kt
@@ -33,11 +33,11 @@ internal class EnvironmentFacade(
     override val classpath: List<String> = compilerSpec.classpathEntries()
 
     override val environment: KotlinCoreEnvironment by lazy {
-        val compilerArguments = K2JVMCompilerArguments().apply {
+        val jvmCompilerArguments = K2JVMCompilerArguments().apply {
             parseCommandLineArguments(compilerSpec.freeCompilerArgs, this)
         }
 
-        validateArguments(compilerArguments.errors)?.let { throw IllegalStateException(it) }
+        validateArguments(jvmCompilerArguments.errors)?.let { throw IllegalStateException(it) }
 
         val compilerConfiguration = createCompilerConfiguration(
             projectSpec.inputPaths.toList(),
@@ -49,7 +49,7 @@ internal class EnvironmentFacade(
         val env = createKotlinCoreEnvironment(compilerConfiguration, disposable)
 
         val visibilityManager = ModuleVisibilityManager.SERVICE.getInstance(env.project)
-        compilerArguments.friendPaths?.forEach(visibilityManager::addFriendPath)
+        jvmCompilerArguments.friendPaths?.forEach(visibilityManager::addFriendPath)
 
         env
     }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/settings/EnvironmentAware.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/settings/EnvironmentAware.kt
@@ -11,6 +11,7 @@ import org.jetbrains.kotlin.com.intellij.openapi.Disposable
 import org.jetbrains.kotlin.com.intellij.openapi.util.Disposer
 import org.jetbrains.kotlin.config.JvmTarget
 import org.jetbrains.kotlin.config.LanguageVersion
+import org.jetbrains.kotlin.load.kotlin.ModuleVisibilityManager
 import java.io.Closeable
 import java.io.File
 
@@ -41,7 +42,13 @@ internal class EnvironmentFacade(
             compilerSpec.parseLanguageVersion(),
             compilerSpec.parseJvmTarget()
         )
-        createKotlinCoreEnvironment(compilerConfiguration, disposable)
+
+        val env = createKotlinCoreEnvironment(compilerConfiguration, disposable)
+
+        val visibilityManager = ModuleVisibilityManager.SERVICE.getInstance(env.project)
+        compilerArguments.friendPaths?.forEach(visibilityManager::addFriendPath)
+
+        env
     }
 
     override fun close() {

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -17,18 +17,21 @@ import io.gitlab.arturbosch.detekt.invoke.DefaultReportArgument
 import io.gitlab.arturbosch.detekt.invoke.DetektInvoker
 import io.gitlab.arturbosch.detekt.invoke.DisableDefaultRuleSetArgument
 import io.gitlab.arturbosch.detekt.invoke.FailFastArgument
+import io.gitlab.arturbosch.detekt.invoke.FreeArgs
 import io.gitlab.arturbosch.detekt.invoke.InputArgument
 import io.gitlab.arturbosch.detekt.invoke.JvmTargetArgument
 import io.gitlab.arturbosch.detekt.invoke.LanguageVersionArgument
 import io.gitlab.arturbosch.detekt.invoke.ParallelArgument
 import io.gitlab.arturbosch.detekt.invoke.isDryRunEnabled
 import org.gradle.api.Action
+import org.gradle.api.Incubating
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.Directory
 import org.gradle.api.file.FileTree
 import org.gradle.api.file.RegularFile
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.reporting.ReportingExtension
@@ -184,6 +187,9 @@ open class Detekt @Inject constructor(
         @Optional
         get() = getTargetFileProvider(reports.sarif)
 
+    @Input @Incubating
+    val freeCompilerArgs: ListProperty<String> = objects.listProperty(String::class.java)
+
     internal val customReportFiles: ConfigurableFileCollection
         @OutputFiles
         @Optional
@@ -220,7 +226,7 @@ open class Detekt @Inject constructor(
             AutoCorrectArgument(autoCorrectProp.getOrElse(false)),
             BasePathArgument(basePathProp.orNull),
             DisableDefaultRuleSetArgument(disableDefaultRuleSetsProp.getOrElse(false))
-        ) + convertCustomReportsToArguments()
+        ) + convertCustomReportsToArguments() + FreeArgs(freeCompilerArgs.get())
 
     @InputFiles
     @SkipWhenEmpty

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/CliArgument.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/CliArgument.kt
@@ -71,6 +71,10 @@ internal data class CustomReportArgument(val reportId: String, val file: Regular
     override fun toArgument() = listOf(REPORT_PARAMETER, "$reportId:${file.asFile.absolutePath}")
 }
 
+internal data class FreeArgs(val args: List<String>) : CliArgument() {
+    override fun toArgument(): List<String> = args
+}
+
 internal data class BasePathArgument(val basePath: String?) : CliArgument() {
     override fun toArgument() = basePath?.let { listOf(BASE_PATH_PARAMETER, it) }.orEmpty()
 }

--- a/detekt-tooling/api/detekt-tooling.api
+++ b/detekt-tooling/api/detekt-tooling.api
@@ -81,6 +81,7 @@ public abstract interface class io/github/detekt/tooling/api/spec/BaselineSpec {
 
 public abstract interface class io/github/detekt/tooling/api/spec/CompilerSpec {
 	public abstract fun getClasspath ()Ljava/lang/String;
+	public abstract fun getFreeCompilerArgs ()Ljava/util/List;
 	public abstract fun getJvmTarget ()Ljava/lang/String;
 	public abstract fun getLanguageVersion ()Ljava/lang/String;
 }
@@ -208,9 +209,11 @@ public final class io/github/detekt/tooling/dsl/CompilerSpecBuilder : io/github/
 	public fun build ()Lio/github/detekt/tooling/api/spec/CompilerSpec;
 	public synthetic fun build ()Ljava/lang/Object;
 	public final fun getClasspath ()Ljava/lang/String;
+	public final fun getFreeCompilerArgs ()Ljava/util/List;
 	public final fun getJvmTarget ()Ljava/lang/String;
 	public final fun getLanguageVersion ()Ljava/lang/String;
 	public final fun setClasspath (Ljava/lang/String;)V
+	public final fun setFreeCompilerArgs (Ljava/util/List;)V
 	public final fun setJvmTarget (Ljava/lang/String;)V
 	public final fun setLanguageVersion (Ljava/lang/String;)V
 }

--- a/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/api/spec/CompilerSpec.kt
+++ b/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/api/spec/CompilerSpec.kt
@@ -19,4 +19,9 @@ interface CompilerSpec {
      * Paths to class files and jars separated by a path separator.
      */
     val classpath: String?
+
+    /**
+     * Options to pass to the Kotlin compiler.
+     */
+    val freeCompilerArgs: List<String>
 }

--- a/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/dsl/CompilerSpecBuilder.kt
+++ b/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/dsl/CompilerSpecBuilder.kt
@@ -8,12 +8,14 @@ class CompilerSpecBuilder : Builder<CompilerSpec> {
     var jvmTarget: String = "1.8"
     var languageVersion: String? = null
     var classpath: String? = null
+    var freeCompilerArgs: List<String> = emptyList()
 
-    override fun build(): CompilerSpec = CompilerModel(jvmTarget, languageVersion, classpath)
+    override fun build(): CompilerSpec = CompilerModel(jvmTarget, languageVersion, classpath, freeCompilerArgs)
 }
 
 private data class CompilerModel(
     override val jvmTarget: String,
     override val languageVersion: String?,
-    override val classpath: String?
+    override val classpath: String?,
+    override val freeCompilerArgs: List<String>,
 ) : CompilerSpec


### PR DESCRIPTION
This PR adds a catch-all ["main parameter"](https://jcommander.org/#_main_parameter) called `freeCompilerArgs` to the CLI. This is a nameless parameter which captures all input on the CLI that isn't matched by one of the existing parameters.

An equivalent task parameter has been added to the `Detekt` task to allow the Gradle plugin to pass those flags to the CLI.

This capability is being used to capture extra flags that detekt doesn't natively support so they can be passed through to the Kotlin compiler environment as required. For this PR, support was added that allows the module friend paths to be used when setting up the Kotlin core environment, which partially resolves issue #3067 (there is still some automation to be added in the Gradle plugin before this can be closed). Also see #3639 - again, not actually fixed by this PR, but it does add some of the framework needed to fix it.

Additionally https://github.com/detekt/detekt/issues/3684 would be fixed once the Gradle plugin is next released and the commented lines added to `build-logic/src/main/kotlin/detekt.gradle.kts` can be uncommented.

I'm looking for feedback before proceeding further.