### PR TITLE
Revert "Display dynamic --jvm-target values when using --help flag (#4694)"

### DIFF
--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/ArgumentConverters.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/ArgumentConverters.kt
@@ -2,7 +2,6 @@ package io.gitlab.arturbosch.detekt.cli
 
 import com.beust.jcommander.IStringConverter
 import com.beust.jcommander.ParameterException
-import org.jetbrains.kotlin.config.JvmTarget
 import org.jetbrains.kotlin.config.LanguageVersion
 import java.io.File
 import java.net.URL
@@ -51,15 +50,6 @@ class LanguageVersionConverter : IStringConverter<LanguageVersion> {
         val validValues by lazy { LanguageVersion.values().joinToString { it.versionString } }
         return requireNotNull(LanguageVersion.fromFullVersionString(value)) {
             "\"$value\" passed to --language-version, expected one of [$validValues]"
-        }
-    }
-}
-
-class JvmTargetConverter : IStringConverter<JvmTarget> {
-    override fun convert(value: String): JvmTarget {
-        val validValues by lazy { JvmTarget.values().joinToString { it.description } }
-        return requireNotNull(JvmTarget.fromString(value)) {
-            "\"$value\" passed to --jvm-target, expected one of [$validValues]"
         }
     }
 }

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt
@@ -188,11 +188,10 @@ class CliArgs {
 
     @Parameter(
         names = ["--jvm-target"],
-        converter = JvmTargetConverter::class,
         description = "EXPERIMENTAL: Target version of the generated JVM bytecode that was generated during " +
-            "compilation and is now being used for type resolution"
+            "compilation and is now being used for type resolution (1.6, 1.8, 9, 10, 11, 12, 13, 14, 15, 16 or 17)"
     )
-    var jvmTarget: JvmTarget = JvmTarget.DEFAULT
+    var jvmTarget: String = JvmTarget.DEFAULT.description
 
     @Parameter(
         names = ["--version"],

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Spec.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Spec.kt
@@ -65,7 +65,7 @@ internal fun CliArgs.createSpec(output: Appendable, error: Appendable): Processi
         }
 
         compiler {
-            jvmTarget = args.jvmTarget.toString()
+            jvmTarget = args.jvmTarget
             languageVersion = args.languageVersion?.versionString
             classpath = args.classpath?.trim()
         }


### PR DESCRIPTION
This reverts commit 7c903c56e0e19e4008abbdc6d931c25f3290827b.

Fixes #4786