### PR TITLE
Fix: Excludes is not evaluated when includes and excludes both specified

### DIFF
--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/PathFilters.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/PathFilters.kt
@@ -26,10 +26,14 @@ class PathFilters internal constructor(
      *   return false iff [path] matches any [includes] and [path] does not match any [excludes].
      */
     fun isIgnored(path: Path): Boolean {
-        fun isIncluded() = includes?.any { it.matches(path) }
-        fun isExcluded() = excludes?.any { it.matches(path) }
+        val isIncluded = includes?.any { it.matches(path) }
+        val isExcluded = excludes?.any { it.matches(path) }
 
-        return isIncluded()?.not() ?: isExcluded() ?: true
+        return if (isIncluded != null && isExcluded != null) {
+            return !isIncluded || isExcluded
+        } else {
+            isIncluded?.not() ?: isExcluded ?: true
+        }
     }
 
     /**

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/PathFiltersSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/PathFiltersSpec.kt
@@ -47,11 +47,12 @@ class PathFiltersSpec {
 
             @Test
             fun `parses both includes and excludes correctly`() {
-                val pathFilter = PathFilters.of(listOf("**/one/**"), listOf("**/two/**"))
+                val pathFilter = PathFilters.of(listOf("**/one/**"), listOf("**/two/**", "**/one/three/**"))
                 assertThat(pathFilter).isNotNull
                 assertThat(pathFilter?.isIgnored(Paths.get("/one/path"))).isFalse
                 assertThat(pathFilter?.isIgnored(Paths.get("/two/path"))).isTrue
-                assertThat(pathFilter?.isIgnored(Paths.get("/three/path"))).isTrue
+                assertThat(pathFilter?.isIgnored(Paths.get("/one/three/path"))).isTrue
+                assertThat(pathFilter?.isIgnored(Paths.get("/four/path"))).isTrue
             }
         }
 


### PR DESCRIPTION
The comment of `PathFilters#isIgnored` says 

```
If [includes] and [excludes] are both specified, return false iff [path] matches any [includes] and [path] does not match any [excludes].
```

but `excludes` is not evaluated when includes and excludes both specified.