### PR TITLE
Disable CI for Windows & JDK8

### DIFF
--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -16,6 +16,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         jdk: [8, 11, 17]
+        exclude: # windows with JDK8 are *really* flaky
+          - os: windows-latest
+            jdk: 8
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout Repo


### PR DESCRIPTION
Windows & JDK8 are *really* flaky. So flaky that we merge more than 50% of our PRs with CI failing. If I see that a PR passes all checks except Windows/JDK8 I just merge it, it's pointless to check it over and over again to always see "oh, the flakyness again".

This also make our contributors a bit unconfortable. They want their builds green. As when they don't get it, they ask and we say "don'y worry about that". And that is not a good standard. A sample: https://github.com/detekt/detekt/pull/4379#issuecomment-997183156

And the last reason, this also hides other issues. For example, I was using a forbidden function on #4315 but I didn't realised because I saw the red `X` in the PR but I thought "the flakyness".

For all of that I think that we should disable this check. If someone wants to expend the time to fix that flakyness it would be great to add that check back again but, meanwhile, I think that it's safer to disable it.