### PR TITLE
Function generics matcher

### DIFF
--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCallSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCallSpec.kt
@@ -386,5 +386,36 @@ class ForbiddenMethodCallSpec : Spek({
                 assertThat(findings).isEmpty()
             }
         }
+
+        context("Should distinguish between runCatching - #4448") {
+            val code = """
+                package org.example
+
+                class A {
+                    fun foo() {
+                        kotlin.runCatching {}
+                        runCatching {}
+                    }
+                }
+            """
+
+            it("forbid the one without receiver") {
+                val findings = ForbiddenMethodCall(
+                    TestConfig(mapOf(METHODS to listOf("kotlin.runCatching(() -> R)")))
+                ).compileAndLintWithContext(env, code)
+                assertThat(findings)
+                    .hasSize(1)
+                    .hasSourceLocation(5, 16)
+            }
+
+            it("forbid the one with receiver") {
+                val findings = ForbiddenMethodCall(
+                    TestConfig(mapOf(METHODS to listOf("kotlin.runCatching(T, (T) -> R)")))
+                ).compileAndLintWithContext(env, code)
+                assertThat(findings)
+                    .hasSize(1)
+                    .hasSourceLocation(6, 9)
+            }
+        }
     }
 })

--- a/detekt-tooling/src/test/kotlin/io/github/detekt/tooling/api/FunctionMatcherSpec.kt
+++ b/detekt-tooling/src/test/kotlin/io/github/detekt/tooling/api/FunctionMatcherSpec.kt
@@ -246,6 +246,21 @@ class FunctionMatcherSpec(private val env: KotlinCoreEnvironment) {
             val methodSignature = FunctionMatcher.fromFunctionSignature("foo(kotlin.String, kotlin.Int)")
             assertThat(methodSignature.match(function, bindingContext)).isEqualTo(result)
         }
+
+        @DisplayName("When generics foo(T, U)")
+        @ParameterizedTest(name = "in case {0} it return {1}")
+        @CsvSource(
+            "'fun <T, U> foo(a: T, b: U)',      true",
+            "'fun <T, U> foo(a: U, b: T)',      false",
+            "'fun <T, U> foo(a: String, b: U)', false",
+            "'fun <T, U> T.foo(a: U)',          true",
+            "'fun <T, U> U.foo(a: T)',          false",
+        )
+        fun `When foo(T, U)`(code: String, result: Boolean) {
+            val (function, bindingContext) = buildKtFunction(env, code)
+            val methodSignature = FunctionMatcher.fromFunctionSignature("foo(T, U)")
+            assertThat(methodSignature.match(function, bindingContext)).isEqualTo(result)
+        }
     }
 }
 


### PR DESCRIPTION
Match generic names in signature functions.

Now ForbiddenMethod call allows to forbid `kotlin.runCatching {}` but allowing `runCatching {}`. 

closes #4448