### PR TITLE
Turn off TrailingWhitespace

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -205,8 +205,6 @@ style:
     excludeGuardClauses: true
   SpacingBetweenPackageAndImports:
     active: true
-  TrailingWhitespace:
-    active: true
   UnderscoresInNumericLiterals:
     active: true
   UnnecessaryAnnotationUseSiteTarget:


### PR DESCRIPTION
This resolves #4193 
We already have `detekt.formatting.NoTrailingSpaces` enabled by default, therefore, in our code base's config, we should turn off `detekt.style.TrailingWhitespace`.