### PR TITLE
Fix AutoCorrection crashing with Missing extension point

### DIFF
--- a/detekt-parser/src/main/kotlin/io/github/detekt/parser/DetektPomModel.kt
+++ b/detekt-parser/src/main/kotlin/io/github/detekt/parser/DetektPomModel.kt
@@ -1,6 +1,7 @@
 package io.github.detekt.parser
 
 import org.jetbrains.kotlin.com.intellij.openapi.extensions.ExtensionPoint
+import org.jetbrains.kotlin.com.intellij.openapi.extensions.Extensions.getRootArea
 import org.jetbrains.kotlin.com.intellij.openapi.project.Project
 import org.jetbrains.kotlin.com.intellij.openapi.util.UserDataHolderBase
 import org.jetbrains.kotlin.com.intellij.pom.PomModel
@@ -20,9 +21,9 @@ class DetektPomModel(project: Project) : UserDataHolderBase(), PomModel {
     init {
         val extension = "org.jetbrains.kotlin.com.intellij.treeCopyHandler"
         val extensionClass = TreeCopyHandler::class.java.name
-        val extensionArea = project.extensionArea
-        synchronized(extensionArea) {
-            if (extensionArea.hasExtensionPoint(extension)) {
+        @Suppress("DEPRECATION")
+        for (extensionArea in listOf(project.extensionArea, getRootArea())) {
+            if (!extensionArea.hasExtensionPoint(extension)) {
                 extensionArea.registerExtensionPoint(extension, extensionClass, ExtensionPoint.Kind.INTERFACE)
             }
         }


### PR DESCRIPTION
Fixes #4003
Fixes #4500
Fixes #4489

This issue was apparently caused by my PR #3848

What is happening is that KtLint is enabling AST mutation on the Root Extension, while we're not. Therefore, as the `autoCorrect` tries to mutate the AST it crashes with the mentioned message.

Moreover there was a `!` missing which was causing the code to do nothing. I've also removed the `syncronized` as KtLint is not using it either.

I've tested locally with a SNAPSHOT version and it works for me. I'm unsure how we can test this with an automated test.

Sadly we will have to live with the deprecated `getRootArea()`. KtLint is having that as well so I guess they'll find a way if JetBrains decides to remove this API (and we'll have to follow their approach).