### PR TITLE
Fixes false negatives in `UnnecessaryAbstractClass`

### DIFF
--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/DelegatingXMLStreamWriter.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/DelegatingXMLStreamWriter.kt
@@ -1,5 +1,0 @@
-package io.gitlab.arturbosch.detekt.core.baseline
-
-import javax.xml.stream.XMLStreamWriter
-
-internal abstract class DelegatingXMLStreamWriter(writer: XMLStreamWriter) : XMLStreamWriter by writer

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/IndentingXMLStreamWriter.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/IndentingXMLStreamWriter.kt
@@ -5,9 +5,9 @@ import javax.xml.stream.XMLStreamWriter
 
 @Suppress("TooManyFunctions")
 internal class IndentingXMLStreamWriter(
-    writer: XMLStreamWriter,
+    private val writer: XMLStreamWriter,
     private val indent: String = "  "
-) : DelegatingXMLStreamWriter(writer) {
+) : XMLStreamWriter by writer {
 
     private var currentState = NOTHING
     private val stateStack = Stack<Any>()
@@ -25,7 +25,7 @@ internal class IndentingXMLStreamWriter(
     private fun onEndTag() {
         indentationDepth--
         if (currentState === TAG) {
-            super.writeCharacters("\n")
+            writer.writeCharacters("\n")
             writeIndent()
         }
         currentState = stateStack.pop()
@@ -39,79 +39,79 @@ internal class IndentingXMLStreamWriter(
 
     private fun writeNL() {
         if (indentationDepth > 0) {
-            super.writeCharacters("\n")
+            writer.writeCharacters("\n")
         }
     }
 
     private fun writeIndent() {
         if (indentationDepth > 0) {
-            (0 until indentationDepth).forEach { _ -> super.writeCharacters(indent) }
+            (0 until indentationDepth).forEach { _ -> writer.writeCharacters(indent) }
         }
     }
 
     override fun writeStartDocument() {
-        super.writeStartDocument()
-        super.writeCharacters("\n")
+        writer.writeStartDocument()
+        writer.writeCharacters("\n")
     }
 
     override fun writeStartDocument(version: String) {
-        super.writeStartDocument(version)
-        super.writeCharacters("\n")
+        writer.writeStartDocument(version)
+        writer.writeCharacters("\n")
     }
 
     override fun writeStartDocument(encoding: String, version: String) {
-        super.writeStartDocument(encoding, version)
-        super.writeCharacters("\n")
+        writer.writeStartDocument(encoding, version)
+        writer.writeCharacters("\n")
     }
 
     override fun writeStartElement(localName: String) {
         onStartTag()
-        super.writeStartElement(localName)
+        writer.writeStartElement(localName)
     }
 
     override fun writeStartElement(namespaceURI: String, localName: String) {
         onStartTag()
-        super.writeStartElement(namespaceURI, localName)
+        writer.writeStartElement(namespaceURI, localName)
     }
 
     override fun writeStartElement(prefix: String, localName: String, namespaceURI: String) {
         onStartTag()
-        super.writeStartElement(prefix, localName, namespaceURI)
+        writer.writeStartElement(prefix, localName, namespaceURI)
     }
 
     override fun writeEmptyElement(namespaceURI: String, localName: String) {
         onEmptyTag()
-        super.writeEmptyElement(namespaceURI, localName)
+        writer.writeEmptyElement(namespaceURI, localName)
     }
 
     override fun writeEmptyElement(prefix: String, localName: String, namespaceURI: String) {
         onEmptyTag()
-        super.writeEmptyElement(prefix, localName, namespaceURI)
+        writer.writeEmptyElement(prefix, localName, namespaceURI)
     }
 
     override fun writeEmptyElement(localName: String) {
         onEmptyTag()
-        super.writeEmptyElement(localName)
+        writer.writeEmptyElement(localName)
     }
 
     override fun writeEndElement() {
         onEndTag()
-        super.writeEndElement()
+        writer.writeEndElement()
     }
 
     override fun writeCharacters(text: String) {
         currentState = DATA
-        super.writeCharacters(text)
+        writer.writeCharacters(text)
     }
 
     override fun writeCharacters(text: CharArray, start: Int, len: Int) {
         currentState = DATA
-        super.writeCharacters(text, start, len)
+        writer.writeCharacters(text, start, len)
     }
 
     override fun writeCData(data: String) {
         currentState = DATA
-        super.writeCData(data)
+        writer.writeCData(data)
     }
 
     companion object {

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAbstractClass.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAbstractClass.kt
@@ -77,6 +77,8 @@ class UnnecessaryAbstractClass(config: Config = Config.empty) : Rule(config) {
             if (namedMembers.isNotEmpty()) {
                 NamedClassMembers(klass, namedMembers)
                     .detectAbstractAndConcreteType()
+            } else if (!klass.hasConstructorParameter()) {
+                report(CodeSmell(issue, Entity.from(klass), noConcreteMember), klass)
             } else {
                 report(CodeSmell(issue, Entity.from(klass), noAbstractMember), klass)
             }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAbstractClass.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAbstractClass.kt
@@ -73,12 +73,11 @@ class UnnecessaryAbstractClass(config: Config = Config.empty) : Rule(config) {
 
     override fun visitClass(klass: KtClass) {
         if (!klass.isInterface() && klass.isAbstract()) {
-            val body = klass.body
-            if (body != null) {
-                val namedMembers = body.children.filterIsInstance<KtNamedDeclaration>()
-                val namedClassMembers = NamedClassMembers(klass, namedMembers)
-                namedClassMembers.detectAbstractAndConcreteType()
-            } else if (klass.superTypeListEntries.isEmpty()) {
+            val namedMembers = klass.body?.children.orEmpty().filterIsInstance<KtNamedDeclaration>()
+            if (namedMembers.isNotEmpty()) {
+                NamedClassMembers(klass, namedMembers)
+                    .detectAbstractAndConcreteType()
+            } else {
                 report(CodeSmell(issue, Entity.from(klass), noAbstractMember), klass)
             }
         }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAbstractClass.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAbstractClass.kt
@@ -75,8 +75,7 @@ class UnnecessaryAbstractClass(config: Config = Config.empty) : Rule(config) {
         if (!klass.isInterface() && klass.isAbstract()) {
             val namedMembers = klass.body?.children.orEmpty().filterIsInstance<KtNamedDeclaration>()
             if (namedMembers.isNotEmpty()) {
-                NamedClassMembers(klass, namedMembers)
-                    .detectAbstractAndConcreteType()
+                NamedClassMembers(klass, namedMembers).detectAbstractAndConcreteType()
             } else if (!klass.hasConstructorParameter()) {
                 report(CodeSmell(issue, Entity.from(klass), noConcreteMember), klass)
             } else {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAbstractClassSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAbstractClassSpec.kt
@@ -62,29 +62,29 @@ class UnnecessaryAbstractClassSpec : Spek({
                     val findings = subject.compileAndLintWithContext(env, code)
                     assertThat(findings).hasSize(1)
                 }
-            }
 
-            it("does not report a completely-empty abstract class that inherits from an interface") {
-                val code = """
-                    interface A {
-                        val i: Int
-                    }
-                    abstract class B : A
-                """.trimIndent()
-                val findings = subject.compileAndLintWithContext(env, code)
-                assertThat(findings).isEmpty()
-            }
+                it("that inherits from an interface") {
+                    val code = """
+                        interface A {
+                            val i: Int
+                        }
+                        abstract class B : A
+                    """.trimIndent()
+                    val findings = subject.compileAndLintWithContext(env, code)
+                    assertThat(findings).hasSize(1)
+                }
 
-            it("that inherits from another abstract class") {
-                val code = """
-                    @Deprecated("We don't care about this first class")
-                    abstract class A {
-                        abstract val i: Int
-                    }
-                    abstract class B : A()
-                """.trimIndent()
-                val findings = subject.compileAndLintWithContext(env, code)
-                assertThat(findings).isEmpty()
+                it("that inherits from another abstract class") {
+                    val code = """
+                        @Deprecated("We don't care about this first class")
+                        abstract class A {
+                            abstract val i: Int
+                        }
+                        abstract class B : A()
+                    """.trimIndent()
+                    val findings = subject.compileAndLintWithContext(env, code)
+                    assertThat(findings).hasSize(1)
+                }
             }
 
             it("does not report an abstract class with concrete members derived from a base class") {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAbstractClassSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAbstractClassSpec.kt
@@ -67,7 +67,7 @@ class UnnecessaryAbstractClassSpec : Spek({
                             val i: Int
                         }
                         abstract class B : A
-                    """.trimIndent()
+                    """
                     val findings = subject.compileAndLintWithContext(env, code)
                     assertFindingMessage(findings, message)
                 }
@@ -79,7 +79,7 @@ class UnnecessaryAbstractClassSpec : Spek({
                             abstract val i: Int
                         }
                         abstract class B : A()
-                    """.trimIndent()
+                    """
                     val findings = subject.compileAndLintWithContext(env, code)
                     assertFindingMessage(findings, message)
                 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAbstractClassSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAbstractClassSpec.kt
@@ -22,6 +22,7 @@ class UnnecessaryAbstractClassSpec : Spek({
     describe("UnnecessaryAbstractClass rule") {
 
         context("abstract classes with no concrete members") {
+            val message = "An abstract class without a concrete member can be refactored to an interface."
 
             it("reports an abstract class with no concrete member") {
                 val code = """
@@ -32,35 +33,32 @@ class UnnecessaryAbstractClassSpec : Spek({
                     }
                 """
                 val findings = subject.compileAndLintWithContext(env, code)
-                assertFindingMessage(
-                    findings,
-                    "An abstract class without a concrete member can be refactored to an interface."
-                )
+                assertFindingMessage(findings, message)
             }
 
             context("reports completely-empty abstract classes") {
                 it("case 1") {
                     val code = "abstract class A"
                     val findings = subject.compileAndLintWithContext(env, code)
-                    assertThat(findings).hasSize(1)
+                    assertFindingMessage(findings, message)
                 }
 
                 it("case 2") {
                     val code = "abstract class A()"
                     val findings = subject.compileAndLintWithContext(env, code)
-                    assertThat(findings).hasSize(1)
+                    assertFindingMessage(findings, message)
                 }
 
                 it("case 3") {
                     val code = "abstract class A {}"
                     val findings = subject.compileAndLintWithContext(env, code)
-                    assertThat(findings).hasSize(1)
+                    assertFindingMessage(findings, message)
                 }
 
                 it("case 4") {
                     val code = "abstract class A() {}"
                     val findings = subject.compileAndLintWithContext(env, code)
-                    assertThat(findings).hasSize(1)
+                    assertFindingMessage(findings, message)
                 }
 
                 it("that inherits from an interface") {
@@ -71,7 +69,7 @@ class UnnecessaryAbstractClassSpec : Spek({
                         abstract class B : A
                     """.trimIndent()
                     val findings = subject.compileAndLintWithContext(env, code)
-                    assertThat(findings).hasSize(1)
+                    assertFindingMessage(findings, message)
                 }
 
                 it("that inherits from another abstract class") {
@@ -83,7 +81,7 @@ class UnnecessaryAbstractClassSpec : Spek({
                         abstract class B : A()
                     """.trimIndent()
                     val findings = subject.compileAndLintWithContext(env, code)
-                    assertThat(findings).hasSize(1)
+                    assertFindingMessage(findings, message)
                 }
             }
 


### PR DESCRIPTION
This PR fixes a false positive in `UnnecessaryAbstractClass`.

Before this PR the class `B` wasn't flagged:

```kotlin
interface A {
    val i: Int
}
abstract class B : A
```

And the same here:

```kotlin
abstract class A {
    abstract val i: Int
}
abstract class B : A()
```

This PR also improves the messages reported for this rule.