### PR TITLE
Fix typo in AvoidReferentialEquality rule description

### DIFF
--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/AvoidReferentialEquality.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/AvoidReferentialEquality.kt
@@ -21,7 +21,7 @@ import org.jetbrains.kotlin.resolve.calls.callUtil.getType
 /**
  * Kotlin supports two types of equality: structural equality and referential equality. While there are
  * use cases for both, checking for referential equality for some types (such as `String` or `List`) is
- * likely not intentional and may case unexpected results.
+ * likely not intentional and may cause unexpected results.
  *
  * <noncompliant>
  *     val areEqual = "aString" === otherString


### PR DESCRIPTION
Fixes typo
