### PR TITLE
Created new rule class that allows for configurable debt time

### DIFF
--- a/detekt-api/api/detekt-api.api
+++ b/detekt-api/api/detekt-api.api
@@ -344,6 +344,30 @@ public final class io/gitlab/arturbosch/detekt/api/Issue {
 	public fun toString ()Ljava/lang/String;
 }
 
+public abstract class io/gitlab/arturbosch/detekt/api/IssueConfigurableRule : io/gitlab/arturbosch/detekt/api/BaseRule, io/gitlab/arturbosch/detekt/api/ConfigAware {
+	public fun <init> ()V
+	public fun <init> (Lio/gitlab/arturbosch/detekt/api/Config;Lio/gitlab/arturbosch/detekt/api/Context;)V
+	public synthetic fun <init> (Lio/gitlab/arturbosch/detekt/api/Config;Lio/gitlab/arturbosch/detekt/api/Context;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun getActive ()Z
+	public final fun getAliases ()Ljava/util/Set;
+	public fun getAutoCorrect ()Z
+	public abstract fun getDefaultDebt ()Lio/gitlab/arturbosch/detekt/api/Debt;
+	public fun getDefaultRuleIdAliases ()Ljava/util/Set;
+	public abstract fun getDescription ()Ljava/lang/String;
+	public fun getFilters ()Lio/gitlab/arturbosch/detekt/api/internal/PathFilters;
+	public final fun getIssue ()Lio/gitlab/arturbosch/detekt/api/Issue;
+	public fun getParentPath ()Ljava/lang/String;
+	public fun getRuleSetConfig ()Lio/gitlab/arturbosch/detekt/api/Config;
+	public abstract fun getSeverity ()Lio/gitlab/arturbosch/detekt/api/Severity;
+	public final fun report (Lio/gitlab/arturbosch/detekt/api/Finding;)V
+	public final fun report (Ljava/util/List;)V
+	public fun subConfig (Ljava/lang/String;)Lio/gitlab/arturbosch/detekt/api/Config;
+	public fun valueOrDefault (Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun valueOrNull (Ljava/lang/String;)Ljava/lang/Object;
+	public fun visitCondition (Lorg/jetbrains/kotlin/psi/KtFile;)Z
+	public fun withAutoCorrect (Lkotlin/jvm/functions/Function0;)V
+}
+
 public final class io/gitlab/arturbosch/detekt/api/LazyRegex : kotlin/properties/ReadOnlyProperty {
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
 	public fun getValue (Lio/gitlab/arturbosch/detekt/api/Rule;Lkotlin/reflect/KProperty;)Lkotlin/text/Regex;

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/IssueConfigurableRule.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/IssueConfigurableRule.kt
@@ -4,8 +4,8 @@ import io.gitlab.arturbosch.detekt.api.internal.DefaultContext
 import io.gitlab.arturbosch.detekt.api.internal.PathFilters
 import io.gitlab.arturbosch.detekt.api.internal.createPathFilters
 import io.gitlab.arturbosch.detekt.api.internal.isSuppressedBy
-import java.util.Locale
 import org.jetbrains.kotlin.psi.KtFile
+import java.util.Locale
 
 /**
  * A rule defines how one specific code structure should look like. If code is found
@@ -43,9 +43,6 @@ abstract class IssueConfigurableRule(
      */
     val issue: Issue by lazy { Issue(ruleId, severity, description, debt) }
 
-    /**
-     * The amount of debt time that is to be assigned to infractions of the rule.
-     */
     private val debt: Debt
         get() = valueOrNull<Int>("debt")
             ?.let { Debt(mins = it) }

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/IssueConfigurableRule.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/IssueConfigurableRule.kt
@@ -1,0 +1,117 @@
+package io.gitlab.arturbosch.detekt.api
+
+import io.gitlab.arturbosch.detekt.api.internal.DefaultContext
+import io.gitlab.arturbosch.detekt.api.internal.PathFilters
+import io.gitlab.arturbosch.detekt.api.internal.createPathFilters
+import io.gitlab.arturbosch.detekt.api.internal.isSuppressedBy
+import java.util.*
+import org.jetbrains.kotlin.psi.KtFile
+
+/**
+ * A rule defines how one specific code structure should look like. If code is found
+ * which does not meet this structure, it is considered as harmful regarding maintainability
+ * or readability.
+ *
+ * A rule is implemented using the visitor pattern and should be started using the visit(KtFile)
+ * function. If calculations must be done before or after the visiting process, here are
+ * two predefined (preVisit/postVisit) functions which can be overridden to setup/teardown additional data.
+ */
+abstract class IssueConfigurableRule(
+    override val ruleSetConfig: Config = Config.empty,
+    ruleContext: Context = DefaultContext()
+) : BaseRule(ruleContext), ConfigAware {
+
+    /**
+     * The grade of severity of the code that violates the defined rule.
+     */
+    abstract val severity: Severity
+
+    /**
+     * A brief outline of the rule.
+     */
+    abstract val description: String
+
+    /**
+     * The amount of debt time that is to be assigned to infractions of the rule
+     * provided that no configuration is provided for debt time in the rule's
+     * configuration entry.
+     */
+    abstract val defaultDebt: Debt
+
+    /**
+     * A rule is motivated to point out a specific issue in the code base.
+     */
+    val issue: Issue by lazy { Issue(ruleId, severity, description, debt) }
+
+    /**
+     * The amount of debt time that is to be assigned to infractions of the rule.
+     */
+    private val debt: Debt
+        get() = valueOrNull<Int>("debt")
+            ?.let { Debt(mins = it) }
+            ?: defaultDebt
+
+    /**
+     * List of rule ids which can optionally be used in suppress annotations to refer to this rule.
+     */
+    val aliases: Set<String> get() = valueOrDefault("aliases", defaultRuleIdAliases)
+
+    /**
+     * The default names which can be used instead of this [ruleId] to refer to this rule in suppression's.
+     *
+     * When overriding this property make sure to meet following structure for detekt-generator to pick
+     * it up and generate documentation for aliases:
+     *
+     *      override val defaultRuleIdAliases = setOf("Name1", "Name2")
+     */
+    open val defaultRuleIdAliases: Set<String> = emptySet()
+
+    internal val ruleSetId: RuleId? get() = ruleSetConfig.parentPath
+
+    /**
+     * Rules are aware of the paths they should run on via configuration properties.
+     */
+    open val filters: PathFilters? by lazy(LazyThreadSafetyMode.NONE) {
+        createPathFilters()
+    }
+
+    override fun visitCondition(root: KtFile): Boolean =
+        active && shouldRunOnGivenFile(root) && !root.isSuppressedBy(ruleId, aliases, ruleSetId)
+
+    private fun shouldRunOnGivenFile(root: KtFile) =
+        filters?.isIgnored(root)?.not() ?: true
+
+    /**
+     * Compute severity in the priority order:
+     * - Severity of the rule
+     * - Severity of the parent ruleset
+     * - Default severity: warning
+     */
+    private fun computeSeverity(): SeverityLevel {
+        val configValue: String = valueOrNull(Config.SEVERITY_KEY)
+            ?: ruleSetConfig.valueOrDefault(Config.SEVERITY_KEY, "warning")
+        return enumValueOf(configValue.toUpperCase(Locale.US))
+    }
+
+    /**
+     * Simplified version of [Context.report] with rule defaults.
+     */
+    fun report(finding: Finding) {
+        (finding as? CodeSmell)?.internalSeverity = computeSeverity()
+        report(finding, aliases, ruleSetId)
+    }
+
+    /**
+     * Simplified version of [Context.report] with rule defaults.
+     */
+    fun report(findings: List<Finding>) {
+        findings.forEach {
+            (it as? CodeSmell)?.internalSeverity = computeSeverity()
+        }
+        report(
+            findings,
+            aliases,
+            ruleSetId
+        )
+    }
+}

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/IssueConfigurableRule.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/IssueConfigurableRule.kt
@@ -4,7 +4,7 @@ import io.gitlab.arturbosch.detekt.api.internal.DefaultContext
 import io.gitlab.arturbosch.detekt.api.internal.PathFilters
 import io.gitlab.arturbosch.detekt.api.internal.createPathFilters
 import io.gitlab.arturbosch.detekt.api.internal.isSuppressedBy
-import java.util.*
+import java.util.Locale
 import org.jetbrains.kotlin.psi.KtFile
 
 /**

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/rules/IssueConfigurableRuleSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/rules/IssueConfigurableRuleSpec.kt
@@ -1,0 +1,35 @@
+package io.gitlab.arturbosch.detekt.core.rules
+
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.IssueConfigurableRule
+import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.test.TestConfig
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+class IssueConfigurableRuleSpec : Spek({
+
+    val id by memoized { "TestRule" }
+    val description by memoized { "A Test Rule" }
+    val debt by memoized { "debt" }
+
+    fun createRule(config: TestConfig) = object : IssueConfigurableRule(config) {
+        override val ruleId = id
+        override val severity = Severity.Defect
+        override val description = description
+        override val defaultDebt = Debt.FIVE_MINS
+    }
+
+    describe("IssueConfigurableRule") {
+        it("should produce an issue that uses a default debt when no configuration is found") {
+            val config = TestConfig()
+            val testRule = createRule(config)
+            assert(testRule.issue.debt == Debt.FIVE_MINS)
+        }
+        it("should produce an issue with a configured debt of 20 minutes") {
+            val config = TestConfig(mapOf(debt to 20))
+            val testRule = createRule(config)
+            assert(testRule.issue.debt == Debt.TWENTY_MINS)
+        }
+    }
+})


### PR DESCRIPTION
This is a proposal for issue #4359. The advantage of this implementation is that it removes the run-time restriction that the fields of `Rule.issue` are not configurable due to an already-instantiated `Issue` instance being needed for its `id` field to look up configuration values. If some iteration of this class is approved, the next step could be to proceed to replace the rules in the Detekt codebase section by section with the new class, after which the original `Rule` class could be marked as `@Deprecated` so that third-party developers could replace it with the new rule class.