### PR TITLE
Remove afterEvaluate wrapper v2

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektAndroid.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektAndroid.kt
@@ -68,7 +68,7 @@ internal class DetektAndroid(private val project: Project) {
         // There is not a single Android plugin, but each registers an extension based on BaseExtension,
         // so we catch them all by looking for this one
         project.extensions.findByType(BaseExtension::class.java)?.let { baseExtension ->
-            val bootClasspath = project.files(baseExtension.bootClasspath)
+            val bootClasspath = project.files(project.provider { baseExtension.bootClasspath })
             baseExtension.variants
                 ?.matching { !extension.matchesIgnoredConfiguration(it) }
                 ?.all { variant ->

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektAndroid.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektAndroid.kt
@@ -67,38 +67,35 @@ internal class DetektAndroid(private val project: Project) {
     fun registerTasks(extension: DetektExtension) {
         // There is not a single Android plugin, but each registers an extension based on BaseExtension,
         // so we catch them all by looking for this one
-        project.afterEvaluate { evaluatedProject ->
-            val baseExtensionOrNull = evaluatedProject.extensions.findByType(BaseExtension::class.java)
-            baseExtensionOrNull?.let { baseExtension ->
-                val bootClasspath = evaluatedProject.files(baseExtension.bootClasspath)
-                baseExtension.variants
-                    ?.matching { !extension.matchesIgnoredConfiguration(it) }
-                    ?.all { variant ->
-                        evaluatedProject.registerAndroidDetektTask(bootClasspath, extension, variant).also { provider ->
-                            mainTaskProvider.dependsOn(provider)
-                        }
-                        evaluatedProject.registerAndroidCreateBaselineTask(bootClasspath, extension, variant)
-                            .also { provider ->
-                                mainBaselineTaskProvider.dependsOn(provider)
-                            }
-                        variant.testVariants
-                            .filter { !extension.matchesIgnoredConfiguration(it) }
-                            .forEach { testVariant ->
-                                evaluatedProject.registerAndroidDetektTask(bootClasspath, extension, testVariant)
-                                    .also { provider ->
-                                        testTaskProvider.dependsOn(provider)
-                                    }
-                                evaluatedProject.registerAndroidCreateBaselineTask(
-                                    bootClasspath,
-                                    extension,
-                                    testVariant
-                                )
-                                    .also { provider ->
-                                        testBaselineTaskProvider.dependsOn(provider)
-                                    }
-                            }
+        project.extensions.findByType(BaseExtension::class.java)?.let { baseExtension ->
+            val bootClasspath = project.files(baseExtension.bootClasspath)
+            baseExtension.variants
+                ?.matching { !extension.matchesIgnoredConfiguration(it) }
+                ?.all { variant ->
+                    project.registerAndroidDetektTask(bootClasspath, extension, variant).also { provider ->
+                        mainTaskProvider.dependsOn(provider)
                     }
-            }
+                    project.registerAndroidCreateBaselineTask(bootClasspath, extension, variant)
+                        .also { provider ->
+                            mainBaselineTaskProvider.dependsOn(provider)
+                        }
+                    variant.testVariants
+                        .filter { !extension.matchesIgnoredConfiguration(it) }
+                        .forEach { testVariant ->
+                            project.registerAndroidDetektTask(bootClasspath, extension, testVariant)
+                                .also { provider ->
+                                    testTaskProvider.dependsOn(provider)
+                                }
+                            project.registerAndroidCreateBaselineTask(
+                                bootClasspath,
+                                extension,
+                                testVariant
+                            )
+                                .also { provider ->
+                                    testBaselineTaskProvider.dependsOn(provider)
+                                }
+                        }
+                }
         }
     }
 

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektJvm.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektJvm.kt
@@ -13,11 +13,9 @@ import java.io.File
 
 internal class DetektJvm(private val project: Project) {
     fun registerTasks(extension: DetektExtension) {
-        project.afterEvaluate {
-            project.convention.getPlugin(JavaPluginConvention::class.java).sourceSets.all { sourceSet ->
-                project.registerJvmDetektTask(extension, sourceSet)
-                project.registerJvmCreateBaselineTask(extension, sourceSet)
-            }
+        project.convention.getPlugin(JavaPluginConvention::class.java).sourceSets.all { sourceSet ->
+            project.registerJvmDetektTask(extension, sourceSet)
+            project.registerJvmCreateBaselineTask(extension, sourceSet)
         }
     }
 

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektMultiplatform.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektMultiplatform.kt
@@ -33,7 +33,7 @@ internal class DetektMultiplatform(private val project: Project) {
             val kmpExtension = evaluatedProject.extensions.getByType(KotlinMultiplatformExtension::class.java)
 
             kmpExtension.targets.all { target ->
-                target.compilations.forEach { compilation ->
+                target.compilations.all { compilation ->
                     val inputSource = compilation.kotlinSourceSets
                         .map { it.kotlin.sourceDirectories }
                         .fold(evaluatedProject.files() as FileCollection) { collection, next -> collection.plus(next) }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektMultiplatform.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektMultiplatform.kt
@@ -58,7 +58,7 @@ internal class DetektMultiplatform(private val project: Project) {
         // For Android targets we delegate to DetektAndroid as we need to access
         // BaseVariant and other AGP apis to properly setup the classpath.
         extensions.findByType(BaseExtension::class.java)?.let {
-            val bootClasspath = files(it.bootClasspath)
+            val bootClasspath = files(provider { it.bootClasspath })
             val variant = compilation.androidVariant
             val detektTaskName = DetektPlugin.DETEKT_TASK_NAME +
                 target.name.capitalize() + variant.name.capitalize()

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektJvmSpec.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektJvmSpec.kt
@@ -3,7 +3,6 @@ package io.gitlab.arturbosch.detekt
 import io.gitlab.arturbosch.detekt.invoke.CliArgument
 import io.gitlab.arturbosch.detekt.testkit.DslGradleRunner
 import io.gitlab.arturbosch.detekt.testkit.ProjectLayout
-import io.gitlab.arturbosch.detekt.testkit.triggerEvaluation
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.repositories
@@ -38,8 +37,6 @@ object DetektJvmSpec : Spek({
             it("configures detekt type resolution task main") {
                 val project = gradleRunner.buildProject()
 
-                project.triggerEvaluation()
-
                 val detektTask = project.tasks.getByPath("detektMain") as Detekt
                 val argumentString = detektTask.arguments.flatMap(CliArgument::toArgument).joinToString(" ")
 
@@ -52,8 +49,6 @@ object DetektJvmSpec : Spek({
 
             it("configures detekt type resolution task test") {
                 val project = gradleRunner.buildProject()
-
-                project.triggerEvaluation()
 
                 val detektTask = project.tasks.getByPath("detektTest") as Detekt
                 val argumentString = detektTask.arguments.flatMap(CliArgument::toArgument).joinToString(" ")

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/report/ReportMergeSpec.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/report/ReportMergeSpec.kt
@@ -80,8 +80,8 @@ class ReportMergeSpec : Spek({
                 projectLayout.submodules.forEach {
                     assertThat(projectFile("${it.name}/build/reports/detekt/main.xml")).exists()
                 }
-                // #4192 this should exist by default
-                assertThat(projectFile("build/reports/detekt/merge.xml")).doesNotExist()
+
+                assertThat(projectFile("build/reports/detekt/merge.xml")).exists()
             }
         }
 

--- a/detekt-gradle-plugin/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/testkit/DslGradleRunner.kt
+++ b/detekt-gradle-plugin/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/testkit/DslGradleRunner.kt
@@ -166,5 +166,3 @@ class DslGradleRunner @Suppress("LongParameterList") constructor(
         private const val DETEKT_TASK = "detekt"
     }
 }
-
-fun Project.triggerEvaluation() { this.getTasksByName("tasks", true) }


### PR DESCRIPTION
v2 of #4159

The reason this didn't work on the first attempt is that `bootClasspath` on the Android Gradle Plugin's `BaseExtension` is a `List<File>` and was being called during the configuration phase when it was empty. By wrapping in a `provider {}` call the parameter becomes live so the value will be queried at task execution instead, when it's been populated. cc @BraisGabin in case you want to confirm (I have successfully tested on a local Android project).

I've also reversed the test behaviour change introduced in #4262 as the test no longer fails.

I still need to add a functional test for Android. I will do this once #4074 is merged.

Original PR description follows:

---

Removes usage of `afterEvaluate` in the Gradle plugin.

This causes race conditions (evidenced by the double use of `afterEvaluate` in DetektMultiplatform class) and makes it more difficult for users to customise individual tasks created by the plugin.

Generally `afterEvaluate` shouldn't be required when Gradle's lazy configuration and task configuration avoidance APIs are used. The only tests that failed when I removed it is the multiplatform Android tests, but switching to reactive DomainObjectContainer#all instead of DomainObjectContainer#forEach fixes that.

If there are other use cases that require using `afterEvaluate` I'll investigate, and if the test coverage didn't pick up issues that removal will now cause, please let me know so I can address it.

Would fix root issue raised in #3428 