### PR TITLE
Fix false positive of UnnecessaryInnerClass

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -233,6 +233,7 @@ style:
     active: true
   UnnecessaryInnerClass:
     active: true
+    ignoreAnnotated: ['Nested']
   UntilInsteadOfRangeTo:
     active: true
   UnusedImports:

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryInnerClassSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryInnerClassSpec.kt
@@ -283,23 +283,44 @@ class UnnecessaryInnerClassSpec : Spek({
             }
         }
 
-        it("does not report a double-nested inner class accessing from an outer-class member") {
-            val code = """
-                class A {
-                    val foo = "BAR"
-                    
-                    inner class B {
-                        val fizz = foo
-                        inner class C {
-                            fun printFoo() {
-                                println(foo)
+        context("does not report a double-nested inner class accessing from an outer-class member") {
+
+            it("when the innermost class refers a inner class and the inner class refers the outermost class") {
+                val code = """
+                    class A {
+                        val foo = "BAR"
+                        
+                        inner class B {
+                            val fizz = foo
+                            inner class C {
+                                fun printFoo() {
+                                    println(foo)
+                                }
                             }
                         }
                     }
-                }
-            """.trimIndent()
+                """.trimIndent()
 
-            assertThat(subject.lintWithContext(env, code)).isEmpty()
+                assertThat(subject.lintWithContext(env, code)).isEmpty()
+            }
+
+            it("when the innermost class refers the outermost class") {
+                val code = """
+                    class A {
+                        val foo = "BAR"
+                        
+                        inner class B {
+                            inner class C {
+                                fun printFoo() {
+                                    println(foo)
+                                }
+                            }
+                        }
+                    }
+                """.trimIndent()
+
+                assertThat(subject.lintWithContext(env, code)).isEmpty()
+            }
         }
 
         it("does not report anonymous inner classes") {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryInnerClassSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryInnerClassSpec.kt
@@ -294,7 +294,7 @@ class UnnecessaryInnerClassSpec : Spek({
                             val fizz = foo
                             inner class C {
                                 fun printFoo() {
-                                    println(foo)
+                                    println(fizz)
                                 }
                             }
                         }


### PR DESCRIPTION
Main branch is failing because `/home/runner/work/detekt/detekt/custom-checks/src/test/kotlin/io/github/detekt/custom/SpekTestDiscoverySpec.kt:16:5: Class 'VariableDeclarationsInSpekGroupsShouldOnlyBeSimple' does not require `inner` keyword. [UnnecessaryInnerClass]` is a false positive. 
- This PR addresses the aforementioned issue by handling the class chain from the current class to the referred class.
- This PR adds a passing unit test that failed before this PR.
- Additionally, `@Nested` tests require the class to be inner. IDE prompts **Only non-static nested classes can serve as '@Nested' test classes. **