### PR TITLE
Dokka 1.5.30

### DIFF
--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/extensions/Loading.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/extensions/Loading.kt
@@ -1,12 +1,14 @@
 package io.gitlab.arturbosch.detekt.core.extensions
 
 import io.gitlab.arturbosch.detekt.api.Extension
+import io.gitlab.arturbosch.detekt.api.UnstableApi
 import io.gitlab.arturbosch.detekt.core.NL
 import io.gitlab.arturbosch.detekt.core.ProcessingSettings
 import java.util.ServiceLoader
 
 val LIST_ITEM_SPACING = "$NL    "
 
+@OptIn(UnstableApi::class)
 inline fun <reified T : Extension> loadExtensions(
     settings: ProcessingSettings,
     predicate: (T) -> Boolean = { true }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/tooling/Lifecycle.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/tooling/Lifecycle.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.api.FileProcessListener
 import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.api.RuleSetId
 import io.gitlab.arturbosch.detekt.api.RuleSetProvider
+import io.gitlab.arturbosch.detekt.api.UnstableApi
 import io.gitlab.arturbosch.detekt.core.Analyzer
 import io.gitlab.arturbosch.detekt.core.DetektResult
 import io.gitlab.arturbosch.detekt.core.FileProcessorLocator
@@ -27,6 +28,7 @@ internal interface Lifecycle {
     val processorsProvider: () -> List<FileProcessListener>
     val ruleSetsProvider: () -> List<RuleSetProvider>
 
+    @OptIn(UnstableApi::class)
     private fun <R> measure(phase: Phase, block: () -> R): R = settings.getOrCreateMonitor().measure(phase, block)
 
     fun analyze(): Detektion {

--- a/detekt-report-sarif/src/test/kotlin/io/github/detekt/report/sarif/SarifOutputReportSpec.kt
+++ b/detekt-report-sarif/src/test/kotlin/io/github/detekt/report/sarif/SarifOutputReportSpec.kt
@@ -5,6 +5,7 @@ import io.github.detekt.tooling.api.VersionProvider
 import io.gitlab.arturbosch.detekt.api.CodeSmell
 import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.api.SeverityLevel
+import io.gitlab.arturbosch.detekt.api.UnstableApi
 import io.gitlab.arturbosch.detekt.api.internal.whichOS
 import io.gitlab.arturbosch.detekt.test.EmptySetupContext
 import io.gitlab.arturbosch.detekt.test.TestDetektion
@@ -16,6 +17,7 @@ import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 import java.nio.file.Paths
 
+@OptIn(UnstableApi::class)
 class SarifOutputReportSpec : Spek({
 
     describe("sarif output report") {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-dokka = "1.5.0"
+dokka = "1.5.30"
 jacoco = "0.8.7"
 kotlin = "1.5.31"
 ktlint = "0.42.1"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 dokka = "1.5.0"
 jacoco = "0.8.7"
-kotlin = "1.5.21"
+kotlin = "1.5.31"
 ktlint = "0.42.1"
 spek = "2.0.17"
 


### PR DESCRIPTION
Stacks on #4113
Blocked by #4113 - this version of Dokka would otherwise pull in newer version of Kotlin as a transitive dependency.