### PR TITLE
Measure flakyness on Windows CI

### DIFF
--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -10,6 +10,7 @@ plugins {
     alias(libs.plugins.pluginPublishing)
     // We use this published version of the Detekt plugin to self analyse this project.
     id("io.gitlab.arturbosch.detekt") version "1.20.0"
+    id("org.gradle.test-retry") version "1.4.0"
 }
 
 repositories {
@@ -178,3 +179,13 @@ if (signingKey.isNullOrBlank() || signingPwd.isNullOrBlank()) {
 }
 
 val String.byProperty: String? get() = findProperty(this) as? String
+
+tasks.withType<Test>().configureEach {
+    retry {
+        @Suppress("MagicNumber")
+        if (System.getenv().containsKey("CI")) {
+            maxRetries.set(2)
+            maxFailures.set(20)
+        }
+    }
+}


### PR DESCRIPTION
We all know that our Windows & JDK11 CI is flaky. It show flakyness. Here I have a list of 8 failed builds because of that:

- https://ge.detekt.dev/s/ptkpjsdzfqcuo/tests/overview
- https://ge.detekt.dev/s/nxk7tsjofd4sy/tests/overview
- https://ge.detekt.dev/s/aoeteqlgutbni/tests/overview
- https://ge.detekt.dev/s/ei3cidvaw6m3s/tests/overview
- https://ge.detekt.dev/s/635dpvmudbutq/tests/overview
- https://ge.detekt.dev/s/ymzazhyn74f3o/tests/overview
- https://ge.detekt.dev/s/6u2n3iuilq3lu/tests/overview
- https://ge.detekt.dev/s/77bto742izr4y/tests/overview

We had this problem already with Windows & JDK8 and we "fixed" it by disabling that combination: #4403

Right now we don't have flakyness information on of Gradle enterprise instance https://ge.detekt.dev/scans/tests because we need to activate this plugin: https://docs.gradle.com/enterprise/flaky-test-detection/

That's what this PR does, add that plugin. I don't like the idea of "retry" tests but I think that this is the only option that we have right now.

Open question: Should I enable it only for Windows?