### PR TITLE
Split InvalidPackageDeclaration to create MissingPackageDeclaration

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -447,7 +447,6 @@ naming:
     ignoreOverridden: true
   InvalidPackageDeclaration:
     active: false
-    excludes: ['**/*.kts']
     rootPackage: ''
   MatchingDeclarationName:
     active: true
@@ -556,6 +555,9 @@ potential-bugs:
     ignoreOnClassesPattern: ''
   MapGetWithNotNullAssertionOperator:
     active: false
+  MissingPackageDeclaration:
+    active: false
+    excludes: ['**/*.kts']
   MissingWhenCase:
     active: true
     allowElseExpression: true

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/defaultconfig/Exclusion.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/defaultconfig/Exclusion.kt
@@ -48,7 +48,7 @@ private object TestExclusions : Exclusions() {
 private object KotlinScriptExclusions : Exclusions() {
 
     override val pattern = "['**/*.kts']"
-    override val rules = setOf("InvalidPackageDeclaration")
+    override val rules = setOf("MissingPackageDeclaration")
 }
 
 private object LibraryExclusions : Exclusions() {

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingPackageDeclaration.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingPackageDeclaration.kt
@@ -1,0 +1,38 @@
+package io.gitlab.arturbosch.detekt.rules.bugs
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtPackageDirective
+
+/**
+ * Reports when the package declaration is missing.
+ */
+class MissingPackageDeclaration(config: Config = Config.empty) : Rule(config) {
+
+    override val issue = Issue(
+        javaClass.simpleName,
+        Severity.Maintainability,
+        "Kotlin source files should define a package",
+        debt = Debt.FIVE_MINS
+    )
+
+    private var packageDeclaration: KtPackageDirective? = null
+
+    override fun visitPackageDirective(directive: KtPackageDirective) {
+        super.visitPackageDirective(directive)
+        packageDeclaration = directive
+    }
+
+    override fun postVisit(root: KtFile) {
+        super.postVisit(root)
+        if (packageDeclaration?.text.isNullOrBlank()) {
+            report(CodeSmell(issue, Entity.from(root), "The file does not contain a package declaration."))
+        }
+    }
+}

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/PotentialBugProvider.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/PotentialBugProvider.kt
@@ -32,6 +32,7 @@ class PotentialBugProvider : DefaultRuleSetProvider {
             IteratorNotThrowingNoSuchElementException(config),
             LateinitUsage(config),
             MapGetWithNotNullAssertionOperator(config),
+            MissingPackageDeclaration(config),
             MissingWhenCase(config),
             RedundantElseInWhen(config),
             UnconditionalJumpStatementInLoop(config),

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingPackageDeclarationSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingPackageDeclarationSpec.kt
@@ -1,0 +1,31 @@
+package io.gitlab.arturbosch.detekt.rules.bugs
+
+import io.gitlab.arturbosch.detekt.test.assertThat
+import io.gitlab.arturbosch.detekt.test.compileAndLint
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+internal class MissingPackageDeclarationSpec : Spek({
+
+    describe("MissingPackageDeclaration rule") {
+
+        it("should pass if package declaration is declared") {
+            val code = """
+                package foo.bar
+
+                class C
+            """
+            val findings = MissingPackageDeclaration().compileAndLint(code)
+
+            assertThat(findings).isEmpty()
+        }
+
+        it("should report if package declaration is missing") {
+            val code = "class C"
+
+            val findings = MissingPackageDeclaration().compileAndLint(code)
+
+            assertThat(findings).hasSize(1)
+        }
+    }
+})

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/InvalidPackageDeclarationSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/InvalidPackageDeclarationSpec.kt
@@ -28,14 +28,6 @@ internal class InvalidPackageDeclarationSpec : Spek({
             assertThat(findings).isEmpty()
         }
 
-        it("should report if package declaration is missing") {
-            val ktFile = compileContentForTest("class C")
-
-            val findings = InvalidPackageDeclaration().lint(ktFile)
-
-            assertThat(findings).hasSize(1)
-        }
-
         it("should report if package declaration does not match source location") {
             val source = "package foo\n\nclass C"
 


### PR DESCRIPTION
InvalidPackageDeclaration was doing two different things. With this PR we split that responsability in two different rules.

I created the new rule `MissingPackageDeclaration` inside the error prone rule set, do you agree?

Closes #3957