### PR TITLE
Remove table of contents for just 1 heading in doc

### DIFF
--- a/docs/pages/suppressing-rules.md
+++ b/docs/pages/suppressing-rules.md
@@ -24,7 +24,7 @@ object Constants {
 
 Some rules like `TooManyFunctions` can be suppressed by using a file level annotation `@file:Suppress("TooManyFunctions")`.
 
-## Formatting rules suppression
+**Formatting rules suppression**
 
 Please note that rules inside the [`formatting`](./formatting.html) ruleset can only be suppressed at **the file level**.
 


### PR DESCRIPTION
It looks weird to have a table of contents present for just 1 heading in the *Suppressing Issues* doc.
