### PR TITLE
MaxChainedCallsOnSameLine: don't count package references as chained calls

### DIFF
--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxChainedCallsOnSameLine.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxChainedCallsOnSameLine.kt
@@ -9,11 +9,15 @@ import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.config
 import io.gitlab.arturbosch.detekt.api.internal.Configuration
+import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
+import org.jetbrains.kotlin.descriptors.PackageViewDescriptor
 import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.psi.KtImportDirective
 import org.jetbrains.kotlin.psi.KtPackageDirective
 import org.jetbrains.kotlin.psi.KtQualifiedExpression
+import org.jetbrains.kotlin.psi.KtReferenceExpression
 import org.jetbrains.kotlin.psi.KtUnaryExpression
+import org.jetbrains.kotlin.resolve.BindingContext
 
 /**
  * Limits the number of chained calls which can be placed on a single line.
@@ -27,6 +31,7 @@ import org.jetbrains.kotlin.psi.KtUnaryExpression
  *   .d().e().f()
  * </compliant>
  */
+@RequiresTypeResolution
 class MaxChainedCallsOnSameLine(config: Config = Config.empty) : Rule(config) {
     override val issue = Issue(
         id = javaClass.simpleName,
@@ -38,8 +43,11 @@ class MaxChainedCallsOnSameLine(config: Config = Config.empty) : Rule(config) {
     @Configuration("maximum chained calls allowed on a single line")
     private val maxChainedCalls: Int by config(defaultValue = 5)
 
+    @Suppress("ReturnCount")
     override fun visitQualifiedExpression(expression: KtQualifiedExpression) {
         super.visitQualifiedExpression(expression)
+
+        if (bindingContext == BindingContext.EMPTY) return
 
         val parent = expression.parent
 
@@ -63,11 +71,19 @@ class MaxChainedCallsOnSameLine(config: Config = Config.empty) : Rule(config) {
 
     private fun KtExpression.countChainedCalls(): Int {
         return when (this) {
-            is KtQualifiedExpression ->
-                if (callOnNewLine()) 0 else receiverExpression.countChainedCalls() + 1
+            is KtQualifiedExpression -> when {
+                receiverExpression.isReferenceToPackage() || callOnNewLine() -> 0
+                else -> receiverExpression.countChainedCalls() + 1
+            }
             is KtUnaryExpression -> baseExpression?.countChainedCalls() ?: 0
             else -> 0
         }
+    }
+
+    private fun KtExpression.isReferenceToPackage(): Boolean {
+        val selectorOrThis = (this as? KtQualifiedExpression)?.selectorExpression ?: this
+        if (selectorOrThis !is KtReferenceExpression) return false
+        return bindingContext[BindingContext.REFERENCE_TARGET, selectorOrThis] is PackageViewDescriptor
     }
 
     private fun KtQualifiedExpression.callOnNewLine(): Boolean {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxChainedCallsOnSameLineSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxChainedCallsOnSameLineSpec.kt
@@ -3,8 +3,8 @@ package io.gitlab.arturbosch.detekt.rules.style
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
+import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
 import io.gitlab.arturbosch.detekt.test.lint
-import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
 
@@ -15,7 +15,7 @@ class MaxChainedCallsOnSameLineSpec(private val env: KotlinCoreEnvironment) {
         val rule = MaxChainedCallsOnSameLine(TestConfig(mapOf("maxChainedCalls" to 3)))
         val code = "val a = 0.plus(0)"
 
-        assertThat(rule.lintWithContext(env, code)).isEmpty()
+        assertThat(rule.compileAndLintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -23,7 +23,7 @@ class MaxChainedCallsOnSameLineSpec(private val env: KotlinCoreEnvironment) {
         val rule = MaxChainedCallsOnSameLine(TestConfig(mapOf("maxChainedCalls" to 3)))
         val code = "val a = 0.plus(0).plus(0)"
 
-        assertThat(rule.lintWithContext(env, code)).isEmpty()
+        assertThat(rule.compileAndLintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -31,7 +31,7 @@ class MaxChainedCallsOnSameLineSpec(private val env: KotlinCoreEnvironment) {
         val rule = MaxChainedCallsOnSameLine(TestConfig(mapOf("maxChainedCalls" to 3)))
         val code = "val a = 0.plus(0).plus(0).plus(0)"
 
-        assertThat(rule.lintWithContext(env, code)).hasSize(1)
+        assertThat(rule.compileAndLintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -39,7 +39,7 @@ class MaxChainedCallsOnSameLineSpec(private val env: KotlinCoreEnvironment) {
         val rule = MaxChainedCallsOnSameLine(TestConfig(mapOf("maxChainedCalls" to 3)))
         val code = "val a = 0?.plus(0)?.plus(0)?.plus(0)"
 
-        assertThat(rule.lintWithContext(env, code)).hasSize(1)
+        assertThat(rule.compileAndLintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -47,7 +47,7 @@ class MaxChainedCallsOnSameLineSpec(private val env: KotlinCoreEnvironment) {
         val rule = MaxChainedCallsOnSameLine(TestConfig(mapOf("maxChainedCalls" to 3)))
         val code = "val a = 0!!.plus(0)!!.plus(0)!!.plus(0)"
 
-        assertThat(rule.lintWithContext(env, code)).hasSize(1)
+        assertThat(rule.compileAndLintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -55,7 +55,7 @@ class MaxChainedCallsOnSameLineSpec(private val env: KotlinCoreEnvironment) {
         val rule = MaxChainedCallsOnSameLine(TestConfig(mapOf("maxChainedCalls" to 3)))
         val code = "val a = 0.plus(0).plus(0).plus(0).plus(0).plus(0).plus(0)"
 
-        assertThat(rule.lintWithContext(env, code)).hasSize(1)
+        assertThat(rule.compileAndLintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -69,7 +69,7 @@ class MaxChainedCallsOnSameLineSpec(private val env: KotlinCoreEnvironment) {
                 .plus(0)
         """
 
-        assertThat(rule.lintWithContext(env, code)).isEmpty()
+        assertThat(rule.compileAndLintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -81,7 +81,7 @@ class MaxChainedCallsOnSameLineSpec(private val env: KotlinCoreEnvironment) {
                 .plus(0).plus(0).plus(0)
         """
 
-        assertThat(rule.lintWithContext(env, code)).isEmpty()
+        assertThat(rule.compileAndLintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -93,7 +93,7 @@ class MaxChainedCallsOnSameLineSpec(private val env: KotlinCoreEnvironment) {
                 .plus(0)
         """
 
-        assertThat(rule.lintWithContext(env, code)).hasSize(1)
+        assertThat(rule.compileAndLintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -106,7 +106,7 @@ class MaxChainedCallsOnSameLineSpec(private val env: KotlinCoreEnvironment) {
                 .plus(0)
         """
 
-        assertThat(rule.lintWithContext(env, code)).hasSize(1)
+        assertThat(rule.compileAndLintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -122,32 +122,24 @@ class MaxChainedCallsOnSameLineSpec(private val env: KotlinCoreEnvironment) {
         val rule = MaxChainedCallsOnSameLine(TestConfig(mapOf("maxChainedCalls" to 3)))
         val code = "package a.b.c.d.e"
 
-        assertThat(rule.lintWithContext(env, code)).isEmpty()
+        assertThat(rule.compileAndLintWithContext(env, code)).isEmpty()
     }
 
     @Test
     fun `does not count package references as chained calls`() {
         val rule = MaxChainedCallsOnSameLine(TestConfig(mapOf("maxChainedCalls" to 3)))
         val code = """
-            package a.b.c
-            fun foo() = 1
-            fun test() {
-                a.b.c.foo().plus(0).plus(0)
-            }
+            val x = kotlin.math.floor(1.0).plus(1).plus(1)
         """
-        assertThat(rule.lintWithContext(env, code)).isEmpty()
+        assertThat(rule.compileAndLintWithContext(env, code)).isEmpty()
     }
 
     @Test
     fun `does not count a package reference as chained calls`() {
         val rule = MaxChainedCallsOnSameLine(TestConfig(mapOf("maxChainedCalls" to 3)))
         val code = """
-            package a
-            fun foo() = 1
-            fun test() {
-                a.foo().plus(0).plus(0)
-            }
+            val x = kotlin.run { 1 }.plus(1).plus(1)
         """
-        assertThat(rule.lintWithContext(env, code)).isEmpty()
+        assertThat(rule.compileAndLintWithContext(env, code)).isEmpty()
     }
 }


### PR DESCRIPTION
Fixes #5028 