### PR TITLE
Fix swallowed exception rule

### DIFF
--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedException.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedException.kt
@@ -124,7 +124,7 @@ class SwallowedException(config: Config = Config.empty) : Rule(config) {
     }
 
     private fun ordinaryCallExpression(expression: PsiElement): Boolean {
-        return expression is KtCallExpression && expression.name != "toString"
+        return expression is KtCallExpression && expression.text != "toString()"
     }
 
     private fun KtThrowExpression.parameterReferences(

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedException.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedException.kt
@@ -124,8 +124,7 @@ class SwallowedException(config: Config = Config.empty) : Rule(config) {
     }
 
     private fun ordinaryCallExpression(expression: PsiElement): Boolean {
-        val commonFunctions = listOf("toString()")
-        return expression is KtCallExpression && expression.text !in commonFunctions
+        return expression is KtCallExpression && expression.name != "toString"
     }
 
     private fun KtThrowExpression.parameterReferences(

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedExceptionSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedExceptionSpec.kt
@@ -271,6 +271,24 @@ class SwallowedExceptionSpec {
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
+    @Test
+    fun `does not report function call on exception object`() {
+        val code = """
+            class MyException(e: Exception) : Exception(e)
+            
+            fun Exception.toMyException() = MyException(this)
+            
+            fun foo() {
+                try {
+                    // ...
+                } catch(e: IOException) {
+                    throw e.toMyException()
+                }
+            }
+        """.trimIndent()
+        assertThat(subject.compileAndLint(code)).hasSize(0)
+    }
+
     @ParameterizedTest(name = "ignores {0} in the catch clause by default")
     @MethodSource("io.gitlab.arturbosch.detekt.rules.exceptions.SwallowedException#getEXCEPTIONS_IGNORED_BY_DEFAULT")
     fun `ignores $exceptionName in the catch clause by default`(exceptionName: String) {

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedExceptionSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedExceptionSpec.kt
@@ -280,8 +280,7 @@ class SwallowedExceptionSpec {
             
             fun foo() {
                 try {
-                    // ...
-                } catch(e: IOException) {
+                } catch(e: Exception) {
                     throw e.toMyException()
                 }
             }

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedExceptionSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedExceptionSpec.kt
@@ -285,7 +285,7 @@ class SwallowedExceptionSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(0)
+        assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
     @ParameterizedTest(name = "ignores {0} in the catch clause by default")


### PR DESCRIPTION
Close #4520 
Introduced a simple check to verify if a `dot qualified expression` is a `function call`. Functions known to be swallowing exceptions are excluded (`toString()` for now).