### PR TITLE
Move detekt-gradle-plugin to be a composite build

### DIFF
--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -82,4 +82,4 @@ jobs:
       - name: Build and compile test snippets
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: test -x :detekt-gradle-plugin:test -Pcompile-test-snippets=true
+          arguments: test -x -Pcompile-test-snippets=true

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -82,4 +82,4 @@ jobs:
       - name: Build and compile test snippets
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: test -x -Pcompile-test-snippets=true
+          arguments: test -Pcompile-test-snippets=true

--- a/build-logic/src/main/kotlin/releasing.gradle.kts
+++ b/build-logic/src/main/kotlin/releasing.gradle.kts
@@ -69,12 +69,4 @@ tasks {
         linePartToFind.set("    detektVersion:")
         lineTransformation.set("    detektVersion: '${Versions.DETEKT}'")
     }
-
-    register<UpdateVersionInFileTask>("applySelfAnalysisVersion") {
-        fileToUpdate.set(file("${rootProject.rootDir}/gradle/libs.versions.toml"))
-        linePartToFind.set("detekt = { id = \"io.gitlab.arturbosch.detekt\"")
-        lineTransformation.set(
-            "detekt = { id = \"io.gitlab.arturbosch.detekt\", version = \"${Versions.DETEKT}\" }"
-        )
-    }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ import io.gitlab.arturbosch.detekt.DetektCreateBaselineTask
 
 plugins {
     id("releasing")
-    alias(libs.plugins.detekt)
+    id("io.gitlab.arturbosch.detekt")
     alias(libs.plugins.gradleVersions)
     alias(libs.plugins.sonarqube)
 }
@@ -104,4 +104,8 @@ val detektProjectBaseline by tasks.registering(DetektCreateBaselineTask::class) 
     exclude(resourceFiles)
     exclude(buildFiles)
     baseline.set(baselineFile)
+}
+
+tasks.register("build") {
+    dependsOn(gradle.includedBuild("detekt-gradle-plugin").task(":build"))
 }

--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -9,14 +9,13 @@ plugins {
     alias(libs.plugins.pluginPublishing)
 }
 
-detekt {
-    source.from("src/functionalTest/kotlin")
-}
-
 repositories {
     mavenCentral()
     google()
 }
+
+group = "io.gitlab.arturbosch.detekt"
+version = Versions.currentOrSnapshot()
 
 testing {
     suites {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,7 +39,6 @@ jcommander = "com.beust:jcommander:1.82"
 
 [plugins]
 binaryCompatibilityValidator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version = "0.9.0" }
-detekt = { id = "io.gitlab.arturbosch.detekt", version = "1.20.0" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 gradleVersions = { id = "com.github.ben-manes.versions", version = "0.42.0" }
 pluginPublishing = { id = "com.gradle.plugin-publish", version = "0.21.0" }

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -4,5 +4,5 @@ gradle build || exit
 gradle publishAllPublicationsToMavenCentralRepository --max-workers 1 || exit
 gradle publishPlugins -DautomatePublishing=true || exit
 gradle githubRelease || exit
-gradle applyDocVersion applySelfAnalysisVersion || exit
+gradle applyDocVersion || exit
 gradle closeAndReleaseRepository || exit

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,6 +4,7 @@ rootProject.name = "detekt"
 
 pluginManagement {
     includeBuild("build-logic")
+    includeBuild("detekt-gradle-plugin")
 }
 
 include("code-coverage-report")
@@ -12,7 +13,6 @@ include("detekt-cli")
 include("detekt-core")
 include("detekt-formatting")
 include("detekt-generator")
-include("detekt-gradle-plugin")
 include("detekt-metrics")
 include("detekt-parser")
 include("detekt-psi-utils")


### PR DESCRIPTION
Stacked on top of #4748 

This converts our project to use Gradle Composite builds.
With this we won't need to depend on external, previously published versions of `detekt-gradle-plugin`. It will help us prevent and catch earlier a lot of bugs we discover during the release process.

I've also introduced a `buildAll` top level task that builds everything (all the subprojects and run the build task on the included build).

I've removed the `applySelfAnalysisVersion` task as that's unnecessary now.