### PR TITLE
Break a dependency between `detekt-gradle-plugin` and `detekt-utils`

### DIFF
--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -66,7 +66,6 @@ configurations.compileOnly { extendsFrom(pluginCompileOnly) }
 dependencies {
     compileOnly(libs.kotlin.gradlePluginApi)
     implementation(libs.sarif4k)
-    implementation(projects.detektUtils)
 
     // Migrate to `implementation(testFixtures(project))` in test suite configuration when Gradle 7.5 released
     // (https://github.com/gradle/gradle/pull/19472)

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
@@ -1,6 +1,5 @@
 package io.gitlab.arturbosch.detekt.extensions
 
-import io.github.detekt.utils.openSafeStream
 import org.gradle.api.Action
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.model.ObjectFactory
@@ -109,6 +108,16 @@ open class DetektExtension @Inject constructor(objects: ObjectFactory) : CodeQua
 }
 
 internal fun loadDetektVersion(classLoader: ClassLoader): String = Properties().run {
-    load(classLoader.getResource("versions.properties")!!.openSafeStream())
+    val inputStream = classLoader.getResource("versions.properties")!!.openConnection()
+        /*
+         * Due to https://bugs.openjdk.java.net/browse/JDK-6947916 and https://bugs.openjdk.java.net/browse/JDK-8155607,
+         * it is necessary to disallow caches to maintain stability on JDK 8 and 11 (and possibly more).
+         * Otherwise, simultaneous invocations of Detekt in the same VM can fail spuriously. A similar bug is referenced in
+         * https://github.com/detekt/detekt/issues/3396. The performance regression is likely unnoticeable.
+         * Due to https://github.com/detekt/detekt/issues/4332 it is included for all JDKs.
+         */
+        .apply { useCaches = false }
+        .getInputStream()
+    load(inputStream)
     getProperty("detektVersion")
 }


### PR DESCRIPTION
I'm removing a dependency between `detekt-gradle-plugin` and `detekt-utils`. This is making harder to move to a composite build + it's an unnecessary dependency as we just use a function from detekt-utils.

This also causes build failures for users if `detekt-gradle-plugin` is published and `detekt-utils` is not yet. See https://github.com/detekt/detekt/discussions/4696#discussioncomment-2579993