### PR TITLE
Improve UnnecessaryLet

### DIFF
--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLet.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLet.kt
@@ -37,13 +37,24 @@ import org.jetbrains.kotlin.resolve.calls.util.getResolvedCall
  * a?.let { that -> that.plus(1) }?.let { it.plus(1) } // can be replaced with `a?.plus(1)?.plus(1)`
  * a.let { 1.plus(1) } // can be replaced with `1.plus(1)`
  * a?.let { 1.plus(1) } // can be replaced with `if (a != null) 1.plus(1)`
+ * fun foo() {
+ *   val a: Any? = getA()
+ *   a?.let { print(a) } // can be replaced by `if (a != null) println(a)`
+ *   a?.let { print(it) } // can be replaced by `if (a != null) println(a)`
+ * }
  * </noncompliant>
  *
  * <compliant>
- * a?.let { print(it) }
- * a?.let { 1.plus(it) } ?.let { msg -> print(msg) }
- * a?.let { it.plus(it) }
- * val b = a?.let { 1.plus(1) }
+ * class A {
+ *   var a: String? = null
+ *
+ *   fun foo() {
+ *     a?.let { print(it) } // needed for thread safety
+ *   }
+ * }
+ * getA()?.let { print(it) } // avoids a variable
+ * val b = a?.let { 1.plus(1) } // avoids an if/else
+ * a?.let { 1.plus(it) }?.let { msg -> print(msg) } // The first one avoids an if/else and the second avoids a variable
  * </compliant>
  *
  */


### PR DESCRIPTION
This PR will make `UnnecessaryLet` a bit more restrictive. `let` is overused (as other socped functions) in Kotlin. This PR makes `UnnecessaryLet` a bit smarter. The main different between this new implementation and the old one is to treat different this two cases:

```kotlin
fun foo() {
  val a: Any? = getA()
  a?.let { print(a) } // can be replaced by `if (a != null) println(a)`
  a?.let { print(it) } // can be replaced by `if (a != null) println(a)`
}
```
```kotlin
class A {
  var a: String? = null

  fun foo() {
    a?.let { print(it) } // needed for thread safety
  }
}
```

and don't allow `let` when `with` is a better fit: 

```kotlin
binding.textView.let {
  it.text = "hi"
  it.visibility = VISIBLE
  it.color = 0xffff0000
}
```
Should be replaced by:
```kotlin
with(binding.textView) {
  text = "hi"
  visibility = VISIBLE
  color = 0xffff0000
}
```

The reason for this second change is this one:

> Grouping function calls on an object: `with`

From https://kotlinlang.org/docs/scope-functions.html#function-selection


-----

IMPORTANT: These changes could be controversia,l for that reason I didn't implement the changes in the rule yet. I just changed the documentation and the tests. I want to know if you agree with this changes to start implementing the changes.

----

Closes #4248