### PR TITLE
NamedArguments: don't count trailing lambda argument

### DIFF
--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NamedArguments.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NamedArguments.kt
@@ -42,7 +42,7 @@ class NamedArguments(config: Config = Config.empty) : Rule(config) {
         Debt.FIVE_MINS
     )
 
-    @Configuration("number of parameters that triggers this inspection")
+    @Configuration("number of arguments that triggers this inspection")
     private val threshold: Int by config(defaultValue = 3)
 
     @Configuration("ignores when argument values are the same as the parameter names")
@@ -50,7 +50,7 @@ class NamedArguments(config: Config = Config.empty) : Rule(config) {
 
     override fun visitCallExpression(expression: KtCallExpression) {
         if (bindingContext == BindingContext.EMPTY) return
-        val valueArguments = expression.valueArguments
+        val valueArguments = expression.valueArguments.filterNot { it is KtLambdaArgument }
         if (valueArguments.size > threshold && expression.canNameArguments()) {
             val message = "This function call has ${valueArguments.size} arguments. To call a function with more " +
                 "than $threshold arguments you should set the name of each argument."

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NamedArgumentsSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NamedArgumentsSpec.kt
@@ -196,6 +196,18 @@ class NamedArgumentsSpec(val env: KotlinCoreEnvironment) {
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
+
+        @Test
+        fun `does not count lambda argument`() {
+            val code = """
+            fun test(n: Int) {
+                require(n == 2) { "N is not 2" }
+            }
+        """
+            val subject = NamedArguments(TestConfig(mapOf("threshold" to 1)))
+            val findings = subject.compileAndLintWithContext(env, code)
+            assertThat(findings).hasSize(0)
+        }
     }
 
     @Nested


### PR DESCRIPTION
Fixes #4999