### PR TITLE
Setup GPG signing on CI

### DIFF
--- a/.github/workflows/deploy-snapshot.yaml
+++ b/.github/workflows/deploy-snapshot.yaml
@@ -27,7 +27,9 @@ jobs:
     - name: Deploy Snapshot
       uses: gradle/gradle-build-action@v2
       env:
-        MAVEN_CENTRAL_USER: ${{ secrets.MAVEN_CENTRAL_USER }}
-        MAVEN_CENTRAL_PW: ${{ secrets.MAVEN_CENTRAL_PW }}
+        ORG_GRADLE_PROJECT_SIGNING_KEY: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_KEY }}
+        ORG_GRADLE_PROJECT_SIGNING_PWD: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_PWD }}
+        ORG_GRADLE_PROJECT_SONATYPE_USERNAME: ${{ secrets.ORG_GRADLE_PROJECT_SONATYPE_USERNAME }}
+        ORG_GRADLE_PROJECT_SONATYPE_PASSWORD: ${{ secrets.ORG_GRADLE_PROJECT_SONATYPE_PASSWORD }}
       with:
         arguments: publishAllPublicationsToSonatypeSnapshotRepository -Dsnapshot=true --stacktrace

--- a/build-logic/src/main/kotlin/packaging.gradle.kts
+++ b/build-logic/src/main/kotlin/packaging.gradle.kts
@@ -4,13 +4,6 @@ plugins {
     signing
 }
 
-val sonatypeUsername: String? = findProperty("sonatypeUsername")
-    ?.toString()
-    ?: System.getenv("MAVEN_CENTRAL_USER")
-val sonatypePassword: String? = findProperty("sonatypePassword")
-    ?.toString()
-    ?: System.getenv("MAVEN_CENTRAL_PW")
-
 tasks.withType<Sign>().configureEach {
     notCompatibleWithConfigurationCache("https://github.com/gradle/gradle/issues/13470")
 }
@@ -21,16 +14,16 @@ publishing {
             name = "mavenCentral"
             url = uri("https://oss.sonatype.org/service/local/staging/deploy/maven2")
             credentials {
-                username = sonatypeUsername
-                password = sonatypePassword
+                username = "SONATYPE_USERNAME".byProperty
+                password = "SONATYPE_PASSWORD".byProperty
             }
         }
         maven {
             name = "sonatypeSnapshot"
             url = uri("https://oss.sonatype.org/content/repositories/snapshots")
             credentials {
-                username = sonatypeUsername
-                password = sonatypePassword
+                username = "SONATYPE_USERNAME".byProperty
+                password = "SONATYPE_PASSWORD".byProperty
             }
         }
     }
@@ -64,10 +57,16 @@ publishing {
     }
 }
 
-if (findProperty("signing.keyId") != null) {
+val signingKey = "SIGNING_KEY".byProperty
+val signingPwd = "SIGNING_PWD".byProperty
+if (signingKey.isNullOrBlank() || signingPwd.isNullOrBlank()) {
+    logger.info("Signing disabled as the GPG key was not found")
+} else {
+    logger.info("GPG Key found - Signing enabled")
     signing {
+        useInMemoryPgpKeys(signingKey, signingPwd)
         sign(publishing.publications[DETEKT_PUBLICATION])
     }
-} else {
-    logger.info("Signing Disabled as the PGP key was not found")
 }
+
+val String.byProperty: String? get() = findProperty(this) as? String


### PR DESCRIPTION
This PR configures the signing of GPG to be done on CI rather than on local machine (is a first step towards improving https://github.com/detekt/detekt/discussions/4696).

I've configured the secrets on the org, so from now on, -SNAPSHOTS version should be signed on CI. The release process will follow the same approach.