### PR TITLE
Search in all versions.properties, not just the first one #4830

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
@@ -107,9 +107,9 @@ open class DetektExtension @Inject constructor(objects: ObjectFactory) : CodeQua
     }
 }
 
-internal fun loadDetektVersion(classLoader: ClassLoader): String =
+internal fun loadDetektVersion(classLoader: ClassLoader): String {
     // Other Gradle plugins can also have a versions.properties.
-    classLoader.getResources("versions.properties").toList().mapNotNull { versions ->
+    val distinctVersions = classLoader.getResources("versions.properties").toList().mapNotNull { versions ->
         Properties().run {
             val inputStream = versions.openConnection()
                 /*
@@ -124,4 +124,9 @@ internal fun loadDetektVersion(classLoader: ClassLoader): String =
             load(inputStream)
             getProperty("detektVersion")
         }
-    }.distinct().single()
+    }.distinct()
+    return distinctVersions.singleOrNull() ?: error(
+        "You're importing two Detekt plugins which have different versions. " +
+            "(${distinctVersions.joinToString()}) Make sure to align the versions."
+    )
+}


### PR DESCRIPTION
See details in #4830 about the issue. 

This searches all resources in the Gradle classpath for `versions.properties` instead of using the first one.
It will fail if there are more than one `versions.properties` with different `detektVersion`s.

I considered another approach where the `::class.java.protectionDomain.codeSource?.location` was used to locate the current jarfile, and pick the right resource based on that. But I was less confident that would work in all environments, as it depended on more low-level classpath details.