### PR TITLE
Disable UnusedImports for the Detekt project

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -243,7 +243,7 @@ style:
   UntilInsteadOfRangeTo:
     active: true
   UnusedImports:
-    active: true
+    active: false # formatting already have this rule enabled
   UnusedPrivateMember:
     active: true
     allowedNames: '(_|ignored|expected)'


### PR DESCRIPTION
This Rule is on `formatting` so it always return duplicated issues.