### PR TITLE
Only recommend using index accessors for Java classes that are known collections

### DIFF
--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitCollectionElementAccessMethodSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitCollectionElementAccessMethodSpec.kt
@@ -440,26 +440,26 @@ class ExplicitCollectionElementAccessMethodSpec {
     inner class WithAdditionalJavaSources(val env: KotlinCoreEnvironment) {
 
         @Test
-        fun `reports setter from java with 2 or less parameters`() {
-            // this test case ensures that the test environment are set up correctly.
+        fun `does not report getters defined in java which are unlikely to be collection accessors`() {
+            val code = """
+                import com.example.fromjava.ByteBuffer
+
+                fun foo() {
+                    val buffer = ByteBuffer()
+                    buffer.get(byteArrayOf(0x42))
+                }
+            """
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
+        }
+
+        @Test
+        fun `does not report setters defined in java which are unlikely to be collection accessors`() {
             val code = """
                 import com.example.fromjava.Rect
 
                 fun foo() {
                     val rect = Rect()
                     rect.set(0, 1)
-                }
-            """
-            assertThat(subject.lintWithContext(env, code)).hasSize(1)
-        }
-
-        @Test
-        fun `does not report if the function has 3 or more arguments and it's defined in java - #4288`() {
-            val code = """
-                import com.example.fromjava.Rect
-
-                fun foo() {
-                    val rect = Rect()
                     rect.set(0, 1, 2)
                 }
             """

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitCollectionElementAccessMethodSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitCollectionElementAccessMethodSpec.kt
@@ -297,6 +297,30 @@ class ExplicitCollectionElementAccessMethodSpec {
         }
 
         @Nested
+        inner class `Java non-collection types` {
+            @Test
+            fun `does not report ByteBuffer get`() {
+                val code = """
+                    fun f() {
+                        val buffer = java.nio.ByteBuffer()
+                        buffer.get(byteArrayOf(0x42))
+                    }
+                """
+                assertThat(subject.lintWithContext(env, code)).isEmpty()
+            }
+
+            @Test
+            fun `does not report Field get`() {
+                val code = """
+                    fun f(field: java.lang.reflect.Field) {
+                        val value = field.get(null) // access static field
+                    }
+                """
+                assertThat(subject.lintWithContext(env, code)).isEmpty()
+            }
+        }
+
+        @Nested
         inner class `custom operators` {
 
             @Test
@@ -438,20 +462,6 @@ class ExplicitCollectionElementAccessMethodSpec {
     @Nested
     @KotlinCoreEnvironmentTest(additionalJavaSourcePaths = ["java"])
     inner class WithAdditionalJavaSources(val env: KotlinCoreEnvironment) {
-
-        @Test
-        fun `does not report getters defined in java which are unlikely to be collection accessors`() {
-            val code = """
-                import com.example.fromjava.ByteBuffer
-
-                fun foo() {
-                    val buffer = ByteBuffer()
-                    buffer.get(byteArrayOf(0x42))
-                }
-            """
-            assertThat(subject.lintWithContext(env, code)).isEmpty()
-        }
-
         @Test
         fun `does not report setters defined in java which are unlikely to be collection accessors`() {
             val code = """

--- a/detekt-rules-style/src/test/resources/java/com/example/fromjava/ByteBuffer.java
+++ b/detekt-rules-style/src/test/resources/java/com/example/fromjava/ByteBuffer.java
@@ -1,7 +1,0 @@
-package com.example.fromjava;
-
-class ByteBuffer
-{
-    ByteBuffer() {}
-    public ByteBuffer get(byte[] dst) { return ByteBuffer(); }
-}

--- a/detekt-rules-style/src/test/resources/java/com/example/fromjava/ByteBuffer.java
+++ b/detekt-rules-style/src/test/resources/java/com/example/fromjava/ByteBuffer.java
@@ -1,0 +1,7 @@
+package com.example.fromjava;
+
+class ByteBuffer
+{
+    ByteBuffer() {}
+    public ByteBuffer get(byte[] dst) { return ByteBuffer(); }
+}


### PR DESCRIPTION
Closes #4918 

The `ExplicitCollectionElementAccessMethod` rule caught cases in which a get/set call _could_ be replaced with indexed accessors, but it is nonsensical to do so. This happens for Java-defined classes, which don't have the concept of operator functions. Yet, the `FunctionDescriptor.isOperator` call seems to default to `true`.

Rather than recommending to replace _all_ such method calls, a default of not reporting them is now assumed, but we can include known Java-defined collection types for which indexed accessors are preferred. For now I just added the necessary types to make the existing tests pass. This is a likely candidate for a rule configuration option.

This also includes a more general solution to a previous bugfix involving getters/setters with type parameters (#4803). The bug was when type inference was impossible, detekt would still recommend replacing with an indexer. Now, an attempt is done to see whether type inference is possible, rather than never recommending replacement in the case of type parameters.

Related and likely obsolete: #3609 
