### PR TITLE
Clean up gradle files for modules migrated to junit

### DIFF
--- a/detekt-core/build.gradle.kts
+++ b/detekt-core/build.gradle.kts
@@ -17,10 +17,9 @@ dependencies {
 
     testRuntimeOnly(projects.detektRules)
     testRuntimeOnly(projects.detektFormatting)
-    testRuntimeOnly(libs.spek.runner)
     testImplementation(projects.detektTest)
     testImplementation(testFixtures(projects.detektApi))
     testImplementation(libs.mockk)
     testImplementation(libs.reflections)
-    testImplementation(libs.bundles.testImplementation)
+    testImplementation(libs.assertj)
 }

--- a/detekt-formatting/build.gradle.kts
+++ b/detekt-formatting/build.gradle.kts
@@ -15,9 +15,7 @@ dependencies {
     }
 
     testImplementation(projects.detektTest)
-    testImplementation(libs.bundles.testImplementation)
-
-    testRuntimeOnly(libs.spek.runner)
+    testImplementation(libs.assertj)
 }
 
 tasks.build { finalizedBy(":detekt-generator:generateDocumentation") }

--- a/detekt-metrics/build.gradle.kts
+++ b/detekt-metrics/build.gradle.kts
@@ -7,6 +7,5 @@ dependencies {
     testImplementation(projects.detektTestUtils)
     testImplementation(testFixtures(projects.detektApi))
     testImplementation(libs.mockk)
-    testImplementation(libs.bundles.testImplementation)
-    testRuntimeOnly(libs.spek.runner)
+    testImplementation(libs.assertj)
 }

--- a/detekt-parser/build.gradle.kts
+++ b/detekt-parser/build.gradle.kts
@@ -8,8 +8,7 @@ dependencies {
     api(libs.kotlin.compilerEmbeddable)
     implementation(projects.detektPsiUtils)
     testImplementation(projects.detektTestUtils)
-    testImplementation(libs.bundles.testImplementation)
-    testRuntimeOnly(libs.spek.runner)
+    testImplementation(libs.assertj)
 }
 
 tasks.withType<Test> {

--- a/detekt-report-html/build.gradle.kts
+++ b/detekt-report-html/build.gradle.kts
@@ -13,6 +13,5 @@ dependencies {
     testImplementation(projects.detektTestUtils)
     testImplementation(testFixtures(projects.detektApi))
     testImplementation(libs.mockk)
-    testImplementation(libs.bundles.testImplementation)
-    testRuntimeOnly(libs.spek.runner)
+    testImplementation(libs.assertj)
 }

--- a/detekt-report-sarif/build.gradle.kts
+++ b/detekt-report-sarif/build.gradle.kts
@@ -9,6 +9,5 @@ dependencies {
     testImplementation(projects.detektTooling)
     testImplementation(projects.detektTestUtils)
     testImplementation(testFixtures(projects.detektApi))
-    testImplementation(libs.bundles.testImplementation)
-    testRuntimeOnly(libs.spek.runner)
+    testImplementation(libs.assertj)
 }

--- a/detekt-report-txt/build.gradle.kts
+++ b/detekt-report-txt/build.gradle.kts
@@ -5,6 +5,5 @@ plugins {
 dependencies {
     implementation(projects.detektApi)
     testImplementation(testFixtures(projects.detektApi))
-    testImplementation(libs.bundles.testImplementation)
-    testRuntimeOnly(libs.spek.runner)
+    testImplementation(libs.assertj)
 }

--- a/detekt-report-xml/build.gradle.kts
+++ b/detekt-report-xml/build.gradle.kts
@@ -5,6 +5,5 @@ plugins {
 dependencies {
     implementation(projects.detektApi)
     testImplementation(testFixtures(projects.detektApi))
-    testImplementation(libs.bundles.testImplementation)
-    testRuntimeOnly(libs.spek.runner)
+    testImplementation(libs.assertj)
 }


### PR DESCRIPTION
This is a follow up to the pull request that migrate tests to junit. I did not realize at the time, that the spek runner was used explicitly in the modules.
