### PR TITLE
Fix reported text position of wrapping rule

### DIFF
--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/Wrapping.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/Wrapping.kt
@@ -2,9 +2,11 @@ package io.gitlab.arturbosch.detekt.formatting.wrappers
 
 import com.pinterest.ktlint.ruleset.standard.WrappingRule
 import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.TextLocation
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
 import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
+import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 
 /**
  * See [ktlint-website](https://ktlint.github.io#rule-indentation) for documentation.
@@ -15,4 +17,6 @@ class Wrapping(config: Config) : FormattingRule(config) {
 
     override val wrapping = WrappingRule()
     override val issue = issueFor("Reports missing newlines (e.g. between parentheses of a multi-line function call")
+
+    override fun getTextLocationForViolation(node: ASTNode, offset: Int) = TextLocation(offset, offset)
 }

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/WrappingSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/WrappingSpec.kt
@@ -16,7 +16,7 @@ class WrappingSpec {
     }
 
     @Test
-    fun `Given a wrong wrapping in the class definition`() {
+    fun `should report a wrong wrapping in the extends clause of the class definition`() {
         val code =
             """
             class A() : B, 
@@ -24,6 +24,8 @@ class WrappingSpec {
             }
             """.trimIndent()
 
-        assertThat(subject.lint(code)).hasSize(1)
+        assertThat(subject.lint(code))
+            .hasSize(1)
+            .hasTextLocations(11 to 11)
     }
 }


### PR DESCRIPTION
Before: notice the Wrapping reporting at the file level

![Screenshot from 2022-06-28 13-48-48](https://user-images.githubusercontent.com/20924106/176186047-37ea90f5-9e9f-4f58-8e01-f4667bcc4ee5.png)

After this PR: after `fold` and at the `}`
![Screenshot from 2022-06-28 15-08-10](https://user-images.githubusercontent.com/20924106/176186596-47c77b8b-85f0-45f3-ab3f-8432fe53e239.png)

Fixes https://github.com/detekt/detekt-intellij-plugin/issues/189