### PR TITLE
fix: add test case that fails if environment is not properly set up

### DIFF
--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitCollectionElementAccessMethodSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitCollectionElementAccessMethodSpec.kt
@@ -434,6 +434,19 @@ class ExplicitCollectionElementAccessMethodSpec(val env: KotlinCoreEnvironment) 
             }
 
             @Test
+            fun `reports setter from java with 2 or less parameters`() {
+                val code = """
+                    import com.example.fromjava.Rect
+    
+                    fun foo() {
+                        val rect = Rect()
+                        rect.set(0, 1)
+                    }
+                """
+                assertThat(subject.lintWithContext(customEnv, code)).hasSize(1)
+            }
+
+            @Test
             fun `does not report if the function has 3 or more arguments and it's defined in java - #4288`() {
                 val code = """
                     import com.example.fromjava.Rect

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitCollectionElementAccessMethodSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitCollectionElementAccessMethodSpec.kt
@@ -435,6 +435,7 @@ class ExplicitCollectionElementAccessMethodSpec(val env: KotlinCoreEnvironment) 
 
             @Test
             fun `reports setter from java with 2 or less parameters`() {
+                // this test case ensures that the test environment are set up correctly.
                 val code = """
                     import com.example.fromjava.Rect
     

--- a/detekt-rules-style/src/test/resources/java/com/example/fromjava/Rect.java
+++ b/detekt-rules-style/src/test/resources/java/com/example/fromjava/Rect.java
@@ -2,4 +2,5 @@ package com.example.fromjava;
 
 class Rect {
     void set(int left, int top, int right) {}
+    void set(int left, int top) {}
 }


### PR DESCRIPTION
This relatest to the comment https://github.com/detekt/detekt/pull/4575#discussion_r841284879 and adds a test case that fails if the java environment is not properly set up. The original test still succeeds because the function cannot be resolved and will not issue a code smell by default.
