### PR TITLE
Support disabling config validation via tooling spec

### DIFF
--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Spec.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Spec.kt
@@ -41,7 +41,7 @@ internal fun CliArgs.createSpec(output: Appendable, error: Appendable): Processi
 
         config {
             useDefaultConfig = args.buildUponDefaultConfig
-            shouldValidateBeforeAnalysis = false
+            shouldValidateBeforeAnalysis = null
             knownPatterns = emptyList()
             // ^^ cli does not have these properties yet; specified in yaml config for now
             configPaths = config?.let { MultipleExistingPathConverter().convert(it) }.orEmpty()

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/ConfigValidators.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/ConfigValidators.kt
@@ -11,9 +11,11 @@ import io.gitlab.arturbosch.detekt.core.reporting.red
 import io.gitlab.arturbosch.detekt.core.reporting.yellow
 
 internal fun checkConfiguration(settings: ProcessingSettings, baseline: Config) {
-    val props = settings.config.subConfig("config")
-    val shouldValidate = props.valueOrDefault("validation", true)
-
+    var shouldValidate = settings.spec.configSpec.shouldValidateBeforeAnalysis
+    if (shouldValidate == null) {
+        val props = settings.config.subConfig("config")
+        shouldValidate = props.valueOrDefault("validation", true)
+    }
     if (shouldValidate) {
         val validators =
             loadExtensions<ConfigValidator>(settings) + DefaultPropertiesConfigValidator(settings, baseline)

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/CheckConfigurationSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/CheckConfigurationSpec.kt
@@ -21,6 +21,28 @@ class SupportConfigValidationSpec {
     private val spec = createNullLoggingSpec {}
 
     @Test
+    fun `passes because config validation is disabled by tooling spec`() {
+        val config = yamlConfigFromContent(
+            """
+            unknown_property:
+              unknown_var: ""
+            """
+        )
+        createProcessingSettings(
+            testDir,
+            config,
+            spec = createNullLoggingSpec {
+                config {
+                    shouldValidateBeforeAnalysis = false
+                }
+            }
+        ).use {
+            assertThatCode { checkConfiguration(it, spec.getDefaultConfiguration()) }
+                .doesNotThrowAnyException()
+        }
+    }
+
+    @Test
     fun `fails when unknown properties are found`() {
         val config = yamlConfigFromContent(
             """

--- a/detekt-tooling/api/detekt-tooling.api
+++ b/detekt-tooling/api/detekt-tooling.api
@@ -100,7 +100,7 @@ public abstract interface class io/github/detekt/tooling/api/spec/ConfigSpec {
 	public abstract fun getConfigPaths ()Ljava/util/Collection;
 	public abstract fun getKnownPatterns ()Ljava/util/Collection;
 	public abstract fun getResources ()Ljava/util/Collection;
-	public abstract fun getShouldValidateBeforeAnalysis ()Z
+	public abstract fun getShouldValidateBeforeAnalysis ()Ljava/lang/Boolean;
 	public abstract fun getUseDefaultConfig ()Z
 }
 
@@ -233,12 +233,12 @@ public final class io/github/detekt/tooling/dsl/ConfigSpecBuilder : io/github/de
 	public final fun getConfigPaths ()Ljava/util/Collection;
 	public final fun getKnownPatterns ()Ljava/util/Collection;
 	public final fun getResources ()Ljava/util/Collection;
-	public final fun getShouldValidateBeforeAnalysis ()Z
+	public final fun getShouldValidateBeforeAnalysis ()Ljava/lang/Boolean;
 	public final fun getUseDefaultConfig ()Z
 	public final fun setConfigPaths (Ljava/util/Collection;)V
 	public final fun setKnownPatterns (Ljava/util/Collection;)V
 	public final fun setResources (Ljava/util/Collection;)V
-	public final fun setShouldValidateBeforeAnalysis (Z)V
+	public final fun setShouldValidateBeforeAnalysis (Ljava/lang/Boolean;)V
 	public final fun setUseDefaultConfig (Z)V
 }
 

--- a/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/api/spec/ConfigSpec.kt
+++ b/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/api/spec/ConfigSpec.kt
@@ -10,7 +10,7 @@ interface ConfigSpec {
      *
      * Unknown properties to detekt will get reported as errors.
      */
-    val shouldValidateBeforeAnalysis: Boolean
+    val shouldValidateBeforeAnalysis: Boolean?
 
     /**
      * Property patterns which should be excluded from validation.

--- a/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/dsl/ConfigSpecBuilder.kt
+++ b/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/dsl/ConfigSpecBuilder.kt
@@ -7,7 +7,7 @@ import java.nio.file.Path
 @ProcessingModelDsl
 class ConfigSpecBuilder : Builder<ConfigSpec> {
 
-    var shouldValidateBeforeAnalysis: Boolean = true
+    var shouldValidateBeforeAnalysis: Boolean? = null
     var knownPatterns: Collection<String> = emptyList()
 
     var useDefaultConfig: Boolean = false // false to be backwards compatible in 1.X
@@ -24,7 +24,7 @@ class ConfigSpecBuilder : Builder<ConfigSpec> {
 }
 
 private data class ConfigModel(
-    override val shouldValidateBeforeAnalysis: Boolean,
+    override val shouldValidateBeforeAnalysis: Boolean?,
     override val knownPatterns: Collection<String>,
     override val useDefaultConfig: Boolean,
     override val resources: Collection<URL>,


### PR DESCRIPTION
Disabling config validation is not yet supported in the cli via a flag.

The cli just set the spec value to false and `shouldValidateBeforeAnalysis` was never evaluated in `core`.

With this PR tools can programmatically disable config validation if needed.

For a usecase see https://github.com/detekt/detekt-intellij-plugin/issues/179.