### PR TITLE
Add dependency-analysis plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     id("releasing")
     id("io.gitlab.arturbosch.detekt")
     alias(libs.plugins.gradleVersions)
+    alias(libs.plugins.dependencyAnalysis)
 }
 
 allprojects {
@@ -40,6 +41,16 @@ allprojects {
     }
     tasks.withType<DetektCreateBaselineTask>().configureEach {
         jvmTarget = "1.8"
+    }
+}
+
+dependencyAnalysis {
+    issues {
+        all {
+            onUsedTransitiveDependencies {
+                severity("ignore")
+            }
+        }
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -43,6 +43,7 @@ contester-driver = { module = "io.github.davidburstrom.contester:contester-drive
 
 [plugins]
 binaryCompatibilityValidator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version = "0.10.1" }
+dependencyAnalysis = { id = "com.autonomousapps.dependency-analysis", version = "1.7.0" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 gradleVersions = { id = "com.github.ben-manes.versions", version = "0.42.0" }
 pluginPublishing = { id = "com.gradle.plugin-publish", version = "0.21.0" }


### PR DESCRIPTION
The issue causing incompatibility with the Kotlin 1.7.0 update (see https://github.com/detekt/detekt/pull/4946) appears to be resolved with the newer 1.7.0 version of the plugin. I've tested the kotlin-1.7 branch with the new dependency-analysis plugin version applied and it builds successfully.