### PR TITLE
Ignore the commit removing unnecessary nested from git blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Remove unnecessary @Nested changing all the tests indentation
+a2734b18c133020520183292c9d2ff0593040a1c


### PR DESCRIPTION
Right now github "blame" me for nearly all the tests of this project. And I didn't write those. This "trick" hide those changes and show the original author of each change.

You can read more about this here: https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view

