### PR TITLE
Reference CLI options doc for details of type resolution CLI flags

### DIFF
--- a/docs/pages/gettingstarted/type-resolution.md
+++ b/docs/pages/gettingstarted/type-resolution.md
@@ -82,18 +82,8 @@ Gradle plugins from configuring Android-specific gradle tasks.
 
 ## Enabling on Detekt CLI
 
-If you're using [Detekt via CLI](cli.md), type resolution will be enabled only if you provide the following flags:
-
-```
-    --classpath, -cp
-      EXPERIMENTAL: Paths where to find user class files and depending jar
-      files. Used for type resolution.
-    --jvm-target
-      EXPERIMENTAL: Target version of the generated JVM bytecode that was 
-      generated during compilation and is now being used for type resolution 
-      (1.6, 1.8, 9, 10, 11, 12, 13, 14, 15 or 16)
-      Default: 1.8
-```
+If you're using [Detekt via CLI](cli.md), type resolution will be enabled only if you provide the `--classpath` and
+`--jvm-target` flags. See the list of [CLI options](cli-options.md) for details.
 
 ## Writing a rule that uses type resolution
 


### PR DESCRIPTION
This avoids having to update the sample output for `--jvm-target` manually.