### PR TITLE
Silence Vercel commits/PR comments

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "github": {
+    "silent": true
+   }
+}


### PR DESCRIPTION
Turns out that Vercel is pretty noisy. I'm turning the commenting off (on commits & PRs). We will still be able to see the website preview in the "Environments" on a opened PR.

Also if you feel we should keep it, I'm also fine :)