### PR TITLE
Add ignoreOverridden support for BooleanPropertyNaming rule

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -284,6 +284,7 @@ naming:
   BooleanPropertyNaming:
     active: false
     allowedPattern: '^(is|has|are)'
+    ignoreOverridden: false
   ClassNaming:
     active: true
     classPattern: '[A-Z][a-zA-Z0-9]*'

--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -284,7 +284,7 @@ naming:
   BooleanPropertyNaming:
     active: false
     allowedPattern: '^(is|has|are)'
-    ignoreOverridden: false
+    ignoreOverridden: true
   ClassNaming:
     active: true
     classPattern: '[A-Z][a-zA-Z0-9]*'

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/BooleanPropertyNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/BooleanPropertyNaming.kt
@@ -37,7 +37,7 @@ class BooleanPropertyNaming(config: Config = Config.empty) : Rule(config) {
     private val allowedPattern: Regex by config("^(is|has|are)", String::toRegex)
 
     @Configuration("ignores properties that have the override modifier")
-    private val ignoreOverridden: Boolean by config(false)
+    private val ignoreOverridden: Boolean by config(true)
 
     override val issue = Issue(
         javaClass.simpleName, Severity.CodeSmell,

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/BooleanPropertyNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/BooleanPropertyNaming.kt
@@ -12,6 +12,7 @@ import io.gitlab.arturbosch.detekt.api.internal.Configuration
 import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.rules.fqNameOrNull
 import io.gitlab.arturbosch.detekt.rules.identifierName
+import io.gitlab.arturbosch.detekt.rules.isOverride
 import org.jetbrains.kotlin.psi.KtCallableDeclaration
 import org.jetbrains.kotlin.psi.KtParameter
 import org.jetbrains.kotlin.psi.KtProperty
@@ -34,6 +35,9 @@ class BooleanPropertyNaming(config: Config = Config.empty) : Rule(config) {
 
     @Configuration("naming pattern")
     private val allowedPattern: Regex by config("^(is|has|are)", String::toRegex)
+
+    @Configuration("ignores properties that have the override modifier")
+    private val ignoreOverridden: Boolean by config(false)
 
     override val issue = Issue(
         javaClass.simpleName, Severity.CodeSmell,
@@ -65,7 +69,7 @@ class BooleanPropertyNaming(config: Config = Config.empty) : Rule(config) {
         val isBooleanType =
             typeName == KOTLIN_BOOLEAN_TYPE_NAME || typeName == JAVA_BOOLEAN_TYPE_NAME
 
-        if (isBooleanType && !name.contains(allowedPattern)) {
+        if (isBooleanType && !name.contains(allowedPattern) && !isIgnoreOverridden(declaration)) {
             report(reportCodeSmell(declaration, name))
         }
     }
@@ -88,6 +92,8 @@ class BooleanPropertyNaming(config: Config = Config.empty) : Rule(config) {
             ?.fqNameOrNull()
             .toString()
     }
+
+    private fun isIgnoreOverridden(declaration: KtCallableDeclaration) = ignoreOverridden && declaration.isOverride()
 
     companion object {
         const val KOTLIN_BOOLEAN_TYPE_NAME = "kotlin.Boolean"

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/BooleanPropertyNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/BooleanPropertyNamingSpec.kt
@@ -27,7 +27,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
             }
 
             @Test
-            fun `should warn about Kotlin Boolean override`() {
+            fun `should not warn about Kotlin Boolean override by default`() {
                 val code = """
                     interface Test {
                         val default: Boolean
@@ -36,6 +36,21 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                     data class TestImpl (override var default: Boolean) : Test
                 """
                 val findings = subject.compileAndLintWithContext(env, code)
+
+                assertThat(findings).hasSize(1)
+            }
+
+            @Test
+            fun `should warn about Kotlin Boolean override if ignoreOverridden is false`() {
+                val code = """
+                    interface Test {
+                        val default: Boolean
+                    }
+
+                    data class TestImpl (override var default: Boolean) : Test
+                """
+                val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to false))
+                val findings = BooleanPropertyNaming(config).compileAndLintWithContext(env, code)
 
                 assertThat(findings).hasSize(2)
             }
@@ -64,7 +79,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
             }
 
             @Test
-            fun `should warn about Kotlin Boolean nullable override`() {
+            fun `should not warn about Kotlin Boolean nullable override by default`() {
                 val code = """
                     interface Test {
                         val default: Boolean?
@@ -73,6 +88,21 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                     data class TestImpl (override var default: Boolean?) : Test
                 """
                 val findings = subject.compileAndLintWithContext(env, code)
+
+                assertThat(findings).hasSize(1)
+            }
+
+            @Test
+            fun `should warn about Kotlin Boolean nullable override if ignoreOverridden is false`() {
+                val code = """
+                    interface Test {
+                        val default: Boolean?
+                    }
+
+                    data class TestImpl (override var default: Boolean?) : Test
+                """
+                val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to false))
+                val findings = BooleanPropertyNaming(config).compileAndLintWithContext(env, code)
 
                 assertThat(findings).hasSize(2)
             }
@@ -101,7 +131,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
             }
 
             @Test
-            fun `should warn about Kotlin Boolean initialized override`() {
+            fun `should not warn about Kotlin Boolean initialized override by default`() {
                 val code = """
                     interface Test {
                         val default: Boolean
@@ -110,6 +140,21 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                     data class TestImpl (override var default: Boolean = false) : Test
                 """
                 val findings = subject.compileAndLintWithContext(env, code)
+
+                assertThat(findings).hasSize(1)
+            }
+
+            @Test
+            fun `should warn about Kotlin Boolean initialized override if ignoreOverridden is false`() {
+                val code = """
+                    interface Test {
+                        val default: Boolean
+                    }
+
+                    data class TestImpl (override var default: Boolean = false) : Test
+                """
+                val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to false))
+                val findings = BooleanPropertyNaming(config).compileAndLintWithContext(env, code)
 
                 assertThat(findings).hasSize(2)
             }
@@ -138,7 +183,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
             }
 
             @Test
-            fun `should warn about Java Boolean override`() {
+            fun `should not warn about Java Boolean override by default`() {
                 val code = """
                     interface Test {
                         val default: java.lang.Boolean
@@ -147,6 +192,21 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                     data class TestImpl (override var default: java.lang.Boolean) : Test
                 """
                 val findings = subject.compileAndLintWithContext(env, code)
+
+                assertThat(findings).hasSize(1)
+            }
+
+            @Test
+            fun `should warn about Java Boolean override if ignoreOverridden is false`() {
+                val code = """
+                    interface Test {
+                        val default: java.lang.Boolean
+                    }
+
+                    data class TestImpl (override var default: java.lang.Boolean) : Test
+                """
+                val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to false))
+                val findings = BooleanPropertyNaming(config).compileAndLintWithContext(env, code)
 
                 assertThat(findings).hasSize(2)
             }
@@ -198,7 +258,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
             }
 
             @Test
-            fun `should warn about Kotlin Boolean override`() {
+            fun `should not warn about Kotlin Boolean override by default`() {
                 val code = """
                     interface Test {
                         val default: Boolean                    
@@ -209,6 +269,23 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                     }
                 """
                 val findings = subject.compileAndLintWithContext(env, code)
+
+                assertThat(findings).hasSize(1)
+            }
+
+            @Test
+            fun `should warn about Kotlin Boolean override if isIgnoreOverridden is false`() {
+                val code = """
+                    interface Test {
+                        val default: Boolean                    
+                    }
+
+                    class TestImpl : Test {
+                        override var default: Boolean = true
+                    }
+                """
+                val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to false))
+                val findings = BooleanPropertyNaming(config).compileAndLintWithContext(env, code)
 
                 assertThat(findings).hasSize(2)
             }
@@ -243,7 +320,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
             }
 
             @Test
-            fun `should warn about Kotlin Boolean nullable override`() {
+            fun `should not warn about Kotlin Boolean nullable override by default`() {
                 val code = """
                     interface Test {
                         val default: Boolean?
@@ -254,6 +331,23 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                     }
                 """
                 val findings = subject.compileAndLintWithContext(env, code)
+
+                assertThat(findings).hasSize(1)
+            }
+
+            @Test
+            fun `should warn about Kotlin Boolean nullable override if ignoreOverridden is false`() {
+                val code = """
+                    interface Test {
+                        val default: Boolean?
+                    }
+
+                    class TestImpl : Test {
+                        override var default: Boolean? = null
+                    }
+                """
+                val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to false))
+                val findings = BooleanPropertyNaming(config).compileAndLintWithContext(env, code)
 
                 assertThat(findings).hasSize(2)
             }
@@ -288,7 +382,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
             }
 
             @Test
-            fun `should warn about Kotlin Boolean initialized override`() {
+            fun `should not warn about Kotlin Boolean initialized override by default`() {
                 val code = """
                     interface Test {
                         val default: Boolean
@@ -299,6 +393,23 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                     }
                 """
                 val findings = subject.compileAndLintWithContext(env, code)
+
+                assertThat(findings).hasSize(1)
+            }
+
+            @Test
+            fun `should warn about Kotlin Boolean initialized override if ignoreOverridden is false`() {
+                val code = """
+                    interface Test {
+                        val default: Boolean
+                    }
+
+                    class TestImpl : Test {
+                        override var default: Boolean = false
+                    }
+                """
+                val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to false))
+                val findings = BooleanPropertyNaming(config).compileAndLintWithContext(env, code)
 
                 assertThat(findings).hasSize(2)
             }
@@ -333,7 +444,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
             }
 
             @Test
-            fun `should warn about inferred boolean type override`() {
+            fun `should not warn about inferred boolean type override by default`() {
                 val code = """
                     interface Test {
                         val default: Boolean
@@ -344,6 +455,23 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                     }
                 """
                 val findings = subject.compileAndLintWithContext(env, code)
+
+                assertThat(findings).hasSize(1)
+            }
+
+            @Test
+            fun `should warn about inferred boolean type override if ignoreOverridden is false`() {
+                val code = """
+                    interface Test {
+                        val default: Boolean
+                    }
+
+                    class TestImpl : Test {
+                        override var default = true
+                    }
+                """
+                val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to false))
+                val findings = BooleanPropertyNaming(config).compileAndLintWithContext(env, code)
 
                 assertThat(findings).hasSize(2)
             }
@@ -378,7 +506,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
             }
 
             @Test
-            fun `should warn about Java Boolean override`() {
+            fun `should not warn about Java Boolean override by default`() {
                 val code = """
                     interface Test {
                         val default: java.lang.Boolean
@@ -389,6 +517,23 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                     }
                 """
                 val findings = subject.compileAndLintWithContext(env, code)
+
+                assertThat(findings).hasSize(1)
+            }
+
+            @Test
+            fun `should warn about Java Boolean override if ignoreOverridden is false`() {
+                val code = """
+                    interface Test {
+                        val default: java.lang.Boolean
+                    }
+
+                    class TestImpl : Test {
+                        override var default: java.lang.Boolean = java.lang.Boolean(true)
+                    }
+                """
+                val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to false))
+                val findings = BooleanPropertyNaming(config).compileAndLintWithContext(env, code)
 
                 assertThat(findings).hasSize(2)
             }

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/BooleanPropertyNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/BooleanPropertyNamingSpec.kt
@@ -27,9 +27,67 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
             }
 
             @Test
+            fun `should warn about Kotlin Boolean override`() {
+                val code = """
+                    interface Test {
+                        val default: Boolean
+                    }
+
+                    data class TestImpl (override var default: Boolean) : Test
+                """
+                val findings = subject.compileAndLintWithContext(env, code)
+
+                assertThat(findings).hasSize(2)
+            }
+
+            @Test
+            fun `should not warn about Kotlin Boolean override if ignoreOverridden is true`() {
+                val code = """
+                    interface Test {
+                        val default: Boolean
+                    }
+
+                    data class TestImpl (override var default: Boolean) : Test
+                """
+                val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to true))
+                val findings = BooleanPropertyNaming(config).compileAndLintWithContext(env, code)
+
+                assertThat(findings).hasSize(1)
+            }
+
+            @Test
             fun `should warn about Kotlin Boolean nullable`() {
                 val code = """data class Test (var default: Boolean?)"""
                 val findings = subject.compileAndLintWithContext(env, code)
+
+                assertThat(findings).hasSize(1)
+            }
+
+            @Test
+            fun `should warn about Kotlin Boolean nullable override`() {
+                val code = """
+                    interface Test {
+                        val default: Boolean?
+                    }
+
+                    data class TestImpl (override var default: Boolean?) : Test
+                """
+                val findings = subject.compileAndLintWithContext(env, code)
+
+                assertThat(findings).hasSize(2)
+            }
+
+            @Test
+            fun `should not warn about Kotlin Boolean nullable override if ignoreOverridden is true`() {
+                val code = """
+                    interface Test {
+                        val default: Boolean?
+                    }
+
+                    data class TestImpl (override var default: Boolean?) : Test
+                """
+                val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to true))
+                val findings = BooleanPropertyNaming(config).compileAndLintWithContext(env, code)
 
                 assertThat(findings).hasSize(1)
             }
@@ -43,9 +101,67 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
             }
 
             @Test
+            fun `should warn about Kotlin Boolean initialized override`() {
+                val code = """
+                    interface Test {
+                        val default: Boolean
+                    }
+
+                    data class TestImpl (override var default: Boolean = false) : Test
+                """
+                val findings = subject.compileAndLintWithContext(env, code)
+
+                assertThat(findings).hasSize(2)
+            }
+
+            @Test
+            fun `should not warn about Kotlin Boolean initialized override if ignoreOverridden is true`() {
+                val code = """
+                    interface Test {
+                        val default: Boolean
+                    }
+
+                    data class TestImpl (override var default: Boolean = false) : Test
+                """
+                val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to true))
+                val findings = BooleanPropertyNaming(config).compileAndLintWithContext(env, code)
+
+                assertThat(findings).hasSize(1)
+            }
+
+            @Test
             fun `should warn about Java Boolean`() {
                 val code = """data class Test (var default: java.lang.Boolean)"""
                 val findings = subject.compileAndLintWithContext(env, code)
+
+                assertThat(findings).hasSize(1)
+            }
+
+            @Test
+            fun `should warn about Java Boolean override`() {
+                val code = """
+                    interface Test {
+                        val default: java.lang.Boolean
+                    }
+
+                    data class TestImpl (override var default: java.lang.Boolean) : Test
+                """
+                val findings = subject.compileAndLintWithContext(env, code)
+
+                assertThat(findings).hasSize(2)
+            }
+
+            @Test
+            fun `should not warn about Java Boolean override if ignoreOverridden is true`() {
+                val code = """
+                    interface Test {
+                        val default: java.lang.Boolean
+                    }
+
+                    data class TestImpl (override var default: java.lang.Boolean) : Test
+                """
+                val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to true))
+                val findings = BooleanPropertyNaming(config).compileAndLintWithContext(env, code)
 
                 assertThat(findings).hasSize(1)
             }
@@ -82,6 +198,39 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
             }
 
             @Test
+            fun `should warn about Kotlin Boolean override`() {
+                val code = """
+                    interface Test {
+                        val default: Boolean                    
+                    }
+
+                    class TestImpl : Test {
+                        override var default: Boolean = true
+                    }
+                """
+                val findings = subject.compileAndLintWithContext(env, code)
+
+                assertThat(findings).hasSize(2)
+            }
+
+            @Test
+            fun `should not warn about Kotlin Boolean override if isIgnoreOverridden is true`() {
+                val code = """
+                    interface Test {
+                        val default: Boolean                    
+                    }
+
+                    class TestImpl : Test {
+                        override var default: Boolean = true
+                    }
+                """
+                val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to true))
+                val findings = BooleanPropertyNaming(config).compileAndLintWithContext(env, code)
+
+                assertThat(findings).hasSize(1)
+            }
+
+            @Test
             fun `should warn about Kotlin Boolean nullable`() {
                 val code = """
                     class Test {
@@ -89,6 +238,39 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                     }
                 """
                 val findings = subject.compileAndLintWithContext(env, code)
+
+                assertThat(findings).hasSize(1)
+            }
+
+            @Test
+            fun `should warn about Kotlin Boolean nullable override`() {
+                val code = """
+                    interface Test {
+                        val default: Boolean?
+                    }
+
+                    class TestImpl : Test {
+                        override var default: Boolean? = null
+                    }
+                """
+                val findings = subject.compileAndLintWithContext(env, code)
+
+                assertThat(findings).hasSize(2)
+            }
+
+            @Test
+            fun `should not warn about Kotlin Boolean nullable override if ignoreOverridden is true`() {
+                val code = """
+                    interface Test {
+                        val default: Boolean?
+                    }
+
+                    class TestImpl : Test {
+                        override var default: Boolean? = null
+                    }
+                """
+                val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to true))
+                val findings = BooleanPropertyNaming(config).compileAndLintWithContext(env, code)
 
                 assertThat(findings).hasSize(1)
             }
@@ -106,6 +288,39 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
             }
 
             @Test
+            fun `should warn about Kotlin Boolean initialized override`() {
+                val code = """
+                    interface Test {
+                        val default: Boolean
+                    }
+
+                    class TestImpl : Test {
+                        override var default: Boolean = false
+                    }
+                """
+                val findings = subject.compileAndLintWithContext(env, code)
+
+                assertThat(findings).hasSize(2)
+            }
+
+            @Test
+            fun `should not warn about Kotlin Boolean initialized override if ignoreOverridden is true`() {
+                val code = """
+                    interface Test {
+                        val default: Boolean
+                    }
+
+                    class TestImpl : Test {
+                        override var default: Boolean = false
+                    }
+                """
+                val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to true))
+                val findings = BooleanPropertyNaming(config).compileAndLintWithContext(env, code)
+
+                assertThat(findings).hasSize(1)
+            }
+
+            @Test
             fun `should warn about inferred boolean type`() {
                 val code = """
                     class Test {
@@ -118,6 +333,39 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
             }
 
             @Test
+            fun `should warn about inferred boolean type override`() {
+                val code = """
+                    interface Test {
+                        val default: Boolean
+                    }
+
+                    class TestImpl : Test {
+                        override var default = true
+                    }
+                """
+                val findings = subject.compileAndLintWithContext(env, code)
+
+                assertThat(findings).hasSize(2)
+            }
+
+            @Test
+            fun `should not warn about inferred boolean type override if ignoreOverridden is true`() {
+                val code = """
+                    interface Test {
+                        val default: Boolean
+                    }
+
+                    class TestImpl : Test {
+                        override var default = true
+                    }
+                """
+                val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to true))
+                val findings = BooleanPropertyNaming(config).compileAndLintWithContext(env, code)
+
+                assertThat(findings).hasSize(1)
+            }
+
+            @Test
             fun `should warn about Java Boolean`() {
                 val code = """
                     class Test {
@@ -125,6 +373,39 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                     }
                 """
                 val findings = subject.compileAndLintWithContext(env, code)
+
+                assertThat(findings).hasSize(1)
+            }
+
+            @Test
+            fun `should warn about Java Boolean override`() {
+                val code = """
+                    interface Test {
+                        val default: java.lang.Boolean
+                    }
+
+                    class TestImpl : Test {
+                        override var default: java.lang.Boolean = java.lang.Boolean(true)
+                    }
+                """
+                val findings = subject.compileAndLintWithContext(env, code)
+
+                assertThat(findings).hasSize(2)
+            }
+
+            @Test
+            fun `should not warn about Java Boolean override if ignoreOverridden is true`() {
+                val code = """
+                    interface Test {
+                        val default: java.lang.Boolean
+                    }
+
+                    class TestImpl : Test {
+                        override var default: java.lang.Boolean = java.lang.Boolean(true)
+                    }
+                """
+                val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to true))
+                val findings = BooleanPropertyNaming(config).compileAndLintWithContext(env, code)
 
                 assertThat(findings).hasSize(1)
             }
@@ -171,3 +452,4 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
 }
 
 private const val ALLOWED_PATTERN = "allowedPattern"
+private const val IGNORE_OVERRIDDEN = "ignoreOverridden"


### PR DESCRIPTION
This PR addresses https://github.com/detekt/detekt/issues/4652.