### PR TITLE
Drop dependency-analysis plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,6 @@ plugins {
     id("io.gitlab.arturbosch.detekt")
     alias(libs.plugins.gradleVersions)
     alias(libs.plugins.sonarqube)
-    alias(libs.plugins.dependencyAnalysis)
 }
 
 allprojects {
@@ -42,16 +41,6 @@ allprojects {
     }
     tasks.withType<DetektCreateBaselineTask>().configureEach {
         jvmTarget = "1.8"
-    }
-}
-
-dependencyAnalysis {
-    issues {
-        all {
-            onUsedTransitiveDependencies {
-                severity("ignore")
-            }
-        }
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -43,7 +43,6 @@ contester-driver = { module = "io.github.davidburstrom.contester:contester-drive
 
 [plugins]
 binaryCompatibilityValidator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version = "0.10.0" }
-dependencyAnalysis = { id = "com.autonomousapps.dependency-analysis", version = "1.5.0" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 gradleVersions = { id = "com.github.ben-manes.versions", version = "0.42.0" }
 pluginPublishing = { id = "com.gradle.plugin-publish", version = "0.21.0" }


### PR DESCRIPTION
This is blocking update to Kotlin 1.7.0 (#4821)