### PR TITLE
Revert "Update plugin pluginPublishing to v0.19.0 (#4429)"

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -44,7 +44,7 @@ binaryCompatibilityValidator = { id = "org.jetbrains.kotlinx.binary-compatibilit
 detekt = { id = "io.gitlab.arturbosch.detekt", version = "1.19.0" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 gradleVersions = { id = "com.github.ben-manes.versions", version = "0.40.0" }
-pluginPublishing = { id = "com.gradle.plugin-publish", version = "0.19.0" }
+pluginPublishing = { id = "com.gradle.plugin-publish", version = "0.18.0" }
 shadow = { id = "com.github.johnrengelman.shadow", version = "7.1.2" }
 sonarqube = { id = "org.sonarqube", version = "3.3" }
 


### PR DESCRIPTION
This reverts commit aec43377a8fe7b5dfa2a3a701107c962771808c7.

reason: gradle/gradle#19458 (comment)

https://github.com/detekt/detekt/pull/4429#issuecomment-1004994923
