### PR TITLE
Remove Sonarqube Gradle Plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,6 @@ plugins {
     id("releasing")
     id("io.gitlab.arturbosch.detekt")
     alias(libs.plugins.gradleVersions)
-    alias(libs.plugins.sonarqube)
 }
 
 allprojects {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,4 @@
 kotlin.code.style=official
-systemProp.sonar.host.url=http://localhost:9000
 systemProp.dependency.analysis.test.analysis=false
 org.gradle.parallel=true
 org.gradle.caching=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -47,4 +47,3 @@ dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 gradleVersions = { id = "com.github.ben-manes.versions", version = "0.42.0" }
 pluginPublishing = { id = "com.gradle.plugin-publish", version = "0.21.0" }
 shadow = { id = "com.github.johnrengelman.shadow", version = "7.1.2" }
-sonarqube = { id = "org.sonarqube", version = "3.3" }


### PR DESCRIPTION
This was a carry-over from the past. I think we can safely remove this gradle plugin.
Closes #4935
