### PR TITLE
Integrate detekt junit

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,6 +29,7 @@ allprojects {
         detekt(project(":detekt-cli"))
         detektPlugins(project(":custom-checks"))
         detektPlugins(project(":detekt-formatting"))
+        detektPlugins("com.github.BraisGabin:detekt-junit-rules:0.0.4")
     }
 
     tasks.withType<Detekt>().configureEach {

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/MainSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/MainSpec.kt
@@ -23,7 +23,8 @@ class MainSpec {
     @Nested
     inner class `Build runner` {
 
-        fun runnerConfigs(): List<Arguments> {
+        @Suppress("UnusedPrivateMember")
+        private fun runnerConfigs(): List<Arguments> {
             return listOf(
                 arguments(arrayOf("--generate-config"), ConfigExporter::class),
                 arguments(arrayOf("--run-rule", "RuleSet:Rule"), Runner::class),

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/ValidateConfigSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/ValidateConfigSpec.kt
@@ -146,7 +146,7 @@ class ValidateConfigSpec {
         @Nested
         inner class `configure additional exclude paths` {
 
-            fun patterns(str: String) = CommaSeparatedPattern(str).mapToRegex()
+            private fun patterns(str: String) = CommaSeparatedPattern(str).mapToRegex()
 
             @Test
             fun `does not report any complexity properties`() {

--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -16,6 +16,7 @@ detekt {
 repositories {
     mavenCentral()
     google()
+    maven { url = uri("https://jitpack.io") }
 }
 
 testing {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumberSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumberSpec.kt
@@ -641,7 +641,7 @@ class MagicNumberSpec {
         inner class `ignoring named arguments` {
             @Nested
             inner class `in constructor invocation` {
-                fun code(numberString: String) = """
+                private fun code(numberString: String) = """
                 data class Model(
                         val someVal: Int,
                         val other: String = "default"
@@ -705,7 +705,7 @@ class MagicNumberSpec {
             @Nested
             inner class `Issue#659 - false-negative reporting on unnamed argument when ignore is true` {
 
-                fun code(numberString: String) = """
+                private fun code(numberString: String) = """
                 data class Model(
                         val someVal: Int,
                         val other: String = "default"
@@ -722,7 +722,7 @@ class MagicNumberSpec {
 
             @Nested
             inner class `in function invocation` {
-                fun code(number: Number) = """
+                private fun code(number: Number) = """
                 fun tested(someVal: Int, other: String = "default")
 
                 val t = tested(someVal = $number)
@@ -888,7 +888,8 @@ class MagicNumberSpec {
         @Nested
         inner class `a number as part of a range` {
 
-            fun cases() = listOf(
+            @Suppress("UnusedPrivateMember")
+            private fun cases() = listOf(
                 "val range = 1..27",
                 "val range = (1..27)",
                 "val range = 27 downTo 1",

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantVisibilityModifierRuleSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantVisibilityModifierRuleSpec.kt
@@ -193,7 +193,7 @@ class RedundantVisibilityModifierRuleSpec {
 
             val rule = RedundantVisibilityModifierRule()
 
-            fun mockCompilerResources(mode: ExplicitApiMode): CompilerResources {
+            private fun mockCompilerResources(mode: ExplicitApiMode): CompilerResources {
                 val languageVersionSettings = mockk<LanguageVersionSettings>()
                 every {
                     hint(ExplicitApiMode::class)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -69,5 +69,6 @@ gradleEnterprise {
 dependencyResolutionManagement {
     repositories {
         mavenCentral()
+        maven { url = uri("https://jitpack.io") }
     }
 }


### PR DESCRIPTION
After see #4699 I implemented the Rule [`MissingTestAnnotation`](https://github.com/BraisGabin/detekt-junit-rules/blob/main/src/main/kotlin/com/braisgabin/detekt/junit/MissingTestAnnotation.kt) to avoid this kind of issues.

The problem that I see si that this rule set is stored on Jitpack (I want to publish it on `mavenCental` but each time I think about all those steps...). What do you think? Is it ok to have a dependency from Jitpack?