### PR TITLE
Allow renovate to report Ruby dependency updates

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -1,9 +1,5 @@
 {
   "labels": ["dependencies"],
-  "packageRules": [{
-    "matchManagers": ["bundler"],
-    "enabled": false
-  }],
   "extends": [
     "config:base"
   ]


### PR DESCRIPTION
detekt/detekt#4702 dropped dependabot config, but it wasn't actually redundant because bundler dependency checks were disabled in the renovate config.

This enables checks for dependencies managed by bundler.