### PR TITLE
Add endColumn/endLine to SARIF region

### DIFF
--- a/detekt-report-sarif/build.gradle.kts
+++ b/detekt-report-sarif/build.gradle.kts
@@ -10,4 +10,5 @@ dependencies {
     testImplementation(projects.detektTestUtils)
     testImplementation(testFixtures(projects.detektApi))
     testImplementation(libs.assertj)
+    testImplementation(libs.mockk)
 }

--- a/detekt-report-sarif/build.gradle.kts
+++ b/detekt-report-sarif/build.gradle.kts
@@ -10,5 +10,5 @@ dependencies {
     testImplementation(projects.detektTestUtils)
     testImplementation(testFixtures(projects.detektApi))
     testImplementation(libs.assertj)
-    testImplementation(libs.mockk)
+    testImplementation(projects.detektTest)
 }

--- a/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/Results.kt
+++ b/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/Results.kt
@@ -29,7 +29,7 @@ private fun Finding.toResult(ruleSetId: RuleSetId): io.github.detekt.sarif4k.Res
     return io.github.detekt.sarif4k.Result(
         ruleID = "detekt.$ruleSetId.$id",
         level = severity.toResultLevel(),
-        locations = (listOf(location) + references.map { it.location }).map { it.toLocation(code) }.toSet().toList(),
+        locations = (listOf(location) + references.map { it.location }).map { it.toLocation(code) }.distinct().toList(),
         message = Message(text = messageOrDescription())
     )
 }

--- a/detekt-report-sarif/src/test/kotlin/io/github/detekt/report/sarif/SarifOutputReportSpec.kt
+++ b/detekt-report-sarif/src/test/kotlin/io/github/detekt/report/sarif/SarifOutputReportSpec.kt
@@ -146,12 +146,12 @@ private fun mockKtElement(): KtElement {
     return ktElementMock
 }
 
-private fun createFinding(ruleName: String, severity: SeverityLevel, entity: Entity? = null): Finding {
-    return object : CodeSmell(
-        createIssue(ruleName),
-        entity ?: createEntity("TestFile.kt"),
-        "TestMessage"
-    ) {
+private fun createFinding(
+    ruleName: String,
+    severity: SeverityLevel,
+    entity: Entity = createEntity("TestFile.kt")
+): Finding {
+    return object : CodeSmell(createIssue(ruleName), entity, "TestMessage") {
         override val severity: SeverityLevel
             get() = severity
     }

--- a/detekt-report-sarif/src/test/kotlin/io/github/detekt/report/sarif/SarifOutputReportSpec.kt
+++ b/detekt-report-sarif/src/test/kotlin/io/github/detekt/report/sarif/SarifOutputReportSpec.kt
@@ -85,8 +85,8 @@ class SarifOutputReportSpec {
          */
         val startLine = 3
         val startColumn = 7
-        val endColumn = 15
         val endLine = 3
+        val endColumn = 15
 
         val refEntity = TestRule().compileAndLint(Snippet.code).first().entity
         val location = Location(
@@ -122,8 +122,8 @@ class SarifOutputReportSpec {
          */
         val startLine = 3
         val startColumn = 17
-        val endColumn = 1
         val endLine = 5
+        val endColumn = 1
 
         val refEntity = TestRule().compileAndLint(Snippet.code).first().entity
         val location = Location(


### PR DESCRIPTION
For #4919 

#### Looks like the following:
<img width="623" alt="SARIF finding image " src="https://user-images.githubusercontent.com/26341194/176519015-ab76625e-01c1-4c14-a812-b547268fe947.png">


But I wasn't able to come up with good tests so I just compare result against predefined text.
