### PR TITLE
Drop (most) Groovy DSL tests

### DIFF
--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/CreateBaselineTaskDslSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/CreateBaselineTaskDslSpec.kt
@@ -4,13 +4,11 @@ import io.gitlab.arturbosch.detekt.testkit.DslTestBuilder
 import io.gitlab.arturbosch.detekt.testkit.ProjectLayout
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.TaskOutcome
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.MethodSource
+import org.junit.jupiter.api.Test
 
 class CreateBaselineTaskDslSpec {
-    @ParameterizedTest(name = "Using {0}, detektBaseline task can be executed when baseline file is specified")
-    @MethodSource("io.gitlab.arturbosch.detekt.testkit.DslTestBuilder#builders")
-    fun baselineTaskExecutableWhenBaselineFileSpecified(builder: DslTestBuilder) {
+    @Test
+    fun `detektBaseline task can be executed when baseline file is specified`() {
         val baselineFilename = "baseline.xml"
 
         val detektConfig = """
@@ -18,7 +16,7 @@ class CreateBaselineTaskDslSpec {
             |   baseline = file("$baselineFilename")
             |}
         """
-        val gradleRunner = builder
+        val gradleRunner = DslTestBuilder.kotlin()
             .withProjectLayout(
                 ProjectLayout(
                     numberOfSourceFilesInRootPerSourceDir = 1,
@@ -35,14 +33,13 @@ class CreateBaselineTaskDslSpec {
         }
     }
 
-    @ParameterizedTest(name = "Using {0}, detektBaseline task can be executed when baseline file is not specified")
-    @MethodSource("io.gitlab.arturbosch.detekt.testkit.DslTestBuilder#builders")
-    fun baselineTaskExecutableWhenBaselineFileNotSpecified(builder: DslTestBuilder) {
+    @Test
+    fun `detektBaseline task can be executed when baseline file is not specified`() {
         val detektConfig = """
             |detekt {
             |}
         """
-        val gradleRunner = builder
+        val gradleRunner = DslTestBuilder.kotlin()
             .withProjectLayout(
                 ProjectLayout(
                     numberOfSourceFilesInRootPerSourceDir = 1,
@@ -58,15 +55,14 @@ class CreateBaselineTaskDslSpec {
         }
     }
 
-    @ParameterizedTest(name = "Using {0}, detektBaseline task can not be executed when baseline file is specified null")
-    @MethodSource("io.gitlab.arturbosch.detekt.testkit.DslTestBuilder#builders")
-    fun baselineTaskNotExecutableWhenBaselineFileIsNull(builder: DslTestBuilder) {
+    @Test
+    fun `detektBaseline task can not be executed when baseline file is specified null`() {
         val detektConfig = """
             |detekt {
             |   baseline = null
             |}
         """
-        val gradleRunner = builder
+        val gradleRunner = DslTestBuilder.kotlin()
             .withProjectLayout(
                 ProjectLayout(
                     numberOfSourceFilesInRootPerSourceDir = 1,

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektReportMergeSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektReportMergeSpec.kt
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test
 
 class DetektReportMergeSpec {
     @Test
+    @Suppress("LongMethod")
     fun `Sarif merge is configured correctly for multi module project`() {
         val builder = DslTestBuilder.kotlin()
         val buildFileContent =
@@ -81,6 +82,7 @@ class DetektReportMergeSpec {
     }
 
     @Test
+    @Suppress("LongMethod")
     fun `XML merge is configured correctly for multi module project`() {
         val builder = DslTestBuilder.kotlin()
         val buildFileContent = """

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektReportMergeSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektReportMergeSpec.kt
@@ -4,55 +4,18 @@ import io.gitlab.arturbosch.detekt.testkit.DslGradleRunner
 import io.gitlab.arturbosch.detekt.testkit.DslTestBuilder
 import io.gitlab.arturbosch.detekt.testkit.ProjectLayout
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Nested
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.Arguments
-import org.junit.jupiter.params.provider.Arguments.arguments
-import org.junit.jupiter.params.provider.MethodSource
+import org.junit.jupiter.api.Test
 
 class DetektReportMergeSpec {
-
-    @Nested
-    inner class `Sarif merge is configured correctly for multi module project` {
-
-        val groovy = DslTestBuilder.groovy()
-        val groovyBuildFileContent =
+    @Test
+    fun `Sarif merge is configured correctly for multi module project`() {
+        val builder = DslTestBuilder.kotlin()
+        val buildFileContent =
             """
-            |${groovy.gradlePlugins}
+            |${builder.gradlePlugins}
             |
             |allprojects {
-            |  ${groovy.gradleRepositories}
-            |}
-            |
-            |task sarifReportMerge(type: io.gitlab.arturbosch.detekt.report.ReportMergeTask) {
-            |  output = project.layout.buildDirectory.file("reports/detekt/merge.sarif")
-            |}
-            |
-            |subprojects {
-            |  ${groovy.gradleSubprojectsApplyPlugins}
-            |  
-            |  detekt {
-            |    reports.sarif.enabled = true
-            |  }
-            |  
-            |  plugins.withType(io.gitlab.arturbosch.detekt.DetektPlugin) {
-            |    tasks.withType(io.gitlab.arturbosch.detekt.Detekt) { detektTask ->
-            |       sarifReportMerge.configure { mergeTask ->
-            |         mergeTask.mustRunAfter(detektTask)
-            |         mergeTask.input.from(detektTask.sarifReportFile)
-            |       }
-            |    }
-            |  }
-            |}
-            |
-            """.trimMargin()
-        val kotlin = DslTestBuilder.kotlin()
-        val kotlinBuildFileContent =
-            """
-            |${kotlin.gradlePlugins}
-            |
-            |allprojects {
-            |  ${kotlin.gradleRepositories}
+            |  ${builder.gradleRepositories}
             |}
             |
             |val sarifReportMerge by tasks.registering(io.gitlab.arturbosch.detekt.report.ReportMergeTask::class) {
@@ -60,7 +23,7 @@ class DetektReportMergeSpec {
             |}
             |
             |subprojects {
-            |  ${kotlin.gradleSubprojectsApplyPlugins}
+            |  ${builder.gradleSubprojectsApplyPlugins}
             |  
             |  detekt {
             |    reports.sarif.enabled = true
@@ -78,95 +41,53 @@ class DetektReportMergeSpec {
             |
             """.trimMargin()
 
-        fun scenarios(): List<Arguments> = listOf(
-            arguments(groovy, groovyBuildFileContent),
-            arguments(kotlin, kotlinBuildFileContent)
-        )
+        val projectLayout = ProjectLayout(numberOfSourceFilesInRootPerSourceDir = 0).apply {
+            addSubmodule(
+                name = "child1",
+                numberOfSourceFilesPerSourceDir = 2,
+                numberOfCodeSmells = 2
+            )
+            addSubmodule(
+                name = "child2",
+                numberOfSourceFilesPerSourceDir = 4,
+                numberOfCodeSmells = 4
+            )
+        }
 
-        @ParameterizedTest(name = "Using {0}")
-        @MethodSource("scenarios")
-        fun sarifMerge(builder: DslTestBuilder, mainBuildFileContent: String) {
-            val projectLayout = ProjectLayout(numberOfSourceFilesInRootPerSourceDir = 0).apply {
-                addSubmodule(
-                    name = "child1",
-                    numberOfSourceFilesPerSourceDir = 2,
-                    numberOfCodeSmells = 2
-                )
-                addSubmodule(
-                    name = "child2",
-                    numberOfSourceFilesPerSourceDir = 4,
-                    numberOfCodeSmells = 4
-                )
-            }
-
-            val gradleRunner = DslGradleRunner(projectLayout, builder.gradleBuildName, mainBuildFileContent)
-            gradleRunner.setupProject()
-            gradleRunner.runTasksAndExpectFailure("detekt", "sarifReportMerge", "--continue") { result ->
-                assertThat(result.output).contains("FAILURE: Build completed with 2 failures.")
-                assertThat(result.output).containsIgnoringWhitespaces(
-                    """
-                    Execution failed for task ':child1:detekt'.
-                    > Analysis failed with 2 weighted issues.
-                    """
-                )
-                assertThat(result.output).containsIgnoringWhitespaces(
-                    """
-                    Execution failed for task ':child2:detekt'.
-                    > Analysis failed with 4 weighted issues.
-                    """
-                )
-                assertThat(projectFile("build/reports/detekt/detekt.sarif")).doesNotExist()
-                assertThat(projectFile("build/reports/detekt/merge.sarif")).exists()
-                assertThat(projectFile("build/reports/detekt/merge.sarif").readText())
-                    .contains("\"ruleId\": \"detekt.style.MagicNumber\"")
-                projectLayout.submodules.forEach {
-                    assertThat(projectFile("${it.name}/build/reports/detekt/detekt.sarif")).exists()
-                }
+        val gradleRunner = DslGradleRunner(projectLayout, builder.gradleBuildName, buildFileContent)
+        gradleRunner.setupProject()
+        gradleRunner.runTasksAndExpectFailure("detekt", "sarifReportMerge", "--continue") { result ->
+            assertThat(result.output).contains("FAILURE: Build completed with 2 failures.")
+            assertThat(result.output).containsIgnoringWhitespaces(
+                """
+                Execution failed for task ':child1:detekt'.
+                > Analysis failed with 2 weighted issues.
+                """
+            )
+            assertThat(result.output).containsIgnoringWhitespaces(
+                """
+                Execution failed for task ':child2:detekt'.
+                > Analysis failed with 4 weighted issues.
+                """
+            )
+            assertThat(projectFile("build/reports/detekt/detekt.sarif")).doesNotExist()
+            assertThat(projectFile("build/reports/detekt/merge.sarif")).exists()
+            assertThat(projectFile("build/reports/detekt/merge.sarif").readText())
+                .contains("\"ruleId\": \"detekt.style.MagicNumber\"")
+            projectLayout.submodules.forEach {
+                assertThat(projectFile("${it.name}/build/reports/detekt/detekt.sarif")).exists()
             }
         }
     }
 
-    @Nested
-    inner class `XML merge is configured correctly for multi module project` {
-
-        val groovy = DslTestBuilder.groovy()
-        val groovyBuildFileContent =
-            """
-            |${groovy.gradlePlugins}
+    @Test
+    fun `XML merge is configured correctly for multi module project`() {
+        val builder = DslTestBuilder.kotlin()
+        val buildFileContent = """
+            |${builder.gradlePlugins}
             |
             |allprojects {
-            |  ${groovy.gradleRepositories}
-            |}
-            |
-            |task xmlReportMerge(type: io.gitlab.arturbosch.detekt.report.ReportMergeTask) {
-            |  output = project.layout.buildDirectory.file("reports/detekt/merge.xml")
-            |}
-            |
-            |subprojects {
-            |  ${groovy.gradleSubprojectsApplyPlugins}
-            |  
-            |  detekt {
-            |    reports.xml.enabled = true
-            |  }
-            |  
-            |  plugins.withType(io.gitlab.arturbosch.detekt.DetektPlugin) {
-            |    tasks.withType(io.gitlab.arturbosch.detekt.Detekt) { detektTask ->
-            |       xmlReportMerge.configure { mergeTask ->
-            |         mergeTask.mustRunAfter(detektTask)
-            |         mergeTask.input.from(detektTask.xmlReportFile)
-            |       }
-            |    }
-            |  }
-            |}
-            |
-            """.trimMargin()
-        val kotlin = DslTestBuilder.kotlin()
-        val kotlinBuildFileContent =
-            """
-            |${kotlin.gradlePlugins}
-            |
-            |allprojects {
-            |  ${kotlin.gradleRepositories}
+            |  ${builder.gradleRepositories}
             |}
             |
             |val xmlReportMerge by tasks.registering(io.gitlab.arturbosch.detekt.report.ReportMergeTask::class) {
@@ -174,7 +95,7 @@ class DetektReportMergeSpec {
             |}
             |
             |subprojects {
-            |  ${kotlin.gradleSubprojectsApplyPlugins}
+            |  ${builder.gradleSubprojectsApplyPlugins}
             |  
             |  detekt {
             |    reports.xml.enabled = true
@@ -190,52 +111,43 @@ class DetektReportMergeSpec {
             |  }
             |}
             |
-            """.trimMargin()
+        """.trimMargin()
 
-        fun scenarios(): List<Arguments> = listOf(
-            arguments(groovy, groovyBuildFileContent),
-            arguments(kotlin, kotlinBuildFileContent)
-        )
+        val projectLayout = ProjectLayout(numberOfSourceFilesInRootPerSourceDir = 0).apply {
+            addSubmodule(
+                name = "child1",
+                numberOfSourceFilesPerSourceDir = 2,
+                numberOfCodeSmells = 2
+            )
+            addSubmodule(
+                name = "child2",
+                numberOfSourceFilesPerSourceDir = 4,
+                numberOfCodeSmells = 4
+            )
+        }
 
-        @ParameterizedTest(name = "Using {0}")
-        @MethodSource("scenarios")
-        fun sarifMerge(builder: DslTestBuilder, mainBuildFileContent: String) {
-            val projectLayout = ProjectLayout(numberOfSourceFilesInRootPerSourceDir = 0).apply {
-                addSubmodule(
-                    name = "child1",
-                    numberOfSourceFilesPerSourceDir = 2,
-                    numberOfCodeSmells = 2
-                )
-                addSubmodule(
-                    name = "child2",
-                    numberOfSourceFilesPerSourceDir = 4,
-                    numberOfCodeSmells = 4
-                )
-            }
-
-            val gradleRunner = DslGradleRunner(projectLayout, builder.gradleBuildName, mainBuildFileContent)
-            gradleRunner.setupProject()
-            gradleRunner.runTasksAndExpectFailure("detekt", "xmlReportMerge", "--continue") { result ->
-                assertThat(result.output).contains("FAILURE: Build completed with 2 failures.")
-                assertThat(result.output).containsIgnoringWhitespaces(
-                    """
-                    Execution failed for task ':child1:detekt'.
-                    > Analysis failed with 2 weighted issues.
-                    """
-                )
-                assertThat(result.output).containsIgnoringWhitespaces(
-                    """
-                    Execution failed for task ':child2:detekt'.
-                    > Analysis failed with 4 weighted issues.
-                    """
-                )
-                assertThat(projectFile("build/reports/detekt/detekt.xml")).doesNotExist()
-                assertThat(projectFile("build/reports/detekt/merge.xml")).exists()
-                assertThat(projectFile("build/reports/detekt/merge.xml").readText())
-                    .contains("<error column=\"30\" line=\"4\"")
-                projectLayout.submodules.forEach {
-                    assertThat(projectFile("${it.name}/build/reports/detekt/detekt.xml")).exists()
-                }
+        val gradleRunner = DslGradleRunner(projectLayout, builder.gradleBuildName, buildFileContent)
+        gradleRunner.setupProject()
+        gradleRunner.runTasksAndExpectFailure("detekt", "xmlReportMerge", "--continue") { result ->
+            assertThat(result.output).contains("FAILURE: Build completed with 2 failures.")
+            assertThat(result.output).containsIgnoringWhitespaces(
+                """
+                Execution failed for task ':child1:detekt'.
+                > Analysis failed with 2 weighted issues.
+                """
+            )
+            assertThat(result.output).containsIgnoringWhitespaces(
+                """
+                Execution failed for task ':child2:detekt'.
+                > Analysis failed with 4 weighted issues.
+                """
+            )
+            assertThat(projectFile("build/reports/detekt/detekt.xml")).doesNotExist()
+            assertThat(projectFile("build/reports/detekt/merge.xml")).exists()
+            assertThat(projectFile("build/reports/detekt/merge.xml").readText())
+                .contains("<error column=\"30\" line=\"4\"")
+            projectLayout.submodules.forEach {
+                assertThat(projectFile("${it.name}/build/reports/detekt/detekt.xml")).exists()
             }
         }
     }

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektTaskGroovyDslSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektTaskGroovyDslSpec.kt
@@ -1,0 +1,124 @@
+package io.gitlab.arturbosch.detekt
+
+import io.gitlab.arturbosch.detekt.testkit.DslTestBuilder
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.jupiter.api.Test
+
+class DetektTaskGroovyDslSpec {
+
+    @Test
+    fun `detekt extension can be configured without errors`() {
+        val config = """
+            |detekt {
+            |    toolVersion = "1.0.0.RC8"
+            |    ignoreFailures = true
+            |    source = files("src/main/kotlin")
+            |    baseline = file("path/to/baseline.xml")
+            |    basePath = projectDir
+            |    config = files("config/detekt/detekt.yml")
+            |    debug = true
+            |    parallel = true
+            |    allRules = true
+            |    buildUponDefaultConfig = true
+            |    disableDefaultRuleSets = true
+            |    autoCorrect = true
+            |    ignoredVariants = ["variantA", "variantB"]
+            |    ignoredBuildTypes = ["buildTypeA", "buildTypeB"]
+            |    ignoredFlavors = ["flavorA", "flavorB"]
+            |}
+        """
+        val groovyBuilder = DslTestBuilder.groovy()
+        val gradleRunner = groovyBuilder.withDetektConfig(config).build()
+        val result = gradleRunner.runTasks(":help")
+        assertThat(result.task(":help")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+    }
+
+    @Test
+    fun `detekt task can be fully configured without errors`() {
+        val config = """
+            |tasks.create("customDetektTask", io.gitlab.arturbosch.detekt.Detekt) {
+            |    source = files("${"$"}projectDir")
+            |    includes = ["**/*.kt", "**/*.kts"]
+            |    excludes = ["build/"]
+            |    ignoreFailures = false
+            |    detektClasspath.setFrom(files("config.yml"))
+            |    pluginClasspath.setFrom(files("config.yml"))
+            |    baseline = file("config.yml")
+            |    config.setFrom(files("config.yml"))
+            |    classpath.setFrom(files("config.yml"))
+            |    languageVersion = "1.6"
+            |    jvmTarget = "1.8"
+            |    debug = true
+            |    parallel = true
+            |    disableDefaultRuleSets = true
+            |    buildUponDefaultConfig = true
+            |    allRules = false
+            |    autoCorrect = false
+            |    basePath = projectDir
+            |    reports {
+            |        xml {
+            |            enabled = true
+            |            destination = file("build/reports/mydetekt.xml")
+            |        }
+            |        html.enabled = true
+            |        html.destination = file("build/reports/mydetekt.html")
+            |        txt.enabled = true
+            |        txt.destination = file("build/reports/mydetekt.txt")
+            |        sarif {
+            |            enabled = true
+            |            destination = file("build/reports/mydetekt.sarif")
+            |        }
+            |    }
+            |    reportsDir = file("config.yml")
+            |}
+        """
+        val groovyBuilder = DslTestBuilder.groovy()
+        val gradleRunner = groovyBuilder.withDetektConfig(config).build()
+        val result = gradleRunner.runTasks(":help")
+        assertThat(result.task(":help")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+    }
+
+    @Test
+    fun `detekt create baseline task can be configured without errors`() {
+        val config = """
+            |tasks.create("customDetektCreateBaselineTask", io.gitlab.arturbosch.detekt.DetektCreateBaselineTask) {
+            |    source = files("${"$"}projectDir")
+            |    includes = ["**/*.kt", "**/*.kts"]
+            |    excludes = ["build/"]
+            |    ignoreFailures = false
+            |    detektClasspath.setFrom(files("config.yml"))
+            |    pluginClasspath.setFrom(files("config.yml"))
+            |    baseline = file("config.yml")
+            |    config.setFrom(files("config.yml"))
+            |    classpath.setFrom(files("config.yml"))
+            |    jvmTarget = "1.8"
+            |    debug = true
+            |    parallel = true
+            |    disableDefaultRuleSets = true
+            |    buildUponDefaultConfig = true
+            |    allRules = false
+            |    autoCorrect = false
+            |    basePath = projectDir
+            |}
+        """
+        val groovyBuilder = DslTestBuilder.groovy()
+        val gradleRunner = groovyBuilder.withDetektConfig(config).build()
+        val result = gradleRunner.runTasks(":help")
+        assertThat(result.task(":help")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+    }
+
+    @Test
+    fun `detekt generate config task can be configured without errors`() {
+        val config = """
+            |tasks.create("customDetektGenerateConfigTask", io.gitlab.arturbosch.detekt.DetektGenerateConfigTask) {
+            |    detektClasspath.setFrom(files("config.yml"))
+            |    config.setFrom(files("config.yml"))
+            |}
+        """
+        val groovyBuilder = DslTestBuilder.groovy()
+        val gradleRunner = groovyBuilder.withDetektConfig(config).build()
+        val result = gradleRunner.runTasks(":help")
+        assertThat(result.task(":help")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+    }
+}

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektTaskMultiModuleSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektTaskMultiModuleSpec.kt
@@ -5,25 +5,27 @@ import io.gitlab.arturbosch.detekt.testkit.DslTestBuilder
 import io.gitlab.arturbosch.detekt.testkit.ProjectLayout
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.TaskOutcome
+import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.MethodSource
+import org.junit.jupiter.api.Test
 
 class DetektTaskMultiModuleSpec {
 
     @Nested
     inner class `The Detekt Gradle plugin used in a multi module project` {
 
-        @ParameterizedTest(
-            name = "Using {0}, it is applied with defaults to all subprojects individually without " +
+        @Test
+        @DisplayName(
+            "it is applied with defaults to all subprojects individually without " +
                 "sources in root project using the subprojects block"
         )
-        @MethodSource("io.gitlab.arturbosch.detekt.testkit.DslTestBuilder#builders")
-        fun applyToSubprojectsWithoutSources(builder: DslTestBuilder) {
+        fun applyToSubprojectsWithoutSources() {
             val projectLayout = ProjectLayout(0).apply {
                 addSubmodule("child1", 2)
                 addSubmodule("child2", 4)
             }
+
+            val builder = DslTestBuilder.kotlin()
 
             val mainBuildFileContent: String = """
                         |${builder.gradlePlugins}
@@ -57,16 +59,18 @@ class DetektTaskMultiModuleSpec {
             }
         }
 
-        @ParameterizedTest(
-            name = "Using {0}, it is applied with defaults to main project and subprojects " +
+        @Test
+        @DisplayName(
+            "it is applied with defaults to main project and subprojects " +
                 "individually using the allprojects block"
         )
-        @MethodSource("io.gitlab.arturbosch.detekt.testkit.DslTestBuilder#builders")
-        fun applyWithAllprojectsBlock(builder: DslTestBuilder) {
+        fun applyWithAllprojectsBlock() {
             val projectLayout = ProjectLayout(1).apply {
                 addSubmodule("child1", 2)
                 addSubmodule("child2", 4)
             }
+
+            val builder = DslTestBuilder.kotlin()
 
             val mainBuildFileContent: String = """
                         |${builder.gradlePlugins}
@@ -98,13 +102,14 @@ class DetektTaskMultiModuleSpec {
             }
         }
 
-        @ParameterizedTest(name = "Using {0}, it uses custom configs when configured in allprojects block")
-        @MethodSource("io.gitlab.arturbosch.detekt.testkit.DslTestBuilder#builders")
-        fun usesCustomConfigsWhenConfiguredInAllprojectsBlock(builder: DslTestBuilder) {
+        @Test
+        fun `it uses custom configs when configured in allprojects block`() {
             val projectLayout = ProjectLayout(1).apply {
                 addSubmodule("child1", 2)
                 addSubmodule("child2", 4)
             }
+
+            val builder = DslTestBuilder.kotlin()
 
             val mainBuildFileContent: String = """
                         |${builder.gradlePlugins}
@@ -139,12 +144,9 @@ class DetektTaskMultiModuleSpec {
             }
         }
 
-        @ParameterizedTest(
-            name = "Using {0}, it allows changing defaults in allprojects block that can be " +
-                "overwritten in subprojects"
-        )
-        @MethodSource("io.gitlab.arturbosch.detekt.testkit.DslTestBuilder#builders")
-        fun allowsChangingDefaultsInAllProjectsThatAreOverwrittenInSubprojects(builder: DslTestBuilder) {
+        @Test
+        @DisplayName("it allows changing defaults in allprojects block that can be overwritten in subprojects")
+        fun allowsChangingDefaultsInAllProjectsThatAreOverwrittenInSubprojects() {
             val child2DetektConfig = """
                         |detekt {
                         |   reportsDir = file("build/custom")
@@ -156,6 +158,8 @@ class DetektTaskMultiModuleSpec {
                 addSubmodule("child1", 2)
                 addSubmodule("child2", 4, buildFileContent = child2DetektConfig)
             }
+
+            val builder = DslTestBuilder.kotlin()
 
             val mainBuildFileContent: String = """
                         |${builder.gradlePlugins}
@@ -192,9 +196,8 @@ class DetektTaskMultiModuleSpec {
             }
         }
 
-        @ParameterizedTest(name = "Using {0}, it can be applied to all files in entire project resulting in 1 report")
-        @MethodSource("io.gitlab.arturbosch.detekt.testkit.DslTestBuilder#builders")
-        fun applyToAllFilesInProjectResultingInSingleReport(builder: DslTestBuilder) {
+        @Test
+        fun `it can be applied to all files in entire project resulting in 1 report`() {
             val projectLayout = ProjectLayout(1).apply {
                 addSubmodule("child1", 2)
                 addSubmodule("child2", 4)
@@ -209,7 +212,7 @@ class DetektTaskMultiModuleSpec {
                         |    )
                         |}
             """.trimMargin()
-            val gradleRunner = builder
+            val gradleRunner = DslTestBuilder.kotlin()
                 .withProjectLayout(projectLayout)
                 .withDetektConfig(detektConfig)
                 .build()

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektTaskSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektTaskSpec.kt
@@ -4,8 +4,7 @@ import io.gitlab.arturbosch.detekt.testkit.DslTestBuilder
 import io.gitlab.arturbosch.detekt.testkit.ProjectLayout
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.TaskOutcome
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.MethodSource
+import org.junit.jupiter.api.Test
 
 class DetektTaskSpec {
 
@@ -14,16 +13,15 @@ class DetektTaskSpec {
         numberOfCodeSmellsInRootPerSourceDir = 15
     )
 
-    @ParameterizedTest(name = "Using {0}, build succeeds with more issues than threshold if ignoreFailures = true")
-    @MethodSource("io.gitlab.arturbosch.detekt.testkit.DslTestBuilder#builders")
-    fun ignoreFailures(builder: DslTestBuilder) {
+    @Test
+    fun `build succeeds with more issues than threshold if ignoreFailures = true`() {
         val config = """
             |detekt {
             |   ignoreFailures = true
             |}
         """
 
-        val gradleRunner = builder
+        val gradleRunner = DslTestBuilder.kotlin()
             .withProjectLayout(projectLayoutWithTooManyIssues)
             .withDetektConfig(config)
             .build()
@@ -33,16 +31,15 @@ class DetektTaskSpec {
         }
     }
 
-    @ParameterizedTest(name = "Using {0}, build fails with more issues than threshold successfully if ignoreFailures = false")
-    @MethodSource("io.gitlab.arturbosch.detekt.testkit.DslTestBuilder#builders")
-    fun doNotIgnoreFailures(builder: DslTestBuilder) {
+    @Test
+    fun `build fails with more issues than threshold successfully if ignoreFailures = false`() {
         val config = """
             |detekt {
             |   ignoreFailures = false
             |}
         """
 
-        val gradleRunner = builder
+        val gradleRunner = DslTestBuilder.kotlin()
             .withProjectLayout(projectLayoutWithTooManyIssues)
             .withDetektConfig(config)
             .build()

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/GenerateConfigTaskSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/GenerateConfigTaskSpec.kt
@@ -3,14 +3,13 @@ package io.gitlab.arturbosch.detekt
 import io.gitlab.arturbosch.detekt.testkit.DslTestBuilder
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.TaskOutcome
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.MethodSource
+import org.junit.jupiter.api.Test
 
 class GenerateConfigTaskSpec {
 
-    @ParameterizedTest(name = "Using {0}, can be executed without any configuration")
-    @MethodSource("io.gitlab.arturbosch.detekt.testkit.DslTestBuilder#builders")
-    fun emptyConfig(builder: DslTestBuilder) {
+    @Test
+    fun `can be executed without any configuration`() {
+        val builder = DslTestBuilder.kotlin()
         val gradleRunner = builder.withConfigFile("config/detekt/detekt.yml").build()
 
         gradleRunner.runTasksAndCheckResult("detektGenerateConfig") { result ->
@@ -19,9 +18,9 @@ class GenerateConfigTaskSpec {
         }
     }
 
-    @ParameterizedTest(name = "Using {0}, chooses the last config file when configured")
-    @MethodSource("io.gitlab.arturbosch.detekt.testkit.DslTestBuilder#builders")
-    fun `chooses the last config file when configured`(builder: DslTestBuilder) {
+    @Test
+    fun `chooses the last config file when configured`() {
+        val builder = DslTestBuilder.kotlin()
         val gradleRunner = builder.withDetektConfig(
             """
                     |detekt {

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektAndroidSpec.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektAndroidSpec.kt
@@ -271,7 +271,7 @@ class DetektAndroidSpec {
                         $LIB_PLUGIN_BLOCK
                         $ANDROID_BLOCK_WITH_FLAVOR
                         detekt {
-                            ignoredBuildTypes = ["release"]
+                            ignoredBuildTypes = listOf("release")
                         }
                     """.trimIndent(),
                     srcDirs = listOf("src/main/java", "src/debug/java", "src/test/java", "src/androidTest/java")
@@ -326,7 +326,7 @@ class DetektAndroidSpec {
                         $LIB_PLUGIN_BLOCK
                         $ANDROID_BLOCK_WITH_FLAVOR
                         detekt {
-                            ignoredVariants = ["youngHarryDebug", "oldHarryRelease"]
+                            ignoredVariants = listOf("youngHarryDebug", "oldHarryRelease")
                         }
                     """.trimIndent(),
                     srcDirs = listOf("src/main/java", "src/debug/java", "src/test/java", "src/androidTest/java")
@@ -381,7 +381,7 @@ class DetektAndroidSpec {
                         $LIB_PLUGIN_BLOCK
                         $ANDROID_BLOCK_WITH_FLAVOR
                         detekt {
-                            ignoredFlavors = ["youngHarry"]
+                            ignoredFlavors = listOf("youngHarry")
                         }
                     """.trimIndent(),
                     srcDirs = listOf("src/main/java", "src/debug/java", "src/test/java", "src/androidTest/java")
@@ -440,38 +440,38 @@ internal fun manifestContent(packageName: String = "io.gitlab.arturbosch.detekt.
 
 private val APP_PLUGIN_BLOCK = """
     plugins {
-        id "com.android.application"
-        id "kotlin-android"
-        id "io.gitlab.arturbosch.detekt"
+        id("com.android.application")
+        id("kotlin-android")
+        id("io.gitlab.arturbosch.detekt")
     }
 """.trimIndent()
 
 private val LIB_PLUGIN_BLOCK = """
     plugins {
-        id "com.android.library"
-        id "kotlin-android"
-        id "io.gitlab.arturbosch.detekt"
+        id("com.android.library")
+        id("kotlin-android")
+        id("io.gitlab.arturbosch.detekt")
     }
 """.trimIndent()
 
 private val ANDROID_BLOCK = """
     android {
-       compileSdkVersion 30
+       compileSdkVersion(30)
     }
 """.trimIndent()
 
 private val ANDROID_BLOCK_WITH_FLAVOR = """
     android {
-        compileSdkVersion 30
+        compileSdkVersion(30)
         flavorDimensions("age", "name")
         productFlavors {
-           harry {
+           create("harry") {
              dimension = "name"
            }
-           young {
+           create("young") {
              dimension = "age"
            }
-           old {
+           create("old") {
              dimension = "age"
            }
         }
@@ -479,7 +479,7 @@ private val ANDROID_BLOCK_WITH_FLAVOR = """
 """.trimIndent()
 
 private val DETEKT_REPORTS_BLOCK = """
-    tasks.withType(io.gitlab.arturbosch.detekt.Detekt).configureEach {
+    tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
         reports {
             txt.enabled = false
         }
@@ -488,7 +488,7 @@ private val DETEKT_REPORTS_BLOCK = """
 
 private fun createGradleRunnerAndSetupProject(projectLayout: ProjectLayout) = DslGradleRunner(
     projectLayout = projectLayout,
-    buildFileName = "build.gradle",
+    buildFileName = "build.gradle.kts",
     mainBuildFileContent = """
         subprojects {
             repositories {

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektAndroidSpec.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektAndroidSpec.kt
@@ -441,7 +441,7 @@ internal fun manifestContent(packageName: String = "io.gitlab.arturbosch.detekt.
 private val APP_PLUGIN_BLOCK = """
     plugins {
         id("com.android.application")
-        id("kotlin-android")
+        kotlin("android")
         id("io.gitlab.arturbosch.detekt")
     }
 """.trimIndent()
@@ -449,7 +449,7 @@ private val APP_PLUGIN_BLOCK = """
 private val LIB_PLUGIN_BLOCK = """
     plugins {
         id("com.android.library")
-        id("kotlin-android")
+        kotlin("android")
         id("io.gitlab.arturbosch.detekt")
     }
 """.trimIndent()

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektJvmSpec.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektJvmSpec.kt
@@ -71,7 +71,7 @@ class DetektJvmSpec {
                 buildFileName = "build.gradle.kts",
                 mainBuildFileContent = """
                     plugins {
-                        id("org.jetbrains.kotlin.jvm")
+                        kotlin("jvm")
                         id("io.gitlab.arturbosch.detekt")
                     }
 
@@ -112,7 +112,7 @@ class DetektJvmSpec {
                 buildFileName = "build.gradle.kts",
                 mainBuildFileContent = """
                     plugins {
-                        id("org.jetbrains.kotlin.jvm")
+                        kotlin("jvm")
                         id("io.gitlab.arturbosch.detekt")
                     }
 

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektJvmSpec.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektJvmSpec.kt
@@ -19,7 +19,7 @@ class DetektJvmSpec {
 
             val gradleRunner = DslGradleRunner(
                 projectLayout = ProjectLayout(numberOfSourceFilesInRootPerSourceDir = 1),
-                buildFileName = "build.gradle",
+                buildFileName = "build.gradle.kts",
                 baselineFiles = listOf("detekt-baseline.xml", "detekt-baseline-main.xml", "detekt-baseline-test.xml"),
                 projectScript = {
                     apply<KotlinPluginWrapper>()
@@ -68,11 +68,11 @@ class DetektJvmSpec {
         inner class `report location set on extension & task` {
             val gradleRunner = DslGradleRunner(
                 projectLayout = ProjectLayout(numberOfSourceFilesInRootPerSourceDir = 1),
-                buildFileName = "build.gradle",
+                buildFileName = "build.gradle.kts",
                 mainBuildFileContent = """
                     plugins {
-                        id "org.jetbrains.kotlin.jvm"
-                        id "io.gitlab.arturbosch.detekt"
+                        id("org.jetbrains.kotlin.jvm")
+                        id("io.gitlab.arturbosch.detekt")
                     }
 
                     repositories {
@@ -86,7 +86,7 @@ class DetektJvmSpec {
                         }
                     }
 
-                    tasks.withType(io.gitlab.arturbosch.detekt.Detekt).configureEach {
+                    tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
                         reports {
                             txt.destination = file("output-path2.txt")
                         }
@@ -109,11 +109,11 @@ class DetektJvmSpec {
         inner class `report location set on task only` {
             val gradleRunner = DslGradleRunner(
                 projectLayout = ProjectLayout(numberOfSourceFilesInRootPerSourceDir = 1),
-                buildFileName = "build.gradle",
+                buildFileName = "build.gradle.kts",
                 mainBuildFileContent = """
                     plugins {
-                        id "org.jetbrains.kotlin.jvm"
-                        id "io.gitlab.arturbosch.detekt"
+                        id("org.jetbrains.kotlin.jvm")
+                        id("io.gitlab.arturbosch.detekt")
                     }
 
                     repositories {
@@ -121,7 +121,7 @@ class DetektJvmSpec {
                         mavenLocal()
                     }
 
-                    tasks.withType(io.gitlab.arturbosch.detekt.Detekt).configureEach {
+                    tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
                         reports {
                             txt.destination = file("output-path2.txt")
                         }

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektMultiplatformSpec.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektMultiplatformSpec.kt
@@ -148,7 +148,7 @@ class DetektMultiplatformSpec {
                     1,
                     buildFileContent = """
                         plugins {
-                            id("kotlin-multiplatform")
+                            kotlin("multiplatform")
                             id("com.android.library")
                             id("io.gitlab.arturbosch.detekt")
                         }
@@ -362,7 +362,7 @@ private fun assertDetektWithClasspath(buildResult: BuildResult) {
 
 private val KMM_PLUGIN_BLOCK = """
     plugins {
-        id("kotlin-multiplatform")
+        kotlin("multiplatform")
         id("io.gitlab.arturbosch.detekt")
     }
 """.trimIndent()

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektMultiplatformSpec.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektMultiplatformSpec.kt
@@ -148,12 +148,12 @@ class DetektMultiplatformSpec {
                     1,
                     buildFileContent = """
                         plugins {
-                            id "kotlin-multiplatform"
-                            id "com.android.library"
-                            id "io.gitlab.arturbosch.detekt"
+                            id("kotlin-multiplatform")
+                            id("com.android.library")
+                            id("io.gitlab.arturbosch.detekt")
                         }
                         android {
-                            compileSdkVersion 30
+                            compileSdkVersion(30)
                             sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
                             buildTypes {
                                 release {
@@ -318,7 +318,7 @@ class DetektMultiplatformSpec {
 private fun setupProject(projectLayoutAction: ProjectLayout.() -> Unit): DslGradleRunner {
     return DslGradleRunner(
         projectLayout = ProjectLayout(numberOfSourceFilesInRootPerSourceDir = 0).apply { projectLayoutAction() },
-        buildFileName = "build.gradle",
+        buildFileName = "build.gradle.kts",
         mainBuildFileContent = """
             subprojects {
                 repositories {
@@ -362,13 +362,13 @@ private fun assertDetektWithClasspath(buildResult: BuildResult) {
 
 private val KMM_PLUGIN_BLOCK = """
     plugins {
-        id "kotlin-multiplatform"
-        id "io.gitlab.arturbosch.detekt"
+        id("kotlin-multiplatform")
+        id("io.gitlab.arturbosch.detekt")
     }
 """.trimIndent()
 
 private val DETEKT_BLOCK = """
-    tasks.withType(io.gitlab.arturbosch.detekt.Detekt).configureEach {
+    tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
         reports.txt.enabled = false
     }
 """.trimIndent()

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektPlainSpec.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektPlainSpec.kt
@@ -15,7 +15,7 @@ class DetektPlainSpec {
             mainBuildFileContent = """
                 plugins {
                     id("io.gitlab.arturbosch.detekt")
-                    id("org.jetbrains.kotlin.jvm")
+                    kotlin("jvm")
                 }
 
                 repositories {
@@ -45,7 +45,7 @@ class DetektPlainSpec {
             baselineFiles = listOf("detekt-baseline.xml"),
             mainBuildFileContent = """
                 plugins {
-                    id("org.jetbrains.kotlin.jvm")
+                    kotlin("jvm")
                     id("io.gitlab.arturbosch.detekt")
                 }
 

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektPlainSpec.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektPlainSpec.kt
@@ -11,11 +11,11 @@ class DetektPlainSpec {
     inner class `When detekt is applied before JVM plugin` {
         val gradleRunner = DslGradleRunner(
             projectLayout = ProjectLayout(numberOfSourceFilesInRootPerSourceDir = 1),
-            buildFileName = "build.gradle",
+            buildFileName = "build.gradle.kts",
             mainBuildFileContent = """
                 plugins {
-                    id "io.gitlab.arturbosch.detekt"
-                    id "org.jetbrains.kotlin.jvm"
+                    id("io.gitlab.arturbosch.detekt")
+                    id("org.jetbrains.kotlin.jvm")
                 }
 
                 repositories {
@@ -41,12 +41,12 @@ class DetektPlainSpec {
     inner class `When applying detekt in a project` {
         val gradleRunner = DslGradleRunner(
             projectLayout = ProjectLayout(numberOfSourceFilesInRootPerSourceDir = 1),
-            buildFileName = "build.gradle",
+            buildFileName = "build.gradle.kts",
             baselineFiles = listOf("detekt-baseline.xml"),
             mainBuildFileContent = """
                 plugins {
-                    id "org.jetbrains.kotlin.jvm"
-                    id "io.gitlab.arturbosch.detekt"
+                    id("org.jetbrains.kotlin.jvm")
+                    id("io.gitlab.arturbosch.detekt")
                 }
 
                 repositories {
@@ -54,7 +54,7 @@ class DetektPlainSpec {
                     mavenLocal()
                 }
 
-                tasks.withType(io.gitlab.arturbosch.detekt.Detekt).configureEach {
+                tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
                     reports {
                         sarif.enabled = true
                         txt.enabled = false

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/GradleVersionSpec.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/GradleVersionSpec.kt
@@ -3,17 +3,18 @@ package io.gitlab.arturbosch.detekt
 import io.gitlab.arturbosch.detekt.testkit.DslTestBuilder
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.TaskOutcome
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.condition.EnabledForJreRange
 import org.junit.jupiter.api.condition.JRE.JAVA_13
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.MethodSource
 
 class GradleVersionSpec {
 
-    @ParameterizedTest(name = "Using {0}, runs on version $gradleVersion")
-    @MethodSource("io.gitlab.arturbosch.detekt.testkit.DslTestBuilder#builders")
+    @Test
+    @DisplayName("Runs on version $gradleVersion")
     @EnabledForJreRange(max = JAVA_13, disabledReason = "Gradle $gradleVersion unsupported on this Java version")
-    fun runsOnOldestSupportedGradleVersion(builder: DslTestBuilder) {
+    fun runsOnOldestSupportedGradleVersion() {
+        val builder = DslTestBuilder.kotlin()
         val gradleRunner = builder.dryRun().withGradleVersion(gradleVersion).build()
         gradleRunner.runDetektTaskAndCheckResult { result ->
             assertThat(result.task(":detekt")?.outcome).isEqualTo(TaskOutcome.SUCCESS)

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/report/ReportMergeSpec.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/report/ReportMergeSpec.kt
@@ -20,14 +20,14 @@ class ReportMergeSpec {
         @Suppress("LongMethod")
         @Test
         fun `for jvm detekt`() {
-            val builder = DslTestBuilder.groovy()
+            val builder = DslTestBuilder.kotlin()
             val projectLayout = ProjectLayout(0).apply {
                 addSubmodule(
                     "child1",
                     numberOfSourceFilesPerSourceDir = 2,
                     buildFileContent = """
                         ${builder.gradleSubprojectsApplyPlugins}
-                        |apply plugin: 'java-library'
+                        |plugins.apply("java-library")
                     """.trimMargin()
                 )
                 addSubmodule(
@@ -35,37 +35,37 @@ class ReportMergeSpec {
                     numberOfSourceFilesPerSourceDir = 2,
                     buildFileContent = """
                         ${builder.gradleSubprojectsApplyPlugins}
-                        |apply plugin: 'java-library'
+                        |plugins.apply("java-library")
                     """.trimMargin()
                 )
             }
             val mainBuildFileContent: String = """
                 |plugins {
-                |    id "io.gitlab.arturbosch.detekt" apply false
+                |    id("io.gitlab.arturbosch.detekt")
                 |}
                 |
                 |allprojects {
                 |    ${builder.gradleRepositories}
                 |}
                 |
-                |task reportMerge(type: io.gitlab.arturbosch.detekt.report.ReportMergeTask) {
-                |    output = project.layout.buildDirectory.file("reports/detekt/merge.xml")
+                |val reportMerge by tasks.registering(io.gitlab.arturbosch.detekt.report.ReportMergeTask::class) {
+                |    output.set(project.layout.buildDirectory.file("reports/detekt/merge.xml"))
                 |    outputs.cacheIf { false }
                 |    outputs.upToDateWhen { false }
                 |}
                 |
                 |subprojects {
-                |    apply plugin: "org.jetbrains.kotlin.jvm"
-                |    apply plugin: "io.gitlab.arturbosch.detekt"
+                |    apply(plugin = "org.jetbrains.kotlin.jvm")
+                |    apply(plugin = "io.gitlab.arturbosch.detekt")
                 |
                 |    detekt {
                 |        reports.xml.enabled = true
                 |    }
                 |    
-                |    plugins.withType(io.gitlab.arturbosch.detekt.DetektPlugin) {
-                |        tasks.withType(io.gitlab.arturbosch.detekt.Detekt).configureEach { detektTask ->
+                |    plugins.withType<io.gitlab.arturbosch.detekt.DetektPlugin> {
+                |        tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
                 |            finalizedBy(reportMerge)
-                |            reportMerge.configure { mergeTask -> mergeTask.input.from(detektTask.xmlReportFile) }
+                |            reportMerge.configure { input.from(xmlReportFile) }
                 |        }
                 |    }
                 |}
@@ -96,22 +96,22 @@ class ReportMergeSpec {
         @EnabledForJreRange(min = JAVA_11, disabledReason = "Android Gradle Plugin 7.0+ requires JDK 11 or newer")
         @EnabledIf("io.gitlab.arturbosch.detekt.DetektAndroidSpecKt#isAndroidSdkInstalled")
         fun `for android detekt`() {
-            val builder = DslTestBuilder.groovy()
+            val builder = DslTestBuilder.kotlin()
             val projectLayout = ProjectLayout(0).apply {
                 addSubmodule(
                     name = "app",
                     numberOfSourceFilesPerSourceDir = 1,
                     buildFileContent = """
                         plugins {
-                            id "com.android.application"
-                            id "kotlin-android"
-                            id "io.gitlab.arturbosch.detekt"
+                            id("com.android.application")
+                            id("kotlin-android")
+                            id("io.gitlab.arturbosch.detekt")
                         }
                         android {
-                           compileSdkVersion 30
+                           compileSdkVersion(30)
                         }
                         dependencies {
-                            implementation project(":lib")
+                            implementation(project(":lib"))
                         }
                     """.trimIndent(),
                     srcDirs = listOf("src/main/java", "src/debug/java", "src/test/java", "src/androidTest/java"),
@@ -121,11 +121,11 @@ class ReportMergeSpec {
                     numberOfSourceFilesPerSourceDir = 1,
                     buildFileContent = """
                         plugins {
-                            id "com.android.library"
-                            id "kotlin-android"
+                            id("com.android.library")
+                            id("kotlin-android")
                         }
                         android {
-                           compileSdkVersion 30
+                           compileSdkVersion(30)
                         }
                     """.trimIndent(),
                     srcDirs = listOf("src/main/java", "src/debug/java", "src/test/java", "src/androidTest/java")
@@ -133,7 +133,7 @@ class ReportMergeSpec {
             }
             val mainBuildFileContent: String = """
                 |plugins {
-                |    id "io.gitlab.arturbosch.detekt" apply false
+                |    id("io.gitlab.arturbosch.detekt")
                 |}
                 |
                 |allprojects {
@@ -144,23 +144,23 @@ class ReportMergeSpec {
                 |    }
                 |}
                 |
-                |task reportMerge(type: io.gitlab.arturbosch.detekt.report.ReportMergeTask) {
-                |    output = project.layout.buildDirectory.file("reports/detekt/merge.xml")
+                |val reportMerge by tasks.registering(io.gitlab.arturbosch.detekt.report.ReportMergeTask::class) {
+                |    output.set(project.layout.buildDirectory.file("reports/detekt/merge.xml"))
                 |    outputs.cacheIf { false }
                 |    outputs.upToDateWhen { false }
                 |}
                 |
                 |subprojects {
-                |    apply plugin: "io.gitlab.arturbosch.detekt"
+                |    apply(plugin = "io.gitlab.arturbosch.detekt")
                 |
                 |    detekt {
                 |        reports.xml.enabled = true
                 |    }
                 |    
-                |    plugins.withType(io.gitlab.arturbosch.detekt.DetektPlugin) {
-                |        tasks.withType(io.gitlab.arturbosch.detekt.Detekt).configureEach { detektTask ->
+                |    plugins.withType<io.gitlab.arturbosch.detekt.DetektPlugin> {
+                |        tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
                 |            finalizedBy(reportMerge)
-                |            reportMerge.configure { mergeTask -> mergeTask.input.from(detektTask.xmlReportFile) }
+                |            reportMerge.configure { input.from(xmlReportFile) }
                 |        }
                 |    }
                 |}

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/report/ReportMergeSpec.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/report/ReportMergeSpec.kt
@@ -104,7 +104,7 @@ class ReportMergeSpec {
                     buildFileContent = """
                         plugins {
                             id("com.android.application")
-                            id("kotlin-android")
+                            kotlin("android")
                             id("io.gitlab.arturbosch.detekt")
                         }
                         android {
@@ -122,7 +122,7 @@ class ReportMergeSpec {
                     buildFileContent = """
                         plugins {
                             id("com.android.library")
-                            id("kotlin-android")
+                            kotlin("android")
                         }
                         android {
                            compileSdkVersion(30)

--- a/detekt-gradle-plugin/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/testkit/DslTestBuilder.kt
+++ b/detekt-gradle-plugin/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/testkit/DslTestBuilder.kt
@@ -71,9 +71,6 @@ abstract class DslTestBuilder {
     companion object {
         fun kotlin(): DslTestBuilder = KotlinBuilder()
         fun groovy(): DslTestBuilder = GroovyBuilder()
-
-        @JvmStatic
-        fun builders(): Set<DslTestBuilder> = setOf(GroovyBuilder(), KotlinBuilder())
     }
 }
 


### PR DESCRIPTION
Closes #4560

There's a new Groovy DSL test in `DetektTaskGroovyDslSpec` which covers the entire DSL for the extension and the three detekt tasks. It doesn't run the task since many files etc. won't be accessible. Instead, the `:help` task is run, which compiles the build files. Using `tasks.create` for these tasks means the tasks will be created & configured even though they're not run.