### PR TITLE
Fix overridden function reporting for CanBeNonNullable rule

### DIFF
--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/CanBeNonNullable.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/CanBeNonNullable.kt
@@ -12,6 +12,7 @@ import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.rules.isNonNullCheck
 import io.gitlab.arturbosch.detekt.rules.isNullCheck
 import io.gitlab.arturbosch.detekt.rules.isOpen
+import io.gitlab.arturbosch.detekt.rules.isOverride
 import org.jetbrains.kotlin.descriptors.CallableDescriptor
 import org.jetbrains.kotlin.descriptors.DeclarationDescriptor
 import org.jetbrains.kotlin.descriptors.PropertyDescriptor
@@ -124,6 +125,10 @@ class CanBeNonNullable(config: Config = Config.empty) : Rule(config) {
         private val nullableParams = mutableMapOf<DeclarationDescriptor, NullableParam>()
 
         override fun visitNamedFunction(function: KtNamedFunction) {
+            if (function.isOverride()) {
+                return
+            }
+
             val candidateDescriptors = mutableSetOf<DeclarationDescriptor>()
             function.valueParameters.asSequence()
                 .filter {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/CanBeNonNullableSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/CanBeNonNullableSpec.kt
@@ -426,6 +426,21 @@ class CanBeNonNullableSpec : Spek({
                     """.trimIndent()
                     assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
                 }
+
+                it("does not report on overridden function parameter") {
+                    val code = """
+                        interface A {
+                            fun foo(a: Int?)
+                        }
+                        
+                        class B : A {
+                            override fun foo(a: Int?) {
+                                val b = a!! + 2 
+                            }
+                        }
+                    """.trimIndent()
+                    assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                }
             }
 
             context("using a null-safe expression") {


### PR DESCRIPTION
Fix #4486. Now `CanBeNonNullable` does not report overridden functions parameters