### PR TITLE
Move Suppressor from `core` module  to `api` module

### DIFF
--- a/detekt-api/api/detekt-api.api
+++ b/detekt-api/api/detekt-api.api
@@ -583,6 +583,9 @@ public final class io/gitlab/arturbosch/detekt/api/SplitPatternKt {
 	public static synthetic fun commaSeparatedPattern$default (Ljava/lang/String;[Ljava/lang/String;ILjava/lang/Object;)Lkotlin/sequences/Sequence;
 	public static final fun simplePatternToRegex (Ljava/lang/String;)Lkotlin/text/Regex;
 }
+public abstract interface class io/gitlab/arturbosch/detekt/api/Suppressor {
+    public abstract fun shouldSuppress (Lio/gitlab/arturbosch/detekt/api/Finding;)Z
+}
 
 public final class io/gitlab/arturbosch/detekt/api/TextLocation {
 	public fun <init> (II)V

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Suppressor.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Suppressor.kt
@@ -1,0 +1,12 @@
+package io.gitlab.arturbosch.detekt.api
+
+/**
+ * The [Suppressor]s are a tool that you can use to customize the reports of detekt. They allow you
+ * to(surprise) suppress some issues detected by some rules, and thy can be applied to any rule.
+ */
+fun interface Suppressor {
+    /**
+     * Given a Finding it decides if it should be suppressed (`true`) or not (`false`)
+     */
+    fun shouldSuppress(finding: Finding): Boolean
+}

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/AnnotationSuppressor.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/AnnotationSuppressor.kt
@@ -2,6 +2,7 @@ package io.gitlab.arturbosch.detekt.core.suppressors
 
 import io.gitlab.arturbosch.detekt.api.AnnotationExcluder
 import io.gitlab.arturbosch.detekt.api.ConfigAware
+import io.gitlab.arturbosch.detekt.api.Suppressor
 import org.jetbrains.kotlin.psi.KtAnnotated
 import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/FunctionSuppressor.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/FunctionSuppressor.kt
@@ -2,6 +2,7 @@ package io.gitlab.arturbosch.detekt.core.suppressors
 
 import io.github.detekt.tooling.api.FunctionMatcher
 import io.gitlab.arturbosch.detekt.api.ConfigAware
+import io.gitlab.arturbosch.detekt.api.Suppressor
 import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/InnerSuppressor.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/InnerSuppressor.kt
@@ -1,18 +1,8 @@
+@file:Suppress("WildcardImport", "NoWildcardImports")
 package io.gitlab.arturbosch.detekt.core.suppressors
 
-import io.gitlab.arturbosch.detekt.api.BaseRule
-import io.gitlab.arturbosch.detekt.api.ConfigAware
-import io.gitlab.arturbosch.detekt.api.Finding
-import io.gitlab.arturbosch.detekt.api.MultiRule
-import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.*
 import org.jetbrains.kotlin.resolve.BindingContext
-
-fun interface Suppressor {
-    /**
-     * Given a Finding it decides if it should be suppressed (`true`) or not (`false`)
-     */
-    fun shouldSuppress(finding: Finding): Boolean
-}
 
 private fun buildSuppressors(rule: ConfigAware, bindingContext: BindingContext): List<Suppressor> {
     return listOfNotNull(

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/FunctionSuppressorSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/FunctionSuppressorSpec.kt
@@ -1,6 +1,7 @@
 package io.gitlab.arturbosch.detekt.core.suppressors
 
 import io.github.detekt.test.utils.compileContentForTest
+import io.gitlab.arturbosch.detekt.api.Suppressor
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtFunction


### PR DESCRIPTION
closes: #4932 

* Moved `Suppressor` from `core` to `api`
* Renamed `core/Suppressor.kt` to `InnerSuppressor`
* Updated `detekt-api.api` file