### PR TITLE
trim values when parsing the baseline

### DIFF
--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineHandler.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineHandler.kt
@@ -33,8 +33,8 @@ internal class BaselineHandler : DefaultHandler() {
             ID -> {
                 check(content.isNotBlank()) { "The content of the ID element must not be empty" }
                 when (current) {
-                    MANUALLY_SUPPRESSED_ISSUES -> manuallySuppressedIssues.add(content)
-                    CURRENT_ISSUES -> currentIssues.add(content)
+                    MANUALLY_SUPPRESSED_ISSUES -> manuallySuppressedIssues.add(content.trim())
+                    CURRENT_ISSUES -> currentIssues.add(content.trim())
                 }
                 content = ""
             }

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineFilteredResultSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineFilteredResultSpec.kt
@@ -1,7 +1,6 @@
 package io.gitlab.arturbosch.detekt.core.baseline
 
 import io.github.detekt.test.utils.resourceAsPath
-import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.test.TestDetektion
 import io.mockk.every
 import io.mockk.mockk
@@ -15,14 +14,14 @@ class BaselineFilteredResultSpec : Spek({
 
         val baselineFile = resourceAsPath("/baseline_feature/valid-baseline.xml")
 
-        val finding by memoized {
-            val issue = mockk<Finding>()
-            every { issue.id }.returns("LongParameterList")
-            every { issue.signature }.returns("Signature")
-            issue
+        val result by memoized {
+            TestDetektion(
+                mockk {
+                    every { id }.returns("LongParameterList")
+                    every { signature }.returns("Signature")
+                },
+            )
         }
-
-        val result by memoized { TestDetektion(finding) }
 
         it("does return the same finding on empty baseline") {
             val actual = BaselineFilteredResult(result, Baseline(emptySet(), emptySet()))

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineFilteredResultSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineFilteredResultSpec.kt
@@ -20,12 +20,20 @@ class BaselineFilteredResultSpec : Spek({
                     every { id }.returns("LongParameterList")
                     every { signature }.returns("Signature")
                 },
+                mockk {
+                    every { id }.returns("LongMethod")
+                    every { signature }.returns("Signature")
+                },
+                mockk {
+                    every { id }.returns("FeatureEnvy")
+                    every { signature }.returns("Signature")
+                },
             )
         }
 
         it("does return the same finding on empty baseline") {
             val actual = BaselineFilteredResult(result, Baseline(emptySet(), emptySet()))
-            assertThat(actual.findings).hasSize(1)
+            assertThat(actual.findings).hasSize(3)
         }
 
         it("filters with an existing baseline file") {
@@ -33,7 +41,7 @@ class BaselineFilteredResultSpec : Spek({
             val actual = BaselineFilteredResult(result, baseline)
             // Note: Detektion works with Map<RuleSetId, List<Finding>
             // but the TestDetektion maps the RuleId as RuleSetId
-            assertThat(actual.findings["LongParameterList"]).isEmpty()
+            actual.findings.forEach { (_, value) -> assertThat(value).isEmpty() }
         }
     }
 })

--- a/detekt-core/src/test/resources/baseline_feature/valid-baseline.xml
+++ b/detekt-core/src/test/resources/baseline_feature/valid-baseline.xml
@@ -5,6 +5,8 @@
         <ID>LongMethod:Signature</ID>
     </ManuallySuppressedIssues>
     <CurrentIssues>
-        <ID>FeatureEnvy:Signature</ID>
+        <ID>
+            FeatureEnvy:Signature
+        </ID>
     </CurrentIssues>
 </SmellBaseline>


### PR DESCRIPTION
Out baseline should treat this:
```xml
<ID>
  FeatureEnvy:Signature
</ID>
```
The same way it treats:
```xml
<ID>FeatureEnvy:Signature</ID>
```

This PR ensures that.