### PR TITLE
Allow constants to be skipped for BooleanPropertyNaming rule

### DIFF
--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/BooleanPropertyNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/BooleanPropertyNaming.kt
@@ -71,10 +71,7 @@ class BooleanPropertyNaming(config: Config = Config.empty) : Rule(config) {
             typeName == KOTLIN_BOOLEAN_TYPE_NAME || typeName == JAVA_BOOLEAN_TYPE_NAME
         val isNonConstantBooleanType = isBooleanType && !declaration.isConstant()
 
-        if (isNonConstantBooleanType
-            && !name.contains(allowedPattern)
-            && !isIgnoreOverridden(declaration)
-        ) {
+        if (isNonConstantBooleanType && !name.contains(allowedPattern) && !isIgnoreOverridden(declaration)) {
             report(reportCodeSmell(declaration, name))
         }
     }

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/BooleanPropertyNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/BooleanPropertyNaming.kt
@@ -12,6 +12,7 @@ import io.gitlab.arturbosch.detekt.api.internal.Configuration
 import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.rules.fqNameOrNull
 import io.gitlab.arturbosch.detekt.rules.identifierName
+import io.gitlab.arturbosch.detekt.rules.isConstant
 import io.gitlab.arturbosch.detekt.rules.isOverride
 import org.jetbrains.kotlin.psi.KtCallableDeclaration
 import org.jetbrains.kotlin.psi.KtParameter
@@ -68,8 +69,12 @@ class BooleanPropertyNaming(config: Config = Config.empty) : Rule(config) {
         val typeName = getTypeName(declaration)
         val isBooleanType =
             typeName == KOTLIN_BOOLEAN_TYPE_NAME || typeName == JAVA_BOOLEAN_TYPE_NAME
+        val isNonConstantBooleanType = isBooleanType && !declaration.isConstant()
 
-        if (isBooleanType && !name.contains(allowedPattern) && !isIgnoreOverridden(declaration)) {
+        if (isNonConstantBooleanType
+            && !name.contains(allowedPattern)
+            && !isIgnoreOverridden(declaration)
+        ) {
             report(reportCodeSmell(declaration, name))
         }
     }

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/BooleanPropertyNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/BooleanPropertyNamingSpec.kt
@@ -271,6 +271,30 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
         }
 
         @Test
+        fun `should not warn about Kotlin Boolean if it is a constant val`() {
+            val code = """
+                class Test {
+                    const val CONSTANT_VAL_BOOLEAN = true
+                }
+            """
+            val findings = subject.compileAndLintWithContext(env, code)
+
+            assertThat(findings).hasSize(0)
+        }
+
+        @Test
+        fun `should not warn about Java Boolean if it is a constant val`() {
+            val code = """
+                class Test {
+                    const val CONSTANT_VAL_BOOLEAN: java.lang.Boolean = true
+                }
+            """
+            val findings = subject.compileAndLintWithContext(env, code)
+
+            assertThat(findings).hasSize(0)
+        }
+
+        @Test
         fun `should warn about Kotlin Boolean override if isIgnoreOverridden is false`() {
             val code = """
                 interface Test {

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/BooleanPropertyNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/BooleanPropertyNamingSpec.kt
@@ -273,20 +273,8 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
         @Test
         fun `should not warn about Kotlin Boolean if it is a constant val`() {
             val code = """
-                class Test {
+                object Test {
                     const val CONSTANT_VAL_BOOLEAN = true
-                }
-            """
-            val findings = subject.compileAndLintWithContext(env, code)
-
-            assertThat(findings).hasSize(0)
-        }
-
-        @Test
-        fun `should not warn about Java Boolean if it is a constant val`() {
-            val code = """
-                class Test {
-                    const val CONSTANT_VAL_BOOLEAN: java.lang.Boolean = true
                 }
             """
             val findings = subject.compileAndLintWithContext(env, code)


### PR DESCRIPTION
Fixes #4920