### PR TITLE
Disable Gradle's configuration cache by default

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,4 @@ systemProp.sonar.host.url=http://localhost:9000
 org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8
-org.gradle.unsafe.configuration-cache=true
+org.gradle.unsafe.configuration-cache=false


### PR DESCRIPTION
There are issues that don't have workarounds at this stage (see #4669). Check again when Gradle 7.5 released.