### PR TITLE
migrate tests in detekt-formatting to junit

### DIFF
--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/ArgumentListWrappingSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/ArgumentListWrappingSpec.kt
@@ -7,7 +7,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
-internal class ArgumentListWrappingSpec {
+class ArgumentListWrappingSpec {
 
     @Nested
     inner class `ArgumentListWrapping rule` {

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/ArgumentListWrappingSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/ArgumentListWrappingSpec.kt
@@ -4,14 +4,16 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.formatting.wrappers.ArgumentListWrapping
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import org.assertj.core.api.Assertions.assertThat
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-class ArgumentListWrappingSpec : Spek({
+internal class ArgumentListWrappingSpec {
 
-    describe("ArgumentListWrapping rule") {
+    @Nested
+    inner class `ArgumentListWrapping rule` {
 
-        it("reports wrong argument wrapping") {
+        @Test
+        fun `reports wrong argument wrapping`() {
             val code = """
                 val x = f(
                     1,
@@ -21,7 +23,8 @@ class ArgumentListWrappingSpec : Spek({
             assertThat(ArgumentListWrapping(Config.empty).lint(code)).hasSize(1)
         }
 
-        it("does not report correct argument list wrapping") {
+        @Test
+        fun `does not report correct argument list wrapping`() {
             val code = """
                 val x = f(
                     1,
@@ -32,7 +35,8 @@ class ArgumentListWrappingSpec : Spek({
             assertThat(ArgumentListWrapping(Config.empty).lint(code)).isEmpty()
         }
 
-        it("does not report when overriding an indentation level config of 1") {
+        @Test
+        fun `does not report when overriding an indentation level config of 1`() {
             val code = """
                 val x = f(
                  1,
@@ -44,7 +48,8 @@ class ArgumentListWrappingSpec : Spek({
             assertThat(ArgumentListWrapping(config).lint(code)).isEmpty()
         }
 
-        it("reports when max line length is exceeded") {
+        @Test
+        fun `reports when max line length is exceeded`() {
             val code = """
                 val x = f(1111, 2222, 3333)
             """.trimIndent()
@@ -52,4 +57,4 @@ class ArgumentListWrappingSpec : Spek({
             assertThat(ArgumentListWrapping(config).lint(code)).hasSize(4)
         }
     }
-})
+}

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/AutoCorrectLevelSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/AutoCorrectLevelSpec.kt
@@ -6,16 +6,19 @@ import io.gitlab.arturbosch.detekt.test.loadRuleSet
 import io.gitlab.arturbosch.detekt.test.yamlConfig
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.psi.KtFile
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-class AutoCorrectLevelSpec : Spek({
+internal class AutoCorrectLevelSpec {
 
-    describe("test different autoCorrect levels in configuration") {
+    @Nested
+    inner class `test different autoCorrect levels in configuration` {
 
-        describe("autoCorrect: true on all levels") {
+        @Nested
+        inner class `autoCorrect_ true on all levels` {
 
-            it("should reformat the test file") {
+            @Test
+            fun `should reformat the test file`() {
                 val config = yamlConfig("/autocorrect/autocorrect-all-true.yml")
 
                 val (file, findings) = runRule(config)
@@ -25,9 +28,11 @@ class AutoCorrectLevelSpec : Spek({
             }
         }
 
-        describe("autoCorrect: false on ruleSet level") {
+        @Nested
+        inner class `autoCorrect_ false on ruleSet level` {
 
-            it("should not reformat the test file") {
+            @Test
+            fun `should not reformat the test file`() {
                 val config = yamlConfig("/autocorrect/autocorrect-ruleset-false.yml")
 
                 val (file, findings) = runRule(config)
@@ -37,9 +42,11 @@ class AutoCorrectLevelSpec : Spek({
             }
         }
 
-        describe("autoCorrect: false on rule level") {
+        @Nested
+        inner class `autoCorrect_ false on rule level` {
 
-            it("should not reformat the test file") {
+            @Test
+            fun `should not reformat the test file`() {
                 val config = yamlConfig("/autocorrect/autocorrect-rule-false.yml")
 
                 val (file, findings) = runRule(config)
@@ -49,9 +56,11 @@ class AutoCorrectLevelSpec : Spek({
             }
         }
 
-        describe("autoCorrect: true but rule active false") {
+        @Nested
+        inner class `autoCorrect_ true but rule active false` {
 
-            it("should not reformat the test file") {
+            @Test
+            fun `should not reformat the test file`() {
                 val config = yamlConfig("/autocorrect/autocorrect-true-rule-active-false.yml")
 
                 val (file, findings) = runRule(config)
@@ -61,7 +70,7 @@ class AutoCorrectLevelSpec : Spek({
             }
         }
     }
-})
+}
 
 private fun runRule(config: Config): Pair<KtFile, List<Finding>> {
     val testFile = loadFile("configTests/fixed.kt")

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/AutoCorrectLevelSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/AutoCorrectLevelSpec.kt
@@ -9,7 +9,7 @@ import org.jetbrains.kotlin.psi.KtFile
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
-internal class AutoCorrectLevelSpec {
+class AutoCorrectLevelSpec {
 
     @Nested
     inner class `test different autoCorrect levels in configuration` {

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/ChainWrappingSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/ChainWrappingSpec.kt
@@ -3,14 +3,16 @@ package io.gitlab.arturbosch.detekt.formatting
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.formatting.wrappers.ChainWrapping
 import org.assertj.core.api.Assertions.assertThat
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-class ChainWrappingSpec : Spek({
+internal class ChainWrappingSpec {
 
-    describe("tests integration of formatting") {
+    @Nested
+    inner class `tests integration of formatting` {
 
-        it("should work like KtLint") {
+        @Test
+        fun `should work like KtLint`() {
             val subject = loadFile("configTests/chain-wrapping-before.kt")
             val expected = loadFileContent("configTests/chain-wrapping-after.kt")
 
@@ -20,4 +22,4 @@ class ChainWrappingSpec : Spek({
             assertThat(subject.text).isEqualTo(expected)
         }
     }
-})
+}

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/ChainWrappingSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/ChainWrappingSpec.kt
@@ -6,7 +6,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
-internal class ChainWrappingSpec {
+class ChainWrappingSpec {
 
     @Nested
     inner class `tests integration of formatting` {

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/FinalNewlineSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/FinalNewlineSpec.kt
@@ -7,7 +7,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
-internal class FinalNewlineSpec {
+class FinalNewlineSpec {
 
     @Nested
     inner class `FinalNewline rule` {

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/FinalNewlineSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/FinalNewlineSpec.kt
@@ -4,21 +4,24 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.formatting.wrappers.FinalNewline
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import org.assertj.core.api.Assertions.assertThat
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-class FinalNewlineSpec : Spek({
+internal class FinalNewlineSpec {
 
-    describe("FinalNewline rule") {
+    @Nested
+    inner class `FinalNewline rule` {
 
-        it("should report missing new line by default") {
+        @Test
+        fun `should report missing new line by default`() {
             val findings = FinalNewline(Config.empty)
                 .lint("fun main() = Unit")
 
             assertThat(findings).hasSize(1)
         }
 
-        it("should not report as new line is present") {
+        @Test
+        fun `should not report as new line is present`() {
             val findings = FinalNewline(Config.empty).lint(
                 """
                     fun main() = Unit
@@ -29,7 +32,8 @@ class FinalNewlineSpec : Spek({
             assertThat(findings).isEmpty()
         }
 
-        it("should report new line when configured") {
+        @Test
+        fun `should report new line when configured`() {
             val findings = FinalNewline(TestConfig(INSERT_FINAL_NEWLINE_KEY to "false"))
                 .lint(
                     """
@@ -41,13 +45,14 @@ class FinalNewlineSpec : Spek({
             assertThat(findings).hasSize(1)
         }
 
-        it("should not report when no new line is configured and not present") {
+        @Test
+        fun `should not report when no new line is configured and not present`() {
             val findings = FinalNewline(TestConfig(INSERT_FINAL_NEWLINE_KEY to "false"))
                 .lint("fun main() = Unit")
 
             assertThat(findings).isEmpty()
         }
     }
-})
+}
 
 private const val INSERT_FINAL_NEWLINE_KEY = "insertFinalNewLine"

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingRuleSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingRuleSpec.kt
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import java.nio.file.Paths
 
-internal class FormattingRuleSpec {
+class FormattingRuleSpec {
 
     private lateinit var subject: NoLineBreakBeforeAssignment
 

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingRuleSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingRuleSpec.kt
@@ -4,17 +4,25 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.formatting.wrappers.NoLineBreakBeforeAssignment
 import io.gitlab.arturbosch.detekt.test.assertThat
 import org.assertj.core.api.Assertions.assertThat
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 import java.nio.file.Paths
 
-class FormattingRuleSpec : Spek({
+internal class FormattingRuleSpec {
 
-    val subject by memoized { NoLineBreakBeforeAssignment(Config.empty) }
+    private lateinit var subject: NoLineBreakBeforeAssignment
 
-    describe("formatting rules can be suppressed") {
+    @BeforeEach
+    fun createSubject() {
+        subject = NoLineBreakBeforeAssignment(Config.empty)
+    }
 
-        it("does support suppression only on file level") {
+    @Nested
+    inner class `formatting rules can be suppressed` {
+
+        @Test
+        fun `does support suppression only on file level`() {
             val findings = subject.lint(
                 """
                 @file:Suppress("NoLineBreakBeforeAssignment")
@@ -26,7 +34,8 @@ class FormattingRuleSpec : Spek({
             assertThat(findings).isEmpty()
         }
 
-        it("does not support suppression on node level") {
+        @Test
+        fun `does not support suppression on node level`() {
             val findings = subject.lint(
                 """
                 @Suppress("NoLineBreakBeforeAssignment")
@@ -39,9 +48,11 @@ class FormattingRuleSpec : Spek({
         }
     }
 
-    describe("formatting rules have a signature") {
+    @Nested
+    inner class `formatting rules have a signature` {
 
-        it("has no package name") {
+        @Test
+        fun `has no package name`() {
             val findings = subject.lint(
                 """
                 fun main() 
@@ -52,7 +63,8 @@ class FormattingRuleSpec : Spek({
             assertThat(findings.first().signature).isEqualTo("Test.kt:2")
         }
 
-        it("has a package name") {
+        @Test
+        fun `has a package name`() {
             val findings = subject.lint(
                 """
                 package test.test.test
@@ -65,7 +77,8 @@ class FormattingRuleSpec : Spek({
         }
     }
 
-    test("#3063: formatting issues have an absolute path") {
+    @Test
+    fun `#3063_ formatting issues have an absolute path`() {
         val expectedPath = Paths.get("/root/kotlin/test.kt").toString()
 
         val findings = subject.lint(
@@ -78,4 +91,4 @@ class FormattingRuleSpec : Spek({
 
         assertThat(findings.first().location.filePath.absolutePath.toString()).isEqualTo(expectedPath)
     }
-})
+}

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/ImportOrderingSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/ImportOrderingSpec.kt
@@ -4,8 +4,8 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.formatting.wrappers.ImportOrdering
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import org.assertj.core.api.Assertions.assertThat
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
 /**
  * Some test cases were used directly from KtLint to verify the wrapper rule:
@@ -14,11 +14,13 @@ import org.spekframework.spek2.style.specification.describe
  * https://github.com/pinterest/ktlint/blob/6bdd345f204e6edcc3dec5e1b139c2d573227dad/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/importordering/ImportOrderingRuleCustomTest.kt
  * https://github.com/pinterest/ktlint/blob/cdf871b6f015359f9a6f02e15ef1b85a6c442437/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/importordering/ImportOrderingRuleIdeaTest.kt
  */
-class ImportOrderingSpec : Spek({
+internal class ImportOrderingSpec {
 
-    describe("different import ordering layouts") {
+    @Nested
+    inner class `different import ordering layouts` {
 
-        it("defaults to the idea layout") {
+        @Test
+        fun `defaults to the idea layout`() {
             val findings = ImportOrdering(Config.empty).lint(
                 """
                 import android.app.Activity
@@ -38,7 +40,8 @@ class ImportOrderingSpec : Spek({
             assertThat(findings).isEmpty()
         }
 
-        describe("can be configured to use the ascii one") {
+        @Nested
+        inner class `can be configured to use the ascii one` {
 
             val negativeCase = """
                 import a.A
@@ -52,35 +55,42 @@ class ImportOrderingSpec : Spek({
                 import a.AB
             """.trimIndent()
 
-            it("passes for alphabetical order") {
+            @Test
+            fun `passes for alphabetical order`() {
                 val findings = ImportOrdering(TestConfig("layout" to ImportOrdering.ASCII_PATTERN))
                     .lint(negativeCase)
 
                 assertThat(findings).isEmpty()
             }
 
-            it("fails for non alphabetical order") {
+            @Test
+            fun `fails for non alphabetical order`() {
                 val findings = ImportOrdering(TestConfig("layout" to ImportOrdering.ASCII_PATTERN))
                     .lint(positiveCase)
 
                 assertThat(findings).hasSize(1)
             }
 
-            describe("defaults to ascii if 'android'' property is set to true") {
+            @Nested
+            inner class `defaults to ascii if 'android'' property is set to true` {
 
-                it("passes for alphabetical order") {
+                @Test
+                fun `passes for alphabetical order`() {
                     assertThat(ImportOrdering(TestConfig("android" to "true")).lint(negativeCase)).isEmpty()
                 }
 
-                it("fails for non alphabetical order") {
+                @Test
+                fun `fails for non alphabetical order`() {
                     assertThat(ImportOrdering(TestConfig("android" to "true")).lint(positiveCase)).hasSize(1)
                 }
             }
         }
 
-        describe("supports custom patterns") {
+        @Nested
+        inner class `supports custom patterns` {
 
-            it("misses a empty line between aliases and other imports") {
+            @Test
+            fun `misses a empty line between aliases and other imports`() {
                 val findings = ImportOrdering(TestConfig("layout" to "*,|,^*")).lint(
                     """
                     import android.app.Activity
@@ -95,7 +105,9 @@ class ImportOrderingSpec : Spek({
 
                 assertThat(findings).hasSize(1)
             }
-            it("passes for empty line between aliases and other imports") {
+
+            @Test
+            fun `passes for empty line between aliases and other imports`() {
                 val findings = ImportOrdering(TestConfig("layout" to "*,|,^*")).lint(
                     """
                     import android.app.Activity
@@ -113,4 +125,4 @@ class ImportOrderingSpec : Spek({
             }
         }
     }
-})
+}

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/ImportOrderingSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/ImportOrderingSpec.kt
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.Test
  * https://github.com/pinterest/ktlint/blob/6bdd345f204e6edcc3dec5e1b139c2d573227dad/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/importordering/ImportOrderingRuleCustomTest.kt
  * https://github.com/pinterest/ktlint/blob/cdf871b6f015359f9a6f02e15ef1b85a6c442437/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/importordering/ImportOrderingRuleIdeaTest.kt
  */
-internal class ImportOrderingSpec {
+class ImportOrderingSpec {
 
     @Nested
     inner class `different import ordering layouts` {

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/IndentationSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/IndentationSpec.kt
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
-internal class IndentationSpec {
+class IndentationSpec {
 
     private lateinit var subject: Indentation
 

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/IndentationSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/IndentationSpec.kt
@@ -5,41 +5,54 @@ import io.gitlab.arturbosch.detekt.formatting.wrappers.Indentation
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assert
 import org.assertj.core.api.Assertions.assertThat
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-class IndentationSpec : Spek({
+internal class IndentationSpec {
 
-    val subject by memoized { Indentation(Config.empty) }
+    private lateinit var subject: Indentation
 
-    describe("Indentation rule") {
+    @BeforeEach
+    fun createSubject() {
+        subject = Indentation(Config.empty)
+    }
 
-        describe("indentation level equals 1") {
+    @Nested
+    inner class `Indentation rule` {
+
+        @Nested
+        inner class `indentation level equals 1` {
 
             val code = "fun main() {\n println()\n}"
 
-            describe("indentation level config of default") {
+            @Nested
+            inner class `indentation level config of default` {
 
-                it("reports wrong indentation level") {
+                @Test
+                fun `reports wrong indentation level`() {
                     assertThat(subject.lint(code)).hasSize(1)
                 }
 
-                it("places finding location to the indentation") {
+                @Test
+                fun `places finding location to the indentation`() {
                     subject.lint(code).assert()
                         .hasSourceLocation(2, 1)
                         .hasTextLocations(13 to 14)
                 }
             }
 
-            it("does not report when using an indentation level config of 1") {
+            @Test
+            fun `does not report when using an indentation level config of 1`() {
                 val config = TestConfig("indentSize" to "1")
                 assertThat(Indentation(config).lint(code)).isEmpty()
             }
         }
 
-        it("does not report correct indentation level") {
+        @Test
+        fun `does not report correct indentation level`() {
             val code = "fun main() {\n    println()\n}"
             assertThat(subject.lint(code)).isEmpty()
         }
     }
-})
+}

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/KtLintMultiRuleSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/KtLintMultiRuleSpec.kt
@@ -6,14 +6,16 @@ import com.pinterest.ktlint.core.Rule.Modifier.RestrictToRootLast
 import io.github.detekt.test.utils.compileContentForTest
 import io.gitlab.arturbosch.detekt.api.Config
 import org.assertj.core.api.Assertions.assertThat
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-class KtLintMultiRuleSpec : Spek({
+internal class KtLintMultiRuleSpec {
 
-    describe("KtLintMultiRule rule") {
+    @Nested
+    inner class `KtLintMultiRule rule` {
 
-        it("sorts rules correctly") {
+        @Test
+        fun `sorts rules correctly`() {
             val ktlintRule = KtLintMultiRule(Config.empty)
             ktlintRule.visitFile(compileContentForTest(""))
             val sortedRules = ktlintRule.getSortedRules()
@@ -29,4 +31,4 @@ class KtLintMultiRuleSpec : Spek({
                 .isLessThan(sortedRules.indexOfFirst { it.wrapping is Last })
         }
     }
-})
+}

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/KtLintMultiRuleSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/KtLintMultiRuleSpec.kt
@@ -9,7 +9,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
-internal class KtLintMultiRuleSpec {
+class KtLintMultiRuleSpec {
 
     @Nested
     inner class `KtLintMultiRule rule` {

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/MaximumLineLengthSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/MaximumLineLengthSpec.kt
@@ -3,31 +3,38 @@ package io.gitlab.arturbosch.detekt.formatting
 import io.gitlab.arturbosch.detekt.formatting.wrappers.MaximumLineLength
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import org.assertj.core.api.Assertions.assertThat
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 import java.nio.file.Paths
 
-class MaximumLineLengthSpec : Spek({
+internal class MaximumLineLengthSpec {
 
-    val subject by memoized {
-        val config = TestConfig(MAX_LINE_LENGTH to "30")
-        MaximumLineLength(config)
+    private lateinit var subject: MaximumLineLength
+
+    @BeforeEach
+    fun createSubject() {
+        subject = MaximumLineLength(TestConfig(MAX_LINE_LENGTH to "30"))
     }
 
-    describe("MaximumLineLength rule") {
+    @Nested
+    inner class `MaximumLineLength rule` {
 
-        describe("a single function") {
+        @Nested
+        inner class `a single function` {
 
             val code = """
                 package home.test
                 fun f() { /* 123456789012345678901234567890 */ }
             """.trimIndent()
 
-            it("reports line which exceeds the threshold") {
+            @Test
+            fun `reports line which exceeds the threshold`() {
                 assertThat(subject.lint(code)).hasSize(1)
             }
 
-            it("reports issues with the filename and package as signature") {
+            @Test
+            fun `reports issues with the filename and package as signature`() {
                 val finding = subject.lint(
                     code,
                     Paths.get("home", "test", "Test.kt").toString()
@@ -36,18 +43,21 @@ class MaximumLineLengthSpec : Spek({
                 assertThat(finding.entity.signature).isEqualTo("home.test.Test.kt:2")
             }
 
-            it("does not report line which does not exceed the threshold") {
+            @Test
+            fun `does not report line which does not exceed the threshold`() {
                 val config = TestConfig(MAX_LINE_LENGTH to code.length)
                 assertThat(MaximumLineLength(config).lint(code)).isEmpty()
             }
         }
 
-        it("does not report line which does not exceed the threshold") {
+        @Test
+        fun `does not report line which does not exceed the threshold`() {
             val code = "val a = 1"
             assertThat(subject.lint(code)).isEmpty()
         }
 
-        it("reports correct line numbers") {
+        @Test
+        fun `reports correct line numbers`() {
             val findings = subject.lint(longLines)
 
             // Note that KtLint's MaximumLineLength rule, in contrast to detekt's MaxLineLength rule, does not report
@@ -58,7 +68,8 @@ class MaximumLineLengthSpec : Spek({
             assertThat(findings[1].entity.location.source.line).isEqualTo(14)
         }
 
-        it("does not report back ticked line which exceeds the threshold") {
+        @Test
+        fun `does not report back ticked line which exceeds the threshold`() {
             val code = """
                 package home.test
                 fun `this is a test method that has more than 30 characters inside the back ticks`() {
@@ -73,6 +84,6 @@ class MaximumLineLengthSpec : Spek({
             assertThat(findings).isEmpty()
         }
     }
-})
+}
 
 const val MAX_LINE_LENGTH = "maxLineLength"

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/MaximumLineLengthSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/MaximumLineLengthSpec.kt
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import java.nio.file.Paths
 
-internal class MaximumLineLengthSpec {
+class MaximumLineLengthSpec {
 
     private lateinit var subject: MaximumLineLength
 

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/ParameterListWrappingSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/ParameterListWrappingSpec.kt
@@ -4,16 +4,24 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.formatting.wrappers.ParameterListWrapping
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import org.assertj.core.api.Assertions.assertThat
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-class ParameterListWrappingSpec : Spek({
+internal class ParameterListWrappingSpec {
 
-    val subject by memoized { ParameterListWrapping(Config.empty) }
+    private lateinit var subject: ParameterListWrapping
 
-    describe("ParameterListWrapping rule") {
+    @BeforeEach
+    fun createSubject() {
+        subject = ParameterListWrapping(Config.empty)
+    }
 
-        describe("indent size equals 1") {
+    @Nested
+    inner class `ParameterListWrapping rule` {
+
+        @Nested
+        inner class `indent size equals 1` {
 
             val code = """
                 fun f(
@@ -21,17 +29,20 @@ class ParameterListWrappingSpec : Spek({
                 ) {}
             """.trimIndent()
 
-            it("reports wrong indent size") {
+            @Test
+            fun `reports wrong indent size`() {
                 assertThat(subject.lint(code)).hasSize(1)
             }
 
-            it("does not report when using an indentation level config of 1") {
+            @Test
+            fun `does not report when using an indentation level config of 1`() {
                 val config = TestConfig("indentSize" to "1")
                 assertThat(ParameterListWrapping(config).lint(code)).isEmpty()
             }
         }
 
-        it("does not report correct ParameterListWrapping level") {
+        @Test
+        fun `does not report correct ParameterListWrapping level`() {
             val code = """
                 fun f(
                     a: Int
@@ -40,7 +51,8 @@ class ParameterListWrappingSpec : Spek({
             assertThat(subject.lint(code)).isEmpty()
         }
 
-        it("reports when max line length is exceeded") {
+        @Test
+        fun `reports when max line length is exceeded`() {
             val code = """
                 fun f(a: Int, b: Int, c: Int) {}
             """.trimIndent()
@@ -48,4 +60,4 @@ class ParameterListWrappingSpec : Spek({
             assertThat(ParameterListWrapping(config).lint(code)).hasSize(4)
         }
     }
-})
+}

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/ParameterListWrappingSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/ParameterListWrappingSpec.kt
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
-internal class ParameterListWrappingSpec {
+class ParameterListWrappingSpec {
 
     private lateinit var subject: ParameterListWrapping
 

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/TrailingCommaSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/TrailingCommaSpec.kt
@@ -3,8 +3,8 @@ package io.gitlab.arturbosch.detekt.formatting
 import io.gitlab.arturbosch.detekt.formatting.wrappers.TrailingComma
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
 private const val ALLOW_TRAILING_COMMA = "allowTrailingComma"
 private const val ALLOW_TRAILING_COMMA_ON_CALL_SITE = "allowTrailingCommaOnCallSite"
@@ -14,11 +14,13 @@ private const val ALLOW_TRAILING_COMMA_ON_CALL_SITE = "allowTrailingCommaOnCallS
  *
  * https://github.com/pinterest/ktlint/blob/master/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/TrailingCommaRuleTest.kt
  */
-class TrailingCommaSpec : Spek({
+internal class TrailingCommaSpec {
 
-    describe("unnecessary comma") {
+    @Nested
+    inner class `unnecessary comma` {
 
-        it("reports unnecessary comma on function call") {
+        @Test
+        fun `reports unnecessary comma on function call`() {
             val code =
                 """
                 val foo1 = listOf("a", "b",)
@@ -27,7 +29,8 @@ class TrailingCommaSpec : Spek({
             assertThat(findings).hasSize(1)
         }
 
-        it("reports unnecessary comma on constructor call") {
+        @Test
+        fun `reports unnecessary comma on constructor call`() {
             val code =
                 """
                 val foo2 = Pair(1, 2,)
@@ -36,7 +39,8 @@ class TrailingCommaSpec : Spek({
             assertThat(findings).hasSize(1)
         }
 
-        it("reports unnecessary comma on generic type definition") {
+        @Test
+        fun `reports unnecessary comma on generic type definition`() {
             val code =
                 """
                 val foo3: List<String,> = emptyList()
@@ -45,7 +49,8 @@ class TrailingCommaSpec : Spek({
             assertThat(findings).hasSize(1)
         }
 
-        it("reports unnecessary comma on array get") {
+        @Test
+        fun `reports unnecessary comma on array get`() {
             val code =
                 """
                 val foo4 = Array(2) { 42 }
@@ -55,7 +60,8 @@ class TrailingCommaSpec : Spek({
             assertThat(findings).hasSize(1)
         }
 
-        it("reports unnecessary comma on annotation") {
+        @Test
+        fun `reports unnecessary comma on annotation`() {
             val code =
                 """
                 @Foo5([1, 2,])
@@ -66,9 +72,11 @@ class TrailingCommaSpec : Spek({
         }
     }
 
-    describe("missing comma") {
+    @Nested
+    inner class `missing comma` {
 
-        it("reports missing comma on function call") {
+        @Test
+        fun `reports missing comma on field definition`() {
             val code =
                 """
                 data class Foo1(val bar: Int)
@@ -80,7 +88,8 @@ class TrailingCommaSpec : Spek({
             assertThat(findings).hasSize(1)
         }
 
-        it("reports missing comma on function call") {
+        @Test
+        fun `reports missing comma on function call`() {
             val code =
                 """
                 val foo1 = listOf("a", "b")
@@ -93,7 +102,8 @@ class TrailingCommaSpec : Spek({
             assertThat(findings).hasSize(1)
         }
 
-        it("reports missing comma on constructor call") {
+        @Test
+        fun `reports missing comma on constructor call`() {
             val code =
                 """
                 val foo2 = Pair(1, 2)
@@ -106,4 +116,4 @@ class TrailingCommaSpec : Spek({
             assertThat(findings).hasSize(1)
         }
     }
-})
+}

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/TrailingCommaSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/TrailingCommaSpec.kt
@@ -14,7 +14,7 @@ private const val ALLOW_TRAILING_COMMA_ON_CALL_SITE = "allowTrailingCommaOnCallS
  *
  * https://github.com/pinterest/ktlint/blob/master/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/TrailingCommaRuleTest.kt
  */
-internal class TrailingCommaSpec {
+class TrailingCommaSpec {
 
     @Nested
     inner class `unnecessary comma` {


### PR DESCRIPTION
This is part of #4450 and migrates all tests in detekt-formatting to junit
