### PR TITLE
Unit tests for TooGenericExceptionThrown

### DIFF
--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionThrownSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionThrownSpec.kt
@@ -38,5 +38,33 @@ class TooGenericExceptionThrownSpec : Spek({
 
             assertThat(findings).isEmpty()
         }
+
+        it("should not report caught exceptions") {
+            val config = TestConfig(mapOf(EXCEPTION_NAMES to "['Exception']"))
+            val rule = TooGenericExceptionThrown(config)
+
+            val code = """
+                fun f() {
+                    try {
+                        throw Throwable()
+                    } catch (caught: Exception) {
+                        throw Error()
+                    }
+                }
+            """
+            val findings = rule.compileAndLint(code)
+
+            assertThat(findings).isEmpty()
+        }
+
+        it("should not report initialize exceptions") {
+            val config = TestConfig(mapOf(EXCEPTION_NAMES to "['Exception']"))
+            val rule = TooGenericExceptionThrown(config)
+
+            val code = """fun f() { val ex = Exception() }"""
+            val findings = rule.compileAndLint(code)
+
+            assertThat(findings).isEmpty()
+        }
     }
 })


### PR DESCRIPTION
- The two unit tests for `TooGenericExceptionThrown` were testing the wrong rule.
- Added a unit test to explicitely test that _caught_ exceptions are excluded.
- Added a unit test to recreate #4197, which doesn't fail at the moment, so more information on this bug report is needed.