### PR TITLE
Set source with SourceDirectorySet instead of file list

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektJvm.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektJvm.kt
@@ -25,7 +25,7 @@ internal class DetektJvm(private val project: Project) {
         val kotlinSourceSet = (sourceSet as HasConvention).convention.plugins["kotlin"] as? KotlinSourceSet
             ?: throw GradleException("Kotlin source set not found. Please report on detekt's issue tracker")
         registerDetektTask(DetektPlugin.DETEKT_TASK_NAME + sourceSet.name.capitalize(), extension) {
-            setSource(kotlinSourceSet.kotlin.files)
+            source = kotlinSourceSet.kotlin
             classpath.setFrom(sourceSet.compileClasspath.existingFiles(), sourceSet.output.classesDirs.existingFiles())
             // If a baseline file is configured as input file, it must exist to be configured, otherwise the task fails.
             // We try to find the configured baseline or alternatively a specific variant matching this task.
@@ -70,7 +70,7 @@ internal class DetektJvm(private val project: Project) {
         val kotlinSourceSet = (sourceSet as HasConvention).convention.plugins["kotlin"] as? KotlinSourceSet
             ?: throw GradleException("Kotlin source set not found. Please report on detekt's issue tracker")
         registerCreateBaselineTask(DetektPlugin.BASELINE_TASK_NAME + sourceSet.name.capitalize(), extension) {
-            setSource(kotlinSourceSet.kotlin.files)
+            source = kotlinSourceSet.kotlin
             classpath.setFrom(sourceSet.compileClasspath.existingFiles(), sourceSet.output.classesDirs.existingFiles())
             val variantBaselineFile = extension.baseline?.addVariantName(sourceSet.name)
             baseline.set(project.layout.file(project.provider { variantBaselineFile }))


### PR DESCRIPTION
Fixes #4127

Unfortunately I can't say definitively why this fixes the problem, but I suspect it's somewhat related to this: https://github.com/gradle/gradle/issues/3417#issuecomment-379306780

Passing `kotlinSourceSet.kotlin.files` passed a list of files to use as the source for the task, while `kotlinSourceSet.kotlin` passes a `SourceDirectorySet`, so it's possible the filtering based on regex described in the comment I linked won't apply when a full file path is provided, but works when the source directory set is passed in instead.