### PR TITLE
Add list of functions to skip in IgnoredReturnValue rule

### DIFF
--- a/build-logic/src/main/kotlin/Versions.kt
+++ b/build-logic/src/main/kotlin/Versions.kt
@@ -1,6 +1,6 @@
 object Versions {
 
-    const val DETEKT: String = "1.19.0"
+    const val DETEKT: String = "1.19.0-artem"
     const val SNAPSHOT_NAME: String = "main"
     const val JVM_TARGET: String = "1.8"
 

--- a/build-logic/src/main/kotlin/Versions.kt
+++ b/build-logic/src/main/kotlin/Versions.kt
@@ -1,6 +1,6 @@
 object Versions {
 
-    const val DETEKT: String = "1.19.0-artem"
+    const val DETEKT: String = "1.19.0"
     const val SNAPSHOT_NAME: String = "main"
     const val JVM_TARGET: String = "1.8"
 

--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -552,7 +552,7 @@ potential-bugs:
       - '*.CheckReturnValue'
     ignoreReturnValueAnnotations:
       - '*.CanIgnoreReturnValue'
-    skipFunctions: []
+    ignoreFunctionCall: []
   ImplicitDefaultLocale:
     active: true
   ImplicitUnitReturnType:

--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -552,6 +552,7 @@ potential-bugs:
       - '*.CheckReturnValue'
     ignoreReturnValueAnnotations:
       - '*.CanIgnoreReturnValue'
+    skipFunctions: []
   ImplicitDefaultLocale:
     active: true
   ImplicitUnitReturnType:

--- a/detekt-rules-errorprone/build.gradle.kts
+++ b/detekt-rules-errorprone/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
 
 dependencies {
     compileOnly(projects.detektApi)
+    implementation(projects.detektTooling)
     testImplementation(projects.detektTest)
     testImplementation(libs.bundles.testImplementation)
     testRuntimeOnly(libs.spek.runner)

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValue.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValue.kt
@@ -60,11 +60,11 @@ class IgnoredReturnValue(config: Config = Config.empty) : Rule(config) {
     }
 
     @Configuration(
-        "List of fully-qualified function call signatures which should be ignored by this rule. " +
-            "Functions can be defined without full signature (i.e. `java.time.LocalDate.now`) which will ignore " +
-            "calls of all functions with this name or with full signature " +
-            "(i.e. `java.time.LocalDate.now(java.time.Clock)`) which would ignore only call " +
-            "with this concrete signature."
+        "List of function signatures which should be ignored by this rule. " +
+            "Specifying fully-qualified function signature with name only (i.e. `java.time.LocalDate.now`) will ignore " +
+            "all function calls matching the name. Specifying fully-qualified function signature with parameters" +
+            "(i.e. `java.time.LocalDate.now(java.time.Clock)`) will ignore only function calls matching the name " +
+            "and parameters exactly."
     )
     private val ignoreFunctionCall: List<FunctionMatcher> by config(emptyList<String>()) {
         it.map(FunctionMatcher::fromFunctionSignature)

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValue.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValue.kt
@@ -59,7 +59,10 @@ class IgnoredReturnValue(config: Config = Config.empty) : Rule(config) {
         it.map(String::simplePatternToRegex)
     }
 
-    @Configuration("List of fully-qualified function names that should be skipped by this check. Example: 'package.class.fun1'")
+    @Configuration(
+        "List of fully-qualified function names that should be skipped by this check. " +
+            "Example: 'package.class.fun1'"
+    )
     private val skipFunctions: List<String> by config(emptyList())
 
     @Suppress("ReturnCount")
@@ -95,6 +98,4 @@ class IgnoredReturnValue(config: Config = Config.empty) : Rule(config) {
         val fqName = annotation.fqName?.asString() ?: return false
         return any { it.matches(fqName) }
     }
-
-
 }

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValue.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValue.kt
@@ -1,17 +1,9 @@
 package io.gitlab.arturbosch.detekt.rules.bugs
 
 import io.github.detekt.tooling.api.FunctionMatcher
-import io.gitlab.arturbosch.detekt.api.CodeSmell
-import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.Debt
-import io.gitlab.arturbosch.detekt.api.Entity
-import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.Rule
-import io.gitlab.arturbosch.detekt.api.Severity
-import io.gitlab.arturbosch.detekt.api.config
+import io.gitlab.arturbosch.detekt.api.*
 import io.gitlab.arturbosch.detekt.api.internal.Configuration
 import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
-import io.gitlab.arturbosch.detekt.api.simplePatternToRegex
 import org.jetbrains.kotlin.descriptors.annotations.AnnotationDescriptor
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.resolve.BindingContext
@@ -66,8 +58,9 @@ class IgnoredReturnValue(config: Config = Config.empty) : Rule(config) {
             "(i.e. `java.time.LocalDate.now(java.time.Clock)`) which would ignore only call " +
             "with this concrete signature."
     )
-    private val ignoreFunctionCall: List<FunctionMatcher> by config(emptyList<String>())
-    { it.map(FunctionMatcher::fromFunctionSignature) }
+    private val ignoreFunctionCall: List<FunctionMatcher> by config(emptyList<String>()) {
+        it.map(FunctionMatcher::fromFunctionSignature)
+    }
 
     @Suppress("ReturnCount")
     override fun visitCallExpression(expression: KtCallExpression) {

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValue.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValue.kt
@@ -1,9 +1,17 @@
 package io.gitlab.arturbosch.detekt.rules.bugs
 
 import io.github.detekt.tooling.api.FunctionMatcher
-import io.gitlab.arturbosch.detekt.api.*
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.config
 import io.gitlab.arturbosch.detekt.api.internal.Configuration
 import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
+import io.gitlab.arturbosch.detekt.api.simplePatternToRegex
 import org.jetbrains.kotlin.descriptors.annotations.AnnotationDescriptor
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.resolve.BindingContext

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValueSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValueSpec.kt
@@ -813,5 +813,28 @@ object IgnoredReturnValueSpec : Spek({
             val findings = rule.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
+
+        it("does not report when a function is in skip list") {
+            val code = """
+                package foo
+
+                fun listOfChecked(value: String) = listOf(value)
+
+                fun foo() : Int {
+                    listOfChecked("hello")
+                    return 42
+                }
+            """
+            val rule = IgnoredReturnValue(
+                TestConfig(
+                    mapOf(
+                        "skipFunctions" to listOf("foo.listOfChecked"),
+                        "restrictToAnnotatedMethods" to false
+                    )
+                )
+            )
+            val findings = rule.compileAndLintWithContext(env, code)
+            assertThat(findings).isEmpty()
+        }
     }
 })

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValueSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValueSpec.kt
@@ -814,7 +814,7 @@ object IgnoredReturnValueSpec : Spek({
             assertThat(findings).isEmpty()
         }
 
-        it("does not report when a function is in skip list") {
+        it("does not report when a function is in ignoreFunctionCall") {
             val code = """
                 package foo
 
@@ -828,7 +828,7 @@ object IgnoredReturnValueSpec : Spek({
             val rule = IgnoredReturnValue(
                 TestConfig(
                     mapOf(
-                        "skipFunctions" to listOf("foo.listOfChecked"),
+                        "ignoreFunctionCall" to listOf("foo.listOfChecked"),
                         "restrictToAnnotatedMethods" to false
                     )
                 )


### PR DESCRIPTION
Hey Detekt team, I was configuring `IgnoredReturnValue` rule in our project and found it extremely useful — fixed few actual bugs! 

In fact, with this rule my old feature request filed to Kotlin team 6 years ago is now fulfilled heh https://youtrack.jetbrains.com/issue/KT-12719 

However the rule does find quite a lot of false-positives that are outside of our or Detekt control.

Thus I'm proposing a configuration option for the `IgnoredReturnValue` rule that will allow user to list fully qualified names of the functions return values of which they don't expect to be consumed — thus skipped by the rule.

```yaml
potential-bugs:
  IgnoredReturnValue:
    active: true
    restrictToAnnotatedMethods: false
    skipFunctions:
      - io.ktor.routing.post
      - io.ktor.routing.get
```

---

Examples:

In [Ktor](https://ktor.io/) some routing DSL methods return values (idk why, seems like bad design, but oh well) and DSL doesn't rely on them to be used:

```kotlin

embeddedServer(Netty, port = 8000) {
	routing {
		// Here get is a DSL configuration function, you never consume its result..
		get ("/") {
			call.respondText("Hello, world!")
		}
	}
}
```

Or some stdlib functions like `use`:

```kotlin
// Here use() returns a value but often you rely only on lambda..
file.outputStream().use { fos ->
        inputStream.use {
            it.copyTo(fos)
        }
}
```

and so on.