### PR TITLE
Avoid false positives in MemberNameEqualsClassName

### DIFF
--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MemberNameEqualsClassName.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MemberNameEqualsClassName.kt
@@ -113,12 +113,13 @@ class MemberNameEqualsClassName(config: Config = Config.empty) : Rule(config) {
                 val refName = (typeReference.typeElement as? KtUserType)?.referencedName ?: typeReference.text
                 refName == klass.name
             }
+            function.bodyExpression is KtBlockExpression -> false
             function.bodyExpression !is KtBlockExpression && bindingContext != BindingContext.EMPTY -> {
                 val functionDescriptor = bindingContext[BindingContext.FUNCTION, function]
                 val classDescriptor = bindingContext[BindingContext.DECLARATION_TO_DESCRIPTOR, klass]
                 functionDescriptor?.returnType?.constructor?.declarationDescriptor == classDescriptor
             }
-            else -> false
+            else -> true // We don't know if it is or not a factory. We assume it is a factory to avoid false-positives
         }
     }
 }

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MemberNameEqualsClassNameSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MemberNameEqualsClassNameSpec.kt
@@ -255,7 +255,7 @@ class MemberNameEqualsClassNameSpec : Spek({
                 assertThat(MemberNameEqualsClassName().compileAndLintWithContext(env, code)).isEmpty()
             }
 
-            it("doesn't report a body-less factory function") {
+            context("doesn't report a body-less factory function") {
                 val code = """
                     open class A {
                       companion object {
@@ -267,7 +267,14 @@ class MemberNameEqualsClassNameSpec : Spek({
 
                     class C: A()
                 """
-                assertThat(MemberNameEqualsClassName().compileAndLintWithContext(env, code)).isEmpty()
+
+                it("with type solving") {
+                    assertThat(MemberNameEqualsClassName().compileAndLintWithContext(env, code)).isEmpty()
+                }
+
+                it("without type solving") {
+                    assertThat(MemberNameEqualsClassName().compileAndLint(code)).isEmpty()
+                }
             }
         }
     }


### PR DESCRIPTION
If we can't infer if it's a factory or not assume that it's ok. False-negatives are better than false-positives.

This rule shoul be moved to type-solving only but that's a huge change that probably can be done for 2.0

fixes #4070