### PR TITLE
Ignore private operators when we don't have ContextBingding in UnusedPrivateMember

### DIFF
--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
@@ -97,58 +97,65 @@ private class UnusedFunctionVisitor(
     private val functionReferences = mutableMapOf<String, MutableList<KtReferenceExpression>>()
     private val propertyDelegates = mutableListOf<KtPropertyDelegate>()
 
+    @Suppress("ComplexMethod")
     override fun getUnusedReports(issue: Issue): List<CodeSmell> {
         val propertyDelegateResultingDescriptors by lazy(LazyThreadSafetyMode.NONE) {
             propertyDelegates.flatMap { it.resultingDescriptors() }
         }
-        return functionDeclarations.flatMap { (functionName, functions) ->
-            val isOperator = functions.any { it.isOperator() }
-            val references = functionReferences[functionName].orEmpty()
-            val unusedFunctions = when {
-                (functions.size > 1 || isOperator) && bindingContext != BindingContext.EMPTY -> {
-                    val functionNameAsName = Name.identifier(functionName)
-                    val referencesViaOperator = if (isOperator) {
-                        val operatorToken = OperatorConventions.getOperationSymbolForName(functionNameAsName)
-                        val operatorValue = (operatorToken as? KtSingleValueToken)?.value
-                        val directReferences = operatorValue?.let { functionReferences[it] }.orEmpty()
-                        val assignmentReferences = when (operatorToken) {
-                            KtTokens.PLUS,
-                            KtTokens.MINUS,
-                            KtTokens.MUL,
-                            KtTokens.DIV,
-                            KtTokens.PERC -> operatorValue?.let { functionReferences["$it="] }.orEmpty()
-                            else -> emptyList()
-                        }
-                        val containingReferences = if (functionNameAsName == OperatorNameConventions.CONTAINS) {
-                            listOf(KtTokens.IN_KEYWORD, KtTokens.NOT_IN).flatMap {
-                                functionReferences[it.value].orEmpty()
+        return functionDeclarations
+            .filterNot { (_, functions) ->
+                // Without a binding context we can't know if an operator is called. So we ignore it to avoid
+                // false positives. More context at #4242
+                bindingContext == BindingContext.EMPTY && functions.any { it.isOperator() }
+            }
+            .flatMap { (functionName, functions) ->
+                val isOperator = functions.any { it.isOperator() }
+                val references = functionReferences[functionName].orEmpty()
+                val unusedFunctions = when {
+                    (functions.size > 1 || isOperator) && bindingContext != BindingContext.EMPTY -> {
+                        val functionNameAsName = Name.identifier(functionName)
+                        val referencesViaOperator = if (isOperator) {
+                            val operatorToken = OperatorConventions.getOperationSymbolForName(functionNameAsName)
+                            val operatorValue = (operatorToken as? KtSingleValueToken)?.value
+                            val directReferences = operatorValue?.let { functionReferences[it] }.orEmpty()
+                            val assignmentReferences = when (operatorToken) {
+                                KtTokens.PLUS,
+                                KtTokens.MINUS,
+                                KtTokens.MUL,
+                                KtTokens.DIV,
+                                KtTokens.PERC -> operatorValue?.let { functionReferences["$it="] }.orEmpty()
+                                else -> emptyList()
                             }
-                        } else emptyList()
-                        directReferences + assignmentReferences + containingReferences
-                    } else {
-                        emptyList()
-                    }
-                    val referenceDescriptors = (references + referencesViaOperator)
-                        .mapNotNull { it.getResolvedCall(bindingContext)?.resultingDescriptor }
-                        .map { it.original }
-                        .let {
-                            if (functionNameAsName in OperatorNameConventions.DELEGATED_PROPERTY_OPERATORS) {
-                                it + propertyDelegateResultingDescriptors
-                            } else {
-                                it
-                            }
+                            val containingReferences = if (functionNameAsName == OperatorNameConventions.CONTAINS) {
+                                listOf(KtTokens.IN_KEYWORD, KtTokens.NOT_IN).flatMap {
+                                    functionReferences[it.value].orEmpty()
+                                }
+                            } else emptyList()
+                            directReferences + assignmentReferences + containingReferences
+                        } else {
+                            emptyList()
                         }
-                    functions.filterNot {
-                        bindingContext[BindingContext.DECLARATION_TO_DESCRIPTOR, it] in referenceDescriptors
+                        val referenceDescriptors = (references + referencesViaOperator)
+                            .mapNotNull { it.getResolvedCall(bindingContext)?.resultingDescriptor }
+                            .map { it.original }
+                            .let {
+                                if (functionNameAsName in OperatorNameConventions.DELEGATED_PROPERTY_OPERATORS) {
+                                    it + propertyDelegateResultingDescriptors
+                                } else {
+                                    it
+                                }
+                            }
+                        functions.filterNot {
+                            bindingContext[BindingContext.DECLARATION_TO_DESCRIPTOR, it] in referenceDescriptors
+                        }
                     }
+                    references.isEmpty() -> functions
+                    else -> emptyList()
                 }
-                references.isEmpty() -> functions
-                else -> emptyList()
+                unusedFunctions.map {
+                    CodeSmell(issue, Entity.from(it), "Private function $functionName is unused.")
+                }
             }
-            unusedFunctions.map {
-                CodeSmell(issue, Entity.from(it), "Private function $functionName is unused.")
-            }
-        }
     }
 
     override fun visitNamedFunction(function: KtNamedFunction) {


### PR DESCRIPTION
Maintaining mixed rules is really painful: #2994.

Note: the change seems big but I just added the `filterNot` on the top. The problem is that with the reformat git thinks that all is new.

fixes #4242
#4435 is related. This will fix the false positives without type solving. But we still have false positives with type solving.