### PR TITLE
Enable Gradle's configuration cache by default

### DIFF
--- a/.github/workflows/codecoverage.yaml
+++ b/.github/workflows/codecoverage.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Generate Coverage Report
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: --configuration-cache jacocoMergedReport
+          arguments: jacocoMergedReport
 
       - name: Publish Coverage
         if: success()

--- a/.github/workflows/detekt-with-type-resolution.yaml
+++ b/.github/workflows/detekt-with-type-resolution.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Run detekt-cli with argsfile
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: --configuration-cache :detekt-cli:runWithArgsFile
+          arguments: :detekt-cli:runWithArgsFile
 
       - name: Upload SARIF to Github using the upload-sarif action
         uses: github/codeql-action/upload-sarif@v1
@@ -49,4 +49,4 @@ jobs:
     - name: Run analysis
       uses: gradle/gradle-build-action@v2
       with:
-        arguments: --configuration-cache detektMain detektTest
+        arguments: detektMain detektTest

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -40,11 +40,11 @@ jobs:
     - name: Run detekt-cli --help
       uses: gradle/gradle-build-action@v2
       with:
-        arguments: --configuration-cache :detekt-cli:runWithHelpFlag
+        arguments: :detekt-cli:runWithHelpFlag
     - name: Run detekt-cli with argsfile
       uses: gradle/gradle-build-action@v2
       with:
-        arguments: --configuration-cache :detekt-cli:runWithArgsFile
+        arguments: :detekt-cli:runWithArgsFile
 
   verify-generated-config-file:
     if: ${{ !contains(github.event.head_commit.message, 'ci skip') }}
@@ -76,4 +76,4 @@ jobs:
       - name: Build and compile test snippets
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: --configuration-cache test -x :detekt-gradle-plugin:test -Pcompile-test-snippets=true
+          arguments: test -x :detekt-gradle-plugin:test -Pcompile-test-snippets=true

--- a/build-logic/src/main/kotlin/module.gradle.kts
+++ b/build-logic/src/main/kotlin/module.gradle.kts
@@ -21,6 +21,10 @@ val versionCatalog = project.extensions.getByType<VersionCatalogsExtension>().na
 
 jacoco.toolVersion = versionCatalog.findVersion("jacoco").get().requiredVersion
 
+tasks.withType<PublishToMavenRepository>().configureEach {
+    notCompatibleWithConfigurationCache("https://github.com/gradle/gradle/issues/13468")
+}
+
 tasks.withType<Test>().configureEach {
     useJUnitPlatform()
     systemProperty("spek2.jvm.cg.scan.concurrency", 1) // use one thread for classpath scanning

--- a/detekt-api/build.gradle.kts
+++ b/detekt-api/build.gradle.kts
@@ -33,6 +33,10 @@ tasks.withType<DokkaTask>().configureEach {
     outputDirectory.set(rootDir.resolve("docs/pages/kdoc"))
 }
 
+tasks.dokkaJekyll {
+    notCompatibleWithConfigurationCache("https://github.com/Kotlin/dokka/issues/1217")
+}
+
 apiValidation {
     ignoredPackages.add("io.gitlab.arturbosch.detekt.api.internal")
 }

--- a/detekt-generator/build.gradle.kts
+++ b/detekt-generator/build.gradle.kts
@@ -67,6 +67,7 @@ val generateDocumentation by tasks.registering(JavaExec::class) {
 }
 
 val verifyGeneratorOutput by tasks.registering(Exec::class) {
+    notCompatibleWithConfigurationCache("cannot serialize object of type java.io.ByteArrayOutputStream")
     dependsOn(generateDocumentation)
     description = "Verifies that the default-detekt-config.yml is up-to-date"
     val configDiff = ByteArrayOutputStream()

--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -136,6 +136,10 @@ tasks {
     check {
         dependsOn(testing.suites.named("functionalTest"))
     }
+
+    ideaModule {
+        notCompatibleWithConfigurationCache("https://github.com/gradle/gradle/issues/13480")
+    }
 }
 
 // Skip publishing of test fixture API & runtime variants

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,3 +3,4 @@ systemProp.sonar.host.url=http://localhost:9000
 org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8
+org.gradle.unsafe.configuration-cache=true


### PR DESCRIPTION
Gradle 7.4 introduces a feature to declare that individual tasks are incompatible with the configuration cache, allowing the feature to be enabled by default while skipping caching when there are tasks in the task graph that don't support it.

More information available in "Disable configuration caching when incompatible tasks are executed" section of the release notes: https://docs.gradle.org/7.4/release-notes.html#config-cache

This PR enables the configuration cache while declaring tasks known to be incompatible with it. Note that there may be some additional tasks that are discovered to be incompatible in future, so this config might need tweaking.