### PR TITLE
Fix broken website due to invalid baseurl

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -115,6 +115,6 @@ description: "Meet detekt, a static code analysis tool for Kotlin."
 
 # needed for sitemap.xml file only
 url: https://detekt.dev
-baseurl: /
+baseurl: ""
 
 detekt_version: 1.19.0


### PR DESCRIPTION
Sadly #4557 didn't fix the issue. It seems like that Jekyll when running inside Github Actions is replacing the baseUrl with `pages/detekt/detekt` resulting in a lot of 404 for us. More on this here https://github.com/github/pages-gem/issues/350

The fix seems to be setting the `baseurl` to `""`. I've verified it works correctly on my fork here: https://github.com/cortinico/detekt/commit/38273839263224a0ba045f8ef9fffa3d6a3153f7
