### PR TITLE
Add documentation link for rules in html report

### DIFF
--- a/detekt-report-html/src/main/kotlin/io/github/detekt/report/html/HtmlOutputReport.kt
+++ b/detekt-report-html/src/main/kotlin/io/github/detekt/report/html/HtmlOutputReport.kt
@@ -123,7 +123,7 @@ class HtmlOutputReport : OutputReport() {
                 span("description") { text(findings.first().issue.description) }
             }
 
-            a("$DETEKT_WEBSITE_BASE_URL/docs/rules/${group.toLowerCase()}#${rule.toLowerCase()}") {
+            a("$DETEKT_WEBSITE_BASE_URL/docs/rules/${group.toLowerCase(Locale.US)}#${rule.toLowerCase(Locale.US)}") {
                 +"Documentation"
             }
 

--- a/detekt-report-html/src/main/kotlin/io/github/detekt/report/html/HtmlOutputReport.kt
+++ b/detekt-report-html/src/main/kotlin/io/github/detekt/report/html/HtmlOutputReport.kt
@@ -15,6 +15,7 @@ import kotlinx.html.FlowOrInteractiveContent
 import kotlinx.html.HTMLTag
 import kotlinx.html.HtmlTagMarker
 import kotlinx.html.TagConsumer
+import kotlinx.html.a
 import kotlinx.html.attributesMapOf
 import kotlinx.html.details
 import kotlinx.html.div
@@ -106,11 +107,11 @@ class HtmlOutputReport : OutputReport() {
             .toList()
             .sortedBy { (rule, _) -> rule }
             .forEach { (rule, ruleFindings) ->
-                renderRule(rule, ruleFindings)
+                renderRule(rule, group, ruleFindings)
             }
     }
 
-    private fun FlowContent.renderRule(rule: String, findings: List<Finding>) {
+    private fun FlowContent.renderRule(rule: String, group: String, findings: List<Finding>) {
         details {
             id = rule
             open = true
@@ -118,6 +119,10 @@ class HtmlOutputReport : OutputReport() {
             summary("rule-container") {
                 span("rule") { text("$rule: %,d ".format(Locale.US, findings.size)) }
                 span("description") { text(findings.first().issue.description) }
+            }
+
+            a("https://detekt.dev/docs/rules/${group.toLowerCase()}#${rule.toLowerCase()}") {
+                +"Documentation"
             }
 
             ul {

--- a/detekt-report-html/src/main/kotlin/io/github/detekt/report/html/HtmlOutputReport.kt
+++ b/detekt-report-html/src/main/kotlin/io/github/detekt/report/html/HtmlOutputReport.kt
@@ -38,6 +38,8 @@ private const val PLACEHOLDER_COMPLEXITY_REPORT = "@@@complexity@@@"
 private const val PLACEHOLDER_VERSION = "@@@version@@@"
 private const val PLACEHOLDER_DATE = "@@@date@@@"
 
+private const val DETEKT_WEBSITE_BASE_URL = "https://detekt.dev"
+
 /**
  * Contains rule violations and metrics formatted in a human friendly way, so that it can be inspected in a web browser.
  * See: https://detekt.dev/configurations.html#output-reports
@@ -121,7 +123,7 @@ class HtmlOutputReport : OutputReport() {
                 span("description") { text(findings.first().issue.description) }
             }
 
-            a("https://detekt.dev/docs/rules/${group.toLowerCase()}#${rule.toLowerCase()}") {
+            a("$DETEKT_WEBSITE_BASE_URL/docs/rules/${group.toLowerCase()}#${rule.toLowerCase()}") {
                 +"Documentation"
             }
 

--- a/detekt-report-html/src/test/kotlin/io/github/detekt/report/html/HtmlOutputReportSpec.kt
+++ b/detekt-report-html/src/test/kotlin/io/github/detekt/report/html/HtmlOutputReportSpec.kt
@@ -115,6 +115,26 @@ class HtmlOutputReportSpec {
     }
 
     @Test
+    fun `renders the right documentation links for the rules`() {
+        val detektion = object : TestDetektion() {
+            override val findings: Map<String, List<Finding>> = mapOf(
+                "Style" to listOf(
+                    createFinding(createIssue("ValCouldBeVar"), createEntity(""))
+                ),
+                "empty" to listOf(
+                    createFinding(createIssue("EmptyBody"), createEntity("")),
+                    createFinding(createIssue("EmptyIf"), createEntity(""))
+                )
+            )
+        }
+
+        val result = htmlReport.render(detektion)
+        assertThat(result).contains("<a href=\"https://detekt.dev/docs/rules/style#valcouldbevar\">Documentation</a>")
+        assertThat(result).contains("<a href=\"https://detekt.dev/docs/rules/empty#emptybody\">Documentation</a>")
+        assertThat(result).contains("<a href=\"https://detekt.dev/docs/rules/empty#emptyif\">Documentation</a>")
+    }
+
+    @Test
     fun `renders a metric report correctly`() {
         val detektion = object : TestDetektion() {
             override val metrics: Collection<ProjectMetric> = listOf(

--- a/detekt-report-html/src/test/resources/HtmlOutputFormatTest.html
+++ b/detekt-report-html/src/test/resources/HtmlOutputFormatTest.html
@@ -172,6 +172,7 @@
   <h3>Section 1: 2</h3>
   <details id="id_a" open="open">
     <summary class="rule-container"><span class="rule">id_a: 2 </span><span class="description">Description id_a</span></summary>
+<a href="https://detekt.dev/docs/rules/section 1#id_a">Documentation</a>
     <ul>
       <li><span class="location">src/main/com/sample/Sample1.kt:11:1</span><span class="message">Message finding 1</span>
         <pre><code><span class="lineno">   8 </span>
@@ -188,6 +189,7 @@
   <h3>Section 2: 1</h3>
   <details id="id_b" open="open">
     <summary class="rule-container"><span class="rule">id_b: 1 </span><span class="description">Description id_b</span></summary>
+<a href="https://detekt.dev/docs/rules/section 2#id_b">Documentation</a>
     <ul>
       <li><span class="location">src/main/com/sample/Sample3.kt:33:3</span></li>
     </ul>


### PR DESCRIPTION
My attempt at #4792.

Adds a documentation link to the HTML reports, so we don't have to find it manually on the Detekt website. Looks like this:
![example](https://user-images.githubusercontent.com/5732795/166142439-f0c75ea9-42fa-4f5a-b502-e0de886ef71e.png)

Printed once for each rule, at the top before the rule violations are printed. The link in the picture is https://detekt.dev/docs/rules/empty-blocks/#emptyclassblock