### PR TITLE
Display dynamic --jvm-target values when using --help flag

### DIFF
--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/ArgumentConverters.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/ArgumentConverters.kt
@@ -2,6 +2,7 @@ package io.gitlab.arturbosch.detekt.cli
 
 import com.beust.jcommander.IStringConverter
 import com.beust.jcommander.ParameterException
+import org.jetbrains.kotlin.config.JvmTarget
 import org.jetbrains.kotlin.config.LanguageVersion
 import java.io.File
 import java.net.URL
@@ -48,6 +49,11 @@ class MultipleExistingPathConverter : DetektInputPathConverter<Path> {
 class LanguageVersionConverter : IStringConverter<LanguageVersion> {
     override fun convert(value: String): LanguageVersion =
         checkNotNull(LanguageVersion.fromFullVersionString(value)) { "Invalid value passed to --language-version" }
+}
+
+class JvmTargetConverter : IStringConverter<JvmTarget> {
+    override fun convert(value: String): JvmTarget =
+        checkNotNull(JvmTarget.fromString(value)) { "Invalid value passed to --jvm-target" }
 }
 
 class ClasspathResourceConverter : IStringConverter<URL> {

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt
@@ -188,10 +188,11 @@ class CliArgs {
 
     @Parameter(
         names = ["--jvm-target"],
+        converter = JvmTargetConverter::class,
         description = "EXPERIMENTAL: Target version of the generated JVM bytecode that was generated during " +
-            "compilation and is now being used for type resolution (1.6, 1.8, 9, 10, 11, 12, 13, 14, 15, 16 or 17)"
+            "compilation and is now being used for type resolution"
     )
-    var jvmTarget: String = JvmTarget.DEFAULT.description
+    var jvmTarget: JvmTarget = JvmTarget.DEFAULT
 
     @Parameter(
         names = ["--version"],

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Spec.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Spec.kt
@@ -65,7 +65,7 @@ internal fun CliArgs.createSpec(output: Appendable, error: Appendable): Processi
         }
 
         compiler {
-            jvmTarget = args.jvmTarget
+            jvmTarget = args.jvmTarget.toString()
             languageVersion = args.languageVersion?.versionString
             classpath = args.classpath?.trim()
         }


### PR DESCRIPTION
This will now print values supported by the embedded Kotlin version and won't have to be updated manually anymore.

The required toString override was introduced in Kotlin 1.6.20 thanks to my first PR on jetbrains/kotlin :)

Before:
```
    --jvm-target
      EXPERIMENTAL: Target version of the generated JVM bytecode that was 
      generated during compilation and is now being used for type resolution 
      (1.6, 1.8, 9, 10, 11, 12, 13, 14, 15, 16 or 17)
      Default: 1.8
```
After:
```
    --jvm-target
      EXPERIMENTAL: Target version of the generated JVM bytecode that was 
      generated during compilation and is now being used for type resolution
      Default: 1.8
      Possible Values: [1.6, 1.8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18]
```