### PR TITLE
Migrate tests in detekt-report-xxx to junit

### DIFF
--- a/detekt-report-html/src/test/kotlin/io/github/detekt/report/html/HtmlOutputReportSpec.kt
+++ b/detekt-report-html/src/test/kotlin/io/github/detekt/report/html/HtmlOutputReportSpec.kt
@@ -21,18 +21,20 @@ import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.com.intellij.psi.PsiFile
 import org.jetbrains.kotlin.psi.KtElement
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 import java.nio.file.Files
 import java.nio.file.Path
 
-class HtmlOutputReportSpec : Spek({
+class HtmlOutputReportSpec {
 
-    describe("HTML output report") {
+    @Nested
+    inner class `HTML output report` {
 
-        val htmlReport by memoized { HtmlOutputReport() }
+        private val htmlReport = HtmlOutputReport()
 
-        it("renders the HTML headers correctly") {
+        @Test
+        fun `renders the HTML headers correctly`() {
             val result = htmlReport.render(TestDetektion())
 
             assertThat(result).startsWith("<!DOCTYPE html>\n<html lang=\"en\">")
@@ -43,7 +45,8 @@ class HtmlOutputReportSpec : Spek({
             assertThat(result).contains("<h2>Findings</h2>")
         }
 
-        it("renders the 'generated with' text correctly") {
+        @Test
+        fun `renders the 'generated with' text correctly`() {
             val version = whichDetekt()
             val header =
                 """generated with <a href="https://detekt.github.io/">detekt version $version</a> on """
@@ -54,13 +57,15 @@ class HtmlOutputReportSpec : Spek({
             assertThat(result).doesNotContain("@@@date@@@")
         }
 
-        it("contains the total number of findings") {
+        @Test
+        fun `contains the total number of findings`() {
             val result = htmlReport.render(createTestDetektionWithMultipleSmells())
 
             assertThat(result).contains("Total: 3")
         }
 
-        it("contains no findings") {
+        @Test
+        fun `contains no findings`() {
             val detektion = object : TestDetektion() {
                 override val findings: Map<String, List<Finding>> = mapOf(
                     "EmptyRuleset" to emptyList()
@@ -70,7 +75,8 @@ class HtmlOutputReportSpec : Spek({
             assertThat(result).contains("Total: 0")
         }
 
-        it("renders the right file locations") {
+        @Test
+        fun `renders the right file locations`() {
             val result = htmlReport.render(createTestDetektionWithMultipleSmells())
 
             assertThat(result).contains("<span class=\"location\">src/main/com/sample/Sample1.kt:11:1</span>")
@@ -78,7 +84,8 @@ class HtmlOutputReportSpec : Spek({
             assertThat(result).contains("<span class=\"location\">src/main/com/sample/Sample3.kt:33:3</span>")
         }
 
-        it("renders the right file locations for relative paths") {
+        @Test
+        fun `renders the right file locations for relative paths`() {
             val result = htmlReport.render(createTestDetektionFromRelativePath())
 
             assertThat(result).contains("<span class=\"location\">src/main/com/sample/Sample1.kt:11:1</span>")
@@ -86,14 +93,16 @@ class HtmlOutputReportSpec : Spek({
             assertThat(result).contains("<span class=\"location\">src/main/com/sample/Sample3.kt:33:3</span>")
         }
 
-        it("renders the right number of issues per rule") {
+        @Test
+        fun `renders the right number of issues per rule`() {
             val result = htmlReport.render(createTestDetektionWithMultipleSmells())
 
             assertThat(result).contains("<span class=\"rule\">id_a: 2 </span>")
             assertThat(result).contains("<span class=\"rule\">id_b: 1 </span>")
         }
 
-        it("renders the right violation messages for the rules") {
+        @Test
+        fun `renders the right violation messages for the rules`() {
             val result = htmlReport.render(createTestDetektionWithMultipleSmells())
 
             assertThat(result).contains("<span class=\"message\">Message finding 1</span>")
@@ -101,14 +110,16 @@ class HtmlOutputReportSpec : Spek({
             assertThat(result).doesNotContain("<span class=\"message\"></span>")
         }
 
-        it("renders the right violation description for the rules") {
+        @Test
+        fun `renders the right violation description for the rules`() {
             val result = htmlReport.render(createTestDetektionWithMultipleSmells())
 
             assertThat(result).contains("<span class=\"description\">Description id_a</span>")
             assertThat(result).contains("<span class=\"description\">Description id_b</span>")
         }
 
-        it("renders a metric report correctly") {
+        @Test
+        fun `renders a metric report correctly`() {
             val detektion = object : TestDetektion() {
                 override val metrics: Collection<ProjectMetric> = listOf(
                     ProjectMetric("M1", 10_000),
@@ -120,7 +131,8 @@ class HtmlOutputReportSpec : Spek({
             assertThat(result).contains("<li>2 M2</li>")
         }
 
-        it("renders the complexity report correctly") {
+        @Test
+        fun `renders the complexity report correctly`() {
             val detektion = TestDetektion()
             detektion.addData(complexityKey, 10)
             detektion.addData(CognitiveComplexity.KEY, 10)
@@ -134,12 +146,14 @@ class HtmlOutputReportSpec : Spek({
             assertThat(result).contains("<li>10 logical lines of code (lloc)</li>")
         }
 
-        it("renders a blank complexity report correctly") {
+        @Test
+        fun `renders a blank complexity report correctly`() {
             val result = htmlReport.render(createTestDetektionWithMultipleSmells())
             assertThat(result).contains("<h2>Complexity Report</h2>\n\n<div>\n  <ul></ul>\n</div>")
         }
 
-        it("asserts that the generated HTML is the same as expected") {
+        @Test
+        fun `asserts that the generated HTML is the same as expected`() {
             val expected = resourceAsPath("HtmlOutputFormatTest.html")
             var result = htmlReport.render(createTestDetektionWithMultipleSmells())
             result = generatedRegex.replace(result, replacement)
@@ -150,7 +164,8 @@ class HtmlOutputReportSpec : Spek({
             assertThat(actual).hasSameTextualContentAs(expected)
         }
 
-        it("asserts that the generated HTML is the same even if we change the order of the findings") {
+        @Test
+        fun `asserts that the generated HTML is the same even if we change the order of the findings`() {
             val findings = findings()
             val reversedFindings = findings
                 .reversedArray()
@@ -163,7 +178,7 @@ class HtmlOutputReportSpec : Spek({
             assertThat(firstReport).hasSameTextualContentAs(secondReport)
         }
     }
-})
+}
 
 private fun mockKtElement(): KtElement {
     val ktElementMock = mockk<KtElement>()

--- a/detekt-report-html/src/test/kotlin/io/github/detekt/report/html/HtmlUtilsSpec.kt
+++ b/detekt-report-html/src/test/kotlin/io/github/detekt/report/html/HtmlUtilsSpec.kt
@@ -4,14 +4,14 @@ import io.gitlab.arturbosch.detekt.api.SourceLocation
 import kotlinx.html.div
 import kotlinx.html.stream.createHTML
 import org.assertj.core.api.Assertions.assertThat
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-class HtmlUtilsSpec : Spek({
+class HtmlUtilsSpec {
 
-    describe("HTML snippet code") {
-        val code by memoized {
-            """
+    @Nested
+    inner class `HTML snippet code` {
+        private val code = """
             package cases
             // reports 1 - line with just one space
 
@@ -28,10 +28,10 @@ class HtmlUtilsSpec : Spek({
                 // reports 1
                 }
             }
-            """.trimIndent().splitToSequence('\n')
-        }
+        """.trimIndent().splitToSequence('\n')
 
-        it("all line") {
+        @Test
+        fun `all line`() {
             val snippet = createHTML().div() {
                 snippetCode("ruleName", code.asSequence(), SourceLocation(7, 1), 34)
             }
@@ -53,7 +53,8 @@ class HtmlUtilsSpec : Spek({
             )
         }
 
-        it("part of line") {
+        @Test
+        fun `part of line`() {
             val snippet = createHTML().div() {
                 snippetCode("ruleName", code.asSequence(), SourceLocation(7, 7), 26)
             }
@@ -75,7 +76,8 @@ class HtmlUtilsSpec : Spek({
             )
         }
 
-        it("more than one line") {
+        @Test
+        fun `more than one line`() {
             val snippet = createHTML().div() {
                 snippetCode("ruleName", code.asSequence(), SourceLocation(7, 7), 66)
             }
@@ -97,7 +99,8 @@ class HtmlUtilsSpec : Spek({
             )
         }
 
-        it("first line") {
+        @Test
+        fun `first line`() {
             val snippet = createHTML().div() {
                 snippetCode("ruleName", code.asSequence(), SourceLocation(1, 1), 1)
             }
@@ -105,7 +108,8 @@ class HtmlUtilsSpec : Spek({
             assertThat(snippet).contains((1..4).map { "  $it " })
         }
 
-        it("second line") {
+        @Test
+        fun `second line`() {
             val snippet = createHTML().div() {
                 snippetCode("ruleName", code.asSequence(), SourceLocation(2, 1), 1)
             }
@@ -113,7 +117,8 @@ class HtmlUtilsSpec : Spek({
             assertThat(snippet).contains((1..5).map { "  $it " })
         }
 
-        it("penultimate line") {
+        @Test
+        fun `penultimate line`() {
             val snippet = createHTML().div() {
                 snippetCode("ruleName", code.asSequence(), SourceLocation(15, 1), 1)
             }
@@ -121,7 +126,8 @@ class HtmlUtilsSpec : Spek({
             assertThat(snippet).contains((12..16).map { "  $it " })
         }
 
-        it("last line") {
+        @Test
+        fun `last line`() {
             val snippet = createHTML().div() {
                 snippetCode("ruleName", code.asSequence(), SourceLocation(16, 1), 1)
             }
@@ -129,7 +135,8 @@ class HtmlUtilsSpec : Spek({
             assertThat(snippet).contains((13..16).map { "  $it " })
         }
 
-        it("when we provide an invalid source location the exception div is shown") {
+        @Test
+        fun `when we provide an invalid source location the exception div is shown`() {
             val snippet = createHTML().div() {
                 snippetCode("ruleName", code.asSequence(), SourceLocation(7, 100), 1)
             }
@@ -137,4 +144,4 @@ class HtmlUtilsSpec : Spek({
             assertThat(snippet).contains("""<div class="exception">""")
         }
     }
-})
+}

--- a/detekt-report-sarif/src/test/kotlin/io/github/detekt/report/sarif/SarifOutputReportSpec.kt
+++ b/detekt-report-sarif/src/test/kotlin/io/github/detekt/report/sarif/SarifOutputReportSpec.kt
@@ -13,16 +13,18 @@ import io.gitlab.arturbosch.detekt.test.createEntity
 import io.gitlab.arturbosch.detekt.test.createFindingForRelativePath
 import io.gitlab.arturbosch.detekt.test.createIssue
 import org.assertj.core.api.Assertions.assertThat
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 import java.nio.file.Paths
 
 @OptIn(UnstableApi::class)
-class SarifOutputReportSpec : Spek({
+class SarifOutputReportSpec {
 
-    describe("sarif output report") {
+    @Nested
+    inner class `sarif output report` {
 
-        it("renders multiple issues") {
+        @Test
+        fun `renders multiple issues`() {
             val result = TestDetektion(
                 createFinding(ruleName = "TestSmellA", severity = SeverityLevel.ERROR),
                 createFinding(ruleName = "TestSmellB", severity = SeverityLevel.WARNING),
@@ -36,7 +38,8 @@ class SarifOutputReportSpec : Spek({
             assertThat(report).isEqualToIgnoringWhitespace(readResourceContent("vanilla.sarif.json"))
         }
 
-        it("renders multiple issues with relative path") {
+        @Test
+        fun `renders multiple issues with relative path`() {
             val basePath = "/Users/tester/detekt/"
             val result = TestDetektion(
                 createFindingForRelativePath(ruleName = "TestSmellA", basePath = basePath),
@@ -68,7 +71,7 @@ class SarifOutputReportSpec : Spek({
             assertThat(report).isEqualToIgnoringWhitespace(systemAwareExpectedReport)
         }
     }
-})
+}
 
 private fun createFinding(ruleName: String, severity: SeverityLevel): Finding {
     return object : CodeSmell(createIssue(ruleName), createEntity("TestFile.kt"), "TestMessage") {

--- a/detekt-report-txt/src/test/kotlin/io/github/detekt/report/txt/TxtOutputReportSpec.kt
+++ b/detekt-report-txt/src/test/kotlin/io/github/detekt/report/txt/TxtOutputReportSpec.kt
@@ -3,28 +3,32 @@ package io.github.detekt.report.txt
 import io.gitlab.arturbosch.detekt.test.TestDetektion
 import io.gitlab.arturbosch.detekt.test.createFinding
 import org.assertj.core.api.Assertions.assertThat
-import org.spekframework.spek2.Spek
-import org.spekframework.spek2.style.specification.describe
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 
-class TxtOutputReportSpec : Spek({
+class TxtOutputReportSpec {
 
-    describe("TXT output report") {
+    @Nested
+    inner class `TXT output report` {
 
-        it("renders none") {
+        @Test
+        fun `renders none`() {
             val report = TxtOutputReport()
             val detektion = TestDetektion()
             val renderedText = ""
             assertThat(report.render(detektion)).isEqualTo(renderedText)
         }
 
-        it("renders one") {
+        @Test
+        fun `renders one`() {
             val report = TxtOutputReport()
             val detektion = TestDetektion(createFinding())
             val renderedText = "TestSmell - [TestEntity] at TestFile.kt:1:1 - Signature=TestEntitySignature\n"
             assertThat(report.render(detektion)).isEqualTo(renderedText)
         }
 
-        it("renders multiple") {
+        @Test
+        fun `renders multiple`() {
             val report = TxtOutputReport()
             val detektion = TestDetektion(
                 createFinding(ruleName = "TestSmellA"),
@@ -40,4 +44,4 @@ class TxtOutputReportSpec : Spek({
             assertThat(report.render(detektion)).isEqualTo(renderedText)
         }
     }
-})
+}


### PR DESCRIPTION
Part of #4450

- migrate tests in detekt-report-html to junit
- migrate tests in detekt-report-txt to junit
- migrate tests in detekt-report-sarif to junit
- migrate tests in detekt-report-xml to junit
