### PR TITLE
split rule documentation printer to improve testability

### DIFF
--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/out/Markdown.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/out/Markdown.kt
@@ -4,6 +4,7 @@ package io.gitlab.arturbosch.detekt.generator.out
 
 sealed class Markdown(open var content: String = "") {
     fun append(value: String) {
+        if (value.isEmpty()) return
         content = if (content.isEmpty()) {
             value
         } else {

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/RuleConfigurationPrinter.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/RuleConfigurationPrinter.kt
@@ -1,0 +1,43 @@
+package io.gitlab.arturbosch.detekt.generator.printer
+
+import io.gitlab.arturbosch.detekt.generator.collection.Configuration
+import io.gitlab.arturbosch.detekt.generator.out.bold
+import io.gitlab.arturbosch.detekt.generator.out.code
+import io.gitlab.arturbosch.detekt.generator.out.crossOut
+import io.gitlab.arturbosch.detekt.generator.out.description
+import io.gitlab.arturbosch.detekt.generator.out.h4
+import io.gitlab.arturbosch.detekt.generator.out.item
+import io.gitlab.arturbosch.detekt.generator.out.list
+import io.gitlab.arturbosch.detekt.generator.out.markdown
+
+internal object RuleConfigurationPrinter : DocumentationPrinter<List<Configuration>> {
+
+    override fun print(item: List<Configuration>): String {
+        if (item.isEmpty()) return ""
+        return markdown {
+            h4 { "Configuration options:" }
+            list {
+                item.forEach {
+                    val defaultValues = it.defaultValue.getQuotedIfNecessary()
+                    val defaultAndroidValues = it.defaultAndroidValue?.getQuotedIfNecessary()
+                    val defaultString = if (defaultAndroidValues != null) {
+                        "(default: ${code { defaultValues }}) (android default: ${code { defaultAndroidValues }})"
+                    } else {
+                        "(default: ${code { defaultValues }})"
+                    }
+                    if (it.isDeprecated()) {
+                        item {
+                            crossOut { code { it.name } } + " " + defaultString
+                        }
+                        description { "${bold { "Deprecated" }}: ${it.deprecated}" }
+                    } else {
+                        item {
+                            code { it.name } + " " + defaultString
+                        }
+                    }
+                    description { it.description }
+                }
+            }
+        }
+    }
+}

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/RulePrinter.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/RulePrinter.kt
@@ -1,0 +1,65 @@
+package io.gitlab.arturbosch.detekt.generator.printer
+
+import io.gitlab.arturbosch.detekt.generator.collection.Active
+import io.gitlab.arturbosch.detekt.generator.collection.Rule
+import io.gitlab.arturbosch.detekt.generator.out.MarkdownContent
+import io.gitlab.arturbosch.detekt.generator.out.bold
+import io.gitlab.arturbosch.detekt.generator.out.codeBlock
+import io.gitlab.arturbosch.detekt.generator.out.h3
+import io.gitlab.arturbosch.detekt.generator.out.h4
+import io.gitlab.arturbosch.detekt.generator.out.markdown
+import io.gitlab.arturbosch.detekt.generator.out.paragraph
+
+internal object RulePrinter : DocumentationPrinter<Rule> {
+
+    override fun print(item: Rule): String {
+        return markdown {
+            h3 { item.name }
+
+            if (item.description.isNotEmpty()) {
+                paragraph { item.description }
+            } else {
+                paragraph { "TODO: Specify description" }
+            }
+
+            paragraph {
+                "${bold { "Active by default" }}: ${if (item.defaultActivationStatus.active) "Yes" else "No"}" +
+                    ((item.defaultActivationStatus as? Active)?.let { " - Since v${it.since}" }.orEmpty())
+            }
+
+            if (item.requiresTypeResolution) {
+                paragraph {
+                    bold { "Requires Type Resolution" }
+                }
+            }
+
+            if (item.debt.isNotEmpty()) {
+                paragraph {
+                    "${bold { "Debt" }}: ${item.debt}"
+                }
+            }
+
+            if (!item.aliases.isNullOrEmpty()) {
+                paragraph {
+                    "${bold { "Aliases" }}: ${item.aliases}"
+                }
+            }
+
+            markdown { RuleConfigurationPrinter.print(item.configuration) }
+
+            printRuleCodeExamples(item)
+        }
+    }
+
+    private fun MarkdownContent.printRuleCodeExamples(rule: Rule) {
+        if (rule.nonCompliantCodeExample.isNotEmpty()) {
+            h4 { "Noncompliant Code:" }
+            paragraph { codeBlock { rule.nonCompliantCodeExample } }
+        }
+
+        if (rule.compliantCodeExample.isNotEmpty()) {
+            h4 { "Compliant Code:" }
+            paragraph { codeBlock { rule.compliantCodeExample } }
+        }
+    }
+}

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/RuleSetPagePrinter.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/RuleSetPagePrinter.kt
@@ -1,18 +1,6 @@
 package io.gitlab.arturbosch.detekt.generator.printer
 
-import io.gitlab.arturbosch.detekt.generator.collection.Active
-import io.gitlab.arturbosch.detekt.generator.collection.Rule
 import io.gitlab.arturbosch.detekt.generator.collection.RuleSetPage
-import io.gitlab.arturbosch.detekt.generator.out.MarkdownContent
-import io.gitlab.arturbosch.detekt.generator.out.bold
-import io.gitlab.arturbosch.detekt.generator.out.code
-import io.gitlab.arturbosch.detekt.generator.out.codeBlock
-import io.gitlab.arturbosch.detekt.generator.out.crossOut
-import io.gitlab.arturbosch.detekt.generator.out.description
-import io.gitlab.arturbosch.detekt.generator.out.h3
-import io.gitlab.arturbosch.detekt.generator.out.h4
-import io.gitlab.arturbosch.detekt.generator.out.item
-import io.gitlab.arturbosch.detekt.generator.out.list
 import io.gitlab.arturbosch.detekt.generator.out.markdown
 import io.gitlab.arturbosch.detekt.generator.out.paragraph
 
@@ -26,83 +14,8 @@ object RuleSetPagePrinter : DocumentationPrinter<RuleSetPage> {
                 paragraph { "TODO: Specify description" }
             }
             item.rules.forEach {
-                markdown { printRule(it) }
+                markdown { RulePrinter.print(it) }
             }
-        }
-    }
-
-    private fun printRule(rule: Rule): String {
-        return markdown {
-            h3 { rule.name }
-
-            if (rule.description.isNotEmpty()) {
-                paragraph { rule.description }
-            } else {
-                paragraph { "TODO: Specify description" }
-            }
-
-            paragraph {
-                "${bold { "Active by default" }}: ${if (rule.defaultActivationStatus.active) "Yes" else "No"}" +
-                    ((rule.defaultActivationStatus as? Active)?.let { " - Since v${it.since}" }.orEmpty())
-            }
-
-            if (rule.requiresTypeResolution) {
-                paragraph {
-                    bold { "Requires Type Resolution" }
-                }
-            }
-
-            if (rule.debt.isNotEmpty()) {
-                paragraph {
-                    "${bold { "Debt" }}: ${rule.debt}"
-                }
-            }
-
-            if (!rule.aliases.isNullOrEmpty()) {
-                paragraph {
-                    "${bold { "Aliases" }}: ${rule.aliases}"
-                }
-            }
-
-            if (rule.configuration.isNotEmpty()) {
-                h4 { "Configuration options:" }
-                list {
-                    rule.configuration.forEach {
-                        val defaultValues = it.defaultValue.getQuotedIfNecessary()
-                        val defaultAndroidValues = it.defaultAndroidValue?.getQuotedIfNecessary()
-                        val defaultString = if (defaultAndroidValues != null) {
-                            "(default: ${code { defaultValues }}) (android default: ${code { defaultAndroidValues }})"
-                        } else {
-                            "(default: ${code { defaultValues }})"
-                        }
-                        if (it.isDeprecated()) {
-                            item {
-                                crossOut { code { it.name } } + " " + defaultString
-                            }
-                            description { "${bold { "Deprecated" }}: ${it.deprecated}" }
-                        } else {
-                            item {
-                                code { it.name } + " " + defaultString
-                            }
-                        }
-                        description { it.description }
-                    }
-                }
-            }
-
-            printRuleCodeExamples(rule)
-        }
-    }
-
-    private fun MarkdownContent.printRuleCodeExamples(rule: Rule) {
-        if (rule.nonCompliantCodeExample.isNotEmpty()) {
-            h4 { "Noncompliant Code:" }
-            paragraph { codeBlock { rule.nonCompliantCodeExample } }
-        }
-
-        if (rule.compliantCodeExample.isNotEmpty()) {
-            h4 { "Compliant Code:" }
-            paragraph { codeBlock { rule.compliantCodeExample } }
         }
     }
 }

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/printer/RuleConfigurationPrinterTest.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/printer/RuleConfigurationPrinterTest.kt
@@ -1,0 +1,81 @@
+package io.gitlab.arturbosch.detekt.generator.printer
+
+import io.gitlab.arturbosch.detekt.generator.collection.Configuration
+import io.gitlab.arturbosch.detekt.generator.collection.DefaultValue
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+internal class RuleConfigurationPrinterTest {
+    private val configTemplate = Configuration(
+        name = "configName",
+        description = "config description",
+        defaultValue = DefaultValue.of(true),
+        defaultAndroidValue = null,
+        deprecated = null
+    )
+
+    @Nested
+    inner class DefaultValues {
+        @Test
+        fun `boolean default`() {
+            val config = configTemplate.copy(defaultValue = DefaultValue.of(true))
+            val actual = RuleConfigurationPrinter.print(listOf(config))
+            assertThat(actual).contains("""* ``configName`` (default: ``true``)""")
+        }
+
+        @Test
+        fun `int default`() {
+            val config = configTemplate.copy(defaultValue = DefaultValue.of(99))
+            val actual = RuleConfigurationPrinter.print(listOf(config))
+            assertThat(actual).contains("""* ``configName`` (default: ``99``)""")
+        }
+
+        @Test
+        fun `int default with groupings`() {
+            val config = configTemplate.copy(defaultValue = DefaultValue.of(99_999))
+            val actual = RuleConfigurationPrinter.print(listOf(config))
+            assertThat(actual).contains("""* ``configName`` (default: ``99999``)""")
+        }
+
+        @Test
+        fun `string default`() {
+            val config = configTemplate.copy(defaultValue = DefaultValue.of("abc"))
+            val actual = RuleConfigurationPrinter.print(listOf(config))
+            assertThat(actual).contains("""* ``configName`` (default: ``'abc'``)""")
+        }
+
+        @Test
+        fun `string list default`() {
+            val config = configTemplate.copy(defaultValue = DefaultValue.of(listOf("a", "b", "c")))
+            val actual = RuleConfigurationPrinter.print(listOf(config))
+            assertThat(actual).contains("""* ``configName`` (default: ``['a', 'b', 'c']``)""")
+        }
+
+        @Test
+        fun `with android default`() {
+            val config = configTemplate.copy(
+                defaultValue = DefaultValue.of(99),
+                defaultAndroidValue = DefaultValue.of(100)
+            )
+            val actual = RuleConfigurationPrinter.print(listOf(config))
+            assertThat(actual).contains("""* ``configName`` (default: ``99``) (android default: ``100``)""")
+        }
+    }
+
+    @Nested
+    inner class DeprecatedProperties {
+        private val config = configTemplate.copy(deprecated = "Use something else instead")
+        private val actual = RuleConfigurationPrinter.print(listOf(config))
+
+        @Test
+        fun `contain deprecation information`() {
+            assertThat(actual).contains("""**Deprecated**: Use something else instead""")
+        }
+
+        @Test
+        fun `have strike through`() {
+            assertThat(actual).contains("""~~``configName``~~""")
+        }
+    }
+}

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/printer/RulePrinterTest.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/printer/RulePrinterTest.kt
@@ -1,0 +1,80 @@
+package io.gitlab.arturbosch.detekt.generator.printer
+
+import io.gitlab.arturbosch.detekt.generator.collection.Active
+import io.gitlab.arturbosch.detekt.generator.collection.Inactive
+import io.gitlab.arturbosch.detekt.generator.collection.Rule
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+internal class RulePrinterTest {
+    val ruleTemplate = Rule(
+        name = "RuleName",
+        description = "rule description",
+        nonCompliantCodeExample = "",
+        compliantCodeExample = "",
+        defaultActivationStatus = Inactive,
+        severity = "Defect",
+        debt = "10min",
+        aliases = "alias1, alias2",
+        parent = "",
+    )
+
+    @Test
+    fun `rule name`() {
+        val rule = ruleTemplate.copy(name = "RuleName")
+        val actual = RulePrinter.print(rule)
+        assertThat(actual).contains("""### RuleName""")
+    }
+
+    @Nested
+    inner class ActiveByDefault {
+        @Test
+        fun inactive() {
+            val rule = ruleTemplate.copy(defaultActivationStatus = Inactive)
+            val actual = RulePrinter.print(rule)
+            assertThat(actual).contains("""**Active by default**: No""")
+        }
+
+        @Test
+        fun active() {
+            val rule = ruleTemplate.copy(defaultActivationStatus = Active("1.2.3"))
+            val actual = RulePrinter.print(rule)
+            assertThat(actual).contains("""**Active by default**: Yes - Since v1.2.3""")
+        }
+    }
+
+    @Nested
+    inner class Aliases {
+        @Test
+        fun `no alias`() {
+            val rule = ruleTemplate.copy(aliases = null)
+            val actual = RulePrinter.print(rule)
+            assertThat(actual).doesNotContain("Aliases")
+        }
+
+        @Test
+        fun `with alias`() {
+            val rule = ruleTemplate.copy(aliases = "alias1, alias2")
+            val actual = RulePrinter.print(rule)
+            assertThat(actual).contains("""**Aliases**: alias1, alias2""")
+        }
+    }
+
+    @Nested
+    inner class TypeResolution {
+        @Test
+        fun `no type resolution`() {
+            val rule = ruleTemplate.copy(requiresTypeResolution = false)
+            val actual = RulePrinter.print(rule)
+            assertThat(actual).doesNotContainIgnoringCase("type resolution")
+        }
+
+        @Test
+        fun `with type resolution`() {
+            val rule = ruleTemplate.copy(requiresTypeResolution = true)
+            val actual = RulePrinter.print(rule)
+            assertThat(actual).contains("""**Requires Type Resolution**""")
+        }
+    }
+}

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/printer/RulePrinterTest.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/printer/RulePrinterTest.kt
@@ -28,6 +28,24 @@ internal class RulePrinterTest {
     }
 
     @Nested
+    inner class Description {
+        @Test
+        fun `empty description`() {
+            val rule = ruleTemplate.copy(description = "")
+            val actual = RulePrinter.print(rule)
+            assertThat(actual).contains("TODO: Specify description")
+        }
+
+        @Test
+        fun `with description`() {
+            val description = "This is the description"
+            val rule = ruleTemplate.copy(description = description)
+            val actual = RulePrinter.print(rule)
+            assertThat(actual).contains(description)
+        }
+    }
+
+    @Nested
     inner class ActiveByDefault {
         @Test
         fun inactive() {
@@ -50,7 +68,14 @@ internal class RulePrinterTest {
         fun `no alias`() {
             val rule = ruleTemplate.copy(aliases = null)
             val actual = RulePrinter.print(rule)
-            assertThat(actual).doesNotContain("Aliases")
+            assertThat(actual).doesNotContainIgnoringCase("aliases")
+        }
+
+        @Test
+        fun `empty alias`() {
+            val rule = ruleTemplate.copy(aliases = "")
+            val actual = RulePrinter.print(rule)
+            assertThat(actual).doesNotContainIgnoringCase("aliases")
         }
 
         @Test

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/printer/RuleSetPagePrinterSpec.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/printer/RuleSetPagePrinterSpec.kt
@@ -3,19 +3,15 @@ package io.gitlab.arturbosch.detekt.generator.printer
 import io.github.detekt.test.utils.resource
 import io.gitlab.arturbosch.detekt.generator.util.createRuleSetPage
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import java.io.File
 
 class RuleSetPagePrinterSpec {
 
-    @Nested
-    inner class `Ruleset page printer` {
-        @Test
-        fun `prints the correct markdown format`() {
-            val markdownString = RuleSetPagePrinter.print(createRuleSetPage())
-            val expectedMarkdownString = File(resource("/RuleSet.md")).readText()
-            assertThat(markdownString).isEqualTo(expectedMarkdownString)
-        }
+    @Test
+    fun `prints the correct markdown format`() {
+        val markdownString = RuleSetPagePrinter.print(createRuleSetPage())
+        val expectedMarkdownString = File(resource("/RuleSet.md")).readText()
+        assertThat(markdownString).isEqualTo(expectedMarkdownString)
     }
 }


### PR DESCRIPTION
This improves the testability of the rule config printer in preparation of configuration items with value and reason (#3501).
