### PR TITLE
UnusedPrivateMember should not report external classes/interfaces

### DIFF
--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
@@ -217,6 +217,7 @@ private class UnusedParameterVisitor(allowedNames: Regex) : UnusedMemberVisitor(
 
     override fun visitClass(klass: KtClass) {
         if (klass.isInterface()) return
+        if (klass.isExternal()) return
 
         super.visitClass(klass)
     }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMemberSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMemberSpec.kt
@@ -133,19 +133,9 @@ class UnusedPrivateMemberSpec : Spek({
             val code = """
                 external class Bugsnag {
                     companion object {
-                        fun start()
-                        fun notify()
+                        fun start(value: Int)
+                        fun notify(error: String)
                     }
-                }
-                """
-            assertThat(subject.lint(code)).isEmpty()
-        }
-
-        it("should not report functions in external interfaces") {
-            val code = """
-                external interface BugsnagParams {
-                    val apiKey: String
-                    val appVersion: String
                 }
                 """
             assertThat(subject.lint(code)).isEmpty()

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMemberSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMemberSpec.kt
@@ -127,6 +127,31 @@ class UnusedPrivateMemberSpec : Spek({
         }
     }
 
+    describe("external classes") {
+
+        it("should not report functions in external classes") {
+            val code = """
+                external class Bugsnag {
+                    companion object {
+                        fun start()
+                        fun notify()
+                    }
+                }
+                """
+            assertThat(subject.lint(code)).isEmpty()
+        }
+
+        it("should not report functions in external interfaces") {
+            val code = """
+                external interface BugsnagParams {
+                    val apiKey: String
+                    val appVersion: String
+                }
+                """
+            assertThat(subject.lint(code)).isEmpty()
+        }
+    }
+
     describe("protected functions") {
 
         it("should not report parameters in protected functions") {


### PR DESCRIPTION
Fixes #4340 
