### PR TITLE
Don't allow the usage of ` in function names

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -446,7 +446,7 @@ naming:
   FunctionNaming:
     active: true
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
-    functionPattern: '([a-z][a-zA-Z0-9]*)|(`.*`)'
+    functionPattern: '[a-z][a-zA-Z0-9]*'
     excludeClassPattern: '$^'
     ignoreOverridden: true
   FunctionParameterNaming:

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNaming.kt
@@ -32,7 +32,7 @@ class FunctionNaming(config: Config = Config.empty) : Rule(config) {
     )
 
     @Configuration("naming pattern")
-    private val functionPattern: Regex by config("([a-z][a-zA-Z0-9]*)|(`.*`)", String::toRegex)
+    private val functionPattern: Regex by config("[a-z][a-zA-Z0-9]*", String::toRegex)
 
     @Configuration("ignores functions in classes which match this regex")
     private val excludeClassPattern: Regex by config("$^", String::toRegex)

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNamingSpec.kt
@@ -97,11 +97,11 @@ class FunctionNamingSpec : Spek({
             )
         }
 
-        it("allow functions with backtick") {
+        it("doesn't allow functions with backtick") {
             val code = """
                 fun `7his is a function name _`() = Unit
             """
-            assertThat(FunctionNaming().compileAndLint(code)).isEmpty()
+            assertThat(FunctionNaming().compileAndLint(code)).hasSourceLocations(SourceLocation(1, 5))
         }
     }
 })

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingConventionLengthSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingConventionLengthSpec.kt
@@ -85,10 +85,10 @@ class NamingConventionLengthSpec : Spek({
             assertThat(subject.findings).isEmpty()
         }
 
-        it("should not report a function name that begins with a backtick, capitals, and spaces") {
+        it("should report a function name that begins with a backtick, capitals, and spaces") {
             val code = "fun `Hi bye`() = 3"
             subject.compileAndLint(code)
-            assertThat(subject.findings).isEmpty()
+            assertThat(subject.findings).hasSize(1)
         }
     }
 })


### PR DESCRIPTION
From the Kotlin Coding conventions:

> In tests (and **only** in tests), you can use method names with spaces enclosed in backticks.

https://kotlinlang.org/docs/coding-conventions.html#names-for-test-methods

And we are excluding this rule from test source sets so there is not point to alow it. It just allow false-negatives in production code.