### PR TITLE
detektGenerateConfig adds the configuration of plugins

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektGenerateConfigTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektGenerateConfigTask.kt
@@ -36,6 +36,9 @@ open class DetektGenerateConfigTask @Inject constructor(
     @get:Classpath
     val detektClasspath: ConfigurableFileCollection = project.objects.fileCollection()
 
+    @get:Classpath
+    val pluginClasspath: ConfigurableFileCollection = objects.fileCollection()
+
     @get:InputFiles
     @get:Optional
     @get:PathSensitive(PathSensitivity.RELATIVE)
@@ -70,7 +73,7 @@ open class DetektGenerateConfigTask @Inject constructor(
 
         DetektInvoker.create(task = this, isDryRun = isDryRun).invokeCli(
             arguments = arguments.get(),
-            classpath = detektClasspath,
+            classpath = detektClasspath.plus(pluginClasspath),
             taskName = name,
         )
     }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
@@ -97,6 +97,7 @@ class DetektPlugin : Plugin<Project> {
 
         project.tasks.withType(DetektGenerateConfigTask::class.java).configureEach {
             it.detektClasspath.setFrom(project.configurations.getAt(CONFIGURATION_DETEKT))
+            it.pluginClasspath.setFrom(project.configurations.getAt(CONFIGURATION_DETEKT_PLUGINS))
         }
     }
 


### PR DESCRIPTION
I don't know how to unit-test this. Any guidance here is more than welcome.

The problem was that we were not passing the information about the configured plugins to the cli when we were using executing `detektGenerateConfig`.

Fix #4812