### PR TITLE
[VarCouldBeVal] fix overrides false positives

### DIFF
--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/VarCouldBeVal.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/VarCouldBeVal.kt
@@ -10,6 +10,7 @@ import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
 import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
+import io.gitlab.arturbosch.detekt.rules.isOverride
 import org.jetbrains.kotlin.descriptors.DeclarationDescriptor
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtBinaryExpression
@@ -196,7 +197,7 @@ class VarCouldBeVal(config: Config = Config.empty) : Rule(config) {
 
         private fun KtProperty.isDeclarationCandidate(): Boolean {
             return when {
-                !isVar -> false
+                !isVar || isOverride() -> false
                 isLocal || isPrivate() -> true
                 else -> {
                     // Check for whether property belongs to an anonymous object

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/VarCouldBeValSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/VarCouldBeValSpec.kt
@@ -290,6 +290,21 @@ class VarCouldBeValSpec(val env: KotlinCoreEnvironment) {
         }
 
         @Test
+        fun `should not report when a property overrides a var`() {
+            val code = """
+                    interface I {
+                        var optionEnabled: Boolean
+                    }
+                    class Test {
+                        val test = object : I {
+                            override var optionEnabled: Boolean = false
+                        }
+                    }
+                """
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        }
+
+        @Test
         fun `should not report assigned properties that have accessors that are accessed`() {
             val code = """
                 interface I {


### PR DESCRIPTION
I'm not sure this is correct as this seems a simple check, but this fixes https://github.com/detekt/detekt/issues/4661 and does not break other tests.