### PR TITLE
Add ending line and column to Location.kt

### DIFF
--- a/detekt-api/api/detekt-api.api
+++ b/detekt-api/api/detekt-api.api
@@ -353,10 +353,12 @@ public final class io/gitlab/arturbosch/detekt/api/LazyRegex : kotlin/properties
 
 public final class io/gitlab/arturbosch/detekt/api/Location : io/gitlab/arturbosch/detekt/api/Compactable {
 	public static final field Companion Lio/gitlab/arturbosch/detekt/api/Location$Companion;
-	public fun <init> (Lio/gitlab/arturbosch/detekt/api/SourceLocation;Lio/gitlab/arturbosch/detekt/api/TextLocation;Lio/github/detekt/psi/FilePath;)V
+	public fun <init> (Lio/gitlab/arturbosch/detekt/api/SourceLocation;Lio/gitlab/arturbosch/detekt/api/TextLocation;Lio/github/detekt/psi/FilePath;Lio/gitlab/arturbosch/detekt/api/SourceLocation;)V
+	public synthetic fun <init> (Lio/gitlab/arturbosch/detekt/api/SourceLocation;Lio/gitlab/arturbosch/detekt/api/TextLocation;Lio/github/detekt/psi/FilePath;Lio/gitlab/arturbosch/detekt/api/SourceLocation;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Lio/gitlab/arturbosch/detekt/api/SourceLocation;Lio/gitlab/arturbosch/detekt/api/TextLocation;Ljava/lang/String;)V
 	public fun <init> (Lio/gitlab/arturbosch/detekt/api/SourceLocation;Lio/gitlab/arturbosch/detekt/api/TextLocation;Ljava/lang/String;Lio/github/detekt/psi/FilePath;)V
-	public synthetic fun <init> (Lio/gitlab/arturbosch/detekt/api/SourceLocation;Lio/gitlab/arturbosch/detekt/api/TextLocation;Ljava/lang/String;Lio/github/detekt/psi/FilePath;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lio/gitlab/arturbosch/detekt/api/SourceLocation;Lio/gitlab/arturbosch/detekt/api/TextLocation;Ljava/lang/String;Lio/github/detekt/psi/FilePath;Lio/gitlab/arturbosch/detekt/api/SourceLocation;)V
+	public synthetic fun <init> (Lio/gitlab/arturbosch/detekt/api/SourceLocation;Lio/gitlab/arturbosch/detekt/api/TextLocation;Ljava/lang/String;Lio/github/detekt/psi/FilePath;Lio/gitlab/arturbosch/detekt/api/SourceLocation;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Lio/gitlab/arturbosch/detekt/api/SourceLocation;Lio/gitlab/arturbosch/detekt/api/TextLocation;Ljava/lang/String;Ljava/lang/String;)V
 	public fun compact ()Ljava/lang/String;
 	public fun compactWithSignature ()Ljava/lang/String;
@@ -364,9 +366,11 @@ public final class io/gitlab/arturbosch/detekt/api/Location : io/gitlab/arturbos
 	public final fun component2 ()Lio/gitlab/arturbosch/detekt/api/TextLocation;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Lio/github/detekt/psi/FilePath;
-	public final fun copy (Lio/gitlab/arturbosch/detekt/api/SourceLocation;Lio/gitlab/arturbosch/detekt/api/TextLocation;Ljava/lang/String;Lio/github/detekt/psi/FilePath;)Lio/gitlab/arturbosch/detekt/api/Location;
-	public static synthetic fun copy$default (Lio/gitlab/arturbosch/detekt/api/Location;Lio/gitlab/arturbosch/detekt/api/SourceLocation;Lio/gitlab/arturbosch/detekt/api/TextLocation;Ljava/lang/String;Lio/github/detekt/psi/FilePath;ILjava/lang/Object;)Lio/gitlab/arturbosch/detekt/api/Location;
+	public final fun component5 ()Lio/gitlab/arturbosch/detekt/api/SourceLocation;
+	public final fun copy (Lio/gitlab/arturbosch/detekt/api/SourceLocation;Lio/gitlab/arturbosch/detekt/api/TextLocation;Ljava/lang/String;Lio/github/detekt/psi/FilePath;Lio/gitlab/arturbosch/detekt/api/SourceLocation;)Lio/gitlab/arturbosch/detekt/api/Location;
+	public static synthetic fun copy$default (Lio/gitlab/arturbosch/detekt/api/Location;Lio/gitlab/arturbosch/detekt/api/SourceLocation;Lio/gitlab/arturbosch/detekt/api/TextLocation;Ljava/lang/String;Lio/github/detekt/psi/FilePath;Lio/gitlab/arturbosch/detekt/api/SourceLocation;ILjava/lang/Object;)Lio/gitlab/arturbosch/detekt/api/Location;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEndSource ()Lio/gitlab/arturbosch/detekt/api/SourceLocation;
 	public final fun getFile ()Ljava/lang/String;
 	public final fun getFilePath ()Lio/github/detekt/psi/FilePath;
 	public final fun getSource ()Lio/gitlab/arturbosch/detekt/api/SourceLocation;

--- a/detekt-api/api/detekt-api.api
+++ b/detekt-api/api/detekt-api.api
@@ -353,12 +353,11 @@ public final class io/gitlab/arturbosch/detekt/api/LazyRegex : kotlin/properties
 
 public final class io/gitlab/arturbosch/detekt/api/Location : io/gitlab/arturbosch/detekt/api/Compactable {
 	public static final field Companion Lio/gitlab/arturbosch/detekt/api/Location$Companion;
-	public fun <init> (Lio/gitlab/arturbosch/detekt/api/SourceLocation;Lio/gitlab/arturbosch/detekt/api/TextLocation;Lio/github/detekt/psi/FilePath;Lio/gitlab/arturbosch/detekt/api/SourceLocation;)V
-	public synthetic fun <init> (Lio/gitlab/arturbosch/detekt/api/SourceLocation;Lio/gitlab/arturbosch/detekt/api/TextLocation;Lio/github/detekt/psi/FilePath;Lio/gitlab/arturbosch/detekt/api/SourceLocation;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lio/gitlab/arturbosch/detekt/api/SourceLocation;Lio/gitlab/arturbosch/detekt/api/SourceLocation;Lio/gitlab/arturbosch/detekt/api/TextLocation;Lio/github/detekt/psi/FilePath;)V
+	public fun <init> (Lio/gitlab/arturbosch/detekt/api/SourceLocation;Lio/gitlab/arturbosch/detekt/api/TextLocation;Lio/github/detekt/psi/FilePath;)V
 	public fun <init> (Lio/gitlab/arturbosch/detekt/api/SourceLocation;Lio/gitlab/arturbosch/detekt/api/TextLocation;Ljava/lang/String;)V
 	public fun <init> (Lio/gitlab/arturbosch/detekt/api/SourceLocation;Lio/gitlab/arturbosch/detekt/api/TextLocation;Ljava/lang/String;Lio/github/detekt/psi/FilePath;)V
-	public fun <init> (Lio/gitlab/arturbosch/detekt/api/SourceLocation;Lio/gitlab/arturbosch/detekt/api/TextLocation;Ljava/lang/String;Lio/github/detekt/psi/FilePath;Lio/gitlab/arturbosch/detekt/api/SourceLocation;)V
-	public synthetic fun <init> (Lio/gitlab/arturbosch/detekt/api/SourceLocation;Lio/gitlab/arturbosch/detekt/api/TextLocation;Ljava/lang/String;Lio/github/detekt/psi/FilePath;Lio/gitlab/arturbosch/detekt/api/SourceLocation;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lio/gitlab/arturbosch/detekt/api/SourceLocation;Lio/gitlab/arturbosch/detekt/api/TextLocation;Ljava/lang/String;Lio/github/detekt/psi/FilePath;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Lio/gitlab/arturbosch/detekt/api/SourceLocation;Lio/gitlab/arturbosch/detekt/api/TextLocation;Ljava/lang/String;Ljava/lang/String;)V
 	public fun compact ()Ljava/lang/String;
 	public fun compactWithSignature ()Ljava/lang/String;
@@ -366,9 +365,8 @@ public final class io/gitlab/arturbosch/detekt/api/Location : io/gitlab/arturbos
 	public final fun component2 ()Lio/gitlab/arturbosch/detekt/api/TextLocation;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Lio/github/detekt/psi/FilePath;
-	public final fun component5 ()Lio/gitlab/arturbosch/detekt/api/SourceLocation;
-	public final fun copy (Lio/gitlab/arturbosch/detekt/api/SourceLocation;Lio/gitlab/arturbosch/detekt/api/TextLocation;Ljava/lang/String;Lio/github/detekt/psi/FilePath;Lio/gitlab/arturbosch/detekt/api/SourceLocation;)Lio/gitlab/arturbosch/detekt/api/Location;
-	public static synthetic fun copy$default (Lio/gitlab/arturbosch/detekt/api/Location;Lio/gitlab/arturbosch/detekt/api/SourceLocation;Lio/gitlab/arturbosch/detekt/api/TextLocation;Ljava/lang/String;Lio/github/detekt/psi/FilePath;Lio/gitlab/arturbosch/detekt/api/SourceLocation;ILjava/lang/Object;)Lio/gitlab/arturbosch/detekt/api/Location;
+	public final fun copy (Lio/gitlab/arturbosch/detekt/api/SourceLocation;Lio/gitlab/arturbosch/detekt/api/TextLocation;Ljava/lang/String;Lio/github/detekt/psi/FilePath;)Lio/gitlab/arturbosch/detekt/api/Location;
+	public static synthetic fun copy$default (Lio/gitlab/arturbosch/detekt/api/Location;Lio/gitlab/arturbosch/detekt/api/SourceLocation;Lio/gitlab/arturbosch/detekt/api/TextLocation;Ljava/lang/String;Lio/github/detekt/psi/FilePath;ILjava/lang/Object;)Lio/gitlab/arturbosch/detekt/api/Location;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getEndSource ()Lio/gitlab/arturbosch/detekt/api/SourceLocation;
 	public final fun getFile ()Ljava/lang/String;

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Location.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Location.kt
@@ -24,17 +24,27 @@ data class Location @Deprecated("Consider relative path by passing a [FilePath]"
         )
     )
     val file: String,
-    val filePath: FilePath = FilePath.fromAbsolute(Paths.get(file)),
-    val endSource: SourceLocation = SourceLocation(-1, -1)
+    val filePath: FilePath = FilePath.fromAbsolute(Paths.get(file))
 ) : Compactable {
+    var endSource: SourceLocation = source
+        private set
 
     @Suppress("DEPRECATION")
     constructor(
         source: SourceLocation,
         text: TextLocation,
+        filePath: FilePath
+    ) : this(source, text, filePath.absolutePath.toString(), filePath)
+
+    @Suppress("DEPRECATION")
+    constructor(
+        source: SourceLocation,
+        endSource: SourceLocation,
+        text: TextLocation,
         filePath: FilePath,
-        endSource: SourceLocation = SourceLocation(-1, -1)
-    ) : this(source, text, filePath.absolutePath.toString(), filePath, endSource)
+    ) : this(source, text, filePath.absolutePath.toString(), filePath) {
+        this.endSource = endSource
+    }
 
     @Suppress("DEPRECATION")
     @Deprecated(
@@ -67,7 +77,7 @@ data class Location @Deprecated("Consider relative path by passing a [FilePath]"
             val end = endLineAndColumn(element, offset)
             val endSourceLocation = SourceLocation(end.line, end.column)
             val textLocation = TextLocation(element.startOffset + offset, element.endOffset + offset)
-            return Location(sourceLocation, textLocation, element.containingFile.toFilePath(), endSourceLocation)
+            return Location(sourceLocation, endSourceLocation, textLocation, element.containingFile.toFilePath())
         }
 
         /**

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/LocationSpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/LocationSpec.kt
@@ -1,0 +1,34 @@
+package io.gitlab.arturbosch.detekt.api
+
+import io.github.detekt.test.utils.compileContentForTest
+import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.junit.jupiter.api.Test
+
+class LocationSpec {
+    @Test
+    fun `start and end positions of block`() {
+        val code = """
+            fun data(): Int {
+                return 0
+            }
+        """.trimIndent()
+        val psiElement = compileContentForTest(code).findChildByClass(KtNamedFunction::class.java)!!
+        val location = Location.from(psiElement)
+
+        assertThat("${location.source} - ${location.endSource}").isEqualTo("1:1 - 3:2")
+    }
+
+    @Test
+    fun `start and end positions of fun keyword`() {
+        val code = """
+            fun data(): Int {
+                return 0
+            }
+        """.trimIndent()
+        val psiElement = compileContentForTest(code).findChildByClass(KtNamedFunction::class.java)!!
+        val location = Location.from(psiElement.funKeyword!!)
+
+        assertThat("${location.source} - ${location.endSource}").isEqualTo("1:1 - 1:4")
+    }
+}

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/LocationSpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/LocationSpec.kt
@@ -6,6 +6,7 @@ import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.junit.jupiter.api.Test
 
 class LocationSpec {
+
     @Test
     fun `start and end positions of block`() {
         val code = """


### PR DESCRIPTION
Close #5025 

Added `endSource` as the last parameter in the `Location` constructor.

I need some guidelines:
 - Is it necessary to change the name of parameters, for example `startSource` and `endSource`?
 - Should the order of the parameters be changed? 
 - Should `compact()`  string representation be updated?
 - Should there be a test for such trivia?

This could trigger changes in many files.