### PR TITLE
Landing page for Compose-related rule customization

### DIFF
--- a/docs/_data/sidebars/home_sidebar.yml
+++ b/docs/_data/sidebars/home_sidebar.yml
@@ -20,6 +20,9 @@ entries:
     - title: Configuration File
       url: /configurations.html
       output: web
+    - title: Configuration for Compose
+      url: /compose.html
+      output: web
     - title: Reporting
       url: /reporting.html
       output: web
@@ -37,9 +40,6 @@ entries:
       output: web
     - title: Compatibility Table
       url: /compatibility.html
-      output: web
-    - title: Customizing For Compose
-      url: /compose.html
       output: web
   - title: Getting Started
     output: web

--- a/docs/_data/sidebars/home_sidebar.yml
+++ b/docs/_data/sidebars/home_sidebar.yml
@@ -38,6 +38,9 @@ entries:
     - title: Compatibility Table
       url: /compatibility.html
       output: web
+    - title: Customizing For Compose
+      url: /compose.html
+      output: web
   - title: Getting Started
     output: web
     folderitems:

--- a/docs/pages/compose.md
+++ b/docs/pages/compose.md
@@ -1,0 +1,66 @@
+---
+title: Customizing for Compose
+sidebar: home_sidebar
+keywords: rules, compose, jetpack-compose
+permalink: compose.html
+toc: true
+folder: documentation
+---
+
+Relevant rule sets and their configuration options for Compose styles & usage.
+
+### TopLevelPropertyNaming
+
+See [TopLevelPropertyNaming](https://detekt.github.io/detekt/naming.html#toplevelpropertynaming).
+
+Compose [guidelines](https://github.com/androidx/androidx/blob/androidx-main/compose/docs/compose-api-guidelines.md#singletons-constants-sealed-class-and-enum-class-values) prescribe `CamelCase` for top-level constants.
+
+##### Default Style:
+
+```kotlin
+private val FOO_PADDING = 16.dp
+```
+
+##### Compose Style:
+
+```kotlin
+private val FooPadding = 16.dp
+```
+
+#### Configurations:
+
+* Set ``constantPattern`` to ``'[A-Z][_A-Za-z0-9]*'`` (default: ``'[A-Z][_A-Z0-9]*'``)
+
+
+### LongParameterList
+
+See [LongParameterList](https://detekt.github.io/detekt/complexity.html#longparameterlist).
+
+Composables may boast more than the typical number of function arguments (albeit mostly with default values). For example, see [OutlinedTextField](https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:compose/material/material/src/commonMain/kotlin/androidx/compose/material/OutlinedTextField.kt;l=133?q=OutlinedTextFieldLayout&ss=androidx%2Fplatform%2Fframeworks%2Fsupport:compose%2F).
+
+#### Configurations:
+
+* Set ``functionThreshold`` to a higher value
+* Additionally, can set ``ignoreDefaultParameters = true``
+
+### MagicNumber
+
+See [MagicNumber](https://detekt.github.io/detekt/style.html#magicnumber).
+
+Class/companion object/top-level properties that declare objects such as ``Color(0xFFEA6D7E)`` may be considered violations if they don't specify the named parameter (i.e. ``Color(color = 0xFFEA6D7E)``).
+
+``` kotlin
+val color1 = Color(0xFFEA6D7E) // Violation
+
+class Foo {
+  val color2 = Color(0xFFEA6D7E) // Violation
+
+  companion object {
+    val color3 = Color(0xFFEA6D7E) // No violation if ignoreCompanionObjectPropertyDeclaration = true by default
+  }
+}
+```
+
+#### Configurations:
+
+* Set ``ignorePropertyDeclaration = true``, ``ignoreCompanionObjectPropertyDeclaration = true`` (default)

--- a/docs/pages/compose.md
+++ b/docs/pages/compose.md
@@ -29,7 +29,7 @@ private val FooPadding = 16.dp
 
 #### Configurations:
 
-* Set ``constantPattern`` to ``'[A-Z][_A-Za-z0-9]*'`` (default: ``'[A-Z][_A-Z0-9]*'``)
+* Set ``constantPattern`` to ``'[A-Z][A-Za-z0-9]*'`` (default: ``'[A-Z][_A-Z0-9]*'``)
 
 
 ### LongParameterList

--- a/docs/pages/compose.md
+++ b/docs/pages/compose.md
@@ -1,19 +1,21 @@
 ---
-title: Customizing for Compose
+title: Configuration for Compose
 sidebar: home_sidebar
-keywords: rules, compose, jetpack-compose
+keywords: compose, config, configuration, jetpack-compose, rules
 permalink: compose.html
 toc: true
 folder: documentation
 ---
 
-Relevant rule sets and their configuration options for Compose styles & usage.
+Relevant rule sets and their configuration options for Compose styles & usage. The following are being used as reference for Compose usage:
+- [Compose API Guidelines](https://github.com/androidx/androidx/blob/androidx-main/compose/docs/compose-api-guidelines.md)
+- [Compose source](https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:compose)
 
 ### TopLevelPropertyNaming
 
 See [TopLevelPropertyNaming](https://detekt.github.io/detekt/naming.html#toplevelpropertynaming).
 
-Compose [guidelines](https://github.com/androidx/androidx/blob/androidx-main/compose/docs/compose-api-guidelines.md#singletons-constants-sealed-class-and-enum-class-values) prescribe `CamelCase` for top-level constants.
+Compose guidelines prescribe `CamelCase` for top-level constants.
 
 ##### Default Style:
 


### PR DESCRIPTION
### What
Addresses https://github.com/detekt/detekt/discussions/4078#discussioncomment-1256162, https://github.com/detekt/detekt/discussions/4078#discussioncomment-1275658

- Adds a landing page within `User Documentation` to go over rule sets that might need customization for Compose styles/usage
- Where "Compose usage" refers to [Compose API Guidelines](https://github.com/androidx/androidx/blob/androidx-main/compose/docs/compose-api-guidelines.md), as well as [Compose source](https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:compose/) as "canon"
- Adds a few starter entries for customizing `TopLevelPropertyNaming`, `LongParameterList`, & `MagicNumber`

### Why & Related
- One needs to search through discussions/issues to know about customizing detekt rules to accommodate Compose styles; there is no central place within detekt docs
- As Compose introduces new paradigms to Kotlin, there might be deviations from JetBrains Kotlin styles; having some centralized docs might become useful as Compose usage becomes more widespread
- A few discussions indicated a need for such docs:
   - https://github.com/detekt/detekt/discussions/4078
   - https://github.com/detekt/detekt/discussions/4078#discussioncomment-1256162
   - https://github.com/detekt/detekt/discussions/4078#discussioncomment-1275658
   - https://github.com/detekt/detekt/issues/3147#issuecomment-797377600
   - https://github.com/detekt/detekt/issues/4080#issuecomment-932996520

### Visual
<img src="https://user-images.githubusercontent.com/2978958/141721211-78c392c6-9b0a-4b58-b269-7abe29d09091.png" width=333/>

### Open thoughts
- Is `User Documentation` a good place to put this?
- Any ways to make this more maintainable? i.e. a new dicussion/issue around Compose is opened that yields some answers, should this page be updated with that answer?, etc.
- General thoughts around improving formatting/organization etc. of this page