### PR TITLE
Disable `UnnecessaryInnerClass` for tests

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -233,6 +233,7 @@ style:
     active: true
   UnnecessaryInnerClass:
     active: true
+    excludes: ['**/*Spec.kt']
   UntilInsteadOfRangeTo:
     active: true
   UnusedImports:


### PR DESCRIPTION
In junit inner classes are a way to structure test contexts. 