### PR TITLE
Use major version tag for github-pages-deploy-action

### DIFF
--- a/.github/workflows/deploy-website.yaml
+++ b/.github/workflows/deploy-website.yaml
@@ -98,7 +98,7 @@ jobs:
       working-directory: docs/
 
     - name: Deploy Github Pages
-      uses: JamesIves/github-pages-deploy-action@4.2.1
+      uses: JamesIves/github-pages-deploy-action@v4
       with:
         branch: gh-pages
         folder: docs/_site/


### PR DESCRIPTION
[4.2.2 release notes](https://github.com/JamesIves/github-pages-deploy-action/releases/tag/v4.2.2):

> Introduces major version tags. You can now point your workflow to JamesIves/github-pages-deploy-action@v4 if you'd like to always have the most cutting edge changes outside of using the release branch directly.