### PR TITLE
Remove kotlin-gradle-plugin-api from runtime classpath

### DIFF
--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -44,7 +44,7 @@ val pluginCompileOnly: Configuration by configurations.creating
 configurations.compileOnly { extendsFrom(pluginCompileOnly) }
 
 dependencies {
-    implementation(libs.kotlin.gradlePluginApi)
+    compileOnly(libs.kotlin.gradlePluginApi)
     implementation(libs.sarif4k)
 
     pluginCompileOnly(libs.android.gradle)


### PR DESCRIPTION
This can interfere with the Kotlin Gradle plugin when the version doesn't match what's used in the project that detekt is applied to.

Fixes #4274