### PR TITLE
Address TextLocation for Wrapping

### DIFF
--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/Indentation.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/Indentation.kt
@@ -38,7 +38,8 @@ class Indentation(config: Config) : FormattingRule(config) {
         )
 
     /**
-     * [wrapping] is working with file's [node] and we don't want to highlight the whole file
+     * [IndentationRule] has visitor modifier RunOnRootNodeOnly, so [node] is always the root file.
+     * Override the parent implementation to highlight the entire file.
      */
     override fun getTextLocationForViolation(node: ASTNode, offset: Int): TextLocation {
         val relativeEnd = node.text

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/Wrapping.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/Wrapping.kt
@@ -2,9 +2,11 @@ package io.gitlab.arturbosch.detekt.formatting.wrappers
 
 import com.pinterest.ktlint.ruleset.standard.WrappingRule
 import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.TextLocation
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
 import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
+import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 
 /**
  * See [ktlint-website](https://ktlint.github.io#rule-indentation) for documentation.
@@ -15,4 +17,13 @@ class Wrapping(config: Config) : FormattingRule(config) {
 
     override val wrapping = WrappingRule()
     override val issue = issueFor("Reports missing newlines (e.g. between parentheses of a multi-line function call")
+
+    /**
+     * [Wrapping] has visitor modifier RunOnRootNodeOnly, so [node] is always the root file.
+     * Override the parent implementation to highlight the entire file.
+     */
+    override fun getTextLocationForViolation(node: ASTNode, offset: Int): TextLocation {
+        // Use offset + 1 since Wrapping always reports the location of missing new line.
+        return TextLocation(offset, offset + 1)
+    }
 }

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/WrappingSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/WrappingSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.formatting
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.formatting.wrappers.Wrapping
-import io.gitlab.arturbosch.detekt.test.assertThat
+import io.gitlab.arturbosch.detekt.test.assert
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
@@ -22,8 +22,16 @@ class WrappingSpec {
             class A() : B, 
                 C {
             }
+            
+            interface B
+
+            interface C
+
             """.trimIndent()
 
-        assertThat(subject.lint(code)).hasSize(1)
+        subject.lint(code).assert()
+            .hasSize(1)
+            .hasSourceLocation(1, 12)
+            .hasTextLocations(11 to 12)
     }
 }


### PR DESCRIPTION
Addresses https://github.com/detekt/detekt-intellij-plugin/issues/189.

This PR applies the solution in https://github.com/detekt/detekt/pull/4030 for `Wrapping` ktlint rule.