### PR TITLE
Bump KtLint to 0.44.0 and add UnnecessaryParenthesesBeforeTrailingLamda rule

### DIFF
--- a/custom-checks/src/test/kotlin/io/github/detekt/custom/SpekTestDiscoverySpec.kt
+++ b/custom-checks/src/test/kotlin/io/github/detekt/custom/SpekTestDiscoverySpec.kt
@@ -26,7 +26,7 @@ class SpekTestDiscoverySpec(private val env: KotlinCoreEnvironment) {
                     val s = "simple"
                     val p = Paths.get("")
                     val f = File("")
-                """
+                    """
                 )
 
                 assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()

--- a/detekt-core/src/main/resources/deprecation.properties
+++ b/detekt-core/src/main/resources/deprecation.properties
@@ -8,3 +8,4 @@ style>UnderscoresInNumericLiterals>acceptableDecimalLength=Use `acceptableLength
 style>UnnecessaryAbstractClass>excludeAnnotatedClasses=Use `ignoreAnnotated` instead
 style>UseDataClass>excludeAnnotatedClasses=Use `ignoreAnnotated` instead
 formatting>Indentation>continuationIndentSize=`continuationIndentSize` is ignored by KtLint and will have no effect
+formatting>ParameterListWrapping>indentSize=`indentSize` is ignored by KtLint and will have no effect

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/SuppressionSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/SuppressionSpec.kt
@@ -170,7 +170,7 @@ class SuppressionSpec {
                     println("FAILED TEST")
                 }
             }
-            """
+                """
             )
             val rule = TestRule()
             rule.visitFile(ktFile)
@@ -188,7 +188,7 @@ class SuppressionSpec {
                     println("FAILED TEST")
                 }
             }
-            """
+                """
             )
             val rule = TestRule()
             rule.visitFile(ktFile)
@@ -206,7 +206,7 @@ class SuppressionSpec {
                     println("FAILED TEST")
                 }
             }
-            """
+                """
             )
             val rule = TestRule()
             rule.visitFile(ktFile)
@@ -228,7 +228,7 @@ class SuppressionSpec {
                     println("FAILED TEST")
                 }
             }
-            """
+                """
             )
             val rule = TestRule(TestConfig(mutableMapOf("aliases" to "[MyTest]")))
             rule.visitFile(ktFile)
@@ -314,7 +314,7 @@ private fun isSuppressedBy(annotation: String, argument: String): Boolean {
     val annotated = """
             @$annotation("$argument")
             class Test
-        """
+    """
     val file = compileContentForTest(annotated)
     val annotatedClass = file.children.first { it is KtClass } as KtAnnotated
     return annotatedClass.isSuppressedBy("Test", setOf("alias"))

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/CheckConfigurationSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/CheckConfigurationSpec.kt
@@ -37,7 +37,7 @@ class SupportConfigValidationSpec {
                 my_additional_properties:
                   magic_number: 7
                   magic_string: 'Hello World'
-            """
+                """
             )
             createProcessingSettings(testDir, config).use {
                 assertThatCode { checkConfiguration(it, spec.getDefaultConfiguration()) }
@@ -56,7 +56,7 @@ class SupportConfigValidationSpec {
                   TooManyFunctions:
                     # This property is tested via the SampleConfigValidator
                     active: 1 # should be true
-            """
+                """
             )
             createProcessingSettings(testDir, config).use {
                 assertThatCode { checkConfiguration(it, spec.getDefaultConfiguration()) }
@@ -86,7 +86,7 @@ class SupportConfigValidationSpec {
                my_additional_properties:
                  magic_number: 7
                  magic_string: 'Hello World'
-            """
+                """
             )
             createProcessingSettings(testDir, config).use {
                 assertThatCode { checkConfiguration(it, spec.getDefaultConfiguration()) }

--- a/detekt-formatting/build.gradle.kts
+++ b/detekt-formatting/build.gradle.kts
@@ -24,7 +24,6 @@ tasks.build { finalizedBy(":detekt-generator:generateDocumentation") }
 val depsToPackage = setOf(
     "org.ec4j.core",
     "com.pinterest.ktlint",
-    "com.pinterest.ktlint",
     "io.github.microutils",
     "org.slf4j",
 )

--- a/detekt-formatting/build.gradle.kts
+++ b/detekt-formatting/build.gradle.kts
@@ -13,6 +13,7 @@ dependencies {
     implementation(libs.ktlint.rulesetExperimental) {
         exclude(group = "org.jetbrains.kotlin")
     }
+    implementation(libs.ktlint.microutilsKotlinLoggingJvm)
 
     testImplementation(projects.detektTest)
     testImplementation(libs.assertj)
@@ -22,7 +23,10 @@ tasks.build { finalizedBy(":detekt-generator:generateDocumentation") }
 
 val depsToPackage = setOf(
     "org.ec4j.core",
-    "com.pinterest.ktlint"
+    "com.pinterest.ktlint",
+    "com.pinterest.ktlint",
+    "io.github.microutils",
+    "org.slf4j",
 )
 
 tasks.jar {

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingRule.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingRule.kt
@@ -1,5 +1,7 @@
 package io.gitlab.arturbosch.detekt.formatting
 
+import com.pinterest.ktlint.core.Rule.VisitorModifier.RunAsLateAsPossible
+import com.pinterest.ktlint.core.Rule.VisitorModifier.RunOnRootNodeOnly
 import com.pinterest.ktlint.core.KtLint
 import com.pinterest.ktlint.core.api.FeatureInAlphaState
 import com.pinterest.ktlint.core.api.UsesEditorConfigProperties
@@ -36,6 +38,12 @@ abstract class FormattingRule(config: Config) : Rule(config) {
      */
     protected val isAndroid
         get() = FormattingProvider.android.value(ruleSetConfig)
+
+    val runOnRootNodeOnly
+        get() = RunOnRootNodeOnly in wrapping.visitorModifiers
+
+    val runAsLateAsPossible
+        get() = RunAsLateAsPossible in wrapping.visitorModifiers
 
     private var positionByOffset: (offset: Int) -> Pair<Int, Int> by SingleAssign()
     private var root: KtFile by SingleAssign()

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingRule.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingRule.kt
@@ -1,8 +1,8 @@
 package io.gitlab.arturbosch.detekt.formatting
 
+import com.pinterest.ktlint.core.KtLint
 import com.pinterest.ktlint.core.Rule.VisitorModifier.RunAsLateAsPossible
 import com.pinterest.ktlint.core.Rule.VisitorModifier.RunOnRootNodeOnly
-import com.pinterest.ktlint.core.KtLint
 import com.pinterest.ktlint.core.api.FeatureInAlphaState
 import com.pinterest.ktlint.core.api.UsesEditorConfigProperties
 import io.github.detekt.psi.fileName
@@ -110,5 +110,5 @@ abstract class FormattingRule(config: Config) : Rule(config) {
         TextLocation(node.startOffset, node.psi.endOffset)
 
     private fun ruleShouldOnlyRunOnFileNode(node: ASTNode) =
-        wrapping is com.pinterest.ktlint.core.Rule.Modifier.RestrictToRoot && node !is FileASTNode
+        runOnRootNodeOnly && node !is FileASTNode
 }

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingRule.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingRule.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.formatting
 
+import com.pinterest.ktlint.core.EditorConfig.Companion.fromMap
 import com.pinterest.ktlint.core.KtLint
 import com.pinterest.ktlint.core.Rule.VisitorModifier.RunAsLateAsPossible
 import com.pinterest.ktlint.core.Rule.VisitorModifier.RunOnRootNodeOnly
@@ -85,6 +86,13 @@ abstract class FormattingRule(config: Config) : Rule(config) {
         if (ruleShouldOnlyRunOnFileNode(node)) {
             return
         }
+
+        // KtLint 0.44.0 is assuming that KtLint.EDITOR_CONFIG_USER_DATA_KEY is available on all the nodes.
+        // If not, it crashes with a NPE. Here we're patching their behavior.
+        if (node.getUserData(KtLint.EDITOR_CONFIG_USER_DATA_KEY) == null) {
+            node.putUserData(KtLint.EDITOR_CONFIG_USER_DATA_KEY, fromMap(emptyMap()))
+        }
+
         wrapping.visit(node, autoCorrect) { offset, message, _ ->
             val (line, column) = positionByOffset(offset)
             val location = Location(

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/KtLintMultiRule.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/KtLintMultiRule.kt
@@ -48,6 +48,7 @@ import io.gitlab.arturbosch.detekt.formatting.wrappers.SpacingBetweenDeclaration
 import io.gitlab.arturbosch.detekt.formatting.wrappers.SpacingBetweenDeclarationsWithComments
 import io.gitlab.arturbosch.detekt.formatting.wrappers.StringTemplate
 import io.gitlab.arturbosch.detekt.formatting.wrappers.TrailingComma
+import io.gitlab.arturbosch.detekt.formatting.wrappers.UnnecessaryParenthesesBeforeTrailingLambda
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.JavaDummyElement
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.JavaDummyHolder
@@ -105,6 +106,7 @@ class KtLintMultiRule(config: Config = Config.empty) : MultiRule() {
         SpacingBetweenDeclarationsWithAnnotations(config),
         SpacingBetweenDeclarationsWithComments(config),
         TrailingComma(config),
+        UnnecessaryParenthesesBeforeTrailingLambda(config),
     )
 
     override fun visit(root: KtFile) {

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/KtLintMultiRule.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/KtLintMultiRule.kt
@@ -1,6 +1,5 @@
 package io.gitlab.arturbosch.detekt.formatting
 
-import com.pinterest.ktlint.core.ast.isRoot
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.MultiRule
 import io.gitlab.arturbosch.detekt.api.Rule
@@ -111,11 +110,7 @@ class KtLintMultiRule(config: Config = Config.empty) : MultiRule() {
         val sortedRules = getSortedRules()
         sortedRules.forEach { it.visit(root) }
         root.node.visitTokens { node ->
-            sortedRules.forEach { rule ->
-                if (!rule.runOnRootNodeOnly || rule.runOnRootNodeOnly && node.isRoot()) {
-                    rule.apply(node)
-                }
-            }
+            sortedRules.forEach { it.apply(node) }
         }
     }
 

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/ParameterListWrapping.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/ParameterListWrapping.kt
@@ -21,14 +21,10 @@ class ParameterListWrapping(config: Config) : FormattingRule(config) {
     override val wrapping = ParameterListWrappingRule()
     override val issue = issueFor("Detects mis-aligned parameter lists")
 
-    @Configuration("indentation size")
-    private val indentSize by config(4)
-
     @Configuration("maximum line length")
     private val maxLineLength: Int by configWithAndroidVariants(120, 100)
 
     override fun overrideEditorConfig() = mapOf(
-        INDENT_SIZE_KEY to indentSize,
         MAX_LINE_LENGTH_KEY to maxLineLength
     )
 }

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/ParameterListWrapping.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/ParameterListWrapping.kt
@@ -2,13 +2,11 @@ package io.gitlab.arturbosch.detekt.formatting.wrappers
 
 import com.pinterest.ktlint.ruleset.standard.ParameterListWrappingRule
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.config
 import io.gitlab.arturbosch.detekt.api.configWithAndroidVariants
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
 import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.api.internal.Configuration
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
-import io.gitlab.arturbosch.detekt.formatting.INDENT_SIZE_KEY
 import io.gitlab.arturbosch.detekt.formatting.MAX_LINE_LENGTH_KEY
 
 /**

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/ParameterListWrapping.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/ParameterListWrapping.kt
@@ -2,6 +2,7 @@ package io.gitlab.arturbosch.detekt.formatting.wrappers
 
 import com.pinterest.ktlint.ruleset.standard.ParameterListWrappingRule
 import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.config
 import io.gitlab.arturbosch.detekt.api.configWithAndroidVariants
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
 import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
@@ -21,6 +22,11 @@ class ParameterListWrapping(config: Config) : FormattingRule(config) {
 
     @Configuration("maximum line length")
     private val maxLineLength: Int by configWithAndroidVariants(120, 100)
+
+    @Configuration("indentation size")
+    @Deprecated("`indentSize` is ignored by KtLint and will have no effect")
+    @Suppress("UnusedPrivateMember")
+    private val indentSize by config(4)
 
     override fun overrideEditorConfig() = mapOf(
         MAX_LINE_LENGTH_KEY to maxLineLength

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/UnnecessaryParenthesesBeforeTrailingLambda.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/UnnecessaryParenthesesBeforeTrailingLambda.kt
@@ -1,0 +1,18 @@
+package io.gitlab.arturbosch.detekt.formatting.wrappers
+
+import com.pinterest.ktlint.core.api.FeatureInAlphaState
+import com.pinterest.ktlint.ruleset.experimental.UnnecessaryParenthesesBeforeTrailingLambdaRule
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
+import io.gitlab.arturbosch.detekt.formatting.FormattingRule
+
+/**
+ * See <a href="https://ktlint.github.io/#rule-spacing">ktlint-website</a> for documentation.
+ */
+@OptIn(FeatureInAlphaState::class)
+@AutoCorrectable(since = "1.20.0")
+class UnnecessaryParenthesesBeforeTrailingLambda(config: Config) : FormattingRule(config) {
+
+    override val wrapping = UnnecessaryParenthesesBeforeTrailingLambdaRule()
+    override val issue = issueFor("Ensures there are no unnecessary parentheses before a trailing lambda")
+}

--- a/detekt-formatting/src/main/resources/config/config.yml
+++ b/detekt-formatting/src/main/resources/config/config.yml
@@ -87,7 +87,6 @@ formatting:
   ParameterListWrapping:
     active: true
     autoCorrect: true
-    indentSize: 4
     maxLineLength: 120
   SpacingAroundAngleBrackets:
     active: false

--- a/detekt-formatting/src/main/resources/config/config.yml
+++ b/detekt-formatting/src/main/resources/config/config.yml
@@ -136,3 +136,6 @@ formatting:
     autoCorrect: true
     allowTrailingComma: false
     allowTrailingCommaOnCallSite: false
+  UnnecessaryParenthesesBeforeTrailingLambda:
+    active: false
+    autoCorrect: true

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/FinalNewlineSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/FinalNewlineSpec.kt
@@ -26,7 +26,7 @@ class FinalNewlineSpec {
                 """
                     fun main() = Unit
 
-            """
+                """
             )
 
             assertThat(findings).isEmpty()
@@ -39,7 +39,7 @@ class FinalNewlineSpec {
                     """
                 fun main() = Unit
 
-            """
+                    """
                 )
 
             assertThat(findings).hasSize(1)

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingRuleSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingRuleSpec.kt
@@ -85,7 +85,7 @@ class FormattingRuleSpec {
             """
                 fun main()
                 = Unit
-                """,
+            """,
             expectedPath
         )
 

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/IndentationSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/IndentationSpec.kt
@@ -54,5 +54,26 @@ class IndentationSpec {
             val code = "fun main() {\n    println()\n}"
             assertThat(subject.lint(code)).isEmpty()
         }
+
+        @Nested
+        inner class `parameter list indent size equals 1` {
+
+            val code = """
+                fun f(
+                 a: Int
+                ) {}
+            """.trimIndent()
+
+            @Test
+            fun `reports wrong indent size`() {
+                assertThat(subject.lint(code)).hasSize(1)
+            }
+
+            @Test
+            fun `does not report when using an indentation level config of 1`() {
+                val config = TestConfig("indentSize" to "1")
+                assertThat(Indentation(config).lint(code)).isEmpty()
+            }
+        }
     }
 }

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/KtLintMultiRuleSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/KtLintMultiRuleSpec.kt
@@ -1,8 +1,5 @@
 package io.gitlab.arturbosch.detekt.formatting
 
-import com.pinterest.ktlint.core.Rule.Modifier.Last
-import com.pinterest.ktlint.core.Rule.Modifier.RestrictToRoot
-import com.pinterest.ktlint.core.Rule.Modifier.RestrictToRootLast
 import io.github.detekt.test.utils.compileContentForTest
 import io.gitlab.arturbosch.detekt.api.Config
 import org.assertj.core.api.Assertions.assertThat
@@ -20,15 +17,15 @@ class KtLintMultiRuleSpec {
             ktlintRule.visitFile(compileContentForTest(""))
             val sortedRules = ktlintRule.getSortedRules()
             assertThat(sortedRules).isNotEmpty
-            assertThat(sortedRules.indexOfFirst { it.wrapping is RestrictToRoot })
+            assertThat(sortedRules.indexOfFirst { it.runOnRootNodeOnly })
                 .isGreaterThan(-1)
-                .isLessThan(sortedRules.indexOfFirst { it.wrapping !is RestrictToRoot })
-            assertThat(sortedRules.indexOfFirst { it.wrapping !is RestrictToRoot })
+                .isLessThan(sortedRules.indexOfFirst { !it.runOnRootNodeOnly })
+            assertThat(sortedRules.indexOfFirst { !it.runOnRootNodeOnly })
                 .isGreaterThan(-1)
-                .isLessThan(sortedRules.indexOfFirst { it.wrapping is RestrictToRootLast })
-            assertThat(sortedRules.indexOfFirst { it.wrapping is RestrictToRootLast })
+                .isLessThan(sortedRules.indexOfFirst { it.runOnRootNodeOnly && it.runAsLateAsPossible})
+            assertThat(sortedRules.indexOfFirst { it.runOnRootNodeOnly && it.runAsLateAsPossible })
                 .isGreaterThan(-1)
-                .isLessThan(sortedRules.indexOfFirst { it.wrapping is Last })
+                .isLessThan(sortedRules.indexOfFirst { it.runAsLateAsPossible && !it.runOnRootNodeOnly })
         }
     }
 }

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/KtLintMultiRuleSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/KtLintMultiRuleSpec.kt
@@ -22,7 +22,7 @@ class KtLintMultiRuleSpec {
                 .isLessThan(sortedRules.indexOfFirst { !it.runOnRootNodeOnly })
             assertThat(sortedRules.indexOfFirst { !it.runOnRootNodeOnly })
                 .isGreaterThan(-1)
-                .isLessThan(sortedRules.indexOfFirst { it.runOnRootNodeOnly && it.runAsLateAsPossible})
+                .isLessThan(sortedRules.indexOfFirst { it.runOnRootNodeOnly && it.runAsLateAsPossible })
             assertThat(sortedRules.indexOfFirst { it.runOnRootNodeOnly && it.runAsLateAsPossible })
                 .isGreaterThan(-1)
                 .isLessThan(sortedRules.indexOfFirst { it.runAsLateAsPossible && !it.runOnRootNodeOnly })

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/ParameterListWrappingSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/ParameterListWrappingSpec.kt
@@ -20,27 +20,6 @@ class ParameterListWrappingSpec {
     @Nested
     inner class `ParameterListWrapping rule` {
 
-        @Nested
-        inner class `indent size equals 1` {
-
-            val code = """
-                fun f(
-                 a: Int
-                ) {}
-            """.trimIndent()
-
-            @Test
-            fun `reports wrong indent size`() {
-                assertThat(subject.lint(code)).hasSize(1)
-            }
-
-            @Test
-            fun `does not report when using an indentation level config of 1`() {
-                val config = TestConfig("indentSize" to "1")
-                assertThat(ParameterListWrapping(config).lint(code)).isEmpty()
-            }
-        }
-
         @Test
         fun `does not report correct ParameterListWrapping level`() {
             val code = """

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/TestFiles.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/TestFiles.kt
@@ -1,6 +1,5 @@
 package io.gitlab.arturbosch.detekt.formatting
 
-import com.pinterest.ktlint.core.ast.isRoot
 import com.pinterest.ktlint.core.ast.visit
 import io.github.detekt.test.utils.compileContentForTest
 import io.github.detekt.test.utils.compileForTest
@@ -11,14 +10,13 @@ import org.jetbrains.kotlin.com.intellij.openapi.util.text.StringUtilRt
 import java.io.File
 import java.nio.file.Paths
 
-fun FormattingRule.lint(@Language("kotlin") content: String, fileName: String = "Test.kt"): List<Finding> {
+fun FormattingRule.lint(
+    @Language("kotlin") content: String,
+    fileName: String = "Test.kt"
+): List<Finding> {
     val root = compileContentForTest(content, fileName)
     this.visit(root)
-    root.node.visit { node ->
-        if(!runOnRootNodeOnly || runOnRootNodeOnly && node.isRoot()) {
-            this.apply(node)
-        }
-    }
+    root.node.visit { node -> this.apply(node) }
     return this.findings
 }
 

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/TestFiles.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/TestFiles.kt
@@ -10,10 +10,7 @@ import org.jetbrains.kotlin.com.intellij.openapi.util.text.StringUtilRt
 import java.io.File
 import java.nio.file.Paths
 
-fun FormattingRule.lint(
-    @Language("kotlin") content: String,
-    fileName: String = "Test.kt"
-): List<Finding> {
+fun FormattingRule.lint(@Language("kotlin") content: String, fileName: String = "Test.kt"): List<Finding> {
     val root = compileContentForTest(content, fileName)
     this.visit(root)
     root.node.visit { node -> this.apply(node) }

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/TestFiles.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/TestFiles.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.formatting
 
+import com.pinterest.ktlint.core.ast.isRoot
 import com.pinterest.ktlint.core.ast.visit
 import io.github.detekt.test.utils.compileContentForTest
 import io.github.detekt.test.utils.compileForTest
@@ -13,7 +14,11 @@ import java.nio.file.Paths
 fun FormattingRule.lint(@Language("kotlin") content: String, fileName: String = "Test.kt"): List<Finding> {
     val root = compileContentForTest(content, fileName)
     this.visit(root)
-    root.node.visit { node -> this.apply(node) }
+    root.node.visit { node ->
+        if(!runOnRootNodeOnly || runOnRootNodeOnly && node.isRoot()) {
+            this.apply(node)
+        }
+    }
     return this.findings
 }
 

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/UnnecessaryParenthesesBeforeTrailingLambdaSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/UnnecessaryParenthesesBeforeTrailingLambdaSpec.kt
@@ -1,0 +1,32 @@
+package io.gitlab.arturbosch.detekt.formatting
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.formatting.wrappers.UnnecessaryParenthesesBeforeTrailingLambda
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class UnnecessaryParenthesesBeforeTrailingLambdaSpec {
+
+    @Nested
+    inner class `UnnecessaryParenthesesBeforeTrailingLambda rule` {
+
+        @Test
+        fun `reports unnecessary parentheses before trailing lambda`() {
+            val code = """
+                fun countDash(input: String) =
+                    "some-string".count() { it == '-' }
+            """.trimIndent()
+            assertThat(UnnecessaryParenthesesBeforeTrailingLambda(Config.empty).lint(code)).hasSize(1)
+        }
+
+        @Test
+        fun `does not report unnecessary parentheses before trailing lambda`() {
+            val code = """
+                fun countDash(input: String) =
+                    "some-string".count { it == '-' }
+            """.trimIndent()
+            assertThat(UnnecessaryParenthesesBeforeTrailingLambda(Config.empty).lint(code)).isEmpty()
+        }
+    }
+}

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/UnnecessaryParenthesesBeforeTrailingLambdaSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/UnnecessaryParenthesesBeforeTrailingLambdaSpec.kt
@@ -3,30 +3,30 @@ package io.gitlab.arturbosch.detekt.formatting
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.formatting.wrappers.UnnecessaryParenthesesBeforeTrailingLambda
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
+/**
+ * Test cases were used directly from KtLint to verify the wrapper rule:
+ *
+ * https://github.com/pinterest/ktlint/blob/master/ktlint-ruleset-experimental/src/test/kotlin/com/pinterest/ktlint/ruleset/experimental/UnnecessaryParenthesesBeforeTrailingLambdaRuleTest.kt
+ */
 class UnnecessaryParenthesesBeforeTrailingLambdaSpec {
 
-    @Nested
-    inner class `UnnecessaryParenthesesBeforeTrailingLambda rule` {
+    @Test
+    fun `reports unnecessary parentheses before trailing lambda`() {
+        val code = """
+            fun countDash(input: String) =
+                "some-string".count() { it == '-' }
+        """.trimIndent()
+        assertThat(UnnecessaryParenthesesBeforeTrailingLambda(Config.empty).lint(code)).hasSize(1)
+    }
 
-        @Test
-        fun `reports unnecessary parentheses before trailing lambda`() {
-            val code = """
-                fun countDash(input: String) =
-                    "some-string".count() { it == '-' }
-            """.trimIndent()
-            assertThat(UnnecessaryParenthesesBeforeTrailingLambda(Config.empty).lint(code)).hasSize(1)
-        }
-
-        @Test
-        fun `does not report unnecessary parentheses before trailing lambda`() {
-            val code = """
-                fun countDash(input: String) =
-                    "some-string".count { it == '-' }
-            """.trimIndent()
-            assertThat(UnnecessaryParenthesesBeforeTrailingLambda(Config.empty).lint(code)).isEmpty()
-        }
+    @Test
+    fun `does not report unnecessary parentheses before trailing lambda`() {
+        val code = """
+            fun countDash(input: String) =
+                "some-string".count { it == '-' }
+        """.trimIndent()
+        assertThat(UnnecessaryParenthesesBeforeTrailingLambda(Config.empty).lint(code)).isEmpty()
     }
 }

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleCollectorSpec.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleCollectorSpec.kt
@@ -580,7 +580,7 @@ class RuleCollectorSpec {
                             @Configuration("description")
                             private val config3: Int by configWithFallback(defaultValue = 99, fallbackProperty = ::prop)
                         }                        
-                    """
+                        """
                         val items = subject.run(code)
                         val fallbackProperties = items[0].configuration.filter { it.name.startsWith("config") }
                         assertThat(fallbackProperties).hasSize(3)
@@ -598,7 +598,7 @@ class RuleCollectorSpec {
                             @Configuration("description")
                             private val config: Int by configWithFallback(::prop, 99)
                         }                        
-                    """
+                        """
                         assertThatThrownBy { subject.run(code) }
                             .isInstanceOf(InvalidDocumentationException::class.java)
                             .hasMessageContaining("delegate")

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleSetProviderCollectorSpec.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleSetProviderCollectorSpec.kt
@@ -31,7 +31,7 @@ class RuleSetProviderCollectorSpec {
                     println(message)
                 }
             }
-        """
+            """
 
             @Test
             fun `collects no rulesets`() {
@@ -50,7 +50,7 @@ class RuleSetProviderCollectorSpec {
                     println(message)
                 }
             }
-        """
+            """
 
             @Test
             fun `collects no rulesets`() {
@@ -69,7 +69,7 @@ class RuleSetProviderCollectorSpec {
                     println(message)
                 }
             }
-        """
+            """
 
             @Test
             fun `throws an exception`() {
@@ -88,7 +88,7 @@ class RuleSetProviderCollectorSpec {
                     println(message)
                 }
             }
-        """
+            """
 
             @Test
             fun `throws an exception`() {
@@ -120,7 +120,7 @@ class RuleSetProviderCollectorSpec {
                     ))
                 }
             }
-        """
+            """
 
             @Test
             fun `collects a RuleSetProvider`() {
@@ -178,7 +178,7 @@ class RuleSetProviderCollectorSpec {
                     ))
                 }
             }
-        """
+            """
 
             @Test
             fun `is not active`() {
@@ -205,7 +205,7 @@ class RuleSetProviderCollectorSpec {
                     ))
                 }
             }
-        """
+            """
 
             @Test
             fun `throws an exception`() {
@@ -230,7 +230,7 @@ class RuleSetProviderCollectorSpec {
                     ))
                 }
             }
-        """
+            """
 
             @Test
             fun `throws an exception`() {
@@ -257,7 +257,7 @@ class RuleSetProviderCollectorSpec {
                     ))
                 }
             }
-        """
+            """
 
             @Test
             fun `throws an exception`() {
@@ -279,7 +279,7 @@ class RuleSetProviderCollectorSpec {
                     return RuleSet(ruleSetId, emptyListOf())
                 }
             }
-        """
+            """
 
             @Test
             fun `throws an exception`() {
@@ -311,7 +311,7 @@ class RuleSetProviderCollectorSpec {
                     ))
                 }
             }
-        """
+            """
 
             @Test
             fun `collects multiple rules`() {
@@ -366,7 +366,7 @@ class RuleSetProviderCollectorSpec {
                     val aString by ruleSetConfig("a")
                 }
             }
-        """
+            """
             private val items = subject.run(code)
 
             @Test
@@ -416,7 +416,7 @@ class RuleSetProviderCollectorSpec {
                     val aConfig by ruleSetConfig(listOf("a"))
                 }
             }
-        """
+            """
 
             @Test
             fun `fails`() {

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/CreateBaselineTaskDslSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/CreateBaselineTaskDslSpec.kt
@@ -17,7 +17,7 @@ class CreateBaselineTaskDslSpec {
             |detekt {
             |   baseline = file("$baselineFilename")
             |}
-            """
+        """
         val gradleRunner = builder
             .withProjectLayout(
                 ProjectLayout(
@@ -41,7 +41,7 @@ class CreateBaselineTaskDslSpec {
         val detektConfig = """
             |detekt {
             |}
-            """
+        """
         val gradleRunner = builder
             .withProjectLayout(
                 ProjectLayout(
@@ -65,7 +65,7 @@ class CreateBaselineTaskDslSpec {
             |detekt {
             |   baseline = null
             |}
-            """
+        """
         val gradleRunner = builder
             .withProjectLayout(
                 ProjectLayout(

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektReportMergeSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektReportMergeSpec.kt
@@ -44,7 +44,8 @@ class DetektReportMergeSpec {
             |    }
             |  }
             |}
-            |""".trimMargin()
+            |
+            """.trimMargin()
         val kotlin = DslTestBuilder.kotlin()
         val kotlinBuildFileContent =
             """
@@ -74,7 +75,8 @@ class DetektReportMergeSpec {
             |    }
             |  }
             |}
-            |""".trimMargin()
+            |
+            """.trimMargin()
 
         fun scenarios(): List<Arguments> = listOf(
             arguments(groovy, groovyBuildFileContent),
@@ -143,7 +145,8 @@ class DetektReportMergeSpec {
             |    }
             |  }
             |}
-            |""".trimMargin()
+            |
+            """.trimMargin()
         val kotlin = DslTestBuilder.kotlin()
         val kotlinBuildFileContent =
             """
@@ -173,7 +176,8 @@ class DetektReportMergeSpec {
             |    }
             |  }
             |}
-            |""".trimMargin()
+            |
+            """.trimMargin()
 
         fun scenarios(): List<Arguments> = listOf(
             arguments(groovy, groovyBuildFileContent),

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektTaskMultiModuleSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektTaskMultiModuleSpec.kt
@@ -34,7 +34,8 @@ class DetektTaskMultiModuleSpec {
                         |subprojects {
                         |   ${builder.gradleSubprojectsApplyPlugins}
                         |}
-                        |""".trimMargin()
+                        |
+            """.trimMargin()
 
             val gradleRunner = DslGradleRunner(projectLayout, builder.gradleBuildName, mainBuildFileContent)
 
@@ -74,7 +75,8 @@ class DetektTaskMultiModuleSpec {
                         |   ${builder.gradleRepositories}
                         |   ${builder.gradleSubprojectsApplyPlugins}
                         |}
-                        |""".trimMargin()
+                        |
+            """.trimMargin()
 
             val gradleRunner = DslGradleRunner(projectLayout, builder.gradleBuildName, mainBuildFileContent)
 
@@ -115,7 +117,8 @@ class DetektTaskMultiModuleSpec {
                         |       reportsDir = file("build/detekt-reports")
                         |   }
                         |}
-                        |""".trimMargin()
+                        |
+            """.trimMargin()
 
             val gradleRunner = DslGradleRunner(projectLayout, builder.gradleBuildName, mainBuildFileContent)
             gradleRunner.setupProject()
@@ -146,7 +149,8 @@ class DetektTaskMultiModuleSpec {
                         |detekt {
                         |   reportsDir = file("build/custom")
                         |}
-                        |""".trimMargin()
+                        |
+            """.trimMargin()
 
             val projectLayout = ProjectLayout(1).apply {
                 addSubmodule("child1", 2)
@@ -164,7 +168,8 @@ class DetektTaskMultiModuleSpec {
                         |       reportsDir = file("build/detekt-reports")
                         |   }
                         |}
-                        |""".trimMargin()
+                        |
+            """.trimMargin()
 
             val gradleRunner = DslGradleRunner(projectLayout, builder.gradleBuildName, mainBuildFileContent)
 
@@ -203,7 +208,7 @@ class DetektTaskMultiModuleSpec {
                         |       "${"$"}projectDir/child2/src"
                         |    )
                         |}
-                        """.trimMargin()
+            """.trimMargin()
             val gradleRunner = builder
                 .withProjectLayout(projectLayout)
                 .withDetektConfig(detektConfig)

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektTaskSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektTaskSpec.kt
@@ -21,7 +21,7 @@ class DetektTaskSpec {
             |detekt {
             |   ignoreFailures = true
             |}
-            """
+        """
 
         val gradleRunner = builder
             .withProjectLayout(projectLayoutWithTooManyIssues)
@@ -40,7 +40,7 @@ class DetektTaskSpec {
             |detekt {
             |   ignoreFailures = false
             |}
-            """
+        """
 
         val gradleRunner = builder
             .withProjectLayout(projectLayoutWithTooManyIssues)

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/GenerateConfigTaskSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/GenerateConfigTaskSpec.kt
@@ -27,7 +27,7 @@ class GenerateConfigTaskSpec {
                     |detekt {
                     |   config = files("config/detekt/detekt.yml", "config/other/detekt.yml")
                     |}
-                """
+            """
         ).withConfigFile("config/detekt/detekt.yml").build()
         gradleRunner.writeProjectFile("config/other/detekt.yml", content = "")
 

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/PluginTaskBehaviorSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/PluginTaskBehaviorSpec.kt
@@ -22,7 +22,7 @@ class PluginTaskBehaviorSpec {
                     |    config = files("$configFileName")
                     |    baseline = file("$baselineFileName")
                     |}
-                """
+    """
 
     @Nested
     inner class `The Detekt Gradle Plugin 'detekt' Task` {
@@ -77,7 +77,7 @@ class PluginTaskBehaviorSpec {
             val configFileWithCommentsDisabled = """
                             |comments:
                             |  active: false
-                        """.trimMargin()
+            """.trimMargin()
 
             gradleRunner.runDetektTaskAndCheckResult { result ->
                 assertThat(result.task(":detekt")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
@@ -98,7 +98,7 @@ class PluginTaskBehaviorSpec {
                             |    <more/>
                             |    <xml/>
                             |</some>
-                        """.trimMargin()
+            """.trimMargin()
 
             gradleRunner.runDetektTaskAndCheckResult { result ->
                 assertThat(result.task(":detekt")?.outcome).isEqualTo(TaskOutcome.SUCCESS)

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/ConfigurationCacheSpec.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/ConfigurationCacheSpec.kt
@@ -34,7 +34,7 @@ class ConfigurationCacheSpec {
                         |detekt {
                         |   baseline = file("build/baseline.xml")
                         |}
-                        """
+            """
             val gradleRunner = DslTestBuilder.kotlin()
                 .dryRun()
                 .withDetektConfig(detektConfig)

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskDslSpec.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskDslSpec.kt
@@ -83,7 +83,7 @@ class DetektTaskDslSpec {
                         |detekt {
                         |    config.setFrom(files("firstConfig.yml", "secondConfig.yml"))
                         |}
-                        """
+                """
 
                 gradleRunner = builder.withDetektConfig(config).build()
 
@@ -110,7 +110,7 @@ class DetektTaskDslSpec {
                         |detekt {
                         |   baseline = file("$baselineFilename")
                         |}
-                        """
+                """
 
                 gradleRunner = builder
                     .withDetektConfig(config)
@@ -137,7 +137,7 @@ class DetektTaskDslSpec {
                         |detekt {
                         |   baseline = file("$baselineFilename")
                         |}
-                        """
+                """
 
                 gradleRunner = builder
                     .withDetektConfig(config)
@@ -163,7 +163,7 @@ class DetektTaskDslSpec {
                         |detekt {
                         |    input = files("$customSrc1", "$customSrc2", "folder_that_does_not_exist")
                         |}
-                        """
+                """
 
                 val projectLayout = ProjectLayout(1, srcDirs = listOf(customSrc1, customSrc2))
                 gradleRunner = builder
@@ -198,7 +198,7 @@ class DetektTaskDslSpec {
                         |detekt {
                         |    source = files("$customSrc1", "$customSrc2", "folder_that_does_not_exist")
                         |}
-                        """
+                """
 
                 val projectLayout = ProjectLayout(1, srcDirs = listOf(customSrc1, customSrc2))
                 gradleRunner = builder
@@ -231,7 +231,7 @@ class DetektTaskDslSpec {
                         |detekt {
                         |    reportsDir = file("build/detekt-reports")
                         |}
-                        """
+                """
 
                 gradleRunner = builder
                     .withDetektConfig(config)
@@ -279,7 +279,7 @@ class DetektTaskDslSpec {
                         |        xml.destination = file("build/xml-reports/custom-detekt.xml")
                         |    }
                         |}
-                        """
+                """
 
                 gradleRunner = builder
                     .withDetektConfig(config)
@@ -326,7 +326,7 @@ class DetektTaskDslSpec {
                         |        }
                         |    }
                         |}
-                        """
+                """
 
                 gradleRunner = builder
                     .withDetektConfig(config)
@@ -359,7 +359,7 @@ class DetektTaskDslSpec {
                                 |       }
                                 |    }
                                 |}
-                                """
+                    """
 
                     gradleRunner = builder.withDetektConfig(config).build()
                     result = gradleRunner.runDetektTask()
@@ -390,7 +390,7 @@ class DetektTaskDslSpec {
                                 |       }
                                 |    }
                                 |}
-                                """
+                    """
 
                     gradleRunner = builder.withDetektConfig(config).build()
                 }
@@ -413,7 +413,7 @@ class DetektTaskDslSpec {
                                 |       }
                                 |    }
                                 |}
-                                """
+                    """
 
                     gradleRunner = builder.withDetektConfig(config).build()
                 }
@@ -439,7 +439,7 @@ class DetektTaskDslSpec {
                                 |       }
                                 |    }
                                 |}
-                                """
+                    """
 
                     gradleRunner = builder.withDetektConfig(config).build()
                 }
@@ -464,7 +464,7 @@ class DetektTaskDslSpec {
                                         |        }
                                         |    }
                                         |}
-                                        """
+                    """
 
                     gradleRunner = builder.withDetektConfig(config).build()
                     gradleRunner.runDetektTaskAndExpectFailure()
@@ -488,7 +488,7 @@ class DetektTaskDslSpec {
                         |    buildUponDefaultConfig = true
                         |    ignoreFailures = true
                         |}
-                        """
+                """
 
                 gradleRunner = builder
                     .withDetektConfig(config)
@@ -560,7 +560,7 @@ class DetektTaskDslSpec {
                             |dependencies {
                             |   detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:$defaultDetektVersion")
                             |}
-                            """
+                """
 
                 gradleRunner = builder
                     .withDetektConfig(config)
@@ -589,7 +589,7 @@ class DetektTaskDslSpec {
                             |detekt {
                             |    toolVersion = "$customVersion"
                             |}
-                            """
+                """
 
                 gradleRunner = builder
                     .withDetektConfig(config)
@@ -644,7 +644,7 @@ class DetektTaskDslSpec {
                         |    }
                         |    basePath = projectDir.toString()
                         |}
-                        """
+                    """
 
                     gradleRunner = builder
                         .withDetektConfig(config)

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/report/ReportMergeSpec.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/report/ReportMergeSpec.kt
@@ -68,7 +68,8 @@ class ReportMergeSpec {
                 |            reportMerge.configure { mergeTask -> mergeTask.input.from(detektTask.xmlReportFile) }
                 |        }
                 |    }
-                |}""".trimMargin()
+                |}
+            """.trimMargin()
 
             val gradleRunner = DslGradleRunner(
                 projectLayout = projectLayout,
@@ -162,7 +163,8 @@ class ReportMergeSpec {
                 |            reportMerge.configure { mergeTask -> mergeTask.input.from(detektTask.xmlReportFile) }
                 |        }
                 |    }
-                |}""".trimMargin()
+                |}
+            """.trimMargin()
 
             val jvmArgs = "-Xmx2g -XX:MaxMetaspaceSize=1g"
 

--- a/detekt-gradle-plugin/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/testkit/DslGradleRunner.kt
+++ b/detekt-gradle-plugin/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/testkit/DslGradleRunner.kt
@@ -28,13 +28,13 @@ class DslGradleRunner @Suppress("LongParameterList") constructor(
         |rootProject.name = "rootDir-project"
         |include(${projectLayout.submodules.joinToString(",") { "\"${it.name}\"" }})
         |
-        """.trimMargin()
+    """.trimMargin()
 
     private val baselineContent = """
         |<some>
         |   <xml/>
         |</some>
-        """.trimMargin()
+    """.trimMargin()
 
     private val configFileContent = """
         |build:
@@ -42,7 +42,7 @@ class DslGradleRunner @Suppress("LongParameterList") constructor(
         |style:
         |  MagicNumber:
         |    active: true
-        """.trimMargin()
+    """.trimMargin()
 
     /**
      * Each generated file is different so the artifacts are not cached in between test runs

--- a/detekt-gradle-plugin/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/testkit/DslTestBuilder.kt
+++ b/detekt-gradle-plugin/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/testkit/DslTestBuilder.kt
@@ -54,7 +54,7 @@ abstract class DslTestBuilder {
         val mainBuildFileContent = """
             |$gradleBuildConfig
             |$detektConfig
-            """.trimMargin()
+        """.trimMargin()
         val runner = DslGradleRunner(
             projectLayout = projectLayout,
             buildFileName = gradleBuildName,
@@ -84,7 +84,8 @@ private class GroovyBuilder : DslTestBuilder() {
         |  id 'java-library'
         |  id "io.gitlab.arturbosch.detekt"
         |}
-        |"""
+        |
+    """
 
     override val gradleBuildConfig: String = """
         |$gradlePlugins
@@ -94,11 +95,12 @@ private class GroovyBuilder : DslTestBuilder() {
         |dependencies {
         |   implementation "org.jetbrains.kotlin:kotlin-stdlib"
         |}
-        """.trimMargin()
+    """.trimMargin()
 
     override val gradleSubprojectsApplyPlugins = """
         |apply plugin: "io.gitlab.arturbosch.detekt"
-        |"""
+        |
+    """
 
     override fun toString() = "build.gradle"
 }
@@ -111,7 +113,8 @@ private class KotlinBuilder : DslTestBuilder() {
         |   `java-library`
         |   id("io.gitlab.arturbosch.detekt")
         |}
-        |"""
+        |
+    """
 
     override val gradleBuildConfig: String = """
         |$gradlePlugins
@@ -121,11 +124,12 @@ private class KotlinBuilder : DslTestBuilder() {
         |dependencies {
         |   implementation(kotlin("stdlib"))
         |}
-        """.trimMargin()
+    """.trimMargin()
 
     override val gradleSubprojectsApplyPlugins = """
         |plugins.apply("io.gitlab.arturbosch.detekt")
-        |"""
+        |
+    """
 
     override fun toString() = "build.gradle.kts"
 }

--- a/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/CognitiveComplexitySpec.kt
+++ b/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/CognitiveComplexitySpec.kt
@@ -27,7 +27,7 @@ class CognitiveComplexitySpec {
                     }
                     return total
                 }
-            """
+                """
             )
 
             assertThat(CognitiveComplexity.calculate(code)).isEqualTo(7)
@@ -43,7 +43,7 @@ class CognitiveComplexitySpec {
                      3 -> "a few"
                      else -> "lots"
                  }
-             """
+                """
             )
 
             assertThat(CognitiveComplexity.calculate(code)).isEqualTo(1)
@@ -60,7 +60,7 @@ class CognitiveComplexitySpec {
                         fun factorial(n: Int): Int =
                             if (n >= 1) n * this.factorial(n - 1) else 1
                     }
-            """
+                    """
                 )
 
                 assertThat(CognitiveComplexity.calculate(code)).isEqualTo(2)
@@ -72,7 +72,7 @@ class CognitiveComplexitySpec {
                     """
                     fun factorial(n: Int): Int =
                         if (n >= 1) n * factorial(n - 1) else 1
-                """
+                    """
                 )
 
                 assertThat(CognitiveComplexity.calculate(code)).isEqualTo(2)
@@ -85,7 +85,7 @@ class CognitiveComplexitySpec {
                     object O { fun factorial(i: Int): Int = i - 1 }
                     fun factorial(n: Int): Int =
                         if (n >= 1) n * O.factorial(n - 1) else 1
-                """
+                    """
                 )
 
                 assertThat(CognitiveComplexity.calculate(code)).isEqualTo(1)
@@ -100,7 +100,7 @@ class CognitiveComplexitySpec {
                 fun main(args: Array<String>) {
                    args.takeIf { it.size > 3 }?.let(::parse) ?: error("not enough arguments")
                 }
-            """
+                """
             )
 
             assertThat(CognitiveComplexity.calculate(code)).isEqualTo(0)
@@ -116,7 +116,7 @@ class CognitiveComplexitySpec {
                     } catch (e: IllegalStateException) {
                     } catch (e: Throwable) {}
                 }
-            """
+                """
             )
 
             assertThat(CognitiveComplexity.calculate(code)).isEqualTo(3)
@@ -139,7 +139,7 @@ class CognitiveComplexitySpec {
                         do {} while(true) // +2
                     }
                 }
-            """
+                """
             )
 
             assertThat(CognitiveComplexity.calculate(code)).isEqualTo(9)
@@ -150,7 +150,7 @@ class CognitiveComplexitySpec {
             val code = compileContentForTest(
                 """
                 fun main() { run { if (true) {} } }
-            """
+                """
             )
 
             assertThat(CognitiveComplexity.calculate(code)).isEqualTo(2)
@@ -161,7 +161,7 @@ class CognitiveComplexitySpec {
             val code = compileContentForTest(
                 """
                 fun main() { fun run() { if (true) {} } }
-            """
+                """
             )
 
             assertThat(CognitiveComplexity.calculate(code)).isEqualTo(2)
@@ -175,7 +175,7 @@ class CognitiveComplexitySpec {
                 val code = compileContentForTest(
                     """
                     fun test(cond_ Boolean) = !cond
-                """
+                    """
                 )
 
                 assertThat(CognitiveComplexity.calculate(code)).isEqualTo(0)
@@ -189,7 +189,7 @@ class CognitiveComplexitySpec {
                     val code = compileContentForTest(
                         """
                         fun test(cond_ Boolean) = !cond && !cond
-                    """
+                        """
                     )
 
                     assertThat(CognitiveComplexity.calculate(code)).isEqualTo(1)
@@ -200,7 +200,7 @@ class CognitiveComplexitySpec {
                     val code = compileContentForTest(
                         """
                         fun test(cond_ Boolean) = !cond && !cond && !cond
-                    """
+                        """
                     )
 
                     assertThat(CognitiveComplexity.calculate(code)).isEqualTo(1)
@@ -211,7 +211,7 @@ class CognitiveComplexitySpec {
                     val code = compileContentForTest(
                         """
                         fun test(cond_ Boolean) = !cond && !cond || cond
-                    """
+                        """
                     )
 
                     assertThat(CognitiveComplexity.calculate(code)).isEqualTo(2)
@@ -229,7 +229,7 @@ class CognitiveComplexitySpec {
                                 && cond             // +1
                             ) {}
                         }
-                    """
+                        """
                     )
 
                     assertThat(CognitiveComplexity.calculate(code)).isEqualTo(4)
@@ -245,7 +245,7 @@ class CognitiveComplexitySpec {
                                 && !(cond && cond)  // +2
                             ) {}
                         }
-                    """
+                        """
                     )
 
                     assertThat(CognitiveComplexity.calculate(code)).isEqualTo(3)
@@ -261,7 +261,7 @@ class CognitiveComplexitySpec {
                                 && !(cond && cond && cond)  // +2
                             ) {}
                         }
-                    """
+                        """
                     )
 
                     assertThat(CognitiveComplexity.calculate(code)).isEqualTo(3)
@@ -278,7 +278,7 @@ class CognitiveComplexitySpec {
                                 || !(cond || cond)          // +2
                             ) {}
                         }
-                    """
+                        """
                     )
 
                     assertThat(CognitiveComplexity.calculate(code)).isEqualTo(5)

--- a/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/CyclomaticComplexitySpec.kt
+++ b/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/CyclomaticComplexitySpec.kt
@@ -77,7 +77,7 @@ class CyclomaticComplexitySpec {
                     fun test(i: Int) {
                         (1..10).forEach { println(it) }
                     }
-                """
+            """
         )
 
         @Test
@@ -129,7 +129,7 @@ class CyclomaticComplexitySpec {
                         else -> println("Meh")
                     }
                 }
-            """
+                """
             ).getFunctionByName("test")
 
             val actual = CyclomaticComplexity.calculate(function) {
@@ -152,7 +152,7 @@ class CyclomaticComplexitySpec {
                         else -> println("Meh")
                     }
                 }
-            """
+                """
             ).getFunctionByName("test")
 
             val actual = CyclomaticComplexity.calculate(function) {
@@ -177,7 +177,7 @@ class CyclomaticComplexitySpec {
                         else -> println("Meh")
                     }
                 }
-            """
+                """
             ).getFunctionByName("test")
 
             val actual = CyclomaticComplexity.calculate(function) {
@@ -203,7 +203,7 @@ class CyclomaticComplexitySpec {
                         else -> println("Meh")
                     }
                 }
-            """
+                """
             ).getFunctionByName("test")
 
             val actual = CyclomaticComplexity.calculate(function) {
@@ -231,7 +231,7 @@ class CyclomaticComplexitySpec {
                         else -> println("Meh")
                     }
                 }
-            """
+                """
             ).getFunctionByName("test")
 
             val actual = CyclomaticComplexity.calculate(function) {

--- a/detekt-report-html/src/main/kotlin/io/github/detekt/report/html/HtmlUtils.kt
+++ b/detekt-report-html/src/main/kotlin/io/github/detekt/report/html/HtmlUtils.kt
@@ -91,7 +91,8 @@ private fun createReportUrl(ruleName: String, throwable: Throwable): String {
             |$stackTrace
             |```
             |- How to reproduce it: <WRITE HERE HOW TO REPRODUCE THIS ISSUE. A CODE SNIPPET IS THE BEST WAY.>
-            |""".trimMargin()
+            |
+    """.trimMargin()
     val body = URLEncoder.encode(bodyMessage, "UTF8")
 
     return "https://github.com/detekt/detekt/issues/new?body=$body&title=$title"

--- a/detekt-report-xml/src/test/kotlin/io/github/detekt/report/xml/XmlOutputFormatSpec.kt
+++ b/detekt-report-xml/src/test/kotlin/io/github/detekt/report/xml/XmlOutputFormatSpec.kt
@@ -208,7 +208,7 @@ class XmlOutputFormatSpec {
                     $TAB<error line="${finding.location.source.line}" column="${finding.location.source.column}" severity="$xmlSeverity" message="${finding.messageOrDescription()}" source="detekt.${finding.id}" />
                     </file>
                     </checkstyle>
-                    """
+                """
 
                 val actual = outputFormat.render(TestDetektion(finding))
 

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexMethodSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexMethodSpec.kt
@@ -32,7 +32,7 @@ class ComplexMethodSpec {
                         do {} while(true)
                         (1..10).forEach {}
                     }
-                """
+                    """
                 )
 
                 assertThat(findings.first()).isThresholded().withValue(defaultComplexity + 4)
@@ -45,7 +45,7 @@ class ComplexMethodSpec {
                     fun test() {
                         try {} catch(e: IllegalArgumentException) {} catch(e: Exception) {} finally {}
                     }
-                """
+                    """
                 )
 
                 assertThat(findings.first()).isThresholded().withValue(defaultComplexity + 2)
@@ -69,7 +69,7 @@ class ComplexMethodSpec {
                             // only catches count
                         }
                     }
-                """
+                    """
                 )
 
                 assertThat(findings.first()).isThresholded().withValue(defaultComplexity + 4)
@@ -84,7 +84,7 @@ class ComplexMethodSpec {
                         for (i in 1..10) {}
                         (1..10).forEach {}
                     }
-                """
+            """
 
             @Test
             fun `counts three with nesting function 'forEach'`() {

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/MethodOverloadingSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/MethodOverloadingSpec.kt
@@ -49,7 +49,8 @@ class MethodOverloadingSpec {
                 class Test {
                     fun x() { }
                     fun x(i: Int) { }
-                }"""
+                }
+                    """
                 )
                 assertThat(subject.findings.size).isZero()
             }
@@ -64,7 +65,8 @@ class MethodOverloadingSpec {
                     """
                 fun Boolean.foo() {}
                 fun Int.foo() {}
-                fun Long.foo() {}"""
+                fun Long.foo() {}
+                    """
                 )
                 assertThat(subject.findings.size).isZero()
             }
@@ -75,7 +77,8 @@ class MethodOverloadingSpec {
                     """
                 fun Int.foo() {}
                 fun Int.foo(i: Int) {}
-                fun Int.foo(i: String) {}"""
+                fun Int.foo(i: String) {}
+                    """
                 )
                 assertThat(subject.findings.size).isEqualTo(1)
             }

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NamedArgumentsSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NamedArgumentsSpec.kt
@@ -26,7 +26,7 @@ class NamedArgumentsSpec(val env: KotlinCoreEnvironment) {
                 fun call() {
                     sum(1, 2, 3)
                 }
-                """
+            """
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
@@ -40,7 +40,7 @@ class NamedArgumentsSpec(val env: KotlinCoreEnvironment) {
                 fun call() {
                     sum(a = 1, b = 2, c = 3)
                 }
-                """
+            """
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(0)
         }
@@ -54,7 +54,7 @@ class NamedArgumentsSpec(val env: KotlinCoreEnvironment) {
                 fun call() {
                     sum(1, b = 2, c = 3)
                 }
-                """
+            """
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
@@ -68,7 +68,7 @@ class NamedArgumentsSpec(val env: KotlinCoreEnvironment) {
                 fun call() {
                     sum(1, 2)
                 }
-                """
+            """
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(0)
         }
@@ -82,7 +82,7 @@ class NamedArgumentsSpec(val env: KotlinCoreEnvironment) {
                 fun call() {
                     sum(a = 1, b = 2)
                 }
-                """
+            """
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(0)
         }
@@ -169,7 +169,7 @@ class NamedArgumentsSpec(val env: KotlinCoreEnvironment) {
                 fun test() {
                     foo(a = 1, b = 2, c = 3, { it })
                 }
-            """
+                """
                 val findings = subject.compileAndLintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }
@@ -182,7 +182,7 @@ class NamedArgumentsSpec(val env: KotlinCoreEnvironment) {
                 fun test() {
                     foo(a = 1, b = 2, c = 3) { it }
                 }
-            """
+                """
                 val findings = subject.compileAndLintWithContext(env, code)
                 assertThat(findings).hasSize(0)
             }
@@ -195,7 +195,7 @@ class NamedArgumentsSpec(val env: KotlinCoreEnvironment) {
                 fun test() {
                     foo(a = 1, b = 2, 3) { it }
                 }
-            """
+                """
                 val findings = subject.compileAndLintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedBlockDepthSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedBlockDepthSpec.kt
@@ -37,7 +37,8 @@ class NestedBlockDepthSpec {
                             }
                         }
                     }
-                }"""
+                }
+            """
             val findings = subject.compileAndLint(code)
 
             assertThat(findings).hasSize(1)
@@ -54,7 +55,8 @@ class NestedBlockDepthSpec {
                             }
                         }
                     }
-                }"""
+                }
+            """
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
@@ -69,7 +71,8 @@ class NestedBlockDepthSpec {
                             }
                         }
                     }
-                }"""
+                }
+            """
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
@@ -86,7 +89,8 @@ class NestedBlockDepthSpec {
                             }
                         }
                     }
-                }"""
+                }
+            """
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
     }

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/StringLiteralDuplicationSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/StringLiteralDuplicationSpec.kt
@@ -30,7 +30,8 @@ class StringLiteralDuplicationSpec {
                     fun f(s: String = "lorem") {
                         s1.equals("lorem")
                     }
-                }"""
+                }
+                """
                 assertThat(subject.compileAndLint(code)).hasSize(1)
             }
 
@@ -130,7 +131,8 @@ class StringLiteralDuplicationSpec {
                     fun f(s: String = "lorem") {
                         s1.equals("lorem")
                     }
-                }"""
+                }
+                """
                 val finding = subject.compileAndLint(code)[0]
                 val locations = finding.references.map { it.location } + finding.entity.location
                 assertThat(locations).hasSize(3)

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/TooManyFunctionsSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/TooManyFunctionsSpec.kt
@@ -134,7 +134,7 @@ class TooManyFunctionsSpec {
                     fun f() {
                     }
                 }
-                """
+            """
 
             @Test
             fun `finds all deprecated functions per default`() {
@@ -163,7 +163,7 @@ class TooManyFunctionsSpec {
                 class A {
                     private fun f() {}
                 }
-                """
+            """
 
             @Test
             fun `finds the private function per default`() {
@@ -236,7 +236,7 @@ class TooManyFunctionsSpec {
                         override fun func1() = Unit
                         override fun func2() = Unit
                     }
-                """
+            """
 
             @Test
             fun `should not report class with overridden functions, if ignoreOverridden is enabled`() {

--- a/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/InjectDispatcherSpec.kt
+++ b/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/InjectDispatcherSpec.kt
@@ -29,7 +29,7 @@ class InjectDispatcherSpec(val env: KotlinCoreEnvironment) {
                         launch(Dispatchers.IO) { }
                     }
                 }
-                """
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
@@ -46,7 +46,7 @@ class InjectDispatcherSpec(val env: KotlinCoreEnvironment) {
                         launch(dispatcher) { }
                     }
                 }
-                """
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -57,7 +57,7 @@ class InjectDispatcherSpec(val env: KotlinCoreEnvironment) {
                 import kotlinx.coroutines.Dispatchers
 
                 class MyRepository(dispatcher: CoroutineDispatcher = Dispatchers.IO)
-                """
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -68,7 +68,7 @@ class InjectDispatcherSpec(val env: KotlinCoreEnvironment) {
                 import kotlinx.coroutines.Dispatchers
 
                 class MyRepository(private val dispatcher: CoroutineDispatcher = Dispatchers.IO)
-                """
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -84,7 +84,7 @@ class InjectDispatcherSpec(val env: KotlinCoreEnvironment) {
                         launch(Dispatchers.Main) { }
                     }
                 }
-                """
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
     }
@@ -106,7 +106,7 @@ class InjectDispatcherSpec(val env: KotlinCoreEnvironment) {
                         launch(Dispatchers.Main) { }
                     }
                 }
-                """
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
     }

--- a/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/RedundantSuspendModifierSpec.kt
+++ b/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/RedundantSuspendModifierSpec.kt
@@ -32,7 +32,7 @@ class RedundantSuspendModifierSpec(val env: KotlinCoreEnvironment) {
                         println("hello world")
                     }
                 }
-                """
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
@@ -50,7 +50,7 @@ class RedundantSuspendModifierSpec(val env: KotlinCoreEnvironment) {
                 suspend fun doesSuspend() {
                     suspendCoroutine()
                 }
-                """
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -62,7 +62,7 @@ class RedundantSuspendModifierSpec(val env: KotlinCoreEnvironment) {
                         println("hello world")
                     }
                 }
-                """
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -72,7 +72,7 @@ class RedundantSuspendModifierSpec(val env: KotlinCoreEnvironment) {
                 interface SuspendInterface {
                     suspend fun empty()
                 }
-                """
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -88,7 +88,7 @@ class RedundantSuspendModifierSpec(val env: KotlinCoreEnvironment) {
                         println("hello world")
                     }
                 }                                
-                """
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -104,7 +104,7 @@ class RedundantSuspendModifierSpec(val env: KotlinCoreEnvironment) {
                         println(x)
                     }
                 }
-                """
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -125,7 +125,7 @@ class RedundantSuspendModifierSpec(val env: KotlinCoreEnvironment) {
                         "Hello"
                     }
                 }
-                """
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
     }

--- a/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunWithFlowReturnTypeSpec.kt
+++ b/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunWithFlowReturnTypeSpec.kt
@@ -39,7 +39,7 @@ class SuspendFunWithFlowReturnTypeSpec(val env: KotlinCoreEnvironment) {
                     yield()
                     return MutableStateFlow(value = 1L)
                 }
-                """
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(3)
         }
 
@@ -63,7 +63,7 @@ class SuspendFunWithFlowReturnTypeSpec(val env: KotlinCoreEnvironment) {
                     yield()
                     return MutableStateFlow(value = 1L)
                 }
-                """
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(3)
         }
 
@@ -86,7 +86,7 @@ class SuspendFunWithFlowReturnTypeSpec(val env: KotlinCoreEnvironment) {
                     yield()
                     return kotlinx.coroutines.flow.MutableStateFlow(value = 1L)
                 }
-                """
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(3)
         }
 
@@ -98,7 +98,7 @@ class SuspendFunWithFlowReturnTypeSpec(val env: KotlinCoreEnvironment) {
 
                 suspend fun flowValues() = flowOf(1L, 2L, 3L)
                 suspend fun mutableStateFlowValues() = MutableStateFlow(value = 1L)
-                """
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(2)
         }
 
@@ -114,7 +114,7 @@ class SuspendFunWithFlowReturnTypeSpec(val env: KotlinCoreEnvironment) {
                     suspend fun stateFlowValues(): StateFlow<Long>
                     suspend fun mutableStateFlowValues(): MutableStateFlow<Long>
                 }
-                """
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(3)
         }
 
@@ -143,7 +143,7 @@ class SuspendFunWithFlowReturnTypeSpec(val env: KotlinCoreEnvironment) {
                         return MutableStateFlow(value = 1L)
                     }
                 }
-                """
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(3)
         }
 
@@ -157,7 +157,7 @@ class SuspendFunWithFlowReturnTypeSpec(val env: KotlinCoreEnvironment) {
                     suspend fun flowValues() = flowOf(1L, 2L, 3L)
                     suspend fun mutableStateFlowValues() = MutableStateFlow(value = 1L)
                 }
-                """
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(2)
         }
 
@@ -184,7 +184,7 @@ class SuspendFunWithFlowReturnTypeSpec(val env: KotlinCoreEnvironment) {
                     yield()
                     return MutableStateFlow(value = this)
                 }
-                """
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(3)
         }
 
@@ -196,7 +196,7 @@ class SuspendFunWithFlowReturnTypeSpec(val env: KotlinCoreEnvironment) {
 
                 suspend fun Long.flowValues() = (0..this).asFlow()
                 suspend fun Long.mutableStateFlowValues() = MutableStateFlow(value = this)
-                """
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(2)
         }
 
@@ -217,7 +217,7 @@ class SuspendFunWithFlowReturnTypeSpec(val env: KotlinCoreEnvironment) {
                 fun doSomething3(block: suspend () -> MutableStateFlow<Long>) {
                     TODO()
                 }
-                """
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -254,7 +254,7 @@ class SuspendFunWithFlowReturnTypeSpec(val env: KotlinCoreEnvironment) {
                 class ValueRepository3 {
                     suspend fun getValue() = 5L.apply { delay(1_000L) }
                 }
-                """
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -277,7 +277,7 @@ class SuspendFunWithFlowReturnTypeSpec(val env: KotlinCoreEnvironment) {
                 fun mutableStateFlowValues(): MutableStateFlow<Long> {
                     return MutableStateFlow(value = 1L)
                 }
-                """
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
     }

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/AbsentOrWrongFileLicenseSpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/AbsentOrWrongFileLicenseSpec.kt
@@ -30,7 +30,7 @@ class AbsentOrWrongFileLicenseSpec {
                     """
                     /* LICENSE */
                     package cases
-                """
+                    """
                 )
 
                 assertThat(findings).isEmpty()
@@ -46,7 +46,7 @@ class AbsentOrWrongFileLicenseSpec {
                     """
                     /* WRONG LICENSE */
                     package cases
-                """
+                    """
                 )
 
                 assertThat(findings).hasSize(1)
@@ -61,7 +61,7 @@ class AbsentOrWrongFileLicenseSpec {
                 val findings = checkLicence(
                     """
                     package cases
-                """
+                    """
                 )
 
                 assertThat(findings).hasSize(1)

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentOverPrivateMethodSpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentOverPrivateMethodSpec.kt
@@ -19,7 +19,8 @@ class CommentOverPrivateMethodSpec {
                      * asdf
                      */
                     private fun f() {}
-                }"""
+                }
+            """
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
@@ -29,7 +30,8 @@ class CommentOverPrivateMethodSpec {
                 /**
                  * asdf
                  */
-                fun f() {}"""
+                fun f() {}
+            """
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
@@ -41,7 +43,8 @@ class CommentOverPrivateMethodSpec {
                      * asdf
                      */
                     fun f() {}
-                }"""
+                }
+            """
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
     }

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentOverPrivatePropertiesSpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentOverPrivatePropertiesSpec.kt
@@ -17,7 +17,8 @@ class CommentOverPrivatePropertiesSpec {
                 /**
                  * asdf
                  */
-                private val v = 1"""
+                private val v = 1
+            """
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
@@ -27,7 +28,8 @@ class CommentOverPrivatePropertiesSpec {
                 /**
                  * asdf
                  */
-                val v = 1"""
+                val v = 1
+            """
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
@@ -39,7 +41,8 @@ class CommentOverPrivatePropertiesSpec {
                      * asdf
                      */
                     private val v = 1
-                }"""
+                }
+            """
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
@@ -51,7 +54,8 @@ class CommentOverPrivatePropertiesSpec {
                      * asdf
                      */
                     val v = 1
-                }"""
+                }
+            """
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
     }

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/DeprecatedBlockTagSpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/DeprecatedBlockTagSpec.kt
@@ -19,7 +19,7 @@ class DeprecatedBlockTagSpec {
                  * Nothing to see here...
                  */
                 val v = 2
-                """
+            """
             assertThat(subject.compileAndLint(code)).hasSize(0)
         }
 

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/OutdatedDocumentationSpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/OutdatedDocumentationSpec.kt
@@ -139,7 +139,7 @@ class OutdatedDocumentationSpec {
                      * @param someProp Description of property
                      */
                     class MyClass(someParam: String, val someProp: String)
-                    """
+                """
                 assertThat(subject.compileAndLint(propertyAsParam)).hasSize(1)
             }
 
@@ -292,7 +292,7 @@ class OutdatedDocumentationSpec {
                      * @param S Description of type param
                      */
                     fun <T, S> myFun(someParam: String) {}
-                    """
+                """
                 assertThat(subject.compileAndLint(incorrectTypeParamsOrder)).hasSize(1)
             }
         }
@@ -414,7 +414,7 @@ class OutdatedDocumentationSpec {
                      * @param someProp Description of property
                      */
                     class MyClass(someParam: String, val someProp: String)
-                    """
+                """
                 assertThat(configuredSubject.compileAndLint(propertyAsParam)).isEmpty()
             }
 
@@ -426,7 +426,7 @@ class OutdatedDocumentationSpec {
                      * @property someProp Description of property
                      */
                     class MyClass(someParam: String, val someProp: String)
-                    """
+                """
                 assertThat(configuredSubject.compileAndLint(propertyAsParam)).isEmpty()
             }
         }
@@ -451,7 +451,7 @@ class OutdatedDocumentationSpec {
                      * @param someProp Description of property
                      */
                     class MyClass(someParam: String, val someProp: String)
-                    """
+                """
                 assertThat(configuredSubject.compileAndLint(propertyAsParam)).isEmpty()
             }
 
@@ -463,7 +463,7 @@ class OutdatedDocumentationSpec {
                      * @property someProp Description of property
                      */
                     class MyClass(someParam: String, val someProp: String)
-                    """
+                """
                 assertThat(configuredSubject.compileAndLint(propertyAsParam)).isEmpty()
             }
         }

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicClassSpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicClassSpec.kt
@@ -18,39 +18,43 @@ class UndocumentedPublicClassSpec {
             /** Some doc */
             class TestInner {
                 inner class Inner
-            }"""
+            }
+    """
 
     val innerObject = """
             /** Some doc */
             class TestInner {
                 object Inner
-            }"""
+            }
+    """
 
     val innerInterface = """
             /** Some doc */
             class TestInner {
                 interface Something
-            }"""
+            }
+    """
 
     val nested = """
             /** Some doc */
             class TestNested {
                 class Nested
-            }"""
+            }
+    """
 
     val nestedPublic = """
             /** Some doc */
             class TestNested {
                 public class Nested
             }
-            """
+    """
 
     val nestedPrivate = """
             /** Some doc */
             class TestNested {
                 private class Nested
             }
-            """
+    """
 
     val privateClass = "private class TestNested {}"
     val internalClass = "internal class TestNested {}"
@@ -140,7 +144,7 @@ class UndocumentedPublicClassSpec {
                 class Nested
                 inner class Inner
             }
-        """
+            """
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
@@ -150,7 +154,7 @@ class UndocumentedPublicClassSpec {
             internal class Outer {
                 interface Inner
             }
-        """
+            """
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
@@ -160,7 +164,7 @@ class UndocumentedPublicClassSpec {
             internal class Outer {
                 object Inner
             }
-        """
+            """
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
@@ -180,7 +184,7 @@ class UndocumentedPublicClassSpec {
                 fun main(args: Array<String>) {
                 }
             }
-        """
+            """
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
@@ -193,7 +197,7 @@ class UndocumentedPublicClassSpec {
                     override fun next() = 1
                 }
             }
-        """
+            """
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
@@ -203,7 +207,7 @@ class UndocumentedPublicClassSpec {
             enum class Enum {
                 CONSTANT
             }
-        """
+            """
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
@@ -214,7 +218,7 @@ class UndocumentedPublicClassSpec {
             enum class Enum {
                 CONSTANT
             }
-        """
+            """
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicFunctionSpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicFunctionSpec.kt
@@ -78,13 +78,13 @@ class UndocumentedPublicFunctionSpec {
         @Test
         fun `does not report documented public function in class`() {
             val code = """
-				class Test {
-					/**
-					*
-					*/
-					fun commented() {}
-				}
-			"""
+            class Test {
+            	/**
+            	*
+            	*/
+            	fun commented() {}
+            }
+            """
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
@@ -115,22 +115,22 @@ class UndocumentedPublicFunctionSpec {
         @Test
         fun `does not report public functions in internal class`() {
             val code = """
-    			internal class NoComments {
-					fun nope1() {}
-					public fun nope2() {}
-				}
-			"""
+                internal class NoComments {
+                    fun nope1() {}
+                    public fun nope2() {}
+                }
+            """
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         @Test
         fun `does not report public functions in private class`() {
             val code = """
-    			private class NoComments {
-					fun nope1() {}
-					public fun nope2() {}
-				}
-			"""
+                private class NoComments {
+                    fun nope1() {}
+                    public fun nope2() {}
+                }
+            """
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicPropertySpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicPropertySpec.kt
@@ -231,7 +231,7 @@ class UndocumentedPublicPropertySpec {
                         }
                     }
                 }
-            """
+                """
                 assertThat(subject.compileAndLint(code)).hasSize(2)
             }
 
@@ -243,7 +243,7 @@ class UndocumentedPublicPropertySpec {
                         val i = 0
                     }
                 }
-            """
+                """
                 assertThat(subject.compileAndLint(code)).hasSize(1)
             }
 
@@ -255,7 +255,7 @@ class UndocumentedPublicPropertySpec {
                         val i = 0
                     }
                 }
-            """
+                """
                 assertThat(subject.compileAndLint(code)).hasSize(1)
             }
 
@@ -267,7 +267,7 @@ class UndocumentedPublicPropertySpec {
                         val i = 0
                     }
                 }
-            """
+                """
                 assertThat(subject.compileAndLint(code)).isEmpty()
             }
 
@@ -279,7 +279,7 @@ class UndocumentedPublicPropertySpec {
                         val i = 0
                     }
                 }
-            """
+                """
                 assertThat(subject.compileAndLint(code)).isEmpty()
             }
         }
@@ -295,7 +295,7 @@ class UndocumentedPublicPropertySpec {
                         class InnerInner(val c: Int)
                     }
                 }
-            """
+                """
                 assertThat(subject.compileAndLint(code)).hasSize(3)
             }
 
@@ -305,7 +305,7 @@ class UndocumentedPublicPropertySpec {
                 class Outer(val a: Int) {
                     inner class Inner(val b: Int)
                 }
-            """
+                """
                 assertThat(subject.compileAndLint(code)).hasSize(2)
             }
 
@@ -315,7 +315,7 @@ class UndocumentedPublicPropertySpec {
                 object Outer {
                     class Inner(val a: Int)
                 }
-            """
+                """
                 assertThat(subject.compileAndLint(code)).hasSize(1)
             }
 
@@ -325,7 +325,7 @@ class UndocumentedPublicPropertySpec {
                 internal class Outer(val a: Int) {
                     class Inner(val b: Int)
                 }
-            """
+                """
                 assertThat(subject.compileAndLint(code)).isEmpty()
             }
 
@@ -335,7 +335,7 @@ class UndocumentedPublicPropertySpec {
                 internal class Outer(val a: Int) {
                     inner class Inner(val b: Int)
                 }
-            """
+                """
                 assertThat(subject.compileAndLint(code)).isEmpty()
             }
         }

--- a/detekt-rules-empty/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyBlocksMultiRuleSpec.kt
+++ b/detekt-rules-empty/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyBlocksMultiRuleSpec.kt
@@ -61,7 +61,7 @@ class EmptyBlocksMultiRuleSpec {
                         }
                     }
                 }
-            """
+                """
             )
             assertThat(findings).hasSize(2)
         }

--- a/detekt-rules-empty/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyClassBlockSpec.kt
+++ b/detekt-rules-empty/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyClassBlockSpec.kt
@@ -67,7 +67,7 @@ class EmptyClassBlockSpec {
                 fun f() {
                      object : Open() {}
                 }
-                """
+            """
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
     }

--- a/detekt-rules-empty/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyCodeSpec.kt
+++ b/detekt-rules-empty/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyCodeSpec.kt
@@ -22,7 +22,8 @@ class EmptyCodeSpec {
                 try {
                 } catch (foo: Exception) {
                 }
-            }"""
+            }
+    """
 
     @Nested
     inner class `EmptyCatchBlock rule` {
@@ -42,7 +43,8 @@ class EmptyCodeSpec {
                     } catch (e: Exception) {
                     }
                 }
-            }"""
+            }
+            """
             assertThat(EmptyCatchBlock(Config.empty).compileAndLint(code)).hasSize(1)
         }
 
@@ -54,7 +56,8 @@ class EmptyCodeSpec {
                 } catch (ignore: IllegalArgumentException) {
                 } catch (expected: Exception) {
                 }
-            }"""
+            }
+            """
             assertThat(EmptyCatchBlock(Config.empty).compileAndLint(code)).isEmpty()
         }
 
@@ -65,7 +68,8 @@ class EmptyCodeSpec {
                 try {
                 } catch (foo: Exception) {
                 }
-            }"""
+            }
+            """
             val config = TestConfig(mapOf(ALLOWED_EXCEPTION_NAME_REGEX to "foo"))
             assertThat(EmptyCatchBlock(config).compileAndLint(code)).isEmpty()
         }

--- a/detekt-rules-empty/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyFunctionBlockSpec.kt
+++ b/detekt-rules-empty/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyFunctionBlockSpec.kt
@@ -22,7 +22,8 @@ class EmptyFunctionBlockSpec {
             val code = """
                 class A {
                     protected fun stuff() {}
-                }"""
+                }
+            """
             assertThat(subject.compileAndLint(code)).hasSourceLocation(2, 27)
         }
 
@@ -31,7 +32,8 @@ class EmptyFunctionBlockSpec {
             val code = """
                 open class A {
                     open fun stuff() {}
-                }"""
+                }
+            """
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
@@ -40,7 +42,8 @@ class EmptyFunctionBlockSpec {
             val code = """
                 interface I {
                     fun stuff() {}
-                }"""
+                }
+            """
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
@@ -49,7 +52,8 @@ class EmptyFunctionBlockSpec {
             val code = """
                 fun a() {
                     fun b() {}
-                }"""
+                }
+            """
             assertThat(subject.compileAndLint(code)).hasSourceLocation(2, 13)
         }
 
@@ -77,7 +81,8 @@ class EmptyFunctionBlockSpec {
                     override fun stuff() {
                         // this is necessary...
                     }
-                }"""
+                }
+            """
 
             @Test
             fun `should flag empty block in overridden function`() {

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DeprecationSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DeprecationSpec.kt
@@ -30,7 +30,7 @@ class DeprecationSpec(private val env: KotlinCoreEnvironment) {
                     fun spam() {
                     }
                 }
-                """
+            """
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
             assertThat(findings.first().message).isEqualTo("Foo is deprecated.")
@@ -49,7 +49,7 @@ class DeprecationSpec(private val env: KotlinCoreEnvironment) {
                     fun baz() {
                     }
                 }
-                """
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
     }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DuplicateCaseInWhenExpressionSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DuplicateCaseInWhenExpressionSpec.kt
@@ -23,7 +23,8 @@ class DuplicateCaseInWhenExpressionSpec {
                         1, 2 -> kotlin.io.println()
                         else -> println()
                     }
-                }"""
+                }
+            """
             val result = subject.compileAndLint(code)
             assertThat(result).hasSize(1)
             assertThat(result.first().message).isEqualTo("When expression has multiple case statements for 1; 1, 2.")
@@ -37,7 +38,8 @@ class DuplicateCaseInWhenExpressionSpec {
                         1 -> println()
                         else -> println()
                     }
-                }"""
+                }
+            """
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
     }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsWithHashCodeExistSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsWithHashCodeExistSpec.kt
@@ -20,7 +20,8 @@ class EqualsWithHashCodeExistSpec {
                 val code = """
                 class A {
                     override fun hashCode(): Int { return super.hashCode() }
-                }"""
+                }
+                """
                 assertThat(subject.compileAndLint(code)).hasSize(1)
             }
 
@@ -29,7 +30,8 @@ class EqualsWithHashCodeExistSpec {
                 val code = """
                 class A {
                     override fun equals(other: Any?): Boolean { return super.equals(other) }
-                }"""
+                }
+                """
                 assertThat(subject.compileAndLint(code)).hasSize(1)
             }
 
@@ -39,7 +41,8 @@ class EqualsWithHashCodeExistSpec {
                 class A {
                     fun equals(other: Any?, i: Int): Boolean { return super.equals(other) }
                     override fun hashCode(): Int { return super.hashCode() }
-                }"""
+                }
+                """
                 assertThat(subject.compileAndLint(code)).hasSize(1)
             }
 
@@ -49,7 +52,8 @@ class EqualsWithHashCodeExistSpec {
                 class A {
                     override fun equals(other: Any?): Boolean { return super.equals(other) }
                     fun hashCode(i: Int): Int { return super.hashCode() }
-                }"""
+                }
+                """
                 assertThat(subject.compileAndLint(code)).hasSize(1)
             }
 
@@ -63,7 +67,8 @@ class EqualsWithHashCodeExistSpec {
                 class A : I {
                     override fun equals(other: Any?, i: Int): Boolean { return super.equals(other) }
                     override fun hashCode(): Int { return super.hashCode() }
-                }"""
+                }
+                """
                 assertThat(subject.compileAndLint(code)).hasSize(1)
             }
 
@@ -77,7 +82,8 @@ class EqualsWithHashCodeExistSpec {
                 class A : I {
                     override fun equals(other: Any?): Boolean { return super.equals(other) }
                     override fun hashCode(i: Int): Int { return super.hashCode() }
-                }"""
+                }
+                """
                 assertThat(subject.compileAndLint(code)).hasSize(1)
             }
 
@@ -87,7 +93,8 @@ class EqualsWithHashCodeExistSpec {
                 class A {
                     override fun equals(other: Any?): Boolean { return super.equals(other) }
                     override fun hashCode(): Int { return super.hashCode() }
-                }"""
+                }
+                """
                 assertThat(subject.compileAndLint(code)).isEmpty()
             }
 
@@ -97,7 +104,8 @@ class EqualsWithHashCodeExistSpec {
                 class A {
                     override fun equals(other: kotlin.Any?): Boolean { return super.equals(other) }
                     override fun hashCode(): Int { return super.hashCode() }
-                }"""
+                }
+                """
                 assertThat(subject.compileAndLint(code)).isEmpty()
             }
         }
@@ -112,7 +120,8 @@ class EqualsWithHashCodeExistSpec {
                     override fun equals(other: Any?): Boolean {
                         return super.equals(other)
                     }
-                }"""
+                }
+                """
                 assertThat(subject.compileAndLint(code)).isEmpty()
             }
         }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ExitOutsideMainSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ExitOutsideMainSpec.kt
@@ -20,7 +20,8 @@ class ExitOutsideMainSpec(private val env: KotlinCoreEnvironment) {
                 import kotlin.system.exitProcess
                 fun f() {
                     exitProcess(0)
-                }"""
+                }
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
@@ -29,7 +30,8 @@ class ExitOutsideMainSpec(private val env: KotlinCoreEnvironment) {
             val code = """
                 fun f() {
                     System.exit(0)
-                }"""
+                }
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
@@ -39,7 +41,8 @@ class ExitOutsideMainSpec(private val env: KotlinCoreEnvironment) {
                 import kotlin.system.exitProcess
                 fun main() {
                     exitProcess(0)
-                }"""
+                }
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -48,7 +51,8 @@ class ExitOutsideMainSpec(private val env: KotlinCoreEnvironment) {
             val code = """
                 fun main() {
                     System.exit(0)
-                }"""
+                }
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -60,7 +64,8 @@ class ExitOutsideMainSpec(private val env: KotlinCoreEnvironment) {
                     fun exit() {
                         exitProcess(0)
                     }
-                }"""
+                }
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
@@ -71,7 +76,8 @@ class ExitOutsideMainSpec(private val env: KotlinCoreEnvironment) {
                     fun exit() {
                         System.exit(0)
                     }
-                }"""
+                }
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
     }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ExplicitGarbageCollectionCallSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ExplicitGarbageCollectionCallSpec.kt
@@ -19,7 +19,8 @@ class ExplicitGarbageCollectionCallSpec {
                     System.gc()
                     Runtime.getRuntime().gc()
                     System.runFinalization()
-                }"""
+                }
+            """
             assertThat(subject.compileAndLint(code)).hasSize(3)
         }
     }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/HasPlatformTypeSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/HasPlatformTypeSpec.kt
@@ -21,7 +21,7 @@ class HasPlatformTypeSpec(private val env: KotlinCoreEnvironment) {
                 class Person {
                     fun apiCall() = System.getProperty("propertyName")
                 }
-                """
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
@@ -31,7 +31,7 @@ class HasPlatformTypeSpec(private val env: KotlinCoreEnvironment) {
                 class Person {
                     private fun apiCall() = System.getProperty("propertyName")
                 }
-                """
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -41,7 +41,7 @@ class HasPlatformTypeSpec(private val env: KotlinCoreEnvironment) {
                 class Person {
                     fun apiCall(): String = System.getProperty("propertyName")
                 }
-                """
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -51,7 +51,7 @@ class HasPlatformTypeSpec(private val env: KotlinCoreEnvironment) {
                 class Person {
                     val name = System.getProperty("name")
                 }
-                """
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
@@ -61,7 +61,7 @@ class HasPlatformTypeSpec(private val env: KotlinCoreEnvironment) {
                 class Person {
                     private val name = System.getProperty("name")
                 }
-                """
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -71,7 +71,7 @@ class HasPlatformTypeSpec(private val env: KotlinCoreEnvironment) {
                 class Person {
                     val name: String = System.getProperty("name")
                 }
-                """
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
     }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ImplicitDefaultLocaleSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ImplicitDefaultLocaleSpec.kt
@@ -20,7 +20,8 @@ class ImplicitDefaultLocaleSpec(private val env: KotlinCoreEnvironment) {
             val code = """
                 fun x() {
                     String.format("%d", 1)
-                }"""
+                }
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
@@ -30,7 +31,8 @@ class ImplicitDefaultLocaleSpec(private val env: KotlinCoreEnvironment) {
                 import java.util.Locale
                 fun x() {
                     String.format(Locale.US, "%d", 1)
-                }"""
+                }
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -40,7 +42,8 @@ class ImplicitDefaultLocaleSpec(private val env: KotlinCoreEnvironment) {
                 fun x() {
                     val s = "deadbeef"
                     s.toUpperCase()
-                }"""
+                }
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
@@ -51,7 +54,8 @@ class ImplicitDefaultLocaleSpec(private val env: KotlinCoreEnvironment) {
                 fun x() {
                     val s = "deadbeef"
                     s.toUpperCase(Locale.US)
-                }"""
+                }
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -61,7 +65,8 @@ class ImplicitDefaultLocaleSpec(private val env: KotlinCoreEnvironment) {
                 fun x() {
                     val s = "deadbeef"
                     s.toLowerCase()
-                }"""
+                }
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
@@ -72,7 +77,8 @@ class ImplicitDefaultLocaleSpec(private val env: KotlinCoreEnvironment) {
                 fun x() {
                     val s = "deadbeef"
                     s.toLowerCase(Locale.US)
-                }"""
+                }
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -82,7 +88,8 @@ class ImplicitDefaultLocaleSpec(private val env: KotlinCoreEnvironment) {
                 fun x() {
                     val s: String? = "deadbeef"
                     s?.toUpperCase()
-                }"""
+                }
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
@@ -92,7 +99,8 @@ class ImplicitDefaultLocaleSpec(private val env: KotlinCoreEnvironment) {
                 fun x() {
                     val s: String? = "deadbeef"
                     s?.toLowerCase()
-                }"""
+                }
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
     }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/InvalidRangeSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/InvalidRangeSpec.kt
@@ -21,7 +21,8 @@ class InvalidRangeSpec {
                     for (i in 2 until 3) {}
                     for (i in 2 until 4 step 2) {}
                     for (i in (1+1)..3) { }
-                }"""
+                }
+            """
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
@@ -33,7 +34,8 @@ class InvalidRangeSpec {
                     for (i in 1 downTo 2) { }
                     for (i in 2 until 2) { }
                     for (i in 2 until 1 step 2) { }
-                }"""
+                }
+            """
             assertThat(subject.compileAndLint(code)).hasSize(4)
         }
 
@@ -44,7 +46,8 @@ class InvalidRangeSpec {
                     for (i in 2..2) {
                         for (i in 2..1) { }
                     }
-                }"""
+                }
+            """
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
     }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MapGetWithNotNullAssertionOperatorSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MapGetWithNotNullAssertionOperatorSpec.kt
@@ -17,7 +17,8 @@ class MapGetWithNotNullAssertionOperatorSpec(private val env: KotlinCoreEnvironm
                 fun f() {
                     val map = emptyMap<Any, Any>()
                     val value = map["key"]!!
-                }"""
+                }
+        """
         assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
     }
 
@@ -27,7 +28,8 @@ class MapGetWithNotNullAssertionOperatorSpec(private val env: KotlinCoreEnvironm
                 fun f() {
                     val map = emptyMap<Any, Any>()
                     val value = map.get("key")!!
-                }"""
+                }
+        """
         assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
     }
 
@@ -37,7 +39,8 @@ class MapGetWithNotNullAssertionOperatorSpec(private val env: KotlinCoreEnvironm
                 fun f() {
                     val map = emptyMap<String, String>()
                     map["key"]
-                }"""
+                }
+        """
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 
@@ -47,7 +50,8 @@ class MapGetWithNotNullAssertionOperatorSpec(private val env: KotlinCoreEnvironm
                 fun f() {
                     val map = emptyMap<String, String>()
                     map.getValue("key")
-                }"""
+                }
+        """
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 
@@ -57,7 +61,8 @@ class MapGetWithNotNullAssertionOperatorSpec(private val env: KotlinCoreEnvironm
                 fun f() {
                     val map = emptyMap<String, String>()
                     map.getOrDefault("key", "")
-                }"""
+                }
+        """
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 
@@ -67,7 +72,8 @@ class MapGetWithNotNullAssertionOperatorSpec(private val env: KotlinCoreEnvironm
                 fun f() {
                     val map = emptyMap<String, String>()
                     map.getOrElse("key", { "" })
-                }"""
+                }
+        """
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/NullCheckOnMutablePropertySpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/NullCheckOnMutablePropertySpec.kt
@@ -25,7 +25,7 @@ class NullCheckOnMutablePropertySpec(private val env: KotlinCoreEnvironment) {
                         } 
                     }
                 }
-                """
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
@@ -39,7 +39,7 @@ class NullCheckOnMutablePropertySpec(private val env: KotlinCoreEnvironment) {
                         } 
                     }
                 }
-                """
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
@@ -53,7 +53,7 @@ class NullCheckOnMutablePropertySpec(private val env: KotlinCoreEnvironment) {
                         } 
                     }
                 }
-                """
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
@@ -67,7 +67,7 @@ class NullCheckOnMutablePropertySpec(private val env: KotlinCoreEnvironment) {
                         } 
                     }
                 }
-                """
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
@@ -84,7 +84,7 @@ class NullCheckOnMutablePropertySpec(private val env: KotlinCoreEnvironment) {
                         } 
                     }
                 }
-                """
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
@@ -98,7 +98,7 @@ class NullCheckOnMutablePropertySpec(private val env: KotlinCoreEnvironment) {
                         } 
                     }
                 }
-                """
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -113,7 +113,7 @@ class NullCheckOnMutablePropertySpec(private val env: KotlinCoreEnvironment) {
                         } 
                     }
                 }
-                """
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -127,7 +127,7 @@ class NullCheckOnMutablePropertySpec(private val env: KotlinCoreEnvironment) {
                         } 
                     }
                 }
-                """
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -142,7 +142,7 @@ class NullCheckOnMutablePropertySpec(private val env: KotlinCoreEnvironment) {
                         } 
                     }
                 }
-                """
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
@@ -157,7 +157,7 @@ class NullCheckOnMutablePropertySpec(private val env: KotlinCoreEnvironment) {
                         } 
                     }
                 }
-                """
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -179,7 +179,7 @@ class NullCheckOnMutablePropertySpec(private val env: KotlinCoreEnvironment) {
                         return if (randInt % 2 == 0) randInt else null
                     }
                 }
-                """
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
@@ -195,7 +195,7 @@ class NullCheckOnMutablePropertySpec(private val env: KotlinCoreEnvironment) {
                         }
                     }
                 }
-                """
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
@@ -217,7 +217,7 @@ class NullCheckOnMutablePropertySpec(private val env: KotlinCoreEnvironment) {
                         } 
                     }
                 }
-                """
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
@@ -233,7 +233,7 @@ class NullCheckOnMutablePropertySpec(private val env: KotlinCoreEnvironment) {
                         } 
                     }
                 }
-                """
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
@@ -249,7 +249,7 @@ class NullCheckOnMutablePropertySpec(private val env: KotlinCoreEnvironment) {
                         } 
                     }
                 }
-                """
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -263,7 +263,7 @@ class NullCheckOnMutablePropertySpec(private val env: KotlinCoreEnvironment) {
                         } 
                     }
                 }
-                """
+            """
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
@@ -277,7 +277,7 @@ class NullCheckOnMutablePropertySpec(private val env: KotlinCoreEnvironment) {
                         } 
                     }
                 }
-                """
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
@@ -292,7 +292,7 @@ class NullCheckOnMutablePropertySpec(private val env: KotlinCoreEnvironment) {
                         } 
                     }
                 }
-                """
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -309,7 +309,7 @@ class NullCheckOnMutablePropertySpec(private val env: KotlinCoreEnvironment) {
                         } 
                     }
                 }
-                """
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
     }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnconditionalJumpStatementInLoopSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnconditionalJumpStatementInLoopSpec.kt
@@ -351,7 +351,7 @@ class UnconditionalJumpStatementInLoopSpec {
                     }
                     return 0
                 }
-            """
+                """
             )
 
             assertThat(findings).isEmpty()

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessaryNotNullOperatorSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessaryNotNullOperatorSpec.kt
@@ -19,7 +19,7 @@ class UnnecessaryNotNullOperatorSpec(private val env: KotlinCoreEnvironment) {
             val code = """
                 val a = 1
                 val b = a!!
-                """
+            """
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasTextLocations(18 to 21)
@@ -30,7 +30,7 @@ class UnnecessaryNotNullOperatorSpec(private val env: KotlinCoreEnvironment) {
             val code = """
                 val a = 1
                 val b = a!!.plus(42)
-                """
+            """
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasTextLocations(18 to 21)
@@ -41,7 +41,7 @@ class UnnecessaryNotNullOperatorSpec(private val env: KotlinCoreEnvironment) {
             val code = """
                 val a = 1
                 val b = a!!.plus(42)!!
-                """
+            """
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(2)
             assertThat(findings).hasTextLocations(18 to 21, 18 to 32)
@@ -56,7 +56,7 @@ class UnnecessaryNotNullOperatorSpec(private val env: KotlinCoreEnvironment) {
             val code = """
                 val a : Int? = 1
                 val b = a!!
-                """
+            """
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessarySafeCallSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessarySafeCallSpec.kt
@@ -21,7 +21,8 @@ class UnnecessarySafeCallSpec(private val env: KotlinCoreEnvironment) {
                 fun test(s: String) {
                     val a = 1
                     val b = a?.toString()
-                }"""
+                }
+            """
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasTextLocations(48 to 61)
@@ -33,7 +34,8 @@ class UnnecessarySafeCallSpec(private val env: KotlinCoreEnvironment) {
                 fun test(s: String) {
                     val a = 1
                     val b = a?.plus(42)
-                }"""
+                }
+            """
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasTextLocations(48 to 59)
@@ -45,7 +47,8 @@ class UnnecessarySafeCallSpec(private val env: KotlinCoreEnvironment) {
                 fun test(s: String) {
                     val a = 1
                     val b = a?.plus(42)?.minus(24)
-                }"""
+                }
+            """
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(2)
             assertThat(findings).hasTextLocations(48 to 59, 48 to 70)
@@ -61,7 +64,8 @@ class UnnecessarySafeCallSpec(private val env: KotlinCoreEnvironment) {
                 fun test(s: String) {
                     val a : Int? = 1
                     val b = a?.plus(42)
-                }"""
+                }
+            """
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
@@ -78,7 +82,8 @@ class UnnecessarySafeCallSpec(private val env: KotlinCoreEnvironment) {
                 fun test(s: String) {
                     val a = outside()
                     val b = a?.plus(42)
-                }"""
+                }
+            """
             val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
@@ -91,7 +96,8 @@ class UnnecessarySafeCallSpec(private val env: KotlinCoreEnvironment) {
                 fun test(s: String) {
                     val a : Int? = outside()
                     val b = a?.plus(42)
-                }"""
+                }
+            """
             val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
@@ -104,7 +110,8 @@ class UnnecessarySafeCallSpec(private val env: KotlinCoreEnvironment) {
                 fun test(s: String) {
                     val a : Int = outside()
                     val b = a?.plus(42)
-                }"""
+                }
+            """
             val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasTextLocations(103 to 114)

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCallOnNullableTypeSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCallOnNullableTypeSpec.kt
@@ -16,7 +16,7 @@ class UnsafeCallOnNullableTypeSpec(private val env: KotlinCoreEnvironment) {
                 fun test(str: String?) {
                     println(str!!.length)
                 }
-                """
+        """
         assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
     }
 
@@ -26,7 +26,7 @@ class UnsafeCallOnNullableTypeSpec(private val env: KotlinCoreEnvironment) {
                 import java.util.UUID
 
                 val version = UUID.randomUUID()!!
-                """
+        """
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 
@@ -36,7 +36,7 @@ class UnsafeCallOnNullableTypeSpec(private val env: KotlinCoreEnvironment) {
                 fun test(str: String?) {
                     println(str?.length)
                 }
-                """
+        """
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 
@@ -46,7 +46,7 @@ class UnsafeCallOnNullableTypeSpec(private val env: KotlinCoreEnvironment) {
                 fun test(str: String?) {
                     println(str?.length ?: 0)
                 }
-                """
+        """
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCastSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCastSpec.kt
@@ -19,7 +19,8 @@ class UnsafeCastSpec(private val env: KotlinCoreEnvironment) {
             val code = """
                 fun test(s: String) {
                     println(s as Int)
-                }"""
+                }
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
@@ -28,7 +29,8 @@ class UnsafeCastSpec(private val env: KotlinCoreEnvironment) {
             val code = """
                 fun test(s: String) {
                     println((s as? Int) ?: 0)
-                }"""
+                }
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
@@ -37,7 +39,8 @@ class UnsafeCastSpec(private val env: KotlinCoreEnvironment) {
             val code = """
                 fun test(s: Any) {
                     println(s as Int)
-                }"""
+                }
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -46,7 +49,8 @@ class UnsafeCastSpec(private val env: KotlinCoreEnvironment) {
             val code = """
                 fun test(s: Any) {
                     println((s as? Int) ?: 0)
-                }"""
+                }
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
     }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UselessPostfixExpressionSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UselessPostfixExpressionSpec.kt
@@ -19,7 +19,8 @@ class UselessPostfixExpressionSpec {
                     i = i-- // invalid
                     i = 1 + i++ // invalid
                     i = i++ + 1 // invalid
-                }"""
+                }
+            """
             assertThat(subject.compileAndLint(code)).hasSize(3)
         }
 
@@ -30,7 +31,8 @@ class UselessPostfixExpressionSpec {
                     var i = 0
                     var j = 0
                     j = i++
-                }"""
+                }
+            """
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
@@ -42,7 +44,8 @@ class UselessPostfixExpressionSpec {
                     var j = 0
                     if (i == 0) return 1 + j++
                     return i++
-                }"""
+                }
+            """
             assertThat(subject.compileAndLint(code)).hasSize(2)
         }
 
@@ -66,7 +69,7 @@ class UselessPostfixExpressionSpec {
                         return i++
                     }
                 }
-                """
+            """
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
@@ -88,7 +91,7 @@ class UselessPostfixExpressionSpec {
                         return i++
                     }
                 }
-                """
+            """
             assertThat(subject.compileAndLint(code)).hasSize(2)
         }
     }
@@ -108,7 +111,7 @@ class UselessPostfixExpressionSpec {
                 fun f2(): Int {
                     return str!!.count()
                 }
-                """
+            """
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
@@ -119,7 +122,7 @@ class UselessPostfixExpressionSpec {
                     val str: String? = ""
                     str!!
                 }
-                """
+            """
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
     }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/WrongEqualsTypeParameterSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/WrongEqualsTypeParameterSpec.kt
@@ -19,7 +19,8 @@ class WrongEqualsTypeParameterSpec {
                     override fun equals(other: Any?): Boolean {
                         return super.equals(other)
                     }
-                }"""
+                }
+            """
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
@@ -30,7 +31,8 @@ class WrongEqualsTypeParameterSpec {
                     fun equals(other: String): Boolean {
                         return super.equals(other)
                     }
-                }"""
+                }
+            """
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
@@ -41,7 +43,8 @@ class WrongEqualsTypeParameterSpec {
                     fun equals(other: Any?, i: Int): Boolean {
                         return super.equals(other)
                     }
-                }"""
+                }
+            """
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
@@ -59,7 +62,8 @@ class WrongEqualsTypeParameterSpec {
                     }
                     
                     override fun equals() = true
-                }"""
+                }
+            """
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
@@ -68,7 +72,8 @@ class WrongEqualsTypeParameterSpec {
             val code = """
                 interface I {
                     fun equals(other: String)
-                }"""
+                }
+            """
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
@@ -77,7 +82,7 @@ class WrongEqualsTypeParameterSpec {
             val code = """
                 fun equals(other: String) {}
                 fun equals(other: Any?) {}
-                """
+            """
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
     }

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ExceptionRaisedInUnexpectedLocationSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ExceptionRaisedInUnexpectedLocationSpec.kt
@@ -33,7 +33,8 @@ class ExceptionRaisedInUnexpectedLocationSpec {
                 """
             fun toDo() {
                 throw IllegalStateException()
-            }"""
+            }
+                """
             )
             assertThat(findings).hasSize(1)
         }
@@ -45,7 +46,8 @@ class ExceptionRaisedInUnexpectedLocationSpec {
                 """
             fun toDo() {
                 throw IllegalStateException()
-            }"""
+            }
+                """
             )
             assertThat(findings).hasSize(1)
         }

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/InstanceOfCheckForExceptionSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/InstanceOfCheckForExceptionSpec.kt
@@ -25,7 +25,7 @@ class InstanceOfCheckForExceptionSpec(val env: KotlinCoreEnvironment) {
                         }
                     }
                 }
-                """
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(2)
         }
 
@@ -40,7 +40,7 @@ class InstanceOfCheckForExceptionSpec(val env: KotlinCoreEnvironment) {
                         }
                     }
                 }
-                """
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(2)
         }
 
@@ -57,7 +57,7 @@ class InstanceOfCheckForExceptionSpec(val env: KotlinCoreEnvironment) {
                         }
                     }
                 }
-                """
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -73,7 +73,7 @@ class InstanceOfCheckForExceptionSpec(val env: KotlinCoreEnvironment) {
                         }
                     }
                 }
-                """
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
     }

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/NotImplementedDeclarationSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/NotImplementedDeclarationSpec.kt
@@ -17,7 +17,8 @@ class NotImplementedDeclarationSpec {
             fun f() {
                 if (1 == 1) throw NotImplementedError()
                 throw NotImplementedError()
-            }"""
+            }
+            """
             assertThat(subject.compileAndLint(code)).hasSize(2)
         }
 
@@ -27,7 +28,8 @@ class NotImplementedDeclarationSpec {
             fun f() {
                 TODO("not implemented")
                 TODO()
-            }"""
+            }
+            """
             assertThat(subject.compileAndLint(code)).hasSize(2)
         }
 
@@ -36,7 +38,8 @@ class NotImplementedDeclarationSpec {
             val code = """
             fun f() {
                 // TODO
-            }"""
+            }
+            """
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
     }

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/PrintStackTraceSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/PrintStackTraceSpec.kt
@@ -22,7 +22,8 @@ class PrintStackTraceSpec {
                     } catch (e: Exception) {
                         e.printStackTrace()
                     }
-                }"""
+                }
+                """
                 assertThat(subject.compileAndLint(code)).hasSize(1)
             }
 
@@ -54,7 +55,8 @@ class PrintStackTraceSpec {
 
                     fun dumpStack() {}
                     dumpStack()
-                }"""
+                }
+                """
                 assertThat(subject.compileAndLint(code)).hasSize(1)
             }
         }

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedExceptionSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedExceptionSpec.kt
@@ -165,7 +165,7 @@ class SwallowedExceptionSpec {
                         } catch (e: IllegalArgumentException) {
                         }
                     }
-                """
+                    """
                     assertThat(rule.compileAndLint(code)).isEmpty()
                 }
 
@@ -177,7 +177,7 @@ class SwallowedExceptionSpec {
                         } catch (e: Exception) {
                         }
                     }
-                """
+                    """
                     assertThat(rule.compileAndLint(code)).hasSize(1)
                 }
             }
@@ -203,7 +203,7 @@ class SwallowedExceptionSpec {
                         } catch (e: IllegalArgumentException) {
                         }
                     }
-                """
+                    """
                     assertThat(rule.compileAndLint(code)).isEmpty()
                 }
 
@@ -215,7 +215,7 @@ class SwallowedExceptionSpec {
                         } catch (e: Exception) {
                         }
                     }
-                """
+                    """
                     assertThat(rule.compileAndLint(code)).hasSize(1)
                 }
             }

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionFromFinallySpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionFromFinallySpec.kt
@@ -21,7 +21,8 @@ class ThrowingExceptionFromFinallySpec {
                             throw IllegalArgumentException()
                         }
                     }
-                }"""
+                }
+            """
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
@@ -33,7 +34,8 @@ class ThrowingExceptionFromFinallySpec {
                     } finally {
                         throw IllegalArgumentException()
                     }
-                }"""
+                }
+            """
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
@@ -45,7 +47,8 @@ class ThrowingExceptionFromFinallySpec {
                     } finally {
                         println()
                     }
-                }"""
+                }
+            """
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
     }

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionInMainSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionInMainSpec.kt
@@ -54,7 +54,8 @@ class ThrowingExceptionInMainSpec {
                 private fun main() { throw IllegalArgumentException() }
                 fun mai() { throw IllegalArgumentException() }
                 fun main(args: String) { throw IllegalArgumentException() }
-                fun main(args: Array<String>, i: Int) { throw IllegalArgumentException() }"""
+                fun main(args: Array<String>, i: Int) { throw IllegalArgumentException() }
+            """
             assertThat(subject.lint(code)).isEmpty()
         }
 
@@ -64,7 +65,8 @@ class ThrowingExceptionInMainSpec {
                 fun main(args: Array<String>) { }
                 fun main() { }
                 fun mai() { }
-                fun main(args: String) { }"""
+                fun main(args: String) { }
+            """
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionsWithoutMessageOrCauseSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionsWithoutMessageOrCauseSpec.kt
@@ -23,7 +23,8 @@ class ThrowingExceptionsWithoutMessageOrCauseSpec {
                     IllegalArgumentException(IllegalArgumentException())
                     IllegalArgumentException("foo")
                     throw IllegalArgumentException()
-                }"""
+                }
+            """
 
             @Test
             fun `reports calls to the default constructor`() {
@@ -47,7 +48,7 @@ class ThrowingExceptionsWithoutMessageOrCauseSpec {
                 fun test() {
                     org.assertj.core.api.Assertions.assertThatIllegalArgumentException().isThrownBy { println() }
                 }
-            """
+                """
                 assertThat(subject.compileAndLint(code)).isEmpty()
             }
         }

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingNewInstanceOfSameExceptionSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingNewInstanceOfSameExceptionSpec.kt
@@ -21,7 +21,7 @@ class ThrowingNewInstanceOfSameExceptionSpec {
                     throw IllegalStateException(e)
                 }
             }
-        """
+            """
 
             @Test
             fun `should report`() {
@@ -39,7 +39,7 @@ class ThrowingNewInstanceOfSameExceptionSpec {
                     throw IllegalArgumentException(e)
                 }
             }
-        """
+            """
 
             @Test
             fun `should not report`() {
@@ -58,7 +58,7 @@ class ThrowingNewInstanceOfSameExceptionSpec {
                     throw IllegalStateException()
                 }
             }
-        """
+            """
 
             @Test
             fun `should not report`() {

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/BooleanPropertyNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/BooleanPropertyNamingSpec.kt
@@ -75,7 +75,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                     class Test {
                         var default: Boolean = true
                     }
-                    """
+                """
                 val findings = subject.compileAndLintWithContext(env, code)
 
                 assertThat(findings).hasSize(1)
@@ -87,7 +87,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                     class Test {
                         var default: Boolean? = null
                     }
-                    """
+                """
                 val findings = subject.compileAndLintWithContext(env, code)
 
                 assertThat(findings).hasSize(1)
@@ -99,7 +99,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                     class Test {
                         var default: Boolean = false
                     }
-                    """
+                """
                 val findings = subject.compileAndLintWithContext(env, code)
 
                 assertThat(findings).hasSize(1)
@@ -111,7 +111,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                     class Test {
                         var default = true
                     }
-                    """
+                """
                 val findings = subject.compileAndLintWithContext(env, code)
 
                 assertThat(findings).hasSize(1)
@@ -123,7 +123,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                     class Test {
                         var default: java.lang.Boolean = java.lang.Boolean(true)
                     }
-                    """
+                """
                 val findings = subject.compileAndLintWithContext(env, code)
 
                 assertThat(findings).hasSize(1)
@@ -135,7 +135,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                     class Test {
                         var count: Int = 0
                     }
-                    """
+                """
                 val findings = subject.compileAndLintWithContext(env, code)
 
                 assertThat(findings).isEmpty()
@@ -148,7 +148,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                         var isEnabled: Boolean = true
                         var hasDefault: Boolean = true
                     }
-                    """
+                """
                 val findings = subject.compileAndLintWithContext(env, code)
 
                 assertThat(findings).isEmpty()
@@ -160,7 +160,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                     class Test {
                         var needReload: Boolean = true
                     }
-                    """
+                """
 
                 val config = TestConfig(mapOf(ALLOWED_PATTERN to "^(is|has|are|need)"))
                 assertThat(BooleanPropertyNaming(config).compileAndLint(code))

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/EnumNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/EnumNamingSpec.kt
@@ -27,7 +27,8 @@ class EnumNamingSpec {
             val code = """
                 enum class WorkFlow {
                     default
-                }"""
+                }
+            """
             assertThat(NamingRules().compileAndLint(code)).hasSize(1)
         }
 
@@ -36,7 +37,8 @@ class EnumNamingSpec {
             val code = """
                 enum class WorkFlow {
                     _Default
-                }"""
+                }
+            """
             assertThat(EnumNaming().compileAndLint(code)).hasSize(1)
         }
 
@@ -45,7 +47,8 @@ class EnumNamingSpec {
             val code = """
                 enum class WorkFlow {
                     @Suppress("EnumNaming") _Default
-                }"""
+                }
+            """
             assertThat(EnumNaming().compileAndLint(code)).isEmpty()
         }
 
@@ -54,7 +57,8 @@ class EnumNamingSpec {
             val code = """
                 enum class WorkFlow {
                     _Default,
-                }"""
+                }
+            """
             val findings = EnumNaming().compileAndLint(code)
             assertThat(findings).hasTextLocations(26 to 34)
         }

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ForbiddenClassNameSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ForbiddenClassNameSpec.kt
@@ -18,7 +18,8 @@ class ForbiddenClassNameSpec {
             val code = """
                 class TestManager {} // violation
                 class TestProvider {} // violation
-                class TestHolder"""
+                class TestHolder
+            """
             assertThat(
                 ForbiddenClassName(TestConfig(mapOf(FORBIDDEN_NAME to listOf("Manager", "Provider"))))
                     .compileAndLint(code)
@@ -41,7 +42,8 @@ class ForbiddenClassNameSpec {
             val code = """
                 class TestManager {} // violation
                 class TestProvider {} // violation
-                class TestHolder"""
+                class TestHolder
+            """
             assertThat(
                 ForbiddenClassName(TestConfig(mapOf(FORBIDDEN_NAME to "Manager, Provider")))
                     .compileAndLint(code)
@@ -54,7 +56,8 @@ class ForbiddenClassNameSpec {
             val code = """
                 class TestManager {} // violation
                 class TestProvider {} // violation
-                class TestHolder"""
+                class TestHolder
+            """
             assertThat(
                 ForbiddenClassName(TestConfig(mapOf(FORBIDDEN_NAME to "*Manager*, *Provider*")))
                     .compileAndLint(code)
@@ -65,7 +68,8 @@ class ForbiddenClassNameSpec {
         @Test
         fun `should report all forbidden names in message`() {
             val code = """
-                class TestManager {}"""
+                class TestManager {}
+            """
             val actual = ForbiddenClassName(TestConfig(mapOf(FORBIDDEN_NAME to "Test, Manager, Provider")))
                 .compileAndLint(code)
             assertThat(actual.first().message)

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNamingSpec.kt
@@ -17,7 +17,7 @@ class FunctionNamingSpec {
             val code = """
             @Suppress("FunctionName")
             fun MY_FUN() {}
-        """
+            """
             assertThat(FunctionNaming().compileAndLint(code)).isEmpty()
         }
 
@@ -27,7 +27,7 @@ class FunctionNamingSpec {
             val f: (Int) -> Int = fun(i: Int): Int {
                 return i + i
             }
-        """
+            """
             assertThat(FunctionNaming().compileAndLint(code)).isEmpty()
         }
 
@@ -37,7 +37,7 @@ class FunctionNamingSpec {
             class WhateverTest {
                 fun SHOULD_NOT_BE_FLAGGED() {}
             }
-        """
+            """
             val config = TestConfig(mapOf(FunctionNaming.EXCLUDE_CLASS_PATTERN to ".*Test$"))
             assertThat(FunctionNaming(config).compileAndLint(code)).isEmpty()
         }
@@ -51,7 +51,7 @@ class FunctionNamingSpec {
                 }
             }
             interface I { fun shouldNotBeFlagged() }
-        """
+            """
             assertThat(FunctionNaming().compileAndLint(code)).hasSourceLocation(3, 13)
         }
 
@@ -62,7 +62,7 @@ class FunctionNamingSpec {
                 override fun SHOULD_NOT_BE_FLAGGED() {}
             }
             interface I { @Suppress("FunctionNaming") fun SHOULD_NOT_BE_FLAGGED() }
-        """
+            """
             assertThat(FunctionNaming().compileAndLint(code)).isEmpty()
         }
 
@@ -73,7 +73,7 @@ class FunctionNamingSpec {
             private class FooImpl : Foo
 
             fun Foo(): Foo = FooImpl()
-        """
+            """
             val config = TestConfig(mapOf(FunctionNaming.IGNORE_OVERRIDDEN to "false"))
             assertThat(FunctionNaming(config).compileAndLint(code)).isEmpty()
         }
@@ -87,7 +87,7 @@ class FunctionNamingSpec {
                 }
             }
             interface I { @Suppress("FunctionNaming") fun SHOULD_BE_FLAGGED() }
-        """
+            """
             assertThat(FunctionNaming().compileAndLint(code)).hasSourceLocation(3, 13)
         }
 
@@ -98,7 +98,7 @@ class FunctionNamingSpec {
                 override fun SHOULD_BE_FLAGGED() {}
             }
             interface I { fun SHOULD_BE_FLAGGED() }
-        """
+            """
             val config = TestConfig(mapOf(FunctionNaming.IGNORE_OVERRIDDEN to "false"))
             assertThat(FunctionNaming(config).compileAndLint(code)).hasSourceLocations(
                 SourceLocation(2, 18),

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MatchingDeclarationNameSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MatchingDeclarationNameSpec.kt
@@ -53,7 +53,7 @@ class MatchingDeclarationNameSpec {
                     enum class E {
                         ONE, TWO, THREE
                     }
-                """,
+                    """,
                     filename = "E.kt"
                 )
                 val findings = MatchingDeclarationName().lint(ktFile)
@@ -67,7 +67,7 @@ class MatchingDeclarationNameSpec {
                     class C
                     object O
                     fun a() = 5
-                """,
+                    """,
                     filename = "MultiDeclarations.kt"
                 )
                 val findings = MatchingDeclarationName().lint(ktFile)
@@ -81,7 +81,7 @@ class MatchingDeclarationNameSpec {
                     class C
                     fun a() = 5
                     fun C.b() = 5
-                """,
+                    """,
                     filename = "C.kt"
                 )
                 val findings = MatchingDeclarationName().lint(ktFile)
@@ -95,7 +95,7 @@ class MatchingDeclarationNameSpec {
                     fun a() = 5
                     fun C.b() = 5
                     class C
-                """,
+                    """,
                     filename = "Classes.kt"
                 )
                 val findings = MatchingDeclarationName().lint(ktFile)
@@ -108,7 +108,7 @@ class MatchingDeclarationNameSpec {
                     """
                 private class C
                 fun a() = 5
-            """,
+                    """,
                     filename = "b.kt"
                 )
                 val findings = MatchingDeclarationName().lint(ktFile)
@@ -120,7 +120,8 @@ class MatchingDeclarationNameSpec {
                 val code = """
                 typealias Foo = FooImpl
 
-                class FooImpl {}"""
+                class FooImpl {}
+                """
                 val ktFile = compileContentForTest(code, filename = "Foo.kt")
                 val findings = MatchingDeclarationName().lint(ktFile)
                 assertThat(findings).isEmpty()
@@ -207,7 +208,7 @@ class MatchingDeclarationNameSpec {
                     fun a() = 5
                     fun C.b() = 5
                     class C
-                """,
+                    """,
                     filename = "Classes.kt"
                 )
                 val findings = MatchingDeclarationName(

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingConventionCustomPatternSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingConventionCustomPatternSpec.kt
@@ -52,7 +52,8 @@ class NamingConventionCustomPatternSpec {
 
             object Foo {
                 val MYVar = 3
-            }"""
+            }
+    """
 
     val excludeClassPatternFunctionRegexCode = """
             class Bar {
@@ -61,7 +62,8 @@ class NamingConventionCustomPatternSpec {
 
             object Foo {
                 fun MYFun() {}
-            }"""
+            }
+    """
 
     @Nested
     inner class `NamingRules rule` {
@@ -81,7 +83,7 @@ class NamingConventionCustomPatternSpec {
                   const val lowerCaseConst = ""
                 }
             }
-        """
+                    """
                 )
             ).isEmpty()
         }
@@ -97,7 +99,7 @@ class NamingConventionCustomPatternSpec {
                   const val lowerCaseConst = ""
                 }
             }
-        """
+                    """
                 )
             ).isEmpty()
         }
@@ -113,7 +115,7 @@ class NamingConventionCustomPatternSpec {
                     enum1, enum2
                 }
             }
-        """
+                    """
                 )
             ).isEmpty()
         }
@@ -133,7 +135,8 @@ class NamingConventionCustomPatternSpec {
 
             object Foo {
                 val MYVar = 3
-            }"""
+            }
+            """
             val config = TestConfig(mapOf(VariableNaming.EXCLUDE_CLASS_PATTERN to "Foo|Bar"))
             assertThat(VariableNaming(config).compileAndLint(code)).isEmpty()
         }
@@ -165,7 +168,8 @@ class NamingConventionCustomPatternSpec {
 
             object Foo {
                 fun MYFun() {}
-            }"""
+            }
+            """
             val config = TestConfig(mapOf(FunctionNaming.EXCLUDE_CLASS_PATTERN to "Foo|Bar"))
             assertThat(FunctionNaming(config).compileAndLint(code)).isEmpty()
         }

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingConventionLengthSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingConventionLengthSpec.kt
@@ -49,7 +49,8 @@ class NamingConventionLengthSpec {
                 val code = """
                     class C {
                         val prop: (Int) -> Unit = { _ -> Unit }
-                }"""
+                }
+                """
                 assertThat(variableMinLength.compileAndLint(code)).isEmpty()
             }
         }

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NonBooleanPropertyWithPrefixIsSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NonBooleanPropertyWithPrefixIsSpec.kt
@@ -62,7 +62,7 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinCoreEnvironment) {
                     data class O (var isDefault: Inner) {
                         class Inner
                     }
-                    """
+                """
                 val findings = subject.compileAndLintWithContext(env, code)
 
                 assertThat(findings).hasSize(1)
@@ -93,7 +93,7 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinCoreEnvironment) {
                     class O {
                         var isDefault = false
                     }
-                    """
+                """
                 val findings = subject.compileAndLintWithContext(env, code)
 
                 assertThat(findings).isEmpty()
@@ -109,7 +109,7 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinCoreEnvironment) {
                             isDefault = true
                         }
                     }
-                    """
+                """
                 val findings = subject.compileAndLintWithContext(env, code)
 
                 assertThat(findings).isEmpty()
@@ -121,7 +121,7 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinCoreEnvironment) {
                     class O {
                         var isDefault: Boolean? = null
                     }
-                    """
+                """
                 val findings = subject.compileAndLintWithContext(env, code)
 
                 assertThat(findings).isEmpty()
@@ -133,7 +133,7 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinCoreEnvironment) {
                     class O {
                         var isDefault: java.lang.Boolean = java.lang.Boolean(false)
                     }
-                    """
+                """
                 val findings = subject.compileAndLintWithContext(env, code)
 
                 assertThat(findings).isEmpty()
@@ -149,7 +149,7 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinCoreEnvironment) {
                             isDefault = java.lang.Boolean(false)
                         }
                    }
-                   """
+                """
                 val findings = subject.compileAndLintWithContext(env, code)
 
                 assertThat(findings).isEmpty()
@@ -161,7 +161,7 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinCoreEnvironment) {
                     class O {
                         var isDefault: java.lang.Boolean? = null
                     }
-                    """
+                """
                 val findings = subject.compileAndLintWithContext(env, code)
 
                 assertThat(findings).isEmpty()
@@ -173,7 +173,7 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinCoreEnvironment) {
                     class O {
                         var isDefault: Int = 0
                     }
-                    """
+                """
                 val findings = subject.compileAndLintWithContext(env, code)
 
                 assertThat(findings).hasSize(1)
@@ -185,7 +185,7 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinCoreEnvironment) {
                     class O {
                         var isDefault = 0
                     }
-                    """
+                """
                 val findings = subject.compileAndLintWithContext(env, code)
 
                 assertThat(findings).hasSize(1)
@@ -197,7 +197,7 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinCoreEnvironment) {
                     class O {
                         var isDefault = listOf(1, 2, 3)
                     }
-                    """
+                """
                 val findings = subject.compileAndLintWithContext(env, code)
 
                 assertThat(findings).hasSize(1)
@@ -211,7 +211,7 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinCoreEnvironment) {
                         
                         class Inner
                     }
-                    """
+                """
                 val findings = subject.compileAndLintWithContext(env, code)
 
                 assertThat(findings).hasSize(1)
@@ -223,7 +223,7 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinCoreEnvironment) {
                     class O {
                         var `is`: Int = 0
                     }
-                    """
+                """
                 val findings = subject.compileAndLintWithContext(env, code)
 
                 assertThat(findings).isEmpty()
@@ -235,7 +235,7 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinCoreEnvironment) {
                     class O {
                         var isengardTowerHeightInFeet: Int = 500
                     }
-                    """
+                """
                 val findings = subject.compileAndLintWithContext(env, code)
 
                 assertThat(findings).isEmpty()
@@ -247,7 +247,7 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinCoreEnvironment) {
                     fun f() {
                         var isDefault: Int = 0
                     }
-                    """
+                """
                 val findings = subject.compileAndLintWithContext(env, code)
 
                 assertThat(findings).hasSize(1)

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNamingSpec.kt
@@ -248,7 +248,8 @@ abstract class NamingSnippet(private val isPrivate: Boolean, private val isConst
                     ${visibility()}${const()}val MyNAME = "Artur"
                     ${visibility()}${const()}val name = "Artur"
                     ${visibility()}${const()}val nAme = "Artur"
-                    ${visibility()}${const()}val serialVersionUID = 42L"""
+                    ${visibility()}${const()}val serialVersionUID = 42L
+    """
     val positive = """${visibility()}${const()}val _nAme = "Artur""""
 
     private fun visibility() = if (isPrivate) "private " else ""

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/PackageNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/PackageNamingSpec.kt
@@ -17,7 +17,7 @@ class PackageNamingSpec {
                     """
                     @file:Suppress("PackageDirectoryMismatch")
                     package FOO.BAR
-                """
+                    """
                 )
             ).isEmpty()
         }

--- a/detekt-rules-performance/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/ForEachOnRangeSpec.kt
+++ b/detekt-rules-performance/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/ForEachOnRangeSpec.kt
@@ -29,7 +29,7 @@ class ForEachOnRangeSpec {
                     println(it)
                 }
             }
-        """
+            """
 
             @Test
             fun `should report the forEach usage`() {
@@ -44,7 +44,7 @@ class ForEachOnRangeSpec {
             fun test() {
                 (1..10).isEmpty()
             }
-        """
+            """
 
             @Test
             fun `should not report any issues`() {
@@ -61,7 +61,7 @@ class ForEachOnRangeSpec {
                     println(it)
                 }
             }
-        """
+            """
 
             @Test
             fun `should not report any issues`() {

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenImport.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenImport.kt
@@ -18,7 +18,6 @@ import org.jetbrains.kotlin.psi.KtImportDirective
  *
  * <noncompliant>
  * package foo
-
  * import kotlin.jvm.JvmField
  * import kotlin.SinceKotlin
  * </noncompliant>

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantVisibilityModifierRule.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantVisibilityModifierRule.kt
@@ -24,7 +24,6 @@ import org.jetbrains.kotlin.psi.psiUtil.isPrivate
 
 /**
  * This rule checks for redundant visibility modifiers.
-
  * One exemption is the
  * [explicit API mode](https://kotlinlang.org/docs/whatsnew14.html#explicit-api-mode-for-library-authors)
  * In this mode, the visibility modifier should be defined explicitly even if it is public.

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/CanBeNonNullableSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/CanBeNonNullableSpec.kt
@@ -24,7 +24,7 @@ class CanBeNonNullableSpec : Spek({
                         a = 6
                     }
                 }
-                """
+            """
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
@@ -76,7 +76,7 @@ class CanBeNonNullableSpec : Spek({
                             }
                         }
                     }
-                    """
+                """
                 assertThat(subject.compileAndLintWithContext(env, code)).hasSize(2)
             }
 
@@ -129,7 +129,7 @@ class CanBeNonNullableSpec : Spek({
                     class A(private var aDelegate: Int?) {
                         private var a: Int? by this::aDelegate
                     }
-                    """
+                """
                 assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
             }
 
@@ -201,7 +201,7 @@ class CanBeNonNullableSpec : Spek({
                             a = 6
                         }
                     }
-                    """
+                """
                 assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
             }
 
@@ -346,7 +346,7 @@ class CanBeNonNullableSpec : Spek({
                             return if (randInt % 2 == 0) randInt else null
                         }
                     }
-                    """
+                """
                 assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
             }
         }
@@ -357,7 +357,7 @@ class CanBeNonNullableSpec : Spek({
                     open val a: Int? = 5
                     open var b: Int? = 5
                 }
-                """
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -370,7 +370,7 @@ class CanBeNonNullableSpec : Spek({
                     // as non-null in Kotlin code.
                     private var a: String? = e.localizedMessage
                 }
-                """
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -380,7 +380,7 @@ class CanBeNonNullableSpec : Spek({
                     val a: Int?
                     var b: Int?
                 }
-                """
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/EqualsNullCallSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/EqualsNullCallSpec.kt
@@ -15,7 +15,8 @@ class EqualsNullCallSpec : Spek({
             val code = """
                 fun x(a: String) {
                     a.equals(null)
-                }"""
+                }
+            """
             assertThat(subject.compileAndLint(code).size).isEqualTo(1)
         }
 
@@ -23,7 +24,8 @@ class EqualsNullCallSpec : Spek({
             val code = """
                 fun x(a: String, b: String) {
                     a.equals(b.equals(null))
-                }"""
+                }
+            """
             assertThat(subject.compileAndLint(code).size).isEqualTo(1)
         }
 
@@ -31,7 +33,8 @@ class EqualsNullCallSpec : Spek({
             val code = """
                 fun x(a: String, b: String) {
                     a.equals(b)
-                }"""
+                }
+            """
             assertThat(subject.compileAndLint(code).size).isEqualTo(0)
         }
     }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/EqualsOnSignatureLineSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/EqualsOnSignatureLineSpec.kt
@@ -17,7 +17,7 @@ class EqualsOnSignatureLineSpec : Spek({
                     """
                     fun foo()
                         = 1
-                """
+                    """
                 )
                 assertThat(findings).hasSize(1)
             }
@@ -29,7 +29,7 @@ class EqualsOnSignatureLineSpec : Spek({
 
                 fun bar() =
                     2
-                """
+                    """
                 )
                 assertThat(findings).isEmpty()
             }
@@ -51,7 +51,7 @@ class EqualsOnSignatureLineSpec : Spek({
                     foo: String
                 ): Int
                     = 3
-                """
+                    """
                 )
                 assertThat(findings).hasSize(3)
             }
@@ -87,7 +87,7 @@ class EqualsOnSignatureLineSpec : Spek({
                 :
                 Int =
                     6
-                """
+                    """
                 )
                 assertThat(findings).isEmpty()
             }
@@ -110,7 +110,7 @@ class EqualsOnSignatureLineSpec : Spek({
                 ): Int
                     where V : Number
                     = 3
-                """
+                    """
                 )
                 assertThat(findings).hasSize(3)
             }
@@ -125,7 +125,7 @@ class EqualsOnSignatureLineSpec : Spek({
                     where V : Number =
                     2
 
-                """
+                    """
                 )
                 assertThat(findings).isEmpty()
             }
@@ -146,7 +146,7 @@ class EqualsOnSignatureLineSpec : Spek({
             Unit
             {
             }
-            """
+                """
             )
             assertThat(findings).isEmpty()
         }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitCollectionElementAccessMethodSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitCollectionElementAccessMethodSpec.kt
@@ -23,7 +23,8 @@ class ExplicitCollectionElementAccessMethodSpec : Spek({
                     fun f() {
                         val map = mapOf<String, String>() 
                         val value = map.get("key") 
-                    }"""
+                    }
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
@@ -32,7 +33,8 @@ class ExplicitCollectionElementAccessMethodSpec : Spek({
                     fun f() {
                         val map = mapOf<String, String>() 
                         val value = map?.get("key") 
-                    }"""
+                    }
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -41,7 +43,8 @@ class ExplicitCollectionElementAccessMethodSpec : Spek({
                     fun f() {
                         val map = mutableMapOf<String, String>() 
                         map.set("key", "value") 
-                    }"""
+                    }
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
@@ -50,7 +53,8 @@ class ExplicitCollectionElementAccessMethodSpec : Spek({
                     fun f() {
                         val map = mutableMapOf<String, String>()
                         map.put("key", "val") 
-                    }"""
+                    }
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
@@ -59,7 +63,8 @@ class ExplicitCollectionElementAccessMethodSpec : Spek({
                     fun f() {
                         val map = mutableMapOf<String, String>() 
                         val oldValue = map.put("key", "val") 
-                    }"""
+                    }
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -68,7 +73,8 @@ class ExplicitCollectionElementAccessMethodSpec : Spek({
                     fun f(): Boolean {
                         val map = mutableMapOf<String, String>()
                         return map.put("key", "val") == null
-                    }"""
+                    }
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -77,7 +83,8 @@ class ExplicitCollectionElementAccessMethodSpec : Spek({
                     fun f() {
                         val map = hashMapOf<String, String>() 
                         val value = map.get("key") 
-                    }"""
+                    }
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
@@ -86,7 +93,8 @@ class ExplicitCollectionElementAccessMethodSpec : Spek({
                     fun f() {
                         val map = hashMapOf<String, String>() 
                         map.put("key", "value") 
-                    }"""
+                    }
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
@@ -95,7 +103,8 @@ class ExplicitCollectionElementAccessMethodSpec : Spek({
                     fun f() {
                         val map = mapOf<String, String>()
                         val value = map["key"] 
-                    }"""
+                    }
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -104,7 +113,8 @@ class ExplicitCollectionElementAccessMethodSpec : Spek({
                     fun f() {
                         val map = mutableMapOf<String, String>()
                         map["key"] = "value" 
-                    }"""
+                    }
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -113,7 +123,8 @@ class ExplicitCollectionElementAccessMethodSpec : Spek({
                     fun f() {
                         val map = mapOf<String, String>()
                         val value = listOf("1", "2").associateBy { it }.get("1")
-                    }"""
+                    }
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
@@ -122,7 +133,8 @@ class ExplicitCollectionElementAccessMethodSpec : Spek({
                     fun f() {
                         val map = linkedMapOf<String, String>()
                         val value = map.get("key") 
-                    }"""
+                    }
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
@@ -143,7 +155,8 @@ class ExplicitCollectionElementAccessMethodSpec : Spek({
                     fun f() {
                         val list = listOf<String>() 
                         val value = list.get(0) 
-                    }"""
+                    }
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
@@ -152,7 +165,8 @@ class ExplicitCollectionElementAccessMethodSpec : Spek({
                     fun f() {
                         val list = mutableListOf<String>()
                         val value = list.get(0) 
-                    }"""
+                    }
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
@@ -161,7 +175,8 @@ class ExplicitCollectionElementAccessMethodSpec : Spek({
                     fun f() {
                         val list = listOf<String>() 
                         val value = list[0] 
-                    }"""
+                    }
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -170,7 +185,8 @@ class ExplicitCollectionElementAccessMethodSpec : Spek({
                     fun f() {
                         val list = arrayListOf<String>() 
                         val value = list.get(0) 
-                    }"""
+                    }
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
@@ -192,7 +208,8 @@ class ExplicitCollectionElementAccessMethodSpec : Spek({
                     fun f() {
                         val map = java.util.HashMap<String, String>() 
                         val value = map.get("key") 
-                    }"""
+                    }
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
@@ -201,7 +218,8 @@ class ExplicitCollectionElementAccessMethodSpec : Spek({
                     fun f() {
                         val map = java.util.HashMap<String, String>() 
                         map.set("key", "val") 
-                    }"""
+                    }
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
@@ -210,7 +228,8 @@ class ExplicitCollectionElementAccessMethodSpec : Spek({
                     fun f() {
                         val map = java.util.HashMap<String, String>() 
                         map.put("key", "val") 
-                    }"""
+                    }
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
@@ -219,7 +238,8 @@ class ExplicitCollectionElementAccessMethodSpec : Spek({
                     fun f() {
                         val map = java.util.HashMap<String, String>() 
                         val value = map["key"] 
-                    }"""
+                    }
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -228,7 +248,8 @@ class ExplicitCollectionElementAccessMethodSpec : Spek({
                     fun f() {
                         val map = java.util.HashMap<String, String>() 
                         map["key"] = "value" 
-                    }"""
+                    }
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -237,7 +258,8 @@ class ExplicitCollectionElementAccessMethodSpec : Spek({
                     fun f() {
                         val map = java.util.HashMap<String, String>() 
                         val value = listOf("1", "2").associateBy { it }.get("1") 
-                    }"""
+                    }
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
     }
@@ -250,7 +272,8 @@ class ExplicitCollectionElementAccessMethodSpec : Spek({
                     fun f() {
                         val custom = Custom()
                         val value = custom.get(0)
-                    }"""
+                    }
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
@@ -260,7 +283,8 @@ class ExplicitCollectionElementAccessMethodSpec : Spek({
                     fun f() {
                         val custom = Custom()
                         val value = custom.get(0)
-                    }"""
+                    }
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -270,7 +294,8 @@ class ExplicitCollectionElementAccessMethodSpec : Spek({
                     fun f() {
                         val custom = Custom()
                         custom.set("key", "value")
-                    }"""
+                    }
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
@@ -280,7 +305,8 @@ class ExplicitCollectionElementAccessMethodSpec : Spek({
                     fun f() {
                         val custom = Custom()
                         custom.set("key", "value")
-                    }"""
+                    }
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
     }
@@ -292,7 +318,8 @@ class ExplicitCollectionElementAccessMethodSpec : Spek({
                     fun f() {
                         val list = java.util.ArrayList<String>() 
                         val value = list.get(0) 
-                    }"""
+                    }
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
@@ -301,7 +328,8 @@ class ExplicitCollectionElementAccessMethodSpec : Spek({
                     fun f() {
                         val list = java.util.ArrayList<String>() 
                         val value = list[0] 
-                    }"""
+                    }
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
     }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitItLambdaParameterSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitItLambdaParameterSpec.kt
@@ -16,7 +16,8 @@ class ExplicitItLambdaParameterSpec : Spek({
                     """
                 fun f() {
                     val digits = 1234.let { it -> listOf(it) }
-                }"""
+                }
+                    """
                 )
                 assertThat(findings).hasSize(1)
             }
@@ -25,7 +26,8 @@ class ExplicitItLambdaParameterSpec : Spek({
                     """
                 fun f() {
                     val lambda = { it: Int -> it.toString() }
-                }"""
+                }
+                    """
                 )
                 assertThat(findings).hasSize(1)
             }
@@ -38,7 +40,8 @@ class ExplicitItLambdaParameterSpec : Spek({
                     val lambda = { i: Int -> i.toString() }
                     val digits = 1234.let { lambda(it) }.toList()
                     val flat = listOf(listOf(1), listOf(2)).flatMap { it }
-                }"""
+                }
+                    """
                 )
                 assertThat(findings).isEmpty()
             }
@@ -50,7 +53,8 @@ class ExplicitItLambdaParameterSpec : Spek({
                     """
                 fun f() {
                     val flat = listOf(listOf(1), listOf(2)).mapIndexed { index, it -> it + index }
-                }"""
+                }
+                    """
                 )
                 assertThat(findings).hasSize(1)
             }
@@ -59,7 +63,8 @@ class ExplicitItLambdaParameterSpec : Spek({
                     """
                 fun f() {
                     val lambda = { it: Int, that: String -> it.toString() + that }
-                }"""
+                }
+                    """
                 )
                 assertThat(findings).hasSize(1)
             }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExpressionBodySyntaxSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExpressionBodySyntaxSpec.kt
@@ -23,7 +23,7 @@ class ExpressionBodySyntaxSpec : Spek({
                     fun stuff(): Int {
                         return 5
                     }
-                """
+                        """
                     )
                 ).hasSize(1)
             }
@@ -35,7 +35,7 @@ class ExpressionBodySyntaxSpec : Spek({
                     fun stuff(): String {
                         return StringBuilder().append(0).toString()
                     }
-                """
+                        """
                     )
                 ).hasSize(1)
             }
@@ -50,7 +50,7 @@ class ExpressionBodySyntaxSpec : Spek({
                     fun stuff(): Int {
                         return try { return 5 } catch (e: Exception) { return 3 }
                     }
-                """
+                        """
                     )
                 ).hasSize(2)
             }
@@ -63,7 +63,7 @@ class ExpressionBodySyntaxSpec : Spek({
                         if (true) return true
                         return false
                     }
-                """
+                        """
                     )
                 ).isEmpty()
             }
@@ -77,7 +77,7 @@ class ExpressionBodySyntaxSpec : Spek({
                     }
 
                     fun callee(a: String): String = ""
-                """
+                        """
                     )
                 ).isEmpty()
             }
@@ -90,7 +90,8 @@ class ExpressionBodySyntaxSpec : Spek({
                     return StringBuilder()
                         .append(1)
                         .toString()
-                }"""
+                }
+            """
 
             it("does not report with the default configuration") {
                 assertThat(subject.compileAndLint(code)).isEmpty()
@@ -110,7 +111,8 @@ class ExpressionBodySyntaxSpec : Spek({
                         0 -> 0
                         else -> 1
                     }
-                }"""
+                }
+            """
 
             it("does not report with the default configuration") {
                 assertThat(subject.compileAndLint(code)).isEmpty()

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/LibraryCodeMustSpecifyReturnTypeSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/LibraryCodeMustSpecifyReturnTypeSpec.kt
@@ -29,7 +29,7 @@ internal class LibraryCodeMustSpecifyReturnTypeSpec : Spek({
                     fun b() = 2
                     val c = 2
                 }
-            """
+                    """
                 )
             ).isEmpty()
         }
@@ -46,7 +46,7 @@ internal class LibraryCodeMustSpecifyReturnTypeSpec : Spek({
                         env,
                         """
                     fun foo() = 5
-                """
+                        """
                     )
                 ).hasSize(1)
             }
@@ -57,7 +57,7 @@ internal class LibraryCodeMustSpecifyReturnTypeSpec : Spek({
                         env,
                         """
                     val foo = 5
-                """
+                        """
                     )
                 ).hasSize(1)
             }
@@ -71,7 +71,7 @@ internal class LibraryCodeMustSpecifyReturnTypeSpec : Spek({
                         val foo = 5
                         fun bar() = 5
                     }
-                """
+                        """
                     )
                 ).hasSize(2)
             }
@@ -85,7 +85,7 @@ internal class LibraryCodeMustSpecifyReturnTypeSpec : Spek({
                         protected val foo = 5
                         protected fun bar() = 5
                     }
-                """
+                        """
                     )
                 ).hasSize(2)
             }
@@ -99,7 +99,7 @@ internal class LibraryCodeMustSpecifyReturnTypeSpec : Spek({
                         env,
                         """
                     fun foo(): Int = 5
-                """
+                        """
                     )
                 ).isEmpty()
             }
@@ -110,7 +110,7 @@ internal class LibraryCodeMustSpecifyReturnTypeSpec : Spek({
                         env,
                         """
                     fun foo() {}
-                """
+                        """
                     )
                 ).isEmpty()
             }
@@ -121,7 +121,7 @@ internal class LibraryCodeMustSpecifyReturnTypeSpec : Spek({
                         env,
                         """
                     val foo: Int = 5
-                """
+                        """
                     )
                 ).isEmpty()
             }
@@ -135,7 +135,7 @@ internal class LibraryCodeMustSpecifyReturnTypeSpec : Spek({
                         val foo: Int = 5
                         fun bar(): Int = 5
                     }
-                """
+                        """
                     )
                 ).isEmpty()
             }
@@ -149,7 +149,7 @@ internal class LibraryCodeMustSpecifyReturnTypeSpec : Spek({
                         """
                     internal fun bar() = 5
                     private fun foo() = 5
-                """
+                        """
                     )
                 ).isEmpty()
             }
@@ -160,7 +160,7 @@ internal class LibraryCodeMustSpecifyReturnTypeSpec : Spek({
                         env,
                         """
                     internal val foo = 5
-                """
+                        """
                     )
                 ).isEmpty()
             }
@@ -177,7 +177,7 @@ internal class LibraryCodeMustSpecifyReturnTypeSpec : Spek({
                             val a = 5
                         }
                     }
-                """
+                        """
                     )
                 ).isEmpty()
             }
@@ -191,7 +191,7 @@ internal class LibraryCodeMustSpecifyReturnTypeSpec : Spek({
                         fun baz() = 5
                         val qux = 5
                     }
-                """
+                        """
                     )
                 ).isEmpty()
             }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/LibraryEntitiesShouldNotBePublicSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/LibraryEntitiesShouldNotBePublicSpec.kt
@@ -16,7 +16,7 @@ internal class LibraryEntitiesShouldNotBePublicSpec : Spek({
                 subject.compileAndLint(
                     """
                     class A 
-            """
+                    """
                 )
             ).isEmpty()
         }
@@ -31,7 +31,7 @@ internal class LibraryEntitiesShouldNotBePublicSpec : Spek({
                     subject.compileAndLint(
                         """
                     class A
-                """
+                        """
                     )
                 ).hasSize(1)
             }
@@ -45,7 +45,7 @@ internal class LibraryEntitiesShouldNotBePublicSpec : Spek({
                             return 1
                         }
                     }
-                """
+                        """
                     )
                 ).hasSize(1)
             }
@@ -55,7 +55,7 @@ internal class LibraryEntitiesShouldNotBePublicSpec : Spek({
                     subject.compileAndLint(
                         """
                     typealias A = List<String>
-                """
+                        """
                     )
                 ).hasSize(1)
             }
@@ -66,7 +66,7 @@ internal class LibraryEntitiesShouldNotBePublicSpec : Spek({
                         """
                     typealias A = List<String>
                     fun foo() = Unit
-                """
+                        """
                     )
                 ).hasSize(2)
             }
@@ -76,7 +76,7 @@ internal class LibraryEntitiesShouldNotBePublicSpec : Spek({
                     subject.compileAndLint(
                         """
                     fun foo() = Unit
-                """
+                        """
                     )
                 ).hasSize(1)
             }
@@ -92,7 +92,7 @@ internal class LibraryEntitiesShouldNotBePublicSpec : Spek({
                             return 1
                         }
                     }
-                """
+                        """
                     )
                 ).isEmpty()
             }
@@ -102,7 +102,7 @@ internal class LibraryEntitiesShouldNotBePublicSpec : Spek({
                     subject.compileAndLint(
                         """
                     internal class A
-                """
+                        """
                     )
                 ).isEmpty()
             }
@@ -112,7 +112,7 @@ internal class LibraryEntitiesShouldNotBePublicSpec : Spek({
                     subject.compileAndLint(
                         """
                     internal typealias A = List<String>
-                """
+                        """
                     )
                 ).isEmpty()
             }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumberSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumberSpec.kt
@@ -286,7 +286,7 @@ class MagicNumberSpec : Spek({
                     3 -> return 3
                 }
             }
-        """
+            """
 
             it("should be reported") {
                 val findings = MagicNumber().lint(code)
@@ -306,7 +306,7 @@ class MagicNumberSpec : Spek({
             fun test(x: Int) {
                 val i = 5
             }
-        """
+            """
 
             it("should be reported") {
                 val findings = MagicNumber().lint(code)
@@ -319,7 +319,7 @@ class MagicNumberSpec : Spek({
             fun test() : Boolean {
                 return true;
             }
-        """
+            """
 
             it("should not be reported") {
                 val findings = MagicNumber().lint(code)
@@ -397,7 +397,7 @@ class MagicNumberSpec : Spek({
             }
 
             data class Color(val color: Int)
-        """
+            """
 
             it("should report all without ignore flags") {
                 val config = TestConfig(
@@ -451,7 +451,7 @@ class MagicNumberSpec : Spek({
                     const val anotherBoringConstant = 93872
                 }
             }
-        """
+            """
 
             it("should not report any issues by default") {
                 val findings = MagicNumber().lint(code)
@@ -559,7 +559,7 @@ class MagicNumberSpec : Spek({
                 )
 
                 var model = Model(someVal = $numberString)
-            """
+                """
 
                 it("should not ignore int") {
                     val rule = MagicNumber(TestConfig(mapOf(IGNORE_NAMED_ARGUMENT to "false")))
@@ -594,7 +594,7 @@ class MagicNumberSpec : Spek({
                     abstract class A(n: Int)
 
                     object B : A(n = 5)
-                """
+                    """
                     assertThat(MagicNumber().compileAndLint(code)).isEmpty()
                 }
 
@@ -614,7 +614,7 @@ class MagicNumberSpec : Spek({
                 )
 
                 var model = Model($numberString)
-            """
+                """
 
                 it("should detect the argument by default") {
                     assertThat(MagicNumber().lint(code("53"))).hasSize(1)
@@ -626,7 +626,7 @@ class MagicNumberSpec : Spek({
                 fun tested(someVal: Int, other: String = "default")
 
                 vaö t = tested(someVal = $number)
-            """
+                """
                 it("should ignore int by default") {
                     assertThat(MagicNumber().lint(code(53))).isEmpty()
                 }
@@ -649,7 +649,7 @@ class MagicNumberSpec : Spek({
                     SMALL(1),
                     EXTRA_LARGE(5)
                 }
-            """
+                """
                 it("should be reported by default") {
                     assertThat(MagicNumber().lint(code)).hasSize(1)
                 }
@@ -664,7 +664,7 @@ class MagicNumberSpec : Spek({
                     SMALL(id = 1),
                     EXTRA_LARGE(id = 5)
                 }
-            """
+                """
                 it("should be reported") {
                     val rule = MagicNumber(TestConfig(mapOf(IGNORE_NAMED_ARGUMENT to "false")))
                     assertThat(rule.lint(code)).hasSize(1)
@@ -688,14 +688,16 @@ class MagicNumberSpec : Spek({
             it("does not report functions that always returns a constant value") {
                 val code = """
                 fun x() = 9
-                fun y(): Int { return 9 }"""
+                fun y(): Int { return 9 }
+                """
                 assertThat(MagicNumber().compileAndLint(code)).isEmpty()
             }
 
             it("reports functions that does not return a constant value") {
                 val code = """
                 fun x() = 9 + 1
-                fun y(): Int { return 9 + 1 }"""
+                fun y(): Int { return 9 + 1 }
+                """
                 assertThat(MagicNumber().compileAndLint(code)).hasSize(2)
             }
         }
@@ -724,7 +726,8 @@ class MagicNumberSpec : Spek({
                 val code = """
                 class SomeClassWithDefault {
                     constructor(val defaultValue: Int = 10) { }
-                }"""
+                }
+                """
                 assertThat(MagicNumber().lint(code)).isEmpty()
             }
 
@@ -732,7 +735,8 @@ class MagicNumberSpec : Spek({
                 val code = """
                 class SomeClassWithDefault {
                     constructor(val defaultValue: Duration = 10.toDuration(DurationUnit.MILLISECONDS)) { }
-                }"""
+                }
+                """
                 assertThat(MagicNumber().lint(code)).isEmpty()
             }
         }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLengthSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLengthSpec.kt
@@ -70,7 +70,7 @@ class MaxLineLengthSpec : Spek({
 
             class Test {
             }
-        """
+            """
 
             val file by memoized { compileContentForTest(code) }
             val lines by memoized { file.text.splitToSequence("\n") }
@@ -179,7 +179,7 @@ class MaxLineLengthSpec : Spek({
             class Test {
                 fun anIncrediblyLongAndComplexMethodNameThatProbablyShouldBeMuchShorterButForTheSakeOfTheTestItsNot() {}
             }
-        """.trim()
+            """.trim()
 
             val file by memoized { compileContentForTest(code) }
             val lines by memoized { file.text.splitToSequence("\n") }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MayBeConstSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MayBeConstSpec.kt
@@ -237,7 +237,7 @@ class MayBeConstSpec : Spek({
                 class Test {
                     @JvmField val a = 3
                 }
-            """
+                """
                 subject.compileAndLint(code)
                 assertThat(subject.findings).isEmpty()
             }
@@ -247,7 +247,7 @@ class MayBeConstSpec : Spek({
                 annotation class A
 
                 @A val a = 55
-            """
+                """
                 subject.compileAndLint(code)
                 assertThat(subject.findings).isEmpty()
             }
@@ -261,7 +261,7 @@ class MayBeConstSpec : Spek({
                 object Derived : Base {
                     override val property = 1
                 }
-            """
+                """
                 subject.compileAndLint(code)
                 assertThat(subject.findings).isEmpty()
             }
@@ -301,7 +301,7 @@ class MayBeConstSpec : Spek({
                             val prop = ""
                         }
                     }
-                """
+                    """
                 )
 
                 assertThat(subject.findings).isEmpty()

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ModifierOrderSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ModifierOrderSpec.kt
@@ -60,7 +60,8 @@ class ModifierOrderSpec : Spek({
                     }
                     abstract class Test : A() {
                         override open fun test() {}
-                    }"""
+                    }
+                """
                 assertThat(subject.compileAndLint(code)).hasSize(1)
             }
 
@@ -71,7 +72,8 @@ class ModifierOrderSpec : Spek({
                     }
                     abstract class Test : A() {
                         override fun test() {}
-                    }"""
+                    }
+                """
                 assertThat(subject.compileAndLint(code)).isEmpty()
             }
         }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MultilineLambdaItParameterSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MultilineLambdaItParameterSpec.kt
@@ -22,7 +22,8 @@ class MultilineLambdaItParameterSpec : Spek({
                         listOf(it)
                         println(it)
                     }
-                }"""
+                }
+                """
                 val findings = subject.compileAndLintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }
@@ -34,7 +35,8 @@ class MultilineLambdaItParameterSpec : Spek({
                         listOf(it)
                         println(it)
                     }
-                }"""
+                }
+                """
                 val findings = subject.compileAndLintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }
@@ -46,7 +48,8 @@ class MultilineLambdaItParameterSpec : Spek({
                         listOf(param)
                         println(param)
                     }
-                }"""
+                }
+                """
                 val findings = subject.compileAndLintWithContext(env, code)
                 assertThat(findings).isEmpty()
             }
@@ -61,7 +64,8 @@ class MultilineLambdaItParameterSpec : Spek({
                         val it = 3
                         println(it)
                     }
-                }"""
+                }
+                """
                 val findings = subject.compileAndLintWithContext(env, code)
                 assertThat(findings).isEmpty()
             }
@@ -74,7 +78,8 @@ class MultilineLambdaItParameterSpec : Spek({
                     val digits = 1234.let { 
                         listOf(it)
                     }
-                }"""
+                }
+                """
                 val findings = subject.compileAndLintWithContext(env, code)
                 assertThat(findings).isEmpty()
             }
@@ -85,7 +90,8 @@ class MultilineLambdaItParameterSpec : Spek({
                     val digits = 1234.let { it ->
                         listOf(it)
                     }
-                }"""
+                }
+                """
                 val findings = subject.compileAndLintWithContext(env, code)
                 assertThat(findings).isEmpty()
             }
@@ -95,7 +101,8 @@ class MultilineLambdaItParameterSpec : Spek({
                     val digits = 1234.let { param ->
                         listOf(param)
                     }
-                }"""
+                }
+                """
                 val findings = subject.compileAndLintWithContext(env, code)
                 assertThat(findings).isEmpty()
             }
@@ -106,7 +113,8 @@ class MultilineLambdaItParameterSpec : Spek({
                 val code = """
                 fun f() {
                     val digits = 1234.let { listOf(it) }
-                }"""
+                }
+                """
                 val findings = subject.compileAndLintWithContext(env, code)
                 assertThat(findings).isEmpty()
             }
@@ -115,7 +123,8 @@ class MultilineLambdaItParameterSpec : Spek({
                 val code = """
                 fun f() {
                     val digits = 1234.let { listOf(it) }
-                }"""
+                }
+                """
                 val findings = subject.compileAndLintWithContext(env, code)
                 assertThat(findings).isEmpty()
             }
@@ -124,7 +133,8 @@ class MultilineLambdaItParameterSpec : Spek({
                 val code = """
                 fun f() {
                     val digits = 1234.let { it -> listOf(it) }
-                }"""
+                }
+                """
                 val findings = subject.compileAndLintWithContext(env, code)
                 assertThat(findings).isEmpty()
             }
@@ -133,7 +143,8 @@ class MultilineLambdaItParameterSpec : Spek({
                 val code = """
                 fun f() {
                     val digits = 1234.let { param -> listOf(param) }
-                }"""
+                }
+                """
                 val findings = subject.compileAndLintWithContext(env, code)
                 assertThat(findings).isEmpty()
             }
@@ -147,7 +158,8 @@ class MultilineLambdaItParameterSpec : Spek({
                         println(it)
                         it + index 
                     }
-                }"""
+                }
+                """
                 val findings = subject.compileAndLintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }
@@ -159,7 +171,8 @@ class MultilineLambdaItParameterSpec : Spek({
                         println(item)
                         item.toString() + that 
                     }
-                }"""
+                }
+                """
                 val findings = subject.compileAndLintWithContext(env, code)
                 assertThat(findings).isEmpty()
             }
@@ -173,7 +186,8 @@ class MultilineLambdaItParameterSpec : Spek({
                         append("a")
                         append("b")
                     }
-                }"""
+                }
+                """
                 val findings = subject.compileAndLintWithContext(env, code)
                 assertThat(findings).isEmpty()
             }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ObjectLiteralToLambdaSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ObjectLiteralToLambdaSpec.kt
@@ -526,7 +526,8 @@ class ObjectLiteralToLambdaSpec : Spek({
             it(
                 """Anonymous objects are always newly created,
                 |but lambdas are singletons,
-                |so they have the same reference.""".trimMargin()
+                |so they have the same reference.
+                """.trimMargin()
             ) {
                 val code = """
                 fun interface Sam {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/OptionalAbstractKeywordSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/OptionalAbstractKeywordSpec.kt
@@ -34,7 +34,8 @@ class OptionalAbstractKeywordSpec : Spek({
                     abstract interface B {
                         abstract fun x()
                     }
-                }"""
+                }
+            """
             assertThat(subject.compileAndLint(code)).hasSize(2)
         }
 
@@ -49,7 +50,8 @@ class OptionalAbstractKeywordSpec : Spek({
                     abstract class A {
                         abstract fun dependency()
                     }
-                }"""
+                }
+            """
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
     }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/OptionalWhenBracesSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/OptionalWhenBracesSpec.kt
@@ -25,7 +25,8 @@ class OptionalWhenBracesSpec : Spek({
                             println()
                         }
                     }
-                }"""
+                }
+            """
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
@@ -36,7 +37,8 @@ class OptionalWhenBracesSpec : Spek({
                         1 -> { print(1) }
                         else -> println()
                     }
-                }"""
+                }
+            """
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantVisibilityModifierRuleSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantVisibilityModifierRuleSpec.kt
@@ -171,7 +171,8 @@ class RedundantVisibilityModifierRuleSpec : Spek({
                     """
                     public class A() {
                         fun f()
-                    }"""
+                    }
+                    """
                 )
             }
             val rule by memoized { RedundantVisibilityModifierRule() }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCountSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCountSpec.kt
@@ -48,7 +48,7 @@ class ReturnCountSpec : Spek({
                 }
                 return 6
             }
-        """
+            """
 
             it("should not get flagged for if condition guard clauses") {
                 val findings = ReturnCount(TestConfig(mapOf(EXCLUDE_GUARD_CLAUSES to "true")))
@@ -70,7 +70,7 @@ class ReturnCountSpec : Spek({
                 }
                 return 6
             }
-        """
+            """
 
             it("should not get flagged for if condition guard clauses") {
                 val findings = ReturnCount(TestConfig(mapOf(EXCLUDE_GUARD_CLAUSES to "true")))
@@ -102,7 +102,7 @@ class ReturnCountSpec : Spek({
                 }
                 return 6
             }
-        """
+            """
 
             it("should report a too-complicated if statement for being a guard clause, with EXCLUDE_GUARD_CLAUSES on") {
                 val findings = ReturnCount(TestConfig(mapOf(EXCLUDE_GUARD_CLAUSES to "true")))
@@ -121,7 +121,7 @@ class ReturnCountSpec : Spek({
                 }
                 return 6
             }
-        """
+            """
 
             it("should not get flagged for ELVIS operator guard clauses") {
                 val findings = ReturnCount(TestConfig(mapOf(EXCLUDE_GUARD_CLAUSES to "true")))
@@ -140,7 +140,7 @@ class ReturnCountSpec : Spek({
                 if (x < 4) return 0
                 return 6
             }
-        """
+            """
 
             it("should get flagged for an if condition guard clause which is not the first statement") {
                 val findings = ReturnCount(TestConfig(mapOf(EXCLUDE_GUARD_CLAUSES to "true")))
@@ -159,7 +159,7 @@ class ReturnCountSpec : Spek({
                 val y = x ?: return 0
                 return 6
             }
-        """
+            """
 
             it("should get flagged for an ELVIS guard clause which is not the first statement") {
                 val findings = ReturnCount(TestConfig(mapOf(EXCLUDE_GUARD_CLAUSES to "true")))
@@ -212,7 +212,7 @@ class ReturnCountSpec : Spek({
                 }
                 return 6
             }
-        """
+            """
 
             it("should get flagged by default") {
                 val findings = ReturnCount().compileAndLint(code)
@@ -239,7 +239,7 @@ class ReturnCountSpec : Spek({
                 }
                 return 6
             }
-        """
+            """
 
             it("should not get flagged by default") {
                 val findings = ReturnCount().compileAndLint(code)
@@ -267,7 +267,7 @@ class ReturnCountSpec : Spek({
                 }
                 return 6
             }
-        """
+            """
 
             it("should not get flagged") {
                 val findings = ReturnCount(
@@ -310,7 +310,7 @@ class ReturnCountSpec : Spek({
                 }
                 return 6
             }
-        """
+            """
 
             it("should flag none of the ignored functions") {
                 val findings = ReturnCount(
@@ -343,7 +343,7 @@ class ReturnCountSpec : Spek({
                 }
                 return 6
             }
-        """
+            """
 
             it("should not get flag when returns is in inner object") {
                 val findings = ReturnCount(TestConfig(mapOf(MAX to "2"))).compileAndLint(code)
@@ -378,7 +378,7 @@ class ReturnCountSpec : Spek({
                 }
                 return 6
             }
-        """
+            """
 
             it("should not get flag when returns is in inner object") {
                 val findings = ReturnCount(TestConfig(mapOf(MAX to "2"))).compileAndLint(code)
@@ -415,7 +415,7 @@ class ReturnCountSpec : Spek({
                 }
                 return 6
             }
-        """
+            """
 
             it("should get flagged when returns is in inner object") {
                 val findings = ReturnCount(TestConfig(mapOf(MAX to "2"))).compileAndLint(code)
@@ -433,7 +433,7 @@ class ReturnCountSpec : Spek({
                     return@flatMap Flowable.just(it[0])
                 }
             }
-        """
+            """
 
             it("should not count labeled returns from lambda by default") {
                 val findings = ReturnCount().lint(code)

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/SafeCastSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/SafeCastSpec.kt
@@ -18,7 +18,8 @@ class SafeCastSpec : Spek({
                     } else {
                         element
                     }
-                }"""
+                }
+            """
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
@@ -30,7 +31,8 @@ class SafeCastSpec : Spek({
                     } else {
                         null
                     }
-                }"""
+                }
+            """
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
@@ -43,7 +45,8 @@ class SafeCastSpec : Spek({
                     } else {
                         null
                     }
-                }"""
+                }
+            """
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
@@ -55,7 +58,8 @@ class SafeCastSpec : Spek({
                     } else {
                         String()
                     }
-                }"""
+                }
+            """
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
     }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/SpacingBetweenPackageAndImportsSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/SpacingBetweenPackageAndImportsSpec.kt
@@ -96,7 +96,7 @@ class SpacingBetweenPackageAndImportsSpec : Spek({
                 import kotlin.collections.Set
 
                 class A { }
-                """
+            """
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
@@ -106,7 +106,7 @@ class SpacingBetweenPackageAndImportsSpec : Spek({
 
                 import kotlin.collections.List
                 import kotlin.collections.Set
-                """
+            """
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
     }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiteralsSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiteralsSpec.kt
@@ -262,7 +262,8 @@ class UnderscoresInNumericLiteralsSpec : Spek({
                     companion object {
                         private const val serialVersionUID = -43857148126114372L
                     }
-                }"""
+                }
+            """
             val findings = UnderscoresInNumericLiterals().compileAndLint(code)
             assertThat(findings).hasSize(0)
         }
@@ -275,7 +276,8 @@ class UnderscoresInNumericLiteralsSpec : Spek({
                     companion object {
                         private const val serialVersionUID = 43857148126114372L
                     }
-                }"""
+                }
+            """
             val findings = UnderscoresInNumericLiterals().compileAndLint(code)
             assertThat(findings).hasSize(0)
         }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryApplySpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryApplySpec.kt
@@ -30,7 +30,7 @@ class UnnecessaryApplySpec : Spek({
                             plus(1)
                         }
                     }
-                """
+                    """
                 )
                 assertThat(findings).hasSize(1)
                 assertThat(findings.first().message).isEqualTo("apply expression can be omitted")
@@ -48,7 +48,7 @@ class UnnecessaryApplySpec : Spek({
                             plus(1)
                         }
                     }
-                """
+                    """
                 )
                 assertThat(findings).hasSize(1)
                 assertThat(findings.first().message).isEqualTo("apply can be replaced with let or an if")
@@ -67,7 +67,7 @@ class UnnecessaryApplySpec : Spek({
                             b()
                         }
                     }
-                """
+                        """
                     )
                 ).hasSize(1)
             }
@@ -83,7 +83,7 @@ class UnnecessaryApplySpec : Spek({
                             plus(1)
                         })
                     }
-                """
+                        """
                     )
                 ).isEmpty()
             }
@@ -101,7 +101,7 @@ class UnnecessaryApplySpec : Spek({
                             toString()
                         })
                     }
-               """
+                        """
                     )
                 ).isEmpty()
             }
@@ -127,7 +127,7 @@ class UnnecessaryApplySpec : Spek({
                             }
                         )
                     }
-                """
+                        """
                     )
                 ).isEmpty()
             }
@@ -140,7 +140,7 @@ class UnnecessaryApplySpec : Spek({
                         val a = listOf(mutableListOf(""))
                                     .map { it.apply { add("") } }
                     }
-                """
+                        """
                     )
                 ).isEmpty()
             }
@@ -167,7 +167,7 @@ class UnnecessaryApplySpec : Spek({
                             plus(2)
                         })
                     }
-                """
+                        """
                     )
                 ).isEmpty()
             }
@@ -239,7 +239,7 @@ class UnnecessaryApplySpec : Spek({
                     }
                     
                     val a = C().apply { f() }
-                """
+                        """
                     )
                 ).isEmpty()
             }
@@ -252,7 +252,7 @@ class UnnecessaryApplySpec : Spek({
                     class C(var prop: Int)
                     
                     fun Int.f() = C(5).apply { prop = 10 }
-                """
+                        """
                     )
                 ).isEmpty()
             }
@@ -267,7 +267,7 @@ class UnnecessaryApplySpec : Spek({
                             C(1).apply { prop = 3 }
                         }
                     }
-                """
+                        """
                     )
                 ).isEmpty()
             }
@@ -280,7 +280,7 @@ class UnnecessaryApplySpec : Spek({
                     class C(var prop: Int)
                     
                     fun f() = (C(5)).apply { prop = 10 }
-                """
+                        """
                     )
                 ).isEmpty()
             }
@@ -296,7 +296,7 @@ class UnnecessaryApplySpec : Spek({
                             ?.apply { if (true) 4 }
                             ?: listOf(0)
                     }
-                """
+                        """
                     )
                 ).isEmpty()
             }
@@ -320,7 +320,7 @@ class UnnecessaryApplySpec : Spek({
                             }
                         }
                     }
-                """
+                        """
                     )
                 ).isEmpty()
             }
@@ -343,7 +343,7 @@ class UnnecessaryApplySpec : Spek({
                             this.prop
                         }
                     }
-                """
+                        """
                     )
                 ).hasSize(2)
             }
@@ -367,7 +367,7 @@ class UnnecessaryApplySpec : Spek({
                             C()
                         }
                     }
-                """
+                        """
                     )
                 ).isEmpty()
             }
@@ -391,7 +391,7 @@ class UnnecessaryApplySpec : Spek({
                             C().apply { f() }
                         }
                     }
-                """
+                        """
                     )
                 ).isEmpty()
             }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryInheritanceSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryInheritanceSpec.kt
@@ -15,7 +15,8 @@ class UnnecessaryInheritanceSpec : Spek({
             val findings = subject.lint(
                 """
                 class A : Any()
-                class B : Object()"""
+                class B : Object()
+                """
             )
             assertThat(findings).hasSize(2)
         }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLetSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLetSpec.kt
@@ -24,7 +24,8 @@ class UnnecessaryLetSpec : Spek({
                     val a: Int = 1
                     a.let { it.plus(1) }
                     a.let { that -> that.plus(1) }
-                }"""
+                }
+                """
             )
             assertThat(findings).hasSize(2)
             assertThat(findings).allMatch { it.message == MESSAGE_OMIT_LET }
@@ -38,7 +39,8 @@ class UnnecessaryLetSpec : Spek({
                     val a: Int? = null
                     a?.let { it.plus(1) }
                     a?.let { that -> that.plus(1) }
-                }"""
+                }
+                """
             )
             assertThat(findings).hasSize(2)
             assertThat(findings).allMatch { it.message == MESSAGE_OMIT_LET }
@@ -52,7 +54,8 @@ class UnnecessaryLetSpec : Spek({
                     val a: Int? = null
                     a?.let { it?.plus(1) }
                     a?.let { that -> that?.plus(1) }
-                }"""
+                }
+                """
             )
             assertThat(findings).hasSize(2)
             assertThat(findings).allMatch { it.message == MESSAGE_OMIT_LET }
@@ -65,7 +68,8 @@ class UnnecessaryLetSpec : Spek({
                 fun f() {
                     val a: Int? = null
                     a?.let { that -> that.plus(1) }?.let { it.plus(1) }
-                }"""
+                }
+                """
             )
             assertThat(findings).hasSize(2)
             assertThat(findings).allMatch { it.message == MESSAGE_OMIT_LET }
@@ -79,7 +83,8 @@ class UnnecessaryLetSpec : Spek({
                     val a: Int = 1
                     a.let { 1.plus(1) }
                     a.let { that -> 1.plus(1) }
-                }"""
+                }
+                """
             )
             assertThat(findings).hasSize(2)
             assertThat(findings).allMatch { it.message == MESSAGE_OMIT_LET }
@@ -93,7 +98,8 @@ class UnnecessaryLetSpec : Spek({
                     val a: Int = 1
                     val x = a.let { 1.plus(1) }
                     val y = a.let { that -> 1.plus(1) }
-                }"""
+                }
+                """
             )
             assertThat(findings).hasSize(2)
             assertThat(findings).allMatch { it.message == MESSAGE_OMIT_LET }
@@ -107,7 +113,8 @@ class UnnecessaryLetSpec : Spek({
                     val a: Int? = null
                     a?.let { 1.plus(1) }
                     a?.let { that -> 1.plus(1) }
-                }"""
+                }
+                """
             )
             assertThat(findings).hasSize(2)
             assertThat(findings).allMatch { it.message == MESSAGE_USE_IF }
@@ -121,7 +128,8 @@ class UnnecessaryLetSpec : Spek({
                     val a: Int? = null
                     a.let { print(it) }
                     a.let { that -> print(that) }
-                }"""
+                }
+                """
             )
             assertThat(findings).hasSize(2)
             assertThat(findings).allMatch { it.message == MESSAGE_OMIT_LET }
@@ -135,7 +143,8 @@ class UnnecessaryLetSpec : Spek({
                     val f: (Int?) -> Boolean = { true }
                     val a: Int? = null
                     a.let(f)
-                }"""
+                }
+                """
             )
             assertThat(findings).hasSize(1)
             assertThat(findings).allMatch { it.message == MESSAGE_OMIT_LET }
@@ -149,7 +158,8 @@ class UnnecessaryLetSpec : Spek({
                     val a: Int? = null
                     a?.let { print(it) }
                     a?.let { that -> 1.plus(that) }
-                }"""
+                }
+                """
             )
             assertThat(findings).isEmpty()
         }
@@ -161,7 +171,8 @@ class UnnecessaryLetSpec : Spek({
                 fun f() {
                     val a: Int? = null
                     a?.let { that -> 1.plus(that) }?.let { print(it) }
-                }"""
+                }
+                """
             )
             assertThat(findings).isEmpty()
         }
@@ -174,7 +185,8 @@ class UnnecessaryLetSpec : Spek({
                     val a: Int? = null
                     val x = a?.let { 1.plus(1) }
                     val y = a?.let { that -> 1.plus(1) }
-                }"""
+                }
+                """
             )
             assertThat(findings).isEmpty()
         }
@@ -200,7 +212,8 @@ class UnnecessaryLetSpec : Spek({
                     val f: (Int?) -> Boolean = { true }
                     val a: Int? = null
                     a?.let(f)
-                }"""
+                }
+                """
             )
             assertThat(findings).hasSize(0)
         }
@@ -235,7 +248,8 @@ class UnnecessaryLetSpec : Spek({
                         it.plus(1)
                         it.plus(2)
                     }
-                }"""
+                }
+                """
             )
             assertThat(findings).isEmpty()
         }
@@ -251,7 +265,8 @@ class UnnecessaryLetSpec : Spek({
                     b.let { it.plus(it) }
                     a?.let { foo -> foo.plus(foo) }
                     b.let { foo -> foo.plus(foo) }
-                }"""
+                }
+                """
             )
             assertThat(findings).isEmpty()
         }
@@ -264,7 +279,7 @@ class UnnecessaryLetSpec : Spek({
                 fun test(foo: Foo) {
                     foo.let { (a, b) -> a + b }
                 }
-            """
+                """
                 val findings = subject.compileAndLintWithContext(env, content)
                 assertThat(findings).isEmpty()
             }
@@ -276,7 +291,7 @@ class UnnecessaryLetSpec : Spek({
                 fun test(foo: Foo) {
                     foo.let { (a, _) -> a + a }
                 }
-            """
+                """
                 val findings = subject.compileAndLintWithContext(env, content)
                 assertThat(findings).isEmpty()
             }
@@ -288,7 +303,7 @@ class UnnecessaryLetSpec : Spek({
                 fun test(foo: Foo) {
                     foo.let { (a: Int, b: Int) -> a + b }
                 }
-            """
+                """
                 val findings = subject.compileAndLintWithContext(env, content)
                 assertThat(findings).isEmpty()
             }
@@ -300,7 +315,7 @@ class UnnecessaryLetSpec : Spek({
                 fun test(foo: Foo) {
                     foo.let { (a, _) -> a }
                 }
-            """
+                """
                 val findings = subject.compileAndLintWithContext(env, content)
                 assertThat(findings).hasSize(1)
                 assertThat(findings).allMatch { it.message == MESSAGE_OMIT_LET }
@@ -313,7 +328,7 @@ class UnnecessaryLetSpec : Spek({
                 fun test(foo: Foo?) {
                     foo?.let { (_, b) -> b.plus(1) }
                 }
-            """
+                """
                 val findings = subject.compileAndLintWithContext(env, content)
                 assertThat(findings).hasSize(1)
                 assertThat(findings).allMatch { it.message == MESSAGE_OMIT_LET }
@@ -326,7 +341,7 @@ class UnnecessaryLetSpec : Spek({
                 fun test(foo: Foo) {
                     foo.let { (_, _) -> 0 }
                 }
-            """
+                """
                 val findings = subject.compileAndLintWithContext(env, content)
                 assertThat(findings).hasSize(1)
                 assertThat(findings).allMatch { it.message == MESSAGE_OMIT_LET }
@@ -339,7 +354,7 @@ class UnnecessaryLetSpec : Spek({
                 fun test(foo: Foo?) {
                     foo?.let { (_, _) -> 0 }
                 }
-            """
+                """
                 val findings = subject.compileAndLintWithContext(env, content)
                 assertThat(findings).hasSize(1)
                 assertThat(findings).allMatch { it.message == MESSAGE_USE_IF }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryParenthesesSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryParenthesesSpec.kt
@@ -32,7 +32,8 @@ class UnnecessaryParenthesesSpec : Spek({
                     if ((a equals b)) {
                         println("Test")
                     }
-                }"""
+                }
+            """
             assertThat(subject.lint(code)).hasSize(1)
         }
 
@@ -45,7 +46,7 @@ class UnnecessaryParenthesesSpec : Spek({
                 fun test() {
                     function({ input -> println(input) })
                 }
-                """
+            """
             assertThat(subject.lint(code)).isEmpty()
         }
 
@@ -58,7 +59,7 @@ class UnnecessaryParenthesesSpec : Spek({
                 fun test() {
                     function(1, { input -> println(input) })
                 }
-                """
+            """
             assertThat(subject.lint(code)).isEmpty()
         }
 
@@ -66,7 +67,8 @@ class UnnecessaryParenthesesSpec : Spek({
             val code = """
                 fun f() {
                     instance.copy(value = { false })
-                }"""
+                }
+            """
             assertThat(subject.lint(code)).isEmpty()
         }
 
@@ -76,7 +78,8 @@ class UnnecessaryParenthesesSpec : Spek({
                     if (a equals b) {
                         println("Test")
                     }
-                }"""
+                }
+            """
             assertThat(subject.lint(code)).isEmpty()
         }
 
@@ -88,7 +91,7 @@ class UnnecessaryParenthesesSpec : Spek({
                         }
                     }
                 })
-                """
+            """
             assertThat(subject.lint(code)).isEmpty()
         }
 
@@ -100,7 +103,7 @@ class UnnecessaryParenthesesSpec : Spek({
                         }
                     }
                 })
-                """
+            """
             assertThat(subject.lint(code)).isEmpty()
         }
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UntilInsteadOfRangeToSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UntilInsteadOfRangeToSpec.kt
@@ -15,7 +15,8 @@ class UntilInsteadOfRangeToSpec : Spek({
             val code = """
                 fun f() {
                     for (i in 0 .. 10 - 1) {}
-                }"""
+                }
+            """
             val findings = subject.lint(code)
             assertThat(findings).hasSize(1)
             assertThat(findings[0]).hasMessage("'..' call can be replaced with 'until'")
@@ -26,7 +27,8 @@ class UntilInsteadOfRangeToSpec : Spek({
                 fun f() {
                     for (i in 0 until 10 - 1) {}
                     for (i in 10 downTo 2 - 1) {}
-                }"""
+                }
+            """
             assertThat(subject.lint(code)).isEmpty()
         }
 
@@ -34,7 +36,8 @@ class UntilInsteadOfRangeToSpec : Spek({
             val code = """
                 fun f() {
                     for (i in 0 .. 10) {}
-                }"""
+                }
+            """
             assertThat(subject.lint(code)).isEmpty()
         }
 
@@ -43,7 +46,8 @@ class UntilInsteadOfRangeToSpec : Spek({
                 fun f() {
                     for (i in 0 .. 10 + 1) {}
                     for (i in 0 .. 10 - 2) {}
-                }"""
+                }
+            """
             assertThat(subject.lint(code)).isEmpty()
         }
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateClassSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateClassSpec.kt
@@ -15,7 +15,7 @@ class UnusedPrivateClassSpec : Spek({
             val code = """
                 private interface Foo
                 class Bar
-                """
+            """
 
             val findings = subject.compileAndLint(code)
 
@@ -73,7 +73,7 @@ class UnusedPrivateClassSpec : Spek({
                 fun something() {
                     val foo: Foo = Foo()
                 }
-                """
+            """
 
             val findings = subject.compileAndLint(code)
 
@@ -86,7 +86,7 @@ class UnusedPrivateClassSpec : Spek({
                 private object Bar {
                   fun bar(foo: Foo) = Unit
                 }
-                """
+            """
 
             val findings = subject.compileAndLint(code)
 
@@ -97,7 +97,7 @@ class UnusedPrivateClassSpec : Spek({
             val code = """
                 private class Foo
                 private val a: Foo? = null
-                """
+            """
 
             val findings = subject.compileAndLint(code)
 
@@ -108,7 +108,7 @@ class UnusedPrivateClassSpec : Spek({
             val code = """
                 private class Foo
                 private lateinit var a: Foo
-                """
+            """
 
             val findings = subject.compileAndLint(code)
 
@@ -119,7 +119,7 @@ class UnusedPrivateClassSpec : Spek({
             val code = """
                 private class Foo
                 private lateinit var foos: List<Foo>
-                """
+            """
 
             val findings = subject.compileAndLint(code)
 
@@ -130,7 +130,7 @@ class UnusedPrivateClassSpec : Spek({
             val code = """
                 private val elements = listOf(42).filterIsInstance<Set<Item>>()
                 private class Item
-                """
+            """
 
             val findings = subject.compileAndLint(code)
 
@@ -141,7 +141,7 @@ class UnusedPrivateClassSpec : Spek({
             val code = """
                 private val elements = listOf(42).filterIsInstance<Something<Int>>()
                 private abstract class Something<E>: Collection<E>
-                """
+            """
 
             val findings = subject.compileAndLint(code)
 
@@ -156,7 +156,7 @@ class UnusedPrivateClassSpec : Spek({
                 fun <T> bar(): T {
                     throw Exception()
                 }
-                """
+            """
 
             val findings = subject.compileAndLint(code)
 
@@ -167,7 +167,7 @@ class UnusedPrivateClassSpec : Spek({
             val code = """
                 private class Foo
                 private lateinit var foos: List<List<Foo>>
-                """
+            """
 
             val findings = subject.compileAndLint(code)
 
@@ -178,7 +178,7 @@ class UnusedPrivateClassSpec : Spek({
             val code = """
                 private class Foo<T>
                 private lateinit var foos: Foo<String>
-                """
+            """
 
             val findings = subject.compileAndLint(code)
 
@@ -189,7 +189,7 @@ class UnusedPrivateClassSpec : Spek({
             val code = """
                 private class Foo<T>
                 private var foos: Foo<String>? = Foo()
-                """
+            """
 
             val findings = subject.compileAndLint(code)
 
@@ -200,7 +200,7 @@ class UnusedPrivateClassSpec : Spek({
             val code = """
                 private class Foo
                 private val a = Foo()
-                """
+            """
 
             val findings = subject.compileAndLint(code)
 
@@ -211,7 +211,7 @@ class UnusedPrivateClassSpec : Spek({
             val code = """
                 private class Foo(val a: String)
                 private val a = Foo("test")
-                """
+            """
 
             val findings = subject.compileAndLint(code)
 
@@ -224,7 +224,7 @@ class UnusedPrivateClassSpec : Spek({
                 private object Bar {
                   fun foo(): Foo? = null
                 }
-                """
+            """
 
             val findings = subject.compileAndLint(code)
 
@@ -235,7 +235,7 @@ class UnusedPrivateClassSpec : Spek({
             val code = """
                 private class Foo
                 private val lambda: ((Foo) -> Unit)? = null
-                """
+            """
 
             val findings = subject.compileAndLint(code)
 
@@ -246,7 +246,7 @@ class UnusedPrivateClassSpec : Spek({
             val code = """
                 private class Foo
                 private val lambda: (() -> Foo)? = null
-                """
+            """
 
             val findings = subject.compileAndLint(code)
 
@@ -257,7 +257,7 @@ class UnusedPrivateClassSpec : Spek({
             val code = """
                 private class Foo
                 private val lambda: (() -> List<Foo>)? = null
-                """
+            """
 
             val findings = subject.compileAndLint(code)
 
@@ -275,7 +275,7 @@ class UnusedPrivateClassSpec : Spek({
                         override fun bar() = Unit
                     }
                 }
-                """
+            """
 
             val findings = subject.compileAndLint(code)
 
@@ -309,7 +309,7 @@ class UnusedPrivateClassSpec : Spek({
                         B("B"),
                         C("C")
                     }
-                """
+            """
 
             val findings = UnusedPrivateClass().compileAndLint(code)
 
@@ -332,7 +332,7 @@ class UnusedPrivateClassSpec : Spek({
                         fun getSomeObject(): ((String) -> Any) = ::InternalClass
                         private class InternalClass(val param: String)
                     }
-                """
+            """
 
             val findings = UnusedPrivateClass().compileAndLint(code)
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMemberSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMemberSpec.kt
@@ -32,7 +32,7 @@ class UnusedPrivateMemberSpec : Spek({
                         println(used)
                     }
                 }
-                """
+    """
 
     describe("interface functions") {
 
@@ -138,7 +138,7 @@ class UnusedPrivateMemberSpec : Spek({
                         fun notify(error: String)
                     }
                 }
-                """
+            """
             assertThat(subject.lint(code)).isEmpty()
         }
     }
@@ -231,7 +231,7 @@ class UnusedPrivateMemberSpec : Spek({
                         println("This is not using a property")
                     }
                 }
-                """
+            """
             assertThat(subject.lint(code)).hasSize(1)
         }
 
@@ -244,7 +244,7 @@ class UnusedPrivateMemberSpec : Spek({
                         println("This is not using a property")
                     }
                 }
-                """
+            """
             assertThat(subject.lint(code)).isEmpty()
         }
 
@@ -257,7 +257,7 @@ class UnusedPrivateMemberSpec : Spek({
                         println(used)
                     }
                 }
-                """
+            """
             assertThat(subject.lint(code)).isEmpty()
         }
 
@@ -271,7 +271,7 @@ class UnusedPrivateMemberSpec : Spek({
                         println(used)
                     }
                 }
-                """
+            """
             assertThat(subject.lint(code)).hasSize(1)
         }
 
@@ -318,7 +318,7 @@ class UnusedPrivateMemberSpec : Spek({
                         println(used)
                     }
                 }
-                """
+            """
             assertThat(subject.lint(code)).hasSize(1)
         }
 
@@ -332,7 +332,7 @@ class UnusedPrivateMemberSpec : Spek({
                         println(text)
                     }
                 }
-                """
+            """
             assertThat(subject.lint(code)).isEmpty()
         }
 
@@ -368,7 +368,7 @@ class UnusedPrivateMemberSpec : Spek({
                         private fun doubleColonObjectReferenced() {}
                     }
                 }
-                """
+            """
             assertThat(subject.lint(code)).isEmpty()
         }
 
@@ -406,7 +406,7 @@ class UnusedPrivateMemberSpec : Spek({
                         println(used)
                     }
                 }
-                """
+            """
             assertThat(subject.lint(code)).hasSize(1)
         }
     }
@@ -464,7 +464,7 @@ class UnusedPrivateMemberSpec : Spek({
                         }
                     }
                 }
-                """
+            """
             assertThat(subject.lint(code)).isEmpty()
         }
 
@@ -476,7 +476,7 @@ class UnusedPrivateMemberSpec : Spek({
                         }
                     }
                 }
-                """
+            """
             assertThat(subject.lint(code)).hasSize(1)
         }
 
@@ -490,7 +490,7 @@ class UnusedPrivateMemberSpec : Spek({
                         }
                     }
                 }
-                """
+            """
             assertThat(subject.lint(code)).hasSize(1)
         }
 
@@ -503,7 +503,7 @@ class UnusedPrivateMemberSpec : Spek({
                         }
                     }
                 }
-                """
+            """
             assertThat(subject.lint(code)).hasSize(2)
         }
 
@@ -518,7 +518,7 @@ class UnusedPrivateMemberSpec : Spek({
                         }
                     }
                 }
-                """
+            """
             assertThat(subject.lint(code)).isEmpty()
         }
     }
@@ -535,7 +535,7 @@ class UnusedPrivateMemberSpec : Spek({
                         println(text)
                     }
                 }
-                """
+            """
             assertThat(subject.lint(code)).isEmpty()
         }
 
@@ -548,7 +548,7 @@ class UnusedPrivateMemberSpec : Spek({
                         val test = unused
                     }
                 }
-                """
+            """
             assertThat(subject.lint(code)).isEmpty()
         }
     }
@@ -677,7 +677,8 @@ class UnusedPrivateMemberSpec : Spek({
             val code = """
                 class Test {
                     private val ignored = ""
-                }"""
+                }
+            """
             assertThat(subject.lint(code)).isEmpty()
         }
 
@@ -685,7 +686,8 @@ class UnusedPrivateMemberSpec : Spek({
             val code = """
                 class Test {
                     private fun ignored(ignored: Int) {}
-                }"""
+                }
+            """
             assertThat(subject.lint(code)).isEmpty()
         }
     }
@@ -698,7 +700,8 @@ class UnusedPrivateMemberSpec : Spek({
                     class Inner {
                         private val unused = 1
                     }
-                }"""
+                }
+            """
             assertThat(subject.lint(code)).hasSize(1)
         }
 
@@ -709,7 +712,8 @@ class UnusedPrivateMemberSpec : Spek({
                         private val used = 1
                         fun someFunction() = used
                     }
-                }"""
+                }
+            """
             assertThat(subject.lint(code)).isEmpty()
         }
     }
@@ -718,14 +722,14 @@ class UnusedPrivateMemberSpec : Spek({
         it("reports unused private property") {
             val code = """
                 class Test(private val unused: Any)
-                """
+            """
             assertThat(subject.lint(code)).hasSize(1)
         }
 
         it("does not report public property") {
             val code = """
                 class Test(val unused: Any)
-                """
+            """
             assertThat(subject.lint(code)).isEmpty()
         }
 
@@ -734,7 +738,7 @@ class UnusedPrivateMemberSpec : Spek({
                 class Test(private val used: Any) {
                     init { used.toString() }
                 }
-                """
+            """
             assertThat(subject.lint(code)).isEmpty()
         }
 
@@ -745,7 +749,7 @@ class UnusedPrivateMemberSpec : Spek({
                         used.toString()
                     }
                 }
-                """
+            """
             assertThat(subject.lint(code)).isEmpty()
         }
     }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateParameterSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateParameterSpec.kt
@@ -157,7 +157,7 @@ class UnusedPrivateParameterSpec : Spek({
         it("reports unused parameter") {
             val code = """
                 class Test(unused: Any)
-                """
+            """
             assertThat(subject.lint(code)).hasSize(1)
         }
 
@@ -165,7 +165,7 @@ class UnusedPrivateParameterSpec : Spek({
             val code = """
                 class Parent(val ignored: Any)
                 class Test(used: Any) : Parent(used)
-                """
+            """
             assertThat(subject.lint(code)).isEmpty()
         }
 
@@ -176,7 +176,7 @@ class UnusedPrivateParameterSpec : Spek({
                         used.toString()
                     }
                 }
-                """
+            """
             assertThat(subject.lint(code)).isEmpty()
         }
 
@@ -185,7 +185,7 @@ class UnusedPrivateParameterSpec : Spek({
                 class Test(used: Any) {
                     val usedString = used.toString()
                 }
-                """
+            """
             assertThat(subject.lint(code)).isEmpty()
         }
     }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseArrayLiteralsInAnnotationsSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseArrayLiteralsInAnnotationsSpec.kt
@@ -17,7 +17,7 @@ class UseArrayLiteralsInAnnotationsSpec : Spek({
             annotation class Test(val values: Array<String>)
             @Test(arrayOf("value"))
             fun test() = Unit
-        """
+                """
             )
 
             assertThat(findings).hasSize(1)
@@ -29,7 +29,7 @@ class UseArrayLiteralsInAnnotationsSpec : Spek({
             annotation class Test(val values: Array<String>)
             @Test(["value"])
             fun test() = Unit
-        """
+                """
             )
 
             assertThat(findings).isEmpty()

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseCheckOrErrorSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseCheckOrErrorSpec.kt
@@ -23,7 +23,8 @@ class UseCheckOrErrorSpec : Spek({
                 fun x() {
                     doSomething()
                     if (a < 0) throw IllegalStateException()
-                }"""
+                }
+            """
             assertThat(subject.lint(code)).hasSourceLocation(3, 16)
         }
 
@@ -32,7 +33,8 @@ class UseCheckOrErrorSpec : Spek({
                 fun x() {
                     doSomething()
                     if (a < 0) throw IllegalStateException("More details")
-                }"""
+                }
+            """
             assertThat(subject.lint(code)).hasSourceLocation(3, 16)
         }
 
@@ -42,7 +44,8 @@ class UseCheckOrErrorSpec : Spek({
                     when (a) {
                         1 -> doSomething()
                         else -> throw IllegalStateException()
-                    }"""
+                    }
+            """
             assertThat(subject.lint(code)).hasSourceLocation(4, 17)
         }
 
@@ -51,7 +54,8 @@ class UseCheckOrErrorSpec : Spek({
                 fun x() {
                     doSomething()
                     if (a < 0) throw java.lang.IllegalStateException()
-                }"""
+                }
+            """
             assertThat(subject.lint(code)).hasSourceLocation(3, 16)
         }
 
@@ -60,7 +64,8 @@ class UseCheckOrErrorSpec : Spek({
                 fun x() {
                     doSomething()
                     if (a < 0) throw kotlin.IllegalStateException()
-                }"""
+                }
+            """
             assertThat(subject.lint(code)).hasSourceLocation(3, 16)
         }
 
@@ -69,7 +74,8 @@ class UseCheckOrErrorSpec : Spek({
                 fun x() {
                     doSomething()
                     if (a < 0) throw SomeBusinessException()
-                }"""
+                }
+            """
             assertThat(subject.lint(code)).isEmpty()
         }
 
@@ -79,7 +85,8 @@ class UseCheckOrErrorSpec : Spek({
                     if  (cause != null) {
                         throw IllegalStateException("message", cause)
                     }
-                }"""
+                }
+            """
             assertThat(subject.lint(code)).isEmpty()
         }
 
@@ -87,7 +94,8 @@ class UseCheckOrErrorSpec : Spek({
             val code = """
                 fun unsafeRunSync(): A =
                     unsafeRunTimed(Duration.INFINITE)
-                        .fold({ throw IllegalStateException("message") }, ::identity)"""
+                        .fold({ throw IllegalStateException("message") }, ::identity)
+            """
             assertThat(subject.lint(code)).isEmpty()
         }
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseDataClassSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseDataClassSpec.kt
@@ -340,7 +340,7 @@ class UseDataClassSpec : Spek({
 
                 @SinceKotlin("1.0.0")
                 class AnnotatedClass(val i: Int) {}
-                """
+            """
             val config = TestConfig(mapOf(EXCLUDE_ANNOTATED_CLASSES to "kotlin.*"))
             assertThat(UseDataClass(config).compileAndLint(code)).isEmpty()
         }
@@ -353,7 +353,7 @@ class UseDataClassSpec : Spek({
                             prop, old, new -> println("")
                     }
                 }
-                """
+            """
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIfInsteadOfWhenSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIfInsteadOfWhenSpec.kt
@@ -20,7 +20,7 @@ object UseIfInsteadOfWhenSpec : Spek({
                         else -> return false
                     }
                 }
-                """
+            """
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
@@ -32,7 +32,7 @@ object UseIfInsteadOfWhenSpec : Spek({
                         else -> return false
                     }
                 }
-                """
+            """
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
@@ -46,7 +46,7 @@ object UseIfInsteadOfWhenSpec : Spek({
                         else -> return false
                     }
                 }
-                """
+            """
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
@@ -60,7 +60,7 @@ object UseIfInsteadOfWhenSpec : Spek({
                     }
                     return false
                 }
-                """
+            """
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
     }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIsNullOrEmptySpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIsNullOrEmptySpec.kt
@@ -320,7 +320,7 @@ class UseIsNullOrEmptySpec : Spek({
                 fun test(x: Sequence<Int>?) {
                     if (x == null || x.count() == 0) return
                 }
-            """
+                """
                 val findings = subject.compileAndLintWithContext(env, code)
                 assertThat(findings).isEmpty()
             }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseRequireSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseRequireSpec.kt
@@ -23,7 +23,8 @@ class UseRequireSpec : Spek({
                 fun x(a: Int) {
                     if (a < 0) throw IllegalArgumentException()
                     doSomething()
-                }"""
+                }
+            """
             assertThat(subject.lint(code)).hasSourceLocation(2, 16)
         }
 
@@ -32,7 +33,8 @@ class UseRequireSpec : Spek({
                 fun x(a: Int) {
                     if (a < 0) throw IllegalArgumentException("More details")
                     doSomething()
-                }"""
+                }
+            """
             assertThat(subject.lint(code)).hasSourceLocation(2, 16)
         }
 
@@ -41,7 +43,8 @@ class UseRequireSpec : Spek({
                 fun x(a: Int) {
                     if (a < 0) throw java.lang.IllegalArgumentException()
                     doSomething()
-                }"""
+                }
+            """
             assertThat(subject.lint(code)).hasSourceLocation(2, 16)
         }
 
@@ -50,7 +53,8 @@ class UseRequireSpec : Spek({
                 fun x(a: Int) {
                     if (a < 0) throw kotlin.IllegalArgumentException()
                     doSomething()
-                }"""
+                }
+            """
             assertThat(subject.lint(code)).hasSourceLocation(2, 16)
         }
 
@@ -59,7 +63,8 @@ class UseRequireSpec : Spek({
                 fun x(a: Int) {
                     if (a < 0) throw SomeBusinessException()
                     doSomething()
-                }"""
+                }
+            """
             assertThat(subject.lint(code)).isEmpty()
         }
 
@@ -68,14 +73,16 @@ class UseRequireSpec : Spek({
                 private fun x(a: Int): Nothing {
                     doSomething()
                     throw IllegalArgumentException("message", cause)
-                }"""
+                }
+            """
             assertThat(subject.lint(code)).isEmpty()
         }
 
         it("does not report an issue if the exception thrown as the only action in a block") {
             val code = """
                 fun unsafeRunSync(): A =
-                    foo.fold({ throw IllegalArgumentException("message") }, ::identity)"""
+                    foo.fold({ throw IllegalArgumentException("message") }, ::identity)
+            """
             assertThat(subject.lint(code)).isEmpty()
         }
 
@@ -165,7 +172,7 @@ class UseRequireSpec : Spek({
                         is LinkedList<*> -> 2
                         else -> throw IllegalArgumentException("Not supported List type")
                     }
-                    """
+                """
                 assertThat(subject.lint(code)).isEmpty()
             }
 
@@ -179,7 +186,8 @@ class UseRequireSpec : Spek({
                             }
                         }
                         throw IllegalArgumentException("Test was too big")
-                    }"""
+                    }
+                """
                 assertThat(subject.lint(code)).isEmpty()
             }
 
@@ -189,7 +197,8 @@ class UseRequireSpec : Spek({
                         val subclass = list as? LinkedList
                             ?: throw IllegalArgumentException("List is not a LinkedList")
                         return subclass
-                    }"""
+                    }
+                """
                 assertThat(subject.lint(code)).isEmpty()
             }
         }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UtilityClassWithPublicConstructorSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UtilityClassWithPublicConstructorSpec.kt
@@ -54,7 +54,7 @@ class UtilityClassWithPublicConstructorSpec : Spek({
                         const val FEMALE = "female"
                     }
                 }
-            """
+                """
                 assertThat(subject.lint(code)).isEmpty()
             }
         }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/WildcardImportSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/WildcardImportSpec.kt
@@ -93,7 +93,7 @@ class WildcardImportSpec : Spek({
 
             class Test {
             }
-        """
+            """
 
             it("should not report any issues") {
                 val findings = WildcardImport().compileAndLint(code)

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/MandatoryBracesIfStatementsSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/MandatoryBracesIfStatementsSpec.kt
@@ -18,7 +18,7 @@ class MandatoryBracesIfStatementsSpec : Spek({
                 if (true)
                     println()
             }
-            """
+                """
             )
 
             assertThat(findings).hasSize(1)
@@ -32,7 +32,7 @@ class MandatoryBracesIfStatementsSpec : Spek({
                 	if (true) 50
                         .toString()
                 }
-            """
+                """
             )
 
             assertThat(findings).hasSize(1)
@@ -46,7 +46,7 @@ class MandatoryBracesIfStatementsSpec : Spek({
                         .toString() else 50
                         .toString()
                 }
-            """
+                """
             )
 
             assertThat(findings).hasSize(2)
@@ -61,7 +61,7 @@ class MandatoryBracesIfStatementsSpec : Spek({
                 else
                     println()
             }
-            """
+                """
             )
 
             assertThat(findings).hasSize(2)
@@ -79,7 +79,7 @@ class MandatoryBracesIfStatementsSpec : Spek({
                 else
                     println()
             }
-            """
+                """
             )
 
             assertThat(findings).hasSize(3)
@@ -95,7 +95,7 @@ class MandatoryBracesIfStatementsSpec : Spek({
                 } else
                     println()
             }
-            """
+                """
             )
 
             assertThat(findings).hasSize(1)
@@ -112,7 +112,7 @@ class MandatoryBracesIfStatementsSpec : Spek({
                     println()
                 }
             }
-            """
+                """
             )
 
             assertThat(findings).hasSize(1)
@@ -126,7 +126,7 @@ class MandatoryBracesIfStatementsSpec : Spek({
                 if (true) println()
                 else println()
             }
-            """
+                """
             )
 
             assertThat(findings).hasSize(1)
@@ -140,7 +140,7 @@ class MandatoryBracesIfStatementsSpec : Spek({
                 if (true) println() else
                     println()
             }
-            """
+                """
             )
 
             assertThat(findings).hasSize(1)

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/OptionalUnitSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/OptionalUnitSpec.kt
@@ -127,7 +127,7 @@ class OptionalUnitSpec : Spek({
                         Unit.equals(null)
                         val i: (Int) -> Unit = { _ -> }
                     }
-                """
+                    """
                 )
                 assertThat(findings).isEmpty()
             }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 dokka = "1.6.10"
 jacoco = "0.8.7"
 kotlin = "1.6.10"
-ktlint = "0.43.2"
+ktlint = "0.44.0"
 spek = "2.0.18"
 junit = "5.8.2"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,7 @@ dokka = "1.6.10"
 jacoco = "0.8.7"
 kotlin = "1.6.10"
 ktlint = "0.44.0"
+microutilsKotlinLoggingJvm = "2.1.21"
 spek = "2.0.18"
 junit = "5.8.2"
 
@@ -26,6 +27,7 @@ android-gradle = "com.android.tools.build:gradle:7.1.2"
 ktlint-core = { module = "com.pinterest.ktlint:ktlint-core", version.ref = "ktlint" }
 ktlint-rulesetStandard = { module = "com.pinterest.ktlint:ktlint-ruleset-standard", version.ref = "ktlint" }
 ktlint-rulesetExperimental = { module = "com.pinterest.ktlint:ktlint-ruleset-experimental", version.ref = "ktlint" }
+ktlint-microutilsKotlinLoggingJvm = { module = "io.github.microutils:kotlin-logging-jvm", version.ref = "microutilsKotlinLoggingJvm" }
 
 dokka-jekyll = { module = "org.jetbrains.dokka:jekyll-plugin", version.ref = "dokka"}
 


### PR DESCRIPTION
See https://github.com/pinterest/ktlint/releases/tag/0.44.0 for the full release note. I've also wrapped the new experimental [UnnecessaryParenthesesBeforeTrailingLamda](https://github.com/pinterest/ktlint/issues/1068) rule.

I also tried to implement the new VisitorModifier instead of the deprecated Rule.Modifier interfaces.

This should also fix the issue #4604

Sadly I get a lot of `Unexpected indent of multiline string closing quotes [Indentation]`-errors for the Unit-Tests. Maybe someone has some ideas how I can fix it. 