### PR TITLE
Update the argsfile to unblock `runWithArgsFile` failing locally

### DIFF
--- a/config/detekt/argsfile
+++ b/config/detekt/argsfile
@@ -3,7 +3,7 @@
 -b
 ./config/detekt/baseline.xml
 -ex
-**/resources/**,**/detekt*/build/**,**/build-logic/build/**
+**/resources/**,**/detekt*/build/**,**/build-logic/build/**,**/build-logic/bin/**
 --build-upon-default-config
 -c
 ./config/detekt/detekt.yml


### PR DESCRIPTION
I had several failures of `runWithArgsFile` locally due to files in the `build-login/bin` folder. I'm excluding it from the args file.
