### PR TITLE
CanBeNonNullable shouldn't consider abstract properties

### DIFF
--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/CanBeNonNullable.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/CanBeNonNullable.kt
@@ -9,6 +9,7 @@ import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
+import io.gitlab.arturbosch.detekt.rules.isAbstract
 import io.gitlab.arturbosch.detekt.rules.isNonNullCheck
 import io.gitlab.arturbosch.detekt.rules.isNullCheck
 import io.gitlab.arturbosch.detekt.rules.isOpen
@@ -474,7 +475,7 @@ class CanBeNonNullable(config: Config = Config.empty) : Rule(config) {
         }
 
         private fun KtProperty.isCandidate(): Boolean {
-            if (isOpen()) return false
+            if (isOpen() || isAbstract()) return false
             val isSetToNonNullable = initializer?.isNullableType() != true &&
                 getter?.isNullableType() != true &&
                 delegate?.returnsNullable() != true

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/CanBeNonNullableSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/CanBeNonNullableSpec.kt
@@ -377,9 +377,20 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
         @Test
         fun `does not report open properties`() {
             val code = """
-                abstract class A {
+                open class A {
                     open val a: Int? = 5
                     open var b: Int? = 5
+                }
+            """
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        }
+
+        @Test
+        fun `does not report abstract properties`() {
+            val code = """
+                abstract class A {
+                    abstract val a: Int?
+                    abstract var b: Int?
                 }
             """
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()


### PR DESCRIPTION
Related with #4677