### PR TITLE
avoid usage of java stream for parameterized tests

### DIFF
--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/MainSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/MainSpec.kt
@@ -14,8 +14,8 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.Arguments.arguments
 import org.junit.jupiter.params.provider.MethodSource
-import java.util.stream.Stream
 import kotlin.reflect.KClass
 
 class MainSpec {
@@ -23,13 +23,13 @@ class MainSpec {
     @Nested
     inner class `Build runner` {
 
-        fun runnerConfigs(): Stream<Arguments> {
-            return Stream.of(
-                Arguments.of(arrayOf("--generate-config"), ConfigExporter::class),
-                Arguments.of(arrayOf("--run-rule", "RuleSet:Rule"), Runner::class),
-                Arguments.of(arrayOf("--print-ast"), AstPrinter::class),
-                Arguments.of(arrayOf("--version"), VersionPrinter::class),
-                Arguments.of(emptyArray<String>(), Runner::class),
+        fun runnerConfigs(): List<Arguments> {
+            return listOf(
+                arguments(arrayOf("--generate-config"), ConfigExporter::class),
+                arguments(arrayOf("--run-rule", "RuleSet:Rule"), Runner::class),
+                arguments(arrayOf("--print-ast"), AstPrinter::class),
+                arguments(arrayOf("--version"), VersionPrinter::class),
+                arguments(emptyArray<String>(), Runner::class),
             )
         }
 

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/config/DetektYmlConfigSpec.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/config/DetektYmlConfigSpec.kt
@@ -8,21 +8,8 @@ import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.Arguments.arguments
 import org.junit.jupiter.params.provider.MethodSource
 import java.nio.file.Paths
-import java.util.stream.Stream
 
 class DetektYmlConfigSpec {
-
-    private val ruleSetsNamesToPackage: List<Pair<String, String>> = listOf(
-        "complexity" to "io.gitlab.arturbosch.detekt.rules.complexity",
-        "coroutines" to "io.gitlab.arturbosch.detekt.rules.coroutines",
-        "comments" to "io.gitlab.arturbosch.detekt.rules.documentation",
-        "empty-blocks" to "io.gitlab.arturbosch.detekt.rules.empty",
-        "exceptions" to "io.gitlab.arturbosch.detekt.rules.exceptions",
-        "naming" to "io.gitlab.arturbosch.detekt.rules.naming",
-        "performance" to "io.gitlab.arturbosch.detekt.rules.performance",
-        "potential-bugs" to "io.gitlab.arturbosch.detekt.rules.bugs",
-        "style" to "io.gitlab.arturbosch.detekt.rules.style",
-    )
 
     private val generalConfigKeys = listOf(
         "build",
@@ -36,11 +23,20 @@ class DetektYmlConfigSpec {
         Paths.get("../detekt-core/src/main/resources/default-detekt-config.yml").toAbsolutePath()
     ) as YamlConfig
 
-    fun ruleSetsNamesToPackageArguments(): Stream<Arguments> =
-        ruleSetsNamesToPackage.stream().map { arguments(it.first, it.second) }
+    private fun ruleSetsNamesToPackage(): List<Arguments> = listOf(
+        arguments("complexity", "io.gitlab.arturbosch.detekt.rules.complexity"),
+        arguments("coroutines", "io.gitlab.arturbosch.detekt.rules.coroutines"),
+        arguments("comments", "io.gitlab.arturbosch.detekt.rules.documentation"),
+        arguments("empty-blocks", "io.gitlab.arturbosch.detekt.rules.empty"),
+        arguments("exceptions", "io.gitlab.arturbosch.detekt.rules.exceptions"),
+        arguments("naming", "io.gitlab.arturbosch.detekt.rules.naming"),
+        arguments("performance", "io.gitlab.arturbosch.detekt.rules.performance"),
+        arguments("potential-bugs", "io.gitlab.arturbosch.detekt.rules.bugs"),
+        arguments("style", "io.gitlab.arturbosch.detekt.rules.style"),
+    )
 
     @ParameterizedTest
-    @MethodSource("ruleSetsNamesToPackageArguments")
+    @MethodSource("ruleSetsNamesToPackage")
     fun `section is valid`(name: String, packageName: String) {
         ConfigAssert(config, name, packageName).assert()
     }
@@ -54,7 +50,7 @@ class DetektYmlConfigSpec {
 
     @Test
     fun `is completely checked`() {
-        val checkedRuleSetNames = ruleSetsNamesToPackage.map { it.first }
+        val checkedRuleSetNames = ruleSetsNamesToPackage().map { it.get()[0] as String }
 
         val topLevelConfigKeys = config.properties.keys
 


### PR DESCRIPTION
This removes the usage of java.util.Stream in parameterized tests.
