### PR TITLE
Report as warnings the Strings that should be an array

### DIFF
--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/ValidateConfig.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/ValidateConfig.kt
@@ -148,6 +148,6 @@ internal fun propertyShouldBeAnArray(
     reportAsError: Boolean,
 ): Notification =
     SimpleNotification(
-        "Property '$prop' should be an array instead of a String.",
+        "Property '$prop' should be a YAML array instead of a comma-separated String.",
         if (reportAsError) Notification.Level.Error else Notification.Level.Warning,
     )

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/ValidateConfig.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/ValidateConfig.kt
@@ -99,6 +99,8 @@ internal fun validateConfig(
 
             if (!base.contains(prop)) {
                 notifications.add(propertyDoesNotExists(propertyPath))
+            } else if (current[prop] is String && base[prop] is List<*>) {
+                notifications.add(propertyShouldBeAnArray(propertyPath, warningsAsErrors))
             }
 
             val next = current[prop] as? Map<String, Any>
@@ -138,5 +140,14 @@ internal fun propertyIsDeprecated(
 ): Notification =
     SimpleNotification(
         "Property '$prop' is deprecated. $deprecationDescription.",
+        if (reportAsError) Notification.Level.Error else Notification.Level.Warning,
+    )
+
+internal fun propertyShouldBeAnArray(
+    prop: String,
+    reportAsError: Boolean,
+): Notification =
+    SimpleNotification(
+        "Property '$prop' should be an array instead of a String.",
         if (reportAsError) Notification.Level.Error else Notification.Level.Warning,
     )

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/ValidateConfigSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/ValidateConfigSpec.kt
@@ -224,4 +224,27 @@ class ValidateConfigSpec {
             )
         }
     }
+
+    @ParameterizedTest
+    @ValueSource(booleans = [true, false])
+    fun `reports a string that should be an array as a warning`(warningsAsErrors: Boolean) {
+        val config = yamlConfigFromContent(
+            """
+                config:
+                  warningsAsErrors: $warningsAsErrors
+                style:
+                  MagicNumber:
+                    ignoreNumbers: '-1,0,1,2'
+            """.trimIndent()
+        )
+
+        val result = validateConfig(config, baseline)
+
+        assertThat(result).contains(
+            propertyShouldBeAnArray(
+                "style>MagicNumber>ignoreNumbers",
+                reportAsError = warningsAsErrors
+            )
+        )
+    }
 }

--- a/detekt-core/src/test/resources/config_validation/baseline.yml
+++ b/detekt-core/src/test/resources/config_validation/baseline.yml
@@ -1,3 +1,5 @@
+config:
+  warningsAsErrors: true
 complexity:
   LongMethod:
     active: true


### PR DESCRIPTION
With this we will show to our users a warning when they are using a comma-separeted String instead of a yaml array. This way, some release later, we can drop the support to the comma-separated String.

Fix #4498 