### PR TITLE
Correct the Rules Documentation label on the website

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,6 +163,6 @@ target/
 !gradle-wrapper.jar
 
 # Avoid committing generated documentation to the repo
-/website/docs/rules
+/website/docs/rules/*.md
 /website/static/kdoc
 /website/docs/gettingstarted/_cli-options.md

--- a/website/docs/rules/_category_.json
+++ b/website/docs/rules/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Rules Documentation",
+  "position": 4
+}


### PR DESCRIPTION
We currently show just "rules" on the Navbar on the website for the generated rules. 
I'm fixing it to be "Rules Documentation"

![Screenshot 2022-06-02 at 16 41 07](https://user-images.githubusercontent.com/3001957/171667557-b896f74c-8b7d-4314-a0b9-9acd9e978b1e.png)
