### PR TITLE
Don't unnecessarily propogate opt-in requirement

### DIFF
--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/settings/PropertiesFacade.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/settings/PropertiesFacade.kt
@@ -4,7 +4,7 @@ import io.gitlab.arturbosch.detekt.api.PropertiesAware
 import io.gitlab.arturbosch.detekt.api.UnstableApi
 import java.util.concurrent.ConcurrentHashMap
 
-@UnstableApi
+@OptIn(UnstableApi::class)
 internal class PropertiesFacade : PropertiesAware {
 
     private val _properties: MutableMap<String, Any?> = ConcurrentHashMap()

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/LicenceHeaderLoaderExtensionSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/LicenceHeaderLoaderExtensionSpec.kt
@@ -11,7 +11,7 @@ import org.spekframework.spek2.style.specification.describe
 import java.io.PrintStream
 import java.net.URI
 
-@UnstableApi
+@OptIn(UnstableApi::class)
 class LicenceHeaderLoaderExtensionSpec : Spek({
 
     describe("Licence header extension - #2503") {


### PR DESCRIPTION
Opt-in doesn't need to be propogated in test code, or in detekt-core which is not public API.

https://kotlinlang.org/docs/opt-in-requirements.html#non-propagating-opt-in

> In modules that don't expose their own API, such as applications, you can
> opt in to using APIs without propagating the opt-in requirement to your
> code. In this case, mark your declaration with @OptIn passing the opt-in
> requirement annotation as its argument.