### PR TITLE
Drop junit-platform-launcher dependency

### DIFF
--- a/custom-checks/build.gradle.kts
+++ b/custom-checks/build.gradle.kts
@@ -6,5 +6,5 @@ dependencies {
     implementation(projects.detektApi)
     testImplementation(projects.detektTest)
     testImplementation(libs.bundles.testImplementation)
-    testRuntimeOnly(libs.bundles.testRuntime)
+    testRuntimeOnly(libs.spek.runner)
 }

--- a/detekt-api/build.gradle.kts
+++ b/detekt-api/build.gradle.kts
@@ -14,7 +14,7 @@ dependencies {
     testImplementation(projects.detektTest)
     testImplementation(libs.bundles.testImplementation)
 
-    testRuntimeOnly(libs.bundles.testRuntime)
+    testRuntimeOnly(libs.spek.runner)
 
     testFixturesApi(libs.kotlin.stdlibJdk8)
 

--- a/detekt-cli/build.gradle.kts
+++ b/detekt-cli/build.gradle.kts
@@ -17,7 +17,7 @@ dependencies {
 
     testImplementation(projects.detektTest)
     testImplementation(libs.bundles.testImplementation)
-    testRuntimeOnly(libs.bundles.testRuntime)
+    testRuntimeOnly(libs.spek.runner)
 }
 
 val javaComponent = components["java"] as AdhocComponentWithVariants

--- a/detekt-core/build.gradle.kts
+++ b/detekt-core/build.gradle.kts
@@ -16,7 +16,7 @@ dependencies {
 
     testRuntimeOnly(projects.detektRules)
     testRuntimeOnly(projects.detektFormatting)
-    testRuntimeOnly(libs.bundles.testRuntime)
+    testRuntimeOnly(libs.spek.runner)
     testImplementation(projects.detektTest)
     testImplementation(testFixtures(projects.detektApi))
     testImplementation(libs.mockk)

--- a/detekt-formatting/build.gradle.kts
+++ b/detekt-formatting/build.gradle.kts
@@ -17,7 +17,7 @@ dependencies {
     testImplementation(projects.detektTest)
     testImplementation(libs.bundles.testImplementation)
 
-    testRuntimeOnly(libs.bundles.testRuntime)
+    testRuntimeOnly(libs.spek.runner)
 }
 
 tasks.build { finalizedBy(":detekt-generator:generateDocumentation") }

--- a/detekt-generator/build.gradle.kts
+++ b/detekt-generator/build.gradle.kts
@@ -14,7 +14,7 @@ dependencies {
 
     testImplementation(projects.detektTestUtils)
     testImplementation(libs.bundles.testImplementation)
-    testRuntimeOnly(libs.bundles.testRuntime)
+    testRuntimeOnly(libs.spek.runner)
 }
 
 val documentationDir = "${rootProject.rootDir}/docs/pages/documentation"

--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -20,7 +20,7 @@ dependencies {
     testImplementation(projects.detektTestUtils)
     testImplementation(libs.kotlin.gradle)
     testImplementation(libs.bundles.testImplementation)
-    testRuntimeOnly(libs.bundles.testRuntime)
+    testRuntimeOnly(libs.spek.runner)
     intTest(libs.kotlin.gradle)
     intTest(libs.android.gradle)
 }

--- a/detekt-metrics/build.gradle.kts
+++ b/detekt-metrics/build.gradle.kts
@@ -8,5 +8,5 @@ dependencies {
     testImplementation(testFixtures(projects.detektApi))
     testImplementation(libs.mockk)
     testImplementation(libs.bundles.testImplementation)
-    testRuntimeOnly(libs.bundles.testRuntime)
+    testRuntimeOnly(libs.spek.runner)
 }

--- a/detekt-parser/build.gradle.kts
+++ b/detekt-parser/build.gradle.kts
@@ -9,7 +9,7 @@ dependencies {
     implementation(projects.detektPsiUtils)
     testImplementation(projects.detektTestUtils)
     testImplementation(libs.bundles.testImplementation)
-    testRuntimeOnly(libs.bundles.testRuntime)
+    testRuntimeOnly(libs.spek.runner)
 }
 
 tasks.withType<Test> {

--- a/detekt-psi-utils/build.gradle.kts
+++ b/detekt-psi-utils/build.gradle.kts
@@ -7,5 +7,5 @@ dependencies {
     implementation(libs.kotlin.compilerEmbeddable)
 
     testImplementation(libs.bundles.testImplementation)
-    testRuntimeOnly(libs.bundles.testRuntime)
+    testRuntimeOnly(libs.spek.runner)
 }

--- a/detekt-report-html/build.gradle.kts
+++ b/detekt-report-html/build.gradle.kts
@@ -13,5 +13,5 @@ dependencies {
     testImplementation(testFixtures(projects.detektApi))
     testImplementation(libs.mockk)
     testImplementation(libs.bundles.testImplementation)
-    testRuntimeOnly(libs.bundles.testRuntime)
+    testRuntimeOnly(libs.spek.runner)
 }

--- a/detekt-report-sarif/build.gradle.kts
+++ b/detekt-report-sarif/build.gradle.kts
@@ -10,5 +10,5 @@ dependencies {
     testImplementation(projects.detektTestUtils)
     testImplementation(testFixtures(projects.detektApi))
     testImplementation(libs.bundles.testImplementation)
-    testRuntimeOnly(libs.bundles.testRuntime)
+    testRuntimeOnly(libs.spek.runner)
 }

--- a/detekt-report-txt/build.gradle.kts
+++ b/detekt-report-txt/build.gradle.kts
@@ -6,5 +6,5 @@ dependencies {
     implementation(projects.detektApi)
     testImplementation(testFixtures(projects.detektApi))
     testImplementation(libs.bundles.testImplementation)
-    testRuntimeOnly(libs.bundles.testRuntime)
+    testRuntimeOnly(libs.spek.runner)
 }

--- a/detekt-report-xml/build.gradle.kts
+++ b/detekt-report-xml/build.gradle.kts
@@ -6,5 +6,5 @@ dependencies {
     implementation(projects.detektApi)
     testImplementation(testFixtures(projects.detektApi))
     testImplementation(libs.bundles.testImplementation)
-    testRuntimeOnly(libs.bundles.testRuntime)
+    testRuntimeOnly(libs.spek.runner)
 }

--- a/detekt-rules-complexity/build.gradle.kts
+++ b/detekt-rules-complexity/build.gradle.kts
@@ -8,5 +8,5 @@ dependencies {
     testImplementation(projects.detektMetrics)
     testImplementation(projects.detektTest)
     testImplementation(libs.bundles.testImplementation)
-    testRuntimeOnly(libs.bundles.testRuntime)
+    testRuntimeOnly(libs.spek.runner)
 }

--- a/detekt-rules-coroutines/build.gradle.kts
+++ b/detekt-rules-coroutines/build.gradle.kts
@@ -6,5 +6,5 @@ dependencies {
     compileOnly(projects.detektApi)
     testImplementation(projects.detektTest)
     testImplementation(libs.bundles.testImplementation)
-    testRuntimeOnly(libs.bundles.testRuntime)
+    testRuntimeOnly(libs.spek.runner)
 }

--- a/detekt-rules-documentation/build.gradle.kts
+++ b/detekt-rules-documentation/build.gradle.kts
@@ -6,5 +6,5 @@ dependencies {
     compileOnly(projects.detektApi)
     testImplementation(projects.detektTest)
     testImplementation(libs.bundles.testImplementation)
-    testRuntimeOnly(libs.bundles.testRuntime)
+    testRuntimeOnly(libs.spek.runner)
 }

--- a/detekt-rules-empty/build.gradle.kts
+++ b/detekt-rules-empty/build.gradle.kts
@@ -6,5 +6,5 @@ dependencies {
     compileOnly(projects.detektApi)
     testImplementation(projects.detektTest)
     testImplementation(libs.bundles.testImplementation)
-    testRuntimeOnly(libs.bundles.testRuntime)
+    testRuntimeOnly(libs.spek.runner)
 }

--- a/detekt-rules-errorprone/build.gradle.kts
+++ b/detekt-rules-errorprone/build.gradle.kts
@@ -6,5 +6,5 @@ dependencies {
     compileOnly(projects.detektApi)
     testImplementation(projects.detektTest)
     testImplementation(libs.bundles.testImplementation)
-    testRuntimeOnly(libs.bundles.testRuntime)
+    testRuntimeOnly(libs.spek.runner)
 }

--- a/detekt-rules-exceptions/build.gradle.kts
+++ b/detekt-rules-exceptions/build.gradle.kts
@@ -6,5 +6,5 @@ dependencies {
     compileOnly(projects.detektApi)
     testImplementation(projects.detektTest)
     testImplementation(libs.bundles.testImplementation)
-    testRuntimeOnly(libs.bundles.testRuntime)
+    testRuntimeOnly(libs.spek.runner)
 }

--- a/detekt-rules-naming/build.gradle.kts
+++ b/detekt-rules-naming/build.gradle.kts
@@ -6,5 +6,5 @@ dependencies {
     compileOnly(projects.detektApi)
     testImplementation(projects.detektTest)
     testImplementation(libs.bundles.testImplementation)
-    testRuntimeOnly(libs.bundles.testRuntime)
+    testRuntimeOnly(libs.spek.runner)
 }

--- a/detekt-rules-performance/build.gradle.kts
+++ b/detekt-rules-performance/build.gradle.kts
@@ -6,5 +6,5 @@ dependencies {
     compileOnly(projects.detektApi)
     testImplementation(projects.detektTest)
     testImplementation(libs.bundles.testImplementation)
-    testRuntimeOnly(libs.bundles.testRuntime)
+    testRuntimeOnly(libs.spek.runner)
 }

--- a/detekt-rules-style/build.gradle.kts
+++ b/detekt-rules-style/build.gradle.kts
@@ -9,5 +9,5 @@ dependencies {
     testImplementation(projects.detektTest)
     testImplementation(libs.mockk)
     testImplementation(libs.bundles.testImplementation)
-    testRuntimeOnly(libs.bundles.testRuntime)
+    testRuntimeOnly(libs.spek.runner)
 }

--- a/detekt-rules/build.gradle.kts
+++ b/detekt-rules/build.gradle.kts
@@ -26,7 +26,7 @@ dependencies {
     testImplementation(projects.detektRulesStyle)
     testImplementation(libs.bundles.testImplementation)
     testImplementation(libs.reflections)
-    testRuntimeOnly(libs.bundles.testRuntime)
+    testRuntimeOnly(libs.spek.runner)
 }
 
 tasks.build { finalizedBy(":detekt-generator:generateDocumentation") }

--- a/detekt-sample-extensions/build.gradle.kts
+++ b/detekt-sample-extensions/build.gradle.kts
@@ -10,5 +10,5 @@ dependencies {
     // e.g. io.gitlab.arturbosch.detekt:detekt-test:1.x.x
     testImplementation(projects.detektTest)
     testImplementation(libs.bundles.testImplementation)
-    testRuntimeOnly(libs.bundles.testRuntime)
+    testRuntimeOnly(libs.spek.runner)
 }

--- a/detekt-tooling/build.gradle.kts
+++ b/detekt-tooling/build.gradle.kts
@@ -6,5 +6,5 @@ dependencies {
     api(projects.detektApi)
     testImplementation(projects.detektTestUtils)
     testImplementation(libs.bundles.testImplementation)
-    testRuntimeOnly(libs.bundles.testRuntime)
+    testRuntimeOnly(libs.spek.runner)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,7 +37,6 @@ sarif4k = "io.github.detekt.sarif4k:sarif4k:0.0.1"
 assertj = "org.assertj:assertj-core:3.20.2"
 reflections = "org.reflections:reflections:0.9.12"
 mockk = "io.mockk:mockk:1.12.0"
-junitLauncher = "org.junit.platform:junit-platform-launcher:1.7.2"
 snakeyaml = "org.yaml:snakeyaml:1.29"
 jcommander = "com.beust:jcommander:1.81"
 
@@ -51,4 +50,3 @@ sonarqube = { id = "org.sonarqube", version = "3.3" }
 
 [bundles]
 testImplementation = ["assertj", "spek-dsl"]
-testRuntime = ["junitLauncher", "spek-runner"]


### PR DESCRIPTION
Modern versions of IntelliJ and Gradle do not require this explicit dependency to be added to the project.