### PR TITLE
Add test cases to RedundantSuspendModifier rule

### DIFF
--- a/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/RedundantSuspendModifierSpec.kt
+++ b/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/RedundantSuspendModifierSpec.kt
@@ -63,6 +63,30 @@ object RedundantSuspendModifierSpec : Spek({
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
+        it("does not report suspend function without body") {
+            val code = """
+                interface SuspendInterface {
+                    suspend fun empty()
+                }
+                """
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        }
+
+        it("does not report overridden suspend function") {
+            val code = """
+                interface SuspendInterface {
+                    suspend fun empty()
+                }
+
+                class SuspendClass : SuspendInterface {
+                    override suspend fun empty() {
+                        println("hello world")
+                    }
+                }                                
+                """
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        }
+
         it("ignores when iterator is suspending") {
             val code = """
                 class SuspendingIterator {


### PR DESCRIPTION
This PR adds tests that run through previously uncovered paths of this rule.
