### PR TITLE
Use standard notation to apply Gradle Enterprise Gradle Plugin

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -41,7 +41,7 @@ enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 // build scan plugin can only be applied in settings file
 plugins {
     // check https://gradle.com/enterprise/releases with new versions. GE plugin version should not lag behind Gradle version
-    `gradle-enterprise` version "3.10"
+    id("com.gradle.enterprise") version "3.10"
     id("com.gradle.common-custom-user-data-gradle-plugin") version "1.6.6"
 }
 


### PR DESCRIPTION
In theory, this will allow Renovate to issue PRs to update the version automatically, even in the settings.gradle.kts file, as in #4842.

We should merge this, then let's see if Renovate creates a PR to update to 3.10.1, and can take care of updates moving forward.