### PR TITLE
Run functionalTest on MavenLocal

### DIFF
--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -51,10 +51,6 @@ jobs:
       uses: gradle/gradle-build-action@v2
       with:
         arguments: :detekt-cli:runWithArgsFile
-    - name: Try to publish to Maven Local
-      uses: gradle/gradle-build-action@v2
-      with:
-        arguments: publishToMavenLocal
 
   verify-generated-config-file:
     if: ${{ !contains(github.event.head_commit.message, 'ci skip') }}

--- a/build-logic/src/main/kotlin/Versions.kt
+++ b/build-logic/src/main/kotlin/Versions.kt
@@ -1,6 +1,6 @@
 object Versions {
 
-    const val DETEKT: String = "1.21.0-RC1"
+    const val DETEKT: String = "1.21.0-RC2"
     const val SNAPSHOT_NAME: String = "main"
     const val JVM_TARGET: String = "1.8"
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -118,5 +118,7 @@ val detektProjectBaseline by tasks.registering(DetektCreateBaselineTask::class) 
 }
 
 tasks.register("build") {
+    dependsOn("publishToMavenLocal")
+    dependsOn(gradle.includedBuild("detekt-gradle-plugin").task(":publishToMavenLocal"))
     dependsOn(gradle.includedBuild("detekt-gradle-plugin").task(":build"))
 }


### PR DESCRIPTION
This tries to address the problem I had in #4900 

Essentially, our Gradle Plugin tests are currently running by fetching `detekt-cli` from Maven Central/Local. The problem is that once I bump the version and `publishToMavenLocal` during the release process, I'm effectivelly exposed to all the tests failures that got never reported on `main` as we're using a older version of `detekt-cli`.

With this PR, I'm bumping the version to use the "next", and forcing the `build` task to depend on `publishToMavenLocal`. This will make sure the Gradle Plugin tests on CI are effectively running on a locally crafted version of detekt-cli.

I agree that this is not idea, as we should instead inject the class-path, but this is better than the status quo. Looking for opinions.

To reproduce this:
* Add the `@ActiveByDefault` to the `MissingPackageDeclaration` rule 
* Verify that tests are actually failing inside the Gradle Plugin
* Previously they were not (that's how #4875 got merged)
