### PR TITLE
Revert "trim values when parsing the baseline (#4335)"

### DIFF
--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineHandler.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineHandler.kt
@@ -33,8 +33,8 @@ internal class BaselineHandler : DefaultHandler() {
             ID -> {
                 check(content.isNotBlank()) { "The content of the ID element must not be empty" }
                 when (current) {
-                    MANUALLY_SUPPRESSED_ISSUES -> manuallySuppressedIssues.add(content.trim())
-                    CURRENT_ISSUES -> currentIssues.add(content.trim())
+                    MANUALLY_SUPPRESSED_ISSUES -> manuallySuppressedIssues.add(content)
+                    CURRENT_ISSUES -> currentIssues.add(content)
                 }
                 content = ""
             }

--- a/detekt-core/src/test/resources/baseline_feature/valid-baseline.xml
+++ b/detekt-core/src/test/resources/baseline_feature/valid-baseline.xml
@@ -5,8 +5,6 @@
         <ID>LongMethod:Signature</ID>
     </ManuallySuppressedIssues>
     <CurrentIssues>
-        <ID>
-            FeatureEnvy:Signature
-        </ID>
+        <ID>FeatureEnvy:Signature</ID>
     </CurrentIssues>
 </SmellBaseline>


### PR DESCRIPTION
This reverts #4335 (26fd459690635d86f597d9599ad07d852f8db5fe)

Fixes #4537