### PR TITLE
Simplify YamlConfig

### DIFF
--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/Configurations.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/Configurations.kt
@@ -2,6 +2,7 @@ package io.gitlab.arturbosch.detekt.core.config
 
 import io.github.detekt.tooling.api.spec.ConfigSpec
 import io.github.detekt.tooling.api.spec.ProcessingSpec
+import io.github.detekt.tooling.internal.openSafeStream
 import io.gitlab.arturbosch.detekt.api.Config
 import java.net.URI
 import java.net.URL
@@ -29,10 +30,10 @@ internal fun ProcessingSpec.loadConfiguration(): Config = with(configSpec) {
 
 private fun parseResourceConfig(urls: Collection<URL>): Config =
     if (urls.size == 1) {
-        YamlConfig.loadResource(urls.first())
+        YamlConfig.load(urls.first().openSafeStream().reader())
     } else {
         urls.asSequence()
-            .map { YamlConfig.loadResource(it) }
+            .map { YamlConfig.load(it.openSafeStream().reader()) }
             .reduce { composite, config -> CompositeConfig(config, composite) }
     }
 

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/Configurations.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/Configurations.kt
@@ -30,10 +30,10 @@ internal fun ProcessingSpec.loadConfiguration(): Config = with(configSpec) {
 
 private fun parseResourceConfig(urls: Collection<URL>): Config =
     if (urls.size == 1) {
-        YamlConfig.load(urls.first().openSafeStream().reader())
+        urls.first().openSafeStream().reader().use(YamlConfig::load)
     } else {
         urls.asSequence()
-            .map { YamlConfig.load(it.openSafeStream().reader()) }
+            .map { it.openSafeStream().reader().use(YamlConfig::load) }
             .reduce { composite, config -> CompositeConfig(config, composite) }
     }
 

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/DefaultConfig.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/DefaultConfig.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.core.config
 
+import io.github.detekt.tooling.internal.getSafeResourceAsStream
 import io.gitlab.arturbosch.detekt.api.Config
 
 internal object DefaultConfig {
@@ -7,7 +8,7 @@ internal object DefaultConfig {
     const val RESOURCE_NAME = "default-detekt-config.yml"
 
     fun newInstance(): Config {
-        val configUrl = javaClass.getResource("/$RESOURCE_NAME")!!
-        return YamlConfig.loadResource(configUrl)
+        val configReader = checkNotNull(javaClass.getSafeResourceAsStream("/$RESOURCE_NAME")).reader()
+        return YamlConfig.load(configReader)
     }
 }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/DefaultConfig.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/DefaultConfig.kt
@@ -8,7 +8,8 @@ internal object DefaultConfig {
     const val RESOURCE_NAME = "default-detekt-config.yml"
 
     fun newInstance(): Config {
-        val configReader = checkNotNull(javaClass.getSafeResourceAsStream("/$RESOURCE_NAME")).reader()
-        return YamlConfig.load(configReader)
+        return checkNotNull(javaClass.getSafeResourceAsStream("/$RESOURCE_NAME"))
+            .reader()
+            .use(YamlConfig::load)
     }
 }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/YamlConfig.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/YamlConfig.kt
@@ -7,7 +7,6 @@ import io.gitlab.arturbosch.detekt.api.Config.Companion.CONFIG_SEPARATOR
 import io.gitlab.arturbosch.detekt.api.Notification
 import org.yaml.snakeyaml.Yaml
 import java.io.Reader
-import java.net.URL
 import java.nio.file.Path
 
 /**
@@ -57,21 +56,6 @@ class YamlConfig internal constructor(
                     require(canRead()) { "Configuration must be readable: $path" }
                 }.reader()
             )
-
-        /**
-         * Factory method to load a yaml configuration from a URL.
-         */
-        fun loadResource(url: URL): Config = load(
-            url.openConnection()
-                /*
-                 * Due to https://bugs.openjdk.java.net/browse/JDK-6947916 and https://bugs.openjdk.java.net/browse/JDK-8155607,
-                 * it is necessary to disallow caches to maintain stability on JDK 8. Otherwise, simultaneous invocations of
-                 * Detekt in the same VM can fail spuriously. A similar bug is referenced in
-                 * https://github.com/detekt/detekt/issues/3396. The performance regression is likely unnoticeable.
-                 */
-                .apply { if (System.getProperty("java.specification.version") == "1.8") useCaches = false }
-                .getInputStream().reader()
-        )
 
         /**
          * Constructs a [YamlConfig] from any [Reader].

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/tooling/DefaultConfigProvider.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/tooling/DefaultConfigProvider.kt
@@ -1,6 +1,7 @@
 package io.gitlab.arturbosch.detekt.core.tooling
 
 import io.github.detekt.tooling.api.DefaultConfigurationProvider
+import io.github.detekt.tooling.internal.openSafeStream
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.core.config.DefaultConfig
 import java.nio.file.Files
@@ -13,6 +14,6 @@ class DefaultConfigProvider : DefaultConfigurationProvider {
 
     override fun copy(targetLocation: Path) {
         val configUrl = javaClass.getResource("/${DefaultConfig.RESOURCE_NAME}")!!
-        Files.copy(configUrl.openStream(), targetLocation, StandardCopyOption.REPLACE_EXISTING)
+        Files.copy(configUrl.openSafeStream(), targetLocation, StandardCopyOption.REPLACE_EXISTING)
     }
 }

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/YamlConfigSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/YamlConfigSpec.kt
@@ -3,6 +3,7 @@
 package io.gitlab.arturbosch.detekt.core.config
 
 import io.github.detekt.test.utils.resourceAsPath
+import io.github.detekt.tooling.internal.getSafeResourceAsStream
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.yamlConfig
 import io.gitlab.arturbosch.detekt.test.yamlConfigFromContent
@@ -58,11 +59,11 @@ class YamlConfigSpec : Spek({
     describe("loading empty configurations") {
 
         it("empty yaml file is equivalent to empty config") {
-            YamlConfig.loadResource(javaClass.getResource("/empty.yml"))
+            YamlConfig.load(javaClass.getSafeResourceAsStream("/empty.yml")!!.reader())
         }
 
         it("single item in yaml file is valid") {
-            YamlConfig.loadResource(javaClass.getResource("/oneitem.yml"))
+            YamlConfig.load(javaClass.getSafeResourceAsStream("/oneitem.yml")!!.reader())
         }
     }
 

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/YamlConfigSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/YamlConfigSpec.kt
@@ -59,11 +59,11 @@ class YamlConfigSpec : Spek({
     describe("loading empty configurations") {
 
         it("empty yaml file is equivalent to empty config") {
-            YamlConfig.load(javaClass.getSafeResourceAsStream("/empty.yml")!!.reader())
+            javaClass.getSafeResourceAsStream("/empty.yml")!!.reader().use(YamlConfig::load)
         }
 
         it("single item in yaml file is valid") {
-            YamlConfig.load(javaClass.getSafeResourceAsStream("/oneitem.yml")!!.reader())
+            javaClass.getSafeResourceAsStream("/oneitem.yml")!!.reader().use(YamlConfig::load)
         }
     }
 

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/Resources.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/Resources.kt
@@ -5,7 +5,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.core.config.YamlConfig
 import java.io.StringReader
 
-fun yamlConfig(name: String) = YamlConfig.loadResource(resource(name).toURL())
+fun yamlConfig(name: String) = YamlConfig.load(resource(name).toURL().openStream().reader())
 
 fun yamlConfigFromContent(content: String): Config =
     YamlConfig.load(StringReader(content.trimIndent()))

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/Resources.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/Resources.kt
@@ -5,7 +5,6 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.core.config.YamlConfig
 import java.io.StringReader
 
-fun yamlConfig(name: String) = YamlConfig.load(resource(name).toURL().openStream().reader())
+fun yamlConfig(name: String) = resource(name).toURL().openStream().reader().use(YamlConfig::load)
 
-fun yamlConfigFromContent(content: String): Config =
-    YamlConfig.load(StringReader(content.trimIndent()))
+fun yamlConfigFromContent(content: String): Config = StringReader(content.trimIndent()).use(YamlConfig::load)

--- a/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/internal/Resources.kt
+++ b/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/internal/Resources.kt
@@ -1,0 +1,20 @@
+package io.github.detekt.tooling.internal
+
+import java.io.InputStream
+import java.net.URL
+
+fun URL.openSafeStream(): InputStream {
+    return openConnection()
+        /*
+         * Due to https://bugs.openjdk.java.net/browse/JDK-6947916 and https://bugs.openjdk.java.net/browse/JDK-8155607,
+         * it is necessary to disallow caches to maintain stability on JDK 8. Otherwise, simultaneous invocations of
+         * Detekt in the same VM can fail spuriously. A similar bug is referenced in
+         * https://github.com/detekt/detekt/issues/3396. The performance regression is likely unnoticeable.
+         */
+        .apply { if (System.getProperty("java.specification.version") == "1.8") useCaches = false }
+        .getInputStream()
+}
+
+fun <T> Class<T>.getSafeResourceAsStream(name: String): InputStream? {
+    return getResource(name)?.openSafeStream()
+}


### PR DESCRIPTION
`YamlConfig.loadResource(URL)` is not needed as method. We can use `YamlConfig.load(Reader)` and convert the URLs to readers when calling.

This is part of the refactor to implement #4315