### PR TITLE
include kotlinx imports in ImportOrdering IDEA list

### DIFF
--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/ImportOrdering.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/ImportOrdering.kt
@@ -32,6 +32,6 @@ class ImportOrdering(config: Config) : FormattingRule(config) {
 
     companion object {
         const val ASCII_PATTERN = "*"
-        const val IDEA_PATTERN = "*,java.**,javax.**,kotlin.**,^"
+        const val IDEA_PATTERN = "*,java.**,javax.**,kotlin.**,kotlinx.**,^"
     }
 }


### PR DESCRIPTION
IDEA applies special ordering rule (end of import block) for `java`, `javax`, `kotlin`, and `kotlinx` imports. Currently, the ImportOrdering rule is missing `kotlinx` from it's IDEA list, so this PR adds it.