### PR TITLE
Deprecate continuationIndentSize from the Indentation rule

### DIFF
--- a/detekt-core/src/main/resources/deprecation.properties
+++ b/detekt-core/src/main/resources/deprecation.properties
@@ -7,3 +7,4 @@ style>FunctionOnlyReturningConstant>excludeAnnotatedFunction=Use `ignoreAnnotate
 style>UnderscoresInNumericLiterals>acceptableDecimalLength=Use `acceptableLength` instead
 style>UnnecessaryAbstractClass>excludeAnnotatedClasses=Use `ignoreAnnotated` instead
 style>UseDataClass>excludeAnnotatedClasses=Use `ignoreAnnotated` instead
+formatting>Indentation>continuationIndentSize=`continuationIndentSize` is ignored by KtLint and will have no effect

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/EditorConfigConstants.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/EditorConfigConstants.kt
@@ -1,14 +1,12 @@
 package io.gitlab.arturbosch.detekt.formatting
 
 const val INDENT_SIZE_KEY = "indent_size"
-const val CONTINUATION_INDENT_SIZE_KEY = "continuation_indent_size"
 const val MAX_LINE_LENGTH_KEY = "max_line_length"
 const val INSERT_FINAL_NEWLINE_KEY = "insert_final_newline"
 const val KOTLIN_IMPORTS_LAYOUT_KEY = "kotlin_imports_layout"
 
 val knownEditorConfigProps = setOf(
     INDENT_SIZE_KEY,
-    CONTINUATION_INDENT_SIZE_KEY,
     MAX_LINE_LENGTH_KEY,
     INSERT_FINAL_NEWLINE_KEY,
     KOTLIN_IMPORTS_LAYOUT_KEY

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/Indentation.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/Indentation.kt
@@ -26,6 +26,7 @@ class Indentation(config: Config) : FormattingRule(config) {
 
     @Configuration("continuation indentation size")
     @Deprecated("`continuationIndentSize` is ignored by KtLint and will have no effect")
+    @Suppress("UnusedPrivateMember")
     private val continuationIndentSize by config(4)
 
     override fun overrideEditorConfig() = mapOf(

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/Indentation.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/Indentation.kt
@@ -7,7 +7,6 @@ import io.gitlab.arturbosch.detekt.api.config
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
 import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.api.internal.Configuration
-import io.gitlab.arturbosch.detekt.formatting.CONTINUATION_INDENT_SIZE_KEY
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 import io.gitlab.arturbosch.detekt.formatting.INDENT_SIZE_KEY
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
@@ -25,12 +24,8 @@ class Indentation(config: Config) : FormattingRule(config) {
     @Configuration("indentation size")
     private val indentSize by config(4)
 
-    @Configuration("continuation indentation size")
-    private val continuationIndentSize by config(4)
-
     override fun overrideEditorConfig() = mapOf(
         INDENT_SIZE_KEY to indentSize,
-        CONTINUATION_INDENT_SIZE_KEY to continuationIndentSize
     )
 
     /**

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/Indentation.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/Indentation.kt
@@ -24,6 +24,10 @@ class Indentation(config: Config) : FormattingRule(config) {
     @Configuration("indentation size")
     private val indentSize by config(4)
 
+    @Configuration("continuation indentation size")
+    @Deprecated("`continuationIndentSize` is ignored by KtLint and will have no effect")
+    private val continuationIndentSize by config(4)
+
     override fun overrideEditorConfig() = mapOf(
         INDENT_SIZE_KEY to indentSize,
     )

--- a/detekt-formatting/src/main/resources/config/config.yml
+++ b/detekt-formatting/src/main/resources/config/config.yml
@@ -36,7 +36,6 @@ formatting:
     active: true
     autoCorrect: true
     indentSize: 4
-    continuationIndentSize: 4
   MaximumLineLength:
     active: true
     maxLineLength: 120

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/DetektPrinter.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/DetektPrinter.kt
@@ -27,7 +27,9 @@ class DetektPrinter(private val arguments: GeneratorArgs) {
             ConfigPrinter.print(pages.filterNot { it.ruleSet.name == "formatting" })
         }
         propertiesWriter.write(arguments.configPath, "deprecation") {
-            DeprecatedPrinter.print(pages.filterNot { it.ruleSet.name == "formatting" })
+            // We intentionally not filter for "formatting" as we want to be able to deprecate
+            // properties from that ruleset as well.
+            DeprecatedPrinter.print(pages)
         }
         yamlWriter.write(Paths.get("../detekt-formatting/src/main/resources/config"), "config") {
             yaml {


### PR DESCRIPTION
Users should not use the `continuationIndentSize` as it's essentially ignored by KtLint. Sadly we don't have a way to deprecate properties from rules inside `formatting` (cc @BraisGabin, were you aware of it? Should we offer this capacity?)

Fixes #2970 