### PR TITLE
UnderscoresInNumericLiterals: Allow numbers with non standard groupings

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -741,6 +741,7 @@ style:
   UnderscoresInNumericLiterals:
     active: false
     acceptableLength: 4
+    allowNonStandardGrouping: false
   UnnecessaryAbstractClass:
     active: true
   UnnecessaryAnnotationUseSiteTarget:

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiterals.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiterals.kt
@@ -37,7 +37,7 @@ class UnderscoresInNumericLiterals(config: Config = Config.empty) : Rule(config)
         javaClass.simpleName,
         Severity.Style,
         "Report missing or invalid underscores in base 10 numbers. Numeric literals " +
-            "should be underscore separated to increase readability. ",
+            "should be underscore separated to increase readability.",
         Debt.FIVE_MINS
     )
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiteralsSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiteralsSpec.kt
@@ -9,6 +9,7 @@ import org.spekframework.spek2.style.specification.describe
 
 private const val ACCEPTABLE_DECIMAL_LENGTH = "acceptableDecimalLength"
 private const val ACCEPTABLE_LENGTH = "acceptableLength"
+private const val ALLOW_NON_STANDARD_GROUPING = "allowNonStandardGrouping"
 
 class UnderscoresInNumericLiteralsSpec : Spek({
 
@@ -160,19 +161,26 @@ class UnderscoresInNumericLiteralsSpec : Spek({
         }
     }
 
-    describe("an Int of 1000_00") {
-        val code = "val myInt = 1000_00"
+    describe("an Int of 1000_00_00") {
+        val code = "val myInt = 1000_00_00"
 
-        it("should not be reported by default") {
+        it("should be reported by default") {
             val findings = UnderscoresInNumericLiterals().compileAndLint(code)
-            assertThat(findings).isEmpty()
+            assertThat(findings).isNotEmpty
         }
 
-        it("should be reported if acceptableLength is 3") {
+        it("should still be reported even if acceptableLength is 99") {
             val findings = UnderscoresInNumericLiterals(
-                TestConfig(mapOf(ACCEPTABLE_LENGTH to "3"))
+                TestConfig(mapOf(ACCEPTABLE_LENGTH to "99"))
             ).compileAndLint(code)
             assertThat(findings).isNotEmpty
+        }
+
+        it("should not be reported if allowNonStandardGrouping is true") {
+            val findings = UnderscoresInNumericLiterals(
+                TestConfig(mapOf(ALLOW_NON_STANDARD_GROUPING to true))
+            ).compileAndLint(code)
+            assertThat(findings).isEmpty()
         }
     }
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiteralsSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiteralsSpec.kt
@@ -160,17 +160,17 @@ class UnderscoresInNumericLiteralsSpec : Spek({
         }
     }
 
-    describe("an Int of 10_00_00") {
-        val code = "val myInt = 10_00_00"
+    describe("an Int of 1000_00") {
+        val code = "val myInt = 1000_00"
 
-        it("should be reported by default") {
+        it("should not be reported by default") {
             val findings = UnderscoresInNumericLiterals().compileAndLint(code)
-            assertThat(findings).isNotEmpty
+            assertThat(findings).isEmpty()
         }
 
-        it("should still be reported even if acceptableLength is 6") {
+        it("should be reported if acceptableLength is 3") {
             val findings = UnderscoresInNumericLiterals(
-                TestConfig(mapOf(ACCEPTABLE_LENGTH to "6"))
+                TestConfig(mapOf(ACCEPTABLE_LENGTH to "3"))
             ).compileAndLint(code)
             assertThat(findings).isNotEmpty
         }
@@ -357,6 +357,15 @@ class UnderscoresInNumericLiteralsSpec : Spek({
             val findings = UnderscoresInNumericLiterals(
                 TestConfig(mapOf(ACCEPTABLE_LENGTH to "7"))
             ).compileAndLint(code)
+            assertThat(findings).isEmpty()
+        }
+    }
+
+    describe("a String of 1000000.3141592") {
+        val code = """val myString = "1000000.3141592""""
+
+        it("should not be reported by default") {
+            val findings = UnderscoresInNumericLiterals().compileAndLint(code)
             assertThat(findings).isEmpty()
         }
     }


### PR DESCRIPTION
fixes #4276

I am somewhat unsure how to handle this. In my opinion this rule should have never reported a violation for groups other than three but changing this now will is a breaking change.
