### PR TITLE
Revert "Use major version tag for github-pages-deploy-action"

### DIFF
--- a/.github/workflows/deploy-website.yaml
+++ b/.github/workflows/deploy-website.yaml
@@ -98,7 +98,7 @@ jobs:
       working-directory: docs/
 
     - name: Deploy Github Pages
-      uses: JamesIves/github-pages-deploy-action@v4
+      uses: JamesIves/github-pages-deploy-action@4.1.7
       with:
         branch: gh-pages
         folder: docs/_site/


### PR DESCRIPTION
Reverts detekt/detekt#4342

I learned today that using the major version tag (`v4` in this case) relies on the maintainer of the action tagging a release with the major version tag. That's not being done by this action's maintainer, so version `v4` is not being resolved, so GH pages are not being published as the action isn't running. We will have to continue pinning a specific version of this action.