### PR TITLE
JaCoCo 0.8.8

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 dokka = "1.6.10"
-jacoco = "0.8.7"
+jacoco = "0.8.8"
 kotlin = "1.6.10"
 ktlint = "0.45.1"
 spek = "2.0.18"


### PR DESCRIPTION
https://github.com/jacoco/jacoco/releases/tag/v0.8.8

Seems this unfortunately isn't picked up automatically as a dependency update by Renovate :(