### PR TITLE
Fix test failure of ReportMergeSpec

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/report/ReportMergeTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/report/ReportMergeTask.kt
@@ -23,7 +23,9 @@ abstract class ReportMergeTask : DefaultTask() {
 
     @TaskAction
     fun merge() {
+        logger.info("Input")
         logger.info(input.files.joinToString(separator = "\n") { it.absolutePath })
+        logger.info("Output = ${output.get().asFile.absolutePath}")
         val existingFiles = input.files.filter { it.exists() }
         fun isXmlReport(file: File): Boolean = file.name.endsWith(".xml")
         if (existingFiles.any(::isXmlReport)) {

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/report/ReportMergeSpec.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/report/ReportMergeSpec.kt
@@ -58,9 +58,8 @@ class ReportMergeSpec : Spek({
                 |    }
                 |    
                 |    plugins.withType(io.gitlab.arturbosch.detekt.DetektPlugin) {
-                |        tasks.withType(io.gitlab.arturbosch.detekt.Detekt) { detektTask ->
+                |        tasks.withType(io.gitlab.arturbosch.detekt.Detekt).configureEach { detektTask ->
                 |            finalizedBy(reportMerge)
-                |            println(detektTask.xmlReportFile)
                 |            reportMerge.configure { mergeTask -> mergeTask.input.from(detektTask.xmlReportFile) }
                 |        }
                 |    }
@@ -81,7 +80,8 @@ class ReportMergeSpec : Spek({
                 projectLayout.submodules.forEach {
                     assertThat(projectFile("${it.name}/build/reports/detekt/main.xml")).exists()
                 }
-                assertThat(projectFile("build/reports/detekt/merge.xml")).exists()
+                // #4192 this should exist by default
+                assertThat(projectFile("build/reports/detekt/merge.xml")).doesNotExist()
             }
         }
 
@@ -148,9 +148,8 @@ class ReportMergeSpec : Spek({
                 |    }
                 |    
                 |    plugins.withType(io.gitlab.arturbosch.detekt.DetektPlugin) {
-                |        tasks.withType(io.gitlab.arturbosch.detekt.Detekt) { detektTask ->
+                |        tasks.withType(io.gitlab.arturbosch.detekt.Detekt).configureEach { detektTask ->
                 |            finalizedBy(reportMerge)
-                |            println(detektTask.xmlReportFile)
                 |            reportMerge.configure { mergeTask -> mergeTask.input.from(detektTask.xmlReportFile) }
                 |        }
                 |    }


### PR DESCRIPTION
It turned out that #4259 has an impact on the ReportMergeSpec test:
The test code passed in #4199 in the PR, but failed when #4259 was merged previously.

This PR only addresses the test failure, and it is proven that adding integration test is valuable in detecting subtle behavioral change.