### PR TITLE
Disable UnsafeCallOnNullableType on tests

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -138,6 +138,9 @@ potential-bugs:
     active: true
   UnreachableCatchBlock:
     active: true
+  UnsafeCallOnNullableType:
+    active: true
+    excludes: ['**/test/**', '**/*.Test.kt', '**/*.Spec.kt']
   UnsafeCast:
     active: true
     excludes: ['**/test/**', '**/*.Test.kt', '**/*.Spec.kt']

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/SuppressionSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/SuppressionSpec.kt
@@ -292,7 +292,6 @@ private class TestRule(config: Config = Config.empty) : Rule(config) {
 private class TestLM : Rule() {
     override val issue = Issue("LongMethod", Severity.CodeSmell, "", Debt.TWENTY_MINS)
     override fun visitNamedFunction(function: KtNamedFunction) {
-        @Suppress("UnsafeCallOnNullableType")
         val start = Location.startLineAndColumn(function.funKeyword!!).line
         val end = Location.startLineAndColumn(function.lastBlockStatementOrThis()).line
         val offset = end - start

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/RuleProviderSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/RuleProviderSpec.kt
@@ -61,12 +61,10 @@ private fun getRulesPackageNameForProvider(providerType: Class<out RuleSetProvid
     assertThat(packageName)
         .withFailMessage("No rules package for provider of type $providerType was defined in the ruleMap")
         .isNotNull()
-    @Suppress("UnsafeCallOnNullableType")
     return packageName!!
 }
 
 private fun getRules(provider: RuleSetProvider): List<BaseRule> {
-    @Suppress("UnsafeCallOnNullableType")
     val ruleSet = provider.instance(Config.empty)
     val rules = ruleSet.rules.flatMap { (it as? MultiRule)?.rules ?: listOf(it) }
     assertThat(rules).isNotEmpty


### PR DESCRIPTION
Disable `UnsafeCallOnNullableType` on tests. The use of `!!` is a type of assertion. It should not be a problem to use it in your tests.