### PR TITLE
Enable ForbiddenMethodCall

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -164,6 +164,11 @@ style:
       - '@author'
       - '@requiresTypeResolution'
     excludes: ['**/detekt-rules-style/**/ForbiddenComment.kt']
+  ForbiddenMethodCall:
+    active: true
+    methods:
+      - 'kotlin.io.print'
+      - 'kotlin.io.println'
   ForbiddenVoid:
     active: true
   LibraryCodeMustSpecifyReturnType:

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -169,6 +169,8 @@ style:
     methods:
       - 'kotlin.io.print'
       - 'kotlin.io.println'
+      - 'java.net.URL.openStream()'
+      - 'java.lang.Class.getResourceAsStream()'
   ForbiddenVoid:
     active: true
   LibraryCodeMustSpecifyReturnType:

--- a/detekt-api/build.gradle.kts
+++ b/detekt-api/build.gradle.kts
@@ -10,6 +10,7 @@ plugins {
 dependencies {
     api(libs.kotlin.compilerEmbeddable)
     api(projects.detektPsiUtils)
+    implementation(projects.detektUtils)
 
     testImplementation(projects.detektTest)
     testImplementation(libs.bundles.testImplementation)

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/Versions.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/Versions.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.api.internal
 
+import io.github.detekt.utils.openSafeStream
 import io.gitlab.arturbosch.detekt.api.Extension
 import java.net.URL
 import java.util.jar.Manifest
@@ -18,7 +19,7 @@ fun whichJava(): String = System.getProperty("java.runtime.version")
  * Returns the bundled detekt version.
  */
 fun whichDetekt(): String? {
-    fun readVersion(resource: URL): String? = resource.openStream()
+    fun readVersion(resource: URL): String? = resource.openSafeStream()
         .use { Manifest(it).mainAttributes.getValue("DetektVersion") }
 
     return Extension::class.java.classLoader.getResources("META-INF/MANIFEST.MF")

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Main.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Main.kt
@@ -17,6 +17,7 @@ import kotlin.system.exitProcess
 
 fun main(args: Array<String>) {
     val result = CliRunner().run(args)
+    @Suppress("ForbiddenMethodCall")
     when (val error = result.error) {
         is InvalidConfig, is MaxIssuesReached -> println(error.message)
         is UnexpectedError -> {

--- a/detekt-core/build.gradle.kts
+++ b/detekt-core/build.gradle.kts
@@ -13,6 +13,7 @@ dependencies {
     implementation(projects.detektReportTxt)
     implementation(projects.detektReportXml)
     implementation(projects.detektReportSarif)
+    implementation(projects.detektUtils)
 
     testRuntimeOnly(projects.detektRules)
     testRuntimeOnly(projects.detektFormatting)

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/Configurations.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/Configurations.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.core.config
 
 import io.github.detekt.tooling.api.spec.ConfigSpec
 import io.github.detekt.tooling.api.spec.ProcessingSpec
-import io.github.detekt.tooling.internal.openSafeStream
+import io.github.detekt.utils.openSafeStream
 import io.gitlab.arturbosch.detekt.api.Config
 import java.net.URI
 import java.net.URL

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/DefaultConfig.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/DefaultConfig.kt
@@ -1,6 +1,6 @@
 package io.gitlab.arturbosch.detekt.core.config
 
-import io.github.detekt.tooling.internal.getSafeResourceAsStream
+import io.github.detekt.utils.getSafeResourceAsStream
 import io.gitlab.arturbosch.detekt.api.Config
 
 internal object DefaultConfig {

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/tooling/DefaultConfigProvider.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/tooling/DefaultConfigProvider.kt
@@ -1,7 +1,7 @@
 package io.gitlab.arturbosch.detekt.core.tooling
 
 import io.github.detekt.tooling.api.DefaultConfigurationProvider
-import io.github.detekt.tooling.internal.openSafeStream
+import io.github.detekt.utils.openSafeStream
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.core.config.DefaultConfig
 import java.nio.file.Files

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/CompositeConfigSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/CompositeConfigSpec.kt
@@ -47,8 +47,7 @@ class CompositeConfigSpec : Spek({
                 "is not of required type Boolean"
 
             assertThatThrownBy {
-                val value: Boolean = config.valueOrDefault("active", true)
-                println(value)
+                config.valueOrDefault("active", true)
             }.isInstanceOf(IllegalStateException::class.java)
                 .hasMessageContaining(expectedErrorMessage)
         }

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/YamlConfigSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/YamlConfigSpec.kt
@@ -3,7 +3,7 @@
 package io.gitlab.arturbosch.detekt.core.config
 
 import io.github.detekt.test.utils.resourceAsPath
-import io.github.detekt.tooling.internal.getSafeResourceAsStream
+import io.github.detekt.utils.getSafeResourceAsStream
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.yamlConfig
 import io.gitlab.arturbosch.detekt.test.yamlConfigFromContent

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/DetektPrinter.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/DetektPrinter.kt
@@ -10,9 +10,9 @@ import io.gitlab.arturbosch.detekt.generator.printer.defaultconfig.ConfigPrinter
 
 class DetektPrinter(private val arguments: GeneratorArgs) {
 
-    private val markdownWriter = MarkdownWriter()
-    private val yamlWriter = YamlWriter()
-    private val propertiesWriter = PropertiesWriter()
+    private val markdownWriter = MarkdownWriter(System.out)
+    private val yamlWriter = YamlWriter(System.out)
+    private val propertiesWriter = PropertiesWriter(System.out)
 
     fun print(pages: List<RuleSetPage>) {
         pages.forEach {

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/out/AbstractWriter.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/out/AbstractWriter.kt
@@ -1,9 +1,12 @@
 package io.gitlab.arturbosch.detekt.generator.out
 
+import java.io.PrintStream
 import java.nio.file.Files
 import java.nio.file.Path
 
-internal abstract class AbstractWriter {
+internal abstract class AbstractWriter(
+    private val outputPrinter: PrintStream,
+) {
 
     protected abstract val ending: String
 
@@ -15,21 +18,21 @@ internal abstract class AbstractWriter {
             }
         }
         Files.write(filePath, content().toByteArray())
-        println("Wrote: $filePath")
+        outputPrinter.println("Wrote: $filePath")
     }
 }
 
-internal class MarkdownWriter : AbstractWriter() {
+internal class MarkdownWriter(outputPrinter: PrintStream) : AbstractWriter(outputPrinter) {
 
     override val ending = "md"
 }
 
-internal class YamlWriter : AbstractWriter() {
+internal class YamlWriter(outputPrinter: PrintStream) : AbstractWriter(outputPrinter) {
 
     override val ending = "yml"
 }
 
-internal class PropertiesWriter : AbstractWriter() {
+internal class PropertiesWriter(outputPrinter: PrintStream) : AbstractWriter(outputPrinter) {
 
     override val ending = "properties"
 }

--- a/detekt-report-html/build.gradle.kts
+++ b/detekt-report-html/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
 dependencies {
     compileOnly(projects.detektApi)
     compileOnly(projects.detektMetrics)
+    implementation(projects.detektUtils)
     implementation(libs.kotlinx.html) {
         exclude(group = "org.jetbrains.kotlin")
     }

--- a/detekt-report-html/src/main/kotlin/io/github/detekt/report/html/HtmlOutputReport.kt
+++ b/detekt-report-html/src/main/kotlin/io/github/detekt/report/html/HtmlOutputReport.kt
@@ -2,6 +2,7 @@ package io.github.detekt.report.html
 
 import io.github.detekt.metrics.ComplexityReportGenerator
 import io.github.detekt.psi.toUnifiedString
+import io.github.detekt.utils.openSafeStream
 import io.gitlab.arturbosch.detekt.api.Detektion
 import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.api.OutputReport
@@ -48,7 +49,7 @@ class HtmlOutputReport : OutputReport() {
 
     override fun render(detektion: Detektion) =
         javaClass.getResource("/$DEFAULT_TEMPLATE")!!
-            .openStream()
+            .openSafeStream()
             .bufferedReader()
             .use { it.readText() }
             .replace(PLACEHOLDER_VERSION, renderVersion())

--- a/detekt-sample-extensions/src/main/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/reports/Reports.kt
+++ b/detekt-sample-extensions/src/main/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/reports/Reports.kt
@@ -5,7 +5,6 @@ import io.gitlab.arturbosch.detekt.sample.extensions.processors.fqNamesKey
 
 fun qualifiedNamesReport(detektion: Detektion): String? {
     val fqNames = detektion.getData(fqNamesKey)
-    println("fqNames: $fqNames")
     if (fqNames.isNullOrEmpty()) return null
 
     return with(StringBuilder()) {

--- a/detekt-test/build.gradle.kts
+++ b/detekt-test/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 dependencies {
     api(projects.detektApi)
     api(projects.detektTestUtils)
+    implementation(projects.detektUtils)
     compileOnly(libs.assertj)
     implementation(projects.detektCore)
     implementation(projects.detektParser)

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/Resources.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/Resources.kt
@@ -1,10 +1,11 @@
 package io.gitlab.arturbosch.detekt.test
 
 import io.github.detekt.test.utils.resource
+import io.github.detekt.utils.openSafeStream
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.core.config.YamlConfig
 import java.io.StringReader
 
-fun yamlConfig(name: String) = resource(name).toURL().openStream().reader().use(YamlConfig::load)
+fun yamlConfig(name: String) = resource(name).toURL().openSafeStream().reader().use(YamlConfig::load)
 
 fun yamlConfigFromContent(content: String): Config = StringReader(content.trimIndent()).use(YamlConfig::load)

--- a/detekt-utils/build.gradle.kts
+++ b/detekt-utils/build.gradle.kts
@@ -1,0 +1,3 @@
+plugins {
+    id("module")
+}

--- a/detekt-utils/src/main/kotlin/io/github/detekt/utils/Resources.kt
+++ b/detekt-utils/src/main/kotlin/io/github/detekt/utils/Resources.kt
@@ -1,4 +1,4 @@
-package io.github.detekt.tooling.internal
+package io.github.detekt.utils
 
 import java.io.InputStream
 import java.net.URL

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -33,6 +33,7 @@ include("detekt-sample-extensions")
 include("detekt-test")
 include("detekt-test-utils")
 include("detekt-tooling")
+include("detekt-utils")
 
 enableFeaturePreview("VERSION_CATALOGS")
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")


### PR DESCRIPTION
This PR enables `ForbiddenMethodCall` by default and then it adds `Url.openStream` and `Class.getResourceAsStream` to the list.

We need to add support to a description for each forbidden method. If someone in one year find this will now know about the existence of the "safe" version.

---

I'm creating a new module `detekt-utils`. The problem is that `detekt-tooling` are toolings related with the compiler and I couldn't add it anywhere becuase I was introducting circular dependenciees. This `detekt-utils` is a more basic module. Right now it only contains one file to avoid those extrange behaviours when using `Url.openStream()` and `Class.openResourceAsStream()`.

I'm not a big fan to create another module but I don't know how to fix this otherwise.