### PR TITLE
Use Java 17 for all CI jobs

### DIFF
--- a/.github/workflows/codecoverage.yaml
+++ b/.github/workflows/codecoverage.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v2
         with:
-          java-version: 11
+          java-version: 17
           distribution: 'temurin'
 
       - name: Generate Coverage Report

--- a/.github/workflows/deploy-snapshot.yaml
+++ b/.github/workflows/deploy-snapshot.yaml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup Java
       uses: actions/setup-java@v2
       with:
-        java-version: 8
+        java-version: 17
         distribution: 'temurin'
 
     - name: Build detekt

--- a/.github/workflows/deploy-website.yaml
+++ b/.github/workflows/deploy-website.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v2
         with:
-          java-version: 11
+          java-version: 17
           distribution: 'temurin'
 
       - name: Build Detekt Documentation

--- a/.github/workflows/detekt-with-type-resolution.yaml
+++ b/.github/workflows/detekt-with-type-resolution.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v2
         with:
-          java-version: 11
+          java-version: 17
           distribution: 'temurin'
 
       - name: Run detekt-cli with argsfile
@@ -44,7 +44,7 @@ jobs:
     - name: Setup Java
       uses: actions/setup-java@v2
       with:
-        java-version: 11
+        java-version: 17
         distribution: 'temurin'
     - name: Run analysis
       uses: gradle/gradle-build-action@v2

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -55,7 +55,7 @@ jobs:
     - name: Setup Java
       uses: actions/setup-java@v2
       with:
-        java-version: 11
+        java-version: 17
         distribution: 'temurin'
     - name: Verify Generated Detekt Config File
       uses: gradle/gradle-build-action@v2
@@ -71,7 +71,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v2
         with:
-          java-version: 11
+          java-version: 17
           distribution: 'temurin'
       - name: Build and compile test snippets
         uses: gradle/gradle-build-action@v2


### PR DESCRIPTION
We should run CI jobs using the latest LTS version of Java.