### PR TITLE
Provide a priority field for DetektProvider

### DIFF
--- a/detekt-tooling/api/detekt-tooling.api
+++ b/detekt-tooling/api/detekt-tooling.api
@@ -45,11 +45,16 @@ public abstract class io/github/detekt/tooling/api/DetektError : java/lang/Runti
 public abstract interface class io/github/detekt/tooling/api/DetektProvider {
 	public static final field Companion Lio/github/detekt/tooling/api/DetektProvider$Companion;
 	public abstract fun get (Lio/github/detekt/tooling/api/spec/ProcessingSpec;)Lio/github/detekt/tooling/api/Detekt;
+	public abstract fun getPriority ()I
 }
 
 public final class io/github/detekt/tooling/api/DetektProvider$Companion {
 	public final fun load (Ljava/lang/ClassLoader;)Lio/github/detekt/tooling/api/DetektProvider;
 	public static synthetic fun load$default (Lio/github/detekt/tooling/api/DetektProvider$Companion;Ljava/lang/ClassLoader;ILjava/lang/Object;)Lio/github/detekt/tooling/api/DetektProvider;
+}
+
+public final class io/github/detekt/tooling/api/DetektProvider$DefaultImpls {
+	public static fun getPriority (Lio/github/detekt/tooling/api/DetektProvider;)I
 }
 
 public abstract class io/github/detekt/tooling/api/FunctionMatcher {

--- a/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/api/DetektProvider.kt
+++ b/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/api/DetektProvider.kt
@@ -9,6 +9,13 @@ import java.util.ServiceLoader
 interface DetektProvider {
 
     /**
+     * Is used to choose the highest priority provider if more than one are found on the classpath.
+     *
+     * Can be useful to stub/mock detekt instances for tests.
+     */
+    val priority: Int get() = -1
+
+    /**
      * Configure a [Detekt] instance based on given [ProcessingSpec].
      */
     fun get(processingSpec: ProcessingSpec): Detekt
@@ -21,6 +28,8 @@ interface DetektProvider {
         fun load(
             classLoader: ClassLoader = DetektProvider::class.java.classLoader
         ): DetektProvider =
-            ServiceLoader.load(DetektProvider::class.java, classLoader).first()
+            ServiceLoader.load(DetektProvider::class.java, classLoader)
+                .maxByOrNull { it.priority }
+                ?: error("No implemention of DetektProvider found.")
     }
 }

--- a/detekt-tooling/src/test/kotlin/io/github/detekt/tooling/api/DetektProviderSpec.kt
+++ b/detekt-tooling/src/test/kotlin/io/github/detekt/tooling/api/DetektProviderSpec.kt
@@ -1,0 +1,20 @@
+package io.github.detekt.tooling.api
+
+import io.github.detekt.tooling.api.spec.ProcessingSpec
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class DetektProviderSpec {
+
+    @Test
+    fun `load provider with highest priority`() {
+        val provider = DetektProvider.load()
+
+        assertThat(provider.priority).isEqualTo(100)
+    }
+}
+
+class PrioritizedProvider : DetektProvider {
+    override val priority: Int = 100
+    override fun get(processingSpec: ProcessingSpec): Detekt = error("No instances.")
+}

--- a/detekt-tooling/src/test/resources/META-INF/services/io.github.detekt.tooling.api.DetektProvider
+++ b/detekt-tooling/src/test/resources/META-INF/services/io.github.detekt.tooling.api.DetektProvider
@@ -1,0 +1,1 @@
+io.github.detekt.tooling.api.PrioritizedProvider


### PR DESCRIPTION
This makes it easier for tools (e.g. IntelliJ plugin) to choose their provider implemention (e.g. in tests).

One usecase can be found here: 

https://github.com/detekt/detekt-intellij-plugin/pull/177/files#diff-3c40938670e13746dcbdadc52f2b01f6fbfbefd6153bd152bf0e69d4c233fd0fR122