### PR TITLE
Always update the baseline if it exist

### DIFF
--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineFacade.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineFacade.kt
@@ -23,5 +23,5 @@ class BaselineFacade {
         BaselineFormat().write(baseline, baselineFile)
     }
 
-    internal fun baselineExists(baseline: Path) = baseline.exists() && baseline.isFile()
+    private fun baselineExists(baseline: Path) = baseline.exists() && baseline.isFile()
 }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineFacade.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineFacade.kt
@@ -9,8 +9,13 @@ import java.nio.file.Path
 
 class BaselineFacade {
 
-    fun transformResult(baselineFile: Path, result: Detektion): Detektion =
-        BaselineFilteredResult(result, Baseline.load(baselineFile))
+    fun transformResult(baselineFile: Path, result: Detektion): Detektion {
+        return if (baselineExists(baselineFile)) {
+            BaselineFilteredResult(result, Baseline.load(baselineFile))
+        } else {
+            result
+        }
+    }
 
     fun createOrUpdate(baselineFile: Path, findings: List<Finding>) {
         val ids = findings.map { it.baselineId }.toSortedSet()

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineFacade.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineFacade.kt
@@ -19,14 +19,19 @@ class BaselineFacade {
 
     fun createOrUpdate(baselineFile: Path, findings: List<Finding>) {
         val ids = findings.map { it.baselineId }.toSortedSet()
-        val baseline = if (baselineExists(baselineFile)) {
+        val exists = baselineExists(baselineFile)
+        val baseline = if (exists) {
             Baseline.load(baselineFile).copy(currentIssues = ids)
         } else {
             Baseline(emptySet(), ids)
         }
-        baselineFile.parent?.let { Files.createDirectories(it) }
-        BaselineFormat().write(baseline, baselineFile)
+        if (baseline.isNotEmpty() || exists) {
+            baselineFile.parent?.let { Files.createDirectories(it) }
+            BaselineFormat().write(baseline, baselineFile)
+        }
     }
 
     private fun baselineExists(baseline: Path) = baseline.exists() && baseline.isFile()
+
+    private fun Baseline.isNotEmpty() = currentIssues.isNotEmpty() || manuallySuppressedIssues.isNotEmpty()
 }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineFacade.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineFacade.kt
@@ -19,19 +19,17 @@ class BaselineFacade {
 
     fun createOrUpdate(baselineFile: Path, findings: List<Finding>) {
         val ids = findings.map { it.baselineId }.toSortedSet()
-        val exists = baselineExists(baselineFile)
-        val baseline = if (exists) {
-            Baseline.load(baselineFile).copy(currentIssues = ids)
+        val oldBaseline = if (baselineExists(baselineFile)) {
+            Baseline.load(baselineFile)
         } else {
-            Baseline(emptySet(), ids)
+            Baseline(emptySet(), emptySet())
         }
-        if (baseline.isNotEmpty() || exists) {
+        val baseline = oldBaseline.copy(currentIssues = ids)
+        if (oldBaseline != baseline) {
             baselineFile.parent?.let { Files.createDirectories(it) }
             BaselineFormat().write(baseline, baselineFile)
         }
     }
 
     private fun baselineExists(baseline: Path) = baseline.exists() && baseline.isFile()
-
-    private fun Baseline.isNotEmpty() = currentIssues.isNotEmpty() || manuallySuppressedIssues.isNotEmpty()
 }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineResultMapping.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineResultMapping.kt
@@ -33,10 +33,6 @@ class BaselineResultMapping : ReportingExtension {
         val facade = BaselineFacade()
         val flatten = this.flatMap { it.value }
 
-        if (flatten.isEmpty()) {
-            return this
-        }
-
         if (createBaseline) {
             facade.createOrUpdate(baselinePath, flatten)
         }

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineFacadeSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineFacadeSpec.kt
@@ -17,10 +17,17 @@ class BaselineFacadeSpec : Spek({
         val dir by memoized { createTempDirectoryForTest("baseline_format") }
         val validBaseline = resourceAsPath("/baseline_feature/valid-baseline.xml")
 
-        it("returns a BaselineFilteredResult") {
+        it("returns a BaselineFilteredResult when the baseline exists") {
             val detektion = BaselineFacade().transformResult(validBaseline, TestDetektion())
 
             assertThat(detektion).isInstanceOf(BaselineFilteredResult::class.java)
+        }
+
+        it("returns the same detektion when the baseline doesn't exist") {
+            val initialDetektion = TestDetektion()
+            val detektion = BaselineFacade().transformResult(dir.resolve("baseline.xml"), initialDetektion)
+
+            assertThat(detektion).isEqualTo(initialDetektion)
         }
 
         it("creates a baseline file") {

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineFacadeSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineFacadeSpec.kt
@@ -33,18 +33,10 @@ class BaselineFacadeSpec : Spek({
             assertThat(detektion).isEqualTo(initialDetektion)
         }
 
-        it("creates a baseline file without findings") {
+        it("doesn't create a baseline file without findings") {
             BaselineFacade().createOrUpdate(baselineFile, emptyList())
 
-            assertThat(baselineFile).hasContent(
-                """
-                <?xml version="1.0" ?>
-                <SmellBaseline>
-                  <ManuallySuppressedIssues></ManuallySuppressedIssues>
-                  <CurrentIssues></CurrentIssues>
-                </SmellBaseline>
-                """.trimIndent()
-            )
+            assertThat(baselineFile).doesNotExist()
         }
 
         it("creates on top of an existing a baseline file without findings") {

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineFacadeSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineFacadeSpec.kt
@@ -2,6 +2,7 @@ package io.gitlab.arturbosch.detekt.core.baseline
 
 import io.github.detekt.test.utils.createTempDirectoryForTest
 import io.github.detekt.test.utils.resourceAsPath
+import io.gitlab.arturbosch.detekt.test.TestDetektion
 import org.assertj.core.api.Assertions.assertThat
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
@@ -15,6 +16,12 @@ class BaselineFacadeSpec : Spek({
 
         val dir by memoized { createTempDirectoryForTest("baseline_format") }
         val validBaseline = resourceAsPath("/baseline_feature/valid-baseline.xml")
+
+        it("returns a BaselineFilteredResult") {
+            val detektion = BaselineFacade().transformResult(validBaseline, TestDetektion())
+
+            assertThat(detektion).isInstanceOf(BaselineFilteredResult::class.java)
+        }
 
         it("creates a baseline file") {
             val fullPath = dir.resolve("baseline.xml")
@@ -31,7 +38,7 @@ class BaselineFacadeSpec : Spek({
     }
 })
 
-fun assertNonEmptyBaseline(fullPath: Path) {
+private fun assertNonEmptyBaseline(fullPath: Path) {
     BaselineFacade().createOrUpdate(fullPath, emptyList())
     val lines = Files.readAllLines(fullPath)
     assertThat(lines).isNotEmpty

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineResultMappingSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineResultMappingSpec.kt
@@ -49,19 +49,6 @@ class BaselineResultMappingSpec : Spek({
             assertThat(baselineFile.exists()).isFalse()
         }
 
-        it("should not update an existing baseline file when no findings occurred") {
-            val existing = Baseline.load(existingBaselineFile)
-            val mapping = resultMapping(
-                baselineFile = existingBaselineFile,
-                createBaseline = true,
-            )
-
-            mapping.transformFindings(emptyMap())
-
-            val changed = Baseline.load(existingBaselineFile)
-            assertThat(existing).isEqualTo(changed)
-        }
-
         it("should not update an existing baseline file if option configured as false") {
             val existing = Baseline.load(existingBaselineFile)
             val mapping = resultMapping(


### PR DESCRIPTION
If you have a module with some issues in the baseline and you fix **all of them**, when you update the baseline detekt does nothing. This PR fixes that. If there is a baseline file, we always update it.

This PR also fixes a really annoying flaky test related with baseline.

Fix #3736