### PR TITLE
No experimental type solving

### DIFF
--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt
@@ -173,7 +173,7 @@ class CliArgs {
     */
     @Parameter(
         names = ["--classpath", "-cp"],
-        description = "EXPERIMENTAL: Paths where to find user class files and depending jar files. " +
+        description = "Paths where to find user class files and depending jar files. " +
             "Used for type resolution."
     )
     var classpath: String? = null
@@ -181,14 +181,14 @@ class CliArgs {
     @Parameter(
         names = ["--language-version"],
         converter = LanguageVersionConverter::class,
-        description = "EXPERIMENTAL: Compatibility mode for Kotlin language version X.Y, reports errors for all " +
+        description = "Compatibility mode for Kotlin language version X.Y, reports errors for all " +
             "language features that came out later"
     )
     var languageVersion: LanguageVersion? = null
 
     @Parameter(
         names = ["--jvm-target"],
-        description = "EXPERIMENTAL: Target version of the generated JVM bytecode that was generated during " +
+        description = "Target version of the generated JVM bytecode that was generated during " +
             "compilation and is now being used for type resolution (1.6, 1.8, 9, 10, 11, 12, 13, 14, 15, 16 or 17)"
     )
     var jvmTarget: String = JvmTarget.DEFAULT.description

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektAndroid.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektAndroid.kt
@@ -23,23 +23,21 @@ internal class DetektAndroid(private val project: Project) {
     private val mainTaskProvider: TaskProvider<Task> by lazy {
         project.tasks.register("${DetektPlugin.DETEKT_TASK_NAME}Main") {
             it.group = "verification"
-            it.description = "EXPERIMENTAL: Run detekt analysis for production classes across " +
-                "all variants with type resolution"
+            it.description = "Run detekt analysis for production classes across all variants with type resolution"
         }
     }
 
     private val testTaskProvider: TaskProvider<Task> by lazy {
         project.tasks.register("${DetektPlugin.DETEKT_TASK_NAME}Test") {
             it.group = "verification"
-            it.description = "EXPERIMENTAL: Run detekt analysis for test classes across " +
-                "all variants with type resolution"
+            it.description = "Run detekt analysis for test classes across all variants with type resolution"
         }
     }
 
     private val mainBaselineTaskProvider: TaskProvider<Task> by lazy {
         project.tasks.register("${DetektPlugin.BASELINE_TASK_NAME}Main") {
             it.group = "verification"
-            it.description = "EXPERIMENTAL: Creates detekt baseline files for production classes across " +
+            it.description = "Creates detekt baseline files for production classes across " +
                 "all variants with type resolution"
         }
     }
@@ -47,8 +45,7 @@ internal class DetektAndroid(private val project: Project) {
     private val testBaselineTaskProvider: TaskProvider<Task> by lazy {
         project.tasks.register("${DetektPlugin.BASELINE_TASK_NAME}Test") {
             it.group = "verification"
-            it.description = "EXPERIMENTAL: Creates detekt baseline files for test classes across " +
-                "all variants with type resolution"
+            it.description = "Creates detekt baseline files for test classes across all variants with type resolution"
         }
     }
 
@@ -127,7 +124,7 @@ internal fun Project.registerAndroidDetektTask(
             baseline.set(layout.file(project.provider { baselineFile }))
         }
         setReportOutputConventions(reports, extension, variant.name)
-        description = "EXPERIMENTAL: Run detekt analysis for ${variant.name} classes with type resolution"
+        description = "Run detekt analysis for ${variant.name} classes with type resolution"
     }
 
 internal fun Project.registerAndroidCreateBaselineTask(
@@ -147,7 +144,7 @@ internal fun Project.registerAndroidCreateBaselineTask(
         )
         val variantBaselineFile = extension.baseline?.addVariantName(variant.name)
         baseline.set(project.layout.file(project.provider { variantBaselineFile }))
-        description = "EXPERIMENTAL: Creates detekt baseline for ${variant.name} classes with type resolution"
+        description = "Creates detekt baseline for ${variant.name} classes with type resolution"
     }
 
 private fun Project.javaCompileDestination(variant: BaseVariant): DirectoryProperty? {

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektJvm.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektJvm.kt
@@ -30,7 +30,7 @@ internal class DetektJvm(private val project: Project) {
                 baseline.set(layout.file(project.provider { baselineFile }))
             }
             setReportOutputConventions(reports, extension, sourceSet.name)
-            description = "EXPERIMENTAL: Run detekt analysis for ${sourceSet.name} classes with type resolution"
+            description = "Run detekt analysis for ${sourceSet.name} classes with type resolution"
         }
     }
 
@@ -42,7 +42,7 @@ internal class DetektJvm(private val project: Project) {
             classpath.setFrom(sourceSet.compileClasspath.existingFiles(), sourceSet.output.classesDirs.existingFiles())
             val variantBaselineFile = extension.baseline?.addVariantName(sourceSet.name)
             baseline.set(project.layout.file(project.provider { variantBaselineFile }))
-            description = "EXPERIMENTAL: Creates detekt baseline for ${sourceSet.name} classes with type resolution"
+            description = "Creates detekt baseline for ${sourceSet.name} classes with type resolution"
         }
     }
 

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektMultiplatform.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektMultiplatform.kt
@@ -111,7 +111,7 @@ internal class DetektMultiplatform(private val project: Project) {
             description =
                 "Run detekt analysis for target ${target.name} and source set ${compilation.name}"
             if (runWithTypeResolution) {
-                description = "EXPERIMENTAL: $description with type resolution."
+                description = "$description with type resolution."
             }
         }
 
@@ -134,7 +134,7 @@ internal class DetektMultiplatform(private val project: Project) {
             description =
                 "Creates detekt baseline for ${target.name} and source set ${compilation.name}"
             if (runWithTypeResolution) {
-                description = "EXPERIMENTAL: $description with type resolution."
+                description = "$description with type resolution."
             }
         }
     }

--- a/website/docs/gettingstarted/gradle.mdx
+++ b/website/docs/gettingstarted/gradle.mdx
@@ -329,7 +329,7 @@ tasks.named("detekt").configure {
 
 ### Using Type Resolution
 
-Type resolution is experimental and works only for [predefined tasks listed above](#a-nametasksavailable-plugin-tasksa)
+Type resolution works only for [predefined tasks listed above](#a-nametasksavailable-plugin-tasksa)
 or when implementing a custom detekt task with the `classpath` and `jvmTarget` properties present.
 
 More information on type resolution are available on the [type resolution](type-resolution.md) page.

--- a/website/docs/gettingstarted/type-resolution.md
+++ b/website/docs/gettingstarted/type-resolution.md
@@ -10,12 +10,6 @@ sidebar_position: 5
 
 This page describes how to use detekt's **type resolution** feature.
 
-:::caution
-
-Please note that type resolution is still an **experimental feature** of Detekt. We expect it to be stable with the upcoming release of Detekt (2.x)
-
-:::
-
 ## What is type resolution
 
 Type resolution is a feature that allows Detekt to perform more **advanced** static analysis on your Kotlin source code. 


### PR DESCRIPTION
From: with https://github.com/detekt/detekt/discussions/4959

Right now a lot of our rules use type-solving and it is battle tested. It works! But we still say in the documentation that it is "experimental" but, to me, it is not experimental at all. It's one of the core features of detekt.

So I would like to remove the "experimental tag" from the type-solving, what do you think?