### PR TITLE
Don't specify Gradle Enterprise Gradle Plugin version

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -39,7 +39,7 @@ enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 
 // build scan plugin can only be applied in settings file
 plugins {
-    id("com.gradle.enterprise") version "3.6.4"
+    `gradle-enterprise`
 }
 
 gradleEnterprise {


### PR DESCRIPTION
Checking if this is up to date is not as simple as it should be as the dependencyUpdates task doesn't identify when it's out of date, so manual checks have to be done.

Removing the specific version means when the Gradle version is updated, a recent Gradle Enterprise Gradle Plugin version will come with it, without having to update it separately.