### PR TITLE
Replace usage of deprecated ConfigureUtil

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektReports.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektReports.kt
@@ -1,12 +1,11 @@
 package io.gitlab.arturbosch.detekt.extensions
 
-import groovy.lang.Closure
 import io.gitlab.arturbosch.detekt.extensions.DetektReportType.HTML
 import io.gitlab.arturbosch.detekt.extensions.DetektReportType.SARIF
 import io.gitlab.arturbosch.detekt.extensions.DetektReportType.TXT
 import io.gitlab.arturbosch.detekt.extensions.DetektReportType.XML
+import org.gradle.api.Action
 import org.gradle.api.model.ObjectFactory
-import org.gradle.util.ConfigureUtil
 import javax.inject.Inject
 
 @Suppress("TooManyFunctions")
@@ -22,20 +21,15 @@ open class DetektReports @Inject constructor(val objects: ObjectFactory) {
 
     val custom = mutableListOf<CustomDetektReport>()
 
-    fun xml(configure: DetektReport.() -> Unit): Unit = xml.configure()
-    fun xml(closure: Closure<*>): DetektReport = ConfigureUtil.configure(closure, xml)
+    fun xml(action: Action<in DetektReport>): Unit = action.execute(xml)
 
-    fun html(configure: DetektReport.() -> Unit): Unit = html.configure()
-    fun html(closure: Closure<*>): DetektReport = ConfigureUtil.configure(closure, html)
+    fun html(action: Action<in DetektReport>): Unit = action.execute(html)
 
-    fun txt(configure: DetektReport.() -> Unit): Unit = txt.configure()
-    fun txt(closure: Closure<*>): DetektReport = ConfigureUtil.configure(closure, txt)
+    fun txt(action: Action<in DetektReport>): Unit = action.execute(txt)
 
-    fun sarif(configure: DetektReport.() -> Unit): Unit = sarif.configure()
-    fun sarif(closure: Closure<*>): DetektReport = ConfigureUtil.configure(closure, sarif)
+    fun sarif(action: Action<in DetektReport>): Unit = action.execute(sarif)
 
-    fun custom(configure: CustomDetektReport.() -> Unit): Unit = createAndAddCustomReport().configure()
-    fun custom(closure: Closure<*>): CustomDetektReport = ConfigureUtil.configure(closure, createAndAddCustomReport())
+    fun custom(action: Action<in CustomDetektReport>): Unit = action.execute(createAndAddCustomReport())
 
     private fun createAndAddCustomReport() =
         objects.newInstance(CustomDetektReport::class.java).apply { custom.add(this) }


### PR DESCRIPTION
ConfigureUtil is planned for removal in Gradle 8.0.

Use of `Closure` has been discouraged for some time. It can be replaced with `Action` ; https://docs.gradle.org/current/userguide/kotlin_dsl.html#groovy_closures_from_kotlin

> Gradle plugins written in any language should prefer the type `Action<T>` type in place of closures. Groovy closures and Kotlin lambdas are automatically mapped to arguments of that type.