### PR TITLE
[VarCouldBeVal] Override vars will not be flagged if bindingContext is not set

### DIFF
--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/VarCouldBeVal.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/VarCouldBeVal.kt
@@ -10,7 +10,6 @@ import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
 import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
-import io.gitlab.arturbosch.detekt.rules.isOverride
 import org.jetbrains.kotlin.descriptors.DeclarationDescriptor
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtBinaryExpression
@@ -70,6 +69,7 @@ class VarCouldBeVal(config: Config = Config.empty) : Rule(config) {
 
     override fun visitKtFile(file: KtFile) {
         super.visitKtFile(file)
+        if (bindingContext == BindingContext.EMPTY) return
         val assignmentVisitor = AssignmentVisitor(bindingContext)
         file.accept(assignmentVisitor)
 
@@ -194,7 +194,6 @@ class VarCouldBeVal(config: Config = Config.empty) : Rule(config) {
             return when {
                 !isVar -> false
                 isLocal || isPrivate() -> true
-                isOverride() && bindingContext == BindingContext.EMPTY -> false
                 else -> {
                     // Check for whether property belongs to an anonymous object
                     // defined in a function.

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/VarCouldBeVal.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/VarCouldBeVal.kt
@@ -10,6 +10,7 @@ import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
 import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
+import io.gitlab.arturbosch.detekt.rules.isOverride
 import org.jetbrains.kotlin.descriptors.DeclarationDescriptor
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtBinaryExpression
@@ -193,6 +194,7 @@ class VarCouldBeVal(config: Config = Config.empty) : Rule(config) {
             return when {
                 !isVar -> false
                 isLocal || isPrivate() -> true
+                isOverride() && bindingContext == BindingContext.EMPTY -> false
                 else -> {
                     // Check for whether property belongs to an anonymous object
                     // defined in a function.

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/VarCouldBeValSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/VarCouldBeValSpec.kt
@@ -412,7 +412,7 @@ class VarCouldBeValSpec : Spek({
                 assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
             }
 
-            it("does not report when an object escapes and there is no type resolution") {
+            it("does not report when an object initializes a variable directly - without type solving") {
                 val code = """
                     interface I {
                         var optionEnabled: Boolean

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/VarCouldBeValSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/VarCouldBeValSpec.kt
@@ -1,6 +1,7 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.rules.setupKotlinEnvironment
+import io.gitlab.arturbosch.detekt.test.compileAndLint
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
@@ -409,6 +410,21 @@ class VarCouldBeValSpec : Spek({
                     } else null
                 """
                 assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            }
+
+            it("does not report when an object escapes and there is no type resolution") {
+                val code = """
+                    interface I {
+                        var optionEnabled: Boolean
+                    }
+                    fun test(): I {
+                        val o = object: I {
+                            override var optionEnabled: Boolean = false
+                        }
+                        return o
+                    }
+                """.trimIndent()
+                assertThat(subject.compileAndLint(code)).isEmpty()
             }
         }
     }


### PR DESCRIPTION
This addresses issue #4474
