### PR TITLE
Android Gradle: add javac intermediates to classpath

### DIFF
--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektAndroidSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektAndroidSpec.kt
@@ -458,7 +458,7 @@ class DetektAndroidSpec {
             @DisplayName("task :app:detektMain has javac intermediates on the classpath")
             fun libDetektMain() {
                 gradleRunner.runTasksAndCheckResult(":app:detektMain") { buildResult ->
-                    assertThat(buildResult.output).doesNotContain("error: unresolved reference: databinding")
+                    assertThat(buildResult.output).doesNotContain("UnreachableCode")
                 }
             }
 
@@ -466,7 +466,7 @@ class DetektAndroidSpec {
             @DisplayName("task :app:detektTest has javac intermediates on the classpath")
             fun libDetektTest() {
                 gradleRunner.runTasksAndCheckResult(":app:detektTest") { buildResult ->
-                    assertThat(buildResult.output).doesNotContain("error: unresolved reference: databinding")
+                    assertThat(buildResult.output).doesNotContain("UnreachableCode")
                 }
             }
         }

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektAndroidSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektAndroidSpec.kt
@@ -423,6 +423,53 @@ class DetektAndroidSpec {
                 }
             }
         }
+
+        @Nested
+        inner class `configures android tasks android tasks have javac intermediates on classpath` {
+            val projectLayout = ProjectLayout(
+                numberOfSourceFilesInRootPerSourceDir = 0,
+            ).apply {
+                addSubmodule(
+                    name = "app",
+                    numberOfSourceFilesPerSourceDir = 0,
+                    numberOfCodeSmells = 0,
+                    buildFileContent = """
+                        $APP_PLUGIN_BLOCK
+                        $ANDROID_BLOCK_WITH_VIEW_BINDING
+                    """.trimIndent(),
+                    srcDirs = listOf("src/main/java"),
+                )
+            }
+            val gradleRunner = createGradleRunnerAndSetupProject(projectLayout, dryRun = false).also {
+                it.projectFile("app/src/main/java").mkdirs()
+                it.projectFile("app/src/main/res/layout").mkdirs()
+                it.writeProjectFile("app/src/main/AndroidManifest.xml", manifestContent())
+                it.writeProjectFile(
+                    "app/src/main/res/layout/activity_sample.xml",
+                    SAMPLE_ACTIVITY_LAYOUT
+                )
+                it.writeProjectFile(
+                    "app/src/main/java/SampleActivity.kt",
+                    SAMPLE_ACTIVITY_USING_VIEW_BINDING
+                )
+            }
+
+            @Test
+            @DisplayName("task :app:detektMain has javac intermediates on the classpath")
+            fun libDetektMain() {
+                gradleRunner.runTasksAndCheckResult(":app:detektMain") { buildResult ->
+                    assertThat(buildResult.output).doesNotContain("error: unresolved reference: databinding")
+                }
+            }
+
+            @Test
+            @DisplayName("task :app:detektTest has javac intermediates on the classpath")
+            fun libDetektTest() {
+                gradleRunner.runTasksAndCheckResult(":app:detektTest") { buildResult ->
+                    assertThat(buildResult.output).doesNotContain("error: unresolved reference: databinding")
+                }
+            }
+        }
     }
 }
 
@@ -478,6 +525,19 @@ private val ANDROID_BLOCK_WITH_FLAVOR = """
     }
 """.trimIndent()
 
+private val ANDROID_BLOCK_WITH_VIEW_BINDING = """
+    android {
+        compileSdkVersion(30)
+        defaultConfig {
+            applicationId = "io.gitlab.arturbosch.detekt.app"
+            minSdkVersion(24)
+        }
+        buildFeatures {
+            viewBinding = true
+        }
+    }
+""".trimIndent()
+
 private val DETEKT_REPORTS_BLOCK = """
     tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
         reports {
@@ -486,7 +546,40 @@ private val DETEKT_REPORTS_BLOCK = """
     }
 """.trimIndent()
 
-private fun createGradleRunnerAndSetupProject(projectLayout: ProjectLayout) = DslGradleRunner(
+private val SAMPLE_ACTIVITY_LAYOUT = """
+    <?xml version="1.0" encoding="utf-8"?>
+    <View
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        android:id="@+id/sample_view"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        />
+""".trimIndent()
+
+private val SAMPLE_ACTIVITY_USING_VIEW_BINDING = """
+    package io.gitlab.arturbosch.detekt.app
+    
+    import android.app.Activity
+    import android.os.Bundle
+    import android.view.LayoutInflater
+    import io.gitlab.arturbosch.detekt.app.databinding.ActivitySampleBinding
+    
+    class SampleActivity : Activity() {
+    
+        private lateinit var binding: ActivitySampleBinding
+    
+        override fun onCreate(savedInstanceState: Bundle?) {
+            binding = ActivitySampleBinding.inflate(LayoutInflater.from(this))
+            binding.sampleView ?: return
+            setContentView(binding.root)
+        }
+    }
+""".trimIndent() + "\n" // new line at end of file rule
+
+private fun createGradleRunnerAndSetupProject(
+    projectLayout: ProjectLayout,
+    dryRun: Boolean = true,
+) = DslGradleRunner(
     projectLayout = projectLayout,
     buildFileName = "build.gradle.kts",
     mainBuildFileContent = """
@@ -498,5 +591,5 @@ private fun createGradleRunnerAndSetupProject(projectLayout: ProjectLayout) = Ds
             }
         }
     """.trimIndent(),
-    dryRun = true
+    dryRun = dryRun,
 ).also { it.setupProject() }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektAndroid.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektAndroid.kt
@@ -17,7 +17,6 @@ import org.gradle.api.Task
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.FileCollection
 import org.gradle.api.tasks.TaskProvider
-import java.util.Locale
 
 internal class DetektAndroid(private val project: Project) {
 

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektAndroid.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektAndroid.kt
@@ -120,7 +120,7 @@ internal fun Project.registerAndroidDetektTask(
         classpath.apply {
             setFrom(variant.getCompileClasspath(null).filter { it.exists() })
             from(bootClasspath)
-            // from(javaCompileDestination(variant))
+            from(javaCompileDestination(variant))
         }
         dependsOn(variant.javaCompileProvider)
         // If a baseline file is configured as input file, it must exist to be configured, otherwise the task fails.
@@ -137,7 +137,7 @@ internal fun Project.registerAndroidCreateBaselineTask(
     bootClasspath: FileCollection,
     extension: DetektExtension,
     variant: BaseVariant,
-    taskName: String = DetektPlugin.BASELINE_TASK_NAME + variant.name.capitalize(Locale.ROOT),
+    taskName: String = DetektPlugin.BASELINE_TASK_NAME + variant.name.capitalize(),
     extraInputSource: FileCollection? = null,
 ): TaskProvider<DetektCreateBaselineTask> =
     registerCreateBaselineTask(taskName, extension) {

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektAndroid.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektAndroid.kt
@@ -112,7 +112,7 @@ internal fun Project.registerAndroidDetektTask(
     extension: DetektExtension,
     variant: BaseVariant,
     taskName: String = DetektPlugin.DETEKT_TASK_NAME + variant.name.capitalize(),
-    extraInputSource: FileCollection? = null,
+    extraInputSource: FileCollection? = null
 ): TaskProvider<Detekt> =
     registerDetektTask(taskName, extension) {
         setSource(variant.sourceSets.map { it.javaDirectories + it.kotlinDirectories })
@@ -129,8 +129,7 @@ internal fun Project.registerAndroidDetektTask(
             baseline.set(layout.file(project.provider { baselineFile }))
         }
         setReportOutputConventions(reports, extension, variant.name)
-        description =
-            "EXPERIMENTAL: Run detekt analysis for ${variant.name} classes with type resolution"
+        description = "EXPERIMENTAL: Run detekt analysis for ${variant.name} classes with type resolution"
     }
 
 internal fun Project.registerAndroidCreateBaselineTask(
@@ -138,7 +137,7 @@ internal fun Project.registerAndroidCreateBaselineTask(
     extension: DetektExtension,
     variant: BaseVariant,
     taskName: String = DetektPlugin.BASELINE_TASK_NAME + variant.name.capitalize(),
-    extraInputSource: FileCollection? = null,
+    extraInputSource: FileCollection? = null
 ): TaskProvider<DetektCreateBaselineTask> =
     registerCreateBaselineTask(taskName, extension) {
         setSource(variant.sourceSets.map { it.javaDirectories + it.kotlinDirectories })
@@ -151,8 +150,7 @@ internal fun Project.registerAndroidCreateBaselineTask(
         dependsOn(variant.javaCompileProvider)
         val variantBaselineFile = extension.baseline?.addVariantName(variant.name)
         baseline.set(project.layout.file(project.provider { variantBaselineFile }))
-        description =
-            "EXPERIMENTAL: Creates detekt baseline for ${variant.name} classes with type resolution"
+        description = "EXPERIMENTAL: Creates detekt baseline for ${variant.name} classes with type resolution"
     }
 
 private fun Project.javaCompileDestination(variant: BaseVariant): DirectoryProperty? {

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektAndroid.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektAndroid.kt
@@ -116,12 +116,11 @@ internal fun Project.registerAndroidDetektTask(
     registerDetektTask(taskName, extension) {
         setSource(variant.sourceSets.map { it.javaDirectories + it.kotlinDirectories })
         extraInputSource?.let { source(it) }
-        classpath.apply {
-            setFrom(variant.getCompileClasspath(null).filter { it.exists() })
-            from(bootClasspath)
-            from(javaCompileDestination(variant))
-        }
-        dependsOn(variant.javaCompileProvider)
+        classpath.setFrom(
+            variant.getCompileClasspath(null).filter { it.exists() },
+            bootClasspath,
+            javaCompileDestination(variant),
+        )
         // If a baseline file is configured as input file, it must exist to be configured, otherwise the task fails.
         // We try to find the configured baseline or alternatively a specific variant matching this task.
         extension.baseline?.existingVariantOrBaseFile(variant.name)?.let { baselineFile ->
@@ -141,12 +140,11 @@ internal fun Project.registerAndroidCreateBaselineTask(
     registerCreateBaselineTask(taskName, extension) {
         setSource(variant.sourceSets.map { it.javaDirectories + it.kotlinDirectories })
         extraInputSource?.let { source(it) }
-        classpath.apply {
-            setFrom(variant.getCompileClasspath(null).filter { it.exists() })
-            from(bootClasspath)
-            from(javaCompileDestination(variant))
-        }
-        dependsOn(variant.javaCompileProvider)
+        classpath.setFrom(
+            variant.getCompileClasspath(null).filter { it.exists() },
+            bootClasspath,
+            javaCompileDestination(variant),
+        )
         val variantBaselineFile = extension.baseline?.addVariantName(variant.name)
         baseline.set(project.layout.file(project.provider { variantBaselineFile }))
         description = "EXPERIMENTAL: Creates detekt baseline for ${variant.name} classes with type resolution"

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektAndroid.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektAndroid.kt
@@ -73,42 +73,28 @@ internal class DetektAndroid(private val project: Project) {
             baseExtension.variants
                 ?.matching { !extension.matchesIgnoredConfiguration(it) }
                 ?.all { variant ->
-                    val intermediatesJavacJar = project.registerIntermediatesJavacJarTask(variant)
-                    project.registerAndroidDetektTask(
-                        bootClasspath = bootClasspath,
-                        extension = extension,
-                        variant = variant,
-                        intermediatesJavaCJar = intermediatesJavacJar
-                    ).also { provider ->
+                    project.registerAndroidDetektTask(bootClasspath, extension, variant).also { provider ->
                         mainTaskProvider.dependsOn(provider)
                     }
-                    project.registerAndroidCreateBaselineTask(
-                        bootClasspath = bootClasspath,
-                        extension = extension,
-                        variant = variant,
-                        intermediatesJavaCJar = intermediatesJavacJar
-                    ).also { provider ->
-                        mainBaselineTaskProvider.dependsOn(provider)
-                    }
+                    project.registerAndroidCreateBaselineTask(bootClasspath, extension, variant)
+                        .also { provider ->
+                            mainBaselineTaskProvider.dependsOn(provider)
+                        }
                     variant.testVariants
                         .filter { !extension.matchesIgnoredConfiguration(it) }
                         .forEach { testVariant ->
-                            project.registerAndroidDetektTask(
-                                bootClasspath = bootClasspath,
-                                extension = extension,
-                                variant = testVariant,
-                                intermediatesJavaCJar = intermediatesJavacJar
-                            ).also { provider ->
-                                testTaskProvider.dependsOn(provider)
-                            }
+                            project.registerAndroidDetektTask(bootClasspath, extension, testVariant)
+                                .also { provider ->
+                                    testTaskProvider.dependsOn(provider)
+                                }
                             project.registerAndroidCreateBaselineTask(
-                                bootClasspath = bootClasspath,
-                                extension = extension,
-                                variant = testVariant,
-                                intermediatesJavaCJar = intermediatesJavacJar
-                            ).also { provider ->
-                                testBaselineTaskProvider.dependsOn(provider)
-                            }
+                                bootClasspath,
+                                extension,
+                                testVariant
+                            )
+                                .also { provider ->
+                                    testBaselineTaskProvider.dependsOn(provider)
+                                }
                         }
                 }
         }
@@ -120,14 +106,12 @@ internal class DetektAndroid(private val project: Project) {
             ignoredFlavors.contains(variant.flavorName)
 }
 
-@Suppress("LongParameterList")
 internal fun Project.registerAndroidDetektTask(
     bootClasspath: FileCollection,
     extension: DetektExtension,
     variant: BaseVariant,
     taskName: String = DetektPlugin.DETEKT_TASK_NAME + variant.name.capitalize(),
     extraInputSource: FileCollection? = null,
-    intermediatesJavaCJar: TaskProvider<Jar>,
 ): TaskProvider<Detekt> =
     registerDetektTask(taskName, extension) {
         setSource(variant.sourceSets.map { it.javaDirectories + it.kotlinDirectories })
@@ -135,9 +119,9 @@ internal fun Project.registerAndroidDetektTask(
         classpath.apply {
             setFrom(variant.getCompileClasspath(null).filter { it.exists() })
             from(bootClasspath)
-            from(intermediatesJavaCJar.map { it.destinationDirectory.asFileTree })
+            from(intermediateClassesDirectory(variant))
         }
-        dependsOn(intermediatesJavaCJar)
+        dependsOn(variant.javaCompileProvider)
         // If a baseline file is configured as input file, it must exist to be configured, otherwise the task fails.
         // We try to find the configured baseline or alternatively a specific variant matching this task.
         extension.baseline?.existingVariantOrBaseFile(variant.name)?.let { baselineFile ->
@@ -148,14 +132,12 @@ internal fun Project.registerAndroidDetektTask(
             "EXPERIMENTAL: Run detekt analysis for ${variant.name} classes with type resolution"
     }
 
-@Suppress("LongParameterList")
 internal fun Project.registerAndroidCreateBaselineTask(
     bootClasspath: FileCollection,
     extension: DetektExtension,
     variant: BaseVariant,
     taskName: String = DetektPlugin.BASELINE_TASK_NAME + variant.name.capitalize(Locale.ROOT),
     extraInputSource: FileCollection? = null,
-    intermediatesJavaCJar: TaskProvider<Jar>,
 ): TaskProvider<DetektCreateBaselineTask> =
     registerCreateBaselineTask(taskName, extension) {
         setSource(variant.sourceSets.map { it.javaDirectories + it.kotlinDirectories })
@@ -163,28 +145,16 @@ internal fun Project.registerAndroidCreateBaselineTask(
         classpath.apply {
             setFrom(variant.getCompileClasspath(null).filter { it.exists() })
             from(bootClasspath)
-            from(intermediatesJavaCJar.map { it.destinationDirectory.asFileTree })
+            from(intermediateClassesDirectory(variant))
         }
-        dependsOn(intermediatesJavaCJar)
+        dependsOn(variant.javaCompileProvider)
         val variantBaselineFile = extension.baseline?.addVariantName(variant.name)
         baseline.set(project.layout.file(project.provider { variantBaselineFile }))
         description =
             "EXPERIMENTAL: Creates detekt baseline for ${variant.name} classes with type resolution"
     }
 
-internal fun Project.registerIntermediatesJavacJarTask(variant: BaseVariant): TaskProvider<Jar> {
-    val jarTaskName = "detektIntermediatesJavacJar${variant.name.capitalize(Locale.ROOT)}"
-    val jarOutputDir = layout.buildDirectory.dir(jarTaskName).get()
-    return tasks.register(jarTaskName, Jar::class.java) { task ->
-        task.from(
-            layout
-                .buildDirectory
-                .dir("intermediates/javac/${variant.name}/classes")
-                .get()
-                .asFileTree
-                .matching { it.include("**/*.class") }
-        )
-        task.destinationDirectory.set(jarOutputDir)
-        task.dependsOn(variant.javaCompileProvider)
-    }
-}
+private fun Project.intermediateClassesDirectory(variant: BaseVariant) =
+    layout
+        .buildDirectory
+        .dir("intermediates/javac/${variant.name}/classes")

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektMultiplatform.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektMultiplatform.kt
@@ -68,14 +68,14 @@ internal class DetektMultiplatform(private val project: Project) {
                 extension,
                 compilation.androidVariant,
                 detektTaskName,
-                inputSource,
+                inputSource
             )
             registerAndroidCreateBaselineTask(
                 bootClasspath,
                 extension,
                 compilation.androidVariant,
                 baselineTaskName,
-                inputSource,
+                inputSource
             )
         }
     }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektMultiplatform.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektMultiplatform.kt
@@ -63,19 +63,22 @@ internal class DetektMultiplatform(private val project: Project) {
                 target.name.capitalize() + variant.name.capitalize()
             val baselineTaskName = DetektPlugin.BASELINE_TASK_NAME +
                 target.name.capitalize() + variant.name.capitalize()
+            val intermediatesJavacJar = project.registerIntermediatesJavacJarTask(variant)
             registerAndroidDetektTask(
                 bootClasspath,
                 extension,
                 compilation.androidVariant,
                 detektTaskName,
-                inputSource
+                inputSource,
+                intermediatesJavacJar,
             )
             registerAndroidCreateBaselineTask(
                 bootClasspath,
                 extension,
                 compilation.androidVariant,
                 baselineTaskName,
-                inputSource
+                inputSource,
+                intermediatesJavacJar,
             )
         }
     }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektMultiplatform.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektMultiplatform.kt
@@ -63,14 +63,12 @@ internal class DetektMultiplatform(private val project: Project) {
                 target.name.capitalize() + variant.name.capitalize()
             val baselineTaskName = DetektPlugin.BASELINE_TASK_NAME +
                 target.name.capitalize() + variant.name.capitalize()
-            val intermediatesJavacJar = project.registerIntermediatesJavacJarTask(variant)
             registerAndroidDetektTask(
                 bootClasspath,
                 extension,
                 compilation.androidVariant,
                 detektTaskName,
                 inputSource,
-                intermediatesJavacJar,
             )
             registerAndroidCreateBaselineTask(
                 bootClasspath,
@@ -78,7 +76,6 @@ internal class DetektMultiplatform(private val project: Project) {
                 compilation.androidVariant,
                 baselineTaskName,
                 inputSource,
-                intermediatesJavacJar,
             )
         }
     }


### PR DESCRIPTION
This PR is mainly a rebuild of #3867 from @damianw and would fix a lot of issues together with Android (#4676 and #4689 as example). The description is almost the same:

> This adds the classes from build/intermediates/javac to the classpath used to compile the code, in order for the compiler to be able to resolve references to Java code (included that which is generated). This resolves issues such as https://github.com/detekt/detekt/issues/3488 among probably others.
> 
> A test is included which enables viewBinding on a sample project and verifies that the Detekt invocation doesn't produce any errors about unresolved references to the generated classes.

I simply updated the tests and changed that the task detektIntermediatesJavacJarVARIANT depends on the java compile task and not the full assemble task. This should be enough to create the intermediate *.class files and is way faster as the whole packaging process. 
Also I wasn't able to reproduce #3952 with this configuration. But maybe someone with deeper gradle knowledge (@chao2zhang ?) could take a look to be sure. 
