### PR TITLE
Add tests for #4786

### DIFF
--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/ArgumentConverters.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/ArgumentConverters.kt
@@ -49,7 +49,7 @@ class MultipleExistingPathConverter : DetektInputPathConverter<Path> {
 class LanguageVersionConverter : IStringConverter<LanguageVersion> {
     override fun convert(value: String): LanguageVersion {
         val validValues by lazy { LanguageVersion.values().joinToString { it.versionString } }
-        return checkNotNull(LanguageVersion.fromFullVersionString(value)) {
+        return requireNotNull(LanguageVersion.fromFullVersionString(value)) {
             "\"$value\" passed to --language-version, expected one of [$validValues]"
         }
     }
@@ -58,7 +58,7 @@ class LanguageVersionConverter : IStringConverter<LanguageVersion> {
 class JvmTargetConverter : IStringConverter<JvmTarget> {
     override fun convert(value: String): JvmTarget {
         val validValues by lazy { JvmTarget.values().joinToString { it.description } }
-        return checkNotNull(JvmTarget.fromString(value)) {
+        return requireNotNull(JvmTarget.fromString(value)) {
             "\"$value\" passed to --jvm-target, expected one of [$validValues]"
         }
     }

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/ArgumentConverters.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/ArgumentConverters.kt
@@ -47,13 +47,21 @@ class MultipleExistingPathConverter : DetektInputPathConverter<Path> {
 }
 
 class LanguageVersionConverter : IStringConverter<LanguageVersion> {
-    override fun convert(value: String): LanguageVersion =
-        checkNotNull(LanguageVersion.fromFullVersionString(value)) { "Invalid value passed to --language-version" }
+    override fun convert(value: String): LanguageVersion {
+        val validValues by lazy { LanguageVersion.values().joinToString { it.versionString } }
+        return checkNotNull(LanguageVersion.fromFullVersionString(value)) {
+            "\"$value\" passed to --language-version, expected one of [$validValues]"
+        }
+    }
 }
 
 class JvmTargetConverter : IStringConverter<JvmTarget> {
-    override fun convert(value: String): JvmTarget =
-        checkNotNull(JvmTarget.fromString(value)) { "Invalid value passed to --jvm-target" }
+    override fun convert(value: String): JvmTarget {
+        val validValues by lazy { JvmTarget.values().joinToString { it.description } }
+        return checkNotNull(JvmTarget.fromString(value)) {
+            "\"$value\" passed to --jvm-target, expected one of [$validValues]"
+        }
+    }
 }
 
 class ClasspathResourceConverter : IStringConverter<URL> {

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgsSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgsSpec.kt
@@ -121,4 +121,26 @@ internal class CliArgsSpec {
             assertThat(spec.rulesSpec.activateAllRules).isTrue()
         }
     }
+
+    @Nested
+    inner class `type resolution parameters are accepted` {
+
+        @Test
+        fun `--jvm-target is accepted`() {
+            val spec = parseArguments(arrayOf("--jvm-target", "11")).toSpec()
+            assertThat(spec.compilerSpec.jvmTarget).isEqualTo("11")
+        }
+
+        @Test
+        fun `--jvm-target with decimal is accepted`() {
+            val spec = parseArguments(arrayOf("--jvm-target", "1.8")).toSpec()
+            assertThat(spec.compilerSpec.jvmTarget).isEqualTo("1.8")
+        }
+
+        @Test
+        fun `--language-version is accepted`() {
+            val spec = parseArguments(arrayOf("--language-version", "1.6")).toSpec()
+            assertThat(spec.compilerSpec.languageVersion).isEqualTo("1.6")
+        }
+    }
 }

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektJvmSpec.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektJvmSpec.kt
@@ -26,6 +26,10 @@ class DetektJvmSpec {
                     reports.txt.required.set(false)
                 }
             }
+            tasks.named("detektTest", Detekt::class.java) {
+                it.jvmTarget = "1.8"
+                it.languageVersion = "1.6"
+            }
         },
     ).also(DslGradleRunner::setupProject)
 
@@ -41,6 +45,8 @@ class DetektJvmSpec {
         assertThat(argumentString).contains("--report sarif:")
         assertThat(argumentString).doesNotContain("--report txt:")
         assertThat(argumentString).contains("--classpath")
+        assertThat(argumentString).doesNotContain("--jvm-target")
+        assertThat(argumentString).doesNotContain("--language-version")
     }
 
     @Test
@@ -55,5 +61,7 @@ class DetektJvmSpec {
         assertThat(argumentString).contains("--report sarif:")
         assertThat(argumentString).doesNotContain("--report txt:")
         assertThat(argumentString).contains("--classpath")
+        assertThat(argumentString).contains("--jvm-target 1.8")
+        assertThat(argumentString).contains("--language-version 1.6")
     }
 }


### PR DESCRIPTION
Tests added to show that correctly formatted strings provided on the CLI are parsed as expected, and that the Gradle plugin maps the `jvmTarget` and `languageVersion` properties to those CLI flags as expected.

I've also improved the error message provided by the CLI when these flags cannot be parsed which should help narrow down issues.