### PR TITLE
Use correct incremental build property type annotations for reports

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -43,7 +43,6 @@ import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
-import org.gradle.api.tasks.OutputFiles
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.SkipWhenEmpty
@@ -188,11 +187,6 @@ open class Detekt @Inject constructor(
         @OutputFile
         @Optional
         get() = getTargetFileProvider(reports.sarif)
-
-    internal val customReportFiles: ConfigurableFileCollection
-        @OutputFiles
-        @Optional
-        get() = objects.fileCollection().from(reports.custom.mapNotNull { it.outputLocation.asFile.orNull })
 
     private val defaultReportsDir: Directory = project.layout.buildDirectory.get()
         .dir(ReportingExtension.DEFAULT_REPORTS_DIR_NAME)

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -41,8 +41,8 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.Optional
-import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.SkipWhenEmpty
@@ -162,30 +162,26 @@ open class Detekt @Inject constructor(
         get() = basePathProp.getOrElse("")
         set(value) = basePathProp.set(value)
 
-    @get:Internal
+    @get:Nested
     var reports: DetektReports = objects.newInstance(DetektReports::class.java)
 
     @get:Internal
     val reportsDir: Property<File> = project.objects.property(File::class.java)
 
     val xmlReportFile: Provider<RegularFile>
-        @OutputFile
-        @Optional
+        @Internal
         get() = getTargetFileProvider(reports.xml)
 
     val htmlReportFile: Provider<RegularFile>
-        @OutputFile
-        @Optional
+        @Internal
         get() = getTargetFileProvider(reports.html)
 
     val txtReportFile: Provider<RegularFile>
-        @OutputFile
-        @Optional
+        @Internal
         get() = getTargetFileProvider(reports.txt)
 
     val sarifReportFile: Provider<RegularFile>
-        @OutputFile
-        @Optional
+        @Internal
         get() = getTargetFileProvider(reports.sarif)
 
     private val defaultReportsDir: Directory = project.layout.buildDirectory.get()

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektReport.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektReport.kt
@@ -4,17 +4,23 @@ import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputFile
 import java.io.File
 import javax.inject.Inject
 
-open class DetektReport @Inject constructor(val type: DetektReportType, objects: ObjectFactory) {
+open class DetektReport @Inject constructor(
+    @Internal val type: DetektReportType,
+    objects: ObjectFactory
+) {
 
+    @get:Internal
     @Deprecated("Use required.set(value)")
     var enabled: Boolean?
         get() = required.get()
         set(value) = required.set(value)
 
+    @get:Internal
     @Deprecated("Use outputLocation.set(value)")
     var destination: File?
         get() = outputLocation.asFile.orNull

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektReports.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektReports.kt
@@ -6,19 +6,25 @@ import io.gitlab.arturbosch.detekt.extensions.DetektReportType.TXT
 import io.gitlab.arturbosch.detekt.extensions.DetektReportType.XML
 import org.gradle.api.Action
 import org.gradle.api.model.ObjectFactory
+import org.gradle.api.tasks.Nested
 import javax.inject.Inject
 
 @Suppress("TooManyFunctions")
-open class DetektReports @Inject constructor(val objects: ObjectFactory) {
+open class DetektReports @Inject constructor(private val objects: ObjectFactory) {
 
+    @Nested
     val xml: DetektReport = objects.newInstance(DetektReport::class.java, XML)
 
+    @Nested
     val html: DetektReport = objects.newInstance(DetektReport::class.java, HTML)
 
+    @Nested
     val txt: DetektReport = objects.newInstance(DetektReport::class.java, TXT)
 
+    @Nested
     val sarif: DetektReport = objects.newInstance(DetektReport::class.java, SARIF)
 
+    @Nested
     val custom = mutableListOf<CustomDetektReport>()
 
     fun xml(action: Action<in DetektReport>): Unit = action.execute(xml)


### PR DESCRIPTION
I found some annotations that were applied incorrectly when investigating usage of unused `customReportFiles` property in the Detekt task in the Gradle plugin.

The unused `customReportFiles` property was removed after correcting the annotations.