### PR TITLE
Self-inspect the detekt-gradle-plugin

### DIFF
--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -7,6 +7,8 @@ plugins {
     `java-test-fixtures`
     idea
     alias(libs.plugins.pluginPublishing)
+    // We use this published version of the Detekt plugin to self analyse this project.
+    id("io.gitlab.arturbosch.detekt") version "1.20.0"
 }
 
 repositories {
@@ -16,6 +18,13 @@ repositories {
 
 group = "io.gitlab.arturbosch.detekt"
 version = Versions.currentOrSnapshot()
+
+detekt {
+    source.from("src/functionalTest/kotlin")
+    buildUponDefaultConfig = true
+    baseline = file("config/gradle-plugin-baseline.xml")
+    config = files("config/gradle-plugin-detekt.yml")
+}
 
 testing {
     suites {
@@ -70,6 +79,9 @@ dependencies {
 
     pluginCompileOnly(libs.android.gradle)
     pluginCompileOnly(libs.kotlin.gradle)
+
+    // We use this published version of the detekt-formatting to self analyse this project.
+    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.20.0")
 }
 
 gradlePlugin {

--- a/detekt-gradle-plugin/config/gradle-plugin-baseline.xml
+++ b/detekt-gradle-plugin/config/gradle-plugin-baseline.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+  </CurrentIssues>
+</SmellBaseline>

--- a/detekt-gradle-plugin/config/gradle-plugin-detekt.yml
+++ b/detekt-gradle-plugin/config/gradle-plugin-detekt.yml
@@ -1,0 +1,35 @@
+complexity:
+  TooManyFunctions:
+    excludes: ["**/test/**", "**/functionalTest/**"]
+
+naming:
+  ClassNaming:
+    excludes: ["**/*Spec.kt"]
+  FunctionNaming:
+    active: true
+    excludes:
+      - "**/test/**"
+      - "**/androidTest/**"
+      - "**/commonTest/**"
+      - "**/functionalTest/**"
+      - "**/jvmTest/**"
+      - "**/jsTest/**"
+      - "**/iosTest/**"
+
+performance:
+  SpreadOperator:
+    excludes: ["**/test/**", "**/functionalTest/**"]
+
+style:
+  MagicNumber:
+    active: true
+    excludes: ["**/test/**", "**/*Test.kt", "**/*Spec.kt"]
+  MaxLineLength:
+    active: true
+    excludes: ["**/test/**", "**/*Test.kt", "**/*Spec.kt"]
+    excludeCommentStatements: true
+
+formatting:
+  active: true
+  MaximumLineLength:
+    active: false


### PR DESCRIPTION
Here I'm setting up the self-inspection on `detekt-gradle-plugin` (cc @3flex).

I have to admit that I'm not extremely excited of this, as we might face problems with the config file of detekt being incompatible between the latest released version and `main`.