### PR TITLE
Don't label yaml changes as core

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -14,7 +14,7 @@ cli:
   - "detekt-cli/src/**/*"
 
 core:
-  - "detekt-core/src/**/*"
+  - "detekt-core/src/**/*.kt"
 
 dependencies:
   - "gradle/libs.versions.toml"


### PR DESCRIPTION
That's a nit, but I noticed that this PR:
https://github.com/detekt/detekt/pull/4745

Was labelled as `core` just because it updated the default config file.
I'm restricting the label to source only changes as a lot of PRs are editing that file.
