### PR TITLE
Disable Gradle's configuration cache when using Sign tasks

### DIFF
--- a/build-logic/src/main/kotlin/packaging.gradle.kts
+++ b/build-logic/src/main/kotlin/packaging.gradle.kts
@@ -11,6 +11,10 @@ val sonatypePassword: String? = findProperty("sonatypePassword")
     ?.toString()
     ?: System.getenv("MAVEN_CENTRAL_PW")
 
+tasks.withType<Sign>().configureEach {
+    notCompatibleWithConfigurationCache("https://github.com/gradle/gradle/issues/13470")
+}
+
 publishing {
     repositories {
         maven {


### PR DESCRIPTION
Will fix #4598 once Gradle 7.5 is released.

This change _should_ work in Gradle 7.4, but it only worked when I also upgraded the Gradle wrapper to a 7.5 daily snapshot version. Also see #4668.