### PR TITLE
migrate tests in detekt-core to junit

### DIFF
--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/AnalyzerSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/AnalyzerSpec.kt
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import java.util.concurrent.CompletionException
 
-internal class AnalyzerSpec {
+class AnalyzerSpec {
 
     @Nested
     inner class `exceptions during analyze()` {

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/AnalyzerSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/AnalyzerSpec.kt
@@ -14,14 +14,16 @@ import io.gitlab.arturbosch.detekt.test.yamlConfig
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.jetbrains.kotlin.psi.KtFile
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 import java.util.concurrent.CompletionException
 
-class AnalyzerSpec : Spek({
+internal class AnalyzerSpec {
 
-    describe("exceptions during analyze()") {
-        it("throw error explicitly when config has wrong value type in config") {
+    @Nested
+    inner class `exceptions during analyze()` {
+        @Test
+        fun `throw error explicitly when config has wrong value type in config`() {
             val testFile = path.resolve("Test.kt")
             val settings = createProcessingSettings(testFile, yamlConfig("configs/config-value-type-wrong.yml"))
             val analyzer = Analyzer(settings, listOf(StyleRuleSetProvider()), emptyList())
@@ -31,7 +33,8 @@ class AnalyzerSpec : Spek({
             }.isInstanceOf(IllegalStateException::class.java)
         }
 
-        it("throw error explicitly in parallel when config has wrong value in config") {
+        @Test
+        fun `throw error explicitly in parallel when config has wrong value in config`() {
             val testFile = path.resolve("Test.kt")
             val settings = createProcessingSettings(
                 inputPath = testFile,
@@ -51,9 +54,11 @@ class AnalyzerSpec : Spek({
         }
     }
 
-    describe("analyze successfully when config has correct value type in config") {
+    @Nested
+    inner class `analyze successfully when config has correct value type in config` {
 
-        it("no findings") {
+        @Test
+        fun `no findings`() {
             val testFile = path.resolve("Test.kt")
             val settings = createProcessingSettings(testFile, yamlConfig("configs/config-value-type-correct.yml"))
             val analyzer = Analyzer(settings, listOf(StyleRuleSetProvider()), emptyList())
@@ -61,7 +66,8 @@ class AnalyzerSpec : Spek({
             assertThat(settings.use { analyzer.run(listOf(compileForTest(testFile))) }).isEmpty()
         }
 
-        it("with findings") {
+        @Test
+        fun `with findings`() {
             val testFile = path.resolve("Test.kt")
             val settings = createProcessingSettings(testFile, yamlConfig("configs/config-value-type-correct.yml"))
             val analyzer = Analyzer(settings, listOf(StyleRuleSetProvider(18)), emptyList())
@@ -69,7 +75,8 @@ class AnalyzerSpec : Spek({
             assertThat(settings.use { analyzer.run(listOf(compileForTest(testFile))) }).hasSize(1)
         }
 
-        it("with findings but ignored") {
+        @Test
+        fun `with findings but ignored`() {
             val testFile = path.resolve("Test.kt")
             val settings = createProcessingSettings(
                 testFile,
@@ -80,7 +87,7 @@ class AnalyzerSpec : Spek({
             assertThat(settings.use { analyzer.run(listOf(compileForTest(testFile))) }).isEmpty()
         }
     }
-})
+}
 
 private class StyleRuleSetProvider(private val threshold: Int? = null) : RuleSetProvider {
     override val ruleSetId: String = "style"

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/CorrectableRulesFirstSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/CorrectableRulesFirstSpec.kt
@@ -11,14 +11,16 @@ import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.test.yamlConfig
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.psi.KtClass
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-class CorrectableRulesFirstSpec : Spek({
+internal class CorrectableRulesFirstSpec {
 
-    describe("correctable rules are run first") {
+    @Nested
+    inner class `correctable rules are run first` {
 
-        it("runs rule with id 'NonCorrectable' last") {
+        @Test
+        fun `runs rule with id 'NonCorrectable' last`() {
             var actualLastRuleId = ""
 
             class First(config: Config) : Rule(config) {
@@ -51,7 +53,7 @@ class CorrectableRulesFirstSpec : Spek({
             assertThat(actualLastRuleId).isEqualTo("NonCorrectable")
         }
     }
-})
+}
 
 private val justAnIssue = Issue(
     "JustAnIssue",

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/CorrectableRulesFirstSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/CorrectableRulesFirstSpec.kt
@@ -14,7 +14,7 @@ import org.jetbrains.kotlin.psi.KtClass
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
-internal class CorrectableRulesFirstSpec {
+class CorrectableRulesFirstSpec {
 
     @Nested
     inner class `correctable rules are run first` {

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/CustomRuleSetProviderSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/CustomRuleSetProviderSpec.kt
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.Test
  *          detekt-core/src/test/resources/sample-rule-set.jar'
  *  4. Now 'gradle build' should be green again.
  */
-internal class CustomRuleSetProviderSpec {
+class CustomRuleSetProviderSpec {
 
     @Nested
     inner class `custom rule sets should be loadable through jars` {

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/CustomRuleSetProviderSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/CustomRuleSetProviderSpec.kt
@@ -4,8 +4,8 @@ import io.github.detekt.test.utils.resourceAsPath
 import io.gitlab.arturbosch.detekt.core.rules.RuleSetLocator
 import io.gitlab.arturbosch.detekt.core.tooling.withSettings
 import org.assertj.core.api.Assertions.assertThat
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
 /**
  * This test runs a precompiled jar with a custom rule provider.
@@ -18,11 +18,13 @@ import org.spekframework.spek2.style.specification.describe
  *          detekt-core/src/test/resources/sample-rule-set.jar'
  *  4. Now 'gradle build' should be green again.
  */
-class CustomRuleSetProviderSpec : Spek({
+internal class CustomRuleSetProviderSpec {
 
-    describe("custom rule sets should be loadable through jars") {
+    @Nested
+    inner class `custom rule sets should be loadable through jars` {
 
-        it("should load the sample provider") {
+        @Test
+        fun `should load the sample provider`() {
             val sampleRuleSet = resourceAsPath("sample-rule-set.jar")
             val spec = createNullLoggingSpec {
                 extensions {
@@ -36,4 +38,4 @@ class CustomRuleSetProviderSpec : Spek({
             assertThat(providers).filteredOn { it.ruleSetId == "sample" }.hasSize(1)
         }
     }
-})
+}

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/DetektMessageCollectorSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/DetektMessageCollectorSpec.kt
@@ -11,11 +11,11 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
-internal class DetektMessageCollectorSpec {
+class DetektMessageCollectorSpec {
 
-    lateinit var debugPrinter: (() -> String) -> Unit
-    lateinit var warningPrinter: ((String) -> Unit)
-    lateinit var subject: DetektMessageCollector
+    private lateinit var debugPrinter: (() -> String) -> Unit
+    private lateinit var warningPrinter: ((String) -> Unit)
+    private lateinit var subject: DetektMessageCollector
 
     @BeforeEach
     fun setupMocksAndSubject() {

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/DetektMessageCollectorSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/DetektMessageCollectorSpec.kt
@@ -7,82 +7,98 @@ import io.mockk.slot
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.lifecycle.CachingMode
-import org.spekframework.spek2.style.specification.describe
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-internal object DetektMessageCollectorSpec : Spek({
-    describe("DetektMessageCollector") {
-        val debugPrinter: (() -> String) -> Unit by memoized(CachingMode.TEST) {
-            mockk {
-                every { this@mockk.invoke(any()) } returns Unit
-            }
+internal class DetektMessageCollectorSpec {
+
+    lateinit var debugPrinter: (() -> String) -> Unit
+    lateinit var warningPrinter: ((String) -> Unit)
+    lateinit var subject: DetektMessageCollector
+
+    @BeforeEach
+    fun setupMocksAndSubject() {
+        debugPrinter = mockk { every { this@mockk.invoke(any()) } returns Unit }
+        warningPrinter = mockk { every { this@mockk.invoke(any()) } returns Unit }
+        subject = DetektMessageCollector(
+            minSeverity = CompilerMessageSeverity.INFO,
+            debugPrinter = debugPrinter,
+            warningPrinter = warningPrinter,
+        )
+    }
+
+    @Nested
+    inner class `message with min severity` {
+        @BeforeEach
+        fun setUp() {
+            subject.report(CompilerMessageSeverity.INFO, "message", null)
         }
-        val warningPrinter: (String) -> Unit by memoized(CachingMode.TEST) {
-            mockk {
-                every { this@mockk.invoke(any()) } returns Unit
-            }
-        }
-        val subject by memoized(CachingMode.TEST) {
-            DetektMessageCollector(
-                minSeverity = CompilerMessageSeverity.INFO,
-                debugPrinter = debugPrinter,
-                warningPrinter = warningPrinter,
-            )
+
+        @Test
+        fun `prints the message`() {
+            val slot = slot<() -> String>()
+            verify { debugPrinter.invoke(capture(slot)) }
+            assertThat(slot.captured()).isEqualTo("info: message")
         }
 
-        describe("message with min severity") {
-            beforeEachTest { subject.report(CompilerMessageSeverity.INFO, "message", null) }
+        @Test
+        fun `adds up to the message count`() {
+            subject.printIssuesCountIfAny()
 
-            it("prints the message") {
-                val slot = slot<() -> String>()
-                verify { debugPrinter.invoke(capture(slot)) }
-                assertThat(slot.captured()).isEqualTo("info: message")
-            }
-
-            it("adds up to the message count") {
-                subject.printIssuesCountIfAny()
-
-                verify {
-                    warningPrinter(
-                        "The BindingContext was created with 1 issues. " +
-                            "Run detekt with --debug to see the error messages."
-                    )
-                }
-            }
-        }
-        describe("message with higher severity than the min severity") {
-            beforeEachTest { subject.report(CompilerMessageSeverity.WARNING, "message", null) }
-
-            it("prints the message") {
-                val slot = slot<() -> String>()
-                verify { debugPrinter.invoke(capture(slot)) }
-                assertThat(slot.captured()).isEqualTo("warning: message")
-            }
-
-            it("adds up to the message count") {
-                subject.printIssuesCountIfAny()
-
-                verify {
-                    warningPrinter(
-                        "The BindingContext was created with 1 issues. " +
-                            "Run detekt with --debug to see the error messages."
-                    )
-                }
-            }
-        }
-        describe("message with lower severity than the min severity") {
-            beforeEachTest { subject.report(CompilerMessageSeverity.LOGGING, "message", null) }
-
-            it("ignores the message") {
-                verify { debugPrinter wasNot Called }
-            }
-
-            it("doesn't add up to the message count") {
-                subject.printIssuesCountIfAny()
-
-                verify { warningPrinter wasNot Called }
+            verify {
+                warningPrinter(
+                    "The BindingContext was created with 1 issues. " +
+                        "Run detekt with --debug to see the error messages."
+                )
             }
         }
     }
-})
+
+    @Nested
+    inner class `message with higher severity than the min severity` {
+        @BeforeEach
+        fun setUp() {
+            subject.report(CompilerMessageSeverity.WARNING, "message", null)
+        }
+
+        @Test
+        fun `prints the message`() {
+            val slot = slot<() -> String>()
+            verify { debugPrinter.invoke(capture(slot)) }
+            assertThat(slot.captured()).isEqualTo("warning: message")
+        }
+
+        @Test
+        fun `adds up to the message count`() {
+            subject.printIssuesCountIfAny()
+
+            verify {
+                warningPrinter(
+                    "The BindingContext was created with 1 issues. " +
+                        "Run detekt with --debug to see the error messages."
+                )
+            }
+        }
+    }
+
+    @Nested
+    inner class `message with lower severity than the min severity` {
+        @BeforeEach
+        fun setUp() {
+            subject.report(CompilerMessageSeverity.LOGGING, "message", null)
+        }
+
+        @Test
+        fun `ignores the message`() {
+            verify { debugPrinter wasNot Called }
+        }
+
+        @Test
+        fun `doesn't add up to the message count`() {
+            subject.printIssuesCountIfAny()
+
+            verify { warningPrinter wasNot Called }
+        }
+    }
+}

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/FileProcessorLocatorSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/FileProcessorLocatorSpec.kt
@@ -5,21 +5,23 @@ import io.gitlab.arturbosch.detekt.api.FileProcessListener
 import io.gitlab.arturbosch.detekt.test.yamlConfig
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.fail
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 import org.reflections.Reflections
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
 import java.lang.reflect.Modifier
 
 /**
  * This tests the existence of all metric processors in the META-INF config file in the core package
  */
-class FileProcessorLocatorSpec : Spek({
+internal class FileProcessorLocatorSpec {
 
-    describe("file processor locator") {
+    @Nested
+    inner class `file processor locator` {
 
         val path = resourceAsPath("")
 
-        it("contains all processors") {
+        @Test
+        fun `contains all processors`() {
             val processors = createProcessingSettings(path).use { FileProcessorLocator(it).load() }
             val processorClasses = getProcessorClasses()
 
@@ -29,13 +31,14 @@ class FileProcessorLocatorSpec : Spek({
                 .forEach { fail("$it processor is not loaded by the FileProcessorLocator") }
         }
 
-        it("has disabled processors") {
+        @Test
+        fun `has disabled processors`() {
             val config = yamlConfig("configs/disabled-processors.yml")
             val processors = createProcessingSettings(path, config).use { FileProcessorLocator(it).load() }
             assertThat(processors).isEmpty()
         }
     }
-})
+}
 
 private fun getProcessorClasses(): List<Class<out FileProcessListener>> {
     return Reflections("io.github.detekt.metrics.processors")

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/FileProcessorLocatorSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/FileProcessorLocatorSpec.kt
@@ -13,7 +13,7 @@ import java.lang.reflect.Modifier
 /**
  * This tests the existence of all metric processors in the META-INF config file in the core package
  */
-internal class FileProcessorLocatorSpec {
+class FileProcessorLocatorSpec {
 
     @Nested
     inner class `file processor locator` {

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/KtTreeCompilerSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/KtTreeCompilerSpec.kt
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import java.nio.file.Paths
 
-internal class KtTreeCompilerSpec {
+class KtTreeCompilerSpec {
 
     @Nested
     inner class `tree compiler functionality` {

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/KtTreeCompilerSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/KtTreeCompilerSpec.kt
@@ -5,22 +5,25 @@ import io.gitlab.arturbosch.detekt.core.tooling.withSettings
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 import org.jetbrains.kotlin.psi.KtFile
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 import java.nio.file.Paths
 
-class KtTreeCompilerSpec : Spek({
+internal class KtTreeCompilerSpec {
 
-    describe("tree compiler functionality") {
+    @Nested
+    inner class `tree compiler functionality` {
 
-        it("should compile all files") {
+        @Test
+        fun `should compile all files`() {
             val (ktFiles, _) = fixture { compile(path) }
             assertThat(ktFiles.size)
                 .describedAs("It should compile at least three files, but did ${ktFiles.size}")
                 .isGreaterThanOrEqualTo(3)
         }
 
-        it("should filter the file 'Default.kt'") {
+        @Test
+        fun `should filter the file 'Default_kt'`() {
             val (ktFiles, output) = fixture("**/Default.kt", loggingDebug = true) { compile(path) }
             val ktFile = ktFiles.find { it.name == "Default.kt" }
             assertThat(ktFile).describedAs("It should have no Default.kt file").isNull()
@@ -28,7 +31,8 @@ class KtTreeCompilerSpec : Spek({
             assertThat(output).contains("Ignoring file ")
         }
 
-        it("should work with two or more filters") {
+        @Test
+        fun `should work with two or more filters`() {
             val (ktFiles, _) = fixture(
                 "**/Default.kt",
                 "**/*Test*",
@@ -38,40 +42,45 @@ class KtTreeCompilerSpec : Spek({
             assertThat(ktFiles).isEmpty()
         }
 
-        it("should also compile regular files") {
+        @Test
+        fun `should also compile regular files`() {
             val (ktFiles, _) = fixture { compile(path.resolve("Default.kt")) }
             assertThat(ktFiles.size).isEqualTo(1)
         }
 
-        it("throws an exception if given file does not exist") {
+        @Test
+        fun `throws an exception if given file does not exist`() {
             val invalidPath = "NOTHERE"
             assertThatIllegalArgumentException()
                 .isThrownBy { fixture { compile(Paths.get(invalidPath)) } }
                 .withMessage("Given path $invalidPath does not exist!")
         }
 
-        it("does not compile a folder with a css file") {
+        @Test
+        fun `does not compile a folder with a css file`() {
             val cssPath = resourceAsPath("css")
             val (ktFiles, output) = fixture { compile(cssPath) }
             assertThat(ktFiles).isEmpty()
             assertThat(output).isEmpty()
         }
 
-        it("does not compile a css file") {
+        @Test
+        fun `does not compile a css file`() {
             val cssPath = resourceAsPath("css").resolve("test.css")
             val (ktFiles, output) = fixture { compile(cssPath) }
             assertThat(ktFiles).isEmpty()
             assertThat(output).isEmpty()
         }
 
-        it("does not compile a css file but show log if debug is enabled") {
+        @Test
+        fun `does not compile a css file but show log if debug is enabled`() {
             val cssPath = resourceAsPath("css").resolve("test.css")
             val (ktFiles, output) = fixture(loggingDebug = true) { compile(cssPath) }
             assertThat(ktFiles).isEmpty()
             assertThat(output).contains("Ignoring a file detekt cannot handle: ")
         }
     }
-})
+}
 
 internal inline fun fixture(
     vararg filters: String,

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/SuppressionSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/SuppressionSpec.kt
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 
-internal class SuppressionSpec {
+class SuppressionSpec {
 
     @Nested
     inner class `detekt findings can be suppressed with @Suppress or @SuppressWarnings` {

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/SuppressionSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/SuppressionSpec.kt
@@ -25,114 +25,142 @@ import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.psiUtil.lastBlockStatementOrThis
 import org.jetbrains.kotlin.resolve.BindingContext
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 
-internal class SuppressionSpec : Spek({
+internal class SuppressionSpec {
 
-    describe("detekt findings can be suppressed with @Suppress or @SuppressWarnings") {
+    @Nested
+    inner class `detekt findings can be suppressed with @Suppress or @SuppressWarnings` {
 
-        it("should not be suppressed by a @Deprecated annotation") {
+        @Test
+        fun `should not be suppressed by a @Deprecated annotation`() {
             assertThat(isSuppressedBy("Deprecated", "This should no longer be used")).isFalse()
         }
 
-        it("should not be suppressed by a @Suppress annotation for another rule") {
+        @Test
+        fun `should not be suppressed by a @Suppress annotation for another rule`() {
             assertThat(isSuppressedBy("Suppress", "NotATest")).isFalse()
         }
 
-        it("should not be suppressed by a @SuppressWarnings annotation for another rule") {
+        @Test
+        fun `should not be suppressed by a @SuppressWarnings annotation for another rule`() {
             assertThat(isSuppressedBy("SuppressWarnings", "NotATest")).isFalse()
         }
 
-        it("should be suppressed by a @Suppress annotation for the rule") {
+        @Test
+        fun `should be suppressed by a @Suppress annotation for the rule`() {
             assertThat(isSuppressedBy("Suppress", "Test")).isTrue()
         }
 
-        it("should be suppressed by a @SuppressWarnings annotation for the rule") {
+        @Test
+        fun `should be suppressed by a @SuppressWarnings annotation for the rule`() {
             assertThat(isSuppressedBy("SuppressWarnings", "Test")).isTrue()
         }
 
-        it("should be suppressed by a @SuppressWarnings annotation for 'all' rules") {
+        @Test
+        fun `should be suppressed by a @SuppressWarnings annotation for 'all' rules`() {
             assertThat(isSuppressedBy("Suppress", "all")).isTrue()
         }
 
-        it("should be suppressed by a @SuppressWarnings annotation for 'ALL' rules") {
+        @Test
+        fun `should be suppressed by a @SuppressWarnings annotation for 'ALL' rules`() {
             assertThat(isSuppressedBy("SuppressWarnings", "ALL")).isTrue()
         }
 
-        it("should not be suppressed by a @Suppress annotation with a Checkstyle prefix") {
+        @Test
+        fun `should not be suppressed by a @Suppress annotation with a Checkstyle prefix`() {
             assertThat(isSuppressedBy("Suppress", "Checkstyle:Test")).isFalse()
         }
 
-        it("should not be suppressed by a @SuppressWarnings annotation with a Checkstyle prefix") {
+        @Test
+        fun `should not be suppressed by a @SuppressWarnings annotation with a Checkstyle prefix`() {
             assertThat(isSuppressedBy("SuppressWarnings", "Checkstyle:Test")).isFalse()
         }
 
-        it("should be suppressed by a @Suppress annotation with a 'Detekt' prefix") {
+        @Test
+        fun `should be suppressed by a @Suppress annotation with a 'Detekt' prefix`() {
             assertThat(isSuppressedBy("Suppress", "Detekt:Test")).isTrue()
         }
 
-        it("should be suppressed by a @SuppressWarnings annotation with a 'Detekt' prefix") {
+        @Test
+        fun `should be suppressed by a @SuppressWarnings annotation with a 'Detekt' prefix`() {
             assertThat(isSuppressedBy("SuppressWarnings", "Detekt:Test")).isTrue()
         }
 
-        it("should be suppressed by a @Suppress annotation with a 'detekt' prefix") {
+        @Test
+        fun `should be suppressed by a @Suppress annotation with a 'detekt' prefix`() {
             assertThat(isSuppressedBy("Suppress", "detekt:Test")).isTrue()
         }
 
-        it("should be suppressed by a @SuppressWarnings annotation with a 'detekt' prefix") {
+        @Test
+        fun `should be suppressed by a @SuppressWarnings annotation with a 'detekt' prefix`() {
             assertThat(isSuppressedBy("SuppressWarnings", "detekt:Test")).isTrue()
         }
 
-        it("should be suppressed by a @Suppress annotation with a 'detekt' prefix with a dot") {
+        @Test
+        fun `should be suppressed by a @Suppress annotation with a 'detekt' prefix with a dot`() {
             assertThat(isSuppressedBy("Suppress", "detekt.Test")).isTrue()
         }
 
-        it("should be suppressed by a @SuppressWarnings annotation with a 'detekt' prefix with a dot") {
+        @Test
+        fun `should be suppressed by a @SuppressWarnings annotation with a 'detekt' prefix with a dot`() {
             assertThat(isSuppressedBy("SuppressWarnings", "detekt.Test")).isTrue()
         }
 
-        it("should not be suppressed by a @Suppress annotation with a 'detekt' prefix with a wrong separator") {
+        @Test
+        fun `should not be suppressed by a @Suppress annotation with a 'detekt' prefix with a wrong separator`() {
             assertThat(isSuppressedBy("Suppress", "detekt/Test")).isFalse()
         }
 
-        it("should not be suppressed by a @SuppressWarnings annotation with a 'detekt' prefix with a wrong separator") {
+        @Test
+        fun `should not be suppressed by a @SuppressWarnings annotation with a 'detekt' prefix with a wrong separator`() {
             assertThat(isSuppressedBy("SuppressWarnings", "detekt/Test")).isFalse()
         }
 
-        it("should be suppressed by a @Suppress annotation with an alias") {
+        @Test
+        fun `should be suppressed by a @Suppress annotation with an alias`() {
             assertThat(isSuppressedBy("Suppress", "alias")).isTrue()
         }
 
-        it("should be suppressed by a @SuppressWarnings annotation with an alias") {
+        @Test
+        fun `should be suppressed by a @SuppressWarnings annotation with an alias`() {
             assertThat(isSuppressedBy("SuppressWarnings", "alias")).isTrue()
         }
     }
 
-    describe("different suppression scenarios") {
+    @Nested
+    inner class `different suppression scenarios` {
 
-        it("rule should be suppressed") {
+        @Test
+        fun `rule should be suppressed`() {
             val ktFile = compileForTest(resourceAsPath("/suppression/SuppressedObject.kt"))
             val rule = TestRule()
             rule.visitFile(ktFile)
             assertThat(rule.expected).isNotNull()
         }
 
-        it("findings are suppressed") {
+        @Test
+        fun `findings are suppressed`() {
             val ktFile = compileForTest(resourceAsPath("/suppression/SuppressedElements.kt"))
             val ruleSet = RuleSet("Test", listOf(TestLM(), TestLPL()))
             val findings = ruleSet.visitFile(ktFile, BindingContext.EMPTY)
             assertThat(findings.size).isZero()
         }
 
-        it("rule should be suppressed by ALL") {
+        @Test
+        fun `rule should be suppressed by ALL`() {
             val ktFile = compileForTest(resourceAsPath("/suppression/SuppressedByAllObject.kt"))
             val rule = TestRule()
             rule.visitFile(ktFile)
             assertThat(rule.expected).isNotNull()
         }
 
-        it("rule should be suppressed by detekt prefix in uppercase with dot separator") {
+        @Test
+        fun `rule should be suppressed by detekt prefix in uppercase with dot separator`() {
             val ktFile = compileContentForTest(
                 """
             @file:Suppress("Detekt.ALL")
@@ -149,7 +177,8 @@ internal class SuppressionSpec : Spek({
             assertThat(rule.expected).isNotNull()
         }
 
-        it("rule should be suppressed by detekt prefix in lowercase with colon separator") {
+        @Test
+        fun `rule should be suppressed by detekt prefix in lowercase with colon separator`() {
             val ktFile = compileContentForTest(
                 """
             @file:Suppress("detekt:ALL")
@@ -166,7 +195,8 @@ internal class SuppressionSpec : Spek({
             assertThat(rule.expected).isNotNull()
         }
 
-        it("rule should be suppressed by detekt prefix in all caps with colon separator") {
+        @Test
+        fun `rule should be suppressed by detekt prefix in all caps with colon separator`() {
             val ktFile = compileContentForTest(
                 """
             @file:Suppress("DETEKT:ALL")
@@ -184,9 +214,11 @@ internal class SuppressionSpec : Spek({
         }
     }
 
-    describe("suppression based on aliases from config property") {
+    @Nested
+    inner class `suppression based on aliases from config property` {
 
-        it("allows to declare") {
+        @Test
+        fun `allows to declare`() {
             val ktFile = compileContentForTest(
                 """
             @file:Suppress("detekt:MyTest")
@@ -204,63 +236,74 @@ internal class SuppressionSpec : Spek({
         }
     }
 
-    describe("suppression's via rule set id") {
+    @Nested
+    inner class `suppression's via rule set id` {
 
         val code = """
             fun lpl(a: Int, b: Int, c: Int, d: Int, e: Int, f: Int) = Unit
         """.trimIndent()
 
-        val config by memoized {
-            yamlConfig("/suppression/ruleset-suppression.yml")
-                .subConfig("complexity")
-        }
+        val config = yamlConfig("/suppression/ruleset-suppression.yml").subConfig("complexity")
 
-        it("reports without a suppression") {
+        @Test
+        fun `reports without a suppression`() {
             assertThat(TestLPL(config).lint(code)).isNotEmpty()
         }
 
-        it("reports with wrong suppression") {
+        @Test
+        fun `reports with wrong suppression`() {
             assertThat(TestLPL(config).lint("""@Suppress("wrong_name_used")$code""")).isNotEmpty()
         }
 
-        it("suppresses by rule set id") {
+        @Test
+        fun `suppresses by rule set id`() {
             assertCodeIsSuppressed("""@Suppress("complexity")$code""", config)
         }
 
-        it("suppresses by rule set id and detekt prefix") {
+        @Test
+        fun `suppresses by rule set id and detekt prefix`() {
             assertCodeIsSuppressed("""@Suppress("detekt.complexity")$code""", config)
         }
 
-        it("suppresses by rule id") {
+        @Test
+        fun `suppresses by rule id`() {
             assertCodeIsSuppressed("""@Suppress("LongParameterList")$code""", config)
         }
 
-        it("suppresses by combination of rule set and rule id") {
+        @Test
+        fun `suppresses by combination of rule set and rule id`() {
             assertCodeIsSuppressed("""@Suppress("complexity.LongParameterList")$code""", config)
         }
 
-        it("suppresses by combination of detekt prefix, rule set and rule id") {
+        @Test
+        fun `suppresses by combination of detekt prefix, rule set and rule id`() {
             assertCodeIsSuppressed("""@Suppress("detekt:complexity:LongParameterList")$code""", config)
         }
 
-        context("MultiRule") {
+        @Nested
+        inner class `MultiRule` {
 
-            val subject by memoized { AMultiRule(config) }
+            private lateinit var subject: io.gitlab.arturbosch.detekt.api.MultiRule
 
-            it("is suppressed by rule id") {
-                assertThat(subject.lint("""@Suppress("complexity")$code""")).isEmpty()
+            @BeforeEach
+            fun setupSubject() {
+                subject = AMultiRule(config)
             }
 
-            it("is suppressed by rule id") {
-                assertThat(subject.lint("""@Suppress("LongParameterList")$code""")).isEmpty()
-            }
-
-            it("is suppressed by combination of detekt.ruleSetId.ruleId") {
-                assertThat(subject.lint("""@Suppress("detekt.complexity.LongParameterList")$code""")).isEmpty()
+            @ParameterizedTest
+            @ValueSource(
+                strings = [
+                    "complexity",
+                    "LongParameterList",
+                    "detekt.complexity.LongParameterList"
+                ]
+            )
+            fun `is suppressed by rule id`(ruleId: String) {
+                assertThat(subject.lint("""@Suppress("$ruleId")$code""")).isEmpty()
             }
         }
     }
-})
+}
 
 private fun assertCodeIsSuppressed(code: String, config: Config) {
     val findings = TestLPL(config).lint(code)

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/TopLevelAutoCorrectSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/TopLevelAutoCorrectSpec.kt
@@ -22,14 +22,16 @@ import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.psi.KtAnnotation
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.resolve.BindingContext
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-class TopLevelAutoCorrectSpec : Spek({
+internal class TopLevelAutoCorrectSpec {
 
-    describe("autoCorrect: false on top level") {
+    @Nested
+    inner class `autoCorrect_ false on top level` {
 
-        it("should format the test file but not print the modified content to disc") {
+        @Test
+        fun `should format the test file but not print the modified content to disc`() {
             val fileContentBeforeAutoCorrect = readResourceContent("cases/Test.kt")
             val fileUnderTest = resourceAsPath("cases/Test.kt")
             val spec = ProcessingSpec {
@@ -68,7 +70,7 @@ class TopLevelAutoCorrectSpec : Spek({
             assertThat(readResourceContent("cases/Test.kt")).isEqualTo(fileContentBeforeAutoCorrect)
         }
     }
-})
+}
 
 private class DeleteAnnotationsRule : Rule() {
     override val issue = Issue("test-rule", Severity.CodeSmell, "", Debt.FIVE_MINS)

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/TopLevelAutoCorrectSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/TopLevelAutoCorrectSpec.kt
@@ -25,7 +25,7 @@ import org.jetbrains.kotlin.resolve.BindingContext
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
-internal class TopLevelAutoCorrectSpec {
+class TopLevelAutoCorrectSpec {
 
     @Nested
     inner class `autoCorrect_ false on top level` {

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/WorkaroundConfigurationKtSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/WorkaroundConfigurationKtSpec.kt
@@ -4,34 +4,36 @@ import io.github.detekt.test.utils.resourceUrl
 import io.github.detekt.tooling.api.spec.ProcessingSpec
 import io.gitlab.arturbosch.detekt.core.config.loadConfiguration
 import org.assertj.core.api.Assertions.assertThat
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-internal class WorkaroundConfigurationKtSpec : Spek({
+internal class WorkaroundConfigurationKtSpec {
 
-    describe("with all rules activated by default") {
+    @Nested
+    inner class `with all rules activated by default` {
 
-        val config by memoized {
-            ProcessingSpec {
-                config { resources = listOf(resourceUrl("/configs/empty.yml")) }
-                rules { activateAllRules = true }
-            }.let { spec ->
-                spec.workaroundConfiguration(spec.loadConfiguration())
-            }
+        private val config = ProcessingSpec {
+            config { resources = listOf(resourceUrl("/configs/empty.yml")) }
+            rules { activateAllRules = true }
+        }.let { spec ->
+            spec.workaroundConfiguration(spec.loadConfiguration())
         }
 
-        it("should override active to true by default") {
+        @Test
+        fun `should override active to true by default`() {
             val actual = config.subConfig("comments")
                 .subConfig("UndocumentedPublicClass")
                 .valueOrDefault("active", false)
             assertThat(actual).isEqualTo(true)
         }
 
-        it("should override maxIssues to 0 by default") {
+        @Test
+        fun `should override maxIssues to 0 by default`() {
             assertThat(config.subConfig("build").valueOrDefault("maxIssues", -1)).isEqualTo(0)
         }
 
-        it("should keep config from default") {
+        @Test
+        fun `should keep config from default`() {
             val actual = config.subConfig("style")
                 .subConfig("MaxLineLength")
                 .valueOrDefault("maxLineLength", -1)
@@ -39,58 +41,62 @@ internal class WorkaroundConfigurationKtSpec : Spek({
         }
     }
 
-    describe("fail fast override") {
+    @Nested
+    inner class `fail fast override` {
 
-        val config by memoized {
-            ProcessingSpec {
-                config { resources = listOf(resourceUrl("/configs/fail-fast-will-override-here.yml")) }
-                rules { activateAllRules = true }
-            }.let { spec ->
-                spec.workaroundConfiguration(spec.loadConfiguration())
-            }
+        private val config = ProcessingSpec {
+            config { resources = listOf(resourceUrl("/configs/fail-fast-will-override-here.yml")) }
+            rules { activateAllRules = true }
+        }.let { spec ->
+            spec.workaroundConfiguration(spec.loadConfiguration())
         }
 
-        it("should override config when specified") {
+        @Test
+        fun `should override config when specified`() {
             val actual = config.subConfig("style")
                 .subConfig("MaxLineLength")
                 .valueOrDefault("maxLineLength", -1)
             assertThat(actual).isEqualTo(100)
         }
 
-        it("should override active when specified") {
+        @Test
+        fun `should override active when specified`() {
             val actual = config.subConfig("comments")
                 .subConfig("CommentOverPrivateMethod")
                 .valueOrDefault("active", true)
             assertThat(actual).isEqualTo(false)
         }
 
-        it("should override maxIssues when specified") {
+        @Test
+        fun `should override maxIssues when specified`() {
             assertThat(config.subConfig("build").valueOrDefault("maxIssues", -1)).isEqualTo(1)
         }
     }
 
-    describe("auto correct config") {
+    @Nested
+    inner class `auto correct config` {
 
-        context("when specified it respects all autoCorrect values of rules and rule sets") {
+        @Nested
+        inner class `when specified it respects all autoCorrect values of rules and rule sets` {
 
-            val config by memoized {
-                ProcessingSpec {
-                    config { resources = listOf(resourceUrl("/configs/config-with-auto-correct.yml")) }
-                    rules { autoCorrect = true }
-                }.let { spec ->
-                    spec.workaroundConfiguration(spec.loadConfiguration())
-                }
+            private val config = ProcessingSpec {
+                config { resources = listOf(resourceUrl("/configs/config-with-auto-correct.yml")) }
+                rules { autoCorrect = true }
+            }.let { spec ->
+                spec.workaroundConfiguration(spec.loadConfiguration())
             }
 
-            val style by memoized { config.subConfig("style") }
-            val comments by memoized { config.subConfig("comments") }
+            private val style = config.subConfig("style")
+            private val comments = config.subConfig("comments")
 
-            it("is disabled for rule sets") {
+            @Test
+            fun `is disabled for rule sets`() {
                 assertThat(style.valueOrNull<Boolean>("autoCorrect")).isTrue()
                 assertThat(comments.valueOrNull<Boolean>("autoCorrect")).isFalse()
             }
 
-            it("is disabled for rules") {
+            @Test
+            fun `is disabled for rules`() {
                 assertThat(style.subConfig("MagicNumber").valueOrNull<Boolean>("autoCorrect")).isTrue()
                 assertThat(style.subConfig("MagicString").valueOrNull<Boolean>("autoCorrect")).isFalse()
                 assertThat(comments.subConfig("ClassDoc").valueOrNull<Boolean>("autoCorrect")).isTrue()
@@ -98,19 +104,60 @@ internal class WorkaroundConfigurationKtSpec : Spek({
             }
         }
 
-        mapOf(
-            ProcessingSpec {
+        @Nested
+        inner class `when not specified all autoCorrect values are overridden to false` {
+            private val config = ProcessingSpec {
                 config { resources = listOf(resourceUrl("/configs/config-with-auto-correct.yml")) }
             }.let { spec ->
                 spec.workaroundConfiguration(spec.loadConfiguration())
-            } to "when not specified all autoCorrect values are overridden to false",
-            ProcessingSpec {
+            }
+            private val style = config.subConfig("style")
+            private val comments = config.subConfig("comments")
+
+            @Test
+            fun `is disabled for rule sets`() {
+                assertThat(style.valueOrNull<Boolean>("autoCorrect")).isFalse()
+                assertThat(comments.valueOrNull<Boolean>("autoCorrect")).isFalse()
+            }
+
+            @Test
+            fun `is disabled for rules`() {
+                assertThat(style.subConfig("MagicNumber").valueOrNull<Boolean>("autoCorrect")).isFalse()
+                assertThat(style.subConfig("MagicString").valueOrNull<Boolean>("autoCorrect")).isFalse()
+                assertThat(comments.subConfig("ClassDoc").valueOrNull<Boolean>("autoCorrect")).isFalse()
+                assertThat(comments.subConfig("FunctionDoc").valueOrNull<Boolean>("autoCorrect")).isFalse()
+            }
+        }
+
+        @Nested
+        inner class `when specified as false, all autoCorrect values are overridden to false` {
+            private val config = ProcessingSpec {
                 config { resources = listOf(resourceUrl("/configs/config-with-auto-correct.yml")) }
                 rules { autoCorrect = false }
             }.let { spec ->
                 spec.workaroundConfiguration(spec.loadConfiguration())
-            } to "when specified as false, all autoCorrect values are overridden to false",
-            ProcessingSpec {
+            }
+            private val style = config.subConfig("style")
+            private val comments = config.subConfig("comments")
+
+            @Test
+            fun `is disabled for rule sets`() {
+                assertThat(style.valueOrNull<Boolean>("autoCorrect")).isFalse()
+                assertThat(comments.valueOrNull<Boolean>("autoCorrect")).isFalse()
+            }
+
+            @Test
+            fun `is disabled for rules`() {
+                assertThat(style.subConfig("MagicNumber").valueOrNull<Boolean>("autoCorrect")).isFalse()
+                assertThat(style.subConfig("MagicString").valueOrNull<Boolean>("autoCorrect")).isFalse()
+                assertThat(comments.subConfig("ClassDoc").valueOrNull<Boolean>("autoCorrect")).isFalse()
+                assertThat(comments.subConfig("FunctionDoc").valueOrNull<Boolean>("autoCorrect")).isFalse()
+            }
+        }
+
+        @Nested
+        inner class `regardless of other cli options, autoCorrect values are overridden to false` {
+            private val config = ProcessingSpec {
                 config {
                     useDefaultConfig = true
                     resources = listOf(resourceUrl("/configs/config-with-auto-correct.yml"))
@@ -121,24 +168,24 @@ internal class WorkaroundConfigurationKtSpec : Spek({
                 }
             }.let { spec ->
                 spec.workaroundConfiguration(spec.loadConfiguration())
-            } to "regardless of other cli options, autoCorrect values are overridden to false"
-        ).forEach { (config, testContext) ->
-            context(testContext) {
-                val style = config.subConfig("style")
-                val comments = config.subConfig("comments")
+            }
 
-                it("is disabled for rule sets") {
-                    assertThat(style.valueOrNull<Boolean>("autoCorrect")).isFalse()
-                    assertThat(comments.valueOrNull<Boolean>("autoCorrect")).isFalse()
-                }
+            private val style = config.subConfig("style")
+            private val comments = config.subConfig("comments")
 
-                it("is disabled for rules") {
-                    assertThat(style.subConfig("MagicNumber").valueOrNull<Boolean>("autoCorrect")).isFalse()
-                    assertThat(style.subConfig("MagicString").valueOrNull<Boolean>("autoCorrect")).isFalse()
-                    assertThat(comments.subConfig("ClassDoc").valueOrNull<Boolean>("autoCorrect")).isFalse()
-                    assertThat(comments.subConfig("FunctionDoc").valueOrNull<Boolean>("autoCorrect")).isFalse()
-                }
+            @Test
+            fun `is disabled for rule sets`() {
+                assertThat(style.valueOrNull<Boolean>("autoCorrect")).isFalse()
+                assertThat(comments.valueOrNull<Boolean>("autoCorrect")).isFalse()
+            }
+
+            @Test
+            fun `is disabled for rules`() {
+                assertThat(style.subConfig("MagicNumber").valueOrNull<Boolean>("autoCorrect")).isFalse()
+                assertThat(style.subConfig("MagicString").valueOrNull<Boolean>("autoCorrect")).isFalse()
+                assertThat(comments.subConfig("ClassDoc").valueOrNull<Boolean>("autoCorrect")).isFalse()
+                assertThat(comments.subConfig("FunctionDoc").valueOrNull<Boolean>("autoCorrect")).isFalse()
             }
         }
     }
-})
+}

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/WorkaroundConfigurationKtSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/WorkaroundConfigurationKtSpec.kt
@@ -7,7 +7,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
-internal class WorkaroundConfigurationKtSpec {
+class WorkaroundConfigurationKtSpec {
 
     @Nested
     inner class `with all rules activated by default` {

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineFacadeSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineFacadeSpec.kt
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import java.nio.file.Files
 
-internal class BaselineFacadeSpec {
+class BaselineFacadeSpec {
 
     @Nested
     inner class `a baseline facade` {

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineFacadeSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineFacadeSpec.kt
@@ -5,41 +5,48 @@ import io.github.detekt.test.utils.resourceAsPath
 import io.gitlab.arturbosch.detekt.test.TestDetektion
 import io.gitlab.arturbosch.detekt.test.createFinding
 import org.assertj.core.api.Assertions.assertThat
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 import java.nio.file.Files
 
-class BaselineFacadeSpec : Spek({
+internal class BaselineFacadeSpec {
 
-    describe("a baseline facade") {
+    @Nested
+    inner class `a baseline facade` {
 
-        val baselineFile by memoized { createTempDirectoryForTest("baseline_format").resolve("baseline.xml") }
-        val validBaseline = resourceAsPath("/baseline_feature/valid-baseline.xml")
+        private val baselineFile = createTempDirectoryForTest("baseline_format").resolve("baseline.xml")
+        private val validBaseline = resourceAsPath("/baseline_feature/valid-baseline.xml")
 
-        afterEachTest {
+        @AfterEach
+        fun tearDown() {
             Files.deleteIfExists(baselineFile)
         }
 
-        it("returns a BaselineFilteredResult when the baseline exists") {
+        @Test
+        fun `returns a BaselineFilteredResult when the baseline exists`() {
             val detektion = BaselineFacade().transformResult(validBaseline, TestDetektion())
 
             assertThat(detektion).isInstanceOf(BaselineFilteredResult::class.java)
         }
 
-        it("returns the same detektion when the baseline doesn't exist") {
+        @Test
+        fun `returns the same detektion when the baseline doesn't exist`() {
             val initialDetektion = TestDetektion()
             val detektion = BaselineFacade().transformResult(baselineFile, initialDetektion)
 
             assertThat(detektion).isEqualTo(initialDetektion)
         }
 
-        it("doesn't create a baseline file without findings") {
+        @Test
+        fun `doesn't create a baseline file without findings`() {
             BaselineFacade().createOrUpdate(baselineFile, emptyList())
 
             assertThat(baselineFile).doesNotExist()
         }
 
-        it("creates on top of an existing a baseline file without findings") {
+        @Test
+        fun `creates on top of an existing a baseline file without findings`() {
             Files.copy(validBaseline, baselineFile)
 
             BaselineFacade().createOrUpdate(baselineFile, emptyList())
@@ -58,7 +65,8 @@ class BaselineFacadeSpec : Spek({
             )
         }
 
-        it("creates on top of an existing a baseline file with findings") {
+        @Test
+        fun `creates on top of an existing a baseline file with findings`() {
             Files.copy(validBaseline, baselineFile)
 
             BaselineFacade().createOrUpdate(baselineFile, listOf(createFinding()))
@@ -79,4 +87,4 @@ class BaselineFacadeSpec : Spek({
             )
         }
     }
-})
+}

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineFilteredResultSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineFilteredResultSpec.kt
@@ -5,38 +5,39 @@ import io.gitlab.arturbosch.detekt.test.TestDetektion
 import io.mockk.every
 import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-class BaselineFilteredResultSpec : Spek({
+internal class BaselineFilteredResultSpec {
 
-    describe("baseline based result transformation") {
+    @Nested
+    inner class `baseline based result transformation` {
 
-        val baselineFile = resourceAsPath("/baseline_feature/valid-baseline.xml")
+        private val baselineFile = resourceAsPath("/baseline_feature/valid-baseline.xml")
 
-        val result by memoized {
-            TestDetektion(
-                mockk {
-                    every { id }.returns("LongParameterList")
-                    every { signature }.returns("Signature")
-                },
-                mockk {
-                    every { id }.returns("LongMethod")
-                    every { signature }.returns("Signature")
-                },
-                mockk {
-                    every { id }.returns("FeatureEnvy")
-                    every { signature }.returns("Signature")
-                },
-            )
-        }
+        private val result = TestDetektion(
+            mockk {
+                every { id }.returns("LongParameterList")
+                every { signature }.returns("Signature")
+            },
+            mockk {
+                every { id }.returns("LongMethod")
+                every { signature }.returns("Signature")
+            },
+            mockk {
+                every { id }.returns("FeatureEnvy")
+                every { signature }.returns("Signature")
+            },
+        )
 
-        it("does return the same finding on empty baseline") {
+        @Test
+        fun `does return the same finding on empty baseline`() {
             val actual = BaselineFilteredResult(result, Baseline(emptySet(), emptySet()))
             assertThat(actual.findings).hasSize(3)
         }
 
-        it("filters with an existing baseline file") {
+        @Test
+        fun `filters with an existing baseline file`() {
             val baseline = Baseline.load(baselineFile)
             val actual = BaselineFilteredResult(result, baseline)
             // Note: Detektion works with Map<RuleSetId, List<Finding>
@@ -44,4 +45,4 @@ class BaselineFilteredResultSpec : Spek({
             actual.findings.forEach { (_, value) -> assertThat(value).isEmpty() }
         }
     }
-})
+}

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineFilteredResultSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineFilteredResultSpec.kt
@@ -8,7 +8,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
-internal class BaselineFilteredResultSpec {
+class BaselineFilteredResultSpec {
 
     @Nested
     inner class `baseline based result transformation` {

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineFormatSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineFormatSpec.kt
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import java.nio.file.Files
 
-internal class BaselineFormatSpec {
+class BaselineFormatSpec {
 
     @Nested
     inner class `baseline format` {

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineFormatSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineFormatSpec.kt
@@ -5,17 +5,20 @@ import io.github.detekt.test.utils.resourceAsPath
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatIllegalStateException
 import org.assertj.core.api.Assertions.assertThatThrownBy
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 import java.nio.file.Files
 
-class BaselineFormatSpec : Spek({
+internal class BaselineFormatSpec {
 
-    describe("baseline format") {
+    @Nested
+    inner class `baseline format` {
 
-        context("read a baseline file") {
+        @Nested
+        inner class `read a baseline file` {
 
-            it("loads the baseline file") {
+            @Test
+            fun `loads the baseline file`() {
                 val path = resourceAsPath("/baseline_feature/valid-baseline.xml")
                 val (manuallySuppressedIssues, currentIssues) = BaselineFormat().read(path)
 
@@ -26,20 +29,23 @@ class BaselineFormatSpec : Spek({
                 assertThat(currentIssues).anySatisfy { it.startsWith("FeatureEnvy") }
             }
 
-            it("throws on an invalid baseline file extension") {
+            @Test
+            fun `throws on an invalid baseline file extension`() {
                 val path = resourceAsPath("/baseline_feature/invalid-txt-baseline.txt")
                 assertThatThrownBy { BaselineFormat().read(path) }
                     .isInstanceOf(BaselineFormat.InvalidState::class.java)
             }
 
-            it("throws on an invalid baseline ID declaration") {
+            @Test
+            fun `throws on an invalid baseline ID declaration`() {
                 val path = resourceAsPath("/baseline_feature/missing-temporary-suppressed-baseline.xml")
                 assertThatIllegalStateException()
                     .isThrownBy { BaselineFormat().read(path) }
                     .withMessage("The content of the ID element must not be empty")
             }
 
-            it("supports deprecated baseline values") {
+            @Test
+            fun `supports deprecated baseline values`() {
                 val path = resourceAsPath("/baseline_feature/deprecated-baseline.xml")
                 val (manuallySuppressedIssues, currentIssues) = BaselineFormat().read(path)
 
@@ -51,11 +57,13 @@ class BaselineFormatSpec : Spek({
             }
         }
 
-        context("writes a baseline file") {
+        @Nested
+        inner class `writes a baseline file` {
 
-            val savedBaseline by memoized { Baseline(setOf("4", "2", "2"), setOf("1", "2", "3")) }
+            private val savedBaseline = Baseline(setOf("4", "2", "2"), setOf("1", "2", "3"))
 
-            it("has a new line at the end of the written baseline file") {
+            @Test
+            fun `has a new line at the end of the written baseline file`() {
                 val tempFile = createTempFileForTest("baseline1", ".xml")
 
                 val format = BaselineFormat()
@@ -66,7 +74,8 @@ class BaselineFormatSpec : Spek({
                 assertThat(content).endsWith(">\n")
             }
 
-            it("asserts that the saved and loaded baseline files are equal") {
+            @Test
+            fun `asserts that the saved and loaded baseline files are equal`() {
                 val tempFile = createTempFileForTest("baseline-saved", ".xml")
 
                 val format = BaselineFormat()
@@ -77,4 +86,4 @@ class BaselineFormatSpec : Spek({
             }
         }
     }
-})
+}

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineResultMappingSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineResultMappingSpec.kt
@@ -21,7 +21,7 @@ import java.nio.file.Files
 import java.nio.file.Path
 
 @OptIn(UnstableApi::class)
-internal class BaselineResultMappingSpec {
+class BaselineResultMappingSpec {
 
     @Nested
     inner class `a baseline result mapping` {

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineResultMappingSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineResultMappingSpec.kt
@@ -11,34 +11,42 @@ import io.gitlab.arturbosch.detekt.core.exists
 import io.mockk.every
 import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 import java.io.PrintStream
 import java.net.URI
 import java.nio.file.Files
 import java.nio.file.Path
 
 @OptIn(UnstableApi::class)
-class BaselineResultMappingSpec : Spek({
+internal class BaselineResultMappingSpec {
 
-    describe("a baseline result mapping") {
+    @Nested
+    inner class `a baseline result mapping` {
 
-        val dir by memoized { createTempDirectoryForTest("baseline_format") }
-        val baselineFile by memoized { dir.resolve("baseline.xml") }
-        val existingBaselineFile by memoized { resourceAsPath("/baseline_feature/valid-baseline.xml") }
-        val finding by memoized {
-            val issue = mockk<Finding>()
-            every { issue.id }.returns("SomeIssueId")
-            every { issue.signature }.returns("SomeSignature")
-            issue
+        private val dir = createTempDirectoryForTest("baseline_format")
+        private val baselineFile = dir.resolve("baseline.xml")
+        private val existingBaselineFile = resourceAsPath("/baseline_feature/valid-baseline.xml")
+        private lateinit var findings: Map<String, List<Finding>>
+        private lateinit var finding: Finding
+
+        @BeforeEach
+        fun setupMocks() {
+            finding = mockk()
+            every { finding.id }.returns("SomeIssueId")
+            every { finding.signature }.returns("SomeSignature")
+            findings = mapOf("RuleSet" to listOf(finding))
         }
-        val findings by memoized { mapOf("RuleSet" to listOf(finding)) }
 
-        afterEachTest {
+        @AfterEach
+        fun tearDown() {
             Files.deleteIfExists(baselineFile)
         }
 
-        it("should not create a new baseline file when no findings occurred") {
+        @Test
+        fun `should not create a new baseline file when no findings occurred`() {
             val mapping = resultMapping(
                 baselineFile = baselineFile,
                 createBaseline = true,
@@ -49,7 +57,8 @@ class BaselineResultMappingSpec : Spek({
             assertThat(baselineFile.exists()).isFalse()
         }
 
-        it("should not update an existing baseline file if option configured as false") {
+        @Test
+        fun `should not update an existing baseline file if option configured as false`() {
             val existing = Baseline.load(existingBaselineFile)
             val mapping = resultMapping(
                 baselineFile = existingBaselineFile,
@@ -62,7 +71,8 @@ class BaselineResultMappingSpec : Spek({
             assertThat(existing).isEqualTo(changed)
         }
 
-        it("should not update an existing baseline file if option is not configured") {
+        @Test
+        fun `should not update an existing baseline file if option is not configured`() {
             val existing = Baseline.load(existingBaselineFile)
             val mapping = resultMapping(
                 baselineFile = existingBaselineFile,
@@ -75,7 +85,8 @@ class BaselineResultMappingSpec : Spek({
             assertThat(existing).isEqualTo(changed)
         }
 
-        it("should not create a new baseline file if no file is configured") {
+        @Test
+        fun `should not create a new baseline file if no file is configured`() {
             val mapping = resultMapping(
                 baselineFile = null,
                 createBaseline = false,
@@ -86,7 +97,8 @@ class BaselineResultMappingSpec : Spek({
             assertThat(baselineFile.exists()).isFalse()
         }
 
-        it("should create a new baseline file if a file is configured") {
+        @Test
+        fun `should create a new baseline file if a file is configured`() {
             val mapping = resultMapping(
                 baselineFile = baselineFile,
                 createBaseline = true,
@@ -97,7 +109,8 @@ class BaselineResultMappingSpec : Spek({
             assertThat(baselineFile.exists()).isTrue()
         }
 
-        it("should update an existing baseline file if a file is configured") {
+        @Test
+        fun `should update an existing baseline file if a file is configured`() {
             Files.copy(existingBaselineFile, baselineFile)
             val existing = Baseline.load(baselineFile)
             val mapping = resultMapping(
@@ -111,7 +124,7 @@ class BaselineResultMappingSpec : Spek({
             assertThat(existing).isNotEqualTo(changed)
         }
     }
-})
+}
 
 @OptIn(UnstableApi::class)
 private fun resultMapping(baselineFile: Path?, createBaseline: Boolean?) =

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/CheckConfigurationSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/CheckConfigurationSpec.kt
@@ -16,7 +16,7 @@ import org.assertj.core.api.Assertions.assertThatCode
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
-internal class SupportConfigValidationSpec {
+class SupportConfigValidationSpec {
 
     @Nested
     inner class `support config validation` {
@@ -96,14 +96,14 @@ internal class SupportConfigValidationSpec {
     }
 }
 
-internal class SampleRuleProvider : RuleSetProvider {
+class SampleRuleProvider : RuleSetProvider {
 
     override val ruleSetId: String = "sample-rule-set"
 
     override fun instance(config: Config) = RuleSet(ruleSetId, emptyList())
 }
 
-internal class SampleConfigValidator : ConfigValidator {
+class SampleConfigValidator : ConfigValidator {
 
     override fun validate(config: Config): Collection<Notification> {
         val result = mutableListOf<Notification>()

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/CheckConfigurationSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/CheckConfigurationSpec.kt
@@ -13,17 +13,19 @@ import io.gitlab.arturbosch.detekt.core.createProcessingSettings
 import io.gitlab.arturbosch.detekt.core.tooling.getDefaultConfiguration
 import io.gitlab.arturbosch.detekt.test.yamlConfigFromContent
 import org.assertj.core.api.Assertions.assertThatCode
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-class SupportConfigValidationSpec : Spek({
+internal class SupportConfigValidationSpec {
 
-    describe("support config validation") {
+    @Nested
+    inner class `support config validation` {
 
-        val testDir by memoized { createTempDirectoryForTest("detekt-sample") }
-        val spec by memoized { createNullLoggingSpec {} }
+        private val testDir = createTempDirectoryForTest("detekt-sample")
+        private val spec = createNullLoggingSpec {}
 
-        it("fails when unknown properties are found") {
+        @Test
+        fun `fails when unknown properties are found`() {
             val config = yamlConfigFromContent(
                 """
                 # Properties of custom rule sets get excluded by default.
@@ -45,7 +47,8 @@ class SupportConfigValidationSpec : Spek({
             }
         }
 
-        it("fails due to custom config validator want active to be booleans") {
+        @Test
+        fun `fails due to custom config validator want active to be booleans`() {
             val config = yamlConfigFromContent(
                 """
                 # Properties of custom rule sets get excluded by default.
@@ -62,7 +65,8 @@ class SupportConfigValidationSpec : Spek({
             }
         }
 
-        it("passes with excluded new properties") {
+        @Test
+        fun `passes with excluded new properties`() {
             val config = yamlConfigFromContent(
                 """
                config:
@@ -90,7 +94,7 @@ class SupportConfigValidationSpec : Spek({
             }
         }
     }
-})
+}
 
 internal class SampleRuleProvider : RuleSetProvider {
 

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/CompositeConfigSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/CompositeConfigSpec.kt
@@ -6,7 +6,7 @@ import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
-internal class CompositeConfigSpec {
+class CompositeConfigSpec {
 
     @Nested
     inner class `both configs should be considered` {

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/CompositeConfigSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/CompositeConfigSpec.kt
@@ -3,44 +3,45 @@ package io.gitlab.arturbosch.detekt.core.config
 import io.gitlab.arturbosch.detekt.test.yamlConfig
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-class CompositeConfigSpec : Spek({
+internal class CompositeConfigSpec {
 
-    describe("both configs should be considered") {
+    @Nested
+    inner class `both configs should be considered` {
 
-        val second by memoized { yamlConfig("composite-test.yml") }
-        val first by memoized { yamlConfig("detekt.yml") }
-        val compositeConfig by memoized { CompositeConfig(second, first) }
+        private val second = yamlConfig("composite-test.yml")
+        private val first = yamlConfig("detekt.yml")
+        private val compositeConfig = CompositeConfig(second, first)
 
-        it(
-            """
-            should have style sub config with active false which is overridden
-            in `second` config regardless of default value
-        """
-        ) {
+        @Test
+        fun `should have style sub config with active false which is overridden in "second" config regardless of default value`() {
             val styleConfig = compositeConfig.subConfig("style").subConfig("WildcardImport")
             assertThat(styleConfig.valueOrDefault("active", true)).isEqualTo(false)
             assertThat(styleConfig.valueOrDefault("active", false)).isEqualTo(false)
         }
 
-        it("should have code smell sub config with LongMethod threshold 20 from `first` config") {
+        @Test
+        fun `should have code smell sub config with LongMethod threshold 20 from _first_ config`() {
             val codeSmellConfig = compositeConfig.subConfig("code-smell").subConfig("LongMethod")
             assertThat(codeSmellConfig.valueOrDefault("threshold", -1)).isEqualTo(20)
         }
 
-        it("should use the default as both part configurations do not have the value") {
+        @Test
+        fun `should use the default as both part configurations do not have the value`() {
             assertThat(compositeConfig.valueOrDefault("TEST", 42)).isEqualTo(42)
         }
 
-        it("should return a string based on default value") {
+        @Test
+        fun `should return a string based on default value`() {
             val config = compositeConfig.subConfig("style").subConfig("MagicNumber")
             val value = config.valueOrDefault("ignoreNumbers", emptyList<String>())
             assertThat(value).isEqualTo(listOf("-1", "0", "1", "2", "100", "1000"))
         }
 
-        it("should fail with a meaningful exception when boolean property is invalid") {
+        @Test
+        fun `should fail with a meaningful exception when boolean property is invalid`() {
             val config = compositeConfig.subConfig("style").subConfig("LargeClass")
 
             val expectedErrorMessage = "Value \"truuu\" set for config parameter \"style > LargeClass > active\" " +
@@ -52,4 +53,4 @@ class CompositeConfigSpec : Spek({
                 .hasMessageContaining(expectedErrorMessage)
         }
     }
-})
+}

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/ConfigurationsSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/ConfigurationsSpec.kt
@@ -4,14 +4,16 @@ import io.github.detekt.test.utils.resourceAsPath
 import io.github.detekt.test.utils.resourceUrl
 import io.github.detekt.tooling.api.spec.ProcessingSpec
 import org.assertj.core.api.Assertions.assertThat
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-internal class ConfigurationsSpec : Spek({
+internal class ConfigurationsSpec {
 
-    describe("a configuration") {
+    @Nested
+    inner class `a configuration` {
 
-        it("should be an empty config") {
+        @Test
+        fun `should be an empty config`() {
             val config = ProcessingSpec {}.loadConfiguration()
             assertThat(config.valueOrDefault("one", -1)).isEqualTo(-1)
             assertThat(config.valueOrDefault("two", -1)).isEqualTo(-1)
@@ -19,20 +21,23 @@ internal class ConfigurationsSpec : Spek({
         }
     }
 
-    describe("parse different path based configuration settings") {
+    @Nested
+    inner class `parse different path based configuration settings` {
 
         val pathOne = resourceAsPath("/configs/one.yml")
         val pathTwo = resourceAsPath("/configs/two.yml")
         val pathThree = resourceAsPath("/configs/three.yml")
 
-        it("should load single config") {
+        @Test
+        fun `should load single config`() {
             val config = ProcessingSpec {
                 config { configPaths = listOf(pathOne) }
             }.loadConfiguration()
             assertThat(config.valueOrDefault("one", -1)).isEqualTo(1)
         }
 
-        it("should load two configs") {
+        @Test
+        fun `should load two configs`() {
             val config = ProcessingSpec {
                 config { configPaths = listOf(pathOne, pathTwo) }
             }.loadConfiguration()
@@ -40,7 +45,8 @@ internal class ConfigurationsSpec : Spek({
             assertThat(config.valueOrDefault("two", -1)).isEqualTo(2)
         }
 
-        it("should load three configs") {
+        @Test
+        fun `should load three configs`() {
             val config = ProcessingSpec {
                 config { configPaths = listOf(pathOne, pathTwo, pathThree) }
             }.loadConfiguration()
@@ -50,9 +56,11 @@ internal class ConfigurationsSpec : Spek({
         }
     }
 
-    describe("parse different resource based configuration settings") {
+    @Nested
+    inner class `parse different resource based configuration settings` {
 
-        it("should load three configs") {
+        @Test
+        fun `should load three configs`() {
             val config = ProcessingSpec {
                 config {
                     resources = listOf(
@@ -68,19 +76,19 @@ internal class ConfigurationsSpec : Spek({
         }
     }
 
-    describe("build upon default config") {
+    @Nested
+    inner class `build upon default config` {
 
-        val config by memoized {
-            ProcessingSpec {
-                config {
-                    resources = listOf(resourceUrl("/configs/fail-fast-wont-override-here.yml"))
-                    useDefaultConfig = true
-                }
-                rules { activateAllRules = true }
-            }.loadConfiguration()
-        }
+        private val config = ProcessingSpec {
+            config {
+                resources = listOf(resourceUrl("/configs/fail-fast-wont-override-here.yml"))
+                useDefaultConfig = true
+            }
+            rules { activateAllRules = true }
+        }.loadConfiguration()
 
-        it("should override config when specified") {
+        @Test
+        fun `should override config when specified`() {
             val ruleConfig = config.subConfig("style").subConfig("MaxLineLength")
             val lineLength = ruleConfig.valueOrDefault("maxLineLength", -1)
             val excludeComments = ruleConfig.valueOrDefault("excludeCommentStatements", false)
@@ -89,16 +97,18 @@ internal class ConfigurationsSpec : Spek({
             assertThat(excludeComments).isTrue()
         }
 
-        it("should be active=false by default") {
+        @Test
+        fun `should be active=false by default`() {
             val actual = config.subConfig("comments")
                 .subConfig("CommentOverPrivateFunction")
                 .valueOrDefault("active", true)
             assertThat(actual).isFalse()
         }
 
-        it("should be maxIssues=0 by default") {
+        @Test
+        fun `should be maxIssues=0 by default`() {
             val actual = config.subConfig("build").valueOrDefault("maxIssues", -1)
             assertThat(actual).isEqualTo(0)
         }
     }
-})
+}

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/ConfigurationsSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/ConfigurationsSpec.kt
@@ -7,7 +7,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
-internal class ConfigurationsSpec {
+class ConfigurationsSpec {
 
     @Nested
     inner class `a configuration` {

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/DefaultConfigValidationSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/DefaultConfigValidationSpec.kt
@@ -2,21 +2,24 @@ package io.gitlab.arturbosch.detekt.core.config
 
 import io.gitlab.arturbosch.detekt.test.yamlConfig
 import org.assertj.core.api.Assertions.assertThat
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-class DefaultConfigValidationSpec : Spek({
+internal class DefaultConfigValidationSpec {
 
-    describe("default configuration is valid") {
+    @Nested
+    inner class `default configuration is valid` {
 
-        val baseline by memoized { yamlConfig("default-detekt-config.yml") }
+        private val baseline = yamlConfig("default-detekt-config.yml")
 
-        it("is valid comparing itself") {
+        @Test
+        fun `is valid comparing itself`() {
             assertThat(validateConfig(baseline, baseline)).isEmpty()
         }
 
-        it("does not flag common known config sub sections") {
+        @Test
+        fun `does not flag common known config sub sections`() {
             assertThat(validateConfig(yamlConfig("common_known_sections.yml"), baseline)).isEmpty()
         }
     }
-})
+}

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/DefaultConfigValidationSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/DefaultConfigValidationSpec.kt
@@ -5,7 +5,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
-internal class DefaultConfigValidationSpec {
+class DefaultConfigValidationSpec {
 
     @Nested
     inner class `default configuration is valid` {

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/IssueExtensionSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/IssueExtensionSpec.kt
@@ -8,19 +8,18 @@ import io.gitlab.arturbosch.detekt.test.TestDetektion
 import io.gitlab.arturbosch.detekt.test.createCorrectableFinding
 import io.gitlab.arturbosch.detekt.test.createFinding
 import org.assertj.core.api.Assertions.assertThat
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-class IssueExtensionSpec : Spek({
+internal class IssueExtensionSpec {
 
-    val issues by memoized {
-        mapOf(
-            "Ruleset1" to listOf(createFinding(), createCorrectableFinding()),
-            "Ruleset2" to listOf(createFinding())
-        )
-    }
+    private val issues = mapOf(
+        "Ruleset1" to listOf(createFinding(), createCorrectableFinding()),
+        "Ruleset2" to listOf(createFinding())
+    )
 
-    test("compute weighted amount of issues") {
+    @Test
+    fun `compute weighted amount of issues`() {
         val detektion = object : TestDetektion() {
             override val findings: Map<String, List<Finding>> = issues
         }
@@ -29,15 +28,18 @@ class IssueExtensionSpec : Spek({
         assertThat(amount).isEqualTo(3)
     }
 
-    describe("filter auto corrected issues") {
+    @Nested
+    inner class `filter auto corrected issues` {
 
-        it("excludeCorrectable = false (default)") {
+        @Test
+        fun `excludeCorrectable = false (default)`() {
             val detektion = TestDetektion(createFinding(), createCorrectableFinding())
             val findings = detektion.filterAutoCorrectedIssues(Config.empty)
             assertThat(findings).hasSize(1)
         }
 
-        it("excludeCorrectable = true") {
+        @Test
+        fun `excludeCorrectable = true`() {
             val config = TestConfig(mapOf("maxIssues" to "0", "excludeCorrectable" to "true"))
             val detektion = object : TestDetektion() {
                 override val findings: Map<String, List<Finding>> = issues
@@ -47,4 +49,4 @@ class IssueExtensionSpec : Spek({
             assertThat(findings).hasSize(2)
         }
     }
-})
+}

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/IssueExtensionSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/IssueExtensionSpec.kt
@@ -11,7 +11,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
-internal class IssueExtensionSpec {
+class IssueExtensionSpec {
 
     private val issues = mapOf(
         "Ruleset1" to listOf(createFinding(), createCorrectableFinding()),

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/MaxIssueCheckSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/MaxIssueCheckSpec.kt
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 
-internal class MaxIssueCheckSpec {
+class MaxIssueCheckSpec {
 
     @Nested
     inner class `based only on MaxIssuePolicy` {

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/ValidateConfigSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/ValidateConfigSpec.kt
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 
-internal class ValidateConfigSpec {
+class ValidateConfigSpec {
 
     @Nested
     inner class `validate configuration file` {

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/ValidateConfigSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/ValidateConfigSpec.kt
@@ -8,21 +8,26 @@ import io.gitlab.arturbosch.detekt.test.yamlConfigFromContent
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 import org.assertj.core.api.Assertions.assertThatIllegalStateException
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 
-internal class ValidateConfigSpec : Spek({
+internal class ValidateConfigSpec {
 
-    describe("validate configuration file") {
+    @Nested
+    inner class `validate configuration file` {
 
-        val baseline by memoized { yamlConfig("config_validation/baseline.yml") }
+        private val baseline = yamlConfig("config_validation/baseline.yml")
 
-        it("passes for same config test") {
+        @Test
+        fun `passes for same config test`() {
             val result = validateConfig(baseline, baseline)
             assertThat(result).isEmpty()
         }
 
-        it("passes for properties which may appear on rules and rule sets but may be not present in default config") {
+        @Test
+        fun `passes for properties which may appear on rules and rule sets but may be not present in default config`() {
             val result = validateConfig(
                 yamlConfig("config_validation/default-excluded-properties.yml"),
                 baseline
@@ -30,7 +35,8 @@ internal class ValidateConfigSpec : Spek({
             assertThat(result).isEmpty()
         }
 
-        it("reports different rule set name") {
+        @Test
+        fun `reports different rule set name`() {
             val result = validateConfig(
                 yamlConfig("config_validation/other-ruleset-name.yml"),
                 baseline
@@ -38,7 +44,8 @@ internal class ValidateConfigSpec : Spek({
             assertThat(result).contains(propertyDoesNotExists("code-smell"))
         }
 
-        it("reports different nested property names") {
+        @Test
+        fun `reports different nested property names`() {
             val result = validateConfig(
                 yamlConfig("config_validation/other-nested-property-names.yml"),
                 baseline
@@ -52,7 +59,8 @@ internal class ValidateConfigSpec : Spek({
             )
         }
 
-        it("reports different rule set name") {
+        @Test
+        fun `reports nested configuration expected`() {
             val result = validateConfig(
                 yamlConfig("config_validation/no-nested-config.yml"),
                 baseline
@@ -63,7 +71,8 @@ internal class ValidateConfigSpec : Spek({
             )
         }
 
-        it("reports unexpected nested configs") {
+        @Test
+        fun `reports unexpected nested configs`() {
             // note that the baseline config is now the first argument
             val result = validateConfig(baseline, yamlConfig("config_validation/no-value.yml"))
             assertThat(result).contains(
@@ -72,40 +81,47 @@ internal class ValidateConfigSpec : Spek({
             )
         }
 
-        it("returns an error for an invalid config type") {
+        @Test
+        fun `returns an error for an invalid config type`() {
             val invalidConfig = TestConfig()
             assertThatIllegalStateException().isThrownBy {
                 validateConfig(invalidConfig, baseline)
             }.withMessageStartingWith("Unsupported config type for validation")
         }
 
-        it("returns an error for an invalid baseline") {
+        @Test
+        fun `returns an error for an invalid baseline`() {
             val invalidBaseline = TestConfig()
             assertThatIllegalArgumentException().isThrownBy {
                 validateConfig(Config.empty, invalidBaseline)
             }.withMessageStartingWith("Only supported baseline config is the YamlConfig.")
         }
 
-        it("returns an error for an empty baseline") {
+        @Test
+        fun `returns an error for an empty baseline`() {
             val invalidBaseline = Config.empty
             assertThatIllegalArgumentException().isThrownBy {
                 validateConfig(Config.empty, invalidBaseline)
             }.withMessageStartingWith("Cannot validate configuration based on an empty baseline config.")
         }
 
-        describe("validate composite configurations") {
+        @Nested
+        inner class `validate composite configurations` {
 
-            it("passes for same left, right and baseline config") {
+            @Test
+            fun `passes for same left, right and baseline config`() {
                 val result = validateConfig(CompositeConfig(baseline, baseline), baseline)
                 assertThat(result).isEmpty()
             }
 
-            it("passes for empty configs") {
+            @Test
+            fun `passes for empty configs`() {
                 val result = validateConfig(CompositeConfig(Config.empty, Config.empty), baseline)
                 assertThat(result).isEmpty()
             }
 
-            it("finds accumulated errors") {
+            @Test
+            fun `finds accumulated errors`() {
                 val result = validateConfig(
                     CompositeConfig(
                         yamlConfig("config_validation/other-nested-property-names.yml"),
@@ -126,11 +142,13 @@ internal class ValidateConfigSpec : Spek({
             }
         }
 
-        describe("configure additional exclude paths") {
+        @Nested
+        inner class `configure additional exclude paths` {
 
             fun patterns(str: String) = CommaSeparatedPattern(str).mapToRegex()
 
-            it("does not report any complexity properties") {
+            @Test
+            fun `does not report any complexity properties`() {
                 val result = validateConfig(
                     yamlConfig("config_validation/other-nested-property-names.yml"),
                     baseline,
@@ -139,7 +157,8 @@ internal class ValidateConfigSpec : Spek({
                 assertThat(result).isEmpty()
             }
 
-            it("does not report 'complexity>LargeClass>howMany'") {
+            @Test
+            fun `does not report 'complexity_LargeClass_howMany'`() {
                 val result = validateConfig(
                     yamlConfig("config_validation/other-nested-property-names.yml"),
                     baseline,
@@ -158,7 +177,8 @@ internal class ValidateConfigSpec : Spek({
                 )
             }
 
-            it("does not report '.*>InnerMap'") {
+            @Test
+            fun `does not report '_*_InnerMap'`() {
                 val result = validateConfig(
                     yamlConfig("config_validation/other-nested-property-names.yml"),
                     baseline,
@@ -178,35 +198,32 @@ internal class ValidateConfigSpec : Spek({
             }
         }
 
-        describe("deprecated configuration option") {
+        @Nested
+        inner class `deprecated configuration option` {
 
-            arrayOf(
-                "reports a deprecated property as a warning" to false,
-                "reports a deprecated property as an error" to true,
-            ).forEach { (testName, warningsAsErrors) ->
-
-                it(testName) {
-                    val config = yamlConfigFromContent(
-                        """
+            @ParameterizedTest
+            @ValueSource(booleans = [true, false])
+            fun `reports a deprecated property as a warning`(warningsAsErrors: Boolean) {
+                val config = yamlConfigFromContent(
+                    """
                     config:
                       warningsAsErrors: $warningsAsErrors
                     naming:
                       FunctionParameterNaming:
                         ignoreOverriddenFunctions: ''
-                        """.trimIndent()
-                    )
+                    """.trimIndent()
+                )
 
-                    val result = validateConfig(config, config)
+                val result = validateConfig(config, config)
 
-                    assertThat(result).contains(
-                        propertyIsDeprecated(
-                            "naming>FunctionParameterNaming>ignoreOverriddenFunctions",
-                            "Use `ignoreOverridden` instead",
-                            reportAsError = warningsAsErrors
-                        )
+                assertThat(result).contains(
+                    propertyIsDeprecated(
+                        "naming>FunctionParameterNaming>ignoreOverriddenFunctions",
+                        "Use `ignoreOverridden` instead",
+                        reportAsError = warningsAsErrors
                     )
-                }
+                )
             }
         }
     }
-})
+}

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/ValueOrDefaultCommaSeparatedSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/ValueOrDefaultCommaSeparatedSpec.kt
@@ -3,28 +3,32 @@ package io.gitlab.arturbosch.detekt.core.config
 import io.gitlab.arturbosch.detekt.api.internal.valueOrDefaultCommaSeparated
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import org.assertj.core.api.Assertions.assertThat
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-class ValueOrDefaultCommaSeparatedSpec : Spek({
+internal class ValueOrDefaultCommaSeparatedSpec {
 
-    describe("valueOrDefaultCommaSeparated") {
+    @Nested
+    inner class `valueOrDefaultCommaSeparated` {
 
-        it("returns the default when there is not a config value") {
+        @Test
+        fun `returns the default when there is not a config value`() {
             val config = TestConfig()
 
             assertThat(config.valueOrDefaultCommaSeparated("imports", listOf("java.utils.*")))
                 .isEqualTo(listOf("java.utils.*"))
         }
 
-        it("returns the default when there is a config String value") {
+        @Test
+        fun `returns the default when there is a config String value`() {
             val config = TestConfig("imports" to "butterknife.*,java.utils.*,")
 
             assertThat(config.valueOrDefaultCommaSeparated("imports", listOf("java.utils.*")))
                 .isEqualTo(listOf("butterknife.*", "java.utils.*"))
         }
 
-        it("returns the config value when there is a config List value") {
+        @Test
+        fun `returns the config value when there is a config List value`() {
             val config = TestConfig("imports" to listOf("butterknife.*"))
 
             assertThat(config.valueOrDefaultCommaSeparated("imports", listOf("java.utils.*")))
@@ -32,9 +36,11 @@ class ValueOrDefaultCommaSeparatedSpec : Spek({
         }
     }
 
-    describe("valueOrDefaultCommaSeparated works with CompositeConfig") {
+    @Nested
+    inner class `valueOrDefaultCommaSeparated works with CompositeConfig` {
 
-        it("and empty String") {
+        @Test
+        fun `and empty String`() {
             val config = CompositeConfig(
                 TestConfig(mapOf("imports" to "")),
                 TestConfig(mapOf("imports" to emptyList<String>()))
@@ -43,7 +49,8 @@ class ValueOrDefaultCommaSeparatedSpec : Spek({
             assertThat(config.valueOrDefaultCommaSeparated("imports", emptyList())).isEmpty()
         }
 
-        it("and empty List") {
+        @Test
+        fun `and empty List`() {
             val config = CompositeConfig(
                 TestConfig(mapOf("imports" to emptyList<String>())),
                 TestConfig(mapOf("imports" to emptyList<String>()))
@@ -52,7 +59,8 @@ class ValueOrDefaultCommaSeparatedSpec : Spek({
             assertThat(config.valueOrDefaultCommaSeparated("imports", emptyList())).isEmpty()
         }
 
-        it("and String with values") {
+        @Test
+        fun `and String with values`() {
             val config = CompositeConfig(
                 TestConfig(mapOf("imports" to "java.utils.*,butterknife.*")),
                 TestConfig(mapOf("imports" to emptyList<String>()))
@@ -62,7 +70,8 @@ class ValueOrDefaultCommaSeparatedSpec : Spek({
                 .containsExactly("java.utils.*", "butterknife.*")
         }
 
-        it("and List with values") {
+        @Test
+        fun `and List with values`() {
             val config = CompositeConfig(
                 TestConfig(mapOf("imports" to listOf("java.utils.*", "butterknife.*"))),
                 TestConfig(mapOf("imports" to emptyList<String>()))
@@ -72,4 +81,4 @@ class ValueOrDefaultCommaSeparatedSpec : Spek({
                 .containsExactly("java.utils.*", "butterknife.*")
         }
     }
-})
+}

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/ValueOrDefaultCommaSeparatedSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/ValueOrDefaultCommaSeparatedSpec.kt
@@ -6,7 +6,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
-internal class ValueOrDefaultCommaSeparatedSpec {
+class ValueOrDefaultCommaSeparatedSpec {
 
     @Nested
     inner class `valueOrDefaultCommaSeparated` {

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/YamlConfigSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/YamlConfigSpec.kt
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test
 import org.yaml.snakeyaml.parser.ParserException
 import java.nio.file.Paths
 
-internal class YamlConfigSpec {
+class YamlConfigSpec {
 
     @Nested
     inner class `load yaml config` {

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/YamlConfigSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/YamlConfigSpec.kt
@@ -11,18 +11,20 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatCode
 import org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 import org.assertj.core.api.Assertions.assertThatIllegalStateException
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 import org.yaml.snakeyaml.parser.ParserException
 import java.nio.file.Paths
 
-class YamlConfigSpec : Spek({
+internal class YamlConfigSpec {
 
-    describe("load yaml config") {
+    @Nested
+    inner class `load yaml config` {
 
-        val config by memoized { yamlConfig("detekt.yml") }
+        private val config = yamlConfig("detekt.yml")
 
-        it("should create a sub config") {
+        @Test
+        fun `should create a sub config`() {
             val subConfig = config.subConfig("style")
             assertThat(subConfig.valueOrDefault("WildcardImport", emptyMap<String, Any>())).isNotEmpty
             assertThat(
@@ -41,89 +43,107 @@ class YamlConfigSpec : Spek({
             assertThat(subConfig.valueOrDefault("NotFound", "")).isEmpty()
         }
 
-        it("should create a sub sub config") {
+        @Test
+        fun `should create a sub sub config`() {
             val subConfig = config.subConfig("style")
             val subSubConfig = subConfig.subConfig("WildcardImport")
             assertThat(subSubConfig.valueOrDefault("active", false)).isTrue()
             assertThat(subSubConfig.valueOrDefault("NotFound", true)).isTrue()
         }
 
-        it("tests wrong sub config conversion") {
+        @Test
+        fun `tests wrong sub config conversion`() {
             assertThatIllegalStateException().isThrownBy {
                 @Suppress("UNUSED_VARIABLE")
                 val ignored = config.valueOrDefault("style", "")
-            }.withMessage("Value \"{WildcardImport={active=true}, NoElseInWhenExpression={active=true}, MagicNumber={active=true, ignoreNumbers=[-1, 0, 1, 2]}}\" set for config parameter \"style\" is not of required type String.")
+            }
+                .withMessage("Value \"{WildcardImport={active=true}, NoElseInWhenExpression={active=true}, MagicNumber={active=true, ignoreNumbers=[-1, 0, 1, 2]}}\" set for config parameter \"style\" is not of required type String.")
         }
     }
 
-    describe("loading empty configurations") {
+    @Nested
+    inner class `loading empty configurations` {
 
-        it("empty yaml file is equivalent to empty config") {
+        @Test
+        fun `empty yaml file is equivalent to empty config`() {
             javaClass.getSafeResourceAsStream("/empty.yml")!!.reader().use(YamlConfig::load)
         }
 
-        it("single item in yaml file is valid") {
+        @Test
+        fun `single item in yaml file is valid`() {
             javaClass.getSafeResourceAsStream("/oneitem.yml")!!.reader().use(YamlConfig::load)
         }
     }
 
-    describe("meaningful error messages") {
+    @Nested
+    inner class `meaningful error messages` {
 
-        val config by memoized { yamlConfig("wrong-property-type.yml") }
+        private val config = yamlConfig("wrong-property-type.yml")
 
-        it("only accepts true and false boolean values") {
+        @Test
+        fun `only accepts true and false boolean values`() {
             assertThatIllegalStateException()
                 .isThrownBy { config.valueOrDefault("bool", false) }
                 .withMessage("""Value "fasle" set for config parameter "bool" is not of required type Boolean.""")
         }
 
-        it("prints whole config-key path for NumberFormatException") {
+        @Test
+        fun `prints whole config-key path for NumberFormatException`() {
             assertThatIllegalStateException().isThrownBy {
                 config.subConfig("RuleSet")
                     .subConfig("Rule")
                     .valueOrDefault("threshold", 6)
-            }.withMessage("Value \"v5.7\" set for config parameter \"RuleSet > Rule > threshold\" is not of required type Int.")
+            }
+                .withMessage("Value \"v5.7\" set for config parameter \"RuleSet > Rule > threshold\" is not of required type Int.")
         }
 
-        it("prints whole config-key path for ClassCastException") {
+        @Test
+        fun `prints whole config-key path for ClassCastException`() {
             assertThatIllegalStateException().isThrownBy {
                 @Suppress("UNUSED_VARIABLE")
                 val bool: Int = config.subConfig("RuleSet")
                     .subConfig("Rule")
                     .valueOrDefault("active", 1)
-            }.withMessage("Value \"[]\" set for config parameter \"RuleSet > Rule > active\" is not of required type Int.")
+            }
+                .withMessage("Value \"[]\" set for config parameter \"RuleSet > Rule > active\" is not of required type Int.")
         }
     }
 
-    describe("yaml config") {
+    @Nested
+    inner class `yaml config` {
 
-        it("loads the config from a given yaml file") {
+        @Test
+        fun `loads the config from a given yaml file`() {
             val path = resourceAsPath("detekt.yml")
             val config = YamlConfig.load(path)
             assertThat(config).isNotNull
         }
 
-        it("loads the config from a given text file") {
+        @Test
+        fun `loads the config from a given text file`() {
             val path = resourceAsPath("detekt.txt")
             val config = YamlConfig.load(path)
             assertThat(config).isNotNull
         }
 
-        it("throws an exception on an non-existing file") {
+        @Test
+        fun `throws an exception on an non-existing file`() {
             val path = Paths.get("doesNotExist.yml")
             assertThatIllegalArgumentException()
                 .isThrownBy { YamlConfig.load(path) }
                 .withMessageStartingWith("Configuration does not exist")
         }
 
-        it("throws an exception on a directory") {
+        @Test
+        fun `throws an exception on a directory`() {
             val path = resourceAsPath("/config_validation")
             assertThatIllegalArgumentException()
                 .isThrownBy { YamlConfig.load(path) }
                 .withMessageStartingWith("Configuration must be a file")
         }
 
-        it("throws InvalidConfigurationError on invalid structured yaml files") {
+        @Test
+        fun `throws InvalidConfigurationError on invalid structured yaml files`() {
             assertThatCode {
                 yamlConfigFromContent(
                     """
@@ -136,4 +156,4 @@ class YamlConfigSpec : Spek({
                 .hasCauseInstanceOf(ParserException::class.java)
         }
     }
-})
+}

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/extensions/LoadingSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/extensions/LoadingSpec.kt
@@ -5,11 +5,12 @@ import io.gitlab.arturbosch.detekt.core.createNullLoggingSpec
 import io.gitlab.arturbosch.detekt.core.rules.RuleSetLocator
 import io.gitlab.arturbosch.detekt.core.tooling.withSettings
 import org.assertj.core.api.Assertions.assertThat
-import org.spekframework.spek2.Spek
+import org.junit.jupiter.api.Test
 
-internal class LoadingSpec : Spek({
+internal class LoadingSpec {
 
-    test("extensions can be excluded via ExtensionSpec") {
+    @Test
+    fun `extensions can be excluded via ExtensionSpec`() {
         val providers = createNullLoggingSpec {
             extensions {
                 disableExtension("SampleConfigValidator")
@@ -20,7 +21,8 @@ internal class LoadingSpec : Spek({
             .doesNotContain("SampleConfigValidator")
     }
 
-    test("RuleSetProvider can be excluded via ExtensionSpec") {
+    @Test
+    fun `RuleSetProvider can be excluded via ExtensionSpec`() {
         val providers = createNullLoggingSpec {
             extensions {
                 disableExtension("sample-rule-set")
@@ -30,4 +32,4 @@ internal class LoadingSpec : Spek({
         assertThat(providers.map { it.ruleSetId })
             .doesNotContain("sample-rule-set")
     }
-})
+}

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/extensions/LoadingSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/extensions/LoadingSpec.kt
@@ -7,7 +7,7 @@ import io.gitlab.arturbosch.detekt.core.tooling.withSettings
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
-internal class LoadingSpec {
+class LoadingSpec {
 
     @Test
     fun `extensions can be excluded via ExtensionSpec`() {

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/OutputFacadeSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/OutputFacadeSpec.kt
@@ -11,12 +11,13 @@ import io.gitlab.arturbosch.detekt.core.createNullLoggingSpec
 import io.gitlab.arturbosch.detekt.core.tooling.withSettings
 import io.gitlab.arturbosch.detekt.test.createFinding
 import org.assertj.core.api.Assertions.assertThat
-import org.spekframework.spek2.Spek
+import org.junit.jupiter.api.Test
 import java.nio.file.Path
 
-internal class OutputFacadeSpec : Spek({
+internal class OutputFacadeSpec {
 
-    test("Running the output facade with multiple reports") {
+    @Test
+    fun `Running the output facade with multiple reports`() {
         val printStream = StringPrintStream()
         val inputPath: Path = resourceAsPath("/cases")
         val defaultResult = DetektResult(mapOf("Key" to listOf(createFinding())))
@@ -46,4 +47,4 @@ internal class OutputFacadeSpec : Spek({
             "Successfully generated ${HtmlOutputReport().name} at $htmlOutputPath"
         )
     }
-})
+}

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/OutputFacadeSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/OutputFacadeSpec.kt
@@ -14,7 +14,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.nio.file.Path
 
-internal class OutputFacadeSpec {
+class OutputFacadeSpec {
 
     @Test
     fun `Running the output facade with multiple reports`() {

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/OutputReportsSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/OutputReportsSpec.kt
@@ -12,51 +12,56 @@ import io.gitlab.arturbosch.detekt.core.createProcessingSettings
 import io.gitlab.arturbosch.detekt.core.tooling.withSettings
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Condition
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 import java.nio.file.Paths
 import java.util.function.Predicate
 
-internal class OutputReportsSpec : Spek({
+internal class OutputReportsSpec {
 
-    describe("reports") {
+    @Nested
+    inner class `reports` {
 
-        context("arguments for spec") {
+        @Nested
+        inner class `arguments for spec` {
 
-            val reportUnderTest by memoized { TestOutputReport::class.java.simpleName }
-            val reports by memoized {
-                ReportsSpecBuilder().apply {
-                    report { "xml" to Paths.get("/tmp/path1") }
-                    report { "txt" to Paths.get("/tmp/path2") }
-                    report { reportUnderTest to Paths.get("/tmp/path3") }
-                    report { "html" to Paths.get("D:_Gradle\\xxx\\xxx\\build\\reports\\detekt\\detekt.html") }
-                }.build().reports.toList()
-            }
+            private val reportUnderTest = TestOutputReport::class.java.simpleName
+            private val reports = ReportsSpecBuilder().apply {
+                report { "xml" to Paths.get("/tmp/path1") }
+                report { "txt" to Paths.get("/tmp/path2") }
+                report { reportUnderTest to Paths.get("/tmp/path3") }
+                report { "html" to Paths.get("D:_Gradle\\xxx\\xxx\\build\\reports\\detekt\\detekt.html") }
+            }.build().reports.toList()
 
-            it("should parse multiple report entries") {
+            @Test
+            fun `should parse multiple report entries`() {
                 assertThat(reports).hasSize(4)
             }
 
-            it("it should properly parse XML report entry") {
+            @Test
+            fun `it should properly parse XML report entry`() {
                 val xmlReport = reports[0]
                 assertThat(xmlReport.type).isEqualTo(defaultReportMapping(XmlOutputReport::class.java.simpleName))
                 assertThat(xmlReport.path).isEqualTo(Paths.get("/tmp/path1"))
             }
 
-            it("it should properly parse TXT report entry") {
+            @Test
+            fun `it should properly parse TXT report entry`() {
                 val txtRepot = reports[1]
                 assertThat(txtRepot.type).isEqualTo(defaultReportMapping(TxtOutputReport::class.java.simpleName))
                 assertThat(txtRepot.path).isEqualTo(Paths.get("/tmp/path2"))
             }
 
-            it("it should properly parse custom report entry") {
+            @Test
+            fun `it should properly parse custom report entry`() {
                 val customReport = reports[2]
                 assertThat(customReport.type).isEqualTo(reportUnderTest)
                 assertThat(defaultReportMapping(customReport.type)).isEqualTo(reportUnderTest)
                 assertThat(customReport.path).isEqualTo(Paths.get("/tmp/path3"))
             }
 
-            it("it should properly parse HTML report entry") {
+            @Test
+            fun `it should properly parse HTML report entry`() {
                 val htmlReport = reports[3]
                 assertThat(htmlReport.type).isEqualTo(defaultReportMapping(HtmlOutputReport::class.java.simpleName))
                 assertThat(htmlReport.path).isEqualTo(
@@ -64,16 +69,19 @@ internal class OutputReportsSpec : Spek({
                 )
             }
 
-            context("default report ids") {
+            @Nested
+            inner class `default report ids` {
 
-                val extensions by memoized { createProcessingSettings().use { OutputReportLocator(it).load() } }
-                val extensionsIds by memoized { extensions.mapTo(HashSet()) { defaultReportMapping(it.id) } }
+                private val extensions = createProcessingSettings().use { OutputReportLocator(it).load() }
+                private val extensionsIds = extensions.mapTo(HashSet()) { defaultReportMapping(it.id) }
 
-                it("should be able to convert to output reports") {
+                @Test
+                fun `should be able to convert to output reports`() {
                     assertThat(reports).allMatch { it.type in extensionsIds }
                 }
 
-                it("should recognize custom output format") {
+                @Test
+                fun `should recognize custom output format`() {
                     assertThat(reports).haveExactly(
                         1,
                         Condition(
@@ -93,9 +101,11 @@ internal class OutputReportsSpec : Spek({
             }
         }
 
-        context("empty reports") {
+        @Nested
+        inner class `empty reports` {
 
-            it("yields empty extension list") {
+            @Test
+            fun `yields empty extension list`() {
                 val spec = createNullLoggingSpec {
                     config {
                         configPaths = listOf(resourceAsPath("/reporting/disabled-reports.yml"))
@@ -108,7 +118,7 @@ internal class OutputReportsSpec : Spek({
             }
         }
     }
-})
+}
 
 internal class TestOutputReport : OutputReport() {
     override val ending: String = "yml"

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/OutputReportsSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/OutputReportsSpec.kt
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.Test
 import java.nio.file.Paths
 import java.util.function.Predicate
 
-internal class OutputReportsSpec {
+class OutputReportsSpec {
 
     @Nested
     inner class `reports` {
@@ -120,7 +120,7 @@ internal class OutputReportsSpec {
     }
 }
 
-internal class TestOutputReport : OutputReport() {
+class TestOutputReport : OutputReport() {
     override val ending: String = "yml"
     override fun render(detektion: Detektion): String? {
         throw UnsupportedOperationException("not implemented")

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/ComplexityReportSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/ComplexityReportSpec.kt
@@ -14,7 +14,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
-internal class ComplexityReportSpec {
+class ComplexityReportSpec {
 
     @Nested
     inner class `complexity report` {

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/ComplexityReportSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/ComplexityReportSpec.kt
@@ -11,16 +11,19 @@ import io.gitlab.arturbosch.detekt.api.Detektion
 import io.gitlab.arturbosch.detekt.core.DetektResult
 import io.gitlab.arturbosch.detekt.test.createFinding
 import org.assertj.core.api.Assertions.assertThat
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-internal class ComplexityReportSpec : Spek({
+internal class ComplexityReportSpec {
 
-    describe("complexity report") {
+    @Nested
+    inner class `complexity report` {
 
-        context("several complexity metrics") {
+        @Nested
+        inner class `several complexity metrics` {
 
-            it("successfully generates a complexity report") {
+            @Test
+            fun `successfully generates a complexity report`() {
                 val report = ComplexityReport()
                 val expectedContent = readResourceContent("/reporting/complexity-report.txt")
                 val detektion = createDetektion()
@@ -28,14 +31,15 @@ internal class ComplexityReportSpec : Spek({
                 assertThat(report.render(detektion)).isEqualTo(expectedContent)
             }
 
-            it("returns null for missing complexity metrics in report") {
+            @Test
+            fun `returns null for missing complexity metrics in report`() {
                 val report = ComplexityReport()
                 val detektion = createDetektion()
                 assertThat(report.render(detektion)).isNull()
             }
         }
     }
-})
+}
 
 private fun createDetektion(): Detektion = DetektResult(mapOf("Key" to listOf(createFinding())))
 

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/FileBasedFindingsReportSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/FileBasedFindingsReportSpec.kt
@@ -8,18 +8,21 @@ import io.gitlab.arturbosch.detekt.core.reporting.decolorized
 import io.gitlab.arturbosch.detekt.test.TestDetektion
 import io.gitlab.arturbosch.detekt.test.createFinding
 import org.assertj.core.api.Assertions.assertThat
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-class FileBasedFindingsReportSpec : Spek({
+internal class FileBasedFindingsReportSpec {
 
-    val subject by memoized { createFileBasedFindingsReport() }
+    private val subject = createFileBasedFindingsReport()
 
-    describe("findings report") {
+    @Nested
+    inner class `findings report` {
 
-        context("reports the debt per file and rule set with the overall debt") {
+        @Nested
+        inner class `reports the debt per file and rule set with the overall debt` {
 
-            it("has the reference content") {
+            @Test
+            fun `has the reference content`() {
                 val expectedContent = readResourceContent("/reporting/grouped-findings-report.txt")
                 val detektion = object : TestDetektion() {
                     override val findings: Map<String, List<Finding>> = mapOf(
@@ -38,12 +41,14 @@ class FileBasedFindingsReportSpec : Spek({
             }
         }
 
-        it("reports no findings") {
+        @Test
+        fun `reports no findings`() {
             val detektion = TestDetektion()
             assertThat(subject.render(detektion)).isNull()
         }
 
-        it("reports no findings when no rule set contains smells") {
+        @Test
+        fun `reports no findings when no rule set contains smells`() {
             val detektion = object : TestDetektion() {
                 override val findings: Map<String, List<Finding>> = mapOf(
                     "EmptySmells" to emptyList()
@@ -52,12 +57,13 @@ class FileBasedFindingsReportSpec : Spek({
             assertThat(subject.render(detektion)).isNull()
         }
 
-        it("should not add auto corrected issues to report") {
+        @Test
+        fun `should not add auto corrected issues to report`() {
             val report = FileBasedFindingsReport()
             AutoCorrectableIssueAssert.isReportNull(report)
         }
     }
-})
+}
 
 private fun createFileBasedFindingsReport(): FileBasedFindingsReport {
     val report = FileBasedFindingsReport()

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/FileBasedFindingsReportSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/FileBasedFindingsReportSpec.kt
@@ -11,7 +11,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
-internal class FileBasedFindingsReportSpec {
+class FileBasedFindingsReportSpec {
 
     private val subject = createFileBasedFindingsReport()
 

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/FindingsReportSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/FindingsReportSpec.kt
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
-internal class FindingsReportSpec {
+class FindingsReportSpec {
 
     private val subject = createFindingsReport()
 

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/FindingsReportSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/FindingsReportSpec.kt
@@ -8,48 +8,54 @@ import io.gitlab.arturbosch.detekt.core.reporting.decolorized
 import io.gitlab.arturbosch.detekt.test.TestDetektion
 import io.gitlab.arturbosch.detekt.test.createFinding
 import org.assertj.core.api.Assertions.assertThat
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-class FindingsReportSpec : Spek({
+internal class FindingsReportSpec {
 
-    val subject by memoized { createFindingsReport() }
+    private val subject = createFindingsReport()
 
-    describe("findings report") {
+    @Nested
+    inner class `findings report` {
 
-        context("reports the debt per rule set and the overall debt") {
-            val expectedContent by memoized { readResourceContent("/reporting/findings-report.txt") }
-            val detektion by memoized {
-                object : TestDetektion() {
-                    override val findings: Map<String, List<Finding>> = mapOf(
-                        "Ruleset1" to listOf(createFinding(), createFinding()),
-                        "EmptyRuleset" to emptyList(),
-                        "Ruleset2" to listOf(createFinding())
-                    )
-                }
+        @Nested
+        inner class `reports the debt per rule set and the overall debt` {
+            private val expectedContent = readResourceContent("/reporting/findings-report.txt")
+            val detektion = object : TestDetektion() {
+                override val findings: Map<String, List<Finding>> = mapOf(
+                    "Ruleset1" to listOf(createFinding(), createFinding()),
+                    "EmptyRuleset" to emptyList(),
+                    "Ruleset2" to listOf(createFinding())
+                )
             }
 
             var output: String? = null
 
-            beforeEachTest {
+            @BeforeEach
+            fun setUp() {
                 output = subject.render(detektion)?.decolorized()
             }
 
-            it("has the reference content") {
+            @Test
+            fun `has the reference content`() {
                 assertThat(output).isEqualTo(expectedContent)
             }
 
-            it("does contain the rule set id of rule sets with findings") {
+            @Test
+            fun `does contain the rule set id of rule sets with findings`() {
                 assertThat(output).contains("TestSmell")
             }
         }
 
-        it("reports no findings") {
+        @Test
+        fun `reports no findings`() {
             val detektion = TestDetektion()
             assertThat(subject.render(detektion)).isNull()
         }
 
-        it("reports no findings with rule set containing no smells") {
+        @Test
+        fun `reports no findings with rule set containing no smells`() {
             val detektion = object : TestDetektion() {
                 override val findings: Map<String, List<Finding>> = mapOf(
                     "Ruleset" to emptyList()
@@ -58,12 +64,13 @@ class FindingsReportSpec : Spek({
             assertThat(subject.render(detektion)).isNull()
         }
 
-        it("should not add auto corrected issues to report") {
+        @Test
+        fun `should not add auto corrected issues to report`() {
             val report = FindingsReport()
             AutoCorrectableIssueAssert.isReportNull(report)
         }
     }
-})
+}
 
 private fun createFindingsReport(): FindingsReport {
     val report = FindingsReport()

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/LiteFindingsReportSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/LiteFindingsReportSpec.kt
@@ -10,7 +10,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
-internal class LiteFindingsReportSpec {
+class LiteFindingsReportSpec {
 
     private val subject = createFindingsReport()
 

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/LiteFindingsReportSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/LiteFindingsReportSpec.kt
@@ -7,15 +7,17 @@ import io.gitlab.arturbosch.detekt.core.reporting.AutoCorrectableIssueAssert
 import io.gitlab.arturbosch.detekt.test.TestDetektion
 import io.gitlab.arturbosch.detekt.test.createFinding
 import org.assertj.core.api.Assertions.assertThat
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-class LiteFindingsReportSpec : Spek({
+internal class LiteFindingsReportSpec {
 
-    val subject by memoized { createFindingsReport() }
+    private val subject = createFindingsReport()
 
-    describe("findings report") {
-        it("reports non-empty findings") {
+    @Nested
+    inner class `findings report` {
+        @Test
+        fun `reports non-empty findings`() {
             assertThat(
                 subject
                     .render(
@@ -27,12 +29,14 @@ class LiteFindingsReportSpec : Spek({
             ).isEqualTo(readResourceContent("/reporting/lite-findings-report.txt"))
         }
 
-        it("reports no findings") {
+        @Test
+        fun `reports no findings`() {
             val detektion = TestDetektion()
             assertThat(subject.render(detektion)).isNull()
         }
 
-        it("reports no findings with rule set containing no smells") {
+        @Test
+        fun `reports no findings with rule set containing no smells`() {
             val detektion = object : TestDetektion() {
                 override val findings: Map<String, List<Finding>> = mapOf(
                     "Ruleset" to emptyList()
@@ -41,12 +45,13 @@ class LiteFindingsReportSpec : Spek({
             assertThat(subject.render(detektion)).isNull()
         }
 
-        it("should not add auto corrected issues to report") {
+        @Test
+        fun `should not add auto corrected issues to report`() {
             val report = LiteFindingsReport()
             AutoCorrectableIssueAssert.isReportNull(report)
         }
     }
-})
+}
 
 private fun createFindingsReport() = LiteFindingsReport().apply {
     init(Config.empty)

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/NotificationReportSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/NotificationReportSpec.kt
@@ -7,7 +7,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
-internal class NotificationReportSpec {
+class NotificationReportSpec {
 
     private val subject = NotificationReport()
 

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/NotificationReportSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/NotificationReportSpec.kt
@@ -4,25 +4,28 @@ import io.gitlab.arturbosch.detekt.api.internal.SimpleNotification
 import io.gitlab.arturbosch.detekt.core.NL
 import io.gitlab.arturbosch.detekt.test.TestDetektion
 import org.assertj.core.api.Assertions.assertThat
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-class NotificationReportSpec : Spek({
+internal class NotificationReportSpec {
 
-    val subject by memoized { NotificationReport() }
+    private val subject = NotificationReport()
 
-    describe("notification report") {
+    @Nested
+    inner class `notification report` {
 
-        it("reports two notifications") {
+        @Test
+        fun `reports two notifications`() {
             val detektion = object : TestDetektion() {
                 override val notifications = listOf(SimpleNotification("test"), SimpleNotification("test"))
             }
             assertThat(subject.render(detektion)).isEqualTo("test${NL}test")
         }
 
-        it("reports no findings") {
+        @Test
+        fun `reports no findings`() {
             val detektion = TestDetektion()
             assertThat(subject.render(detektion)).isNull()
         }
     }
-})
+}

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/ProjectStatisticsReportSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/ProjectStatisticsReportSpec.kt
@@ -3,16 +3,18 @@ package io.gitlab.arturbosch.detekt.core.reporting.console
 import io.gitlab.arturbosch.detekt.api.ProjectMetric
 import io.gitlab.arturbosch.detekt.test.TestDetektion
 import org.assertj.core.api.Assertions.assertThat
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-class ProjectStatisticsReportSpec : Spek({
+internal class ProjectStatisticsReportSpec {
 
-    val subject by memoized { ProjectStatisticsReport() }
+    private val subject = ProjectStatisticsReport()
 
-    describe("project statistics") {
+    @Nested
+    inner class `project statistics` {
 
-        it("reports the project statistics") {
+        @Test
+        fun `reports the project statistics`() {
             val expected = "Project Statistics:\n\t- M2: 2\n\t- M1: 1\n"
             val detektion = object : TestDetektion() {
                 override val metrics: Collection<ProjectMetric> = listOf(
@@ -23,8 +25,9 @@ class ProjectStatisticsReportSpec : Spek({
             assertThat(subject.render(detektion)).isEqualTo(expected)
         }
 
-        it("does not report anything for zero metrics") {
+        @Test
+        fun `does not report anything for zero metrics`() {
             assertThat(subject.render(TestDetektion())).isNull()
         }
     }
-})
+}

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/ProjectStatisticsReportSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/ProjectStatisticsReportSpec.kt
@@ -6,7 +6,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
-internal class ProjectStatisticsReportSpec {
+class ProjectStatisticsReportSpec {
 
     private val subject = ProjectStatisticsReport()
 

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/rules/MultiRuleSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/rules/MultiRuleSpec.kt
@@ -19,7 +19,7 @@ import org.jetbrains.kotlin.psi.KtFile
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
-internal class MultiRuleSpec {
+class MultiRuleSpec {
 
     @Nested
     inner class `a multi rule` {

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/rules/MultiRuleSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/rules/MultiRuleSpec.kt
@@ -16,55 +16,63 @@ import io.gitlab.arturbosch.detekt.test.loadRuleSet
 import io.gitlab.arturbosch.detekt.test.yamlConfig
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.psi.KtFile
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.lifecycle.CachingMode
-import org.spekframework.spek2.style.specification.describe
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-internal class MultiRuleSpec : Spek({
+internal class MultiRuleSpec {
 
-    describe("a multi rule") {
+    @Nested
+    inner class `a multi rule` {
 
-        val file by memoized(CachingMode.SCOPE) { compileForTest(resourceAsPath("/cases/Default.kt")) }
+        private val file = compileForTest(resourceAsPath("/cases/Default.kt"))
 
-        context("runs once on a KtFile for every rules and respects configured path filters") {
+        @Nested
+        inner class `runs once on a KtFile for every rules and respects configured path filters` {
 
-            it("should not run any rules if rule set defines the filter") {
+            @Test
+            fun `should not run any rules if rule set defines the filter`() {
                 val config = yamlConfig("/pathFilters/multi-rule-with-excludes-on-ruleset.yml")
                 assertThat(config.subConfig("TestMultiRule").shouldAnalyzeFile(file)).isFalse()
             }
 
-            it("should not run any rules if rule set defines the filter with string") {
+            @Test
+            fun `should not run any rules if rule set defines the filter with string`() {
                 val config = yamlConfig("/pathFilters/multi-rule-with-excludes-on-ruleset-string.yml")
                 assertThat(config.subConfig("TestMultiRule").shouldAnalyzeFile(file)).isFalse()
             }
 
-            it("should only run one rule as the other is filtered") {
+            @Test
+            fun `should only run one rule as the other is filtered`() {
                 val config = yamlConfig("/pathFilters/multi-rule-with-one-exclude.yml")
                 assertThat(loadRuleSet<MultiRuleProvider>(config).visitFile(file)).hasSize(1)
             }
 
-            it("should only run one rule as the other is filtered with string") {
+            @Test
+            fun `should only run one rule as the other is filtered with string`() {
                 val config = yamlConfig("/pathFilters/multi-rule-with-one-exclude-string.yml")
                 assertThat(loadRuleSet<MultiRuleProvider>(config).visitFile(file)).hasSize(1)
             }
 
-            it("should run both when no filter is applied") {
+            @Test
+            fun `should run both when no filter is applied`() {
                 val config = yamlConfig("/pathFilters/multi-rule-without-excludes.yml")
                 assertThat(loadRuleSet<MultiRuleProvider>(config).visitFile(file)).hasSize(2)
             }
 
-            it("should run none when both rules are filtered") {
+            @Test
+            fun `should run none when both rules are filtered`() {
                 val config = yamlConfig("/pathFilters/multi-rule-with-excludes.yml")
                 assertThat(loadRuleSet<MultiRuleProvider>(config).visitFile(file)).isEmpty()
             }
 
-            it("should run none when both rules are filtered with string") {
+            @Test
+            fun `should run none when both rules are filtered with string`() {
                 val config = yamlConfig("/pathFilters/multi-rule-with-excludes-string.yml")
                 assertThat(loadRuleSet<MultiRuleProvider>(config).visitFile(file)).isEmpty()
             }
         }
     }
-})
+}
 
 private class MultiRuleProvider : RuleSetProvider {
     override val ruleSetId: String = "TestMultiRule"

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/rules/RuleSetLocatorSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/rules/RuleSetLocatorSpec.kt
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test
 import org.reflections.Reflections
 import java.lang.reflect.Modifier
 
-internal class RuleSetLocatorSpec {
+class RuleSetLocatorSpec {
 
     @Nested
     inner class `locating RuleSetProvider's` {

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/rules/RuleSetLocatorSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/rules/RuleSetLocatorSpec.kt
@@ -5,16 +5,18 @@ import io.gitlab.arturbosch.detekt.core.createNullLoggingSpec
 import io.gitlab.arturbosch.detekt.core.tooling.withSettings
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.fail
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 import org.reflections.Reflections
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
 import java.lang.reflect.Modifier
 
-class RuleSetLocatorSpec : Spek({
+internal class RuleSetLocatorSpec {
 
-    describe("locating RuleSetProvider's") {
+    @Nested
+    inner class `locating RuleSetProvider's` {
 
-        it("contains all RuleSetProviders") {
+        @Test
+        fun `contains all RuleSetProviders`() {
             val providers = createNullLoggingSpec().withSettings { RuleSetLocator(this).load() }
             val providerClasses = getProviderClasses()
 
@@ -24,7 +26,8 @@ class RuleSetLocatorSpec : Spek({
                 .forEach { fail("$it rule set is not loaded by the RuleSetLocator") }
         }
 
-        it("does not load any default rule set provider when opt out") {
+        @Test
+        fun `does not load any default rule set provider when opt out`() {
             val providers = createNullLoggingSpec { extensions { disableDefaultRuleSets = true } }
                 .withSettings { RuleSetLocator(this).load() }
 
@@ -33,7 +36,7 @@ class RuleSetLocatorSpec : Spek({
             assertThat(providers).noneMatch { it.javaClass in defaultProviders }
         }
     }
-})
+}
 
 private fun getProviderClasses(): List<Class<out RuleSetProvider>> =
     Reflections("io.gitlab.arturbosch.detekt.rules")

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/rules/RuleSetSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/rules/RuleSetSpec.kt
@@ -6,40 +6,48 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.yamlConfig
 import org.assertj.core.api.Assertions.assertThat
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-class RuleSetSpec : Spek({
+internal class RuleSetSpec {
 
-    describe("rule sets") {
+    @Nested
+    inner class `rule sets` {
 
-        context("should rule set be used") {
+        @Nested
+        inner class `should rule set be used` {
 
-            it("is explicitly deactivated") {
+            @Test
+            fun `is explicitly deactivated`() {
                 val config = yamlConfig("configs/deactivated_ruleset.yml")
                 assertThat(config.subConfig("comments").isActive()).isFalse()
             }
 
-            it("is active with an empty config") {
+            @Test
+            fun `is active with an empty config`() {
                 assertThat(Config.empty.isActive()).isTrue()
             }
         }
 
-        context("should rule analyze a file") {
+        @Nested
+        inner class `should rule analyze a file` {
 
-            val file by memoized { compileForTest(resourceAsPath("/cases/Default.kt")) }
+            private val file = compileForTest(resourceAsPath("/cases/Default.kt"))
 
-            it("analyzes file with an empty config") {
+            @Test
+            fun `analyzes file with an empty config`() {
                 val config = Config.empty
                 assertThat(config.subConfig("comments").shouldAnalyzeFile(file)).isTrue()
             }
 
-            it("should not analyze file with *.kt excludes") {
+            @Test
+            fun `should not analyze file with *_kt excludes`() {
                 val config = TestConfig(Config.EXCLUDES_KEY to "**/*.kt")
                 assertThat(config.subConfig("comments").shouldAnalyzeFile(file)).isFalse()
             }
 
-            it("should analyze file as it's path is first excluded but then included") {
+            @Test
+            fun `should analyze file as it's path is first excluded but then included`() {
                 val config = TestConfig(
                     Config.EXCLUDES_KEY to "**/*.kt",
                     Config.INCLUDES_KEY to "**/*.kt"
@@ -48,4 +56,4 @@ class RuleSetSpec : Spek({
             }
         }
     }
-})
+}

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/rules/RuleSetSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/rules/RuleSetSpec.kt
@@ -9,7 +9,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
-internal class RuleSetSpec {
+class RuleSetSpec {
 
     @Nested
     inner class `rule sets` {

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/rules/SingleRuleProviderSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/rules/SingleRuleProviderSpec.kt
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 
-internal class SingleRuleProviderSpec {
+class SingleRuleProviderSpec {
 
     @Nested
     inner class `SingleRuleProvider` {

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/rules/SingleRuleProviderSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/rules/SingleRuleProviderSpec.kt
@@ -9,51 +9,52 @@ import io.gitlab.arturbosch.detekt.api.RuleSetProvider
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.test.yamlConfigFromContent
 import org.assertj.core.api.Assertions.assertThat
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 
-internal class SingleRuleProviderSpec : Spek({
+internal class SingleRuleProviderSpec {
 
-    describe("SingleRuleProvider") {
+    @Nested
+    inner class `SingleRuleProvider` {
 
-        val provider by memoized {
-            SingleRuleProvider(
-                "MagicNumber",
-                object : RuleSetProvider {
-                    override val ruleSetId: String = "style"
-                    override fun instance(config: Config): RuleSet {
-                        val rule = object : Rule(config) {
-                            override val issue = Issue(
-                                "MagicNumber",
-                                Severity.CodeSmell,
-                                "",
-                                Debt.FIVE_MINS
-                            )
-                        }
-                        return RuleSet(ruleSetId, listOf(rule))
+        private val provider = SingleRuleProvider(
+            "MagicNumber",
+            object : RuleSetProvider {
+                override val ruleSetId: String = "style"
+                override fun instance(config: Config): RuleSet {
+                    val rule = object : Rule(config) {
+                        override val issue = Issue(
+                            "MagicNumber",
+                            Severity.CodeSmell,
+                            "",
+                            Debt.FIVE_MINS
+                        )
                     }
+                    return RuleSet(ruleSetId, listOf(rule))
                 }
-            )
-        }
+            }
+        )
 
-        context("the right sub config is passed to the rule") {
+        @Nested
+        inner class `the right sub config is passed to the rule` {
 
-            arrayOf("true", "false").forEach { value ->
-                it("configures rule with active=$value") {
-                    val config = yamlConfigFromContent(
-                        """
+            @ParameterizedTest
+            @ValueSource(booleans = [true, false])
+            fun `configures rule with active=$value`(value: Boolean) {
+                val config = yamlConfigFromContent(
+                    """
                     style:
                       MagicNumber:
                         active: $value
-                        """.trimIndent()
-                    )
+                    """.trimIndent()
+                )
 
-                    assertThat(produceRule(provider, config).active).isEqualTo(value.toBoolean())
-                }
+                assertThat(produceRule(provider, config).active).isEqualTo(value)
             }
         }
     }
-})
+}
 
 private fun produceRule(provider: RuleSetProvider, config: Config): Rule =
     provider.instance(config.subConfig("style")).rules.first() as Rule

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/settings/EnvironmentFacadeSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/settings/EnvironmentFacadeSpec.kt
@@ -7,7 +7,7 @@ import org.jetbrains.kotlin.konan.file.File
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
-internal class EnvironmentFacadeSpec {
+class EnvironmentFacadeSpec {
 
     @Nested
     inner class `classpath entries should be separated by platform-specific separator` {

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/settings/EnvironmentFacadeSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/settings/EnvironmentFacadeSpec.kt
@@ -4,12 +4,13 @@ import io.gitlab.arturbosch.detekt.core.createNullLoggingSpec
 import io.gitlab.arturbosch.detekt.core.createProcessingSettings
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.konan.file.File
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-internal class EnvironmentFacadeSpec : Spek({
+internal class EnvironmentFacadeSpec {
 
-    describe("classpath entries should be separated by platform-specific separator") {
+    @Nested
+    inner class `classpath entries should be separated by platform-specific separator` {
 
         val classpath = when (File.pathSeparator) {
             ":" -> "/path/to/file1:/path/to/file2:/path/to/file3"
@@ -17,13 +18,14 @@ internal class EnvironmentFacadeSpec : Spek({
             else -> ""
         }
 
-        it("supports ${File.pathSeparator}") {
+        @Test
+        fun `supports ${File_pathSeparator}`() {
             testSettings(classpath).use {
                 assertThat(it.classpath).hasSize(3)
             }
         }
     }
-})
+}
 
 private fun testSettings(classpath: String) = createProcessingSettings(
     spec = createNullLoggingSpec {

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/AnnotationSuppressorSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/AnnotationSuppressorSpec.kt
@@ -1,7 +1,7 @@
 package io.gitlab.arturbosch.detekt.core.suppressors
 
 import io.github.detekt.test.utils.compileContentForTest
-import io.gitlab.arturbosch.detekt.rules.setupKotlinEnvironment
+import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.getContextForPaths
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
@@ -11,21 +11,23 @@ import org.jetbrains.kotlin.psi.KtParameter
 import org.jetbrains.kotlin.psi.psiUtil.findDescendantOfType
 import org.jetbrains.kotlin.psi.psiUtil.findFunctionByName
 import org.jetbrains.kotlin.resolve.BindingContext
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-class AnnotationSuppressorSpec : Spek({
-    setupKotlinEnvironment()
-    val env: KotlinCoreEnvironment by memoized()
+@KotlinCoreEnvironmentTest
+class AnnotationSuppressorSpec(private val env: KotlinCoreEnvironment) {
 
-    describe("AnnotationSuppressorFactory") {
-        it("Factory returns null if ignoreAnnotated is not set") {
+    @Nested
+    inner class `AnnotationSuppressorFactory` {
+        @Test
+        fun `Factory returns null if ignoreAnnotated is not set`() {
             val suppressor = annotationSuppressorFactory(buildConfigAware(/* empty */), BindingContext.EMPTY)
 
             assertThat(suppressor).isNull()
         }
 
-        it("Factory returns null if ignoreAnnotated is set to empty") {
+        @Test
+        fun `Factory returns null if ignoreAnnotated is set to empty`() {
             val suppressor = annotationSuppressorFactory(
                 buildConfigAware("ignoreAnnotated" to emptyList<String>()),
                 BindingContext.EMPTY,
@@ -34,7 +36,8 @@ class AnnotationSuppressorSpec : Spek({
             assertThat(suppressor).isNull()
         }
 
-        it("Factory returns not null if ignoreAnnotated is set to a not empty list") {
+        @Test
+        fun `Factory returns not null if ignoreAnnotated is set to a not empty list`() {
             val suppressor = annotationSuppressorFactory(
                 buildConfigAware("ignoreAnnotated" to listOf("Composable")),
                 BindingContext.EMPTY,
@@ -44,22 +47,22 @@ class AnnotationSuppressorSpec : Spek({
         }
     }
 
-    describe("AnnotationSuppressor") {
-        val suppressor by memoized {
-            annotationSuppressorFactory(
-                buildConfigAware("ignoreAnnotated" to listOf("Composable")),
-                BindingContext.EMPTY,
-            )!!
-        }
+    @Nested
+    inner class `AnnotationSuppressor` {
+        val suppressor = annotationSuppressorFactory(
+            buildConfigAware("ignoreAnnotated" to listOf("Composable")),
+            BindingContext.EMPTY,
+        )!!
 
-        it("If KtElement is null it returns false") {
+        @Test
+        fun `If KtElement is null it returns false`() {
             assertThat(suppressor.shouldSuppress(buildFinding(element = null))).isFalse()
         }
 
-        context("If annotation is at file level") {
-            val root by memoized {
-                compileContentForTest(
-                    """
+        @Nested
+        inner class `If annotation is at file level` {
+            val root = compileContentForTest(
+                """
                     @file:Composable
 
                     class OneClass {
@@ -69,28 +72,31 @@ class AnnotationSuppressorSpec : Spek({
                     }
 
                     fun topLevelFunction() = Unit
-                    """.trimIndent()
-                )
-            }
+                """.trimIndent()
+            )
 
-            it("If reports root it returns true") {
+            @Test
+            fun `If reports root it returns true`() {
                 assertThat(suppressor.shouldSuppress(buildFinding(element = root))).isTrue()
             }
 
-            it("If reports class it returns true") {
+            @Test
+            fun `If reports class it returns true`() {
                 val ktClass = root.findChildByClass(KtClass::class.java)!!
 
                 assertThat(suppressor.shouldSuppress(buildFinding(element = ktClass))).isTrue()
             }
 
-            it("If reports function in class it returns true") {
+            @Test
+            fun `If reports function in class it returns true`() {
                 val ktFunction = root.findChildByClass(KtClass::class.java)!!
                     .findFunctionByName("function")!!
 
                 assertThat(suppressor.shouldSuppress(buildFinding(element = ktFunction))).isTrue()
             }
 
-            it("If reports parameter in function in class it returns true") {
+            @Test
+            fun `If reports parameter in function in class it returns true`() {
                 val ktParameter = root.findChildByClass(KtClass::class.java)!!
                     .findFunctionByName("function")!!
                     .findDescendantOfType<KtParameter>()!!
@@ -98,17 +104,18 @@ class AnnotationSuppressorSpec : Spek({
                 assertThat(suppressor.shouldSuppress(buildFinding(element = ktParameter))).isTrue()
             }
 
-            it("If reports top level function it returns true") {
+            @Test
+            fun `If reports top level function it returns true`() {
                 val ktFunction = root.findChildByClass(KtFunction::class.java)!!
 
                 assertThat(suppressor.shouldSuppress(buildFinding(element = ktFunction))).isTrue()
             }
         }
 
-        context("If annotation is at function level") {
-            val root by memoized {
-                compileContentForTest(
-                    """
+        @Nested
+        inner class `If annotation is at function level` {
+            val root = compileContentForTest(
+                """
                     class OneClass {
                         @Composable
                         fun function(parameter: String) {
@@ -117,28 +124,31 @@ class AnnotationSuppressorSpec : Spek({
                     }
 
                     fun topLevelFunction() = Unit
-                    """.trimIndent()
-                )
-            }
+                """.trimIndent()
+            )
 
-            it("If reports root it returns false") {
+            @Test
+            fun `If reports root it returns false`() {
                 assertThat(suppressor.shouldSuppress(buildFinding(element = root))).isFalse()
             }
 
-            it("If reports class it returns false") {
+            @Test
+            fun `If reports class it returns false`() {
                 val ktClass = root.findChildByClass(KtClass::class.java)!!
 
                 assertThat(suppressor.shouldSuppress(buildFinding(element = ktClass))).isFalse()
             }
 
-            it("If reports function in class it returns true") {
+            @Test
+            fun `If reports function in class it returns true`() {
                 val ktFunction = root.findChildByClass(KtClass::class.java)!!
                     .findFunctionByName("function")!!
 
                 assertThat(suppressor.shouldSuppress(buildFinding(element = ktFunction))).isTrue()
             }
 
-            it("If reports parameter in function in class it returns true") {
+            @Test
+            fun `If reports parameter in function in class it returns true`() {
                 val ktParameter = root.findChildByClass(KtClass::class.java)!!
                     .findFunctionByName("function")!!
                     .findDescendantOfType<KtParameter>()!!
@@ -146,17 +156,18 @@ class AnnotationSuppressorSpec : Spek({
                 assertThat(suppressor.shouldSuppress(buildFinding(element = ktParameter))).isTrue()
             }
 
-            it("If reports top level function it returns false") {
+            @Test
+            fun `If reports top level function it returns false`() {
                 val ktFunction = root.findChildByClass(KtFunction::class.java)!!
 
                 assertThat(suppressor.shouldSuppress(buildFinding(element = ktFunction))).isFalse()
             }
         }
 
-        context("If there is not annotations") {
-            val root by memoized {
-                compileContentForTest(
-                    """
+        @Nested
+        inner class `If there is not annotations` {
+            val root = compileContentForTest(
+                """
                     class OneClass {
                         fun function(parameter: String) {
                             val a = 0
@@ -164,28 +175,31 @@ class AnnotationSuppressorSpec : Spek({
                     }
 
                     fun topLevelFunction() = Unit
-                    """.trimIndent()
-                )
-            }
+                """.trimIndent()
+            )
 
-            it("If reports root it returns false") {
+            @Test
+            fun `If reports root it returns false`() {
                 assertThat(suppressor.shouldSuppress(buildFinding(element = root))).isFalse()
             }
 
-            it("If reports class it returns false") {
+            @Test
+            fun `If reports class it returns false`() {
                 val ktClass = root.findChildByClass(KtClass::class.java)!!
 
                 assertThat(suppressor.shouldSuppress(buildFinding(element = ktClass))).isFalse()
             }
 
-            it("If reports function in class it returns false") {
+            @Test
+            fun `If reports function in class it returns false`() {
                 val ktFunction = root.findChildByClass(KtClass::class.java)!!
                     .findFunctionByName("function")!!
 
                 assertThat(suppressor.shouldSuppress(buildFinding(element = ktFunction))).isFalse()
             }
 
-            it("If reports parameter in function in class it returns false") {
+            @Test
+            fun `If reports parameter in function in class it returns false`() {
                 val ktParameter = root.findChildByClass(KtClass::class.java)!!
                     .findFunctionByName("function")!!
                     .findDescendantOfType<KtParameter>()!!
@@ -193,17 +207,18 @@ class AnnotationSuppressorSpec : Spek({
                 assertThat(suppressor.shouldSuppress(buildFinding(element = ktParameter))).isFalse()
             }
 
-            it("If reports top level function it returns false") {
+            @Test
+            fun `If reports top level function it returns false`() {
                 val ktFunction = root.findChildByClass(KtFunction::class.java)!!
 
                 assertThat(suppressor.shouldSuppress(buildFinding(element = ktFunction))).isFalse()
             }
         }
 
-        context("If there are other annotations") {
-            val root by memoized {
-                compileContentForTest(
-                    """
+        @Nested
+        inner class `If there are other annotations` {
+            val root = compileContentForTest(
+                """
                     @file:A
 
                     @B
@@ -217,28 +232,31 @@ class AnnotationSuppressorSpec : Spek({
 
                     @E
                     fun topLevelFunction() = Unit
-                    """.trimIndent()
-                )
-            }
+                """.trimIndent()
+            )
 
-            it("If reports root it returns false") {
+            @Test
+            fun `If reports root it returns false`() {
                 assertThat(suppressor.shouldSuppress(buildFinding(element = root))).isFalse()
             }
 
-            it("If reports class it returns false") {
+            @Test
+            fun `If reports class it returns false`() {
                 val ktClass = root.findChildByClass(KtClass::class.java)!!
 
                 assertThat(suppressor.shouldSuppress(buildFinding(element = ktClass))).isFalse()
             }
 
-            it("If reports function in class it returns true") {
+            @Test
+            fun `If reports function in class it returns true`() {
                 val ktFunction = root.findChildByClass(KtClass::class.java)!!
                     .findFunctionByName("function")!!
 
                 assertThat(suppressor.shouldSuppress(buildFinding(element = ktFunction))).isTrue()
             }
 
-            it("If reports parameter in function in class it returns true") {
+            @Test
+            fun `If reports parameter in function in class it returns true`() {
                 val ktParameter = root.findChildByClass(KtClass::class.java)!!
                     .findFunctionByName("function")!!
                     .findDescendantOfType<KtParameter>()!!
@@ -246,7 +264,8 @@ class AnnotationSuppressorSpec : Spek({
                 assertThat(suppressor.shouldSuppress(buildFinding(element = ktParameter))).isTrue()
             }
 
-            it("If reports top level function it returns false") {
+            @Test
+            fun `If reports top level function it returns false`() {
                 val ktFunction = root.findChildByClass(KtFunction::class.java)!!
 
                 assertThat(suppressor.shouldSuppress(buildFinding(element = ktFunction))).isFalse()
@@ -254,44 +273,42 @@ class AnnotationSuppressorSpec : Spek({
         }
     }
 
-    describe("Full Qualified names") {
-        val composableFiles by memoized {
-            arrayOf(
-                compileContentForTest(
-                    """
+    @Nested
+    inner class `Full Qualified names` {
+        val composableFiles = arrayOf(
+            compileContentForTest(
+                """
                     package androidx.compose.runtime
 
                     annotation class Composable
-                    """.trimIndent()
-                ),
-                compileContentForTest(
-                    """
+                """.trimIndent()
+            ),
+            compileContentForTest(
+                """
                     package foo.bar
 
                     annotation class Composable
-                    """.trimIndent()
-                ),
-            )
-        }
+                """.trimIndent()
+            ),
+        )
 
-        context("general cases") {
-            val root by memoized {
-                compileContentForTest(
-                    """
+        @Nested
+        inner class `general cases` {
+            val root = compileContentForTest(
+                """
                     package foo.bar
 
                     import androidx.compose.runtime.Composable
 
                     @Composable
                     fun function() = Unit
-                    """.trimIndent()
-                )
-            }
-            val binding by memoized {
-                env.getContextForPaths(listOf(root, *composableFiles))
-            }
+                """.trimIndent()
+            )
 
-            it("Just name") {
+            val binding = env.getContextForPaths(listOf(root, *composableFiles))
+
+            @Test
+            fun `Just name`() {
                 val suppressor = annotationSuppressorFactory(
                     buildConfigAware("ignoreAnnotated" to listOf("Composable")),
                     binding,
@@ -302,7 +319,8 @@ class AnnotationSuppressorSpec : Spek({
                 assertThat(suppressor.shouldSuppress(buildFinding(ktFunction))).isTrue()
             }
 
-            it("Full qualified name name") {
+            @Test
+            fun `Full qualified name name`() {
                 val suppressor = annotationSuppressorFactory(
                     buildConfigAware("ignoreAnnotated" to listOf("androidx.compose.runtime.Composable")),
                     binding,
@@ -313,7 +331,8 @@ class AnnotationSuppressorSpec : Spek({
                 assertThat(suppressor.shouldSuppress(buildFinding(ktFunction))).isTrue()
             }
 
-            it("With glob doesn't match because * doesn't match .") {
+            @Test
+            fun `With glob doesn't match because * doesn't match _`() {
                 val suppressor = annotationSuppressorFactory(
                     buildConfigAware("ignoreAnnotated" to listOf("*.Composable")),
                     binding,
@@ -324,7 +343,8 @@ class AnnotationSuppressorSpec : Spek({
                 assertThat(suppressor.shouldSuppress(buildFinding(ktFunction))).isFalse()
             }
 
-            it("With glob2") {
+            @Test
+            fun `With glob2`() {
                 val suppressor = annotationSuppressorFactory(
                     buildConfigAware("ignoreAnnotated" to listOf("**.Composable")),
                     binding,
@@ -335,7 +355,8 @@ class AnnotationSuppressorSpec : Spek({
                 assertThat(suppressor.shouldSuppress(buildFinding(ktFunction))).isTrue()
             }
 
-            it("With glob3") {
+            @Test
+            fun `With glob3`() {
                 val suppressor = annotationSuppressorFactory(
                     buildConfigAware("ignoreAnnotated" to listOf("Compo*")),
                     binding,
@@ -346,7 +367,8 @@ class AnnotationSuppressorSpec : Spek({
                 assertThat(suppressor.shouldSuppress(buildFinding(ktFunction))).isTrue()
             }
 
-            it("With glob4") {
+            @Test
+            fun `With glob4`() {
                 val suppressor = annotationSuppressorFactory(
                     buildConfigAware("ignoreAnnotated" to listOf("*")),
                     binding,
@@ -358,7 +380,8 @@ class AnnotationSuppressorSpec : Spek({
             }
         }
 
-        it("Doesn't mix annotations") {
+        @Test
+        fun `Doesn't mix annotations`() {
             val root = compileContentForTest(
                 """
                 package foo.bar
@@ -378,7 +401,8 @@ class AnnotationSuppressorSpec : Spek({
             assertThat(suppressor.shouldSuppress(buildFinding(ktFunction))).isFalse()
         }
 
-        it("Works when no using imports") {
+        @Test
+        fun `Works when no using imports`() {
             val root = compileContentForTest(
                 """
                 package foo.bar
@@ -398,7 +422,8 @@ class AnnotationSuppressorSpec : Spek({
             assertThat(suppressor.shouldSuppress(buildFinding(ktFunction))).isTrue()
         }
 
-        it("Works when using import alias") {
+        @Test
+        fun `Works when using import alias`() {
             val root = compileContentForTest(
                 """
                 package foo.bar
@@ -420,4 +445,4 @@ class AnnotationSuppressorSpec : Spek({
             assertThat(suppressor.shouldSuppress(buildFinding(ktFunction))).isTrue()
         }
     }
-})
+}

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/FunctionSuppressorSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/FunctionSuppressorSpec.kt
@@ -11,7 +11,7 @@ import org.jetbrains.kotlin.resolve.BindingContext
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
-internal class FunctionSuppressorSpec {
+class FunctionSuppressorSpec {
 
     @Nested
     inner class `FunctionSuppressorFactory` {

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/FunctionSuppressorSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/FunctionSuppressorSpec.kt
@@ -8,13 +8,15 @@ import org.jetbrains.kotlin.psi.KtParameter
 import org.jetbrains.kotlin.psi.psiUtil.findDescendantOfType
 import org.jetbrains.kotlin.psi.psiUtil.findFunctionByName
 import org.jetbrains.kotlin.resolve.BindingContext
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-class FunctionSuppressorSpec : Spek({
+internal class FunctionSuppressorSpec {
 
-    describe("FunctionSuppressorFactory") {
-        it("Factory returns null if ignoreFunction is not set") {
+    @Nested
+    inner class `FunctionSuppressorFactory` {
+        @Test
+        fun `Factory returns null if ignoreFunction is not set`() {
             val suppressor = functionSuppressorFactory(
                 buildConfigAware(/* empty */),
                 BindingContext.EMPTY,
@@ -23,7 +25,8 @@ class FunctionSuppressorSpec : Spek({
             assertThat(suppressor).isNull()
         }
 
-        it("Factory returns null if ignoreFunction is set to empty") {
+        @Test
+        fun `Factory returns null if ignoreFunction is set to empty`() {
             val suppressor = functionSuppressorFactory(
                 buildConfigAware("ignoreFunction" to emptyList<String>()),
                 BindingContext.EMPTY,
@@ -32,7 +35,8 @@ class FunctionSuppressorSpec : Spek({
             assertThat(suppressor).isNull()
         }
 
-        it("Factory returns not null if ignoreFunction is set to a not empty list") {
+        @Test
+        fun `Factory returns not null if ignoreFunction is set to a not empty list`() {
             val suppressor = functionSuppressorFactory(
                 buildConfigAware("ignoreFunction" to listOf("toString")),
                 BindingContext.EMPTY,
@@ -42,17 +46,19 @@ class FunctionSuppressorSpec : Spek({
         }
     }
 
-    describe("FunctionSuppressor") {
-        it("If KtElement is null it returns false") {
+    @Nested
+    inner class `FunctionSuppressor` {
+        @Test
+        fun `If KtElement is null it returns false`() {
             val suppressor = buildFunctionSuppressor(listOf("toString"), BindingContext.EMPTY)
 
             assertThat(suppressor.shouldSuppress(buildFinding(element = null))).isFalse()
         }
 
-        context("If the function is suppressed") {
-            val root by memoized {
-                compileContentForTest(
-                    """
+        @Nested
+        inner class `If the function is suppressed` {
+            val root = compileContentForTest(
+                """
                     class OneClass {
                         fun toString(parameter: String): String {
                             fun hello(name: String) {
@@ -64,24 +70,26 @@ class FunctionSuppressorSpec : Spek({
                     }
 
                     fun toString() = Unit
-                    """.trimIndent()
-                )
-            }
+                """.trimIndent()
+            )
 
-            it("If reports root it returns false") {
+            @Test
+            fun `If reports root it returns false`() {
                 val suppressor = buildFunctionSuppressor(listOf("toString"), BindingContext.EMPTY)
 
                 assertThat(suppressor.shouldSuppress(buildFinding(element = root))).isFalse()
             }
 
-            it("If reports class it returns false") {
+            @Test
+            fun `If reports class it returns false`() {
                 val suppressor = buildFunctionSuppressor(listOf("toString"), BindingContext.EMPTY)
                 val ktClass = root.findChildByClass(KtClass::class.java)!!
 
                 assertThat(suppressor.shouldSuppress(buildFinding(element = ktClass))).isFalse()
             }
 
-            it("If reports function in class it returns true") {
+            @Test
+            fun `If reports function in class it returns true`() {
                 val suppressor = buildFunctionSuppressor(listOf("toString"), BindingContext.EMPTY)
                 val ktFunction = root.findChildByClass(KtClass::class.java)!!
                     .findFunctionByName("toString")!!
@@ -89,7 +97,8 @@ class FunctionSuppressorSpec : Spek({
                 assertThat(suppressor.shouldSuppress(buildFinding(element = ktFunction))).isTrue()
             }
 
-            it("If reports parameter in function in class it returns true") {
+            @Test
+            fun `If reports parameter in function in class it returns true`() {
                 val suppressor = buildFunctionSuppressor(listOf("toString"), BindingContext.EMPTY)
                 val ktParameter = root.findChildByClass(KtClass::class.java)!!
                     .findFunctionByName("toString")!!
@@ -98,7 +107,8 @@ class FunctionSuppressorSpec : Spek({
                 assertThat(suppressor.shouldSuppress(buildFinding(element = ktParameter))).isTrue()
             }
 
-            it("If reports function in function it returns true") {
+            @Test
+            fun `If reports function in function it returns true`() {
                 val suppressor = buildFunctionSuppressor(listOf("toString"), BindingContext.EMPTY)
                 val ktFunction = root.findChildByClass(KtClass::class.java)!!
                     .findFunctionByName("toString")!!
@@ -109,7 +119,8 @@ class FunctionSuppressorSpec : Spek({
                 assertThat(suppressor.shouldSuppress(buildFinding(element = ktFunction))).isTrue()
             }
 
-            it("If reports parameter function in function it returns true") {
+            @Test
+            fun `If reports parameter function in function it returns true`() {
                 val suppressor = buildFunctionSuppressor(listOf("toString"), BindingContext.EMPTY)
                 val ktFunction = root.findChildByClass(KtClass::class.java)!!
                     .findFunctionByName("toString")!!
@@ -121,7 +132,8 @@ class FunctionSuppressorSpec : Spek({
                 assertThat(suppressor.shouldSuppress(buildFinding(element = ktFunction))).isTrue()
             }
 
-            it("If reports parameter function in function it returns true 2") {
+            @Test
+            fun `If reports parameter function in function it returns true 2`() {
                 val suppressor = buildFunctionSuppressor(listOf("hello"), BindingContext.EMPTY)
                 val ktFunction = root.findChildByClass(KtClass::class.java)!!
                     .findFunctionByName("toString")!!
@@ -133,7 +145,8 @@ class FunctionSuppressorSpec : Spek({
                 assertThat(suppressor.shouldSuppress(buildFinding(element = ktFunction))).isTrue()
             }
 
-            it("If reports top level function it returns true") {
+            @Test
+            fun `If reports top level function it returns true`() {
                 val suppressor = buildFunctionSuppressor(listOf("toString"), BindingContext.EMPTY)
                 val ktFunction = root.findChildByClass(KtFunction::class.java)!!
 
@@ -141,10 +154,10 @@ class FunctionSuppressorSpec : Spek({
             }
         }
 
-        context("If the function is not suppressed") {
-            val root by memoized {
-                compileContentForTest(
-                    """
+        @Nested
+        inner class `If the function is not suppressed` {
+            val root = compileContentForTest(
+                """
                     class OneClass {
                         fun compare(parameter: String): String {
                             return ""
@@ -152,23 +165,25 @@ class FunctionSuppressorSpec : Spek({
                     }
 
                     fun compare() = Unit
-                    """.trimIndent()
-                )
-            }
+                """.trimIndent()
+            )
 
-            it("If reports root it returns false") {
+            @Test
+            fun `If reports root it returns false`() {
                 val suppressor = buildFunctionSuppressor(listOf("toString"), BindingContext.EMPTY)
                 assertThat(suppressor.shouldSuppress(buildFinding(element = root))).isFalse()
             }
 
-            it("If reports class it returns false") {
+            @Test
+            fun `If reports class it returns false`() {
                 val suppressor = buildFunctionSuppressor(listOf("toString"), BindingContext.EMPTY)
                 val ktClass = root.findChildByClass(KtClass::class.java)!!
 
                 assertThat(suppressor.shouldSuppress(buildFinding(element = ktClass))).isFalse()
             }
 
-            it("If reports function in class it returns false") {
+            @Test
+            fun `If reports function in class it returns false`() {
                 val suppressor = buildFunctionSuppressor(listOf("toString"), BindingContext.EMPTY)
                 val ktFunction = root.findChildByClass(KtClass::class.java)!!
                     .findFunctionByName("compare")!!
@@ -176,7 +191,8 @@ class FunctionSuppressorSpec : Spek({
                 assertThat(suppressor.shouldSuppress(buildFinding(element = ktFunction))).isFalse()
             }
 
-            it("If reports parameter in function in class it returns false") {
+            @Test
+            fun `If reports parameter in function in class it returns false`() {
                 val suppressor = buildFunctionSuppressor(listOf("toString"), BindingContext.EMPTY)
                 val ktParameter = root.findChildByClass(KtClass::class.java)!!
                     .findFunctionByName("compare")!!
@@ -185,7 +201,8 @@ class FunctionSuppressorSpec : Spek({
                 assertThat(suppressor.shouldSuppress(buildFinding(element = ktParameter))).isFalse()
             }
 
-            it("If reports top level function it returns false") {
+            @Test
+            fun `If reports top level function it returns false`() {
                 val suppressor = buildFunctionSuppressor(listOf("toString"), BindingContext.EMPTY)
                 val ktFunction = root.findChildByClass(KtFunction::class.java)!!
 
@@ -193,7 +210,7 @@ class FunctionSuppressorSpec : Spek({
             }
         }
     }
-})
+}
 
 private fun buildFunctionSuppressor(ignoreFunction: List<String>, bindingContext: BindingContext): Suppressor {
     return functionSuppressorFactory(buildConfigAware("ignoreFunction" to ignoreFunction), bindingContext)!!

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/SuppressorsSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/SuppressorsSpec.kt
@@ -15,7 +15,7 @@ import org.jetbrains.kotlin.resolve.BindingContext
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
-internal class SuppressorsSpec {
+class SuppressorsSpec {
 
     val noIgnorableCodeSmell = CodeSmell(
         issue = ARule().issue,

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/SuppressorsSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/SuppressorsSpec.kt
@@ -12,63 +12,62 @@ import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.resolve.BindingContext
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-class SuppressorsSpec : Spek({
+internal class SuppressorsSpec {
 
-    describe("test getSuppressors") {
-        val noIgnorableCodeSmell by memoized {
-            val root = compileContentForTest(
-                """
-                fun foo() = Unit
-                """.trimIndent()
-            )
-            CodeSmell(ARule().issue, Entity.from(root), "")
-        }
-        val ignorableCodeSmell by memoized {
-            val root = compileContentForTest(
-                """
-                @file:Composable
-                fun foo() = Unit
-                """.trimIndent()
-            )
-            CodeSmell(ARule().issue, Entity.from(root), "")
-        }
+    val noIgnorableCodeSmell = CodeSmell(
+        issue = ARule().issue,
+        entity = Entity.from(compileContentForTest("""fun foo() = Unit""".trimIndent())),
+        message = ""
+    )
 
-        it("A finding that should be suppressed") {
-            val rule = ARule(TestConfig("ignoreAnnotated" to listOf("Composable")))
+    val ignorableCodeSmell = CodeSmell(
+        issue = ARule().issue,
+        entity = Entity.from(compileContentForTest("""@file:Composable fun foo() = Unit""".trimIndent())),
+        message = ""
+    )
+
+    @Test
+    fun `A finding that should be suppressed`() {
+        val rule = ARule(TestConfig("ignoreAnnotated" to listOf("Composable")))
+        val suppress = getSuppressors(rule, BindingContext.EMPTY)
+            .fold(false) { acc, suppressor -> acc || suppressor.shouldSuppress(noIgnorableCodeSmell) }
+
+        assertThat(suppress).isFalse()
+    }
+
+    @Test
+    fun `A finding that should not be suppressed`() {
+        val rule = ARule(TestConfig("ignoreAnnotated" to listOf("Composable")))
+        val suppress = getSuppressors(rule, BindingContext.EMPTY)
+            .fold(false) { acc, suppressor -> acc || suppressor.shouldSuppress(ignorableCodeSmell) }
+
+        assertThat(suppress).isTrue()
+    }
+
+    @Nested
+    inner class `MultiRule` {
+        @Test
+        fun `A finding that should be suppressed`() {
+            val rule = AMultiRule(TestConfig("ignoreAnnotated" to listOf("Composable")))
             val suppress = getSuppressors(rule, BindingContext.EMPTY)
                 .fold(false) { acc, suppressor -> acc || suppressor.shouldSuppress(noIgnorableCodeSmell) }
 
             assertThat(suppress).isFalse()
         }
-        it("A finding that should not be suppressed") {
-            val rule = ARule(TestConfig("ignoreAnnotated" to listOf("Composable")))
+
+        @Test
+        fun `A finding that should not be suppressed`() {
+            val rule = AMultiRule(TestConfig("ignoreAnnotated" to listOf("Composable")))
             val suppress = getSuppressors(rule, BindingContext.EMPTY)
                 .fold(false) { acc, suppressor -> acc || suppressor.shouldSuppress(ignorableCodeSmell) }
 
             assertThat(suppress).isTrue()
         }
-
-        context("MultiRule") {
-            it("A finding that should be suppressed") {
-                val rule = AMultiRule(TestConfig("ignoreAnnotated" to listOf("Composable")))
-                val suppress = getSuppressors(rule, BindingContext.EMPTY)
-                    .fold(false) { acc, suppressor -> acc || suppressor.shouldSuppress(noIgnorableCodeSmell) }
-
-                assertThat(suppress).isFalse()
-            }
-            it("A finding that should not be suppressed") {
-                val rule = AMultiRule(TestConfig("ignoreAnnotated" to listOf("Composable")))
-                val suppress = getSuppressors(rule, BindingContext.EMPTY)
-                    .fold(false) { acc, suppressor -> acc || suppressor.shouldSuppress(ignorableCodeSmell) }
-
-                assertThat(suppress).isTrue()
-            }
-        }
     }
-})
+}
 
 private class AMultiRule(config: Config) : MultiRule() {
     override val rules: List<Rule> = listOf(ARule(config))

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/tooling/DefaultConfigProviderSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/tooling/DefaultConfigProviderSpec.kt
@@ -4,17 +4,17 @@ import io.github.detekt.test.utils.createTempFileForTest
 import io.github.detekt.test.utils.resourceAsPath
 import io.gitlab.arturbosch.detekt.core.createNullLoggingSpec
 import org.assertj.core.api.Assertions.assertThat
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 import java.nio.file.Files
 
-internal class DefaultConfigProviderSpec : Spek({
-    describe("defaultConfigProvider without plugins") {
-        val spec by memoized {
-            createNullLoggingSpec {}
-        }
+internal class DefaultConfigProviderSpec {
+    @Nested
+    inner class `defaultConfigProvider without plugins` {
+        val spec = createNullLoggingSpec {}
 
-        it("gets") {
+        @Test
+        fun `gets`() {
             val config = DefaultConfigProvider().apply { init(spec) }.get()
 
             assertThat(config.parentPath).isNull()
@@ -22,7 +22,8 @@ internal class DefaultConfigProviderSpec : Spek({
             assertThat(config.valueOrNull<Any>("sample")).isNull()
         }
 
-        it("copies") {
+        @Test
+        fun `copies`() {
             val path = createTempFileForTest("test", "test")
             DefaultConfigProvider().apply { init(spec) }.copy(path)
 
@@ -31,16 +32,16 @@ internal class DefaultConfigProviderSpec : Spek({
         }
     }
 
-    describe("defaultConfigProvider with plugins") {
-        val spec by memoized {
-            createNullLoggingSpec {
-                extensions {
-                    fromPaths { listOf(resourceAsPath("sample-rule-set.jar")) }
-                }
+    @Nested
+    inner class `defaultConfigProvider with plugins` {
+        val spec = createNullLoggingSpec {
+            extensions {
+                fromPaths { listOf(resourceAsPath("sample-rule-set.jar")) }
             }
         }
 
-        it("gets") {
+        @Test
+        fun `gets`() {
             val config = DefaultConfigProvider().apply { init(spec) }.get()
 
             assertThat(config.parentPath).isNull()
@@ -48,7 +49,8 @@ internal class DefaultConfigProviderSpec : Spek({
             assertThat(config.valueOrNull<Any>("sample")).isNotNull()
         }
 
-        it("copies") {
+        @Test
+        fun `copies`() {
             val path = createTempFileForTest("test", "test")
             DefaultConfigProvider().apply { init(spec) }.copy(path)
 
@@ -67,4 +69,4 @@ internal class DefaultConfigProviderSpec : Spek({
             assertThat(actual).isEqualTo(expected)
         }
     }
-})
+}

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/tooling/DefaultConfigProviderSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/tooling/DefaultConfigProviderSpec.kt
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import java.nio.file.Files
 
-internal class DefaultConfigProviderSpec {
+class DefaultConfigProviderSpec {
     @Nested
     inner class `defaultConfigProvider without plugins` {
         val spec = createNullLoggingSpec {}

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/util/PerformanceMonitorSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/util/PerformanceMonitorSpec.kt
@@ -7,7 +7,7 @@ import io.gitlab.arturbosch.detekt.core.tooling.DefaultDetektProvider
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
-internal class PerformanceMonitorSpec {
+class PerformanceMonitorSpec {
 
     @Test
     fun `all phases have a measurement`() {

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/util/PerformanceMonitorSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/util/PerformanceMonitorSpec.kt
@@ -5,11 +5,12 @@ import io.github.detekt.test.utils.resourceAsPath
 import io.github.detekt.tooling.api.spec.ProcessingSpec
 import io.gitlab.arturbosch.detekt.core.tooling.DefaultDetektProvider
 import org.assertj.core.api.Assertions.assertThat
-import org.spekframework.spek2.Spek
+import org.junit.jupiter.api.Test
 
-class PerformanceMonitorSpec : Spek({
+internal class PerformanceMonitorSpec {
 
-    test("all phases have a measurement") {
+    @Test
+    fun `all phases have a measurement`() {
         val actual = StringPrintStream()
         val spec = ProcessingSpec {
             project {
@@ -25,4 +26,4 @@ class PerformanceMonitorSpec : Spek({
 
         assertThat(actual.toString()).contains(PerformanceMonitor.Phase.values().map { it.name })
     }
-})
+}


### PR DESCRIPTION
This is part of #4450 and migrates the tests in detekt-core to junit
