### PR TITLE
False positive for unused imports #4815

### DIFF
--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedImports.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedImports.kt
@@ -115,14 +115,12 @@ class UnusedImports(config: Config) : Rule(config) {
         override fun visitDeclaration(dcl: KtDeclaration) {
             val kdoc = dcl.docComment?.getAllSections()
 
-            kdoc?.forEach {
-                it.getChildrenOfType<KDocTag>()
+            kdoc?.forEach { kdocSection ->
+                kdocSection.getChildrenOfType<KDocTag>()
                     .map { it.text }
                     .forEach { handleKDoc(it) }
 
-                it.getContent().let {
-                    handleKDoc(it)
-                }
+                handleKDoc(kdocSection.getContent())
             }
 
             super.visitDeclaration(dcl)

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedImports.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedImports.kt
@@ -113,15 +113,18 @@ class UnusedImports(config: Config) : Rule(config) {
         }
 
         override fun visitDeclaration(dcl: KtDeclaration) {
-            val kdoc = dcl.docComment?.getDefaultSection()
+            val kdoc = dcl.docComment?.getAllSections()
 
-            kdoc?.getChildrenOfType<KDocTag>()
-                ?.map { it.text }
-                ?.forEach { handleKDoc(it) }
+            kdoc?.forEach {
+                it.getChildrenOfType<KDocTag>()
+                    .map { it.text }
+                    .forEach { handleKDoc(it) }
 
-            kdoc?.getContent()?.let {
-                handleKDoc(it)
+                it.getContent().let {
+                    handleKDoc(it)
+                }
             }
+
             super.visitDeclaration(dcl)
         }
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedImportsSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedImportsSpec.kt
@@ -609,4 +609,29 @@ class UnusedImportsSpec(val env: KotlinCoreEnvironment) {
         """
         assertThat(subject.lintWithContext(env, mainFile, additionalFile)).isEmpty()
     }
+
+    @Test
+    fun `does not report unused import for import used in kdoc - #4815`() {
+        val mainFile = """
+        import x.y.z.SomeClass
+
+        class MyView
+
+        /**
+         * Style for [MyView]
+         * Blablabla
+         * 
+         * @property someVal Someval for [SomeClass]
+         */
+         data class StyleClass(val someVal: String)
+        """
+
+        val additionalFile = """
+        package x.y.z
+
+        class SomeClass
+        """
+
+        assertThat(subject.lintWithContext(env, mainFile, additionalFile)).isEmpty()
+    }
 }


### PR DESCRIPTION
Handle all kdoc sections in UnusedImports, not just the first one. The KDoc method getDefaultSection only gets the first section of the KDoc (text before an empty line). This fix now checks all sections/paragraphs of a KDoc instead.

Fixes #4815 