### PR TITLE
Extend VarCouldBeVal to include analysis of file- and class-level properties

### DIFF
--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/VarCouldBeValSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/VarCouldBeValSpec.kt
@@ -48,22 +48,44 @@ class VarCouldBeValSpec : Spek({
     }
 
     describe("class-level declarations") {
-        it("does not report variables that are re-assigned") {
+        it("does not report non-private variables in non-private classes") {
             val code = """
                 class A {
-                    fun test() {
-                        var a = 1
-                        a = 2
-                    }
-                }
-                
-                
-                fun test() {
                     var a = 1
-                    a = 2
                 }
             """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        }
+
+        it("does not report non-private variables in non-private objects") {
+            val code = """
+                object A {
+                    var a = 1
+                }
+            """.trimIndent()
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        }
+
+        it("does not report variables that are re-assigned") {
+            val code = """
+                class A {
+                    private var a = 1
+                    
+                    fun foo() {
+                        a = 2
+                    }
+                }
+            """.trimIndent()
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        }
+
+        it("reports variables that are not re-assigned") {
+            val code = """
+                class A {
+                    private var a = 1
+                }
+            """.trimIndent()
+            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
     }
 


### PR DESCRIPTION
Second poor soul attempting to conquer #1964. Also, I noticed what could be a potential false-positive issue for `var` properties declared in object literals that escape their containing declaration, so this code includes checks for that.