### PR TITLE
`VarCouldBeVal`: Add configuration flag `ignoreLateinitVar`

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -675,6 +675,7 @@ style:
     active: true
   VarCouldBeVal:
     active: true
+    ignoreLateinitVar: false
   WildcardImport:
     active: true
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/VarCouldBeValSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/VarCouldBeValSpec.kt
@@ -1,6 +1,7 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
+import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
 import org.assertj.core.api.Assertions.assertThat
@@ -489,6 +490,26 @@ class VarCouldBeValSpec(val env: KotlinCoreEnvironment) {
                 """.trimIndent()
                 assertThat(subject.compileAndLint(code)).isEmpty()
             }
+        }
+    }
+
+    @Nested
+    inner class `lateinit vars - #4731` {
+        val code = """
+            public class A {
+                private lateinit var test: String
+            }
+        """.trimIndent()
+
+        @Test
+        fun `reports uninitialized lateinit vars by default`() {
+            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        }
+
+        @Test
+        fun `does not report uninitialized lateinit vars if disabled in config`() {
+            val subject = VarCouldBeVal(TestConfig("ignoreLateinitVar" to true))
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
     }
 }


### PR DESCRIPTION
I'm not entirely convinced that it makes sense to disable this across the entire codebase, but maybe someone else has a use-case.

Fixes #4731
