### PR TITLE
Add missing redirect

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -72,6 +72,7 @@ const config = {
           { to: '/docs/rules/performance', from: '/performance.html' },
           { to: '/docs/rules/potential-bugs', from: '/potential-bugs.html' },
           { to: '/docs/rules/style', from: '/style.html' },
+          { to: '/docs/introduction/suppressors', from: '/suppressors.html'}
         ],
       },
     ],


### PR DESCRIPTION
Google right now links to a 404 page when you look for `suppressors detekt`. This should fix it.