### PR TITLE
Fix the table of contents in Reporting doc

### DIFF
--- a/docs/pages/reporting.md
+++ b/docs/pages/reporting.md
@@ -80,7 +80,7 @@ the merging makes most sense in a multi-module project. In this spirit, only Gra
 At the moment, merging XML and SARIF are supported. You can refer to the sample build script below and 
 run `./gradlew detekt reportMerge --continue` to execute detekt tasks and merge the corresponding reports.
 
-#### Groovy DSL
+### Groovy DSL
 ```groovy
 task reportMerge(type: io.gitlab.arturbosch.detekt.report.ReportMergeTask) {
   output = project.layout.buildDirectory.file("reports/detekt/merge.xml") // or "reports/detekt/merge.sarif"
@@ -104,7 +104,7 @@ subprojects {
 }
 ```
 
-#### Kotlin DSL
+### Kotlin DSL
 
 ```kotlin
 val reportMerge by tasks.registering(io.gitlab.arturbosch.detekt.report.ReportMergeTask::class) { 


### PR DESCRIPTION
As shown in the screenshot below, the table of contents looks odd. This PR fixes this.

![image](https://user-images.githubusercontent.com/30376729/147496939-5de41748-d81d-4f4e-9559-14cd4666e435.png)