### PR TITLE
Improve Undocumented* rules (WIP)

### DIFF
--- a/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentUtil.kt
+++ b/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentUtil.kt
@@ -1,6 +1,18 @@
 package io.gitlab.arturbosch.detekt.rules.documentation
 
+import org.jetbrains.kotlin.kdoc.psi.impl.KDocTag
 import org.jetbrains.kotlin.psi.KtDeclaration
+import org.jetbrains.kotlin.psi.KtFunction
 import org.jetbrains.kotlin.psi.psiUtil.isPrivate
 
 internal fun KtDeclaration.hasCommentInPrivateMember() = docComment != null && isPrivate()
+
+internal fun KtFunction.getEntriesForTagAndSubject(tagName: String, subject: String? = null): List<KDocTag> =
+    docComment?.getAllSections()?.flatMap {
+        it.findTagsByName(tagName).filter { tag ->
+            when (subject) {
+                null -> true
+                else -> tag.getSubjectName() == subject
+            }
+        }
+    } ?: listOf()

--- a/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicFunction.kt
+++ b/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicFunction.kt
@@ -4,12 +4,19 @@ import io.gitlab.arturbosch.detekt.api.CodeSmell
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.config
+import io.gitlab.arturbosch.detekt.api.internal.Configuration
 import io.gitlab.arturbosch.detekt.rules.isPublicNotOverridden
 import org.jetbrains.kotlin.psi.KtClassOrObject
+import org.jetbrains.kotlin.psi.KtFunction
+import org.jetbrains.kotlin.psi.KtNamedDeclaration
 import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.KtParameter
+import org.jetbrains.kotlin.psi.KtTypeParameter
 import org.jetbrains.kotlin.psi.psiUtil.isPublic
 import org.jetbrains.kotlin.psi.psiUtil.parents
 
@@ -17,8 +24,16 @@ import org.jetbrains.kotlin.psi.psiUtil.parents
  * This rule will report any public function which does not have the required documentation.
  * If the codebase should have documentation on all public functions enable this rule to enforce this.
  * Overridden functions are excluded by this rule.
+ *
+ * Optionally, this rule can also report missing documentation for undocumented parameters (e.g. missing @param tag) and
+ * receivers (e.g. missing @receiver tag).
  */
 class UndocumentedPublicFunction(config: Config = Config.empty) : Rule(config) {
+    @Configuration("If set to true, this rule will also report type and value parameters that are not properly documented (either using a '@param' tag on the function's KDoc or by directly documenting them).")
+    private val reportUndocumentedParameter by config(false)
+
+    @Configuration("If set to true, this rule will also report receivers that are not documented using a '@receiver' tag on the function's KDoc.")
+    private val reportUndocumentedReceiver by config(false)
 
     override val issue = Issue(
         javaClass.simpleName,
@@ -30,17 +45,56 @@ class UndocumentedPublicFunction(config: Config = Config.empty) : Rule(config) {
     override fun visitNamedFunction(function: KtNamedFunction) {
         if (function.funKeyword == null && function.isLocal) return
 
-        if (function.docComment == null && function.shouldBeDocumented()) {
-            report(
-                CodeSmell(
-                    issue,
-                    Entity.atName(function),
-                    "The function ${function.nameAsSafeName} is missing documentation."
-                )
-            )
+        if (function.shouldBeDocumented()) {
+            if (function.docComment == null) {
+                report(createFinding(function, "function ${function.nameAsSafeName}"))
+            }
+
+            if (reportUndocumentedParameter) {
+                function.valueParameters.forEach { parameter: KtParameter ->
+                    if (parameter.isNotDocumented(function)) {
+                        report(createFinding(parameter, "parameter ${parameter.nameAsSafeName}"))
+                    }
+                }
+                function.typeParameters.forEach { parameter ->
+                    if (parameter.isNotDocumented(function)) {
+                        report(createFinding(parameter, "type parameter ${parameter.nameAsSafeName}"))
+                    }
+                }
+            }
+
+            if (reportUndocumentedReceiver && function.receiverTypeReference != null && function.isReceiverNotDocumented()) {
+                report(createFinding(function, "receiver of the function ${function.nameAsSafeName}"))
+            }
         }
     }
 
+    private fun createFinding(location: KtNamedDeclaration, culprit: String): Finding =
+        CodeSmell(issue, Entity.atName(location), "The $culprit is missing documentation.")
+
     private fun KtNamedFunction.shouldBeDocumented() =
         parents.filterIsInstance<KtClassOrObject>().all { it.isPublic } && isPublicNotOverridden()
+
+    private fun KtParameter.isNotDocumented(function: KtNamedFunction): Boolean {
+        if (docComment != null) return false
+        val paramName = name ?: return true
+        return !function.hasEntryForTag("param", paramName)
+    }
+
+    private fun KtTypeParameter.isNotDocumented(function: KtNamedFunction): Boolean {
+        val paramName = name ?: return true
+        return !function.hasEntryForTag("param", paramName)
+    }
+
+    private fun KtNamedFunction.isReceiverNotDocumented() = !hasEntryForTag("receiver")
+
+    private fun KtFunction.hasEntryForTag(tagName: String, subject: String? = null) =
+        docComment?.getAllSections()?.any {
+            val tag = it.findTagByName(tagName)
+            when {
+                tag == null -> false
+                subject == null -> true
+                else -> tag.getSubjectName() == subject
+            }
+        } ?: false
 }

--- a/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicFunction.kt
+++ b/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicFunction.kt
@@ -29,10 +29,12 @@ import org.jetbrains.kotlin.psi.psiUtil.parents
  * receivers (e.g. missing @receiver tag).
  */
 class UndocumentedPublicFunction(config: Config = Config.empty) : Rule(config) {
-    @Configuration("If set to true, this rule will also report type and value parameters that are not properly documented (either using a '@param' tag on the function's KDoc or by directly documenting them).")
+    @Configuration("If set to true, this rule will also report type and value parameters that are not " +
+        "properly documented (either using a '@param' tag on the function's KDoc or by directly documenting them).")
     private val reportUndocumentedParameter by config(false)
 
-    @Configuration("If set to true, this rule will also report receivers that are not documented using a '@receiver' tag on the function's KDoc.")
+    @Configuration("If set to true, this rule will also report receivers that are not documented using a " +
+        "'@receiver' tag on the function's KDoc.")
     private val reportUndocumentedReceiver by config(false)
 
     override val issue = Issue(
@@ -78,23 +80,13 @@ class UndocumentedPublicFunction(config: Config = Config.empty) : Rule(config) {
     private fun KtParameter.isNotDocumented(function: KtNamedFunction): Boolean {
         if (docComment != null) return false
         val paramName = name ?: return true
-        return !function.hasEntryForTag("param", paramName)
+        return function.getEntriesForTagAndSubject("param", paramName).isEmpty()
     }
 
     private fun KtTypeParameter.isNotDocumented(function: KtNamedFunction): Boolean {
         val paramName = name ?: return true
-        return !function.hasEntryForTag("param", paramName)
+        return function.getEntriesForTagAndSubject("param", paramName).isEmpty()
     }
 
-    private fun KtNamedFunction.isReceiverNotDocumented() = !hasEntryForTag("receiver")
-
-    private fun KtFunction.hasEntryForTag(tagName: String, subject: String? = null) =
-        docComment?.getAllSections()?.any {
-            val tag = it.findTagByName(tagName)
-            when {
-                tag == null -> false
-                subject == null -> true
-                else -> tag.getSubjectName() == subject
-            }
-        } ?: false
+    private fun KtNamedFunction.isReceiverNotDocumented() = getEntriesForTagAndSubject("receiver").isEmpty()
 }


### PR DESCRIPTION
*Apologies for creating the PR before the functionality is done, this requires a bit of work and I'd like to track the progress somewhere.*

Fixes #4395, please check that issue for more details on what is being attempted here

### TODO

- **Classes**
    - [ ] Undocumented type/value parameters on constructors ➡️ UndocumentedPublicClass gated behind a configuration flag 
        - ⚠️ This should also NOT report public properties that may be contained in the constructor, as they are already detected by UndocumentedPublicProperty
    - [ ] Duplicate type/value parameters or type/value parameters that do not actually match any parameter➡️ Probably a new rule? Might be a rule that is in common with functions
- **Functions**
    - [x] Undocumented type and value parameters ➡️ UndocumentedPublicFunction gated behind a configuration flag
    - [x] Undocumented receiver ➡️ UndocumentedPublicFunction gated behind a configuration flag
    - [ ] Undocumented return value if returning anything other than Unit ➡️ Probably a separate rule with a configurable allowlist to ignore other classes than just Unit. May require type resolution?
    - [ ] Undocumented exception if returning Nothing ➡️ Probably a separate rule with a configurable blocklist to report classes other than just Nothing. May require type resolution?
    - [ ] Duplica type parameters/value parameters/receivers documentation and type parameters/value parameters/receiver documentation that do not match anything ➡️ Probably a new rule, maybe the same as with classes?
- **Properties**
    - [ ] Missing type parameter documentation ➡️ UndocumentedPublicProperty gated behind a configuration flag