### PR TITLE
`IgnoredReturnValue`: add option `returnValueTypes` to enable rule for particular types

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -431,7 +431,7 @@ potential-bugs:
     active: true
   IgnoredReturnValue:
     active: true
-    restrictToAnnotatedMethods: true
+    restrictToConfig: true
     returnValueAnnotations:
       - '*.CheckResult'
       - '*.CheckReturnValue'

--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -437,6 +437,10 @@ potential-bugs:
       - '*.CheckReturnValue'
     ignoreReturnValueAnnotations:
       - '*.CanIgnoreReturnValue'
+    returnValueTypes:
+      - 'kotlin.sequences.Sequence'
+      - 'kotlinx.coroutines.flow.*Flow'
+      - 'java.util.stream.*Stream'
     ignoreFunctionCall: []
   ImplicitDefaultLocale:
     active: true

--- a/detekt-core/src/main/resources/deprecation.properties
+++ b/detekt-core/src/main/resources/deprecation.properties
@@ -1,5 +1,6 @@
 complexity>LongParameterList>threshold=Use `functionThreshold` and `constructorThreshold` instead
 empty-blocks>EmptyFunctionBlock>ignoreOverriddenFunctions=Use `ignoreOverridden` instead
+potential-bugs>IgnoredReturnValue>restrictToAnnotatedMethods=Use `restrictToConfig` instead
 potential-bugs>LateinitUsage>excludeAnnotatedProperties=Use `ignoreAnnotated` instead
 naming>FunctionParameterNaming>ignoreOverriddenFunctions=Use `ignoreOverridden` instead
 naming>MemberNameEqualsClassName>ignoreOverriddenFunction=Use `ignoreOverridden` instead

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValue.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValue.kt
@@ -8,7 +8,9 @@ import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.UnstableApi
 import io.gitlab.arturbosch.detekt.api.config
+import io.gitlab.arturbosch.detekt.api.configWithFallback
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
 import io.gitlab.arturbosch.detekt.api.internal.Configuration
 import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
@@ -52,7 +54,13 @@ class IgnoredReturnValue(config: Config = Config.empty) : Rule(config) {
     )
 
     @Configuration("if the rule should check only annotated methods")
+    @Deprecated("Use `restrictToConfig` instead")
     private val restrictToAnnotatedMethods: Boolean by config(defaultValue = true)
+
+    @Suppress("DEPRECATION")
+    @OptIn(UnstableApi::class)
+    @Configuration("If the rule should check only methods matching to configuration, or all methods")
+    private val restrictToConfig: Boolean by configWithFallback(::restrictToAnnotatedMethods, defaultValue = true)
 
     @Configuration("List of glob patterns to be used as inspection annotation")
     private val returnValueAnnotations: List<Regex> by config(listOf("*.CheckResult", "*.CheckReturnValue")) {
@@ -98,7 +106,7 @@ class IgnoredReturnValue(config: Config = Config.empty) : Rule(config) {
 
         val annotations = resultingDescriptor.annotations
         if (annotations.any { it in ignoreReturnValueAnnotations }) return
-        if (restrictToAnnotatedMethods &&
+        if (restrictToConfig &&
             resultingDescriptor.returnType !in returnValueTypes &&
             (annotations + resultingDescriptor.containingDeclaration.annotations).none { it in returnValueAnnotations }
         ) return

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValueSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValueSpec.kt
@@ -771,8 +771,8 @@ class IgnoredReturnValueSpec(private val env: KotlinCoreEnvironment) {
     }
 
     @Nested
-    inner class `restrict to annotated methods config` {
-        val subject = IgnoredReturnValue(TestConfig(mapOf("restrictToAnnotatedMethods" to false)))
+    inner class `restrict to config` {
+        val subject = IgnoredReturnValue(TestConfig(mapOf("restrictToConfig" to false)))
 
         @Test
         fun `reports when a function is annotated with a custom annotation`() {
@@ -809,6 +809,25 @@ class IgnoredReturnValueSpec(private val env: KotlinCoreEnvironment) {
             assertThat(findings).hasSize(1)
             assertThat(findings).hasStartSourceLocation(4, 5)
             assertThat(findings[0]).hasMessage("The call listOfChecked is returning a value that is ignored.")
+        }
+
+        @Test
+        fun `reports when a function returns type that should not be ignored`() {
+            val code = """
+                import kotlinx.coroutines.flow.MutableStateFlow
+
+                fun flowOfChecked(value: String) = MutableStateFlow(value)
+
+                fun foo() : Int {
+                    flowOfChecked("hello")
+                    return 42
+                }
+            """
+            val findings = subject.compileAndLintWithContext(env, code)
+            assertThat(findings)
+                .singleElement()
+                .hasSourceLocation(6, 5)
+                .hasMessage("The call flowOfChecked is returning a value that is ignored.")
         }
 
         @Test
@@ -849,7 +868,7 @@ class IgnoredReturnValueSpec(private val env: KotlinCoreEnvironment) {
                 TestConfig(
                     mapOf(
                         "ignoreReturnValueAnnotations" to listOf("*.CustomIgnoreReturn"),
-                        "restrictToAnnotatedMethods" to false
+                        "restrictToConfig" to false
                     )
                 )
             )
@@ -873,7 +892,7 @@ class IgnoredReturnValueSpec(private val env: KotlinCoreEnvironment) {
                 TestConfig(
                     mapOf(
                         "ignoreFunctionCall" to listOf("foo.listOfChecked"),
-                        "restrictToAnnotatedMethods" to false
+                        "restrictToConfig" to false
                     )
                 )
             )

--- a/detekt-test/api/detekt-test.api
+++ b/detekt-test/api/detekt-test.api
@@ -2,6 +2,7 @@ public final class io/gitlab/arturbosch/detekt/test/FindingAssert : org/assertj/
 	public fun <init> (Lio/gitlab/arturbosch/detekt/api/Finding;)V
 	public final fun getActual ()Lio/gitlab/arturbosch/detekt/api/Finding;
 	public final fun hasMessage (Ljava/lang/String;)Lio/gitlab/arturbosch/detekt/test/FindingAssert;
+	public final fun hasSourceLocation (II)Lio/gitlab/arturbosch/detekt/test/FindingAssert;
 }
 
 public final class io/gitlab/arturbosch/detekt/test/FindingsAssert : org/assertj/core/api/AbstractListAssert {

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/FindingsAssertions.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/FindingsAssertions.kt
@@ -117,6 +117,15 @@ class FindingsAssert(actual: List<Finding>) :
 }
 
 class FindingAssert(val actual: Finding?) : AbstractAssert<FindingAssert, Finding>(actual, FindingAssert::class.java) {
+
+    fun hasSourceLocation(line: Int, column: Int) = apply {
+        val expectedLocation = SourceLocation(line, column)
+        val actualLocation = actual.location.source
+        if (actualLocation != expectedLocation) {
+            failWithMessage("Expected source location to be $expectedLocation but was $actualLocation")
+        }
+    }
+
     fun hasMessage(expectedMessage: String) = apply {
         if (expectedMessage.isNotBlank() && actual.message.isBlank()) {
             failWithMessage("Expected message <$expectedMessage> but finding has no message")


### PR DESCRIPTION
> @BraisGabin said:
> We could extend IgnoredReturnValue and make it receive a list of types from the configuration. The rule will flag any call to a function that returns one of those types if the returned is ignored.

This PR adds config option `returnValueTypes` (is this option name OK?) to make it possible to enable the rule for functions returning specified types.
Also, I've added `kotlinx.coroutines.flow.Flow` to the default config.

Resolves #4640 