### PR TITLE
Enable strict Kotlin DSL precompiled script plugins accessors generation

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,3 +4,4 @@ org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8
 org.gradle.unsafe.configuration-cache=false
+systemProp.org.gradle.kotlin.dsl.precompiled.accessors.strict=true


### PR DESCRIPTION
This opts-in to a stricter mode of operation that fails the build when a plugin application fails, and enables the build cache for the :generatePrecompiledScriptPluginAccessors task.

This will be the default in Gradle 8.0, but there's no reason not to enable this in advance of that release given our build is stable with it enabled.

Information sourced from https://docs.gradle.org/nightly/userguide/upgrading_version_7.html#strict-kotlin-dsl-precompiled-scripts-accessors