### PR TITLE
Fix performance issue for regexp in Reporting.kt

### DIFF
--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/Reporting.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/Reporting.kt
@@ -49,6 +49,7 @@ const val DETEKT_OUTPUT_REPORT_PATHS_KEY = "detekt.output.report.paths.key"
 const val DETEKT_OUTPUT_REPORT_BASE_PATH_KEY = "detekt.output.report.base.path"
 
 private const val REPORT_MESSAGE_SIZE_LIMIT = 80
+private val messageReplacementRegex = Regex("\\s+")
 
 fun Config.excludeCorrectable(): Boolean = subConfig(BUILD).valueOrDefault(EXCLUDE_CORRECTABLE, false)
 
@@ -75,7 +76,7 @@ fun Detektion.filterAutoCorrectedIssues(config: Config): Map<RuleSetId, List<Fin
 
 private fun Finding.truncatedMessage(): String {
     val message = messageOrDescription()
-        .replace(Regex("\\s+"), " ")
+        .replace(messageReplacementRegex, " ")
         .trim()
     return when {
         message.length > REPORT_MESSAGE_SIZE_LIMIT -> "${message.take(REPORT_MESSAGE_SIZE_LIMIT)}($ellipsis)"


### PR DESCRIPTION
A regexp object is compiled into an internal data structure during initialization.
This could to a potential performance impact, if the `Regex()` constructor is called multiple times for the same pattern.
Since the private function `truncatedMessage()` could be called a lot, this PR fixes this potential performance issue.

Because of the overhead of object instantiation and regular expression compilation, reusing the initialized object is the recommended way.
