### PR TITLE
Completely-empty abstract classes will now be flagged by UnnecessaryAbstractClass

### DIFF
--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAbstractClass.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAbstractClass.kt
@@ -78,7 +78,7 @@ class UnnecessaryAbstractClass(config: Config = Config.empty) : Rule(config) {
                 val namedMembers = body.children.filterIsInstance<KtNamedDeclaration>()
                 val namedClassMembers = NamedClassMembers(klass, namedMembers)
                 namedClassMembers.detectAbstractAndConcreteType()
-            } else if (klass.superTypeListEntries.isEmpty() && klass.hasConstructorParameter()) {
+            } else if (klass.superTypeListEntries.isEmpty()) {
                 report(CodeSmell(issue, Entity.from(klass), noAbstractMember), klass)
             }
         }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAbstractClassSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAbstractClassSpec.kt
@@ -52,6 +52,16 @@ class UnnecessaryAbstractClassSpec : Spek({
                 assertThat(subject.compileAndLintWithContext(env, code)).hasSize(2)
             }
 
+            it("does not report a completely-empty abstract class that inherits from an interface") {
+                val code = """
+                    interface A {
+                        val i: Int
+                    }
+                    abstract class B : A
+                """.trimIndent()
+                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            }
+
             it("does not report an abstract class with concrete members derived from a base class") {
                 val code = """
                     abstract class A {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAbstractClassSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAbstractClassSpec.kt
@@ -44,6 +44,14 @@ class UnnecessaryAbstractClassSpec : Spek({
                 )
             }
 
+            it("reports completely-empty abstract classes") {
+                val code = """
+                    abstract class A
+                    abstract class B()
+                """
+                assertThat(subject.compileAndLintWithContext(env, code)).hasSize(2)
+            }
+
             it("does not report an abstract class with concrete members derived from a base class") {
                 val code = """
                     abstract class A {
@@ -187,14 +195,6 @@ class UnnecessaryAbstractClassSpec : Spek({
                     interface Interface {
                         fun f()
                     }
-                """
-                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
-            }
-
-            it("does not report empty abstract classes") {
-                val code = """
-                    abstract class A
-                    abstract class B()
                 """
                 assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
             }


### PR DESCRIPTION
This resolves issue #4357