### PR TITLE
UnnecessaryInnerClass: add test for safe qualified expressions

### DIFF
--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryInnerClassSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryInnerClassSpec.kt
@@ -275,6 +275,23 @@ class UnnecessaryInnerClassSpec(val env: KotlinCoreEnvironment) {
         }
 
         @Test
+        fun `as a safe qualified expression`() {
+            val code = """
+                class A {
+                    var foo: String? = null
+
+                    inner class B {
+                        fun fooLength() {
+                            foo?.length
+                        }
+                    }
+                }
+            """.trimIndent()
+
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
+        }
+
+        @Test
         fun `to call a function of the member`() {
             val code = """
                 class FooClass {


### PR DESCRIPTION
Add a unit test for a bug in which safe qualified references to a nullable field
in the parent class (i.e. as `?.`) would not be marked as warnings in release
1.20.0. This issue has been inadvertently fixed by
https://github.com/detekt/detekt/pull/4738, but adding a unit test will guard
against future regressions.

I was able to confirm this test fails by checking out the 1.20.0 tag and running
the unit test; against that tag the fix was to override the
visitSafeQualifiedExpression() function with the same logic as
visitCallExpression().