### PR TITLE
Fix FunctionParameterNamingSpec

### DIFF
--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionParameterNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionParameterNamingSpec.kt
@@ -19,7 +19,7 @@ object FunctionParameterNamingSpec : Spek({
                     fun someStuff(param: String) {}
                 }
             """
-            assertThat(ConstructorParameterNaming().compileAndLint(code)).isEmpty()
+            assertThat(FunctionParameterNaming().compileAndLint(code)).isEmpty()
         }
 
         it("should not detect violations in overridden function by default") {
@@ -68,7 +68,7 @@ object FunctionParameterNamingSpec : Spek({
 
         it("should not detect constructor parameter") {
             val code = "class Excluded(val PARAM: Int) {}"
-            assertThat(ConstructorParameterNaming(config).compileAndLint(code)).isEmpty()
+            assertThat(FunctionParameterNaming(config).compileAndLint(code)).isEmpty()
         }
     }
 })


### PR DESCRIPTION
We weren't testing the correct rule.