### PR TITLE
Improve exception message

### DIFF
--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Analyzer.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Analyzer.kt
@@ -153,13 +153,9 @@ private fun MutableMap<String, List<Finding>>.mergeSmells(other: Map<String, Lis
 }
 
 private fun throwIllegalStateException(file: KtFile, error: Throwable): Nothing {
-    val location = error.stackTrace.firstOrNull()?.let {
-        "${it.fileName} => ${it.className} => ${it.methodName} => ${it.lineNumber}."
-    } ?: "Unknown."
-
     val message = """
     Analyzing ${file.absolutePath()} led to an exception. 
-    Location: $location
+    Location: ${error.stackTrace.firstOrNull()?.toString()}
     The original exception message was: ${error.localizedMessage}
     Running detekt '${whichDetekt() ?: "unknown"}' on Java '${whichJava()}' on OS '${whichOS()}'
     If the exception message does not help, please feel free to create an issue on our GitHub page.

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Analyzer.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Analyzer.kt
@@ -153,8 +153,13 @@ private fun MutableMap<String, List<Finding>>.mergeSmells(other: Map<String, Lis
 }
 
 private fun throwIllegalStateException(file: KtFile, error: Throwable): Nothing {
+    val location = error.stackTrace.firstOrNull()?.let {
+        "${it.fileName} => ${it.className} => ${it.methodName} => ${it.lineNumber}."
+    } ?: "Unknown."
+
     val message = """
     Analyzing ${file.absolutePath()} led to an exception. 
+    Location: $location
     The original exception message was: ${error.localizedMessage}
     Running detekt '${whichDetekt() ?: "unknown"}' on Java '${whichJava()}' on OS '${whichOS()}'
     If the exception message does not help, please feel free to create an issue on our GitHub page.

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/AnalyzerSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/AnalyzerSpec.kt
@@ -98,7 +98,7 @@ class AnalyzerSpec {
 
             assertThatThrownBy { settings.use { analyzer.run(listOf(compileForTest(testFile))) } }
                 .hasCauseInstanceOf(IllegalStateException::class.java)
-                .hasMessageContaining(FaultyRule::class.java.name)
+                .hasMessageContaining("Location: ${FaultyRule::class.java.name}")
         }
 
         @Test
@@ -112,7 +112,7 @@ class AnalyzerSpec {
 
             assertThatThrownBy { settings.use { analyzer.run(listOf(compileForTest(testFile))) } }
                 .hasCauseInstanceOf(IllegalStateException::class.java)
-                .hasMessageContaining("Unknown.")
+                .hasMessageContaining("Location: ${null}")
         }
     }
 }

--- a/detekt-core/src/test/resources/configs/config-value-type-correct.yml
+++ b/detekt-core/src/test/resources/configs/config-value-type-correct.yml
@@ -4,4 +4,5 @@ style:
     maxLineLength: 120
   FaultyRule:
     active: true
-    isStacktraceEmpty: false
+  FaultyRuleNoStackTrace:
+    active: true

--- a/detekt-core/src/test/resources/configs/config-value-type-correct.yml
+++ b/detekt-core/src/test/resources/configs/config-value-type-correct.yml
@@ -2,3 +2,5 @@ style:
   MaxLineLength:
     active: true
     maxLineLength: 120
+  FaultyRule:
+    active: true

--- a/detekt-core/src/test/resources/configs/config-value-type-correct.yml
+++ b/detekt-core/src/test/resources/configs/config-value-type-correct.yml
@@ -4,3 +4,4 @@ style:
     maxLineLength: 120
   FaultyRule:
     active: true
+    isStacktraceEmpty: false


### PR DESCRIPTION
For #4615 
Report detailed location of an error using first stack trace element.

> Analyzing /Users/vvp/IdeaProjects/detekt/detekt-core/build/resources/test/cases/Test.kt led to an exception. 
> Location: AnalyzerSpec.kt => io.gitlab.arturbosch.detekt.core.FaultyRule => visitKtFile => 132.
> The original exception message was: Deliberately triggered error.
> Running detekt '1.20.0' on Java '1.8.0_332-b08' on OS 'Mac OS X'
> If the exception message does not help, please feel free to create an issue on our GitHub page.