### PR TITLE
Don't hide null issues

### DIFF
--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/DefaultConfig.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/DefaultConfig.kt
@@ -7,7 +7,7 @@ internal object DefaultConfig {
     const val RESOURCE_NAME = "default-detekt-config.yml"
 
     fun newInstance(): Config {
-        val configUrl = javaClass.getResource("/$RESOURCE_NAME")
+        val configUrl = javaClass.getResource("/$RESOURCE_NAME")!!
         return YamlConfig.loadResource(configUrl)
     }
 }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/tooling/DefaultConfigProvider.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/tooling/DefaultConfigProvider.kt
@@ -12,7 +12,7 @@ class DefaultConfigProvider : DefaultConfigurationProvider {
     override fun get(): Config = DefaultConfig.newInstance()
 
     override fun copy(targetLocation: Path) {
-        val configUrl = javaClass.getResource("/${DefaultConfig.RESOURCE_NAME}")
+        val configUrl = javaClass.getResource("/${DefaultConfig.RESOURCE_NAME}")!!
         Files.copy(configUrl.openStream(), targetLocation, StandardCopyOption.REPLACE_EXISTING)
     }
 }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
@@ -120,6 +120,6 @@ const val CONFIGURATION_DETEKT = "detekt"
 const val CONFIGURATION_DETEKT_PLUGINS = "detektPlugins"
 
 internal fun loadDetektVersion(classLoader: ClassLoader): String = Properties().run {
-    load(classLoader.getResourceAsStream("versions.properties"))
+    load(classLoader.getResourceAsStream("versions.properties")!!)
     getProperty("detektVersion")
 }

--- a/detekt-report-html/src/main/kotlin/io/github/detekt/report/html/HtmlOutputReport.kt
+++ b/detekt-report-html/src/main/kotlin/io/github/detekt/report/html/HtmlOutputReport.kt
@@ -47,7 +47,7 @@ class HtmlOutputReport : OutputReport() {
     override val name = "HTML report"
 
     override fun render(detektion: Detektion) =
-        javaClass.getResource("/$DEFAULT_TEMPLATE")
+        javaClass.getResource("/$DEFAULT_TEMPLATE")!!
             .openStream()
             .bufferedReader()
             .use { it.readText() }

--- a/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/Resources.kt
+++ b/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/Resources.kt
@@ -10,9 +10,7 @@ internal object Resources
 
 fun resourceUrl(name: String): URL {
     val explicitName = if (name.startsWith("/")) name else "/$name"
-    val resource = Resources::class.java.getResource(explicitName)
-    requireNotNull(resource) { "Make sure the resource '$name' exists!" }
-    return resource
+    return requireNotNull(Resources::class.java.getResource(explicitName)) { "Make sure the resource '$name' exists!" }
 }
 
 fun resource(name: String): URI = resourceUrl(name).toURI()


### PR DESCRIPTION
`getResource` and `getResourceAsStream` can return a `null` value But they are java functions so the compiler doesn't complain about it.

This PR only shows clearly in the code where we could have a `NullPointerException`.