### PR TITLE
Support full qualified names in AnnotationSuppressor

### DIFF
--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -2,6 +2,6 @@
 <SmellBaseline>
   <ManuallySuppressedIssues/>
   <CurrentIssues>
-    <ID>LargeClass:UnusedPrivateMemberSpec.kt$UnusedPrivateMemberSpec : Spek</ID>
+    <ID>UnusedPrivateMember:AnnotationSuppressor.kt$private operator fun Iterable&lt;Regex&gt;.contains(a: String?): Boolean</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Analyzer.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Analyzer.kt
@@ -120,7 +120,7 @@ internal class Analyzer(
         fun executeRules(rules: List<BaseRule>) {
             for (rule in rules) {
                 rule.visitFile(file, bindingContext, compilerResources)
-                for (finding in filterSuppressedFindings(rule)) {
+                for (finding in filterSuppressedFindings(rule, bindingContext)) {
                     val mappedRuleSet = checkNotNull(ruleIdsToRuleSetIds[finding.id]) {
                         "Mapping for '${finding.id}' expected."
                     }
@@ -137,8 +137,8 @@ internal class Analyzer(
     }
 }
 
-private fun filterSuppressedFindings(rule: BaseRule): List<Finding> {
-    val suppressors = getSuppressors(rule)
+private fun filterSuppressedFindings(rule: BaseRule, bindingContext: BindingContext): List<Finding> {
+    val suppressors = getSuppressors(rule, bindingContext)
     return if (suppressors.isNotEmpty()) {
         rule.findings.filter { finding -> !suppressors.any { suppressor -> suppressor.shouldSuppress(finding) } }
     } else {

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/AnnotationSuppressor.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/AnnotationSuppressor.kt
@@ -4,27 +4,32 @@ import io.gitlab.arturbosch.detekt.api.ConfigAware
 import org.jetbrains.kotlin.psi.KtAnnotated
 import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
+import org.jetbrains.kotlin.resolve.BindingContext
 
-internal fun annotationSuppressorFactory(rule: ConfigAware): Suppressor? {
+internal fun annotationSuppressorFactory(rule: ConfigAware, bindingContext: BindingContext): Suppressor? {
     val annotations = rule.valueOrDefault("ignoreAnnotated", emptyList<String>())
     return if (annotations.isNotEmpty()) {
         Suppressor { finding ->
             val element = finding.entity.ktElement
-            element != null && annotationSuppressor(element, annotations)
+            element != null && annotationSuppressor(element, annotations, bindingContext)
         }
     } else {
         null
     }
 }
 
-private fun annotationSuppressor(element: KtElement, annotations: List<String>): Boolean {
-    return element.isAnnotatedWith(annotations)
+private fun annotationSuppressor(
+    element: KtElement,
+    annotations: List<String>,
+    bindingContext: BindingContext
+): Boolean {
+    return element.isAnnotatedWith(annotations, bindingContext)
 }
 
-private fun KtElement.isAnnotatedWith(annotationNames: Iterable<String>): Boolean {
+private fun KtElement.isAnnotatedWith(annotationNames: Iterable<String>, bindingContext: BindingContext): Boolean {
     return if (this is KtAnnotated && annotationEntries.find { it.typeReference?.text in annotationNames } != null) {
         true
     } else {
-        getStrictParentOfType<KtAnnotated>()?.isAnnotatedWith(annotationNames) ?: false
+        getStrictParentOfType<KtAnnotated>()?.isAnnotatedWith(annotationNames, bindingContext) ?: false
     }
 }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/Suppressor.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/Suppressor.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.api.ConfigAware
 import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.api.MultiRule
 import io.gitlab.arturbosch.detekt.api.Rule
+import org.jetbrains.kotlin.resolve.BindingContext
 
 fun interface Suppressor {
     /**
@@ -13,18 +14,18 @@ fun interface Suppressor {
     fun shouldSuppress(finding: Finding): Boolean
 }
 
-private fun buildSuppressors(rule: ConfigAware): List<Suppressor> {
+private fun buildSuppressors(rule: ConfigAware, bindingContext: BindingContext): List<Suppressor> {
     return listOfNotNull(
-        annotationSuppressorFactory(rule),
+        annotationSuppressorFactory(rule, bindingContext),
     )
 }
 
-internal fun getSuppressors(rule: BaseRule): List<Suppressor> {
+internal fun getSuppressors(rule: BaseRule, bindingContext: BindingContext): List<Suppressor> {
     return when (rule) {
         is MultiRule -> rule.rules.flatMap { innerRule ->
-            buildSuppressors(innerRule).map { suppressor -> InnerSuppressor(innerRule, suppressor) }
+            buildSuppressors(innerRule, bindingContext).map { suppressor -> InnerSuppressor(innerRule, suppressor) }
         }
-        is ConfigAware -> buildSuppressors(rule)
+        is ConfigAware -> buildSuppressors(rule, bindingContext)
         else -> emptyList()
     }
 }

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/AnnotationSuppressorSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/AnnotationSuppressorSpec.kt
@@ -328,6 +328,50 @@ class AnnotationSuppressorSpec : Spek({
 
                 assertThat(suppressor.shouldSuppress(buildFinding(ktFunction))).isTrue()
             }
+
+            it("With glob doesn't match because * doesn't match .") {
+                val suppressor = annotationSuppressorFactory(
+                    buildConfigAware("ignoreAnnotated" to listOf("*.Composable")),
+                    binding,
+                )!!
+
+                val ktFunction = root.findChildByClass(KtFunction::class.java)!!
+
+                assertThat(suppressor.shouldSuppress(buildFinding(ktFunction))).isFalse()
+            }
+
+            it("With glob2") {
+                val suppressor = annotationSuppressorFactory(
+                    buildConfigAware("ignoreAnnotated" to listOf("**.Composable")),
+                    binding,
+                )!!
+
+                val ktFunction = root.findChildByClass(KtFunction::class.java)!!
+
+                assertThat(suppressor.shouldSuppress(buildFinding(ktFunction))).isTrue()
+            }
+
+            it("With glob3") {
+                val suppressor = annotationSuppressorFactory(
+                    buildConfigAware("ignoreAnnotated" to listOf("Compo*")),
+                    binding,
+                )!!
+
+                val ktFunction = root.findChildByClass(KtFunction::class.java)!!
+
+                assertThat(suppressor.shouldSuppress(buildFinding(ktFunction))).isTrue()
+            }
+
+            it("With glob4") {
+                val suppressor = annotationSuppressorFactory(
+                    buildConfigAware("ignoreAnnotated" to listOf("*")),
+                    binding,
+                )!!
+
+                val ktFunction = root.findChildByClass(KtFunction::class.java)!!
+
+                assertThat(suppressor.shouldSuppress(buildFinding(ktFunction))).isTrue()
+            }
         }
 
         it("Doesn't mix annotations") {

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/AnnotationSuppressorSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/AnnotationSuppressorSpec.kt
@@ -22,6 +22,7 @@ import org.jetbrains.kotlin.psi.KtFunction
 import org.jetbrains.kotlin.psi.KtParameter
 import org.jetbrains.kotlin.psi.psiUtil.findDescendantOfType
 import org.jetbrains.kotlin.psi.psiUtil.findFunctionByName
+import org.jetbrains.kotlin.resolve.BindingContext
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 import java.nio.file.Paths
@@ -30,14 +31,15 @@ class AnnotationSuppressorSpec : Spek({
 
     describe("AnnotationSuppressorFactory") {
         it("Factory returns null if ignoreAnnotated is not set") {
-            val suppressor = annotationSuppressorFactory(buildConfigAware(/* empty */))
+            val suppressor = annotationSuppressorFactory(buildConfigAware(/* empty */), BindingContext.EMPTY)
 
             assertThat(suppressor).isNull()
         }
 
         it("Factory returns null if ignoreAnnotated is set to empty") {
             val suppressor = annotationSuppressorFactory(
-                buildConfigAware("ignoreAnnotated" to emptyList<String>())
+                buildConfigAware("ignoreAnnotated" to emptyList<String>()),
+                BindingContext.EMPTY,
             )
 
             assertThat(suppressor).isNull()
@@ -45,7 +47,8 @@ class AnnotationSuppressorSpec : Spek({
 
         it("Factory returns not null if ignoreAnnotated is set to a not empty list") {
             val suppressor = annotationSuppressorFactory(
-                buildConfigAware("ignoreAnnotated" to listOf("Composable"))
+                buildConfigAware("ignoreAnnotated" to listOf("Composable")),
+                BindingContext.EMPTY,
             )
 
             assertThat(suppressor).isNotNull()
@@ -54,7 +57,10 @@ class AnnotationSuppressorSpec : Spek({
 
     describe("AnnotationSuppressor") {
         val suppressor by memoized {
-            annotationSuppressorFactory(buildConfigAware("ignoreAnnotated" to listOf("Composable")))!!
+            annotationSuppressorFactory(
+                buildConfigAware("ignoreAnnotated" to listOf("Composable")),
+                BindingContext.EMPTY,
+            )!!
         }
 
         it("If KtElement is null it returns false") {

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/SuppressorsSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/SuppressorsSpec.kt
@@ -11,6 +11,7 @@ import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.kotlin.resolve.BindingContext
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
@@ -37,14 +38,14 @@ class SuppressorsSpec : Spek({
 
         it("A finding that should be suppressed") {
             val rule = ARule(TestConfig("ignoreAnnotated" to listOf("Composable")))
-            val suppress = getSuppressors(rule)
+            val suppress = getSuppressors(rule, BindingContext.EMPTY)
                 .fold(false) { acc, suppressor -> acc || suppressor.shouldSuppress(noIgnorableCodeSmell) }
 
             assertThat(suppress).isFalse()
         }
         it("A finding that should not be suppressed") {
             val rule = ARule(TestConfig("ignoreAnnotated" to listOf("Composable")))
-            val suppress = getSuppressors(rule)
+            val suppress = getSuppressors(rule, BindingContext.EMPTY)
                 .fold(false) { acc, suppressor -> acc || suppressor.shouldSuppress(ignorableCodeSmell) }
 
             assertThat(suppress).isTrue()
@@ -53,14 +54,14 @@ class SuppressorsSpec : Spek({
         context("MultiRule") {
             it("A finding that should be suppressed") {
                 val rule = AMultiRule(TestConfig("ignoreAnnotated" to listOf("Composable")))
-                val suppress = getSuppressors(rule)
+                val suppress = getSuppressors(rule, BindingContext.EMPTY)
                     .fold(false) { acc, suppressor -> acc || suppressor.shouldSuppress(noIgnorableCodeSmell) }
 
                 assertThat(suppress).isFalse()
             }
             it("A finding that should not be suppressed") {
                 val rule = AMultiRule(TestConfig("ignoreAnnotated" to listOf("Composable")))
-                val suppress = getSuppressors(rule)
+                val suppress = getSuppressors(rule, BindingContext.EMPTY)
                     .fold(false) { acc, suppressor -> acc || suppressor.shouldSuppress(ignorableCodeSmell) }
 
                 assertThat(suppress).isTrue()


### PR DESCRIPTION
This add supports to full qualified name matching in `AnnotationSuppresor`. It also allow Glob patterns.

Fixes #4233