### PR TITLE
Fix UselessCallOnNotNull rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ If you contributed to detekt but your name is not in the list, please feel free 
 - [Michael McCormick](https://github.com/MichaelM97) - Documentation improvement
 - [Hans-Martin Schuller](https://github.com/hmSchuller) - Rule Improvement: ForbiddenComment
 - [Lukasz Osowicki](https://github.com/lukaszosowicki) - New rule: OutdatedDocumentation
+- [Luan Nico](https://github.com/luanpotter) - Bug fix for the UselessCallOnNotNull rule
 
 ### Mentions
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UselessCallOnNotNull.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UselessCallOnNotNull.kt
@@ -97,8 +97,17 @@ class UselessCallOnNotNull(config: Config = Config.empty) : Rule(config) {
         }
     }
 
-    private fun ValueArgument.isNullable(): Boolean =
-        getArgumentExpression()?.getType(bindingContext)?.isNullable() == true
+    private fun ValueArgument.isNullable(): Boolean {
+        val wrapperType = getArgumentExpression()?.getType(bindingContext) ?: return false
+        val type = if (getSpreadElement() != null) {
+            // in case of a spread operator (`*list`),
+            // we actually want to get the generic parameter from the collection
+            wrapperType.arguments.first().type
+        } else {
+            wrapperType
+        }
+        return type.isNullable()
+    }
 
     private data class Conversion(val replacementName: String? = null)
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UselessCallOnNotNullSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UselessCallOnNotNullSpec.kt
@@ -156,7 +156,7 @@ object UselessCallOnNotNullSpec : Spek({
 
         it("does not report when calling listOfNotNull with spread operator") {
             val code = """
-                val nullableList = listOf("string", null)
+                val nullableList = arrayOf("string", null)
                 val strings = listOfNotNull(*nullableList)
             """
             val findings = subject.compileAndLintWithContext(env, code)
@@ -165,7 +165,7 @@ object UselessCallOnNotNullSpec : Spek({
 
         it("reports when calling listOfNotNull with spread operator on all non-nullable arguments") {
             val code = """
-                val nonNullableList = listOf("string", "bar")
+                val nonNullableList = arrayOf("string", "bar")
                 val strings = listOfNotNull(*nonNullableList)
             """
             val findings = subject.compileAndLintWithContext(env, code)
@@ -175,8 +175,8 @@ object UselessCallOnNotNullSpec : Spek({
 
         it("does not report when calling listOfNotNull with a mix of null spread and non-null non-spread") {
             val code = """
-                val nullableList = listOf("string", null)
-                val nonNullableList = listOf("string", "bar")
+                val nullableList = arrayOf("string", null)
+                val nonNullableList = arrayOf("string", "bar")
                 val strings = listOfNotNull("string", *nonNullableList, "foo", *nullableList)
             """
             val findings = subject.compileAndLintWithContext(env, code)
@@ -185,7 +185,7 @@ object UselessCallOnNotNullSpec : Spek({
 
         it("does not report when calling listOfNotNull with a mix of non-null spread and null non-spread") {
             val code = """
-                val nonNullableList = listOf("string", "bar")
+                val nonNullableList = arrayOf("string", "bar")
                 val strings = listOfNotNull("string", *nonNullableList, null)
             """
             val findings = subject.compileAndLintWithContext(env, code)
@@ -194,8 +194,8 @@ object UselessCallOnNotNullSpec : Spek({
 
         it("reports when calling listOfNotNull with a mix of spread and non-spread, all non-null") {
             val code = """
-                val nonNullableList = listOf("string", "bar")
-                val otherNonNullableList = listOf("foobar")
+                val nonNullableList = arrayOf("string", "bar")
+                val otherNonNullableList = arrayOf("foobar")
                 val strings = listOfNotNull("string", *nonNullableList, "foo", *otherNonNullableList)
             """
             val findings = subject.compileAndLintWithContext(env, code)

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UselessCallOnNotNullSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UselessCallOnNotNullSpec.kt
@@ -156,8 +156,8 @@ object UselessCallOnNotNullSpec : Spek({
 
         it("does not report when calling listOfNotNull with spread operator") {
             val code = """
-                val nullableList = arrayOf("string", null)
-                val strings = listOfNotNull(*nullableList)
+                val nullableArray = arrayOf("string", null)
+                val strings = listOfNotNull(*nullableArray)
             """
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
@@ -165,8 +165,8 @@ object UselessCallOnNotNullSpec : Spek({
 
         it("reports when calling listOfNotNull with spread operator on all non-nullable arguments") {
             val code = """
-                val nonNullableList = arrayOf("string", "bar")
-                val strings = listOfNotNull(*nonNullableList)
+                val nonNullableArray = arrayOf("string", "bar")
+                val strings = listOfNotNull(*nonNullableArray)
             """
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
@@ -175,9 +175,9 @@ object UselessCallOnNotNullSpec : Spek({
 
         it("does not report when calling listOfNotNull with a mix of null spread and non-null non-spread") {
             val code = """
-                val nullableList = arrayOf("string", null)
-                val nonNullableList = arrayOf("string", "bar")
-                val strings = listOfNotNull("string", *nonNullableList, "foo", *nullableList)
+                val nullableArray = arrayOf("string", null)
+                val nonNullableArray = arrayOf("string", "bar")
+                val strings = listOfNotNull("string", *nonNullableArray, "foo", *nullableArray)
             """
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
@@ -185,8 +185,8 @@ object UselessCallOnNotNullSpec : Spek({
 
         it("does not report when calling listOfNotNull with a mix of non-null spread and null non-spread") {
             val code = """
-                val nonNullableList = arrayOf("string", "bar")
-                val strings = listOfNotNull("string", *nonNullableList, null)
+                val nonNullableArray = arrayOf("string", "bar")
+                val strings = listOfNotNull("string", *nonNullableArray, null)
             """
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
@@ -194,9 +194,9 @@ object UselessCallOnNotNullSpec : Spek({
 
         it("reports when calling listOfNotNull with a mix of spread and non-spread, all non-null") {
             val code = """
-                val nonNullableList = arrayOf("string", "bar")
-                val otherNonNullableList = arrayOf("foobar")
-                val strings = listOfNotNull("string", *nonNullableList, "foo", *otherNonNullableList)
+                val nonNullableArray = arrayOf("string", "bar")
+                val otherNonNullableArray = arrayOf("foobar")
+                val strings = listOfNotNull("string", *nonNullableArray, "foo", *otherNonNullableArray)
             """
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)


### PR DESCRIPTION
Fixes https://github.com/detekt/detekt/issues/4236

This considers that each actual parameter of a `listOfNotNull` call can be a spread expression, so it correctly handles a mix of spread + non-spread elements (by making sure at least one is nullable).