### PR TITLE
Migrate tests in detekt-metrics to junit

### DIFF
--- a/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/CognitiveComplexitySpec.kt
+++ b/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/CognitiveComplexitySpec.kt
@@ -2,14 +2,16 @@ package io.github.detekt.metrics
 
 import io.github.detekt.test.utils.compileContentForTest
 import org.assertj.core.api.Assertions.assertThat
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-class CognitiveComplexitySpec : Spek({
+class CognitiveComplexitySpec {
 
-    describe("cognitive complexity") {
+    @Nested
+    inner class `cognitive complexity` {
 
-        it("sums seven for sumOfPrimes example") {
+        @Test
+        fun `sums seven for sumOfPrimes example`() {
             val code = compileContentForTest(
                 """
                 fun sumOfPrimes(max: Int): Int {
@@ -31,7 +33,8 @@ class CognitiveComplexitySpec : Spek({
             assertThat(CognitiveComplexity.calculate(code)).isEqualTo(7)
         }
 
-        it("sums one for getWords example for a single when expression") {
+        @Test
+        fun `sums one for getWords example for a single when expression`() {
             val code = compileContentForTest(
                 """
                  fun getWords(number: Int): String = when (number) {
@@ -46,9 +49,11 @@ class CognitiveComplexitySpec : Spek({
             assertThat(CognitiveComplexity.calculate(code)).isEqualTo(1)
         }
 
-        describe("recursion") {
+        @Nested
+        inner class `recursion` {
 
-            it("adds one for recursion inside class") {
+            @Test
+            fun `adds one for recursion inside class`() {
                 val code = compileContentForTest(
                     """
                     class A {
@@ -61,7 +66,8 @@ class CognitiveComplexitySpec : Spek({
                 assertThat(CognitiveComplexity.calculate(code)).isEqualTo(2)
             }
 
-            it("adds one for top level recursion") {
+            @Test
+            fun `adds one for top level recursion`() {
                 val code = compileContentForTest(
                     """
                     fun factorial(n: Int): Int =
@@ -72,7 +78,8 @@ class CognitiveComplexitySpec : Spek({
                 assertThat(CognitiveComplexity.calculate(code)).isEqualTo(2)
             }
 
-            it("does not add as it is only the same name") {
+            @Test
+            fun `does not add as it is only the same name`() {
                 val code = compileContentForTest(
                     """
                     object O { fun factorial(i: Int): Int = i - 1 }
@@ -85,7 +92,8 @@ class CognitiveComplexitySpec : Spek({
             }
         }
 
-        it("ignores shorthand operators") {
+        @Test
+        fun `ignores shorthand operators`() {
             val code = compileContentForTest(
                 """
                 fun parse(args: Array<String>): Nothing = TODO()
@@ -98,7 +106,8 @@ class CognitiveComplexitySpec : Spek({
             assertThat(CognitiveComplexity.calculate(code)).isEqualTo(0)
         }
 
-        it("adds one per catch clause") {
+        @Test
+        fun `adds one per catch clause`() {
             val code = compileContentForTest(
                 """
                 fun main() {
@@ -113,7 +122,8 @@ class CognitiveComplexitySpec : Spek({
             assertThat(CognitiveComplexity.calculate(code)).isEqualTo(3)
         }
 
-        it("adds extra complexity for nesting") {
+        @Test
+        fun `adds extra complexity for nesting`() {
             val code = compileContentForTest(
                 """
                 fun main() {
@@ -135,7 +145,8 @@ class CognitiveComplexitySpec : Spek({
             assertThat(CognitiveComplexity.calculate(code)).isEqualTo(9)
         }
 
-        it("adds nesting for lambdas but not complexity") {
+        @Test
+        fun `adds nesting for lambdas but not complexity`() {
             val code = compileContentForTest(
                 """
                 fun main() { run { if (true) {} } }
@@ -145,7 +156,8 @@ class CognitiveComplexitySpec : Spek({
             assertThat(CognitiveComplexity.calculate(code)).isEqualTo(2)
         }
 
-        it("adds nesting for nested functions but not complexity") {
+        @Test
+        fun `adds nesting for nested functions but not complexity`() {
             val code = compileContentForTest(
                 """
                 fun main() { fun run() { if (true) {} } }
@@ -155,54 +167,61 @@ class CognitiveComplexitySpec : Spek({
             assertThat(CognitiveComplexity.calculate(code)).isEqualTo(2)
         }
 
-        describe("binary expressions") {
+        @Nested
+        inner class `binary expressions` {
 
-            it("does not increment on just a condition") {
+            @Test
+            fun `does not increment on just a condition`() {
                 val code = compileContentForTest(
                     """
-                    fun test(cond: Boolean) = !cond
+                    fun test(cond_ Boolean) = !cond
                 """
                 )
 
                 assertThat(CognitiveComplexity.calculate(code)).isEqualTo(0)
             }
 
-            describe("increments for every non-like operator") {
+            @Nested
+            inner class `increments for every non-like operator` {
 
-                it("adds one for just a &&") {
+                @Test
+                fun `adds one for just a &&`() {
                     val code = compileContentForTest(
                         """
-                        fun test(cond: Boolean) = !cond && !cond
+                        fun test(cond_ Boolean) = !cond && !cond
                     """
                     )
 
                     assertThat(CognitiveComplexity.calculate(code)).isEqualTo(1)
                 }
 
-                it("adds only one for repeated &&") {
+                @Test
+                fun `adds only one for repeated &&`() {
                     val code = compileContentForTest(
                         """
-                        fun test(cond: Boolean) = !cond && !cond && !cond
+                        fun test(cond_ Boolean) = !cond && !cond && !cond
                     """
                     )
 
                     assertThat(CognitiveComplexity.calculate(code)).isEqualTo(1)
                 }
 
-                it("adds one per logical alternate operator") {
+                @Test
+                fun `adds one per logical alternate operator`() {
                     val code = compileContentForTest(
                         """
-                        fun test(cond: Boolean) = !cond && !cond || cond
+                        fun test(cond_ Boolean) = !cond && !cond || cond
                     """
                     )
 
                     assertThat(CognitiveComplexity.calculate(code)).isEqualTo(2)
                 }
 
-                it("adds one per logical alternate operator with like operators in between") {
+                @Test
+                fun `adds one per logical alternate operator with like operators in between`() {
                     val code = compileContentForTest(
                         """
-                        fun test(cond: Boolean) {
+                        fun test(cond_ Boolean) {
                             if (                    // +1
                                 !cond 
                                 && !cond && !cond   // +1
@@ -216,10 +235,11 @@ class CognitiveComplexitySpec : Spek({
                     assertThat(CognitiveComplexity.calculate(code)).isEqualTo(4)
                 }
 
-                it("adds one for negated but similar operators") {
+                @Test
+                fun `adds one for negated but similar operators`() {
                     val code = compileContentForTest(
                         """
-                        fun test(cond: Boolean) {
+                        fun test(cond_ Boolean) {
                             if (                    // +1
                                 !cond 
                                 && !(cond && cond)  // +2
@@ -231,10 +251,11 @@ class CognitiveComplexitySpec : Spek({
                     assertThat(CognitiveComplexity.calculate(code)).isEqualTo(3)
                 }
 
-                it("adds only one for a negated chain of similar operators") {
+                @Test
+                fun `adds only one for a negated chain of similar operators`() {
                     val code = compileContentForTest(
                         """
-                        fun test(cond: Boolean) {
+                        fun test(cond_ Boolean) {
                             if (                    // +1
                                 !cond 
                                 && !(cond && cond && cond)  // +2
@@ -246,10 +267,11 @@ class CognitiveComplexitySpec : Spek({
                     assertThat(CognitiveComplexity.calculate(code)).isEqualTo(3)
                 }
 
-                it("adds one for every negated similar operator chain") {
+                @Test
+                fun `adds one for every negated similar operator chain`() {
                     val code = compileContentForTest(
                         """
-                        fun test(cond: Boolean) {
+                        fun test(cond_ Boolean) {
                             if (                            // +1
                                 !cond 
                                 && !(cond && cond && cond)  // +2
@@ -264,4 +286,4 @@ class CognitiveComplexitySpec : Spek({
             }
         }
     }
-})
+}

--- a/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/ComplexityReportGeneratorSpec.kt
+++ b/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/ComplexityReportGeneratorSpec.kt
@@ -11,23 +11,29 @@ import io.gitlab.arturbosch.detekt.test.TestDetektion
 import io.mockk.every
 import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.lifecycle.CachingMode
-import org.spekframework.spek2.style.specification.describe
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-internal class ComplexityReportGeneratorSpec : Spek({
+internal class ComplexityReportGeneratorSpec {
 
-    describe("complexity report generator") {
+    @Nested
+    inner class `complexity report generator` {
 
-        val detektion by memoized(CachingMode.TEST) {
+        private lateinit var detektion: TestDetektion
+
+        @BeforeEach
+        fun setupMocks() {
             val finding = mockk<Finding>()
             every { finding.id }.returns("test")
-            TestDetektion(finding).withTestData()
+            detektion = TestDetektion(finding).withTestData()
         }
 
-        context("several complexity metrics") {
+        @Nested
+        inner class `several complexity metrics` {
 
-            it("successfully generates a complexity report") {
+            @Test
+            fun `successfully generates a complexity report`() {
                 val expectedContent = listOf(
                     "1,000 lines of code (loc)",
                     "6 source lines of code (sloc)",
@@ -45,14 +51,17 @@ internal class ComplexityReportGeneratorSpec : Spek({
             }
         }
 
-        context("several invalid complexity metrics") {
+        @Nested
+        inner class `several invalid complexity metrics` {
 
-            it("returns null for missing mcc") {
+            @Test
+            fun `returns null for missing mcc`() {
                 detektion.removeData(complexityKey)
                 assertThat(generateComplexityReport(detektion)).isNull()
             }
 
-            it("returns null for missing lloc") {
+            @Test
+            fun `returns null for missing lloc`() {
                 detektion.removeData(logicalLinesKey)
                 assertThat(generateComplexityReport(detektion)).isNull()
 
@@ -60,7 +69,8 @@ internal class ComplexityReportGeneratorSpec : Spek({
                 assertThat(generateComplexityReport(detektion)).isNull()
             }
 
-            it("returns null for missing sloc") {
+            @Test
+            fun `returns null for missing sloc`() {
                 detektion.removeData(sourceLinesKey)
                 assertThat(generateComplexityReport(detektion)).isNull()
 
@@ -68,13 +78,14 @@ internal class ComplexityReportGeneratorSpec : Spek({
                 assertThat(generateComplexityReport(detektion)).isNull()
             }
 
-            it("returns null for missing cloc") {
+            @Test
+            fun `returns null for missing cloc`() {
                 detektion.removeData(complexityKey)
                 assertThat(generateComplexityReport(detektion)).isNull()
             }
         }
     }
-})
+}
 
 private fun TestDetektion.withTestData(): TestDetektion {
     addData(complexityKey, 2)

--- a/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/CyclomaticComplexitySpec.kt
+++ b/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/CyclomaticComplexitySpec.kt
@@ -7,16 +7,18 @@ import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.psi.KtNamed
 import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.psiUtil.getChildOfType
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-class CyclomaticComplexitySpec : Spek({
+class CyclomaticComplexitySpec {
 
     val defaultFunctionComplexity = 1
 
-    describe("basic function expressions are tested") {
+    @Nested
+    inner class `basic function expressions are tested` {
 
-        it("counts for safe navigation") {
+        @Test
+        fun `counts for safe navigation`() {
             val code = compileContentForTest(
                 """
                     fun test() = null as? String ?: ""
@@ -28,7 +30,8 @@ class CyclomaticComplexitySpec : Spek({
             assertThat(actual).isEqualTo(defaultFunctionComplexity + 1)
         }
 
-        it("counts if and && and || expressions") {
+        @Test
+        fun `counts if and && and || expressions`() {
             val code = compileContentForTest(
                 """
                     fun test() = if (true || true && false) 1 else 0
@@ -40,10 +43,11 @@ class CyclomaticComplexitySpec : Spek({
             assertThat(actual).isEqualTo(defaultFunctionComplexity + 3)
         }
 
-        it("counts while, continue and break") {
+        @Test
+        fun `counts while, continue and break`() {
             val code = compileContentForTest(
                 """
-                    fun test(i: Int) {
+                    fun test(i_ Int) {
                         var j = i
                         while(true) { // 1
                             if (j == 5) { // 1
@@ -65,25 +69,26 @@ class CyclomaticComplexitySpec : Spek({
         }
     }
 
-    describe("counts function calls used for nesting") {
+    @Nested
+    inner class `counts function calls used for nesting` {
 
-        val code by memoized {
-            compileContentForTest(
-                """
+        private val code = compileContentForTest(
+            """
                     fun test(i: Int) {
                         (1..10).forEach { println(it) }
                     }
                 """
-            )
-        }
+        )
 
-        it("counts them by default") {
+        @Test
+        fun `counts them by default`() {
             assertThat(
                 CyclomaticComplexity.calculate(code)
             ).isEqualTo(defaultFunctionComplexity + 1)
         }
 
-        it("does not count them when ignored") {
+        @Test
+        fun `does not count them when ignored`() {
             assertThat(
                 CyclomaticComplexity.calculate(code) {
                     ignoreNestingFunctions = true
@@ -91,7 +96,8 @@ class CyclomaticComplexitySpec : Spek({
             ).isEqualTo(defaultFunctionComplexity)
         }
 
-        it("does not count when forEach is not specified") {
+        @Test
+        fun `does not count when forEach is not specified`() {
             assertThat(
                 CyclomaticComplexity.calculate(code) {
                     nestingFunctions = emptySet()
@@ -99,7 +105,8 @@ class CyclomaticComplexitySpec : Spek({
             ).isEqualTo(defaultFunctionComplexity)
         }
 
-        it("counts them by default") {
+        @Test
+        fun `counts them when forEach is specified`() {
             assertThat(
                 CyclomaticComplexity.calculate(code) {
                     nestingFunctions = setOf("forEach")
@@ -108,9 +115,11 @@ class CyclomaticComplexitySpec : Spek({
         }
     }
 
-    describe("ignoreSimpleWhenEntries is false") {
+    @Nested
+    inner class `ignoreSimpleWhenEntries is false` {
 
-        it("counts simple when branches as 1") {
+        @Test
+        fun `counts simple when branches as 1`() {
             val function = compileContentForTest(
                 """
                 fun test() {
@@ -130,7 +139,8 @@ class CyclomaticComplexitySpec : Spek({
             assertThat(actual).isEqualTo(defaultFunctionComplexity + 3)
         }
 
-        it("counts block when branches as 1") {
+        @Test
+        fun `counts block when branches as 1`() {
             val function = compileContentForTest(
                 """
                 fun test() {
@@ -153,9 +163,11 @@ class CyclomaticComplexitySpec : Spek({
         }
     }
 
-    describe("ignoreSimpleWhenEntries is true") {
+    @Nested
+    inner class `ignoreSimpleWhenEntries is true` {
 
-        it("counts a when with only simple branches as 1") {
+        @Test
+        fun `counts a when with only simple branches as 1`() {
             val function = compileContentForTest(
                 """
                 fun test() {
@@ -175,7 +187,8 @@ class CyclomaticComplexitySpec : Spek({
             assertThat(actual).isEqualTo(defaultFunctionComplexity + 1)
         }
 
-        it("does not count simple when branches") {
+        @Test
+        fun `does not count simple when branches`() {
             val function = compileContentForTest(
                 """
                 fun test() {
@@ -200,7 +213,8 @@ class CyclomaticComplexitySpec : Spek({
             assertThat(actual).isEqualTo(defaultFunctionComplexity + 2)
         }
 
-        it("counts block when branches as 1") {
+        @Test
+        fun `counts block when branches as 1`() {
             val function = compileContentForTest(
                 """
                 fun test() {
@@ -227,7 +241,7 @@ class CyclomaticComplexitySpec : Spek({
             assertThat(actual).isEqualTo(defaultFunctionComplexity + 2)
         }
     }
-})
+}
 
 private fun KtElement.getFunctionByName(name: String): KtNamedFunction {
     val node = getChildOfType<KtNamedFunction>() ?: error("Expected node of type ${KtNamedFunction::class}")

--- a/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/CyclomaticComplexitySpec.kt
+++ b/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/CyclomaticComplexitySpec.kt
@@ -31,7 +31,7 @@ class CyclomaticComplexitySpec {
         }
 
         @Test
-        fun `counts if and && and || expressions`() {
+        fun `counts 'and' and 'or' expressions`() {
             val code = compileContentForTest(
                 """
                     fun test() = if (true || true && false) 1 else 0

--- a/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/processors/CLOCVisitorSpec.kt
+++ b/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/processors/CLOCVisitorSpec.kt
@@ -2,13 +2,15 @@ package io.github.detekt.metrics.processors
 
 import io.github.detekt.test.utils.compileContentForTest
 import org.assertj.core.api.Assertions.assertThat
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-class CLOCVisitorSpec : Spek({
-    describe("CLOC") {
+class CLOCVisitorSpec {
+    @Nested
+    inner class `CLOC` {
 
-        it("commentCases") {
+        @Test
+        fun `commentCases`() {
             val file = compileContentForTest(commentsClass)
             val commentLines = with(file) {
                 accept(CLOCVisitor())
@@ -17,4 +19,4 @@ class CLOCVisitorSpec : Spek({
             assertThat(commentLines).isEqualTo(10)
         }
     }
-})
+}

--- a/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/processors/ClassCountVisitorSpec.kt
+++ b/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/processors/ClassCountVisitorSpec.kt
@@ -3,13 +3,15 @@ package io.github.detekt.metrics.processors
 import io.github.detekt.test.utils.compileContentForTest
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.psi.KtFile
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-class ClassCountVisitorSpec : Spek({
-    describe("something") {
+class ClassCountVisitorSpec {
+    @Nested
+    inner class `something` {
 
-        it("twoClassesInSeparateFile") {
+        @Test
+        fun `twoClassesInSeparateFile`() {
             val files = arrayOf(
                 compileContentForTest(default),
                 compileContentForTest(classWithFields)
@@ -18,13 +20,15 @@ class ClassCountVisitorSpec : Spek({
             assertThat(count).isEqualTo(2)
         }
 
-        it("oneClassWithOneNestedClass") {
+        @Test
+        fun `oneClassWithOneNestedClass`() {
             val file = compileContentForTest(complexClass)
             val count = getClassCount(arrayOf(file))
             assertThat(count).isEqualTo(2)
         }
 
-        it("testEnumAndInterface") {
+        @Test
+        fun `testEnumAndInterface`() {
             val files = arrayOf(
                 compileContentForTest(emptyEnum),
                 compileContentForTest(emptyInterface)
@@ -33,7 +37,7 @@ class ClassCountVisitorSpec : Spek({
             assertThat(count).isEqualTo(2)
         }
     }
-})
+}
 
 private fun getClassCount(files: Array<KtFile>): Int {
     return files.sumOf { getData(it) }

--- a/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/processors/CognitiveComplexityProcessorSpec.kt
+++ b/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/processors/CognitiveComplexityProcessorSpec.kt
@@ -3,14 +3,16 @@ package io.github.detekt.metrics.processors
 import io.github.detekt.metrics.CognitiveComplexity
 import io.github.detekt.test.utils.compileContentForTest
 import org.assertj.core.api.Assertions.assertThat
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-class CognitiveComplexityProcessorSpec : Spek({
+class CognitiveComplexityProcessorSpec {
 
-    describe("CognitiveComplexityProcessor") {
+    @Nested
+    inner class `CognitiveComplexityProcessor` {
 
-        it("counts the complexity for the whole file") {
+        @Test
+        fun `counts the complexity for the whole file`() {
             val file = compileContentForTest(complexClass)
 
             val value = MetricProcessorTester(file)
@@ -19,4 +21,4 @@ class CognitiveComplexityProcessorSpec : Spek({
             assertThat(value).isEqualTo(46)
         }
     }
-})
+}

--- a/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/processors/ComplexityVisitorSpec.kt
+++ b/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/processors/ComplexityVisitorSpec.kt
@@ -2,25 +2,28 @@ package io.github.detekt.metrics.processors
 
 import io.github.detekt.test.utils.compileContentForTest
 import org.assertj.core.api.Assertions.assertThat
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-class ComplexityVisitorSpec : Spek({
-    describe("something") {
+class ComplexityVisitorSpec {
+    @Nested
+    inner class `something` {
 
-        it("complexityOfDefaultCaseIsOne") {
+        @Test
+        fun `complexityOfDefaultCaseIsOne`() {
             val mcc = calcComplexity(default)
 
             assertThat(mcc).isEqualTo(0)
         }
 
-        it("complexityOfComplexAndNestedClass") {
+        @Test
+        fun `complexityOfComplexAndNestedClass`() {
             val mcc = calcComplexity(complexClass)
 
             assertThat(mcc).isEqualTo(44)
         }
     }
-})
+}
 
 private fun calcComplexity(content: String) =
     with(compileContentForTest(content)) {

--- a/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/processors/FieldCountVisitorSpec.kt
+++ b/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/processors/FieldCountVisitorSpec.kt
@@ -2,13 +2,15 @@ package io.github.detekt.metrics.processors
 
 import io.github.detekt.test.utils.compileContentForTest
 import org.assertj.core.api.Assertions.assertThat
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-class FieldCountVisitorSpec : Spek({
-    describe("something") {
+class FieldCountVisitorSpec {
+    @Nested
+    inner class `something` {
 
-        it("defaultFieldCount") {
+        @Test
+        fun `defaultFieldCount`() {
             val file = compileContentForTest(classWithFields)
             val count = with(file) {
                 accept(PropertyCountVisitor())
@@ -17,4 +19,4 @@ class FieldCountVisitorSpec : Spek({
             assertThat(count).isEqualTo(2)
         }
     }
-})
+}

--- a/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/processors/KtFileCountVisitorSpec.kt
+++ b/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/processors/KtFileCountVisitorSpec.kt
@@ -3,13 +3,15 @@ package io.github.detekt.metrics.processors
 import io.github.detekt.test.utils.compileContentForTest
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.psi.KtFile
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-class KtFileCountVisitorSpec : Spek({
-    describe("files") {
+class KtFileCountVisitorSpec {
+    @Nested
+    inner class `files` {
 
-        it("twoFiles") {
+        @Test
+        fun `twoFiles`() {
             val files = arrayOf(
                 compileContentForTest(default),
                 compileContentForTest(complexClass)
@@ -18,7 +20,7 @@ class KtFileCountVisitorSpec : Spek({
             assertThat(count).isEqualTo(2)
         }
     }
-})
+}
 
 private fun getData(file: KtFile): Int {
     return with(file) {

--- a/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/processors/LLOCVisitorSpec.kt
+++ b/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/processors/LLOCVisitorSpec.kt
@@ -2,13 +2,15 @@ package io.github.detekt.metrics.processors
 
 import io.github.detekt.test.utils.compileContentForTest
 import org.assertj.core.api.Assertions.assertThat
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-class LLOCVisitorSpec : Spek({
-    describe("LLOC Visitor") {
+class LLOCVisitorSpec {
+    @Nested
+    inner class `LLOC Visitor` {
 
-        it("defaultCaseHasOneClassAndAnnotationLine") {
+        @Test
+        fun `defaultCaseHasOneClassAndAnnotationLine`() {
             val file = compileContentForTest(default)
 
             val lloc = with(file) {
@@ -19,7 +21,8 @@ class LLOCVisitorSpec : Spek({
             assertThat(lloc).isEqualTo(2)
         }
 
-        it("llocOfComplexClass") {
+        @Test
+        fun `llocOfComplexClass`() {
             val file = compileContentForTest(complexClass)
 
             val lloc = with(file) {
@@ -30,4 +33,4 @@ class LLOCVisitorSpec : Spek({
             assertThat(lloc).isEqualTo(85)
         }
     }
-})
+}

--- a/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/processors/LOCVisitorSpec.kt
+++ b/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/processors/LOCVisitorSpec.kt
@@ -2,13 +2,15 @@ package io.github.detekt.metrics.processors
 
 import io.github.detekt.test.utils.compileContentForTest
 import org.assertj.core.api.Assertions.assertThat
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-class LOCVisitorSpec : Spek({
-    describe("LOC Visitor") {
+class LOCVisitorSpec {
+    @Nested
+    inner class `LOC Visitor` {
 
-        it("defaultClass") {
+        @Test
+        fun `defaultClass`() {
             val file = compileContentForTest(default)
             val loc = with(file) {
                 accept(LOCVisitor())
@@ -17,4 +19,4 @@ class LOCVisitorSpec : Spek({
             assertThat(loc).isEqualTo(8)
         }
     }
-})
+}

--- a/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/processors/MethodCountVisitorSpec.kt
+++ b/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/processors/MethodCountVisitorSpec.kt
@@ -3,19 +3,21 @@ package io.github.detekt.metrics.processors
 import io.github.detekt.test.utils.compileContentForTest
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.psi.KtFile
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-class MethodCountVisitorSpec : Spek({
-    describe("Method Count Visitor") {
+class MethodCountVisitorSpec {
+    @Nested
+    inner class `Method Count Visitor` {
 
-        it("defaultMethodCount") {
+        @Test
+        fun `defaultMethodCount`() {
             val file = compileContentForTest(complexClass)
             val count = getMethodCount(file)
             assertThat(count).isEqualTo(6)
         }
     }
-})
+}
 
 private fun getMethodCount(file: KtFile): Int {
     return with(file) {

--- a/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/processors/PackageCountVisitorSpec.kt
+++ b/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/processors/PackageCountVisitorSpec.kt
@@ -3,13 +3,15 @@ package io.github.detekt.metrics.processors
 import io.github.detekt.test.utils.compileContentForTest
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.psi.KtFile
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-class PackageCountVisitorSpec : Spek({
-    describe("Package Count Visitor") {
+class PackageCountVisitorSpec {
+    @Nested
+    inner class `Package Count Visitor` {
 
-        it("twoClassesInSeparatePackage") {
+        @Test
+        fun `twoClassesInSeparatePackage`() {
             val files = arrayOf(
                 compileContentForTest(default),
                 compileContentForTest(emptyEnum)
@@ -21,7 +23,7 @@ class PackageCountVisitorSpec : Spek({
             assertThat(count).isEqualTo(2)
         }
     }
-})
+}
 
 private fun getData(file: KtFile): String {
     return with(file) {

--- a/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/processors/SLOCVisitorSpec.kt
+++ b/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/processors/SLOCVisitorSpec.kt
@@ -2,13 +2,15 @@ package io.github.detekt.metrics.processors
 
 import io.github.detekt.test.utils.compileContentForTest
 import org.assertj.core.api.Assertions.assertThat
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-class SLOCVisitorSpec : Spek({
-    describe("SLOC Visitor") {
+class SLOCVisitorSpec {
+    @Nested
+    inner class `SLOC Visitor` {
 
-        it("defaultClass") {
+        @Test
+        fun `defaultClass`() {
             val file = compileContentForTest(default)
             val loc = with(file) {
                 accept(SLOCVisitor())
@@ -17,4 +19,4 @@ class SLOCVisitorSpec : Spek({
             assertThat(loc).isEqualTo(3)
         }
     }
-})
+}


### PR DESCRIPTION
Next module as part of #4450

- migrate tests in detekt-metrics to junit
- fix compiler warning about possible problems on windows
