### PR TITLE
Add two new config steps for Compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ If you contributed to detekt but your name is not in the list, please feel free 
 - [Hans-Martin Schuller](https://github.com/hmSchuller) - Rule Improvement: ForbiddenComment
 - [Lukasz Osowicki](https://github.com/lukaszosowicki) - New rule: OutdatedDocumentation
 - [Luan Nico](https://github.com/luanpotter) - Bug fix for the UselessCallOnNotNull rule
+- [Tasha Ramesh](https://github.com/drinkthestars) - Docs around configuring for Compose
 
 ### Mentions
 

--- a/docs/pages/compose.md
+++ b/docs/pages/compose.md
@@ -23,8 +23,9 @@ fun FooButton(text: String, onClick: () -> Unit) { // Violation for FooButton()
 ```
 
 #### Configurations:
+Choose _either_ of the following options:
 
-* Augment default ``functionPattern`` to ``'([A-Za-z][a-zA-Z0-9]*)|(`.*`)'`` (default: ``'([a-z][a-zA-Z0-9]*)|(`.*`)'``) OR
+* Augment default ``functionPattern`` to ``'([A-Za-z][a-zA-Z0-9]*)|(`.*`)'`` (default: ``'([a-z][a-zA-Z0-9]*)|(`.*`)'``)
 * Set ``ignoreAnnotated`` to ``['Composable']``
 
 ### TopLevelPropertyNaming

--- a/docs/pages/compose.md
+++ b/docs/pages/compose.md
@@ -11,6 +11,22 @@ Relevant rule sets and their configuration options for Compose styles & usage. T
 - [Compose API Guidelines](https://github.com/androidx/androidx/blob/androidx-main/compose/docs/compose-api-guidelines.md)
 - [Compose source](https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:compose)
 
+### FunctionNaming
+
+See [FunctionNaming](https://detekt.github.io/detekt/naming.html#functionnaming).
+
+``@Composable`` functions that return ``Unit`` are named using ``PascalCase``. Detekt may see this as a violation:
+
+``` kotlin
+@Composable
+fun FooButton(text: String, onClick: () -> Unit) { // Violation for FooButton()
+```
+
+#### Configurations:
+
+* Augment default ``functionPattern`` to ``'([A-Za-z][a-zA-Z0-9]*)|(`.*`)'`` (default: ``'([a-z][a-zA-Z0-9]*)|(`.*`)'``) OR
+* Set ``ignoreAnnotated`` to ``['Composable']``
+
 ### TopLevelPropertyNaming
 
 See [TopLevelPropertyNaming](https://detekt.github.io/detekt/naming.html#toplevelpropertynaming).
@@ -66,3 +82,21 @@ class Foo {
 #### Configurations:
 
 * Set ``ignorePropertyDeclaration = true``, ``ignoreCompanionObjectPropertyDeclaration = true`` (default)
+
+### UnusedPrivateMember
+
+See [UnusedPrivateMember](https://detekt.github.io/detekt/style.html#unusedprivatemember).
+
+Detekt may see composable preview functions, i.e. those marked with ``@Preview``, as unused.
+
+``` kotlin
+@Preview
+@Composable
+private fun FooLazyColumnPreview() { // Violation for FooLazyColumnPreview()
+    FooLazyColumn()
+}
+```
+
+#### Configurations:
+
+* Set ``ignoreAnnotated`` to ``['Preview']``


### PR DESCRIPTION
### What
- Adds configuration steps for `FunctionNaming`, and `UnusedPrivateMember` to the `Configuration for Compose` section of the docs


### Why & Related
- Library-specific configurations were removed in https://github.com/detekt/detekt/pull/4101 which included the `FunctionName` ignore for `@Composable` functions, and an issue (https://github.com/detekt/detekt/issues/3944) was raised around that. Since we now have a page for Compose configurations, this crucial one can be added there
- This issue wasn't previously raised, but `@Preview` composables get flagged as unused. Hence this change shows a configuration option for that as well
- References `ignoreAnnotated ` from `1.19.0-RC1/RC2` 
