### PR TITLE
Config to ignore function/constructor annotations from LongParameterList check

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -123,6 +123,8 @@ complexity:
     ignoreDefaultParameters: false
     ignoreDataClasses: true
     ignoreAnnotatedParameter: []
+    ignoreAnnotatedFunctions: []
+    ignoreAnnotatedConstructors: []
   MethodOverloading:
     active: false
     threshold: 6

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterList.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterList.kt
@@ -70,7 +70,8 @@ class LongParameterList(config: Config = Config.empty) : Rule(config) {
     private val ignoreAnnotatedFunctions: List<String> by config(emptyList())
 
     @Configuration(
-        "ignore annotated constructors from the check (e.g. `data class MyClass @Something constructor(...)` would not be checked)"
+        "ignore annotated constructors from the check " +
+            "(e.g. `data class MyClass @Something constructor(...)` would not be checked)"
     )
     private val ignoreAnnotatedConstructors: List<String> by config(emptyList())
 
@@ -121,7 +122,6 @@ class LongParameterList(config: Config = Config.empty) : Rule(config) {
 
     private fun checkLongParameterList(function: KtFunction, threshold: Int, identifier: String) {
         if (function.isOverride()) return
-
         val parameterList = function.valueParameterList ?: return
         val parameterNumber = parameterList.parameterCount()
 

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterListSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterListSpec.kt
@@ -202,7 +202,6 @@ class LongParameterListSpec : Spek({
                 assertThat(rule.compileAndLint(code)).isEmpty()
             }
 
-
             it("does not report long parameter list for functions if enough function parameters are annotated with ignored annotation") {
                 val code = """class Data {
                     fun foo(@kotlin.Suppress("") a: Int) {} }

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterListSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterListSpec.kt
@@ -99,6 +99,8 @@ class LongParameterListSpec : Spek({
             val config by memoized {
                 TestConfig(
                     mapOf(
+                        "ignoreAnnotatedConstructors" to listOf("com.test.Composable"),
+                        "ignoreAnnotatedFunctions" to listOf("com.test.Composable"),
                         "ignoreAnnotatedParameter" to listOf(
                             "Generated",
                             "kotlin.Deprecated",
@@ -137,6 +139,29 @@ class LongParameterListSpec : Spek({
                 val code = "class Data constructor(@kotlin.Suppress(\"\") val a: Int)"
                 assertThat(rule.compileAndLint(code)).isEmpty()
             }
+
+            it("does not report long parameter list for functions if function is annotated with ignored annotation") {
+                val code = """
+                    import com.test.Composable
+                    @Target(AnnotationTarget.FUNCTION)
+                    annotation class Composable
+
+                    @Composable fun foo(a: Int) {} 
+                """
+                assertThat(rule.compileAndLint(code)).isEmpty()
+            }
+
+            it("does not report long parameter list for constructor is annotated with ignored annotation") {
+                val code = """
+                    import com.test.Composable
+                    @Target(AnnotationTarget.CONSTRUCTOR)
+                    annotation class Composable
+
+                    class Data @Composable constructor(val a: Int)
+                """
+                assertThat(rule.compileAndLint(code)).isEmpty()
+            }
+
 
             it("does not report long parameter list for functions if enough function parameters are annotated with ignored annotation") {
                 val code = """class Data {


### PR DESCRIPTION
In our codebase, we have several common function/constructor annotations that tend to come with long parameter lists. We'd like to add the opportunity to ignore functions/constructors with those annotations from the LongParameterList check.

Adds two new config fields for `LongParameterList`:
* `ignoreAnnotatedFunctions` - functions with the annotations specified in this config array will be excluded from the check
* `ignoreAnnotatedConstructors` - constructors with the annotations specified in this config array will be excluded from the check

Example:
our codebase is an Android application, and we're adding a lot of new functions with `@Composable` annotations. These functions tend to have a lot of parameters, and we'd like to specifically exclude these from the check rather than having to suppress each one manually.

