### PR TITLE
Add functional test for type resolution for JVM

### DIFF
--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/JvmSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/JvmSpec.kt
@@ -1,0 +1,22 @@
+package io.gitlab.arturbosch.detekt
+
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.testkit.runner.GradleRunner
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import java.io.File
+
+object JvmSpec : Spek({
+    describe("Type resolution on JVM") {
+        val projectDir = checkNotNull(javaClass.classLoader.getResource("jvm")?.file)
+        val result = GradleRunner.create()
+            .withProjectDir(File(projectDir))
+            .withPluginClasspath()
+            .withArguments("detektMain")
+            .buildAndFail()
+
+        assertThat(result.output).contains("Build failed with 2 weighted issues.")
+        assertThat(result.output).contains("ExitOutsideMain - [kotlinExit]")
+        assertThat(result.output).contains("ExitOutsideMain - [javaExit]")
+    }
+})

--- a/detekt-gradle-plugin/src/functionalTest/resources/jvm/build.gradle
+++ b/detekt-gradle-plugin/src/functionalTest/resources/jvm/build.gradle
@@ -1,0 +1,8 @@
+plugins {
+    id("org.jetbrains.kotlin.jvm")
+    id("io.gitlab.arturbosch.detekt")
+}
+
+repositories {
+    mavenCentral()
+}

--- a/detekt-gradle-plugin/src/functionalTest/resources/jvm/config/detekt/detekt.yml
+++ b/detekt-gradle-plugin/src/functionalTest/resources/jvm/config/detekt/detekt.yml
@@ -1,0 +1,3 @@
+potential-bugs:
+  ExitOutsideMain:
+    active: true

--- a/detekt-gradle-plugin/src/functionalTest/resources/jvm/src/main/kotlin/Errors.kt
+++ b/detekt-gradle-plugin/src/functionalTest/resources/jvm/src/main/kotlin/Errors.kt
@@ -1,0 +1,13 @@
+package jvm.src.main.kotlin
+
+import kotlin.system.exitProcess
+
+class Errors {
+    fun kotlinExit() {
+        exitProcess(0)
+    }
+
+    fun javaExit() {
+        System.exit(1)
+    }
+}


### PR DESCRIPTION
This is a simple functional test for type resolution on JVM, checking that both Kotlin & Java types are being checked.

I have used the complete file structure instead of using the helpers in the test-fixtures module. Although this test is simple, when we start adding functional tests for more complex project structures, building it out from code like the existing TestKit tests is (IMHO) going to get out of hand. I always get a bit lost when reviewing the existing tests due to the heavy use of parameters & functions to build out the build file & modules.

I intend to add other tests (Android, multiplatform) using the same structure as used here, assuming agreement on the approach.