### PR TITLE
UnusedImports: fix false positive for unresolved imports

### DIFF
--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedImportsSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedImportsSpec.kt
@@ -634,4 +634,36 @@ class UnusedImportsSpec(val env: KotlinCoreEnvironment) {
 
         assertThat(subject.lintWithContext(env, mainFile, additionalFile)).isEmpty()
     }
+
+    @Test
+    fun `does not report imports which detekt cannot resolve but have string matches`() {
+        val mainFile = """
+        import x.y.z.foo
+        import x.y.z.Bar
+
+        fun test() {
+            foo()
+            foo("", 123)
+            foo
+
+            Bar().baz()
+        }
+        """
+
+        assertThat(subject.lintWithContext(env, mainFile)).isEmpty()
+    }
+
+    @Test
+    fun `reports imports which detekt cannot resolve and do not have string matches`() {
+        val mainFile = """
+        import x.y.z.foo
+        import x.y.z.Bar
+
+        fun test() {
+            2 + 3
+        }
+        """
+
+        assertThat(subject.lintWithContext(env, mainFile)).hasSize(2)
+    }
 }


### PR DESCRIPTION
Fix a false positive where UnusedImports would report extension function imports whose signature cannot be resolved by the BindingContext. This can happen for autogenerated classes, etc. (especially Android UI binding classes and the like).

To do this we need to generate text matchers for all the references which cannot be resolved and check if there are any unresolved matches to them, similar to the approach without type resolution.

Along the way, extract mappings inside `KtImportDirective.isNotUsed()` to lazy properties to avoid recalculating them for each import directive. Also make sure to map to a set for constant rather than linear lookup time.