### PR TITLE
Force that no one uses `Assertions.assertThat()`

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -166,6 +166,10 @@ style:
       - '@author'
       - '@requiresTypeResolution'
     excludes: ['**/detekt-rules-style/**/ForbiddenComment.kt']
+  ForbiddenImport:
+    active: true
+    imports:
+      - 'org.assertj.core.api.Assertions'
   ForbiddenMethodCall:
     active: true
     methods:

--- a/detekt-rules-empty/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyElseBlockSpec.kt
+++ b/detekt-rules-empty/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyElseBlockSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.empty
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.compileAndLint
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
@@ -22,7 +22,7 @@ class EmptyElseBlockSpec : Spek({
                     }
                 }
             """
-            Assertions.assertThat(subject.compileAndLint(code)).hasSize(1)
+            assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
         it("reports empty else blocks with trailing semicolon") {
@@ -34,7 +34,7 @@ class EmptyElseBlockSpec : Spek({
                     } else ;
                 }
             """
-            Assertions.assertThat(subject.compileAndLint(code)).hasSize(1)
+            assertThat(subject.compileAndLint(code)).hasSize(1)
         }
         it("reports empty else with trailing semicolon on new line") {
             val code = """
@@ -47,7 +47,7 @@ class EmptyElseBlockSpec : Spek({
                     i++
                 }
             """
-            Assertions.assertThat(subject.compileAndLint(code)).hasSize(1)
+            assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
         it("reports empty else with trailing semicolon and braces") {
@@ -61,7 +61,7 @@ class EmptyElseBlockSpec : Spek({
                     i++
                 }
             """
-            Assertions.assertThat(subject.compileAndLint(code)).hasSize(1)
+            assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
         it("does not report nonempty else with braces") {
@@ -75,7 +75,7 @@ class EmptyElseBlockSpec : Spek({
                     }
                 }
             """
-            Assertions.assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         it("does not report nonempty else without braces") {
@@ -87,7 +87,7 @@ class EmptyElseBlockSpec : Spek({
                     } else i++
                 }
             """
-            Assertions.assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         it("does not report nonempty else without braces but semicolon") {
@@ -99,7 +99,7 @@ class EmptyElseBlockSpec : Spek({
                     } else i++;
                 }
             """
-            Assertions.assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
     }
 })

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/NullCheckOnMutablePropertySpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/NullCheckOnMutablePropertySpec.kt
@@ -4,7 +4,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.setupKotlinEnvironment
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
@@ -26,7 +26,7 @@ class NullCheckOnMutablePropertySpec : Spek({
                     }
                 }
                 """
-            Assertions.assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
         it("should report a null-check on a mutable property in non-initial clauses in an if-statement") {
@@ -39,7 +39,7 @@ class NullCheckOnMutablePropertySpec : Spek({
                     }
                 }
                 """
-            Assertions.assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
         it("should report a null-check on a mutable property used in the same if-statement") {
@@ -52,7 +52,7 @@ class NullCheckOnMutablePropertySpec : Spek({
                     }
                 }
                 """
-            Assertions.assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
         it("should report on a mutable property that is not subject to a double-bang") {
@@ -65,7 +65,7 @@ class NullCheckOnMutablePropertySpec : Spek({
                     }
                 }
                 """
-            Assertions.assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
         it("should report on a mutable property even if it is checked multiple times") {
@@ -81,7 +81,7 @@ class NullCheckOnMutablePropertySpec : Spek({
                     }
                 }
                 """
-            Assertions.assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
         it("should not report when the checked property is not used afterwards") {
@@ -94,7 +94,7 @@ class NullCheckOnMutablePropertySpec : Spek({
                     }
                 }
                 """
-            Assertions.assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
         it("should not report a null-check on a shadowed property") {
@@ -108,7 +108,7 @@ class NullCheckOnMutablePropertySpec : Spek({
                     }
                 }
                 """
-            Assertions.assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
         it("should not report a null-check on a non-mutable constructor property") {
@@ -121,7 +121,7 @@ class NullCheckOnMutablePropertySpec : Spek({
                     }
                 }
                 """
-            Assertions.assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
         it("should report a null-check on a mutable class property") {
@@ -135,7 +135,7 @@ class NullCheckOnMutablePropertySpec : Spek({
                     }
                 }
                 """
-            Assertions.assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
         it("should not report a null-check on a val property") {
@@ -149,7 +149,7 @@ class NullCheckOnMutablePropertySpec : Spek({
                     }
                 }
                 """
-            Assertions.assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
         it("should report a null-check on a val property with a getter") {
@@ -170,7 +170,7 @@ class NullCheckOnMutablePropertySpec : Spek({
                     }
                 }
                 """
-            Assertions.assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
         it("should report a null-check conducted within an inner class") {
@@ -185,7 +185,7 @@ class NullCheckOnMutablePropertySpec : Spek({
                     }
                 }
                 """
-            Assertions.assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
         it("should report an inner-class mutable property") {
@@ -206,7 +206,7 @@ class NullCheckOnMutablePropertySpec : Spek({
                     }
                 }
                 """
-            Assertions.assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
         it("should report a null-check on a mutable file property") {
@@ -221,7 +221,7 @@ class NullCheckOnMutablePropertySpec : Spek({
                     }
                 }
                 """
-            Assertions.assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
         it("should not report a null-check on a non-mutable file property") {
@@ -236,7 +236,7 @@ class NullCheckOnMutablePropertySpec : Spek({
                     }
                 }
                 """
-            Assertions.assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
         it("should not report a null-check when there is no binding context") {
@@ -249,7 +249,7 @@ class NullCheckOnMutablePropertySpec : Spek({
                     }
                 }
                 """
-            Assertions.assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         it("should report a null-check when null is the first element in the if-statement") {
@@ -262,7 +262,7 @@ class NullCheckOnMutablePropertySpec : Spek({
                     }
                 }
                 """
-            Assertions.assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
         it("should not report when the if-expression has no explicit null value") {
@@ -276,7 +276,7 @@ class NullCheckOnMutablePropertySpec : Spek({
                     }
                 }
                 """
-            Assertions.assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
         it("should not report a null-check on a function") {
@@ -292,7 +292,7 @@ class NullCheckOnMutablePropertySpec : Spek({
                     }
                 }
                 """
-            Assertions.assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
     }
 })

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/CanBeNonNullableSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/CanBeNonNullableSpec.kt
@@ -4,7 +4,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.setupKotlinEnvironment
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
@@ -25,7 +25,7 @@ class CanBeNonNullableSpec : Spek({
                     }
                 }
                 """
-            Assertions.assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         context("evaluating private vars") {
@@ -47,7 +47,7 @@ class CanBeNonNullableSpec : Spek({
                     }
                 }
                 """
-                Assertions.assertThat(subject.compileAndLintWithContext(env, code)).hasSize(2)
+                assertThat(subject.compileAndLintWithContext(env, code)).hasSize(2)
             }
 
             it("reports when vars utilize non-nullable delegate values") {
@@ -77,7 +77,7 @@ class CanBeNonNullableSpec : Spek({
                         }
                     }
                     """
-                Assertions.assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+                assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
             }
 
             it("reports when file-level vars are never assigned nullable values") {
@@ -89,7 +89,7 @@ class CanBeNonNullableSpec : Spek({
                     fileB = 6
                 }
                 """
-                Assertions.assertThat(subject.compileAndLintWithContext(env, code)).hasSize(2)
+                assertThat(subject.compileAndLintWithContext(env, code)).hasSize(2)
             }
 
             it("does not report when class-level vars are assigned nullable values") {
@@ -121,7 +121,7 @@ class CanBeNonNullableSpec : Spek({
                     }
                 }
                 """
-                Assertions.assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
             }
 
             it("does not report vars that utilize nullable delegate values") {
@@ -130,7 +130,7 @@ class CanBeNonNullableSpec : Spek({
                         private var a: Int? by this::aDelegate
                     }
                     """
-                Assertions.assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
             }
 
             it("does not report when file-level vars are assigned nullable values") {
@@ -151,7 +151,7 @@ class CanBeNonNullableSpec : Spek({
                     }
                 }
                 """
-                Assertions.assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
             }
 
             it("reports when vars with private setters are never assigned nullable values") {
@@ -164,7 +164,7 @@ class CanBeNonNullableSpec : Spek({
                     }
                 }
                 """
-                Assertions.assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+                assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
             }
 
             it("does not report when vars with private setters are assigned nullable values") {
@@ -177,7 +177,7 @@ class CanBeNonNullableSpec : Spek({
                     }
                 }
                 """
-                Assertions.assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
             }
 
             it("does not report when vars use public setters") {
@@ -189,7 +189,7 @@ class CanBeNonNullableSpec : Spek({
                     }
                 }
                 """
-                Assertions.assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
             }
 
             it("does not report when vars use non-private setters") {
@@ -202,7 +202,7 @@ class CanBeNonNullableSpec : Spek({
                         }
                     }
                     """
-                Assertions.assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
             }
 
             it("does not report when private vars are declared in the constructor") {
@@ -213,7 +213,7 @@ class CanBeNonNullableSpec : Spek({
                     }
                 }
                 """
-                Assertions.assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
             }
         }
 
@@ -231,7 +231,7 @@ class CanBeNonNullableSpec : Spek({
                     }
                 }
                 """
-                Assertions.assertThat(subject.compileAndLintWithContext(env, code)).hasSize(3)
+                assertThat(subject.compileAndLintWithContext(env, code)).hasSize(3)
             }
 
             it("reports when vals utilize non-nullable delegate values") {
@@ -242,14 +242,14 @@ class CanBeNonNullableSpec : Spek({
                     }
                 }
                 """
-                Assertions.assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+                assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
             }
 
             it("reports when file-level vals are set to non-nullable values") {
                 val code = """
                 val fileA: Int? = 5
                 """
-                Assertions.assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+                assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
             }
 
             it("does not report when class-level vals are assigned a nullable value") {
@@ -267,7 +267,7 @@ class CanBeNonNullableSpec : Spek({
                     }
                 }
                 """
-                Assertions.assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
             }
 
             it("does not report when vals utilize nullable delegate values") {
@@ -281,14 +281,14 @@ class CanBeNonNullableSpec : Spek({
                     }
                 }
                 """
-                Assertions.assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
             }
 
             it("does not report when file-level vals are assigned a nullable value") {
                 val code = """
                 val fileA: Int? = null
                 """
-                Assertions.assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
             }
 
             it("does not report when vals are declared non-nullable") {
@@ -297,14 +297,14 @@ class CanBeNonNullableSpec : Spek({
                     val a: Int = 5
                 }
                 """
-                Assertions.assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
             }
 
             it("does not report when vals are declared in the constructor") {
                 val code = """
                 class A(private val a: Int?)
                 """
-                Assertions.assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
             }
 
             it("reports when vals with getters never return nullable values") {
@@ -324,7 +324,7 @@ class CanBeNonNullableSpec : Spek({
                     }
                 }
                 """
-                Assertions.assertThat(subject.compileAndLintWithContext(env, code)).hasSize(3)
+                assertThat(subject.compileAndLintWithContext(env, code)).hasSize(3)
             }
 
             it("does not report when vals with getters return potentially-nullable values") {
@@ -347,7 +347,7 @@ class CanBeNonNullableSpec : Spek({
                         }
                     }
                     """
-                Assertions.assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
             }
         }
 
@@ -358,7 +358,7 @@ class CanBeNonNullableSpec : Spek({
                     open var b: Int? = 5
                 }
                 """
-            Assertions.assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
         it("does not report properties whose initial assignment derives from unsafe non-Java code") {
@@ -371,7 +371,7 @@ class CanBeNonNullableSpec : Spek({
                     private var a: String? = e.localizedMessage
                 }
                 """
-            Assertions.assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
         it("does not report interface properties") {
@@ -381,7 +381,7 @@ class CanBeNonNullableSpec : Spek({
                     var b: Int?
                 }
                 """
-            Assertions.assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
     }
 })


### PR DESCRIPTION
Usually we need to add comments saying: "don't use `Assertions.assertThat`, use `assertThat()`". With this PR detekt will make that check for us.