### PR TITLE
Bump ktlint to version 0.46.1 

### DIFF
--- a/code-coverage-report/build.gradle.kts
+++ b/code-coverage-report/build.gradle.kts
@@ -51,7 +51,8 @@ tasks.check {
 configurations.allCodeCoverageReportClassDirectories.get().attributes {
     attributes.attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category::class, Category.LIBRARY))
     attributes.attribute(
-        LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements::class, LibraryElements.CLASSES)
+        LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE,
+        objects.named(LibraryElements::class, LibraryElements.CLASSES)
     )
 }
 

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -73,6 +73,8 @@ formatting:
     active: true
   EnumEntryNameCase:
     active: true
+  Filename:
+    active: false
   MaximumLineLength:
     active: false
   MultiLineIfElse:

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Location.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Location.kt
@@ -14,7 +14,10 @@ import java.nio.file.Paths
 /**
  * Specifies a position within a source code fragment.
  */
-data class Location @Deprecated("Consider relative path by passing a [FilePath]") @JvmOverloads constructor(
+data class Location
+@Deprecated("Consider relative path by passing a [FilePath]")
+@JvmOverloads
+constructor(
     val source: SourceLocation,
     val text: TextLocation,
     @Deprecated(

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/AnnotationExcluderSpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/AnnotationExcluderSpec.kt
@@ -27,7 +27,9 @@ class AnnotationExcluderSpec(private val env: KotlinCoreEnvironment) {
         """.trimIndent()
     )
 
-    @ParameterizedTest(name = "Given {0} is excluded when the {1} is found then the excluder returns {2} without type solving")
+    @ParameterizedTest(
+        name = "Given {0} is excluded when the {1} is found then the excluder returns {2} without type solving"
+    )
     @CsvFileSource(resources = ["/annotation_excluder.csv"])
     fun `all cases`(exclusion: String, annotation: String, shouldExclude: Boolean) {
         val (file, ktAnnotation) = createKtFile(annotation)
@@ -36,7 +38,9 @@ class AnnotationExcluderSpec(private val env: KotlinCoreEnvironment) {
         assertThat(excluder.shouldExclude(listOf(ktAnnotation))).isEqualTo(shouldExclude)
     }
 
-    @ParameterizedTest(name = "Given {0} is excluded when the {1} is found then the excluder returns {2} with type solving")
+    @ParameterizedTest(
+        name = "Given {0} is excluded when the {1} is found then the excluder returns {2} with type solving"
+    )
     @CsvFileSource(resources = ["/annotation_excluder.csv"])
     fun `all cases - Type Solving`(exclusion: String, annotation: String, shouldExclude: Boolean) {
         val (file, ktAnnotation) = createKtFile(annotation)

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/internal/PathMatchersSpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/internal/PathMatchersSpec.kt
@@ -41,7 +41,9 @@ class PathMatchersSpec {
         fun `should work as a regex path matcher when syntax not specified`() {
             assertThatThrownBy { pathMatcher("regex:.*/detekt/api/.*") }
                 .isInstanceOf(IllegalArgumentException::class.java)
-                .hasMessage("Only globbing patterns are supported as they are treated os-independently by the PathMatcher api.")
+                .hasMessage(
+                    "Only globbing patterns are supported as they are treated os-independently by the PathMatcher api."
+                )
         }
     }
 }

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/YamlConfigSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/YamlConfigSpec.kt
@@ -57,7 +57,9 @@ class YamlConfigSpec {
                 @Suppress("UNUSED_VARIABLE")
                 val ignored = config.valueOrDefault("style", "")
             }
-                .withMessage("Value \"{WildcardImport={active=true}, NoElseInWhenExpression={active=true}, MagicNumber={active=true, ignoreNumbers=[-1, 0, 1, 2]}}\" set for config parameter \"style\" is not of required type String.")
+                .withMessage(
+                    "Value \"{WildcardImport={active=true}, NoElseInWhenExpression={active=true}, MagicNumber={active=true, ignoreNumbers=[-1, 0, 1, 2]}}\" set for config parameter \"style\" is not of required type String."
+                )
         }
     }
 
@@ -94,7 +96,9 @@ class YamlConfigSpec {
                     .subConfig("Rule")
                     .valueOrDefault("threshold", 6)
             }
-                .withMessage("Value \"v5.7\" set for config parameter \"RuleSet > Rule > threshold\" is not of required type Int.")
+                .withMessage(
+                    "Value \"v5.7\" set for config parameter \"RuleSet > Rule > threshold\" is not of required type Int."
+                )
         }
 
         @Test
@@ -105,7 +109,9 @@ class YamlConfigSpec {
                     .subConfig("Rule")
                     .valueOrDefault("active", 1)
             }
-                .withMessage("Value \"[]\" set for config parameter \"RuleSet > Rule > active\" is not of required type Int.")
+                .withMessage(
+                    "Value \"[]\" set for config parameter \"RuleSet > Rule > active\" is not of required type Int."
+                )
         }
     }
 

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingRule.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingRule.kt
@@ -4,11 +4,20 @@ import com.pinterest.ktlint.core.KtLint
 import com.pinterest.ktlint.core.Rule.VisitorModifier.RunAsLateAsPossible
 import com.pinterest.ktlint.core.Rule.VisitorModifier.RunOnRootNodeOnly
 import com.pinterest.ktlint.core.api.DefaultEditorConfigProperties.codeStyleSetProperty
-import com.pinterest.ktlint.core.api.FeatureInAlphaState
 import com.pinterest.ktlint.core.api.UsesEditorConfigProperties
 import io.github.detekt.psi.fileName
 import io.github.detekt.psi.toFilePath
-import io.gitlab.arturbosch.detekt.api.*
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.CorrectableCodeSmell
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Location
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.SingleAssign
+import io.gitlab.arturbosch.detekt.api.SourceLocation
+import io.gitlab.arturbosch.detekt.api.TextLocation
 import org.ec4j.core.model.Property
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.lang.FileASTNode
@@ -49,7 +58,7 @@ abstract class FormattingRule(config: Config) : Rule(config) {
         val editorConfigProperties = overrideEditorConfigProperties()?.toMutableMap()
             ?: mutableMapOf()
 
-        if(isAndroid) {
+        if (isAndroid) {
             editorConfigProperties[codeStyleSetProperty] = "android"
         }
 

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingRule.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingRule.kt
@@ -3,21 +3,12 @@ package io.gitlab.arturbosch.detekt.formatting
 import com.pinterest.ktlint.core.KtLint
 import com.pinterest.ktlint.core.Rule.VisitorModifier.RunAsLateAsPossible
 import com.pinterest.ktlint.core.Rule.VisitorModifier.RunOnRootNodeOnly
+import com.pinterest.ktlint.core.api.DefaultEditorConfigProperties.codeStyleSetProperty
 import com.pinterest.ktlint.core.api.FeatureInAlphaState
 import com.pinterest.ktlint.core.api.UsesEditorConfigProperties
 import io.github.detekt.psi.fileName
 import io.github.detekt.psi.toFilePath
-import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.CorrectableCodeSmell
-import io.gitlab.arturbosch.detekt.api.Debt
-import io.gitlab.arturbosch.detekt.api.Entity
-import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.Location
-import io.gitlab.arturbosch.detekt.api.Rule
-import io.gitlab.arturbosch.detekt.api.Severity
-import io.gitlab.arturbosch.detekt.api.SingleAssign
-import io.gitlab.arturbosch.detekt.api.SourceLocation
-import io.gitlab.arturbosch.detekt.api.TextLocation
+import io.gitlab.arturbosch.detekt.api.*
 import org.ec4j.core.model.Property
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.lang.FileASTNode
@@ -27,7 +18,6 @@ import org.jetbrains.kotlin.psi.psiUtil.endOffset
 /**
  * Rule to detect formatting violations.
  */
-@OptIn(FeatureInAlphaState::class)
 abstract class FormattingRule(config: Config) : Rule(config) {
 
     abstract val wrapping: com.pinterest.ktlint.core.Rule
@@ -53,15 +43,20 @@ abstract class FormattingRule(config: Config) : Rule(config) {
 
     override fun visit(root: KtFile) {
         this.root = root
-        root.node.putUserData(KtLint.ANDROID_USER_DATA_KEY, isAndroid)
         positionByOffset = KtLintLineColCalculator
             .calculateLineColByOffset(KtLintLineColCalculator.normalizeText(root.text))
 
-        val editorConfigProperties = overrideEditorConfigProperties()
+        val editorConfigProperties = overrideEditorConfigProperties()?.toMutableMap()
+            ?: mutableMapOf()
 
-        if (!editorConfigProperties.isNullOrEmpty()) {
+        if(isAndroid) {
+            editorConfigProperties[codeStyleSetProperty] = "android"
+        }
+
+        if (editorConfigProperties.isNotEmpty()) {
             val userData = (root.node.getUserData(KtLint.EDITOR_CONFIG_PROPERTIES_USER_DATA_KEY).orEmpty())
                 .toMutableMap()
+
             editorConfigProperties.forEach { (editorConfigProperty, defaultValue) ->
                 userData[editorConfigProperty.type.name] = Property.builder()
                     .name(editorConfigProperty.type.name)
@@ -79,18 +74,6 @@ abstract class FormattingRule(config: Config) : Rule(config) {
     fun apply(node: ASTNode) {
         if (ruleShouldOnlyRunOnFileNode(node)) {
             return
-        }
-
-        // KtLint 0.44.0 is assuming that KtLint.EDITOR_CONFIG_USER_DATA_KEY is available on all the nodes.
-        // If not, it crashes with a NPE. Here we're patching their behavior.
-        // This block is deprecated and will be removed in KtLint 0.46. But we have to suppress the
-        // deprecation warning because the ci runs with -Werror.
-        @Suppress("DEPRECATION")
-        if (node.getUserData(KtLint.EDITOR_CONFIG_USER_DATA_KEY) == null) {
-            node.putUserData(
-                KtLint.EDITOR_CONFIG_USER_DATA_KEY,
-                com.pinterest.ktlint.core.EditorConfig.Companion.fromMap(emptyMap())
-            )
         }
 
         wrapping.visit(node, autoCorrect) { offset, message, _ ->

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/KtLintMultiRule.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/KtLintMultiRule.kt
@@ -24,6 +24,7 @@ import io.gitlab.arturbosch.detekt.formatting.wrappers.ModifierListSpacing
 import io.gitlab.arturbosch.detekt.formatting.wrappers.ModifierOrdering
 import io.gitlab.arturbosch.detekt.formatting.wrappers.MultiLineIfElse
 import io.gitlab.arturbosch.detekt.formatting.wrappers.NoBlankLineBeforeRbrace
+import io.gitlab.arturbosch.detekt.formatting.wrappers.NoBlankLinesInChainedMethodCalls
 import io.gitlab.arturbosch.detekt.formatting.wrappers.NoConsecutiveBlankLines
 import io.gitlab.arturbosch.detekt.formatting.wrappers.NoEmptyClassBody
 import io.gitlab.arturbosch.detekt.formatting.wrappers.NoEmptyFirstLineInMethodBlock
@@ -77,6 +78,7 @@ class KtLintMultiRule(config: Config = Config.empty) : MultiRule() {
         MaximumLineLength(config),
         ModifierOrdering(config),
         NoBlankLineBeforeRbrace(config),
+        NoBlankLinesInChainedMethodCalls(config),
         NoConsecutiveBlankLines(config),
         NoEmptyClassBody(config),
         NoLineBreakAfterElse(config),

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/AnnotationOnSeparateLine.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/AnnotationOnSeparateLine.kt
@@ -10,7 +10,7 @@ import io.gitlab.arturbosch.detekt.formatting.FormattingRule
  * See [ktlint-website](https://ktlint.github.io) for documentation.
  */
 @AutoCorrectable(since = "1.0.0")
-@ActiveByDefault(since = "1.21.0")
+@ActiveByDefault(since = "1.22.0")
 class AnnotationOnSeparateLine(config: Config) : FormattingRule(config) {
 
     override val wrapping = AnnotationRule()

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/AnnotationOnSeparateLine.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/AnnotationOnSeparateLine.kt
@@ -1,7 +1,8 @@
 package io.gitlab.arturbosch.detekt.formatting.wrappers
 
-import com.pinterest.ktlint.ruleset.experimental.AnnotationRule
+import com.pinterest.ktlint.ruleset.standard.AnnotationRule
 import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
 import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
@@ -9,6 +10,7 @@ import io.gitlab.arturbosch.detekt.formatting.FormattingRule
  * See [ktlint-website](https://ktlint.github.io) for documentation.
  */
 @AutoCorrectable(since = "1.0.0")
+@ActiveByDefault(since = "1.21.0")
 class AnnotationOnSeparateLine(config: Config) : FormattingRule(config) {
 
     override val wrapping = AnnotationRule()

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/AnnotationSpacing.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/AnnotationSpacing.kt
@@ -1,7 +1,8 @@
 package io.gitlab.arturbosch.detekt.formatting.wrappers
 
-import com.pinterest.ktlint.ruleset.experimental.AnnotationSpacingRule
+import com.pinterest.ktlint.ruleset.standard.AnnotationSpacingRule
 import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
 import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
@@ -9,6 +10,7 @@ import io.gitlab.arturbosch.detekt.formatting.FormattingRule
  * See [ktlint-website](https://ktlint.github.io) for documentation.
  */
 @AutoCorrectable(since = "1.0.0")
+@ActiveByDefault(since = "1.21.0")
 class AnnotationSpacing(config: Config) : FormattingRule(config) {
 
     override val wrapping = AnnotationSpacingRule()

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/AnnotationSpacing.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/AnnotationSpacing.kt
@@ -10,7 +10,7 @@ import io.gitlab.arturbosch.detekt.formatting.FormattingRule
  * See [ktlint-website](https://ktlint.github.io) for documentation.
  */
 @AutoCorrectable(since = "1.0.0")
-@ActiveByDefault(since = "1.21.0")
+@ActiveByDefault(since = "1.22.0")
 class AnnotationSpacing(config: Config) : FormattingRule(config) {
 
     override val wrapping = AnnotationSpacingRule()

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/ArgumentListWrapping.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/ArgumentListWrapping.kt
@@ -3,10 +3,11 @@ package io.gitlab.arturbosch.detekt.formatting.wrappers
 import com.pinterest.ktlint.core.api.DefaultEditorConfigProperties
 import com.pinterest.ktlint.core.api.FeatureInAlphaState
 import com.pinterest.ktlint.core.api.UsesEditorConfigProperties
-import com.pinterest.ktlint.ruleset.experimental.ArgumentListWrappingRule
+import com.pinterest.ktlint.ruleset.standard.ArgumentListWrappingRule
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.config
 import io.gitlab.arturbosch.detekt.api.configWithAndroidVariants
+import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
 import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.api.internal.Configuration
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
@@ -14,8 +15,8 @@ import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 /**
  * See [ktlint-website](https://ktlint.github.io) for documentation.
  */
-@OptIn(FeatureInAlphaState::class)
 @AutoCorrectable(since = "1.0.0")
+@ActiveByDefault(since = "1.21.0")
 class ArgumentListWrapping(config: Config) : FormattingRule(config) {
 
     override val wrapping = ArgumentListWrappingRule()

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/ArgumentListWrapping.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/ArgumentListWrapping.kt
@@ -1,7 +1,6 @@
 package io.gitlab.arturbosch.detekt.formatting.wrappers
 
 import com.pinterest.ktlint.core.api.DefaultEditorConfigProperties
-import com.pinterest.ktlint.core.api.FeatureInAlphaState
 import com.pinterest.ktlint.core.api.UsesEditorConfigProperties
 import com.pinterest.ktlint.ruleset.standard.ArgumentListWrappingRule
 import io.gitlab.arturbosch.detekt.api.Config
@@ -16,7 +15,7 @@ import io.gitlab.arturbosch.detekt.formatting.FormattingRule
  * See [ktlint-website](https://ktlint.github.io) for documentation.
  */
 @AutoCorrectable(since = "1.0.0")
-@ActiveByDefault(since = "1.21.0")
+@ActiveByDefault(since = "1.22.0")
 class ArgumentListWrapping(config: Config) : FormattingRule(config) {
 
     override val wrapping = ArgumentListWrappingRule()

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/EnumEntryNameCase.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/EnumEntryNameCase.kt
@@ -1,7 +1,8 @@
 package io.gitlab.arturbosch.detekt.formatting.wrappers
 
-import com.pinterest.ktlint.ruleset.experimental.EnumEntryNameCaseRule
+import com.pinterest.ktlint.ruleset.standard.EnumEntryNameCaseRule
 import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
 import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
@@ -9,6 +10,7 @@ import io.gitlab.arturbosch.detekt.formatting.FormattingRule
  * See [ktlint-website](https://ktlint.github.io) for documentation.
  */
 @AutoCorrectable(since = "1.4.0")
+@ActiveByDefault(since = "1.21.0")
 class EnumEntryNameCase(config: Config) : FormattingRule(config) {
 
     override val wrapping = EnumEntryNameCaseRule()

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/EnumEntryNameCase.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/EnumEntryNameCase.kt
@@ -10,7 +10,7 @@ import io.gitlab.arturbosch.detekt.formatting.FormattingRule
  * See [ktlint-website](https://ktlint.github.io) for documentation.
  */
 @AutoCorrectable(since = "1.4.0")
-@ActiveByDefault(since = "1.21.0")
+@ActiveByDefault(since = "1.22.0")
 class EnumEntryNameCase(config: Config) : FormattingRule(config) {
 
     override val wrapping = EnumEntryNameCaseRule()

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/MultiLineIfElse.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/MultiLineIfElse.kt
@@ -10,7 +10,7 @@ import io.gitlab.arturbosch.detekt.formatting.FormattingRule
  * See [ktlint-website](https://ktlint.github.io#rule-modifier-order) for documentation.
  */
 @AutoCorrectable(since = "1.0.0")
-@ActiveByDefault(since = "1.21.0")
+@ActiveByDefault(since = "1.22.0")
 class MultiLineIfElse(config: Config) : FormattingRule(config) {
 
     override val wrapping = MultiLineIfElseRule()

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/MultiLineIfElse.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/MultiLineIfElse.kt
@@ -1,7 +1,8 @@
 package io.gitlab.arturbosch.detekt.formatting.wrappers
 
-import com.pinterest.ktlint.ruleset.experimental.MultiLineIfElseRule
+import com.pinterest.ktlint.ruleset.standard.MultiLineIfElseRule
 import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
 import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
@@ -9,6 +10,7 @@ import io.gitlab.arturbosch.detekt.formatting.FormattingRule
  * See [ktlint-website](https://ktlint.github.io#rule-modifier-order) for documentation.
  */
 @AutoCorrectable(since = "1.0.0")
+@ActiveByDefault(since = "1.21.0")
 class MultiLineIfElse(config: Config) : FormattingRule(config) {
 
     override val wrapping = MultiLineIfElseRule()

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/NoBlankLinesInChainedMethodCalls.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/NoBlankLinesInChainedMethodCalls.kt
@@ -1,0 +1,18 @@
+package io.gitlab.arturbosch.detekt.formatting.wrappers
+
+import com.pinterest.ktlint.ruleset.standard.NoBlankLinesInChainedMethodCallsRule
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
+import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
+import io.gitlab.arturbosch.detekt.formatting.FormattingRule
+
+/**
+ * See [ktlint-website](https://ktlint.github.io) for documentation.
+ */
+@ActiveByDefault(since = "1.21.0")
+@AutoCorrectable(since = "1.21.0")
+class NoBlankLinesInChainedMethodCalls(config: Config) : FormattingRule(config) {
+
+    override val wrapping = NoBlankLinesInChainedMethodCallsRule()
+    override val issue = issueFor("Detects blank lines in chained method rules.")
+}

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/NoBlankLinesInChainedMethodCalls.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/NoBlankLinesInChainedMethodCalls.kt
@@ -9,8 +9,8 @@ import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 /**
  * See [ktlint-website](https://ktlint.github.io) for documentation.
  */
-@ActiveByDefault(since = "1.21.0")
-@AutoCorrectable(since = "1.21.0")
+@ActiveByDefault(since = "1.22.0")
+@AutoCorrectable(since = "1.22.0")
 class NoBlankLinesInChainedMethodCalls(config: Config) : FormattingRule(config) {
 
     override val wrapping = NoBlankLinesInChainedMethodCallsRule()

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/NoEmptyFirstLineInMethodBlock.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/NoEmptyFirstLineInMethodBlock.kt
@@ -10,7 +10,7 @@ import io.gitlab.arturbosch.detekt.formatting.FormattingRule
  * See [ktlint-website](https://ktlint.github.io) for documentation.
  */
 @AutoCorrectable(since = "1.4.0")
-@ActiveByDefault(since = "1.21.0")
+@ActiveByDefault(since = "1.22.0")
 class NoEmptyFirstLineInMethodBlock(config: Config) : FormattingRule(config) {
 
     override val wrapping = NoEmptyFirstLineInMethodBlockRule()

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/NoEmptyFirstLineInMethodBlock.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/NoEmptyFirstLineInMethodBlock.kt
@@ -1,7 +1,8 @@
 package io.gitlab.arturbosch.detekt.formatting.wrappers
 
-import com.pinterest.ktlint.ruleset.experimental.NoEmptyFirstLineInMethodBlockRule
+import com.pinterest.ktlint.ruleset.standard.NoEmptyFirstLineInMethodBlockRule
 import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
 import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
@@ -9,6 +10,7 @@ import io.gitlab.arturbosch.detekt.formatting.FormattingRule
  * See [ktlint-website](https://ktlint.github.io) for documentation.
  */
 @AutoCorrectable(since = "1.4.0")
+@ActiveByDefault(since = "1.21.0")
 class NoEmptyFirstLineInMethodBlock(config: Config) : FormattingRule(config) {
 
     override val wrapping = NoEmptyFirstLineInMethodBlockRule()

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/PackageName.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/PackageName.kt
@@ -1,7 +1,8 @@
 package io.gitlab.arturbosch.detekt.formatting.wrappers
 
-import com.pinterest.ktlint.ruleset.experimental.PackageNameRule
+import com.pinterest.ktlint.ruleset.standard.PackageNameRule
 import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
 import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
@@ -9,6 +10,7 @@ import io.gitlab.arturbosch.detekt.formatting.FormattingRule
  * See [ktlint-website](https://ktlint.github.io) for documentation.
  */
 @AutoCorrectable(since = "1.0.0")
+@ActiveByDefault(since = "1.21.0")
 class PackageName(config: Config) : FormattingRule(config) {
 
     override val wrapping = PackageNameRule()

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/PackageName.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/PackageName.kt
@@ -10,7 +10,7 @@ import io.gitlab.arturbosch.detekt.formatting.FormattingRule
  * See [ktlint-website](https://ktlint.github.io) for documentation.
  */
 @AutoCorrectable(since = "1.0.0")
-@ActiveByDefault(since = "1.21.0")
+@ActiveByDefault(since = "1.22.0")
 class PackageName(config: Config) : FormattingRule(config) {
 
     override val wrapping = PackageNameRule()

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingAroundAngleBrackets.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingAroundAngleBrackets.kt
@@ -1,7 +1,8 @@
 package io.gitlab.arturbosch.detekt.formatting.wrappers
 
-import com.pinterest.ktlint.ruleset.experimental.SpacingAroundAngleBracketsRule
+import com.pinterest.ktlint.ruleset.standard.SpacingAroundAngleBracketsRule
 import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
 import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
@@ -9,6 +10,7 @@ import io.gitlab.arturbosch.detekt.formatting.FormattingRule
  * See [ktlint-website](https://ktlint.github.io#rule-spacing) for documentation.
  */
 @AutoCorrectable(since = "1.16.0")
+@ActiveByDefault(since = "1.21.0")
 class SpacingAroundAngleBrackets(config: Config) : FormattingRule(config) {
 
     override val wrapping = SpacingAroundAngleBracketsRule()

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingAroundAngleBrackets.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingAroundAngleBrackets.kt
@@ -10,7 +10,7 @@ import io.gitlab.arturbosch.detekt.formatting.FormattingRule
  * See [ktlint-website](https://ktlint.github.io#rule-spacing) for documentation.
  */
 @AutoCorrectable(since = "1.16.0")
-@ActiveByDefault(since = "1.21.0")
+@ActiveByDefault(since = "1.22.0")
 class SpacingAroundAngleBrackets(config: Config) : FormattingRule(config) {
 
     override val wrapping = SpacingAroundAngleBracketsRule()

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingAroundDoubleColon.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingAroundDoubleColon.kt
@@ -1,7 +1,8 @@
 package io.gitlab.arturbosch.detekt.formatting.wrappers
 
-import com.pinterest.ktlint.ruleset.experimental.SpacingAroundDoubleColonRule
+import com.pinterest.ktlint.ruleset.standard.SpacingAroundDoubleColonRule
 import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
 import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
@@ -9,6 +10,7 @@ import io.gitlab.arturbosch.detekt.formatting.FormattingRule
  * See [ktlint-website](https://ktlint.github.io#rule-spacing) for documentation.
  */
 @AutoCorrectable(since = "1.10.0")
+@ActiveByDefault(since = "1.21.0")
 class SpacingAroundDoubleColon(config: Config) : FormattingRule(config) {
 
     override val wrapping = SpacingAroundDoubleColonRule()

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingAroundDoubleColon.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingAroundDoubleColon.kt
@@ -10,7 +10,7 @@ import io.gitlab.arturbosch.detekt.formatting.FormattingRule
  * See [ktlint-website](https://ktlint.github.io#rule-spacing) for documentation.
  */
 @AutoCorrectable(since = "1.10.0")
-@ActiveByDefault(since = "1.21.0")
+@ActiveByDefault(since = "1.22.0")
 class SpacingAroundDoubleColon(config: Config) : FormattingRule(config) {
 
     override val wrapping = SpacingAroundDoubleColonRule()

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingAroundUnaryOperator.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingAroundUnaryOperator.kt
@@ -10,7 +10,7 @@ import io.gitlab.arturbosch.detekt.formatting.FormattingRule
  * See [ktlint-website](https://ktlint.github.io#rule-spacing) for documentation.
  */
 @AutoCorrectable(since = "1.16.0")
-@ActiveByDefault(since = "1.21.0")
+@ActiveByDefault(since = "1.22.0")
 class SpacingAroundUnaryOperator(config: Config) : FormattingRule(config) {
 
     override val wrapping = SpacingAroundUnaryOperatorRule()

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingAroundUnaryOperator.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingAroundUnaryOperator.kt
@@ -1,7 +1,8 @@
 package io.gitlab.arturbosch.detekt.formatting.wrappers
 
-import com.pinterest.ktlint.ruleset.experimental.SpacingAroundUnaryOperatorRule
+import com.pinterest.ktlint.ruleset.standard.SpacingAroundUnaryOperatorRule
 import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
 import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
@@ -9,6 +10,7 @@ import io.gitlab.arturbosch.detekt.formatting.FormattingRule
  * See [ktlint-website](https://ktlint.github.io#rule-spacing) for documentation.
  */
 @AutoCorrectable(since = "1.16.0")
+@ActiveByDefault(since = "1.21.0")
 class SpacingAroundUnaryOperator(config: Config) : FormattingRule(config) {
 
     override val wrapping = SpacingAroundUnaryOperatorRule()

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingBetweenDeclarationsWithAnnotations.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingBetweenDeclarationsWithAnnotations.kt
@@ -10,7 +10,7 @@ import io.gitlab.arturbosch.detekt.formatting.FormattingRule
  * See [ktlint-website](https://ktlint.github.io#rule-spacing) for documentation.
  */
 @AutoCorrectable(since = "1.10.0")
-@ActiveByDefault(since = "1.21.0")
+@ActiveByDefault(since = "1.22.0")
 class SpacingBetweenDeclarationsWithAnnotations(config: Config) : FormattingRule(config) {
 
     override val wrapping = SpacingBetweenDeclarationsWithAnnotationsRule()

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingBetweenDeclarationsWithAnnotations.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingBetweenDeclarationsWithAnnotations.kt
@@ -1,7 +1,8 @@
 package io.gitlab.arturbosch.detekt.formatting.wrappers
 
-import com.pinterest.ktlint.ruleset.experimental.SpacingBetweenDeclarationsWithAnnotationsRule
+import com.pinterest.ktlint.ruleset.standard.SpacingBetweenDeclarationsWithAnnotationsRule
 import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
 import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
@@ -9,6 +10,7 @@ import io.gitlab.arturbosch.detekt.formatting.FormattingRule
  * See [ktlint-website](https://ktlint.github.io#rule-spacing) for documentation.
  */
 @AutoCorrectable(since = "1.10.0")
+@ActiveByDefault(since = "1.21.0")
 class SpacingBetweenDeclarationsWithAnnotations(config: Config) : FormattingRule(config) {
 
     override val wrapping = SpacingBetweenDeclarationsWithAnnotationsRule()

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingBetweenDeclarationsWithComments.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingBetweenDeclarationsWithComments.kt
@@ -1,7 +1,8 @@
 package io.gitlab.arturbosch.detekt.formatting.wrappers
 
-import com.pinterest.ktlint.ruleset.experimental.SpacingBetweenDeclarationsWithCommentsRule
+import com.pinterest.ktlint.ruleset.standard.SpacingBetweenDeclarationsWithCommentsRule
 import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
 import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
@@ -9,6 +10,7 @@ import io.gitlab.arturbosch.detekt.formatting.FormattingRule
  * See [ktlint-website](https://ktlint.github.io#rule-spacing) for documentation.
  */
 @AutoCorrectable(since = "1.10.0")
+@ActiveByDefault(since = "1.21.0")
 class SpacingBetweenDeclarationsWithComments(config: Config) : FormattingRule(config) {
 
     override val wrapping = SpacingBetweenDeclarationsWithCommentsRule()

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingBetweenDeclarationsWithComments.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingBetweenDeclarationsWithComments.kt
@@ -10,7 +10,7 @@ import io.gitlab.arturbosch.detekt.formatting.FormattingRule
  * See [ktlint-website](https://ktlint.github.io#rule-spacing) for documentation.
  */
 @AutoCorrectable(since = "1.10.0")
-@ActiveByDefault(since = "1.21.0")
+@ActiveByDefault(since = "1.22.0")
 class SpacingBetweenDeclarationsWithComments(config: Config) : FormattingRule(config) {
 
     override val wrapping = SpacingBetweenDeclarationsWithCommentsRule()

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/Wrapping.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/Wrapping.kt
@@ -34,7 +34,8 @@ class Wrapping(config: Config) : FormattingRule(config) {
         return TextLocation(offset, offset + 1)
     }
 
-    override fun overrideEditorConfigProperties(): Map<UsesEditorConfigProperties.EditorConfigProperty<*>, String> = mapOf(
-        DefaultEditorConfigProperties.indentSizeProperty to indentSize.toString(),
-    )
+    override fun overrideEditorConfigProperties(): Map<UsesEditorConfigProperties.EditorConfigProperty<*>, String> =
+        mapOf(
+            DefaultEditorConfigProperties.indentSizeProperty to indentSize.toString(),
+        )
 }

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/Wrapping.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/Wrapping.kt
@@ -1,10 +1,14 @@
 package io.gitlab.arturbosch.detekt.formatting.wrappers
 
+import com.pinterest.ktlint.core.api.DefaultEditorConfigProperties
+import com.pinterest.ktlint.core.api.UsesEditorConfigProperties
 import com.pinterest.ktlint.ruleset.standard.WrappingRule
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.TextLocation
+import io.gitlab.arturbosch.detekt.api.config
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
 import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
+import io.gitlab.arturbosch.detekt.api.internal.Configuration
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 
@@ -18,6 +22,9 @@ class Wrapping(config: Config) : FormattingRule(config) {
     override val wrapping = WrappingRule()
     override val issue = issueFor("Reports missing newlines (e.g. between parentheses of a multi-line function call")
 
+    @Configuration("indentation size")
+    private val indentSize by config(4)
+
     /**
      * [Wrapping] has visitor modifier RunOnRootNodeOnly, so [node] is always the root file.
      * Override the parent implementation to highlight the entire file.
@@ -26,4 +33,8 @@ class Wrapping(config: Config) : FormattingRule(config) {
         // Use offset + 1 since Wrapping always reports the location of missing new line.
         return TextLocation(offset, offset + 1)
     }
+
+    override fun overrideEditorConfigProperties(): Map<UsesEditorConfigProperties.EditorConfigProperty<*>, String> = mapOf(
+        DefaultEditorConfigProperties.indentSizeProperty to indentSize.toString(),
+    )
 }

--- a/detekt-formatting/src/main/resources/config/config.yml
+++ b/detekt-formatting/src/main/resources/config/config.yml
@@ -3,13 +3,13 @@ formatting:
   android: false
   autoCorrect: true
   AnnotationOnSeparateLine:
-    active: false
+    active: true
     autoCorrect: true
   AnnotationSpacing:
-    active: false
+    active: true
     autoCorrect: true
   ArgumentListWrapping:
-    active: false
+    active: true
     autoCorrect: true
     indentSize: 4
     maxLineLength: 120
@@ -30,7 +30,7 @@ formatting:
     active: false
     autoCorrect: true
   EnumEntryNameCase:
-    active: false
+    active: true
     autoCorrect: true
   Filename:
     active: true
@@ -67,7 +67,7 @@ formatting:
     active: true
     autoCorrect: true
   MultiLineIfElse:
-    active: false
+    active: true
     autoCorrect: true
   NoBlankLineBeforeRbrace:
     active: true
@@ -82,7 +82,7 @@ formatting:
     active: true
     autoCorrect: true
   NoEmptyFirstLineInMethodBlock:
-    active: false
+    active: true
     autoCorrect: true
   NoLineBreakAfterElse:
     active: true
@@ -109,14 +109,14 @@ formatting:
     active: true
     packagesToUseImportOnDemandProperty: 'java.util.*,kotlinx.android.synthetic.**'
   PackageName:
-    active: false
+    active: true
     autoCorrect: true
   ParameterListWrapping:
     active: true
     autoCorrect: true
     maxLineLength: 120
   SpacingAroundAngleBrackets:
-    active: false
+    active: true
     autoCorrect: true
   SpacingAroundColon:
     active: true
@@ -131,7 +131,7 @@ formatting:
     active: true
     autoCorrect: true
   SpacingAroundDoubleColon:
-    active: false
+    active: true
     autoCorrect: true
   SpacingAroundKeyword:
     active: true
@@ -146,13 +146,13 @@ formatting:
     active: true
     autoCorrect: true
   SpacingAroundUnaryOperator:
-    active: false
+    active: true
     autoCorrect: true
   SpacingBetweenDeclarationsWithAnnotations:
-    active: false
+    active: true
     autoCorrect: true
   SpacingBetweenDeclarationsWithComments:
-    active: false
+    active: true
     autoCorrect: true
   StringTemplate:
     active: true
@@ -171,3 +171,4 @@ formatting:
   Wrapping:
     active: true
     autoCorrect: true
+    indentSize: 4

--- a/detekt-formatting/src/main/resources/config/config.yml
+++ b/detekt-formatting/src/main/resources/config/config.yml
@@ -72,6 +72,9 @@ formatting:
   NoBlankLineBeforeRbrace:
     active: true
     autoCorrect: true
+  NoBlankLinesInChainedMethodCalls:
+    active: true
+    autoCorrect: true
   NoConsecutiveBlankLines:
     active: true
     autoCorrect: true

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektAndroidSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektAndroidSpec.kt
@@ -78,13 +78,23 @@ class DetektAndroidSpec {
         @DisplayName("task :app:detektTest")
         fun appDetektTest() {
             gradleRunner.runTasksAndCheckResult(":app:detektTest") { buildResult ->
-                assertThat(buildResult.output).containsPattern("""--baseline \S*[/\\]detekt-baseline-releaseUnitTest.xml """)
-                assertThat(buildResult.output).containsPattern("""--baseline \S*[/\\]detekt-baseline-debugUnitTest.xml """)
-                assertThat(buildResult.output).containsPattern("""--baseline \S*[/\\]detekt-baseline-debugAndroidTest.xml """)
+                assertThat(buildResult.output).containsPattern(
+                    """--baseline \S*[/\\]detekt-baseline-releaseUnitTest.xml """
+                )
+                assertThat(buildResult.output).containsPattern(
+                    """--baseline \S*[/\\]detekt-baseline-debugUnitTest.xml """
+                )
+                assertThat(buildResult.output).containsPattern(
+                    """--baseline \S*[/\\]detekt-baseline-debugAndroidTest.xml """
+                )
                 assertThat(buildResult.output).containsPattern("""--input \S*[/\\]app[/\\]src[/\\]test[/\\]java""")
-                assertThat(buildResult.output).containsPattern("""--input \S*[/\\]app[/\\]src[/\\]androidTest[/\\]java""")
+                assertThat(buildResult.output).containsPattern(
+                    """--input \S*[/\\]app[/\\]src[/\\]androidTest[/\\]java"""
+                )
                 assertThat(buildResult.output).containsPattern("""--input \S*[/\\]app[/\\]src[/\\]test[/\\]kotlin""")
-                assertThat(buildResult.output).containsPattern("""--input \S*[/\\]app[/\\]src[/\\]androidTest[/\\]kotlin""")
+                assertThat(buildResult.output).containsPattern(
+                    """--input \S*[/\\]app[/\\]src[/\\]androidTest[/\\]kotlin"""
+                )
                 assertThat(buildResult.output).contains("--report xml:")
                 assertThat(buildResult.output).contains("--report sarif:")
                 assertThat(buildResult.output).doesNotContain("--report txt:")
@@ -190,9 +200,15 @@ class DetektAndroidSpec {
         @DisplayName("task :lib:detektTest")
         fun libDetektTest() {
             gradleRunner.runTasksAndCheckResult(":lib:detektTest") { buildResult ->
-                assertThat(buildResult.output).containsPattern("""--baseline \S*[/\\]detekt-baseline-releaseUnitTest.xml """)
-                assertThat(buildResult.output).containsPattern("""--baseline \S*[/\\]detekt-baseline-debugUnitTest.xml """)
-                assertThat(buildResult.output).containsPattern("""--baseline \S*[/\\]detekt-baseline-debugAndroidTest.xml """)
+                assertThat(buildResult.output).containsPattern(
+                    """--baseline \S*[/\\]detekt-baseline-releaseUnitTest.xml """
+                )
+                assertThat(buildResult.output).containsPattern(
+                    """--baseline \S*[/\\]detekt-baseline-debugUnitTest.xml """
+                )
+                assertThat(buildResult.output).containsPattern(
+                    """--baseline \S*[/\\]detekt-baseline-debugAndroidTest.xml """
+                )
                 assertThat(buildResult.output).contains("--report xml:")
                 assertThat(buildResult.output).contains("--report sarif:")
                 assertThat(buildResult.output).doesNotContain("--report txt:")

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektJvmSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektJvmSpec.kt
@@ -40,7 +40,9 @@ class DetektJvmSpec {
         @Test
         fun `logs a warning`() {
             gradleRunner.runTasksAndCheckResult(":detektMain") { buildResult ->
-                assertThat(buildResult.output).contains("TXT report location set on detekt {} extension will be ignored for detektMain task.")
+                assertThat(buildResult.output).contains(
+                    "TXT report location set on detekt {} extension will be ignored for detektMain task."
+                )
             }
         }
     }
@@ -72,7 +74,9 @@ class DetektJvmSpec {
         @Test
         fun `logs a warning`() {
             gradleRunner.runTasksAndCheckResult(":detektMain") { buildResult ->
-                assertThat(buildResult.output).doesNotContain("report location set on detekt {} extension will be ignored")
+                assertThat(buildResult.output).doesNotContain(
+                    "report location set on detekt {} extension will be ignored"
+                )
             }
         }
     }

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektMultiplatformSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektMultiplatformSpec.kt
@@ -257,7 +257,10 @@ class DetektMultiplatformSpec {
 
     @Nested
     @EnabledOnOs(MAC)
-    @EnabledIf("io.gitlab.arturbosch.detekt.DetektMultiplatformSpecKt#isXCodeInstalled", disabledReason = "XCode is not installed.")
+    @EnabledIf(
+        "io.gitlab.arturbosch.detekt.DetektMultiplatformSpecKt#isXCodeInstalled",
+        disabledReason = "XCode is not installed."
+    )
     inner class `multiplatform projects - iOS target` {
         val gradleRunner =
             setupProject {

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/JvmSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/JvmSpec.kt
@@ -15,7 +15,9 @@ class JvmSpec {
             .buildAndFail()
 
         assertThat(result.output).contains("failed with 2 weighted issues.")
-        assertThat(result.output).contains("Do not directly exit the process outside the `main` function. Throw an exception(...)")
+        assertThat(result.output).contains(
+            "Do not directly exit the process outside the `main` function. Throw an exception(...)"
+        )
         assertThat(result.output).contains("Errors.kt:7:9")
         assertThat(result.output).contains("Errors.kt:12:16")
     }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektMultiplatform.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektMultiplatform.kt
@@ -116,7 +116,8 @@ internal class DetektMultiplatform(private val project: Project) {
         }
 
         registerCreateBaselineTask(
-            DetektPlugin.BASELINE_TASK_NAME + taskSuffix, extension
+            DetektPlugin.BASELINE_TASK_NAME + taskSuffix,
+            extension
         ) {
             setSource(inputSource)
             if (runWithTypeResolution) {

--- a/detekt-gradle-plugin/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/testkit/DslGradleRunner.kt
+++ b/detekt-gradle-plugin/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/testkit/DslGradleRunner.kt
@@ -9,7 +9,8 @@ import java.nio.file.Files
 import java.util.UUID
 
 @Suppress("TooManyFunctions", "ClassOrdering")
-class DslGradleRunner @Suppress("LongParameterList") constructor(
+class DslGradleRunner @Suppress("LongParameterList")
+constructor(
     val projectLayout: ProjectLayout,
     val buildFileName: String,
     val mainBuildFileContent: String = "",
@@ -18,7 +19,7 @@ class DslGradleRunner @Suppress("LongParameterList") constructor(
     val gradleVersionOrNone: String? = null,
     val dryRun: Boolean = false,
     val jvmArgs: String = "-Xmx2g -XX:MaxMetaspaceSize=1g",
-    val projectScript: Project.() -> Unit = {},
+    val projectScript: Project.() -> Unit = {}
 ) {
 
     private val rootDir: File = Files.createTempDirectory("applyPlugin").toFile().apply { deleteOnExit() }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingWhenCaseSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingWhenCaseSpec.kt
@@ -36,7 +36,9 @@ class MissingWhenCaseSpec(private val env: KotlinCoreEnvironment) {
                 val actual = subject.compileAndLintWithContext(env, code)
                 assertThat(actual).hasSize(1)
                 assertThat(actual.first().issue.id).isEqualTo("MissingWhenCase")
-                assertThat(actual.first().message).isEqualTo("When expression is missing cases: RED. Either add missing cases or a default `else` case.")
+                assertThat(actual.first().message).isEqualTo(
+                    "When expression is missing cases: RED. Either add missing cases or a default `else` case."
+                )
             }
 
             @Test
@@ -58,7 +60,9 @@ class MissingWhenCaseSpec(private val env: KotlinCoreEnvironment) {
                 val actual = subject.compileAndLintWithContext(env, code)
                 assertThat(actual).hasSize(1)
                 assertThat(actual.first().issue.id).isEqualTo("MissingWhenCase")
-                assertThat(actual.first().message).isEqualTo("When expression is missing cases: RED, null. Either add missing cases or a default `else` case.")
+                assertThat(actual.first().message).isEqualTo(
+                    "When expression is missing cases: RED, null. Either add missing cases or a default `else` case."
+                )
             }
 
             @Test
@@ -81,7 +85,9 @@ class MissingWhenCaseSpec(private val env: KotlinCoreEnvironment) {
                 val actual = subject.compileAndLintWithContext(env, code)
                 assertThat(actual).hasSize(1)
                 assertThat(actual.first().issue.id).isEqualTo("MissingWhenCase")
-                assertThat(actual.first().message).isEqualTo("When expression is missing cases: null. Either add missing cases or a default `else` case.")
+                assertThat(actual.first().message).isEqualTo(
+                    "When expression is missing cases: null. Either add missing cases or a default `else` case."
+                )
             }
 
             @Test
@@ -154,7 +160,9 @@ class MissingWhenCaseSpec(private val env: KotlinCoreEnvironment) {
                 val actual = subject.compileAndLintWithContext(env, code)
                 assertThat(actual).hasSize(1)
                 assertThat(actual.first().issue.id).isEqualTo("MissingWhenCase")
-                assertThat(actual.first().message).isEqualTo("When expression is missing cases: VariantC. Either add missing cases or a default `else` case.")
+                assertThat(actual.first().message).isEqualTo(
+                    "When expression is missing cases: VariantC. Either add missing cases or a default `else` case."
+                )
             }
 
             @Test
@@ -177,7 +185,9 @@ class MissingWhenCaseSpec(private val env: KotlinCoreEnvironment) {
                 val actual = subject.compileAndLintWithContext(env, code)
                 assertThat(actual).hasSize(1)
                 assertThat(actual.first().issue.id).isEqualTo("MissingWhenCase")
-                assertThat(actual.first().message).isEqualTo("When expression is missing cases: null. Either add missing cases or a default `else` case.")
+                assertThat(actual.first().message).isEqualTo(
+                    "When expression is missing cases: null. Either add missing cases or a default `else` case."
+                )
             }
 
             @Test
@@ -199,7 +209,9 @@ class MissingWhenCaseSpec(private val env: KotlinCoreEnvironment) {
                 val actual = subject.compileAndLintWithContext(env, code)
                 assertThat(actual).hasSize(1)
                 assertThat(actual.first().issue.id).isEqualTo("MissingWhenCase")
-                assertThat(actual.first().message).isEqualTo("When expression is missing cases: VariantC, null. Either add missing cases or a default `else` case.")
+                assertThat(actual.first().message).isEqualTo(
+                    "When expression is missing cases: VariantC, null. Either add missing cases or a default `else` case."
+                )
             }
 
             @Test

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingNewInstanceOfSameExceptionSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingNewInstanceOfSameExceptionSpec.kt
@@ -46,7 +46,9 @@ class ThrowingNewInstanceOfSameExceptionSpec {
     }
 
     @Nested
-    @DisplayName("a catch block which throws a new instance of the same exception type without wrapping the caught exception")
+    @DisplayName(
+        "a catch block which throws a new instance of the same exception type without wrapping the caught exception"
+    )
     inner class CatchBlockThrowingSameExceptionWithoutWrapping {
         val code = """
         fun x() {

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/BooleanPropertyNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/BooleanPropertyNaming.kt
@@ -41,7 +41,8 @@ class BooleanPropertyNaming(config: Config = Config.empty) : Rule(config) {
     private val ignoreOverridden: Boolean by config(true)
 
     override val issue = Issue(
-        javaClass.simpleName, Severity.CodeSmell,
+        javaClass.simpleName,
+        Severity.CodeSmell,
         "Boolean property name should follow the naming convention set in the projects configuration.",
         Debt.FIVE_MINS
     )

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenImportSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenImportSpec.kt
@@ -65,7 +65,9 @@ class ForbiddenImportSpec {
     }
 
     @Test
-    @DisplayName("should report kotlin.SinceKotlin and kotlin.jvm.JvmField when specified via fully qualified names list")
+    @DisplayName(
+        "should report kotlin.SinceKotlin and kotlin.jvm.JvmField when specified via fully qualified names list"
+    )
     fun reportMultipleConfiguredImportsInList() {
         val findings =
             ForbiddenImport(

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/FunctionOnlyReturningConstantSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/FunctionOnlyReturningConstantSpec.kt
@@ -71,7 +71,9 @@ class FunctionOnlyReturningConstantSpec {
         }
 
         @Test
-        @DisplayName("does not report excluded annotated function which returns a constant when given \"kotlin.SinceKotlin\"")
+        @DisplayName(
+            "does not report excluded annotated function which returns a constant when given \"kotlin.SinceKotlin\""
+        )
         fun ignoreAnnotatedFunctionWhichReturnsConstantWhenGivenKotlinSinceKotlin() {
             val config = TestConfig(mapOf(EXCLUDE_ANNOTATED_FUNCTION to "kotlin.SinceKotlin"))
             val rule = FunctionOnlyReturningConstant(config)
@@ -79,7 +81,9 @@ class FunctionOnlyReturningConstantSpec {
         }
 
         @Test
-        @DisplayName("does not report excluded annotated function which returns a constant when given listOf(\"kotlin.SinceKotlin\")")
+        @DisplayName(
+            "does not report excluded annotated function which returns a constant when given listOf(\"kotlin.SinceKotlin\")"
+        )
         fun ignoreAnnotatedFunctionWhichReturnsConstantWhenGivenListOfKotlinSinceKotlin() {
             val config = TestConfig(mapOf(EXCLUDE_ANNOTATED_FUNCTION to listOf("kotlin.SinceKotlin")))
             val rule = FunctionOnlyReturningConstant(config)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 dokka = "1.7.0"
 jacoco = "0.8.8"
 kotlin = "1.6.21"
-ktlint = "0.45.2"
+ktlint = "0.46.1"
 junit = "5.8.2"
 contester = "0.2.0"
 

--- a/scripts/github-milestone-report.main.kts
+++ b/scripts/github-milestone-report.main.kts
@@ -7,7 +7,8 @@
  * You need kotlin 1.3.70+ installed on your machine
  */
 
-@file:Suppress("detekt.CommentSpacing") // for the exec line
+// for the exec line
+@file:Suppress("detekt.CommentSpacing")
 @file:DependsOn("org.kohsuke:github-api:1.135")
 @file:DependsOn("com.github.ajalt:clikt:2.8.0")
 

--- a/scripts/github-milestone-report.main.kts
+++ b/scripts/github-milestone-report.main.kts
@@ -7,8 +7,7 @@
  * You need kotlin 1.3.70+ installed on your machine
  */
 
-// for the exec line
-@file:Suppress("detekt.CommentSpacing")
+@file:Suppress("detekt.CommentSpacing") // for the exec line
 @file:DependsOn("org.kohsuke:github-api:1.135")
 @file:DependsOn("com.github.ajalt:clikt:2.8.0")
 


### PR DESCRIPTION
See https://github.com/pinterest/ktlint/releases/tag/0.46.0 and https://github.com/pinterest/ktlint/releases/tag/0.46.1 for full release notes.

This PR is part of the ktlint upgrade to version 0.46. See #5040

It includes:
- Upgrade to ktlint version 0.46.11
- Changed the rules from experimental ruleset to the standard ruleset which changed with the new version (see https://github.com/pinterest/ktlint/pull/1481). These are also tagged with @ActiveByDefault v1.22
- Added the NoBlankLinesInChainedMethodCallsRule (because it's not a new rule, just an old rule which is split up into two rules)

Closes #5022