### PR TITLE
Make `runWithHelpFlag` adopting incremental build

### DIFF
--- a/detekt-cli/build.gradle.kts
+++ b/detekt-cli/build.gradle.kts
@@ -42,12 +42,18 @@ tasks {
     }
 
     val runWithHelpFlag by registering(JavaExec::class) {
+        inputs.files(shadowJar)
+        outputs.upToDateWhen { true }
         classpath = files(shadowJar)
         args = listOf("--help")
     }
 
     val runWithArgsFile by registering(JavaExec::class) {
-        inputs.files(formattingJar) // ensures detekt-formatting JAR is built before this task is executed
+        // The task generating these jar files run first.
+        inputs.files(shadowJar, formattingJar)
+        // This task does not adopt incremental-build (up-to-date) check because it is reading
+        // the entire directory as the input source.
+        outputs.upToDateWhen { false }
         classpath = files(shadowJar)
         workingDir = rootDir
         args = listOf("@./config/detekt/argsfile", "-p", formattingJar.singleFile.path)

--- a/detekt-cli/build.gradle.kts
+++ b/detekt-cli/build.gradle.kts
@@ -42,7 +42,6 @@ tasks {
     }
 
     val runWithHelpFlag by registering(JavaExec::class) {
-        inputs.files(shadowJar)
         outputs.upToDateWhen { true }
         classpath = files(shadowJar)
         args = listOf("--help")
@@ -50,7 +49,7 @@ tasks {
 
     val runWithArgsFile by registering(JavaExec::class) {
         // The task generating these jar files run first.
-        inputs.files(shadowJar, formattingJar)
+        inputs.files(formattingJar)
         // This task does not adopt incremental-build (up-to-date) check because it is reading
         // the entire directory as the input source.
         outputs.upToDateWhen { false }

--- a/detekt-cli/build.gradle.kts
+++ b/detekt-cli/build.gradle.kts
@@ -50,9 +50,7 @@ tasks {
     val runWithArgsFile by registering(JavaExec::class) {
         // The task generating these jar files run first.
         inputs.files(formattingJar)
-        // This task does not adopt incremental-build (up-to-date) check because it is reading
-        // the entire directory as the input source.
-        outputs.upToDateWhen { false }
+        doNotTrackState("The entire root directory is read as the input source.")
         classpath = files(shadowJar)
         workingDir = rootDir
         args = listOf("@./config/detekt/argsfile", "-p", formattingJar.singleFile.path)


### PR DESCRIPTION
This is part of the practice of Gradle enterprise onboarding

After running the following command
```
./gradlew clean build --no-build-cache -Dscan.tag.exp1
./gradlew build --no-build-cache -Dscan.tag.exp1
```
We should let as many tasks as incremental build (up-to-date) check as possible. In this PR:
- `runWithHelpFlag` will be compatible
- `runWithArgsFile` won't be compatible because it is reading the entire directory as the input source
- `:detekt-gradle-plugin:functionalTest` will be inspected further.