### PR TITLE
Add Gradle Enterprise instructions for maintainers.

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -311,8 +311,30 @@ warning: Using the last argument as keyword parameters is deprecated (Ruby 2.7.0
 - `gradle increment<Patch|Minor|Major>` - update version
 - `./scripts/release.sh` - publish all artifacts
 
+## Gradle Enterprise Access
+
+We do have access to a managed [Gradle Enterprise instance](6) that is publishing
+build scans for all the builds executed on CI (not from forks).
+
+This is extremely helpful to debug build failures and have access to remote build cache.
+Build scans are public so everyone can get insights on our build status.
+
+If you're a **maintaner** of a project under github.com/detekt/, you can request an access token
+to connect your local machine to the Gradle Enterprise instance, so you will also be publishign scans.
+
+To do you mush:
+
+1. Email us at [info@detekt.dev][7] or get in touch with one of the existing maintainer.
+2. An account on https://ge.detekt.dev/ will be created for you, which you need to configure upon login (e.g. reset your password).
+3. Run the `./gradlew provisionGradleEnterpriseAccessKey` tasks from the Detekt root folder
+4. Complete the access key provisioning process (you will have to go through a browser).
+5. Verify that the access key is correctly stored inside `~/.gradle/enterprise/keys.properties`
+6. Do a test run (say with `./gradlew tasks`) to verify that a scan is correctly published.
+
 [1]: https://github.com/detekt/detekt/blob/v1.19.0/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Issue.kt
 [2]: https://github.com/detekt/detekt/blob/v1.19.0/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/CodeSmell.kt
 [3]: https://kotlinlang.org/docs/kotlin-doc.html
 [4]: https://daringfireball.net/projects/markdown/syntax
 [5]: https://kotlinlang.org/docs/functions.html#named-arguments
+[6]: https://ge.detekt.dev/
+[7]: mailto:info@detekt.dev

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -322,7 +322,7 @@ Build scans are public so everyone can get insights on our build status.
 If you're a **maintaner** of a project under github.com/detekt/, you can request an access token
 to connect your local machine to the Gradle Enterprise instance, so you will also be publishign scans.
 
-To do you mush:
+You must follow the steps below:
 
 1. Email us at [info@detekt.dev][7] or get in touch with one of the existing maintainer.
 2. An account on https://ge.detekt.dev/ will be created for you, which you need to configure upon login (e.g. reset your password).

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -319,14 +319,14 @@ build scans for all the builds executed on CI (not from forks).
 This is extremely helpful to debug build failures and have access to remote build cache.
 Build scans are public so everyone can get insights on our build status.
 
-If you're a **maintaner** of a project under github.com/detekt/, you can request an access token
-to connect your local machine to the Gradle Enterprise instance, so you will also be publishign scans.
+If you're a **maintainer** of a project under github.com/detekt/, you can request an access token
+to connect your local machine to the Gradle Enterprise instance, so you will also be publishing scans.
 
 You must follow the steps below:
 
-1. Email us at [info@detekt.dev][7] or get in touch with one of the existing maintainer.
+1. Email us at [info@detekt.dev][7] or get in touch with one of the existing maintainers.
 2. An account on https://ge.detekt.dev/ will be created for you, which you need to configure upon login (e.g. reset your password).
-3. Run the `./gradlew provisionGradleEnterpriseAccessKey` tasks from the Detekt root folder
+3. Run the `./gradlew provisionGradleEnterpriseAccessKey` task from the detekt root folder
 4. Complete the access key provisioning process (you will have to go through a browser).
 5. Verify that the access key is correctly stored inside `~/.gradle/enterprise/keys.properties`
 6. Do a test run (say with `./gradlew tasks`) to verify that a scan is correctly published.


### PR DESCRIPTION
Adding some instructions on how to use Gradle Enterprise for our maintainers.
