### PR TITLE
Use major version tag for github-pages-deploy-action

### DIFF
--- a/.github/workflows/deploy-website.yaml
+++ b/.github/workflows/deploy-website.yaml
@@ -98,7 +98,7 @@ jobs:
       working-directory: docs/
 
     - name: Deploy Github Pages
-      uses: JamesIves/github-pages-deploy-action@4.1.7
+      uses: JamesIves/github-pages-deploy-action@v4
       with:
         branch: gh-pages
         folder: docs/_site/


### PR DESCRIPTION
This slightly reduces workload as we don't need to make a new update for every new point release. This aligns to what we do for other GitHub actions.

https://github.com/detekt/detekt/pull/4309#issuecomment-975630789