### PR TITLE
Add failure message assertions to Gradle's "expect failure" tests

### DIFF
--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektReportMergeSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektReportMergeSpec.kt
@@ -101,7 +101,20 @@ class DetektReportMergeSpec {
 
             val gradleRunner = DslGradleRunner(projectLayout, builder.gradleBuildName, mainBuildFileContent)
             gradleRunner.setupProject()
-            gradleRunner.runTasksAndExpectFailure("detekt", "sarifReportMerge", "--continue") { _ ->
+            gradleRunner.runTasksAndExpectFailure("detekt", "sarifReportMerge", "--continue") { result ->
+                assertThat(result.output).contains("FAILURE: Build completed with 2 failures.")
+                assertThat(result.output).containsIgnoringWhitespaces(
+                    """
+                    Execution failed for task ':child1:detekt'.
+                    > Analysis failed with 2 weighted issues.
+                    """
+                )
+                assertThat(result.output).containsIgnoringWhitespaces(
+                    """
+                    Execution failed for task ':child2:detekt'.
+                    > Analysis failed with 4 weighted issues.
+                    """
+                )
                 assertThat(projectFile("build/reports/detekt/detekt.sarif")).doesNotExist()
                 assertThat(projectFile("build/reports/detekt/merge.sarif")).exists()
                 assertThat(projectFile("build/reports/detekt/merge.sarif").readText())
@@ -202,7 +215,20 @@ class DetektReportMergeSpec {
 
             val gradleRunner = DslGradleRunner(projectLayout, builder.gradleBuildName, mainBuildFileContent)
             gradleRunner.setupProject()
-            gradleRunner.runTasksAndExpectFailure("detekt", "xmlReportMerge", "--continue") { _ ->
+            gradleRunner.runTasksAndExpectFailure("detekt", "xmlReportMerge", "--continue") { result ->
+                assertThat(result.output).contains("FAILURE: Build completed with 2 failures.")
+                assertThat(result.output).containsIgnoringWhitespaces(
+                    """
+                    Execution failed for task ':child1:detekt'.
+                    > Analysis failed with 2 weighted issues.
+                    """
+                )
+                assertThat(result.output).containsIgnoringWhitespaces(
+                    """
+                    Execution failed for task ':child2:detekt'.
+                    > Analysis failed with 4 weighted issues.
+                    """
+                )
                 assertThat(projectFile("build/reports/detekt/detekt.xml")).doesNotExist()
                 assertThat(projectFile("build/reports/detekt/merge.xml")).exists()
                 assertThat(projectFile("build/reports/detekt/merge.xml").readText())

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektTaskSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektTaskSpec.kt
@@ -47,6 +47,8 @@ class DetektTaskSpec {
             .withDetektConfig(config)
             .build()
 
-        gradleRunner.runDetektTaskAndExpectFailure()
+        gradleRunner.runDetektTaskAndExpectFailure { result ->
+            assertThat(result.output).contains("Analysis failed with 15 weighted issues.")
+        }
     }
 }

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskDslSpec.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskDslSpec.kt
@@ -383,7 +383,7 @@ class DetektTaskDslSpec {
                 @BeforeAll
                 fun beforeGroup() {
                     val config = """
-                                |tasks.withType(io.gitlab.arturbosch.detekt.Detekt).configureEach {
+                                |tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
                                 |    reports {
                                 |        custom {
                                 |           destination = file("build/reports/custom.xml")
@@ -409,7 +409,7 @@ class DetektTaskDslSpec {
                 @BeforeAll
                 fun beforeGroup() {
                     val config = """
-                                |tasks.withType(io.gitlab.arturbosch.detekt.Detekt).configureEach {
+                                |tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
                                 |    reports {
                                 |        custom {
                                 |           reportId = "customJson"
@@ -437,7 +437,7 @@ class DetektTaskDslSpec {
                     val aDirectory = "\${rootDir}/src"
 
                     val config = """
-                                |tasks.withType(io.gitlab.arturbosch.detekt.Detekt).configureEach {
+                                |tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
                                 |    reports {
                                 |        custom {
                                 |           reportId = "foo"
@@ -464,7 +464,7 @@ class DetektTaskDslSpec {
                 @EnumSource(DetektReportType::class)
                 fun `fails the build`(wellKnownType: DetektReportType) {
                     val config = """
-                                        |tasks.withType(io.gitlab.arturbosch.detekt.Detekt).configureEach {
+                                        |tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
                                         |    reports {
                                         |        custom {
                                         |            reportId = "${wellKnownType.reportId}"

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskDslSpec.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektTaskDslSpec.kt
@@ -397,7 +397,10 @@ class DetektTaskDslSpec {
 
                 @Test
                 fun `fails the build`() {
-                    gradleRunner.runDetektTaskAndExpectFailure()
+                    gradleRunner.runDetektTaskAndExpectFailure { result ->
+                        assertThat(result.output)
+                            .contains("If a custom report is specified, the reportId must be present")
+                    }
                 }
             }
 
@@ -420,7 +423,10 @@ class DetektTaskDslSpec {
 
                 @Test
                 fun `fails the build`() {
-                    gradleRunner.runDetektTaskAndExpectFailure()
+                    gradleRunner.runDetektTaskAndExpectFailure { result ->
+                        assertThat(result.output)
+                            .contains("If a custom report is specified, the destination must be present")
+                    }
                 }
             }
 
@@ -446,7 +452,9 @@ class DetektTaskDslSpec {
 
                 @Test
                 fun `fails the build`() {
-                    gradleRunner.runDetektTaskAndExpectFailure()
+                    gradleRunner.runDetektTaskAndExpectFailure { result ->
+                        assertThat(result.output).contains("Cannot write a file to a location pointing at a directory.")
+                    }
                 }
             }
 
@@ -467,7 +475,10 @@ class DetektTaskDslSpec {
                     """
 
                     gradleRunner = builder.withDetektConfig(config).build()
-                    gradleRunner.runDetektTaskAndExpectFailure()
+                    gradleRunner.runDetektTaskAndExpectFailure { result ->
+                        assertThat(result.output)
+                            .contains("The custom report reportId may not be same as one of the default reports")
+                    }
                 }
             }
         }


### PR DESCRIPTION
When working on #4687 I found some tests that should have failed after making changes, but didn't.

This is because some tests expected the Gradle job to fail, but didn't check the reason for the failure - so the test would be green even when it wasn't behaving correctly.

This PR adds failure message assertions when using `runDetektTaskAndExpectFailure` or `runTasksAndExpectFailure` where that was missing, and fixes a couple of tests that had problems in the specified build file that were found as a result.

I considered adding a required string parameter to those two functions to ensure a message was always provided, which would be a way to avoid this in future, but that could be done separately if desired.