### PR TITLE
ExplicitCollectionElementAccessMethod: fix false positive for get operators with type parameters

### DIFF
--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitCollectionElementAccessMethod.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitCollectionElementAccessMethod.kt
@@ -57,8 +57,11 @@ class ExplicitCollectionElementAccessMethod(config: Config = Config.empty) : Rul
         }
     }
 
-    private fun isIndexableGetter(expression: KtCallExpression): Boolean =
-        expression.calleeExpression?.text == "get" && expression.getFunctionDescriptor()?.isOperator == true
+    private fun isIndexableGetter(expression: KtCallExpression): Boolean {
+        if (expression.calleeExpression?.text != "get") return false
+        val descriptor = expression.getFunctionDescriptor() ?: return false
+        return descriptor.isOperator && descriptor.typeParameters.isEmpty()
+    }
 
     private fun isIndexableSetter(expression: KtCallExpression): Boolean =
         when (expression.calleeExpression?.text) {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitCollectionElementAccessMethodSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitCollectionElementAccessMethodSpec.kt
@@ -347,6 +347,19 @@ class ExplicitCollectionElementAccessMethodSpec(val env: KotlinCoreEnvironment) 
             """
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
+
+        @Test
+        fun `does not report custom get operator with type parameters`() {
+            val code = """
+                class C {
+                    operator fun <T> get(key: String): List<T>? = null
+                }
+                fun test(c: C) {
+                    c.get<Int>("key")
+                }
+            """
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        }
     }
 
     @Nested


### PR DESCRIPTION
Fix for #4791