### PR TITLE
Add option for OutdatedDocumentation to allow param in constructor pr…

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -66,6 +66,7 @@ comments:
     active: false
     matchTypeParameters: true
     matchDeclarationsOrder: true
+    allowParamOnConstructorProperties: false
   UndocumentedPublicClass:
     active: false
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/OutdatedDocumentationSpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/OutdatedDocumentationSpec.kt
@@ -364,5 +364,67 @@ class OutdatedDocumentationSpec : Spek({
                 assertThat(configuredSubject.compileAndLint(incorrectDeclarationsOrderWithType)).isEmpty()
             }
         }
+        describe("configuration allowParamOnConstructorProperties") {
+            val configuredSubject by memoized {
+                OutdatedDocumentation(TestConfig(mapOf("allowParamOnConstructorProperties" to "true")))
+            }
+
+            it("should not report when property is documented as param") {
+                val propertyAsParam = """
+                    /**
+                     * @param someParam Description of param
+                     * @param someProp Description of property
+                     */
+                    class MyClass(someParam: String, val someProp: String)
+                    """
+                assertThat(configuredSubject.compileAndLint(propertyAsParam)).isEmpty()
+            }
+
+            it("should not report when property is documented as property") {
+                val propertyAsParam = """
+                    /**
+                     * @param someParam Description of param
+                     * @property someProp Description of property
+                     */
+                    class MyClass(someParam: String, val someProp: String)
+                    """
+                assertThat(configuredSubject.compileAndLint(propertyAsParam)).isEmpty()
+            }
+        }
+
+        describe("configuration matchDeclarationsOrder and allowParamOnConstructorProperties") {
+            val configuredSubject by memoized {
+                OutdatedDocumentation(
+                    TestConfig(
+                        mapOf(
+                            "matchDeclarationsOrder" to "false",
+                            "allowParamOnConstructorProperties" to "true"
+                        )
+                    )
+                )
+            }
+
+            it("should not report when property is documented as param") {
+                val propertyAsParam = """
+                    /**
+                     * @param someParam Description of param
+                     * @param someProp Description of property
+                     */
+                    class MyClass(someParam: String, val someProp: String)
+                    """
+                assertThat(configuredSubject.compileAndLint(propertyAsParam)).isEmpty()
+            }
+
+            it("should not report when property is documented as property") {
+                val propertyAsParam = """
+                    /**
+                     * @param someParam Description of param
+                     * @property someProp Description of property
+                     */
+                    class MyClass(someParam: String, val someProp: String)
+                    """
+                assertThat(configuredSubject.compileAndLint(propertyAsParam)).isEmpty()
+            }
+        }
     }
 })


### PR DESCRIPTION
This fixes #4366

Ideally, all constructor parameters should be marked as `@property` (since they are properties), but currently IntelliJ does not display parameter docs for these: https://youtrack.jetbrains.com/issue/KTIJ-12948

as a workaround until this is fixed on Jetbrains side, we add a property to the OutdatedDocumentation that allows `@param` on constructor properties.