### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/codecoverage.yaml
+++ b/.github/workflows/codecoverage.yaml
@@ -8,6 +8,9 @@ on:
     branches:
       - '**'
 
+permissions:
+  contents: read
+
 jobs:
   publish-code-coverage:
     if: ${{ !contains(github.event.head_commit.message, 'coverage skip') }}

--- a/.github/workflows/deploy-snapshot.yaml
+++ b/.github/workflows/deploy-snapshot.yaml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   gradle:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-website.yaml
+++ b/.github/workflows/deploy-website.yaml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build-detekt-docs:
     if: github.repository == 'detekt/detekt'
@@ -43,6 +46,8 @@ jobs:
           path: docs/pages/gettingstarted/cli-options.md
 
   build-website:
+    permissions:
+      contents: write  # for JamesIves/github-pages-deploy-action to push changes in repo
     needs: build-detekt-docs
     runs-on: ubuntu-latest
     container: jekyll/builder

--- a/.github/workflows/detekt-with-type-resolution.yaml
+++ b/.github/workflows/detekt-with-type-resolution.yaml
@@ -11,8 +11,14 @@ on:
 env:
   GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
 
+permissions:
+  contents: read
+
 jobs:
   plain:
+    permissions:
+      contents: read  # for actions/checkout to fetch code
+      security-events: write  # for github/codeql-action/upload-sarif to upload SARIF results
     runs-on: ubuntu-latest
     if: ${{ !contains(github.event.head_commit.message, 'ci skip') }}
     steps:

--- a/.github/workflows/fossascan.yaml
+++ b/.github/workflows/fossascan.yaml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   fossa-scan:
     if: ${{ github.repository == 'detekt/detekt' }}

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -7,6 +7,9 @@ on:
     branches:
       - '**'
 
+permissions:
+  contents: read
+
 jobs:
   validation:
     name: Validation

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -11,6 +11,9 @@ on:
 env:
   GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
 
+permissions:
+  contents: read
+
 jobs:
   gradle:
     if: ${{ !contains(github.event.head_commit.message, 'ci skip') }}


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveensrinivasan <172697+naveensrinivasan@users.noreply.github.com>
