### PR TITLE
Setup Algolia search bar on website

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -170,6 +170,12 @@ const config = {
         darkTheme: darkCodeTheme,
         additionalLanguages: ['kotlin', 'groovy', 'java'],
       },
+        algolia: {
+          appId: '5PZNXB7M3G',
+          apiKey: '6f23d0811156d77c936736893b97c5fd',
+          indexName: 'detekt',
+          contextualSearch: true,
+        },
     }),
 
   customFields: {

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -170,12 +170,12 @@ const config = {
         darkTheme: darkCodeTheme,
         additionalLanguages: ['kotlin', 'groovy', 'java'],
       },
-        algolia: {
-          appId: '5PZNXB7M3G',
-          apiKey: '6f23d0811156d77c936736893b97c5fd',
-          indexName: 'detekt',
-          contextualSearch: true,
-        },
+      algolia: {
+        appId: '5PZNXB7M3G',
+        apiKey: '6f23d0811156d77c936736893b97c5fd',
+        indexName: 'detekt',
+        contextualSearch: true,
+      },
     }),
 
   customFields: {


### PR DESCRIPTION
I'm adding a search bar to the website. This be backed by Algolia DocSearch which will crawl all the docs + all the rule sets and I believe will give us a big boost in discoverability.

Preview https://detekt-dafxa4asc-detekt.vercel.app/