### PR TITLE
Add helper to check if a KtProperty is an "actual"

### DIFF
--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MayBeConst.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MayBeConst.kt
@@ -57,6 +57,8 @@ class MayBeConst(config: Config = Config.empty) : Rule(config) {
 
     private val topLevelConstants = HashSet<String?>()
     private val companionObjectConstants = HashSet<String?>()
+    private val KtProperty.isActual
+        get() = hasModifier(KtTokens.ACTUAL_KEYWORD)
 
     override fun visitKtFile(file: KtFile) {
         topLevelConstants.clear()
@@ -110,6 +112,7 @@ class MayBeConst(config: Config = Config.empty) : Rule(config) {
     private fun KtProperty.cannotBeConstant(): Boolean {
         return isLocal ||
             isVar ||
+            isActual ||
             getter != null ||
             isConstant() ||
             isOverride()

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MayBeConstSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MayBeConstSpec.kt
@@ -3,6 +3,7 @@ package io.gitlab.arturbosch.detekt.rules.style
 import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
@@ -303,6 +304,12 @@ class MayBeConstSpec : Spek({
                 """
                 )
 
+                assertThat(subject.findings).isEmpty()
+            }
+
+            it("does not report actual vals") {
+                // Until the [KotlinScriptEngine] can compile KMP, we will only lint.
+                subject.lint("""actual val abc123 = "abc123" """)
                 assertThat(subject.findings).isEmpty()
             }
         }


### PR DESCRIPTION
Small change to ignore said `actual val` properties when checking `MayBeConst` rule.

Fixes Issue #4330 