### PR TITLE
Match functions signatures with lambdas on it

### DIFF
--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCallSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCallSpec.kt
@@ -302,5 +302,21 @@ class ForbiddenMethodCallSpec : Spek({
             ).compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(2)
         }
+
+        it("should report functions with lambda params") {
+            val code = """
+                package org.example
+
+                fun bar(b: (String) -> String) = Unit
+
+                fun foo() {
+                    bar { "" }
+                }
+            """
+            val findings = ForbiddenMethodCall(
+                TestConfig(mapOf(METHODS to listOf("org.example.bar((kotlin.String) -> kotlin.String)")))
+            ).compileAndLintWithContext(env, code)
+            assertThat(findings).hasSize(1)
+        }
     }
 })

--- a/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/api/FunctionMatcher.kt
+++ b/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/api/FunctionMatcher.kt
@@ -58,21 +58,77 @@ sealed class FunctionMatcher {
 
     companion object {
         fun fromFunctionSignature(methodSignature: String): FunctionMatcher {
-            val tokens = methodSignature.split("(", ")")
-                .map { it.trim() }
+            @Suppress("TooGenericExceptionCaught", "UnsafeCallOnNullableType")
+            try {
+                val result = functionSignatureRegex.matchEntire(methodSignature)!!
 
-            val methodName = tokens.first().replace("`", "")
-            val params = if (tokens.size > 1) {
-                tokens[1].split(",").map { it.trim() }.filter { it.isNotBlank() }
-            } else {
-                null
-            }
+                val methodName = result.groups[1]!!.value.replace("`", "")
+                val params = result.groups[2]?.value?.splitParams()
+                    ?.map { changeIfLambda(it) ?: it }
 
-            return if (params == null) {
-                NameOnly(methodName)
-            } else {
-                WithParameters(methodName, params)
+                return if (params == null) {
+                    NameOnly(methodName)
+                } else {
+                    WithParameters(methodName, params)
+                }
+            } catch (ex: Exception) {
+                throw IllegalStateException("$methodSignature doesn't match a method signature", ex)
             }
         }
     }
 }
+
+// Extracted from: https://stackoverflow.com/a/16108347/842697
+private fun String.splitParams(): List<String> {
+    val split: MutableList<String> = ArrayList()
+    var nestingLevel = 0
+    val result = StringBuilder()
+    this.forEach { c ->
+        if (c == ',' && nestingLevel == 0) {
+            split.add(result.toString())
+            result.setLength(0)
+        } else {
+            if (c == '(') nestingLevel++
+            if (c == ')') nestingLevel--
+            check(nestingLevel >= 0)
+            result.append(c)
+        }
+    }
+    split.add(result.toString())
+    return split.map { it.trim() }.filter { it.isNotBlank() }
+}
+
+private fun changeIfLambda(param: String): String? {
+    val (paramsRaw, _) = splitLambda(param) ?: return null
+    val params = paramsRaw.splitParams()
+
+    return "kotlin.Function${params.count()}"
+}
+
+private fun splitLambda(param: String): Pair<String, String>? {
+    if (!param.startsWith("(")) return null
+
+    var nestingLevel = 0
+    val paramsRaw = StringBuilder()
+    val returnValue = StringBuilder()
+
+    param.toCharArray()
+        .drop(1)
+        .forEach { c ->
+            if (nestingLevel >= 0) {
+                if (c == '(') nestingLevel++
+                if (c == ')') nestingLevel--
+                if (nestingLevel >= 0) {
+                    paramsRaw.append(c)
+                }
+            } else {
+                returnValue.append(c)
+            }
+        }
+
+    check(returnValue.contains("->"))
+
+    return paramsRaw.toString().trim() to returnValue.toString().substringAfter("->").trim()
+}
+
+private val functionSignatureRegex = """((?:[^()`]|`.*`)*)(?:\((.*)\))?""".toRegex()

--- a/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/api/FunctionMatcher.kt
+++ b/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/api/FunctionMatcher.kt
@@ -80,12 +80,12 @@ sealed class FunctionMatcher {
 
 // Extracted from: https://stackoverflow.com/a/16108347/842697
 private fun String.splitParams(): List<String> {
-    val split: MutableList<String> = ArrayList()
+    val split: MutableList<String> = mutableListOf()
     var nestingLevel = 0
     val result = StringBuilder()
     this.forEach { c ->
         if (c == ',' && nestingLevel == 0) {
-            split.add(result.toString())
+            split.add(result.toString().trim())
             result.setLength(0)
         } else {
             if (c == '(') nestingLevel++
@@ -94,8 +94,11 @@ private fun String.splitParams(): List<String> {
             result.append(c)
         }
     }
-    split.add(result.toString())
-    return split.map { it.trim() }.filter { it.isNotBlank() }
+    val lastParam = result.toString().trim()
+    if (lastParam.isNotEmpty()) {
+        split.add(lastParam)
+    }
+    return split
 }
 
 private fun changeIfLambda(param: String): String? {
@@ -112,6 +115,10 @@ private fun splitLambda(param: String): Pair<String, String>? {
     val paramsRaw = StringBuilder()
     val returnValue = StringBuilder()
 
+    /*
+     * We don't count the first `(` so as soon as the nestingLevel reaches the last `)` we know that we read all the
+     * params. Then we handle the rest of the String as the result.
+     */
     param.toCharArray()
         .drop(1)
         .forEach { c ->
@@ -126,7 +133,7 @@ private fun splitLambda(param: String): Pair<String, String>? {
             }
         }
 
-    check(returnValue.contains("->"))
+    check(returnValue.trim().startsWith("->"))
 
     return paramsRaw.toString().trim() to returnValue.toString().substringAfter("->").trim()
 }

--- a/detekt-tooling/src/test/kotlin/io/github/detekt/tooling/api/FunctionMatcherSpec.kt
+++ b/detekt-tooling/src/test/kotlin/io/github/detekt/tooling/api/FunctionMatcherSpec.kt
@@ -50,7 +50,31 @@ class FunctionMatcherSpec : Spek({
                     "io.gitlab.arturbosch.detekt.SomeClass.some , method",
                     listOf("kotlin.String"),
                 ),
-            )
+            ),
+            TestCase(
+                testDescription = "should return method name and param list when it has lambdas",
+                functionSignature = "hello((Bar, Foo) -> Unit, (Bar) -> Bar, Foo, () -> Foo)",
+                expectedFunctionMatcher = FunctionMatcher.WithParameters(
+                    "hello",
+                    listOf(
+                        "kotlin.Function2",
+                        "kotlin.Function1",
+                        "Foo",
+                        "kotlin.Function0",
+                    ),
+                ),
+            ),
+            TestCase(
+                testDescription = "should return method name and param list when it has complex lambdas",
+                functionSignature = "hello((Bar, (Bar) -> Unit) -> (Bar) -> Foo, () -> Unit)",
+                expectedFunctionMatcher = FunctionMatcher.WithParameters(
+                    "hello",
+                    listOf(
+                        "kotlin.Function2",
+                        "kotlin.Function0",
+                    ),
+                ),
+            ),
         ).forEach { testCase ->
             it(testCase.testDescription) {
                 val functionMatcher = FunctionMatcher.fromFunctionSignature(testCase.functionSignature)
@@ -132,6 +156,20 @@ private val matrixCase: Map<FunctionMatcher, Map<String, Boolean>> = run {
             functions[3] to false, // fun compare()
             functions[4] to false, // fun compare(hello: String)
             functions[5] to false, // fun compare(hello: String, world: Int)
+        ),
+        FunctionMatcher.fromFunctionSignature("foo(() -> kotlin.String)") to linkedMapOf(
+            "fun foo(a: () -> String)" to true,
+            "fun foo(a: () -> Unit)" to true,
+            "fun foo(a: (String) -> String)" to false,
+            "fun foo(a: (String) -> Unit)" to false,
+            "fun foo(a: (Int) -> Unit)" to false,
+        ),
+        FunctionMatcher.fromFunctionSignature("foo((kotlin.String) -> Unit)") to linkedMapOf(
+            "fun foo(a: () -> String)" to false,
+            "fun foo(a: () -> Unit)" to false,
+            "fun foo(a: (String) -> String)" to true,
+            "fun foo(a: (String) -> Unit)" to true,
+            "fun foo(a: (Int) -> Unit)" to true,
         ),
     )
 }


### PR DESCRIPTION
Related with #4448 but it doesn't fix it yet. The next step is to support extension functions.

*Note:* If you check the tests you will see that the signature `foo(() -> kotlin.String)` matches a functione like this one: `fun foo(a: () -> Unit)`. That's because we don't need to distinguish between this two functions:

```kotlin
fun foo(a: () -> Unit)
fun foo(a: () -> String)
```

The compiler doesn't allow to define both at the same time.

If we want to distinguish between those we would introduce a breaking change because until now this signature: `foo(List)` was matching `fun foo(a: List<String>)` but if we enforce to specify the generics that type should be changed.

For those two reasons combined I think that it's better to ignore the generics.