### PR TITLE
Bump minimum supported Gradle version to 6.7.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ If you want to use a SNAPSHOT version, you can find more info on [this documenta
 
 #### Requirements
 
-Gradle 6.1+ is the minimum requirement. However, the recommended versions together with the other tools recommended versions are:
+Gradle 6.7.1+ is the minimum requirement. However, the recommended versions together with the other tools recommended versions are:
 
 | Detekt Version | Gradle  | Kotlin   | AGP     | Java Target Level | JDK Max Version |
 | -------------- | ------- | -------- | ------- | ----------------- | --------------- |

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/GradleVersionSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/GradleVersionSpec.kt
@@ -6,13 +6,13 @@ import org.gradle.testkit.runner.TaskOutcome
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.condition.EnabledForJreRange
-import org.junit.jupiter.api.condition.JRE.JAVA_13
+import org.junit.jupiter.api.condition.JRE.JAVA_15
 
 class GradleVersionSpec {
 
     @Test
     @DisplayName("Runs on version $gradleVersion")
-    @EnabledForJreRange(max = JAVA_13, disabledReason = "Gradle $gradleVersion unsupported on this Java version")
+    @EnabledForJreRange(max = JAVA_15, disabledReason = "Gradle $gradleVersion unsupported on this Java version")
     fun runsOnOldestSupportedGradleVersion() {
         val builder = DslTestBuilder.kotlin()
         val gradleRunner = builder.withGradleVersion(gradleVersion).build()
@@ -22,6 +22,6 @@ class GradleVersionSpec {
     }
 
     companion object {
-        const val gradleVersion = "6.1"
+        const val gradleVersion = "6.7.1"
     }
 }

--- a/website/docs/gettingstarted/gradle.mdx
+++ b/website/docs/gettingstarted/gradle.mdx
@@ -8,7 +8,7 @@ summary:
 sidebar_position: 2
 ---
 
-Detekt requires **Gradle 6.1** or higher. We, however, recommend using the version of Gradle that is [listed in this table](/docs/introduction/compatibility).
+Detekt requires **Gradle 6.7.1** or higher. We, however, recommend using the version of Gradle that is [listed in this table](/docs/introduction/compatibility).
 
 ## <a name="tasks">Available plugin tasks</a>
 


### PR DESCRIPTION
Aligns to Kotlin 1.7.0, and allows us to support [Java Toolchains](https://docs.gradle.org/current/userguide/toolchains.html).