### PR TITLE
Document the overlapping rules from `formatting`

### DIFF
--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/Filename.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/Filename.kt
@@ -7,6 +7,9 @@ import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
  * See <a href="https://ktlint.github.io">ktlint-website</a> for documentation.
+ *
+ * This rules overlaps with [`naming>MatchingDeclarationName`](https://detekt.github.io/detekt/naming.html#matchingdeclarationname)
+ * from the standard rules, make sure to enable just one.
  */
 @ActiveByDefault(since = "1.0.0")
 class Filename(config: Config) : FormattingRule(config) {

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/FinalNewline.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/FinalNewline.kt
@@ -12,6 +12,9 @@ import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
  * See <a href="https://ktlint.github.io">ktlint-website</a> for documentation.
+ *
+ * This rules overlaps with [`style>NewLineAtEndOfFile`](https://detekt.github.io/detekt/style.html#newlineatendoffile)
+ * from the standard rules, make sure to enable just one. The pro of this rule is that it can auto-correct the issue.
  */
 @OptIn(FeatureInAlphaState::class)
 @ActiveByDefault(since = "1.0.0")

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/MaximumLineLength.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/MaximumLineLength.kt
@@ -14,7 +14,9 @@ import io.gitlab.arturbosch.detekt.formatting.MAX_LINE_LENGTH_KEY
 /**
  * See <a href="https://ktlint.github.io">ktlint-website</a> for documentation.
  *
- * This rules overlaps with [`MaxLineLength`](https://detekt.github.io/detekt/style.html#maxlinelength) from the standard rules, make sure to enable just one or keep them aligned.
+ * This rules overlaps with [`style>MaxLineLength`](https://detekt.github.io/detekt/style.html#maxlinelength)
+ * from the standard rules, make sure to enable just one or keep them aligned. The pro of this rule is that it can
+ * auto-correct the issue.
  */
 @ActiveByDefault(since = "1.0.0")
 @OptIn(FeatureInAlphaState::class)

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/ModifierOrdering.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/ModifierOrdering.kt
@@ -8,6 +8,9 @@ import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
  * See <a href="https://ktlint.github.io/#rule-modifier-order">ktlint-website</a> for documentation.
+ *
+ * This rules overlaps with [`style>ModifierOrder`](https://detekt.github.io/detekt/style.html#modifierorder)
+ * from the standard rules, make sure to enable just one. The pro of this rule is that it can auto-correct the issue.
  */
 @ActiveByDefault(since = "1.0.0")
 @AutoCorrectable(since = "1.0.0")


### PR DESCRIPTION
Aware the users of `formatting` that some rules overlap with some of our standard rules.