### PR TITLE
UnnecessaryInnerClass: fix false positives labeled expression to outer class

### DIFF
--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryInnerClassSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryInnerClassSpec.kt
@@ -382,4 +382,34 @@ class UnnecessaryInnerClassSpec(val env: KotlinCoreEnvironment) {
 
         assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
+
+    @Test
+    fun `does not report labeled expressions to outer class`() {
+        val code = """
+            class A {
+                inner class B {
+                    fun outer(): A {
+                        return this@A
+                    }
+                }
+            }
+        """.trimIndent()
+
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
+    }
+
+    @Test
+    fun `reports irrelevant labeled expressions`() {
+        val code = """
+            class A {
+                inner class B {
+                    fun inner() {
+                        return Unit.apply { this@inner }
+                    }
+                }
+            }
+        """.trimIndent()
+
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
+    }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryInnerClassSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryInnerClassSpec.kt
@@ -356,6 +356,23 @@ class UnnecessaryInnerClassSpec(val env: KotlinCoreEnvironment) {
 
             assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
+
+        @Test
+        fun `when the innermost class refers the outermost class via a labeled expression`() {
+            val code = """
+                class A {
+                    inner class B {
+                        inner class C {
+                            fun outer(): A {
+                                return this@A
+                            }
+                        }
+                    }
+                }
+            """.trimIndent()
+
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
+        }
     }
 
     @Test


### PR DESCRIPTION
Fix an issue where inner classes which reference their outer class via a labeled
expression would still be reported as unnecessary. This seems to be due to a
missing visitExpressionWithLabel() check which resolves the label name: if the
label is referencing a parent class, then the nested class must be `inner`.

I wasn't able to find a way to resolve the labeled expression as a ClassId to
match the existing class check from KtReferenceExpression, so I settled for
using the class name instead, which is easy to obtain. This means there's a fair
bit of duplication in overriden checkForOuterUsage() methods to check parent
classes which could probably be removed, but I didn't see a particularly clean
way to do so.