### PR TITLE
Do not allow junit assertions

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -180,6 +180,7 @@ style:
     active: true
     imports:
       - 'org.assertj.core.api.Assertions'
+      - 'org.junit.jupiter.api.Assertions*'
   ForbiddenMethodCall:
     active: true
     methods:


### PR DESCRIPTION
This adds junit assertions to the list of forbidden imports for the detekt code base to avoid accidental usage (see [pr comment](https://github.com/detekt/detekt/pull/4979/files#r903085740))