### PR TITLE
Housekeep Gradle scripts

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,19 +17,12 @@ allprojects {
     detekt {
         source = objects.fileCollection().from(
             io.gitlab.arturbosch.detekt.extensions.DetektExtension.DEFAULT_SRC_DIR_JAVA,
-            "src/test/java",
+            io.gitlab.arturbosch.detekt.extensions.DetektExtension.DEFAULT_TEST_SRC_DIR_JAVA,
             io.gitlab.arturbosch.detekt.extensions.DetektExtension.DEFAULT_SRC_DIR_KOTLIN,
-            "src/test/kotlin"
+            io.gitlab.arturbosch.detekt.extensions.DetektExtension.DEFAULT_TEST_SRC_DIR_KOTLIN,
         )
         buildUponDefaultConfig = true
         baseline = file("$rootDir/config/detekt/baseline.xml")
-
-        reports {
-            xml.enabled = true
-            html.enabled = true
-            txt.enabled = true
-            sarif.enabled = true
-        }
     }
 
     dependencies {
@@ -40,6 +33,12 @@ allprojects {
 
     tasks.withType<Detekt>().configureEach {
         jvmTarget = "1.8"
+        reports {
+            xml.required.set(true)
+            html.required.set(true)
+            txt.required.set(true)
+            sarif.required.set(true)
+        }
     }
     tasks.withType<DetektCreateBaselineTask>().configureEach {
         jvmTarget = "1.8"
@@ -70,9 +69,9 @@ val detektFormat by tasks.registering(Detekt::class) {
     exclude(buildFiles)
     baseline.set(baselineFile)
     reports {
-        xml.enabled = false
-        html.enabled = false
-        txt.enabled = false
+        xml.required.set(false)
+        html.required.set(false)
+        txt.required.set(false)
     }
 }
 
@@ -88,9 +87,9 @@ val detektAll by tasks.registering(Detekt::class) {
     exclude(buildFiles)
     baseline.set(baselineFile)
     reports {
-        xml.enabled = false
-        html.enabled = false
-        txt.enabled = false
+        xml.required.set(false)
+        html.required.set(false)
+        txt.required.set(false)
     }
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,38 +4,36 @@ pluginManagement {
     includeBuild("build-logic")
 }
 
-include(
-    "code-coverage-report",
-    "custom-checks",
-    "detekt-api",
-    "detekt-cli",
-    "detekt-core",
-    "detekt-formatting",
-    "detekt-generator",
-    "detekt-gradle-plugin",
-    "detekt-metrics",
-    "detekt-parser",
-    "detekt-psi-utils",
-    "detekt-report-html",
-    "detekt-report-sarif",
-    "detekt-report-txt",
-    "detekt-report-xml",
-    "detekt-rules",
-    "detekt-rules-complexity",
-    "detekt-rules-coroutines",
-    "detekt-rules-documentation",
-    "detekt-rules-empty",
-    "detekt-rules-errorprone",
-    "detekt-rules-exceptions",
-    "detekt-rules-naming",
-    "detekt-rules-performance",
-    "detekt-rules-style",
-    "detekt-sample-extensions",
-    "detekt-test",
-    "detekt-test-utils",
-    "detekt-tooling",
-    "detekt-utils",
-)
+include("code-coverage-report")
+include("custom-checks")
+include("detekt-api")
+include("detekt-cli")
+include("detekt-core")
+include("detekt-formatting")
+include("detekt-generator")
+include("detekt-gradle-plugin")
+include("detekt-metrics")
+include("detekt-parser")
+include("detekt-psi-utils")
+include("detekt-report-html")
+include("detekt-report-sarif")
+include("detekt-report-txt")
+include("detekt-report-xml")
+include("detekt-rules")
+include("detekt-rules-complexity")
+include("detekt-rules-coroutines")
+include("detekt-rules-documentation")
+include("detekt-rules-empty")
+include("detekt-rules-errorprone")
+include("detekt-rules-exceptions")
+include("detekt-rules-naming")
+include("detekt-rules-performance")
+include("detekt-rules-style")
+include("detekt-sample-extensions")
+include("detekt-test")
+include("detekt-test-utils")
+include("detekt-tooling")
+include("detekt-utils")
 
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,36 +4,38 @@ pluginManagement {
     includeBuild("build-logic")
 }
 
-include("code-coverage-report")
-include("custom-checks")
-include("detekt-api")
-include("detekt-cli")
-include("detekt-core")
-include("detekt-formatting")
-include("detekt-generator")
-include("detekt-gradle-plugin")
-include("detekt-metrics")
-include("detekt-parser")
-include("detekt-psi-utils")
-include("detekt-report-html")
-include("detekt-report-sarif")
-include("detekt-report-txt")
-include("detekt-report-xml")
-include("detekt-rules")
-include("detekt-rules-complexity")
-include("detekt-rules-coroutines")
-include("detekt-rules-documentation")
-include("detekt-rules-empty")
-include("detekt-rules-errorprone")
-include("detekt-rules-exceptions")
-include("detekt-rules-naming")
-include("detekt-rules-performance")
-include("detekt-rules-style")
-include("detekt-sample-extensions")
-include("detekt-test")
-include("detekt-test-utils")
-include("detekt-tooling")
-include("detekt-utils")
+include(
+    "code-coverage-report",
+    "custom-checks",
+    "detekt-api",
+    "detekt-cli",
+    "detekt-core",
+    "detekt-formatting",
+    "detekt-generator",
+    "detekt-gradle-plugin",
+    "detekt-metrics",
+    "detekt-parser",
+    "detekt-psi-utils",
+    "detekt-report-html",
+    "detekt-report-sarif",
+    "detekt-report-txt",
+    "detekt-report-xml",
+    "detekt-rules",
+    "detekt-rules-complexity",
+    "detekt-rules-coroutines",
+    "detekt-rules-documentation",
+    "detekt-rules-empty",
+    "detekt-rules-errorprone",
+    "detekt-rules-exceptions",
+    "detekt-rules-naming",
+    "detekt-rules-performance",
+    "detekt-rules-style",
+    "detekt-sample-extensions",
+    "detekt-test",
+    "detekt-test-utils",
+    "detekt-tooling",
+    "detekt-utils",
+)
 
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 


### PR DESCRIPTION
- Move our own Gradle scripts to the new reporting configuration API.
- Use Constants defined in `DetektExtension`