### PR TITLE
Declare nested test classes as non-static

### DIFF
--- a/detekt-psi-utils/src/test/kotlin/io/github/detekt/psi/internal/FullQualifiedNameGuesserSpec.kt
+++ b/detekt-psi-utils/src/test/kotlin/io/github/detekt/psi/internal/FullQualifiedNameGuesserSpec.kt
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test
 class FullQualifiedNameGuesserSpec {
 
     @Nested
-    class `With package` {
+    inner class `With package` {
         private val sut = FullQualifiedNameGuesser(
             compileContentForTest(
                 """
@@ -75,7 +75,7 @@ class FullQualifiedNameGuesserSpec {
     }
 
     @Nested
-    class `Without package` {
+    inner class `Without package` {
         private val sut = FullQualifiedNameGuesser(compileContentForTest("import kotlin.jvm.JvmField"))
 
         @Test


### PR DESCRIPTION
The @Nested annotation cannot be used on static classes.
