### PR TITLE
Fix false-negative for CanBeNonNullable

### DIFF
--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/CanBeNonNullable.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/CanBeNonNullable.kt
@@ -47,6 +47,7 @@ import org.jetbrains.kotlin.psi.KtWhenConditionWithExpression
 import org.jetbrains.kotlin.psi.KtWhenExpression
 import org.jetbrains.kotlin.psi.psiUtil.allChildren
 import org.jetbrains.kotlin.psi.psiUtil.collectDescendantsOfType
+import org.jetbrains.kotlin.psi.psiUtil.isFirstStatement
 import org.jetbrains.kotlin.psi.psiUtil.isPrivate
 import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.calls.smartcasts.getKotlinTypeForComparison
@@ -241,7 +242,9 @@ class CanBeNonNullable(config: Config = Config.empty) : Rule(config) {
 
         override fun visitIfExpression(expression: KtIfExpression) {
             expression.condition.evaluateCheckStatement(expression.`else`)
-            evaluateNullCheckReturnsUnit(expression.condition, expression.then)
+            if (expression.isFirstStatement()) {
+                evaluateNullCheckReturnsUnit(expression.condition, expression.then)
+            }
             super.visitIfExpression(expression)
         }
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/CanBeNonNullableSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/CanBeNonNullableSpec.kt
@@ -898,6 +898,40 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
             }
 
             @Test
+            fun `does report null-check returning unit type`() {
+                val code = """   
+                    fun foo(a: Int?) {
+                        if (a == null) return
+                        println(a)
+                    }
+                """.trimIndent()
+                assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            }
+
+            @Test
+            fun `does report null-check returning unit type in block`() {
+                val code = """   
+                    fun foo(a: Int?) {
+                        if (a == null) { return }
+                        println(a)
+                    }
+                """.trimIndent()
+                assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            }
+
+            @Test
+            fun `does not report null-check returning non-unit type`() {
+                val code = """   
+                    fun foo(a: Int?): Int {
+                        if (a == null) return 0
+                        println(a)
+                        return a
+                    }
+                """.trimIndent()
+                assertThat(subject.compileAndLintWithContext(env, code)).hasSize(0)
+            }
+
+            @Test
             fun `does not report when the parameter is checked on non-nullity with an else statement`() {
                 val code = """
                     fun foo(a: Int?) {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/CanBeNonNullableSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/CanBeNonNullableSpec.kt
@@ -920,6 +920,18 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
             }
 
             @Test
+            fun `does not report guard statement with side effect ahead`() {
+                val code = """   
+                    fun foo(a: Int?) {
+                        println("side effect")
+                        if (a == null) return
+                        println(a)
+                    }
+                """.trimIndent()
+                assertThat(subject.compileAndLintWithContext(env, code)).hasSize(0)
+            }
+
+            @Test
             fun `does not report null-check returning non-unit type`() {
                 val code = """   
                     fun foo(a: Int?): Int {


### PR DESCRIPTION
For #4492 
Report code smell when null-check expression returns 'Unit'