### PR TITLE
UnnecessaryApply: fix false negative for assignment

### DIFF
--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryApplySpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryApplySpec.kt
@@ -117,12 +117,12 @@ class UnnecessaryApplySpec(val env: KotlinCoreEnvironment) {
                 class C {
                     var prop = 0
                 }
-                    
+
                 fun main() {
                     val list = ArrayList<C>()
                     list.add(
                         if (true) {
-                            C().apply { 
+                            C().apply {
                                 prop = 1
                             }
                         } else {
@@ -232,6 +232,50 @@ class UnnecessaryApplySpec(val env: KotlinCoreEnvironment) {
                 """
             )
             assertThat(findings).hasSize(1)
+        }
+    }
+
+    @Nested
+    inner class `unnecessary apply expressions that can be changed to assignment` {
+        @Test
+        fun `reports apply with a single assignment whose result is unused`() {
+            assertThat(
+                subject.compileAndLintWithContext(
+                    env,
+                    """
+                class C {
+                    var prop = 0
+                }
+
+                fun main() {
+                    val c = C()
+                    c.apply {
+                        prop = 1
+                    }
+                }
+                    """
+                )
+            ).hasSize(1)
+        }
+
+        @Test
+        fun `does not report apply with a single assignment whose result is used`() {
+            assertThat(
+                subject.compileAndLintWithContext(
+                    env,
+                    """
+                class C {
+                    var prop = 0
+                }
+
+                fun main() {
+                    val c = C().apply {
+                        prop = 1
+                    }
+                }
+                    """
+                )
+            ).isEmpty()
         }
     }
 


### PR DESCRIPTION
Fix a missed case of UnnecessaryApply where the apply contains a single field assignment but the result of the apply{} is unused. This pattern is actually used in 2/3 of the `<noncompliant>` examples and while it occurred in tests for false positives, no test actually checked that warnings were generated in the simple case.

I only added a few tests for the simple cases to avoid duplicating a number of the ones for function calls; more could be added for completeness but it would bloat the test file considerably.