### PR TITLE
Fix CLI link that is incorrect on the website

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -127,7 +127,7 @@ const config = {
               },
               {
                 label: 'Getting Started with the CLI',
-                to: '/docs/gettingstarted/gradle',
+                to: '/docs/gettingstarted/cli',
               },
               {
                 label: 'Rules Documentation',


### PR DESCRIPTION
A picture is worth a thousand words :). The website footer link mentioning CLI setup links to Gradle :). I fixed that


<img width="375" alt="image" src="https://user-images.githubusercontent.com/921666/176677125-f9f2f339-1750-4205-8487-c9ff75259779.png">



A similar PR may already be submitted!
Please search among the [Pull requests](https://github.com/detekt/detekt/pulls) before creating one.

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Link to relevant issues if possible.

For more information, see the [CONTRIBUTING guide](https://github.com/detekt/detekt/blob/main/.github/CONTRIBUTING.md).
