### PR TITLE
Show finding at declaration name instead of the whole declaration

### DIFF
--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MatchingDeclarationName.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MatchingDeclarationName.kt
@@ -79,7 +79,7 @@ class MatchingDeclarationName(config: Config = Config.empty) : Rule(config) {
             val declarationName = declaration.name
             val filename = file.fileNameWithoutSuffix()
             if (declarationName != filename && hasNoMatchingTypeAlias(filename)) {
-                val entity = Entity.from(declaration).copy(ktElement = file)
+                val entity = Entity.atName(declaration).copy(ktElement = file)
                 report(
                     CodeSmell(
                         issue,

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MatchingDeclarationNameSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MatchingDeclarationNameSpec.kt
@@ -132,7 +132,7 @@ class MatchingDeclarationNameSpec {
         fun `should not pass for object declaration`() {
             val ktFile = compileContentForTest("object O", filename = "Objects.kt")
             val findings = MatchingDeclarationName().lint(ktFile)
-            assertThat(findings).hasSourceLocation(1, 1)
+            assertThat(findings).hasSourceLocation(1, 8)
         }
 
         @Test
@@ -142,14 +142,14 @@ class MatchingDeclarationNameSpec {
                 filename = "Objects.kt"
             )
             val findings = MatchingDeclarationName().lint(ktFile)
-            assertThat(findings).hasSourceLocation(1, 1)
+            assertThat(findings).hasSourceLocation(1, 45)
         }
 
         @Test
         fun `should not pass for class declaration`() {
             val ktFile = compileContentForTest("class C", filename = "Classes.kt")
             val findings = MatchingDeclarationName().lint(ktFile)
-            assertThat(findings).hasSourceLocation(1, 1)
+            assertThat(findings).hasSourceLocation(1, 7)
         }
 
         @Test
@@ -163,14 +163,14 @@ class MatchingDeclarationNameSpec {
                 filename = "ClassUtils.kt"
             )
             val findings = MatchingDeclarationName().lint(ktFile)
-            assertThat(findings).hasSourceLocation(1, 1)
+            assertThat(findings).hasSourceLocation(1, 7)
         }
 
         @Test
         fun `should not pass for interface declaration`() {
             val ktFile = compileContentForTest("interface I", filename = "Not_I.kt")
             val findings = MatchingDeclarationName().lint(ktFile)
-            assertThat(findings).hasSourceLocation(1, 1)
+            assertThat(findings).hasSourceLocation(1, 11)
         }
 
         @Test
@@ -184,7 +184,7 @@ class MatchingDeclarationNameSpec {
                 filename = "E.kt"
             )
             val findings = MatchingDeclarationName().lint(ktFile)
-            assertThat(findings).hasSourceLocation(1, 1)
+            assertThat(findings).hasSourceLocation(1, 12)
         }
 
         @Test
@@ -211,7 +211,7 @@ class MatchingDeclarationNameSpec {
             val findings = MatchingDeclarationName(
                 TestConfig("mustBeFirst" to "false")
             ).lint(ktFile)
-            assertThat(findings).hasSourceLocation(3, 1)
+            assertThat(findings).hasSourceLocation(3, 7)
         }
     }
 }


### PR DESCRIPTION
MatchingDeclarationName findings are reported at the whole declaration and make the IntelliJ plugin harder to use:

![Screenshot from 2022-06-28 13-48-48](https://user-images.githubusercontent.com/20924106/176171392-b85c0b74-3e70-4eff-bdf0-63449c6201c2.png)
