### PR TITLE
Add missing task inputs

### DIFF
--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -37,6 +37,14 @@ testing {
                     )
                 )
             }
+            targets {
+                all {
+                    testTask.configure {
+                        inputs.property("androidSdkRoot", System.getenv("ANDROID_SDK_ROOT")).optional(true)
+                        inputs.property("androidHome", System.getenv("ANDROID_HOME")).optional(true)
+                    }
+                }
+            }
         }
         register("functionalTest", JvmTestSuite::class) {
             useJUnitJupiter(libs.versions.junit.get())


### PR DESCRIPTION
The ANDROID_HOME and ANDROID_SDK_ROOT environment variables are accessed
by the test suite. They need to be registered as task inputs so Gradle's
up-to-date checks work correctly when the environment variable values
change.