### PR TITLE
Report SwallowedException on catchParameter

### DIFF
--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Location.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Location.kt
@@ -69,7 +69,6 @@ data class Location @Deprecated("Consider relative path by passing a [FilePath]"
         /**
          * Determines the line and column of a [PsiElement] in the source file.
          */
-        @Suppress("TooGenericExceptionCaught", "SwallowedException")
         fun startLineAndColumn(element: PsiElement, offset: Int = 0): PsiDiagnosticUtils.LineAndColumn {
             return try {
                 val range = element.textRange
@@ -77,7 +76,7 @@ data class Location @Deprecated("Consider relative path by passing a [FilePath]"
                     element.containingFile,
                     TextRange(range.startOffset + offset, range.endOffset + offset)
                 )
-            } catch (e: IndexOutOfBoundsException) {
+            } catch (@Suppress("SwallowedException", "TooGenericExceptionCaught") e: IndexOutOfBoundsException) {
                 // #3317 If any rule mutates the PsiElement, searching the original PsiElement may throw exception.
                 PsiDiagnosticUtils.LineAndColumn(-1, -1, null)
             }

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/JCommander.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/JCommander.kt
@@ -10,11 +10,11 @@ fun parseArguments(args: Array<out String>): CliArgs {
     val jCommander = JCommander(cli)
     jCommander.programName = "detekt"
 
-    @Suppress("SwallowedException") // Stacktrace in jCommander is likely irrelevant.
     try {
         @Suppress("SpreadOperator")
         jCommander.parse(*args)
-    } catch (ex: ParameterException) {
+    } catch (@Suppress("SwallowedException") ex: ParameterException) {
+        // Stacktrace in jCommander is likely irrelevant
         throw HandledArgumentViolation(ex.message, jCommander.usageAsString())
     }
 

--- a/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/LinesOfCode.kt
+++ b/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/LinesOfCode.kt
@@ -45,10 +45,9 @@ fun KtElement.linesOfCode(inFile: KtFile = this.containingKtFile): Int =
         .distinct()
         .count()
 
-@Suppress("SwallowedException", "TooGenericExceptionCaught")
 fun ASTNode.line(inFile: KtFile): Int = try {
     DiagnosticUtils.getLineAndColumnInPsiFile(inFile, this.textRange).line
-} catch (e: IndexOutOfBoundsException) {
+} catch (@Suppress("SwallowedException", "TooGenericExceptionCaught") e: IndexOutOfBoundsException) {
     // When auto-correctable rules performs actual mutation, KtFile.text is updated but
     // KtFile.viewProvider.document is not updated. This will cause crash in subsequent rules
     // if they are using any function relying on the KtFile.viewProvider.document.

--- a/detekt-report-html/src/main/kotlin/io/github/detekt/report/html/HtmlUtils.kt
+++ b/detekt-report-html/src/main/kotlin/io/github/detekt/report/html/HtmlUtils.kt
@@ -17,7 +17,6 @@ import kotlin.math.max
 import kotlin.math.min
 
 internal fun FlowContent.snippetCode(ruleName: String, lines: Sequence<String>, location: SourceLocation, length: Int) {
-    @Suppress("TooGenericExceptionCaught")
     try {
         pre {
             code {
@@ -41,7 +40,7 @@ internal fun FlowContent.snippetCode(ruleName: String, lines: Sequence<String>, 
                     }
             }
         }
-    } catch (ex: Throwable) {
+    } catch (@Suppress("TooGenericExceptionCaught") ex: Throwable) {
         showError(ruleName, ex)
     }
 }

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedException.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedException.kt
@@ -87,12 +87,13 @@ class SwallowedException(config: Config = Config.empty) : Rule(config) {
     private val allowedExceptionNameRegex: Regex by config("_|(ignore|expected).*", String::toRegex)
 
     override fun visitCatchSection(catchClause: KtCatchClause) {
-        val exceptionType = catchClause.catchParameter?.typeReference?.text
+        val catchParameter = catchClause.catchParameter ?: return
+        val exceptionType = catchParameter.typeReference?.text
         if (!ignoredExceptionTypes.any { exceptionType?.contains(it, ignoreCase = true) == true } &&
             isExceptionSwallowedOrUnused(catchClause) &&
             !catchClause.isAllowedExceptionName(allowedExceptionNameRegex)
         ) {
-            report(CodeSmell(issue, Entity.from(catchClause), issue.description))
+            report(CodeSmell(issue, Entity.from(catchParameter), issue.description))
         }
     }
 

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionCaught.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionCaught.kt
@@ -53,12 +53,11 @@ class TooGenericExceptionCaught(config: Config) : Rule(config) {
     private val allowedExceptionNameRegex: Regex by config("_|(ignore|expected).*", String::toRegex)
 
     override fun visitCatchSection(catchClause: KtCatchClause) {
-        catchClause.catchParameter?.let {
-            if (isTooGenericException(it.typeReference) &&
-                !catchClause.isAllowedExceptionName(allowedExceptionNameRegex)
-            ) {
-                report(CodeSmell(issue, Entity.from(it), issue.description))
-            }
+        val catchParameter = catchClause.catchParameter ?: return
+        if (isTooGenericException(catchParameter.typeReference) &&
+            !catchClause.isAllowedExceptionName(allowedExceptionNameRegex)
+        ) {
+            report(CodeSmell(issue, Entity.from(catchParameter), issue.description))
         }
         super.visitCatchSection(catchClause)
     }


### PR DESCRIPTION
This improves the ergonomics so that users can minimize the suppression scope.
Addresses #4154

I am using the detekt repo itself as the integration test for the PR change, otherwise I probably need to write an integration test in detekt-core which does not seem like the right place because the change is in `detekt-rules-exceptions`.