### PR TITLE
Make detekt a bit less noisy when mixing java and kotlin files

### DIFF
--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/KtTreeCompiler.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/KtTreeCompiler.kt
@@ -24,7 +24,7 @@ class KtTreeCompiler(
             path.isFile() && path.isKotlinFile() -> listOf(compiler.compile(basePath, path))
             path.isDirectory() -> compileProject(path)
             else -> {
-                settings.info("Ignoring a file detekt cannot handle: $path")
+                settings.debug { "Ignoring a file detekt cannot handle: $path" }
                 emptyList()
             }
         }

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/KtTreeCompilerSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/KtTreeCompilerSpec.kt
@@ -5,6 +5,7 @@ import io.github.detekt.test.utils.resourceAsPath
 import io.gitlab.arturbosch.detekt.core.tooling.withSettings
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatIllegalArgumentException
+import org.jetbrains.kotlin.psi.KtFile
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 import java.nio.file.Paths
@@ -61,11 +62,11 @@ class KtTreeCompilerSpec : Spek({
     }
 })
 
-internal inline fun <reified T> fixture(
+internal inline fun fixture(
     vararg filters: String,
     assertIgnoreMessage: Boolean = false,
-    crossinline block: KtTreeCompiler.() -> T
-): T {
+    crossinline block: KtTreeCompiler.() -> List<KtFile>
+): List<KtFile> {
     val channel = if (assertIgnoreMessage) StringBuilder() else NullPrintStream()
     val spec = createNullLoggingSpec {
         project {

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/KtTreeCompilerSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/KtTreeCompilerSpec.kt
@@ -52,14 +52,16 @@ class KtTreeCompilerSpec : Spek({
 
         it("does not compile a folder with a css file") {
             val cssPath = resourceAsPath("css")
-            val (ktFiles, _) = fixture { compile(cssPath) }
+            val (ktFiles, output) = fixture { compile(cssPath) }
             assertThat(ktFiles).isEmpty()
+            assertThat(output).isEmpty()
         }
 
         it("does not compile a css file") {
             val cssPath = resourceAsPath("css").resolve("test.css")
-            val (ktFiles, _) = fixture { compile(cssPath) }
+            val (ktFiles, output) = fixture { compile(cssPath) }
             assertThat(ktFiles).isEmpty()
+            assertThat(output).matches("Ignoring a file detekt cannot handle: .*css/test.css\n")
         }
     }
 })

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/KtTreeCompilerSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/KtTreeCompilerSpec.kt
@@ -61,7 +61,14 @@ class KtTreeCompilerSpec : Spek({
             val cssPath = resourceAsPath("css").resolve("test.css")
             val (ktFiles, output) = fixture { compile(cssPath) }
             assertThat(ktFiles).isEmpty()
-            assertThat(output).matches("Ignoring a file detekt cannot handle: .*css/test.css\n")
+            assertThat(output).isEmpty()
+        }
+
+        it("does not compile a css file but show log if debug is enabled") {
+            val cssPath = resourceAsPath("css").resolve("test.css")
+            val (ktFiles, output) = fixture(loggingDebug = true) { compile(cssPath) }
+            assertThat(ktFiles).isEmpty()
+            assertThat(output).contains("Ignoring a file detekt cannot handle: ")
         }
     }
 })


### PR DESCRIPTION
Only print not handled files in debug mode.

Fix #3788