### PR TITLE
Disable `UnsafeCallOnNullableType` on tests

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -577,6 +577,7 @@ potential-bugs:
     active: true
   UnsafeCallOnNullableType:
     active: true
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
   UnsafeCast:
     active: true
   UnusedUnaryOperator:

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/SuppressionSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/SuppressionSpec.kt
@@ -292,7 +292,6 @@ private class TestRule(config: Config = Config.empty) : Rule(config) {
 private class TestLM : Rule() {
     override val issue = Issue("LongMethod", Severity.CodeSmell, "", Debt.TWENTY_MINS)
     override fun visitNamedFunction(function: KtNamedFunction) {
-        @Suppress("UnsafeCallOnNullableType")
         val start = Location.startLineAndColumn(function.funKeyword!!).line
         val end = Location.startLineAndColumn(function.lastBlockStatementOrThis()).line
         val offset = end - start

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/defaultconfig/Exclusion.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/defaultconfig/Exclusion.kt
@@ -40,7 +40,8 @@ private object TestExclusions : Exclusions() {
         "ThrowingExceptionsWithoutMessageOrCause",
         "UndocumentedPublicClass",
         "UndocumentedPublicFunction",
-        "UndocumentedPublicProperty"
+        "UndocumentedPublicProperty",
+        "UnsafeCallOnNullableType",
     )
 }
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/RuleProviderSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/RuleProviderSpec.kt
@@ -61,12 +61,10 @@ private fun getRulesPackageNameForProvider(providerType: Class<out RuleSetProvid
     assertThat(packageName)
         .withFailMessage("No rules package for provider of type $providerType was defined in the ruleMap")
         .isNotNull()
-    @Suppress("UnsafeCallOnNullableType")
     return packageName!!
 }
 
 private fun getRules(provider: RuleSetProvider): List<BaseRule> {
-    @Suppress("UnsafeCallOnNullableType")
     val ruleSet = provider.instance(Config.empty)
     val rules = ruleSet.rules.flatMap { (it as? MultiRule)?.rules ?: listOf(it) }
     assertThat(rules).isNotEmpty


### PR DESCRIPTION
Disable `UnsafeCallOnNullableType` on tests. The use of `!!` is a type of assertion. It should not be a problem to use it in your tests.

Fixes #4119
Closes #4118