### PR TITLE
Fix UP-TO-DATE checks for `functionalTest`

### DIFF
--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -82,4 +82,4 @@ jobs:
       - name: Build and compile test snippets
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: test -x :detekt-gradle-plugin:test -Pcompile-test-snippets=true
+          arguments: test -x -Pcompile-test-snippets=true

--- a/build-logic/src/main/kotlin/releasing.gradle.kts
+++ b/build-logic/src/main/kotlin/releasing.gradle.kts
@@ -69,12 +69,4 @@ tasks {
         linePartToFind.set("    detektVersion:")
         lineTransformation.set("    detektVersion: '${Versions.DETEKT}'")
     }
-
-    register<UpdateVersionInFileTask>("applySelfAnalysisVersion") {
-        fileToUpdate.set(file("${rootProject.rootDir}/gradle/libs.versions.toml"))
-        linePartToFind.set("detekt = { id = \"io.gitlab.arturbosch.detekt\"")
-        lineTransformation.set(
-            "detekt = { id = \"io.gitlab.arturbosch.detekt\", version = \"${Versions.DETEKT}\" }"
-        )
-    }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ import io.gitlab.arturbosch.detekt.DetektCreateBaselineTask
 
 plugins {
     id("releasing")
-    alias(libs.plugins.detekt)
+    id("io.gitlab.arturbosch.detekt")
     alias(libs.plugins.gradleVersions)
     alias(libs.plugins.sonarqube)
 }
@@ -104,4 +104,8 @@ val detektProjectBaseline by tasks.registering(DetektCreateBaselineTask::class) 
     exclude(resourceFiles)
     exclude(buildFiles)
     baseline.set(baselineFile)
+}
+
+tasks.register("build") {
+    dependsOn(gradle.includedBuild("detekt-gradle-plugin").task(":build"))
 }

--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -9,14 +9,13 @@ plugins {
     alias(libs.plugins.pluginPublishing)
 }
 
-detekt {
-    source.from("src/functionalTest/kotlin")
-}
-
 repositories {
     mavenCentral()
     google()
 }
+
+group = "io.gitlab.arturbosch.detekt"
+version = Versions.currentOrSnapshot()
 
 testing {
     suites {

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/JvmSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/JvmSpec.kt
@@ -4,13 +4,17 @@ import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.jupiter.api.Test
 import java.io.File
+import java.nio.file.Files
 
 class JvmSpec {
     @Test
     fun `Type resolution on JVM`() {
-        val projectDir = checkNotNull(javaClass.classLoader.getResource("jvm")?.file)
+        val resourceDir = File(javaClass.classLoader.getResource("jvm")?.file!!)
+        val projectDir: File = Files.createTempDirectory("jvmWithTypeResolution").toFile()
+        resourceDir.copyRecursively(projectDir)
+
         val result = GradleRunner.create()
-            .withProjectDir(File(projectDir))
+            .withProjectDir(projectDir)
             .withPluginClasspath()
             .withArguments("detektMain")
             .buildAndFail()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,7 +39,6 @@ jcommander = "com.beust:jcommander:1.82"
 
 [plugins]
 binaryCompatibilityValidator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version = "0.9.0" }
-detekt = { id = "io.gitlab.arturbosch.detekt", version = "1.20.0" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 gradleVersions = { id = "com.github.ben-manes.versions", version = "0.42.0" }
 pluginPublishing = { id = "com.gradle.plugin-publish", version = "0.21.0" }

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -4,5 +4,5 @@ gradle build || exit
 gradle publishAllPublicationsToMavenCentralRepository --max-workers 1 || exit
 gradle publishPlugins -DautomatePublishing=true || exit
 gradle githubRelease || exit
-gradle applyDocVersion applySelfAnalysisVersion || exit
+gradle applyDocVersion || exit
 gradle closeAndReleaseRepository || exit

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,6 +4,7 @@ rootProject.name = "detekt"
 
 pluginManagement {
     includeBuild("build-logic")
+    includeBuild("detekt-gradle-plugin")
 }
 
 include("code-coverage-report")
@@ -12,7 +13,6 @@ include("detekt-cli")
 include("detekt-core")
 include("detekt-formatting")
 include("detekt-generator")
-include("detekt-gradle-plugin")
 include("detekt-metrics")
 include("detekt-parser")
 include("detekt-psi-utils")


### PR DESCRIPTION
Stacked on top of #4751 

This fixes a failure on a UP-TO-DATE checks for `functionalTest`.
Proof: https://ge.detekt.dev/c/c52dhidy2tdqc/tcq346kqad2pq/task-inputs

The problem was that this specific test was generating output (i.e. a detekt HTML report) in a resource folder. Solved by reading the resource folder and copying the content inside a temp folder.

(cc @chao2zhang @runningcode as they have context).