### PR TITLE
Allow a function to declare a Unit return type when it uses a generic function initializer

### DIFF
--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/OptionalUnit.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/OptionalUnit.kt
@@ -113,7 +113,8 @@ class OptionalUnit(config: Config = Config.empty) : Rule(config) {
     private fun checkFunctionWithExplicitReturnType(function: KtNamedFunction, typeReference: KtTypeReference) {
         val typeElementText = typeReference.typeElement?.text
         if (typeElementText == UNIT) {
-            if (function.initializer.isGenericOrNothingType()) return
+            val initializer = function.initializer
+            if (initializer?.isGenericOrNothingType() == true) return
             report(CodeSmell(issue, Entity.from(typeReference), createMessage(function)))
         }
     }
@@ -128,10 +129,10 @@ class OptionalUnit(config: Config = Config.empty) : Rule(config) {
     private fun createMessage(function: KtNamedFunction) = "The function ${function.name} " +
         "defines a return type of Unit. This is unnecessary and can safely be removed."
 
-    private fun KtExpression?.isGenericOrNothingType(): Boolean {
+    private fun KtExpression.isGenericOrNothingType(): Boolean {
         if (bindingContext == BindingContext.EMPTY) return false
-        val isGenericType = this?.getResolvedCall(bindingContext)?.getReturnType()?.isTypeParameter() == true
-        val isNothingType = this?.getType(bindingContext)?.isNothing() == true
+        val isGenericType = getResolvedCall(bindingContext)?.getReturnType()?.isTypeParameter() == true
+        val isNothingType = getType(bindingContext)?.isNothing() == true
         // Either the function initializer returns Nothing or it is a generic function
         // into which Unit is passed, but not both.
         return (isGenericType && !isNothingType) || (isNothingType && !isGenericType)

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/OptionalUnitSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/OptionalUnitSpec.kt
@@ -346,6 +346,14 @@ class OptionalUnitSpec : Spek({
                 assertThat(findings).isEmpty()
             }
 
+            it("should report when it cannot resolve the initializer call") {
+                val code = """
+                    fun doFoo(): Unit = unknownCall {}
+                """.trimIndent()
+                val findings = subject.compileAndLintWithContext(env, code)
+                assertThat(findings).hasSize(1)
+            }
+
             it("should report on function initializers when there is no context") {
                 val code = """
                     fun test(): Unit = throw UnsupportedOperationException()

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/OptionalUnitSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/OptionalUnitSpec.kt
@@ -346,14 +346,6 @@ class OptionalUnitSpec : Spek({
                 assertThat(findings).isEmpty()
             }
 
-            it("should report when it cannot resolve the initializer call") {
-                val code = """
-                    fun doFoo(): Unit = unknownCall {}
-                """.trimIndent()
-                val findings = subject.compileAndLintWithContext(env, code)
-                assertThat(findings).hasSize(1)
-            }
-
             it("should report on function initializers when there is no context") {
                 val code = """
                     fun test(): Unit = throw UnsupportedOperationException()

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/OptionalUnitSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/OptionalUnitSpec.kt
@@ -333,5 +333,13 @@ class OptionalUnitSpec : Spek({
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
+
+        it("should report when a function has an explicit Unit return type with context") {
+            val code = """
+                fun foo(): Unit { }
+            """.trimIndent()
+            val findings = subject.compileAndLintWithContext(env, code)
+            assertThat(findings).hasSize(1)
+        }
     }
 })

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/OptionalUnitSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/OptionalUnitSpec.kt
@@ -18,6 +18,21 @@ class OptionalUnitSpec : Spek({
     val env: KotlinCoreEnvironment by memoized()
 
     describe("OptionalUnit rule") {
+        it("should report when a function has an explicit Unit return type with context") {
+            val code = """
+                fun foo(): Unit { }
+            """.trimIndent()
+            val findings = subject.compileAndLintWithContext(env, code)
+            assertThat(findings).hasSize(1)
+        }
+
+        it("should not report when a function has a non-unit body expression") {
+            val code = """
+                fun foo() = String
+            """.trimIndent()
+            val findings = subject.compileAndLintWithContext(env, code)
+            assertThat(findings).isEmpty()
+        }
 
         context("several functions which return Unit") {
 
@@ -296,50 +311,72 @@ class OptionalUnitSpec : Spek({
                 val findings = subject.compileAndLintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }
+
+            it("another object is used as the last expression") {
+                val code = """
+                    fun foo() {
+                        String
+                    }
+                """.trimIndent()
+                val findings = subject.compileAndLintWithContext(env, code)
+                assertThat(findings).isEmpty()
+            }
         }
 
-        it("should not report when function initializer is Nothing") {
-            val code = """
+        context("function initializers") {
+            it("should not report when function initializer is Nothing") {
+                val code = """
                     fun test(): Unit = throw UnsupportedOperationException()
                 """
-            val findings = subject.compileAndLintWithContext(env, code)
-            assertThat(findings).isEmpty()
-        }
+                val findings = subject.compileAndLintWithContext(env, code)
+                assertThat(findings).isEmpty()
+            }
 
-        it("should not report when the function initializer requires a type") {
-            val code = """
-                fun <T> foo(block: (List<T>) -> Unit): T {
-                    val list = listOf<T>()
-                    block(list)
-                    return list.first()
-                }
+            it("should not report when the function initializer requires a type") {
+                val code = """
+                    fun <T> foo(block: (List<T>) -> Unit): T {
+                        val list = listOf<T>()
+                        block(list)
+                        return list.first()
+                    }
+    
+                    fun doFoo(): Unit = foo {}
+                """.trimIndent()
+                val findings = subject.compileAndLintWithContext(env, code)
+                assertThat(findings).isEmpty()
+            }
 
-                fun doFoo(): Unit = foo {}
-            """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
-            assertThat(findings).isEmpty()
-        }
+            it("should report on function initializers when there is no context") {
+                val code = """
+                    fun test(): Unit = throw UnsupportedOperationException()
+                """
+                val findings = subject.compileAndLint(code)
+                assertThat(findings).hasSize(1)
+            }
 
-        it("should report when the function initializer takes in the type Nothing") {
-            val code = """
-                fun <T> foo(block: (List<T>) -> Unit): T {
-                    val list = listOf<T>()
-                    block(list)
-                    return list.first()
-                }
+            it("should report when the function initializer takes in the type Nothing") {
+                val code = """
+                    fun <T> foo(block: (List<T>) -> Unit): T {
+                        val list = listOf<T>()
+                        block(list)
+                        return list.first()
+                    }
+    
+                    fun doFoo(): Unit = foo<Nothing> {}
+                """.trimIndent()
+                val findings = subject.compileAndLintWithContext(env, code)
+                assertThat(findings).hasSize(1)
+            }
 
-                fun doFoo(): Unit = foo<Nothing> {}
-            """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
-            assertThat(findings).hasSize(1)
-        }
-
-        it("should report when a function has an explicit Unit return type with context") {
-            val code = """
-                fun foo(): Unit { }
-            """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
-            assertThat(findings).hasSize(1)
+            it("should report when the function initializer does not provide a different type") {
+                val code = """
+                    fun foo() {}
+                    
+                    fun doFoo(): Unit = foo()
+                """.trimIndent()
+                val findings = subject.compileAndLintWithContext(env, code)
+                assertThat(findings).hasSize(1)
+            }
         }
     }
 })

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/OptionalUnitSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/OptionalUnitSpec.kt
@@ -305,5 +305,19 @@ class OptionalUnitSpec : Spek({
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
+
+        it("should not report when the function initializer requires a type") {
+            val code = """
+                fun <T> foo(block: (List<T>) -> Unit): T {
+                    val list = listOf<T>()
+                    block(list)
+                    return list.first()
+                }
+
+                fun doFoo(): Unit = foo {}
+            """.trimIndent()
+            val findings = subject.compileAndLintWithContext(env, code)
+            assertThat(findings).isEmpty()
+        }
     }
 })

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/OptionalUnitSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/OptionalUnitSpec.kt
@@ -319,5 +319,19 @@ class OptionalUnitSpec : Spek({
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
+
+        it("should report when the function initializer takes in the type Nothing") {
+            val code = """
+                fun <T> foo(block: (List<T>) -> Unit): T {
+                    val list = listOf<T>()
+                    block(list)
+                    return list.first()
+                }
+
+                fun doFoo(): Unit = foo<Nothing> {}
+            """.trimIndent()
+            val findings = subject.compileAndLintWithContext(env, code)
+            assertThat(findings).hasSize(1)
+        }
     }
 })


### PR DESCRIPTION
This addresses issue #4363.