### PR TITLE
NamedArguments: Ignore when argument values are the same as the parameter name

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -129,6 +129,7 @@ complexity:
   NamedArguments:
     active: false
     threshold: 3
+    ignoreArgumentsMatchingNames: false
   NestedBlockDepth:
     active: true
     threshold: 4

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NamedArgumentsSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NamedArgumentsSpec.kt
@@ -200,5 +200,53 @@ class NamedArgumentsSpec(val env: KotlinCoreEnvironment) {
                 assertThat(findings).hasSize(1)
             }
         }
+
+        @Nested
+        inner class IgnoreArgumentsMatchingNames {
+            @Nested
+            inner class `ignoreArgumentsMatchingNames is true` {
+                val subject =
+                    NamedArguments(TestConfig(mapOf("threshold" to 2, "ignoreArgumentsMatchingNames" to true)))
+
+                @Test
+                fun `all arguments are the same as the parameter names`() {
+                    val code = """
+                        fun foo(a: Int, b: Int, c: Int) {}
+                        fun bar(a: Int, b: Int, c: Int) {
+                            foo(a, b, c)
+                        }
+                    """
+                    val findings = subject.compileAndLintWithContext(env, code)
+                    assertThat(findings).hasSize(0)
+                }
+
+                @Test
+                fun `some arguments are not the same as the parameter names`() {
+                    val code = """
+                        fun foo(a: Int, b: Int, c: Int) {}
+                        fun bar(a: Int, b: Int, c: Int) {
+                            foo(a, c, b)
+                        }
+                    """
+                    val findings = subject.compileAndLintWithContext(env, code)
+                    assertThat(findings).hasSize(1)
+                }
+            }
+
+            @Nested
+            inner class `ignoreArgumentsMatchingNames is false` {
+                @Test
+                fun `all arguments are the same as parameter names`() {
+                    val code = """
+                        fun foo(a: Int, b: Int, c: Int) {}
+                        fun bar(a: Int, b: Int, c: Int) {
+                            foo(a, b, c)
+                        }
+                    """
+                    val findings = subject.compileAndLintWithContext(env, code)
+                    assertThat(findings).hasSize(1)
+                }
+            }
+        }
     }
 }

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NamedArgumentsSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NamedArgumentsSpec.kt
@@ -231,6 +231,34 @@ class NamedArgumentsSpec(val env: KotlinCoreEnvironment) {
                     val findings = subject.compileAndLintWithContext(env, code)
                     assertThat(findings).hasSize(1)
                 }
+
+                @Test
+                fun `all arguments are the same as the parameter names and have a this receiver`() {
+                    val code = """
+                        class Baz {
+                            private var b: Int = 42
+                            fun foo(a: Int, b: Int, c: Int) {}
+                            fun bar(a: Int, c: Int) {
+                                foo(a, this.b, c)
+                            }
+                        }
+                    """
+                    val findings = subject.compileAndLintWithContext(env, code)
+                    assertThat(findings).hasSize(1)
+                }
+
+                @Test
+                fun `all arguments are the same as the parameter names and have a it receiver`() {
+                    val code = """
+                        data class Baz(val b: Int)
+                        fun foo(a: Int, b: Int, c: Int) {}
+                        fun bar(a: Int, c: Int, baz: Baz?) {
+                            baz?.let { foo(a, it.b, c) }
+                        }
+                    """
+                    val findings = subject.compileAndLintWithContext(env, code)
+                    assertThat(findings).hasSize(1)
+                }
             }
 
             @Nested


### PR DESCRIPTION
Fixes #4591