### PR TITLE
Less restrictive OutdatedDocumentation rule and add UndocumentedPublicFunctionReturn rule

### DIFF
--- a/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicFunctionReturn.kt
+++ b/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicFunctionReturn.kt
@@ -79,7 +79,6 @@ class UndocumentedPublicFunctionReturn(config: Config = Config.empty) : Rule(con
     private val throwsOrExceptionReturnTypes: List<String> by config(listOf("kotlin.Nothing"))
 
     override fun visitNamedFunction(function: KtNamedFunction) {
-        val ctx = bindingContext
         val doc = function.docComment
         if (bindingContext == BindingContext.EMPTY || doc == null) return
         val returnType = function.createTypeBindingForReturnType(bindingContext)?.type?.fqNameOrNull()?.toString()

--- a/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicFunctionReturn.kt
+++ b/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicFunctionReturn.kt
@@ -1,0 +1,116 @@
+package io.gitlab.arturbosch.detekt.rules.documentation
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Finding
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.config
+import io.gitlab.arturbosch.detekt.api.internal.Configuration
+import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
+import io.gitlab.arturbosch.detekt.rules.fqNameOrNull
+import org.jetbrains.kotlin.kdoc.psi.api.KDoc
+import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.resolve.BindingContext
+import org.jetbrains.kotlin.resolve.typeBinding.createTypeBindingForReturnType
+
+/**
+ * This rule reports functions that are documented yet miss documentation for their return type.
+ *
+ * There are two kinds of problems this rule reports:
+ *
+ * - Missing `@return` in documentation for functions that do not return Unit.
+ * - Missing `@return`, `@throws` or `@exception` documentation for functions that return Nothing.
+ *
+ * You can configure:
+ *
+ * - which types are considered to be Unit via the `nonDocumentedReturnTypes` configuration.
+ * - which types are considered to be Nothing via the `throwsOrExceptionReturnTypes` configuration.
+ *
+ * <noncompliant>
+ * /**
+ *  * My return type is not documented
+ *  */
+ *  fun foo(): String = /* ... */
+ *
+ *  /**
+ *   * My return type is documented
+ *   */
+ *  fun bar(): Nothing = /* ... */
+ * </noncompliant>
+ *
+ * <compliant>
+ * /**
+ *  * My return type is documented
+ *  *
+ *  * @return Something
+ *  */
+ * fun baz(): String = /* ... */
+ *
+ * fun okBecauseNotDocumented(): String = /* ... */
+ *
+ * /**
+ *  * I am nothing, so I can also document my return type with a throws/exception
+ *  *
+ *  * @throws ExceptionOne if something goes wrong
+ *  * @exception ExceptionTwo if something else goes wrong
+ *  */
+ * fun nothingish(): Nothing = /* ... */
+ * </compliant>
+ */
+@RequiresTypeResolution
+class UndocumentedPublicFunctionReturn(config: Config = Config.empty) : Rule(config) {
+    override val issue = Issue(
+        javaClass.simpleName,
+        Severity.Maintainability,
+        "Non-trivial return types should be documented.",
+        Debt.TEN_MINS
+    )
+
+    @Configuration("Return types that do not need to be documented (e.g. kotlin.Unit)")
+    private val nonDocumentedReturnTypes: List<String> by config(listOf("kotlin.Unit"))
+
+    @Configuration(
+        "Return types that can also be documented with @throws or @exception tags (e.g. kotlin.Nothing)"
+    )
+    private val throwsOrExceptionReturnTypes: List<String> by config(listOf("kotlin.Nothing"))
+
+    override fun visitNamedFunction(function: KtNamedFunction) {
+        val ctx = bindingContext
+        val doc = function.docComment
+        if (bindingContext == BindingContext.EMPTY || doc == null) return
+        val returnType = function.createTypeBindingForReturnType(bindingContext)?.type?.fqNameOrNull()?.toString()
+            ?: return
+        if (returnType in throwsOrExceptionReturnTypes) {
+            handleNothingLikeDocs(doc, function)
+        } else if (returnType !in nonDocumentedReturnTypes) {
+            handleShouldHaveReturnDocs(doc, function)
+        }
+    }
+
+    private fun handleNothingLikeDocs(doc: KDoc, function: KtNamedFunction) {
+        val hasThrows = doc.getAllSections().any { it.findTagsByName("throws").isNotEmpty() }
+        val hasException = doc.getAllSections().any { it.findTagsByName("exception").isNotEmpty() }
+        val hasReturn = doc.getAllSections().any { it.findTagsByName("return").isNotEmpty() }
+        if (!hasThrows && !hasException && !hasReturn) {
+            report(
+                function.createReport("Missing @throws, @exception or @return tag to document special return type.")
+            )
+        }
+    }
+
+    private fun handleShouldHaveReturnDocs(doc: KDoc, function: KtNamedFunction) {
+        val hasReturn = doc.getAllSections().any { it.findTagsByName("return").isNotEmpty() }
+        if (!hasReturn) {
+            report(
+                function.createReport("Missing @return tag to document returned value.")
+            )
+        }
+    }
+
+    private fun KtNamedFunction.createReport(message: String): Finding =
+        CodeSmell(issue, Entity.atName(this), message)
+}

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/OutdatedDocumentationSpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/OutdatedDocumentationSpec.kt
@@ -364,5 +364,31 @@ class OutdatedDocumentationSpec : Spek({
                 assertThat(configuredSubject.compileAndLint(incorrectDeclarationsOrderWithType)).isEmpty()
             }
         }
+
+        describe("configuration reportIfNonePresent") {
+            val configuredSubject by memoized {
+                OutdatedDocumentation(TestConfig(mapOf("reportIfNonePresent" to "true")))
+            }
+
+            it("should report on class when no tags are present and option is on") {
+                val noDoc = """
+                /**
+                 * I'm a class without param docs 
+                 */
+                class MyClass(someParam: String)
+                """
+                assertThat(configuredSubject.compileAndLint(noDoc)).hasSize(1)
+            }
+
+            it("should report on function when no tags are present and option is on") {
+                val noDoc = """
+                /**
+                 * I'm a function without param docs 
+                 */
+                fun myFunction(someParam: String)
+                """
+                assertThat(configuredSubject.compileAndLint(noDoc)).hasSize(1)
+            }
+        }
     }
 })

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicFunctionReturnSpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicFunctionReturnSpec.kt
@@ -1,0 +1,136 @@
+package io.gitlab.arturbosch.detekt.rules.documentation
+
+import io.gitlab.arturbosch.detekt.rules.setupKotlinEnvironment
+import io.gitlab.arturbosch.detekt.test.assertThat
+import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+class UndocumentedPublicFunctionReturnSpec : Spek({
+    setupKotlinEnvironment()
+
+    val env: KotlinCoreEnvironment by memoized()
+    val subject by memoized { UndocumentedPublicFunctionReturn() }
+
+    describe("UndocumentedPublicFunction rule") {
+        context("non-Unit return") {
+            it("reports missing return tag on documented function") {
+                val code = """
+                    /**
+                     * I don't have a return tag
+                     */
+                    fun hello(): String { TODO() }
+                """
+                assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            }
+
+            it("reports missing return tag on documented function with throws") {
+                val code = """
+                    /**
+                     * I don't have a return tag
+                     *
+                     * @throws Exception Although I do have this one
+                     */
+                    fun hello(): String { TODO() }
+                """.trimIndent()
+                assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            }
+
+            it("reports missing return tag on documented function with exception") {
+                val code = """
+                    /**
+                     * I don't have a return tag
+                     *
+                     * @exception Exception Although I do have this one
+                     */
+                    fun hello(): String { TODO() }
+                """.trimIndent()
+                assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            }
+
+            it("does not report missing return tag on undocumented function") {
+                val code = """
+                    fun hello(): String { TODO() }
+                """
+                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            }
+
+            it("does not report when return tag is present") {
+                val code = """
+                    /**
+                     * @return I have a return tag
+                     */
+                    fun hello(): String { TODO() }
+                """
+                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            }
+        }
+
+        context("Unit return") {
+            it("does not report when return tag is absent when unit is returned") {
+                val code = """
+                   /**
+                    * I don't have a return tag
+                    */
+                    fun hello(): Unit { TODO() }
+                """
+                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            }
+        }
+
+        context("Nothing return") {
+            it("reports missing return tag on documented function") {
+                val code = """
+                    /**
+                     * I don't have a return tag
+                     */
+                    fun hello(): Nothing { TODO() }
+                """
+                assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            }
+
+
+            it("does not report on documented function with throws") {
+                val code = """
+                    /**
+                     * I don't have a return tag
+                     *
+                     * @throws Exception Although I do have this one
+                     */
+                    fun hello(): Nothing { TODO() }
+                """.trimIndent()
+                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            }
+
+            it("does not report on documented function with exception") {
+                val code = """
+                    /**
+                     * I don't have a return tag
+                     *
+                     * @exception Exception Although I do have this one
+                     */
+                    fun hello(): Nothing { TODO() }
+                """.trimIndent()
+                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            }
+
+            it("does not report on undocumented function") {
+                val code = """
+                    fun hello(): Nothing { TODO() }
+                """
+                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            }
+
+            it("does not report when return tag is present") {
+                val code = """
+                    /**
+                     * @return I have a return tag
+                     */
+                    fun hello(): Nothing { TODO() }
+                """
+                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            }
+        }
+    }
+})

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicFunctionReturnSpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicFunctionReturnSpec.kt
@@ -90,7 +90,6 @@ class UndocumentedPublicFunctionReturnSpec : Spek({
                 assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
             }
 
-
             it("does not report on documented function with throws") {
                 val code = """
                     /**


### PR DESCRIPTION
This PR:

- adds a flag that lets OutdatedDocumentation run even if no `@param` or `@property` tags are present
- adds an UndocumentedPublicFunctionReturn rule that reports missing `@return` tags for functions that return anything other than Unit. It also handles `Nothing` return types by allowing `@exception` or `@throws` to be used instead of `@return`.

This should fulfill everything I talked about in #4395 (as most of the functionality was already present in OutdatedDocumentation)

Apologies for this "two in one" PR, but the changes to OutdatedDocumentation are very small and I did not feel like making two PRs for such a small change

Fixes #4395 

### TODO

- [ ] Need to add the new rule to a ruleset
- [ ] Also, the change might also report private functions? Need to check this