### PR TITLE
Fix false positive in RethrowCaughtException for try with more than one catch (#4367)

### DIFF
--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/RethrowCaughtExceptionSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/RethrowCaughtExceptionSpec.kt
@@ -22,6 +22,21 @@ class RethrowCaughtExceptionSpec : Spek({
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
+        it("does not report when the other exception is rethrown with same name") {
+            val code = """
+                class A {
+                    private lateinit var e: Exception
+                    fun f() {
+                        try {
+                        } catch (e: IllegalStateException) {
+                            throw this.e
+                        }
+                    }
+                }
+            """
+            assertThat(subject.compileAndLint(code)).isEmpty()
+        }
+
         it("reports when the same exception succeeded by dead code is rethrown") {
             val code = """
                 fun f() {
@@ -107,6 +122,79 @@ class RethrowCaughtExceptionSpec : Spek({
                 }
             """
             assertThat(subject.compileAndLint(code)).isEmpty()
+        }
+
+        it("does not report when exception rethrown only in first catch") {
+            val code = """
+                fun f() {
+                    try {
+                    } catch (e: IllegalStateException) {
+                        throw e
+                    } catch (e: Exception) {
+                        print(e)
+                    }
+                }
+            """
+            assertThat(subject.compileAndLint(code)).isEmpty()
+        }
+
+        it("does not report when some work is done in last catch") {
+            val code = """
+                fun f() {
+                    try {
+                    } catch (e: IllegalStateException) {
+                        throw e
+                    } catch (e: Exception) {
+                        print(e)
+                        throw e
+                    }
+                }
+            """
+            assertThat(subject.compileAndLint(code)).isEmpty()
+        }
+
+        it("does not report when there is no catch clauses") {
+            val code = """
+                fun f() {
+                    try {
+                    } finally {
+                    }
+                }
+            """
+            assertThat(subject.compileAndLint(code)).isEmpty()
+        }
+
+        it("reports when exception rethrown in last catch") {
+            val code = """
+                fun f() {
+                    try {
+                    } catch (e: IllegalStateException) {
+                        print(e)
+                    } catch (e: Exception) {
+                        throw e
+                    }
+                }
+            """
+            assertThat(subject.compileAndLint(code)).hasSize(1)
+        }
+
+        it("reports 2 violations for each catch") {
+            val code = """
+                fun f() {
+                    try {
+                    } catch (e: IllegalStateException) {
+                        throw e
+                    } catch (e: Exception) {
+                        // some comment
+                        throw e
+                    }
+                }
+            """
+            val result = subject.compileAndLint(code)
+            assertThat(result).hasSize(2)
+            // ensure correct violation order
+            assertThat(result[0].startPosition.line == 4).isTrue
+            assertThat(result[1].startPosition.line == 7).isTrue
         }
     }
 })


### PR DESCRIPTION
Closes #4367 

1. Fixes false positive
2. One more test input is added (when same exception is thrown but with `this` qualifier)