### PR TITLE
Set strict dependency on tested Kotlin compiler version

### DIFF
--- a/detekt-cli/build.gradle.kts
+++ b/detekt-cli/build.gradle.kts
@@ -16,6 +16,11 @@ dependencies {
     implementation(libs.jcommander)
     implementation(projects.detektTooling)
     implementation(projects.detektParser)
+    implementation(libs.kotlin.compilerEmbeddable) {
+        version {
+            strictly(libs.versions.kotlin.get())
+        }
+    }
     runtimeOnly(projects.detektCore)
     runtimeOnly(projects.detektRules)
 


### PR DESCRIPTION
This effectively pins the Kotlin compiler version used by detekt-cli, minimising the chance of it being overridden and causing issues such as #4786. The only alternative I can think of to this approach is using the shadowed/bundled JAR in the Gradle plugin, and only publishing that artifact of detekt-cli.

On the consumer side, the version can still be overridden, but only in specific configurations which a user would have to specifically go out of their way to use (and, given the only override on the consumer side requires use of a `strictly` version declaration, it should be respected).

On the consumer side, the version can be overridden with strictly applied versions (when this PR was authored, detekt-cli strictly depends on version 1.6.21):
```kotlin
// Downgrade attempt. Successful, Gradle uses 1.6.20
detekt("org.jetbrains.kotlin:kotlin-compiler-embeddable") {
    version {
        strictly("1.6.20")
    }
}

// Upgrade attempt. Successful, Gradle uses 1.7.0-Beta
detekt("org.jetbrains.kotlin:kotlin-compiler-embeddable") {
    version {
        strictly("1.7.0-Beta")
    }
}
```

When overriding the version using non-strictly applied versions, the version is unchanged, though upgrade attempts lead to [this error](https://ge.detekt.dev/s/o23fphpzqhnw2/failure#1):
```kotlin
// Downgrade attempt. No error, Gradle still uses 1.6.21
detekt("org.jetbrains.kotlin:kotlin-compiler-embeddable:1.6.20")

// Upgrade attempt. Gradle error "Cannot find a version of 'org.jetbrains.kotlin:kotlin-compiler-embeddable' that satisfies the version constraints"
detekt("org.jetbrains.kotlin:kotlin-compiler-embeddable:1.7.0-Beta")
```

There's more background [here](https://docs.gradle.org/current/userguide/rich_versions.html) and [here](https://docs.gradle.org/current/userguide/dependency_downgrade_and_exclude.html#sec:strict-version-consequences).