### PR TITLE
Add option to add a reason to `ForbiddenImport`

### DIFF
--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenImport.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenImport.kt
@@ -18,7 +18,6 @@ import org.jetbrains.kotlin.psi.KtImportDirective
  * or deprecated APIs. Detekt will then report all imports that are forbidden.
  *
  * <noncompliant>
- * package foo
  * import kotlin.jvm.JvmField
  * import kotlin.SinceKotlin
  * </noncompliant>

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenImport.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenImport.kt
@@ -69,4 +69,4 @@ class ForbiddenImport(config: Config = Config.empty) : Rule(config) {
         forbiddenPatterns.pattern.isNotEmpty() && forbiddenPatterns.containsMatchIn(import)
 }
 
-private class Forbidden(val import: Regex, val reason: String?)
+private data class Forbidden(val import: Regex, val reason: String?)

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenImport.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenImport.kt
@@ -49,8 +49,7 @@ class ForbiddenImport(config: Config = Config.empty) : Rule(config) {
                 CodeSmell(
                     issue,
                     Entity.from(importDirective),
-                    "The import " +
-                        "$import has been forbidden in the Detekt config."
+                    "The import `$import` has been forbidden in the Detekt config."
                 )
             )
         }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenImportSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenImportSpec.kt
@@ -1,7 +1,9 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.gitlab.arturbosch.detekt.api.ValueWithReason
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.lint
+import io.gitlab.arturbosch.detekt.test.toConfig
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -48,6 +50,18 @@ class ForbiddenImportSpec {
             .isEqualTo("The import `kotlin.jvm.JvmField` has been forbidden in the Detekt config.")
         assertThat(findings[1].message)
             .isEqualTo("The import `kotlin.SinceKotlin` has been forbidden in the Detekt config.")
+    }
+
+    @Test
+    @DisplayName("should report kotlin.* when imports are kotlin.* with reasons")
+    fun reportKotlinWildcardImports2() {
+        val config = TestConfig(mapOf(IMPORTS to listOf(ValueWithReason("kotlin.*", "I'm just joking!").toConfig())))
+        val findings = ForbiddenImport(config).lint(code)
+        assertThat(findings).hasSize(2)
+        assertThat(findings[0].message)
+            .isEqualTo("The import `kotlin.jvm.JvmField` has been forbidden: I'm just joking!")
+        assertThat(findings[1].message)
+            .isEqualTo("The import `kotlin.SinceKotlin` has been forbidden: I'm just joking!")
     }
 
     @Test

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenImportSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenImportSpec.kt
@@ -45,9 +45,9 @@ class ForbiddenImportSpec {
         val findings = ForbiddenImport(TestConfig(mapOf(IMPORTS to listOf("kotlin.*")))).lint(code)
         assertThat(findings).hasSize(2)
         assertThat(findings[0].message)
-            .isEqualTo("The import kotlin.jvm.JvmField has been forbidden in the Detekt config.")
+            .isEqualTo("The import `kotlin.jvm.JvmField` has been forbidden in the Detekt config.")
         assertThat(findings[1].message)
-            .isEqualTo("The import kotlin.SinceKotlin has been forbidden in the Detekt config.")
+            .isEqualTo("The import `kotlin.SinceKotlin` has been forbidden in the Detekt config.")
     }
 
     @Test
@@ -116,8 +116,8 @@ class ForbiddenImportSpec {
             ForbiddenImport(TestConfig(mapOf(FORBIDDEN_PATTERNS to "net.*R|com.*expiremental"))).lint(code)
         assertThat(findings).hasSize(2)
         assertThat(findings[0].message)
-            .isEqualTo("The import net.example.R.dimen has been forbidden in the Detekt config.")
+            .isEqualTo("The import `net.example.R.dimen` has been forbidden in the Detekt config.")
         assertThat(findings[1].message)
-            .isEqualTo("The import net.example.R.dimension has been forbidden in the Detekt config.")
+            .isEqualTo("The import `net.example.R.dimension` has been forbidden in the Detekt config.")
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenImportSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenImportSpec.kt
@@ -29,38 +29,41 @@ class ForbiddenImportSpec {
 
     @Test
     fun `should report nothing when imports are blank`() {
-        val findings = ForbiddenImport(TestConfig(mapOf(IMPORTS to "  "))).lint(code)
+        val findings = ForbiddenImport(TestConfig(mapOf(IMPORTS to listOf("  ")))).lint(code)
         assertThat(findings).isEmpty()
     }
 
     @Test
     fun `should report nothing when imports do not match`() {
-        val findings = ForbiddenImport(TestConfig(mapOf(IMPORTS to "org.*"))).lint(code)
+        val findings = ForbiddenImport(TestConfig(mapOf(IMPORTS to listOf("org.*")))).lint(code)
         assertThat(findings).isEmpty()
     }
 
     @Test
     @DisplayName("should report kotlin.* when imports are kotlin.*")
     fun reportKotlinWildcardImports() {
-        val findings = ForbiddenImport(TestConfig(mapOf(IMPORTS to "kotlin.*"))).lint(code)
+        val findings = ForbiddenImport(TestConfig(mapOf(IMPORTS to listOf("kotlin.*")))).lint(code)
         assertThat(findings).hasSize(2)
+        assertThat(findings[0].message)
+            .isEqualTo("The import kotlin.jvm.JvmField has been forbidden in the Detekt config.")
+        assertThat(findings[1].message)
+            .isEqualTo("The import kotlin.SinceKotlin has been forbidden in the Detekt config.")
     }
 
     @Test
     @DisplayName("should report kotlin.SinceKotlin when specified via fully qualified name")
     fun reportKotlinSinceKotlinWhenFqdnSpecified() {
-        val findings =
-            ForbiddenImport(TestConfig(mapOf(IMPORTS to "kotlin.SinceKotlin"))).lint(code)
-        assertThat(findings).hasSize(1)
+        val findings = ForbiddenImport(TestConfig(mapOf(IMPORTS to listOf("kotlin.SinceKotlin")))).lint(code)
+        assertThat(findings)
+            .hasSize(1)
     }
 
     @Test
     @DisplayName("should report kotlin.SinceKotlin and kotlin.jvm.JvmField when specified via fully qualified names")
     fun reportMultipleConfiguredImportsCommaSeparated() {
         val findings =
-            ForbiddenImport(TestConfig(mapOf(IMPORTS to "kotlin.SinceKotlin,kotlin.jvm.JvmField"))).lint(
-                code
-            )
+            ForbiddenImport(TestConfig(mapOf(IMPORTS to listOf("kotlin.SinceKotlin", "kotlin.jvm.JvmField"))))
+                .lint(code)
         assertThat(findings).hasSize(2)
     }
 
@@ -81,14 +84,14 @@ class ForbiddenImportSpec {
     @Test
     @DisplayName("should report kotlin.SinceKotlin when specified via kotlin.Since*")
     fun reportsKotlinSinceKotlinWhenSpecifiedWithWildcard() {
-        val findings = ForbiddenImport(TestConfig(mapOf(IMPORTS to "kotlin.Since*"))).lint(code)
+        val findings = ForbiddenImport(TestConfig(mapOf(IMPORTS to listOf("kotlin.Since*")))).lint(code)
         assertThat(findings).hasSize(1)
     }
 
     @Test
     @DisplayName("should report all of com.example.R.string, net.example.R.dimen, and net.example.R.dimension")
     fun preAndPostWildcard() {
-        val findings = ForbiddenImport(TestConfig(mapOf(IMPORTS to "*.R.*"))).lint(code)
+        val findings = ForbiddenImport(TestConfig(mapOf(IMPORTS to listOf("*.R.*")))).lint(code)
         assertThat(findings).hasSize(3)
     }
 
@@ -96,7 +99,7 @@ class ForbiddenImportSpec {
     @DisplayName("should report net.example.R.dimen but not net.example.R.dimension")
     fun doNotReportSubstringOfFqdn() {
         val findings =
-            ForbiddenImport(TestConfig(mapOf(IMPORTS to "net.example.R.dimen"))).lint(code)
+            ForbiddenImport(TestConfig(mapOf(IMPORTS to listOf("net.example.R.dimen")))).lint(code)
         assertThat(findings).hasSize(1)
     }
 
@@ -112,5 +115,9 @@ class ForbiddenImportSpec {
         val findings =
             ForbiddenImport(TestConfig(mapOf(FORBIDDEN_PATTERNS to "net.*R|com.*expiremental"))).lint(code)
         assertThat(findings).hasSize(2)
+        assertThat(findings[0].message)
+            .isEqualTo("The import net.example.R.dimen has been forbidden in the Detekt config.")
+        assertThat(findings[1].message)
+            .isEqualTo("The import net.example.R.dimension has been forbidden in the Detekt config.")
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenImportSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenImportSpec.kt
@@ -45,11 +45,12 @@ class ForbiddenImportSpec {
     @DisplayName("should report kotlin.* when imports are kotlin.*")
     fun reportKotlinWildcardImports() {
         val findings = ForbiddenImport(TestConfig(mapOf(IMPORTS to listOf("kotlin.*")))).lint(code)
-        assertThat(findings).hasSize(2)
-        assertThat(findings[0].message)
-            .isEqualTo("The import `kotlin.jvm.JvmField` has been forbidden in the Detekt config.")
-        assertThat(findings[1].message)
-            .isEqualTo("The import `kotlin.SinceKotlin` has been forbidden in the Detekt config.")
+        assertThat(findings)
+            .extracting("message")
+            .containsExactlyInAnyOrder(
+                "The import `kotlin.jvm.JvmField` has been forbidden in the Detekt config.",
+                "The import `kotlin.SinceKotlin` has been forbidden in the Detekt config.",
+            )
     }
 
     @Test

--- a/detekt-test/api/detekt-test.api
+++ b/detekt-test/api/detekt-test.api
@@ -55,6 +55,10 @@ public final class io/gitlab/arturbosch/detekt/test/TestConfig$Companion {
 	public final fun invoke ([Lkotlin/Pair;)Lio/gitlab/arturbosch/detekt/test/TestConfig;
 }
 
+public final class io/gitlab/arturbosch/detekt/test/TestConfigKt {
+	public static final fun toConfig (Lio/gitlab/arturbosch/detekt/api/ValueWithReason;)Ljava/util/Map;
+}
+
 public final class io/gitlab/arturbosch/detekt/test/ThresholdedCodeSmellAssert : org/assertj/core/api/AbstractAssert {
 	public fun <init> (Lio/gitlab/arturbosch/detekt/api/ThresholdedCodeSmell;)V
 	public final fun hasThreshold (I)V

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/TestConfig.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/TestConfig.kt
@@ -1,6 +1,7 @@
 package io.gitlab.arturbosch.detekt.test
 
 import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.ValueWithReason
 import io.gitlab.arturbosch.detekt.core.config.tryParseBasedOnDefault
 import io.gitlab.arturbosch.detekt.core.config.valueOrDefaultInternal
 
@@ -52,4 +53,8 @@ open class TestConfig(
     companion object {
         operator fun invoke(vararg pairs: Pair<String, Any>) = TestConfig(mapOf(*pairs))
     }
+}
+
+fun ValueWithReason.toConfig(): Map<String, String?> {
+    return mapOf("value" to value, "reason" to reason)
 }


### PR DESCRIPTION
I'm really happy to be able to introduce this feature :). Thanks @marschwar for creating the necesary tooling to be able to implement it.

Important: This introduces a breaking change in `ForbiddenImport`. It no longer allows comma-separated imports as a String. It should use yml lists. I'm targetting this to `1.22.0` because on `1.21.0` we added make that all those usages will be a warning. Tell me is we should be more conservative.

The reason that this is a draft is just to avoid accidental merges. But the code should be ready to merge.

Related with #3501