### PR TITLE
Update dependency com.gradle.plugin-publish to 1.0.0-rc-3

### DIFF
--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -89,9 +89,11 @@ dependencies {
 
 gradlePlugin {
     plugins {
-        register("detektPlugin") {
+        create("detektPlugin") {
             id = "io.gitlab.arturbosch.detekt"
             implementationClass = "io.gitlab.arturbosch.detekt.DetektPlugin"
+            displayName = "Static code analysis for Kotlin"
+            description = "Static code analysis for Kotlin"
         }
     }
     // Source sets that require the Gradle TestKit dependency
@@ -119,15 +121,7 @@ tasks.validatePlugins {
 pluginBundle {
     website = "https://detekt.dev"
     vcsUrl = "https://github.com/detekt/detekt"
-    description = "Static code analysis for Kotlin"
     tags = listOf("kotlin", "detekt", "code-analysis", "linter", "codesmells", "android")
-
-    (plugins) {
-        "detektPlugin" {
-            id = "io.gitlab.arturbosch.detekt"
-            displayName = "Static code analysis for Kotlin"
-        }
-    }
 }
 
 tasks {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,5 +45,5 @@ contester-driver = { module = "io.github.davidburstrom.contester:contester-drive
 binaryCompatibilityValidator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version = "0.10.1" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 gradleVersions = { id = "com.github.ben-manes.versions", version = "0.42.0" }
-pluginPublishing = { id = "com.gradle.plugin-publish", version = "0.21.0" }
+pluginPublishing = { id = "com.gradle.plugin-publish", version = "1.0.0-rc-3" }
 shadow = { id = "com.github.johnrengelman.shadow", version = "7.1.2" }


### PR DESCRIPTION
Since this plugin was always pre-v1.0 I think this update will be at least as safe as previous updates. That said, I'm not aware of any local publishing tasks that can be used to check all published elements of the plugin will actually be published as expected...

Updated docs: https://plugins.gradle.org/docs/publish-plugin-new