### PR TITLE
Config file in directory test

### DIFF
--- a/detekt-gradle-plugin/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/testkit/DslGradleRunner.kt
+++ b/detekt-gradle-plugin/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/testkit/DslGradleRunner.kt
@@ -94,7 +94,9 @@ class DslGradleRunner @Suppress("LongParameterList") constructor(
     fun projectFile(path: String): File = File(rootDir, path).canonicalFile
 
     fun writeProjectFile(filename: String, content: String) {
-        File(rootDir, filename).writeText(content)
+        File(rootDir, filename)
+            .also { it.parentFile.mkdirs() }
+            .writeText(content)
     }
 
     fun writeKtFile(srcDir: String, className: String) {

--- a/detekt-gradle-plugin/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/testkit/DslTestBuilder.kt
+++ b/detekt-gradle-plugin/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/testkit/DslTestBuilder.kt
@@ -56,13 +56,13 @@ abstract class DslTestBuilder {
             |$detektConfig
             """.trimMargin()
         val runner = DslGradleRunner(
-            projectLayout,
-            gradleBuildName,
-            mainBuildFileContent,
-            configFile,
-            baselineFile?.let { listOf(it) }.orEmpty(),
-            gradleVersion,
-            dryRun
+            projectLayout = projectLayout,
+            buildFileName = gradleBuildName,
+            mainBuildFileContent = mainBuildFileContent,
+            configFileOrNone = configFile,
+            baselineFiles = baselineFile?.let { listOf(it) }.orEmpty(),
+            gradleVersionOrNone = gradleVersion,
+            dryRun = dryRun,
         )
         runner.setupProject()
         return runner


### PR DESCRIPTION
Allow to specify `configFileOrNone` like this: `config/detekt/detekt.yml`. Until now only files on the current directory were allowed (like `detekt.yml`).

Context: I found this working on #4380