### PR TITLE
Fix wrong replacement suggestion for UnnecessaryFilter

### DIFF
--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryFilter.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryFilter.kt
@@ -94,7 +94,7 @@ class UnnecessaryFilter(config: Config = Config.empty) : Rule(config) {
         )
 
         private val secondCalls = listOf(
-            SecondCall(FqName("kotlin.collections.List.size")),
+            SecondCall(FqName("kotlin.collections.List.size"), "count"),
             SecondCall(FqName("kotlin.collections.List.isEmpty"), "any"),
             SecondCall(FqName("kotlin.collections.isNotEmpty"), "none"),
             SecondCall(FqName("kotlin.collections.count")),

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryFilterSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryFilterSpec.kt
@@ -24,7 +24,7 @@ class UnnecessaryFilterSpec(val env: KotlinCoreEnvironment) {
 
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
-            assertThat(findings[0]).hasMessage("'filter { it > 1 }' can be replaced by 'size { it > 1 }'")
+            assertThat(findings[0]).hasMessage("'filter { it > 1 }' can be replaced by 'count { it > 1 }'")
         }
 
         @Test


### PR DESCRIPTION
Fixes #4806 

size is a property/member, not a method/function, and does not take any inputs.