### PR TITLE
Simplify signing configuration

### DIFF
--- a/build-logic/src/main/kotlin/packaging.gradle.kts
+++ b/build-logic/src/main/kotlin/packaging.gradle.kts
@@ -66,10 +66,12 @@ if (signingKey.isNullOrBlank() || signingPwd.isNullOrBlank()) {
     logger.info("Signing disabled as the GPG key was not found")
 } else {
     logger.info("GPG Key found - Signing enabled")
-    signing {
-        useInMemoryPgpKeys(signingKey, signingPwd)
-        publishing.publications.forEach(::sign)
-    }
+}
+
+signing {
+    useInMemoryPgpKeys(signingKey, signingPwd)
+    sign(publishing.publications)
+    isRequired = !(signingKey.isNullOrBlank() || signingPwd.isNullOrBlank())
 }
 
 val String.byProperty: String? get() = findProperty(this) as? String

--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -6,7 +6,6 @@ plugins {
     `java-gradle-plugin`
     `java-test-fixtures`
     idea
-    signing
     alias(libs.plugins.pluginPublishing)
     // We use this published version of the Detekt plugin to self analyse this project.
     id("io.gitlab.arturbosch.detekt") version "1.20.0"
@@ -164,20 +163,6 @@ with(components["java"] as AdhocComponentWithVariants) {
 
 tasks.withType<Sign>().configureEach {
     notCompatibleWithConfigurationCache("https://github.com/gradle/gradle/issues/13470")
-}
-
-val signingKey = "SIGNING_KEY".byProperty
-val signingPwd = "SIGNING_PWD".byProperty
-if (signingKey.isNullOrBlank() || signingPwd.isNullOrBlank()) {
-    logger.info("Signing disabled as the GPG key was not found")
-} else {
-    logger.info("GPG Key found - Signing enabled")
-    afterEvaluate {
-        signing {
-            useInMemoryPgpKeys(signingKey, signingPwd)
-            publishing.publications.forEach(::sign)
-        }
-    }
 }
 
 afterEvaluate {


### PR DESCRIPTION
Now the signing tasks will always be registered, but their execution will be skipped when the signing key or password is missing. This is a change from today where the tasks are only registered when the signing key and password are provided.

This is required to play nicely with com.gradle.plugin-publish v1.0.