### PR TITLE
Fix broken website due to missing baseurl

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -115,5 +115,6 @@ description: "Meet detekt, a static code analysis tool for Kotlin."
 
 # needed for sitemap.xml file only
 url: https://detekt.dev
+baseurl: /
 
 detekt_version: 1.19.0


### PR DESCRIPTION
After #4544 I realized that I accidentally broke the website links: https://detekt.dev/
That's because removing the `baseUrl` caused it to fallback to a default value. We need to specify instead `/` as `baseUrl`
