### PR TITLE
Don't exclude the naming rules by default for tests

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -103,6 +103,8 @@ formatting:
     active: true
 
 naming:
+  TopLevelPropertyNaming:
+    constantPattern: '[a-z][_A-Za-z0-9]*|[A-Z][_A-Z0-9]*'
   InvalidPackageDeclaration:
     active: true
     excludes: ['**/build-logic/**/*.kt', '**/*.kts']

--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -414,34 +414,27 @@ naming:
   active: true
   BooleanPropertyNaming:
     active: false
-    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
     allowedPattern: '^(is|has|are)'
   ClassNaming:
     active: true
-    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
     classPattern: '[A-Z][a-zA-Z0-9]*'
   ConstructorParameterNaming:
     active: true
-    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
     parameterPattern: '[a-z][A-Za-z0-9]*'
     privateParameterPattern: '[a-z][A-Za-z0-9]*'
     excludeClassPattern: '$^'
     ignoreOverridden: true
   EnumNaming:
     active: true
-    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
     enumEntryPattern: '[A-Z][_a-zA-Z0-9]*'
   ForbiddenClassName:
     active: false
-    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
     forbiddenName: []
   FunctionMaxLength:
     active: false
-    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
     maximumFunctionNameLength: 30
   FunctionMinLength:
     active: false
-    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
     minimumFunctionNameLength: 3
   FunctionNaming:
     active: true
@@ -451,7 +444,6 @@ naming:
     ignoreOverridden: true
   FunctionParameterNaming:
     active: true
-    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
     parameterPattern: '[a-z][A-Za-z0-9]*'
     excludeClassPattern: '$^'
     ignoreOverridden: true
@@ -460,7 +452,6 @@ naming:
     rootPackage: ''
   LambdaParameterNaming:
     active: false
-    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
     parameterPattern: '[a-z][A-Za-z0-9]*|_'
   MatchingDeclarationName:
     active: true
@@ -472,34 +463,27 @@ naming:
     active: false
   NonBooleanPropertyPrefixedWithIs:
     active: false
-    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
   ObjectPropertyNaming:
     active: true
-    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
     constantPattern: '[A-Za-z][_A-Za-z0-9]*'
     propertyPattern: '[A-Za-z][_A-Za-z0-9]*'
     privatePropertyPattern: '(_)?[A-Za-z][_A-Za-z0-9]*'
   PackageNaming:
     active: true
-    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
     packagePattern: '[a-z]+(\.[a-z][A-Za-z0-9]*)*'
   TopLevelPropertyNaming:
     active: true
-    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
     constantPattern: '[A-Z][_A-Z0-9]*'
     propertyPattern: '[A-Za-z][_A-Za-z0-9]*'
     privatePropertyPattern: '_?[A-Za-z][_A-Za-z0-9]*'
   VariableMaxLength:
     active: false
-    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
     maximumVariableNameLength: 64
   VariableMinLength:
     active: false
-    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
     minimumVariableNameLength: 1
   VariableNaming:
     active: true
-    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
     variablePattern: '[a-z][A-Za-z0-9]*'
     privateVariablePattern: '(_)?[a-z][A-Za-z0-9]*'
     excludeClassPattern: '$^'

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/defaultconfig/Exclusion.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/defaultconfig/Exclusion.kt
@@ -26,7 +26,7 @@ private object TestExclusions : Exclusions() {
         "['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']"
     override val ruleSets = emptySet<String>()
     override val rules = setOf(
-        "NamingRules",
+        "FunctionNaming",
         "WildcardImport",
         "MagicNumber",
         "LateinitUsage",
@@ -34,7 +34,6 @@ private object TestExclusions : Exclusions() {
         "SpreadOperator",
         "TooManyFunctions",
         "ForEachOnRange",
-        "FunctionMaxLength",
         "TooGenericExceptionCaught",
         "InstanceOfCheckForException",
         "ThrowingExceptionsWithoutMessageOrCause",

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionSpec.kt
@@ -24,7 +24,7 @@ class TooGenericExceptionSpec : Spek({
 })
 
 const val tooGenericExceptionCode = """
-        fun main() {
+    fun main() {
         try {
             throw Throwable()
         } catch (e: ArrayIndexOutOfBoundsException) {
@@ -41,4 +41,5 @@ const val tooGenericExceptionCode = """
         } catch (e: NullPointerException) {
 
         }
-    }"""
+    }
+"""

--- a/detekt-sample-extensions/src/test/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/TooManyFunctionsSpec.kt
+++ b/detekt-sample-extensions/src/test/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/TooManyFunctionsSpec.kt
@@ -20,73 +20,72 @@ class TooManyFunctionsSpec : Spek({
     }
 })
 
-const val code: String =
-    """
-            class TooManyFunctions : Rule("TooManyFunctions") {
+private const val code: String = """
+    class TooManyFunctions : Rule("TooManyFunctions") {
 
-                override fun visitUserType(type: KtUserType) {
-                    super.visitUserType(type)
-                }
+        override fun visitUserType(type: KtUserType) {
+            super.visitUserType(type)
+        }
 
-                override fun visitReferenceExpression(expression: KtReferenceExpression) {
-                    super.visitReferenceExpression(expression)
-                }
+        override fun visitReferenceExpression(expression: KtReferenceExpression) {
+            super.visitReferenceExpression(expression)
+        }
 
-                override fun visitCallExpression(expression: KtCallExpression) {
-                    super.visitCallExpression(expression)
-                }
+        override fun visitCallExpression(expression: KtCallExpression) {
+            super.visitCallExpression(expression)
+        }
 
-                override fun visitBlockStringTemplateEntry(entry: KtBlockStringTemplateEntry) {
-                    super.visitBlockStringTemplateEntry(entry)
-                }
+        override fun visitBlockStringTemplateEntry(entry: KtBlockStringTemplateEntry) {
+            super.visitBlockStringTemplateEntry(entry)
+        }
 
-                override fun visitUnaryExpression(expression: KtUnaryExpression) {
-                    super.visitUnaryExpression(expression)
-                }
+        override fun visitUnaryExpression(expression: KtUnaryExpression) {
+            super.visitUnaryExpression(expression)
+        }
 
-                override fun visitDynamicType(type: KtDynamicType) {
-                    super.visitDynamicType(type)
-                }
+        override fun visitDynamicType(type: KtDynamicType) {
+            super.visitDynamicType(type)
+        }
 
-                override fun visitDynamicType(type: KtDynamicType, data: Void?): Void {
-                    return super.visitDynamicType(type, data)
-                }
+        override fun visitDynamicType(type: KtDynamicType, data: Void?): Void {
+            return super.visitDynamicType(type, data)
+        }
 
-                override fun visitSuperTypeCallEntry(call: KtSuperTypeCallEntry) {
-                    super.visitSuperTypeCallEntry(call)
-                }
+        override fun visitSuperTypeCallEntry(call: KtSuperTypeCallEntry) {
+            super.visitSuperTypeCallEntry(call)
+        }
 
-                override fun visitParenthesizedExpression(expression: KtParenthesizedExpression) {
-                    super.visitParenthesizedExpression(expression)
-                }
+        override fun visitParenthesizedExpression(expression: KtParenthesizedExpression) {
+            super.visitParenthesizedExpression(expression)
+        }
 
-                override fun visitFinallySection(finallySection: KtFinallySection) {
-                    super.visitFinallySection(finallySection)
-                }
+        override fun visitFinallySection(finallySection: KtFinallySection) {
+            super.visitFinallySection(finallySection)
+        }
 
-                override fun visitStringTemplateExpression(expression: KtStringTemplateExpression) {
-                    super.visitStringTemplateExpression(expression)
-                }
+        override fun visitStringTemplateExpression(expression: KtStringTemplateExpression) {
+            super.visitStringTemplateExpression(expression)
+        }
 
-                override fun visitDeclaration(dcl: KtDeclaration) {
-                    super.visitDeclaration(dcl)
-                }
+        override fun visitDeclaration(dcl: KtDeclaration) {
+            super.visitDeclaration(dcl)
+        }
 
-                override fun visitLabeledExpression(expression: KtLabeledExpression) {
-                    super.visitLabeledExpression(expression)
-                }
+        override fun visitLabeledExpression(expression: KtLabeledExpression) {
+            super.visitLabeledExpression(expression)
+        }
 
-                override fun visitEscapeStringTemplateEntry(entry: KtEscapeStringTemplateEntry) {
-                    super.visitEscapeStringTemplateEntry(entry)
-                }
+        override fun visitEscapeStringTemplateEntry(entry: KtEscapeStringTemplateEntry) {
+            super.visitEscapeStringTemplateEntry(entry)
+        }
 
-                override fun visitScript(script: KtScript) {
-                    super.visitScript(script)
-                }
+        override fun visitScript(script: KtScript) {
+            super.visitScript(script)
+        }
 
-                override fun visitTypeConstraintList(list: KtTypeConstraintList) {
-                    super.visitTypeConstraintList(list)
-                }
+        override fun visitTypeConstraintList(list: KtTypeConstraintList) {
+            super.visitTypeConstraintList(list)
+        }
 
-            }
-        """
+    }
+"""

--- a/detekt-sample-extensions/src/test/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/processors/QualifiedNameProcessorSpec.kt
+++ b/detekt-sample-extensions/src/test/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/processors/QualifiedNameProcessorSpec.kt
@@ -54,7 +54,7 @@ private val result = object : Detektion {
     }
 }
 
-const val code = """
+private const val code = """
     package io.gitlab.arturbosch.detekt.sample
 
     class Foo {}


### PR DESCRIPTION
In general, the rules that apply to good naming patterns in production code can be applied for the test code too. The only exception are the function names. And to be honest that's mainly because of JUnit but I don't want to cross that bridge yet. So this PR remove the excludes for all the rules except `FunctionNaming`.

I also changed our (not the default one) value for `TopLevelPropertyNaming.constantPattern:`. Otherwise I would need to do this changes like this that I think that are way worst:

```diff
     describe("QualifiedNameProcessor") {
 
         it("fqNamesOfTestFiles") {
-            val ktFile = compileContentForTest(code)
+            val ktFile = compileContentForTest(CODE)
             val processor = QualifiedNameProcessor()
             processor.onProcess(ktFile, BindingContext.EMPTY)
             processor.onFinish(listOf(ktFile), result, BindingContext.EMPTY)
@@ -54,7 +54,7 @@ private val result = object : Detektion {
     }
 }
 
-private const val code = """
+private const val CODE = """
     package io.gitlab.arturbosch.detekt.sample
 
     class Foo {}
```

closes #4144