### PR TITLE
Add dependency on slf4j-nop to silence warning

### DIFF
--- a/detekt-formatting/build.gradle.kts
+++ b/detekt-formatting/build.gradle.kts
@@ -13,6 +13,7 @@ dependencies {
     implementation(libs.ktlint.rulesetExperimental) {
         exclude(group = "org.jetbrains.kotlin")
     }
+    runtimeOnly(libs.slf4j.nop)
 
     testImplementation(projects.detektTest)
     testImplementation(libs.assertj)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,6 +25,7 @@ android-gradle = "com.android.tools.build:gradle:7.1.3"
 ktlint-core = { module = "com.pinterest.ktlint:ktlint-core", version.ref = "ktlint" }
 ktlint-rulesetStandard = { module = "com.pinterest.ktlint:ktlint-ruleset-standard", version.ref = "ktlint" }
 ktlint-rulesetExperimental = { module = "com.pinterest.ktlint:ktlint-ruleset-experimental", version.ref = "ktlint" }
+slf4j-nop = { module = "org.slf4j:slf4j-nop", version = "1.7.36"  }
 
 spek-dsl = { module = "org.spekframework.spek2:spek-dsl-jvm", version = "2.0.18" }
 


### PR DESCRIPTION
Fixes #4679

See https://ge.detekt.dev/s/lotfhvt2gspyq for a run without the SLF4J warning.