### PR TITLE
Make links clickable in rule classes documentation

### DIFF
--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitCollectionElementAccessMethod.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitCollectionElementAccessMethod.kt
@@ -22,7 +22,7 @@ import org.jetbrains.kotlin.types.typeUtil.supertypes
 
 /**
  * In Kotlin functions `get` or `set` can be replaced with the shorter operator — `[]`,
- * see https://kotlinlang.org/docs/operator-overloading.html#indexed-access-operator.
+ * see [Indexed access operator](https://kotlinlang.org/docs/operator-overloading.html#indexed-access-operator).
  * Prefer the usage of the indexed access operator `[]` for map or list element access or insert methods.
  *
  * <noncompliant>

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenPublicDataClass.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenPublicDataClass.kt
@@ -20,7 +20,7 @@ import org.jetbrains.kotlin.psi.psiUtil.visibilityModifierTypeOrDefault
  *
  * This rule is aimed at library maintainers. If you are developing a final application you can ignore this issue.
  *
- * More info: https://jakewharton.com/public-api-challenges-in-kotlin/
+ * More info: [Public API challenges in Kotlin](https://jakewharton.com/public-api-challenges-in-kotlin/)
  *
  * <noncompliant>
  * data class C(val a: String) // violation: public data class

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ModifierOrder.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ModifierOrder.kt
@@ -41,7 +41,7 @@ import org.jetbrains.kotlin.psi.psiUtil.allChildren
 
 /**
  * This rule reports cases in the code where modifiers are not in the correct order. The default modifier order is
- * taken from: https://kotlinlang.org/docs/coding-conventions.html#modifiers-order
+ * taken from: [Modifiers order](https://kotlinlang.org/docs/coding-conventions.html#modifiers-order)
  *
  * <noncompliant>
  * lateinit internal val str: String

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ObjectLiteralToLambda.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ObjectLiteralToLambda.kt
@@ -27,8 +27,8 @@ import org.jetbrains.kotlin.types.KotlinType
  * An anonymous object that does nothing other than the implementation of a single method
  * can be used as a lambda.
  *
- * See https://kotlinlang.org/docs/java-interop.html#sam-conversions
- * See https://kotlinlang.org/docs/fun-interfaces.html
+ * See [SAM conversions](https://kotlinlang.org/docs/java-interop.html#sam-conversions),
+ * [Functional (SAM) interfaces](https://kotlinlang.org/docs/fun-interfaces.html)
  *
  * <noncompliant>
  * object : Foo {

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAnnotationUseSiteTarget.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAnnotationUseSiteTarget.kt
@@ -16,7 +16,7 @@ import org.jetbrains.kotlin.psi.KtProperty
 /**
  * This rule inspects the use of the Annotation use-site Target. In case that the use-site Target is not needed it can
  * be removed. For more information check the kotlin documentation:
- * https://kotlinlang.org/docs/annotations.html#annotation-use-site-targets
+ * [Annotation use-site targets](https://kotlinlang.org/docs/annotations.html#annotation-use-site-targets)
  *
  * <noncompliant>
  * @@property:Inject private val foo: String = "bar" // violation: unnecessary @property:

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseDataClass.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseDataClass.kt
@@ -28,7 +28,7 @@ import org.jetbrains.kotlin.types.KotlinType
  * Classes that simply hold data should be refactored into a `data class`. Data classes are specialized to hold data
  * and generate `hashCode`, `equals` and `toString` implementations as well.
  *
- * Read more about [Data classes](https://kotlinlang.org/docs/data-classes.html)
+ * Read more about [data classes](https://kotlinlang.org/docs/data-classes.html)
  *
  * <noncompliant>
  * class DataClassCandidate(val i: Int) {

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseDataClass.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseDataClass.kt
@@ -28,7 +28,7 @@ import org.jetbrains.kotlin.types.KotlinType
  * Classes that simply hold data should be refactored into a `data class`. Data classes are specialized to hold data
  * and generate `hashCode`, `equals` and `toString` implementations as well.
  *
- * Read more about `data class`: https://kotlinlang.org/docs/data-classes.html
+ * Read more about [Data classes](https://kotlinlang.org/docs/data-classes.html)
  *
  * <noncompliant>
  * class DataClassCandidate(val i: Int) {

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIfInsteadOfWhen.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIfInsteadOfWhen.kt
@@ -12,7 +12,7 @@ import org.jetbrains.kotlin.psi.KtWhenExpression
 /**
  * Binary expressions are better expressed using an `if` expression than a `when` expression.
  *
- * See https://kotlinlang.org/docs/coding-conventions.html#if-versus-when
+ * See [if versus when](https://kotlinlang.org/docs/coding-conventions.html#if-versus-when)
  *
  * <noncompliant>
  * when (x) {


### PR DESCRIPTION
Fixes #4656 
Making the links clickable in the documentation of the rule classes as following:

<img width="855" alt="Screenshot 2022-04-13 at 21 25 32" src="https://user-images.githubusercontent.com/26341194/163246197-66819b7d-db95-4bdd-b90e-304974330d41.png">
 
