### PR TITLE
Enable `LiteFindingsReport` by default

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -36,9 +36,9 @@ console-reports:
      - 'ProjectStatisticsReport'
      - 'ComplexityReport'
      - 'NotificationReport'
-  #  - 'FindingsReport'
+     - 'FindingsReport'
      - 'FileBasedFindingsReport'
-     - 'LiteFindingsReport'
+  #  - 'LiteFindingsReport'
 
 output-reports:
   active: true

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/defaultconfig/ConfigPrinter.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/defaultconfig/ConfigPrinter.kt
@@ -115,9 +115,9 @@ object ConfigPrinter : DocumentationPrinter<List<RuleSetPage>> {
            - 'ProjectStatisticsReport'
            - 'ComplexityReport'
            - 'NotificationReport'
-        #  - 'FindingsReport'
+           - 'FindingsReport'
            - 'FileBasedFindingsReport'
-           - 'LiteFindingsReport'
+        #  - 'LiteFindingsReport'
     """.trimIndent()
 
     private fun defaultOutputReportsConfiguration(): String = """


### PR DESCRIPTION
`LiteFindingsReport` is way better report than `FindingsReport` basically because it explain what's wrong with the code that it is flagging. For more context: #4446

Fixes #4446