### PR TITLE
Create SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,21 @@
+# Security Policy
+
+## Supported Versions
+
+Use this section to tell people about which versions of your project are
+currently being supported with security updates.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 5.1.x   | :white_check_mark: |
+| 5.0.x   | :x:                |
+| 4.0.x   | :white_check_mark: |
+| < 4.0   | :x:                |
+
+## Reporting a Vulnerability
+
+Use this section to tell people how to report a vulnerability.
+
+Tell them where to go, how often they can expect to get an update on a
+reported vulnerability, what to expect if the vulnerability is accepted or
+declined, etc.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,20 +2,11 @@
 
 ## Supported Versions
 
-Use this section to tell people about which versions of your project are
-currently being supported with security updates.
-
-| Version | Supported          |
-| ------- | ------------------ |
-| 5.1.x   | :white_check_mark: |
-| 5.0.x   | :x:                |
-| 4.0.x   | :white_check_mark: |
-| < 4.0   | :x:                |
+| Version | Supported                                                                                                          | Fix   |
+|---------|--------------------------------------------------------------------------------------------------------------------|-------|
+| 1.20.0  | Improper Restriction of XML External Entity Reference - [CWE-611](https://cwe.mitre.org/data/definitions/611.html) | #4499 |
 
 ## Reporting a Vulnerability
 
-Use this section to tell people how to report a vulnerability.
-
-Tell them where to go, how often they can expect to get an update on a
-reported vulnerability, what to expect if the vulnerability is accepted or
-declined, etc.
+Please report vulnerability to security@detekt.dev.
+If you have already reported on vulnerability disclosure platform, please include its link in the email.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,6 +2,10 @@
 
 ## Supported Versions
 
+Generally updating to the latest stable version will have all security issues addressed.
+- Security patches are applied up to the current minor version.
+- Earlier versions are not supported by default, but we will examine them on a case-by-case basis.
+
 | Version | Supported                                                                                                        | Fix                                                 |
 |---------|------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------|
 | 1.20.0  | [CWE-611](https://cwe.mitre.org/data/definitions/611.html) Improper Restriction of XML External Entity Reference | [#4499](https://github.com/detekt/detekt/pull/4499) |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,12 +1,12 @@
 # Security Policy
 
-## Supported Versions
+## Versions
 
 Generally updating to the latest stable version will have all security issues addressed.
 - Security patches are applied up to the **current minor version**.
 - Earlier versions are not supported by default, but we will examine them on a case-by-case basis.
 
-| Version | Supported                                                                                                        | Fix                                                 |
+| Version | Addressed issues                                                                                                 | Fix                                                 |
 |---------|------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------|
 | 1.20.0  | [CWE-611](https://cwe.mitre.org/data/definitions/611.html) Improper Restriction of XML External Entity Reference | [#4499](https://github.com/detekt/detekt/pull/4499) |
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,9 +2,9 @@
 
 ## Supported Versions
 
-| Version | Supported                                                                                                          | Fix   |
-|---------|--------------------------------------------------------------------------------------------------------------------|-------|
-| 1.20.0  | Improper Restriction of XML External Entity Reference - [CWE-611](https://cwe.mitre.org/data/definitions/611.html) | #4499 |
+| Version | Supported                                                                                                        | Fix                                                 |
+|---------|------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------|
+| 1.20.0  | [CWE-611](https://cwe.mitre.org/data/definitions/611.html) Improper Restriction of XML External Entity Reference | [#4499](https://github.com/detekt/detekt/pull/4499) |
 
 ## Reporting a Vulnerability
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,5 +12,6 @@ Generally updating to the latest stable version will have all security issues ad
 
 ## Reporting a Vulnerability
 
-Please report vulnerability to security@detekt.dev.
-If you have already reported on vulnerability disclosure platform, please include its link in the email.
+Please report vulnerability to security@detekt.dev. 
+We commit to respond within 2 weeks. You may also find us in #detekt channel of [kotlinlang Slack](https://kotlinlang.slack.com/).
+If you have already reported on vulnerability disclosure platform, please include its link in the report.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,7 +3,7 @@
 ## Supported Versions
 
 Generally updating to the latest stable version will have all security issues addressed.
-- Security patches are applied up to the current minor version.
+- Security patches are applied up to the **current minor version**.
 - Earlier versions are not supported by default, but we will examine them on a case-by-case basis.
 
 | Version | Supported                                                                                                        | Fix                                                 |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,5 +13,5 @@ Generally updating to the latest stable version will have all security issues ad
 ## Reporting a Vulnerability
 
 Please report vulnerability to security@detekt.dev. 
-We commit to respond within 2 weeks. You may also find us in #detekt channel of [kotlinlang Slack](https://kotlinlang.slack.com/).
+We commit to respond within 2 weeks. You may also find us in the [#detekt](https://kotlinlang.slack.com/archives/C88E12QH4) channel of [kotlinlang Slack](https://kotlinlang.slack.com/).
 If you have already reported on vulnerability disclosure platform, please include its link in the report.


### PR DESCRIPTION
In response to #4496 - adding the default suggested `SECURITY.md` template.

Usually good to add a point of contact, e-mail or person that should be contacted when potential security issues are discovered.
