### PR TITLE
Use ConTester to prove that the synchronized block is required

### DIFF
--- a/detekt-parser/build.gradle.kts
+++ b/detekt-parser/build.gradle.kts
@@ -7,6 +7,8 @@ plugins {
 dependencies {
     api(libs.kotlin.compilerEmbeddable)
     implementation(projects.detektPsiUtils)
+    implementation(libs.contester.breakpoint)
+    testImplementation(libs.contester.driver)
     testImplementation(projects.detektTestUtils)
     testImplementation(libs.assertj)
 }

--- a/detekt-parser/src/main/kotlin/io/github/detekt/parser/DetektPomModel.kt
+++ b/detekt-parser/src/main/kotlin/io/github/detekt/parser/DetektPomModel.kt
@@ -1,5 +1,6 @@
 package io.github.detekt.parser
 
+import io.github.davidburstrom.contester.ConTesterBreakpoint
 import org.jetbrains.kotlin.com.intellij.openapi.extensions.ExtensionPoint
 import org.jetbrains.kotlin.com.intellij.openapi.extensions.Extensions.getRootArea
 import org.jetbrains.kotlin.com.intellij.openapi.project.Project
@@ -26,6 +27,9 @@ class DetektPomModel(project: Project) : UserDataHolderBase(), PomModel {
             // Addresses https://github.com/detekt/detekt/issues/4609
             synchronized(extensionArea) {
                 if (!extensionArea.hasExtensionPoint(extension)) {
+                    ConTesterBreakpoint.defineBreakpoint("DetektPomModel.registerExtensionPoint") {
+                        extensionArea == getRootArea()
+                    }
                     extensionArea.registerExtensionPoint(
                         extension,
                         extensionClass,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,7 @@ jacoco = "0.8.8"
 kotlin = "1.6.21"
 ktlint = "0.45.2"
 junit = "5.8.2"
+contester = "0.2.0"
 
 [libraries]
 githubRelease-gradle = "com.github.breadmoirai:github-release:2.3.7"
@@ -37,6 +38,8 @@ reflections = "org.reflections:reflections:0.10.2"
 mockk = "io.mockk:mockk:1.12.4"
 snakeyaml = "org.yaml:snakeyaml:1.30"
 jcommander = "com.beust:jcommander:1.82"
+contester-breakpoint = { module = "io.github.davidburstrom.contester:contester-breakpoint", version.ref = "contester" }
+contester-driver = { module = "io.github.davidburstrom.contester:contester-driver", version.ref = "contester" }
 
 [plugins]
 binaryCompatibilityValidator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version = "0.10.0" }


### PR DESCRIPTION
Relates to PR https://github.com/detekt/detekt/pull/4631

The issue that was fixed was never proven, due to lack of test tooling. Therefore, I wrote the ConTester utility (https://github.com/davidburstrom/contester) which allows for defining breakpoints in the production code.

If the `synchronized` block is removed, the tests start to fail for the reason indicated in https://github.com/detekt/detekt/issues/4609