### PR TITLE
Loading a specific resource from a module must use class from module

### DIFF
--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/tooling/DefaultConfigProvider.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/tooling/DefaultConfigProvider.kt
@@ -32,7 +32,7 @@ class DefaultConfigProvider : DefaultConfigurationProvider {
 private fun configInputStream(extensionsSpec: ExtensionsSpec): InputStream {
     val outputStream = ByteArrayOutputStream()
 
-    requireNotNull(extensionsSpec.javaClass.getSafeResourceAsStream("/default-detekt-config.yml"))
+    requireNotNull(DefaultConfigProvider::class.java.getSafeResourceAsStream("/default-detekt-config.yml"))
         .use { it.copyTo(outputStream) }
 
     ExtensionFacade(extensionsSpec.plugins).pluginLoader


### PR DESCRIPTION
Image following scenario:

A tool (e.g. IntelliJ plugin) uses `detekt-tooling` to run detekt.
The tool does not include the detekt jars by default (no `implementation("detekt-core")` usage) but loads them dynamically.
For example the user can specify the detekt version and plugin jars. The tool downloads `cli-all.jar` and the plugin jars, loads them via a `URLClassLoader`, gets a `DetektProvider.get(): Detekt` instance and runs detekt.

Notice that the tool must use the `detekt-tooling` api which is not inside the `URLClassLoader` (!). `ExtensionSpec` was loaded via the AppClassLoader (ClassLoader which wants to load detekt dynamically where detekt-tooling is known). `ExtensionSpec.javaClass.getResource` won't find the `default-detekt-config.yml` file.

Conclusion: when loading detekt core and all plugins dynamically detekt's modules are not allowed to use the `ClassLoader` from `detekt-tooling` or `detekt-api`.