### PR TITLE
Fixes test for LiteFindingsReport

### DIFF
--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/LiteFindingsReportSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/LiteFindingsReportSpec.kt
@@ -42,7 +42,7 @@ class LiteFindingsReportSpec : Spek({
         }
 
         it("should not add auto corrected issues to report") {
-            val report = FindingsReport()
+            val report = LiteFindingsReport()
             AutoCorrectableIssueAssert.isReportNull(report)
         }
     }


### PR DESCRIPTION
One of the tests for `LiteFindingsReport` was referencing `FindingsReport`. Changes the test to reference the correct class.
