### PR TITLE
Fix syntax and logical issue in "Integration with Github Code Scanning"

### DIFF
--- a/docs/pages/reporting.md
+++ b/docs/pages/reporting.md
@@ -150,11 +150,11 @@ jobs:
       - name: Run detekt
         run: ./gradlew detekt
 
-      # Make sure we always run this upload task, because the previous step fails if there are
-      # findings.
+      # Make sure we always run this upload task,
+      # because the previous step may fail if there are findings.
       - name: Upload SARIF to Github using the upload-sarif action
         uses: github/codeql-action/upload-sarif@v1
-        if: ${{ always() }}
+        if: success() || failure()
         with:
           sarif_file: build/detekt.sarif
 ```


### PR DESCRIPTION
This is a documentation change only.

This fixes two issues:

1. `${{ always() }}` is not rendered correctly in `if`
![image](https://user-images.githubusercontent.com/2906988/136095174-0b3d8c02-8b5e-439d-a420-859c7e164e9a.png)

Removed the `${{ }}` container, it's not necessary. I'm using this in multiple places and it's fine:
https://github.com/TWiStErRob/net.twisterrob.cinema/blob/9397020ca5d828adfd2235374f14ccf4fc771f48/.github/workflows/Heroku.yml#L73

2. `always()` is not the right choice for uploading Detekt results.
`always()` can mean 3 things: `success()`, `failure()` or `cancelled()`.
See https://docs.github.com/en/actions/learn-github-actions/expressions#job-status-check-functions
This means that using `always()` is running in case of someone cancelling a job. If a job is cancelled it should terminate as soon as possible, not taking any further actions, except doing some potential cleanup, like closing resources or deleting temp files.