### PR TITLE
Refactor Gradle tasks to use Gradle's managed properties

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -56,33 +56,33 @@ import java.io.File
 import javax.inject.Inject
 
 @CacheableTask
-open class Detekt @Inject constructor(
+abstract class Detekt @Inject constructor(
     private val objects: ObjectFactory
 ) : SourceTask(), VerificationTask {
 
     @get:Classpath
-    val detektClasspath: ConfigurableFileCollection = objects.fileCollection()
+    abstract val detektClasspath: ConfigurableFileCollection
 
     @get:Classpath
-    val pluginClasspath: ConfigurableFileCollection = objects.fileCollection()
+    abstract val pluginClasspath: ConfigurableFileCollection
 
     @get:InputFile
     @get:Optional
     @get:PathSensitive(PathSensitivity.RELATIVE)
-    val baseline: RegularFileProperty = project.objects.fileProperty()
+    abstract val baseline: RegularFileProperty
 
     @get:InputFiles
     @get:Optional
     @get:PathSensitive(PathSensitivity.RELATIVE)
-    val config: ConfigurableFileCollection = objects.fileCollection()
+    abstract val config: ConfigurableFileCollection
 
     @get:Classpath
     @get:Optional
-    val classpath: ConfigurableFileCollection = objects.fileCollection()
+    abstract val classpath: ConfigurableFileCollection
 
     @get:Input
     @get:Optional
-    internal val languageVersionProp: Property<String> = project.objects.property(String::class.javaObjectType)
+    internal abstract val languageVersionProp: Property<String>
     var languageVersion: String
         @Internal
         get() = languageVersionProp.get()
@@ -90,42 +90,42 @@ open class Detekt @Inject constructor(
 
     @get:Input
     @get:Optional
-    internal val jvmTargetProp: Property<String> = project.objects.property(String::class.javaObjectType)
+    internal abstract val jvmTargetProp: Property<String>
     var jvmTarget: String
         @Internal
         get() = jvmTargetProp.get()
         set(value) = jvmTargetProp.set(value)
 
     @get:Internal
-    internal val debugProp: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
+    internal abstract val debugProp: Property<Boolean>
     var debug: Boolean
         @Console
         get() = debugProp.getOrElse(false)
         set(value) = debugProp.set(value)
 
     @get:Internal
-    internal val parallelProp: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
+    internal abstract val parallelProp: Property<Boolean>
     var parallel: Boolean
         @Internal
         get() = parallelProp.getOrElse(false)
         set(value) = parallelProp.set(value)
 
     @get:Internal
-    internal val disableDefaultRuleSetsProp: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
+    internal abstract val disableDefaultRuleSetsProp: Property<Boolean>
     var disableDefaultRuleSets: Boolean
         @Input
         get() = disableDefaultRuleSetsProp.getOrElse(false)
         set(value) = disableDefaultRuleSetsProp.set(value)
 
     @get:Internal
-    internal val buildUponDefaultConfigProp: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
+    internal abstract val buildUponDefaultConfigProp: Property<Boolean>
     var buildUponDefaultConfig: Boolean
         @Input
         get() = buildUponDefaultConfigProp.getOrElse(false)
         set(value) = buildUponDefaultConfigProp.set(value)
 
     @get:Internal
-    internal val failFastProp: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
+    internal abstract val failFastProp: Property<Boolean>
 
     @Deprecated("Please use the buildUponDefaultConfig and allRules flags instead.", ReplaceWith("allRules"))
     var failFast: Boolean
@@ -134,17 +134,17 @@ open class Detekt @Inject constructor(
         set(value) = failFastProp.set(value)
 
     @get:Internal
-    internal val allRulesProp: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
+    internal abstract val allRulesProp: Property<Boolean>
     var allRules: Boolean
         @Input
         get() = allRulesProp.getOrElse(false)
         set(value) = allRulesProp.set(value)
 
     @get:Internal
-    internal val ignoreFailuresProp: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
+    internal abstract val ignoreFailuresProp: Property<Boolean>
 
     @get:Internal
-    internal val autoCorrectProp: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
+    internal abstract val autoCorrectProp: Property<Boolean>
 
     @set:Option(option = "auto-correct", description = "Allow rules to auto correct code if they support it")
     var autoCorrect: Boolean
@@ -157,7 +157,7 @@ open class Detekt @Inject constructor(
      */
     @get:Input
     @get:Optional
-    internal val basePathProp: Property<String> = project.objects.property(String::class.java)
+    internal abstract val basePathProp: Property<String>
     var basePath: String
         @Internal
         get() = basePathProp.getOrElse("")
@@ -167,7 +167,7 @@ open class Detekt @Inject constructor(
     var reports: DetektReports = objects.newInstance(DetektReports::class.java)
 
     @get:Internal
-    val reportsDir: Property<File> = project.objects.property(File::class.java)
+    abstract val reportsDir: Property<File>
 
     val xmlReportFile: Provider<RegularFile>
         @OutputFile

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
@@ -38,7 +38,7 @@ import org.gradle.api.tasks.TaskAction
 import org.gradle.language.base.plugins.LifecycleBasePlugin
 
 @CacheableTask
-open class DetektCreateBaselineTask : SourceTask() {
+abstract class DetektCreateBaselineTask : SourceTask() {
 
     init {
         description = "Creates a detekt baseline on the given --baseline path."
@@ -46,60 +46,60 @@ open class DetektCreateBaselineTask : SourceTask() {
     }
 
     @get:OutputFile
-    val baseline: RegularFileProperty = project.objects.fileProperty()
+    abstract val baseline: RegularFileProperty
 
     @get:InputFiles
     @get:Optional
-    @PathSensitive(PathSensitivity.RELATIVE)
-    val config: ConfigurableFileCollection = project.objects.fileCollection()
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val config: ConfigurableFileCollection
 
     @get:Classpath
-    val detektClasspath: ConfigurableFileCollection = project.objects.fileCollection()
+    abstract val detektClasspath: ConfigurableFileCollection
 
     @get:Classpath
-    val pluginClasspath: ConfigurableFileCollection = project.objects.fileCollection()
+    abstract val pluginClasspath: ConfigurableFileCollection
 
     @get:Classpath
     @get:Optional
-    val classpath: ConfigurableFileCollection = project.objects.fileCollection()
+    abstract val classpath: ConfigurableFileCollection
 
     @get:Console
-    val debug: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
+    abstract val debug: Property<Boolean>
 
     @get:Internal
-    val parallel: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
+    abstract val parallel: Property<Boolean>
 
     @get:Input
     @get:Optional
-    val disableDefaultRuleSets: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
+    abstract val disableDefaultRuleSets: Property<Boolean>
 
     @get:Input
     @get:Optional
-    val buildUponDefaultConfig: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
+    abstract val buildUponDefaultConfig: Property<Boolean>
 
     @get:Input
     @get:Optional
     @Deprecated("Please use the buildUponDefaultConfig and allRules flags instead.", ReplaceWith("allRules"))
-    val failFast: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
+    abstract val failFast: Property<Boolean>
 
     @get:Input
     @get:Optional
-    val ignoreFailures: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
+    abstract val ignoreFailures: Property<Boolean>
 
     @get:Input
     @get:Optional
-    val allRules: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
+    abstract val allRules: Property<Boolean>
 
     @get:Input
     @get:Optional
-    val autoCorrect: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType)
+    abstract val autoCorrect: Property<Boolean>
 
     /**
      * Respect only the file path for incremental build. Using @InputFile respects both file path and content.
      */
     @get:Input
     @get:Optional
-    internal val basePathProp: Property<String> = project.objects.property(String::class.java)
+    internal abstract val basePathProp: Property<String>
     var basePath: String
         @Internal
         get() = basePathProp.get()
@@ -107,7 +107,7 @@ open class DetektCreateBaselineTask : SourceTask() {
 
     @get:Input
     @get:Optional
-    internal val jvmTargetProp: Property<String> = project.objects.property(String::class.javaObjectType)
+    internal abstract val jvmTargetProp: Property<String>
     var jvmTarget: String
         @Internal
         get() = jvmTargetProp.get()

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektGenerateConfigTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektGenerateConfigTask.kt
@@ -23,7 +23,7 @@ import java.nio.file.Files
 import javax.inject.Inject
 
 @CacheableTask
-open class DetektGenerateConfigTask @Inject constructor(
+abstract class DetektGenerateConfigTask @Inject constructor(
     private val objects: ObjectFactory
 ) : DefaultTask() {
 
@@ -33,15 +33,15 @@ open class DetektGenerateConfigTask @Inject constructor(
     }
 
     @get:Classpath
-    val detektClasspath: ConfigurableFileCollection = project.objects.fileCollection()
+    abstract val detektClasspath: ConfigurableFileCollection
 
     @get:Classpath
-    val pluginClasspath: ConfigurableFileCollection = objects.fileCollection()
+    abstract val pluginClasspath: ConfigurableFileCollection
 
     @get:InputFiles
     @get:Optional
     @get:PathSensitive(PathSensitivity.RELATIVE)
-    val config: ConfigurableFileCollection = project.objects.fileCollection()
+    abstract val config: ConfigurableFileCollection
 
     private val defaultConfigPath = project.rootDir.toPath().resolve(CONFIG_DIR_NAME).resolve(CONFIG_FILE)
 

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/CustomDetektReport.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/CustomDetektReport.kt
@@ -1,16 +1,14 @@
 package io.gitlab.arturbosch.detekt.extensions
 
 import org.gradle.api.file.RegularFileProperty
-import org.gradle.api.model.ObjectFactory
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputFile
 import java.io.File
-import javax.inject.Inject
 
-open class CustomDetektReport @Inject constructor(objects: ObjectFactory) {
+abstract class CustomDetektReport {
 
-    @Internal
-    var reportId: String? = null
+    @get:Internal
+    abstract var reportId: String?
 
     @Deprecated("Use outputLocation.set(value)")
     @get:Internal
@@ -20,8 +18,8 @@ open class CustomDetektReport @Inject constructor(objects: ObjectFactory) {
             outputLocation.set(value)
         }
 
-    @OutputFile
-    val outputLocation: RegularFileProperty = objects.fileProperty()
+    @get:OutputFile
+    abstract val outputLocation: RegularFileProperty
 
     override fun toString(): String {
         return "CustomDetektReport(reportId=$reportId, outputLocation=$outputLocation)"

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektReport.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektReport.kt
@@ -1,14 +1,13 @@
 package io.gitlab.arturbosch.detekt.extensions
 
 import org.gradle.api.file.RegularFileProperty
-import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.OutputFile
 import java.io.File
 import javax.inject.Inject
 
-open class DetektReport @Inject constructor(val type: DetektReportType, objects: ObjectFactory) {
+abstract class DetektReport @Inject constructor(val type: DetektReportType) {
 
     @Deprecated("Use required.set(value)")
     var enabled: Boolean?
@@ -22,11 +21,11 @@ open class DetektReport @Inject constructor(val type: DetektReportType, objects:
             outputLocation.set(value)
         }
 
-    @Input
-    val required: Property<Boolean> = objects.property(Boolean::class.java)
+    @get:Input
+    abstract val required: Property<Boolean>
 
-    @OutputFile
-    val outputLocation: RegularFileProperty = objects.fileProperty()
+    @get:OutputFile
+    abstract val outputLocation: RegularFileProperty
 
     override fun toString(): String {
         return "DetektReport(type='$type', required=$required, outputLocation=$outputLocation)"


### PR DESCRIPTION
Unfortunately we can't use managed properties everywhere without some additional refactoring, but this still helps simplify a few things.