### PR TITLE
Fix typo in Gradle lib definition

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ import io.gitlab.arturbosch.detekt.DetektCreateBaselineTask
 plugins {
     id("releasing")
     alias(libs.plugins.detekt)
-    alias(libs.plugins.gradleVersionz)
+    alias(libs.plugins.gradleVersions)
     alias(libs.plugins.sonarqube)
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -43,7 +43,7 @@ jcommander = "com.beust:jcommander:1.81"
 binaryCompatibilityValidator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version = "0.7.0" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version = "1.18.1" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
-gradleVersionz = { id = "com.github.ben-manes.versions", version = "0.39.0" }
+gradleVersions = { id = "com.github.ben-manes.versions", version = "0.39.0" }
 pluginPublishing = { id = "com.gradle.plugin-publish", version = "0.15.0" }
 shadow = { id = "com.github.johnrengelman.shadow", version = "7.0.0" }
 sonarqube = { id = "org.sonarqube", version = "3.3" }


### PR DESCRIPTION
See "Lifted restrictions for alias names" in https://docs.gradle.org/7.3/release-notes.html#new-features-and-usability-improvements.