### PR TITLE
NonBooleanPropertyPrefixedWithIs: Allow boolean function reference

### DIFF
--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NonBooleanPropertyPrefixedWithIs.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NonBooleanPropertyPrefixedWithIs.kt
@@ -68,11 +68,11 @@ class NonBooleanPropertyPrefixedWithIs(config: Config = Config.empty) : Rule(con
         if (name.startsWith("is") && name.length > 2 && !name[2].isLowerCase()) {
             val type = getType(declaration)
             val typeName = type?.getTypeName()
+            val isNotBooleanType = typeName != kotlinBooleanTypeName && typeName != javaBooleanTypeName
 
-            if (!typeName.isNullOrEmpty()
-                && typeName != kotlinBooleanTypeName
-                && typeName != javaBooleanTypeName
-                && !type.isBooleanFunctionReference()
+            if (!typeName.isNullOrEmpty() &&
+                isNotBooleanType &&
+                !type.isBooleanFunctionReference()
             ) {
                 report(
                     reportCodeSmell(declaration, name, typeName)

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NonBooleanPropertyWithPrefixIsSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NonBooleanPropertyWithPrefixIsSpec.kt
@@ -253,5 +253,33 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinCoreEnvironment) {
                 assertThat(findings).hasSize(1)
             }
         }
+
+        @Nested
+        inner class `issue regression test` {
+            @Test
+            fun `issue 4674 should handle unknown type as correct`() {
+                val code = """
+                class Test {
+                    val isDebuggable get() = BuildConfig.DEBUG
+                }
+                """
+                val findings = subject.compileAndLintWithContext(env, code)
+
+                assertThat(findings).isEmpty()
+            }
+
+            @Test
+            fun `issue 4675 check function reference type parameter`() {
+                val code = """
+                    val isRemoved = suspend { null == null }
+
+                    fun trueFun() = true
+                    val isReferenceBoolean = ::trueFun
+                """
+                val findings = subject.compileAndLintWithContext(env, code)
+
+                assertThat(findings).isEmpty()
+            }
+        }
     }
 }

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NonBooleanPropertyWithPrefixIsSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NonBooleanPropertyWithPrefixIsSpec.kt
@@ -3,6 +3,7 @@ package io.gitlab.arturbosch.detekt.rules.naming
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -263,7 +264,9 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinCoreEnvironment) {
                     val isDebuggable get() = BuildConfig.DEBUG
                 }
                 """
-                val findings = subject.compileAndLintWithContext(env, code)
+
+                // BuildConfig is missing in this test so we can't compile it
+                val findings = subject.lintWithContext(env, code)
 
                 assertThat(findings).isEmpty()
             }


### PR DESCRIPTION
This PR will allow boolean function reference properties for the NonBooleanPropertyPrefixedWithIs rule. (And fix issue #4675).
It also fixes a little issue that unknown types are not null, the string is just empty. This should also fix issue #4674.
