### PR TITLE
Implement `MultilineRawStringIndentation`

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -191,6 +191,7 @@ style:
       - 'java.net.URL.openStream'
       - 'java.lang.Class.getResourceAsStream'
       - 'java.lang.ClassLoader.getResourceAsStream'
+      - 'org.jetbrains.kotlin.diagnostics.DiagnosticUtils.getLineAndColumnInPsiFile'
   ForbiddenVoid:
     active: true
   LibraryCodeMustSpecifyReturnType:

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Location.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Location.kt
@@ -1,10 +1,10 @@
 package io.gitlab.arturbosch.detekt.api
 
 import io.github.detekt.psi.FilePath
+import io.github.detekt.psi.getLineAndColumnInPsiFile
 import io.github.detekt.psi.toFilePath
 import org.jetbrains.kotlin.com.intellij.openapi.util.TextRange
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
-import org.jetbrains.kotlin.diagnostics.DiagnosticUtils
 import org.jetbrains.kotlin.diagnostics.PsiDiagnosticUtils
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.psiUtil.endOffset
@@ -99,12 +99,8 @@ data class Location @Deprecated("Consider relative path by passing a [FilePath]"
             )
 
         private fun lineAndColumn(element: PsiElement, range: TextRange): PsiDiagnosticUtils.LineAndColumn {
-            return try {
-                DiagnosticUtils.getLineAndColumnInPsiFile(element.containingFile, range)
-            } catch (@Suppress("SwallowedException", "TooGenericExceptionCaught") e: IndexOutOfBoundsException) {
-                // #3317 If any rule mutates the PsiElement, searching the original PsiElement may throw exception.
-                PsiDiagnosticUtils.LineAndColumn(-1, -1, null)
-            }
+            return getLineAndColumnInPsiFile(element.containingFile, range)
+                ?: PsiDiagnosticUtils.LineAndColumn(-1, -1, null)
         }
     }
 }

--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -597,6 +597,9 @@ style:
     active: true
   MultilineLambdaItParameter:
     active: false
+  MultilineRawStringIndentation:
+    active: false
+    indentSize: 4
   NestedClassesVisibility:
     active: true
   NewLineAtEndOfFile:

--- a/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/LinesOfCode.kt
+++ b/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/LinesOfCode.kt
@@ -2,6 +2,7 @@
 
 package io.github.detekt.metrics
 
+import io.github.detekt.psi.getLineAndColumnInPsiFile
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.psi.PsiComment
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
@@ -10,7 +11,6 @@ import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafElement
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.PsiCommentImpl
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.PsiCoreCommentImpl
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.PsiWhiteSpaceImpl
-import org.jetbrains.kotlin.diagnostics.DiagnosticUtils
 import org.jetbrains.kotlin.kdoc.psi.api.KDoc
 import org.jetbrains.kotlin.kdoc.psi.api.KDocElement
 import org.jetbrains.kotlin.kdoc.psi.impl.KDocElementImpl
@@ -44,16 +44,7 @@ fun KtElement.linesOfCode(inFile: KtFile = this.containingKtFile): Int =
         .distinct()
         .count()
 
-fun ASTNode.line(inFile: KtFile): Int = try {
-    DiagnosticUtils.getLineAndColumnInPsiFile(inFile, this.textRange).line
-} catch (@Suppress("SwallowedException", "TooGenericExceptionCaught") e: IndexOutOfBoundsException) {
-    // When auto-correctable rules performs actual mutation, KtFile.text is updated but
-    // KtFile.viewProvider.document is not updated. This will cause crash in subsequent rules
-    // if they are using any function relying on the KtFile.viewProvider.document.
-    // The exception is silenced to return -1 while we should seek long-term solution for execution
-    // order of rules (#3445)
-    -1
-}
+fun ASTNode.line(inFile: KtFile): Int = getLineAndColumnInPsiFile(inFile, this.textRange)?.line ?: -1
 
 private val comments: Set<Class<out PsiElement>> = setOf(
     PsiWhiteSpace::class.java,

--- a/detekt-psi-utils/api/detekt-psi-utils.api
+++ b/detekt-psi-utils/api/detekt-psi-utils.api
@@ -33,6 +33,7 @@ public final class io/github/detekt/psi/KtFilesKt {
 	public static final fun basePath (Lorg/jetbrains/kotlin/com/intellij/psi/PsiFile;)Ljava/nio/file/Path;
 	public static final fun fileNameWithoutSuffix (Lorg/jetbrains/kotlin/com/intellij/psi/PsiFile;)Ljava/lang/String;
 	public static final fun getFileName (Lorg/jetbrains/kotlin/com/intellij/psi/PsiFile;)Ljava/lang/String;
+	public static final fun getLineAndColumnInPsiFile (Lorg/jetbrains/kotlin/com/intellij/psi/PsiFile;Lorg/jetbrains/kotlin/com/intellij/openapi/util/TextRange;)Lorg/jetbrains/kotlin/diagnostics/PsiDiagnosticUtils$LineAndColumn;
 	public static final fun relativePath (Lorg/jetbrains/kotlin/com/intellij/psi/PsiFile;)Ljava/nio/file/Path;
 	public static final fun toFilePath (Lorg/jetbrains/kotlin/com/intellij/psi/PsiFile;)Lio/github/detekt/psi/FilePath;
 	public static final fun toUnifiedString (Ljava/nio/file/Path;)Ljava/lang/String;

--- a/detekt-psi-utils/src/main/kotlin/io/github/detekt/psi/KtFiles.kt
+++ b/detekt-psi-utils/src/main/kotlin/io/github/detekt/psi/KtFiles.kt
@@ -1,6 +1,9 @@
 package io.github.detekt.psi
 
+import org.jetbrains.kotlin.com.intellij.openapi.util.TextRange
 import org.jetbrains.kotlin.com.intellij.psi.PsiFile
+import org.jetbrains.kotlin.diagnostics.DiagnosticUtils
+import org.jetbrains.kotlin.diagnostics.PsiDiagnosticUtils
 import java.io.File
 import java.nio.file.Path
 import java.nio.file.Paths
@@ -66,6 +69,14 @@ fun PsiFile.toFilePath(): FilePath {
         basePath == null && relativePath == null -> FilePath(absolutePath = absolutePath())
         else -> error("Cannot build a FilePath from base path = $basePath and relative path = $relativePath")
     }
+}
+
+// #3317 If any rule mutates the PsiElement, searching the original PsiElement may throw exception.
+fun getLineAndColumnInPsiFile(file: PsiFile, range: TextRange): PsiDiagnosticUtils.LineAndColumn? {
+    return runCatching {
+        @Suppress("ForbiddenMethodCall")
+        DiagnosticUtils.getLineAndColumnInPsiFile(file, range)
+    }.getOrNull()
 }
 
 /**

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MultilineRawStringIndentation.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MultilineRawStringIndentation.kt
@@ -1,0 +1,185 @@
+package io.gitlab.arturbosch.detekt.rules.style
+
+import io.github.detekt.psi.getLineAndColumnInPsiFile
+import io.github.detekt.psi.toFilePath
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Location
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.SourceLocation
+import io.gitlab.arturbosch.detekt.api.TextLocation
+import io.gitlab.arturbosch.detekt.api.config
+import io.gitlab.arturbosch.detekt.api.internal.Configuration
+import org.jetbrains.kotlin.com.intellij.psi.PsiFile
+import org.jetbrains.kotlin.psi.KtElement
+import org.jetbrains.kotlin.psi.KtStringTemplateExpression
+
+/**
+ * This rule ensure that the raw strings have a consistent indentation.
+ *
+ * The baseIndentation is the indentation that has the line where the raw string started. The content of the
+ * raw string should have baseIndent plus one identation extra. And the closing raw string (`"""`) should have
+ * baseIndentation.
+ *
+ * <noncompliant>
+ * val a = """
+ * Hello World!
+ * How are you?
+ * """.trimMargin()
+ *
+ * val a = """
+ *         Hello World!
+ *         How are you?
+ *         """.trimMargin()
+ * </noncompliant>
+ *
+ * <compliant>
+ * val a = """
+ *     Hello World!
+ *     How are you?
+ * """.trimMargin()
+ *
+ * val a = """
+ *     Hello World!
+ *       How are you?
+ * """.trimMargin()
+ * </compliant>
+ */
+class MultilineRawStringIndentation(val config: Config) : Rule(config) {
+    override val issue = Issue(
+        javaClass.simpleName,
+        Severity.Style,
+        "The indentation of the raw String should be consistent",
+        Debt.FIVE_MINS
+    )
+
+    @Configuration("indentation size")
+    private val indentSize by config(4)
+
+    @Suppress("ReturnCount")
+    override fun visitStringTemplateExpression(expression: KtStringTemplateExpression) {
+        super.visitStringTemplateExpression(expression)
+
+        val text = expression.text
+        val lineCount = text.lines().count()
+        if (lineCount <= 1) return
+        if (!expression.isTrimmed()) return
+        if (!text.matches(rawStringRegex)) return
+
+        val lineAndColumn = getLineAndColumnInPsiFile(expression.containingFile, expression.textRange) ?: return
+
+        expression.checkIndentation(
+            baseIndent = lineAndColumn.lineContent?.countIndent() ?: return,
+            firstLineNumber = lineAndColumn.line,
+            lastLineNumber = lineAndColumn.line + lineCount - 1
+        )
+    }
+
+    private fun KtStringTemplateExpression.checkIndentation(
+        baseIndent: Int,
+        firstLineNumber: Int,
+        lastLineNumber: Int,
+    ) {
+        checkContent(desiredIndent = baseIndent + indentSize, (firstLineNumber + 1)..(lastLineNumber - 1))
+        checkClosing(baseIndent, lastLineNumber)
+    }
+
+    private fun KtStringTemplateExpression.checkContent(
+        desiredIndent: Int,
+        lineNumberRange: IntRange,
+    ) {
+        val indentation = lineNumberRange
+            .map { lineNumber ->
+                val line = containingFile.getLine(lineNumber)
+                Triple(lineNumber, line, line.countIndent())
+            }
+
+        if (indentation.isNotEmpty()) {
+            indentation
+                .filter { (_, line, currentIndent) -> line.isNotEmpty() && currentIndent < desiredIndent }
+                .onEach { (lineNumber, line, currentIndent) ->
+                    val location = containingFile.getLocation(
+                        SourceLocation(lineNumber, if (line.isBlank()) 1 else currentIndent + 1),
+                        SourceLocation(lineNumber, line.length + 1)
+                    )
+
+                    report(this, location, message(desiredIndent, currentIndent))
+                }
+                .ifEmpty {
+                    if (indentation.none { (_, _, currentIndent) -> currentIndent == desiredIndent }) {
+                        val location = containingFile.getLocation(
+                            SourceLocation(lineNumberRange.first, desiredIndent + 1),
+                            SourceLocation(lineNumberRange.last, indentation.last().second.length + 1),
+                        )
+
+                        report(
+                            this,
+                            location,
+                            message(desiredIndent, indentation.minOf { (_, _, indent) -> indent }),
+                        )
+                    }
+                }
+        }
+    }
+
+    private fun KtStringTemplateExpression.checkClosing(
+        desiredIndent: Int,
+        lineNumber: Int,
+    ) {
+        val currentIndent = containingFile.getLine(lineNumber).countIndent()
+        if (currentIndent != desiredIndent) {
+            val location = if (currentIndent < desiredIndent) {
+                containingFile.getLocation(
+                    SourceLocation(lineNumber, currentIndent + 1),
+                    SourceLocation(lineNumber, currentIndent + "\"\"\"".length + 1),
+                )
+            } else {
+                containingFile.getLocation(
+                    SourceLocation(lineNumber, desiredIndent + 1),
+                    SourceLocation(lineNumber, currentIndent + 1),
+                )
+            }
+
+            report(this, location, message(desiredIndent, currentIndent))
+        }
+    }
+}
+
+private fun Rule.report(element: KtElement, location: Location, message: String) {
+    report(CodeSmell(issue, Entity.from(element, location), message))
+}
+
+private fun message(desiredIntent: Int, currentIndent: Int): String {
+    return "The indentation should be $desiredIntent but it is $currentIndent."
+}
+
+private val rawStringRegex = "\"\"\"\n(.|\n)*\n *\"\"\"".toRegex()
+
+private fun String.countIndent() = this.takeWhile { it == ' ' }.count()
+
+private fun PsiFile.getLine(line: Int): String {
+    return text.lineSequence().drop(line - 1).first()
+}
+
+private fun PsiFile.getLocation(start: SourceLocation, end: SourceLocation): Location {
+    val lines = this.text.lines()
+    var startOffset = 0
+    for (i in 1 until start.line) {
+        startOffset += lines[i - 1].length + 1
+    }
+    var endOffset = startOffset
+    for (i in start.line until end.line) {
+        endOffset += lines[i - 1].length + 1
+    }
+    this.text.lines()
+    return Location(
+        start,
+        end,
+        TextLocation(startOffset + start.column - 1, endOffset + end.column - 1),
+        toFilePath()
+    )
+}

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/NewLineAtEndOfFile.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/NewLineAtEndOfFile.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.github.detekt.psi.getLineAndColumnInPsiFile
 import io.github.detekt.psi.toFilePath
 import io.gitlab.arturbosch.detekt.api.CodeSmell
 import io.gitlab.arturbosch.detekt.api.Config
@@ -13,7 +14,6 @@ import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.api.TextLocation
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
 import org.jetbrains.kotlin.com.intellij.openapi.util.TextRange
-import org.jetbrains.kotlin.diagnostics.DiagnosticUtils
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.psiUtil.endOffset
 
@@ -33,11 +33,11 @@ class NewLineAtEndOfFile(config: Config = Config.empty) : Rule(config) {
     override fun visitKtFile(file: KtFile) {
         val text = file.text
         if (text.isNotEmpty() && !text.endsWith('\n')) {
-            val coords = DiagnosticUtils.getLineAndColumnInPsiFile(
+            val coords = getLineAndColumnInPsiFile(
                 file,
                 TextRange(file.endOffset, file.endOffset)
             )
-            val sourceLocation = SourceLocation(coords.line, coords.column)
+            val sourceLocation = SourceLocation(coords?.line ?: 0, coords?.column ?: 0)
             val textLocation = TextLocation(file.endOffset, file.endOffset)
             val location = Location(sourceLocation, textLocation, file.containingFile.toFilePath())
             report(

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/StyleGuideProvider.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/StyleGuideProvider.kt
@@ -96,6 +96,7 @@ class StyleGuideProvider : DefaultRuleSetProvider {
             RedundantHigherOrderMapUsage(config),
             UseIfEmptyOrIfBlank(config),
             MultilineLambdaItParameter(config),
+            MultilineRawStringIndentation(config),
             UseIsNullOrEmpty(config),
             UseOrEmpty(config),
             UseAnyOrNoneInsteadOfFind(config),

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/TrimMultilineRawString.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/TrimMultilineRawString.kt
@@ -50,14 +50,7 @@ class TrimMultilineRawString(val config: Config) : Rule(config) {
 
         if (expression.text.lines().count() <= 1) return
 
-        val nextCall = expression.getQualifiedExpressionForSelectorOrThis()
-            .getQualifiedExpressionForReceiver()
-            ?.selectorExpression
-            ?.asKtCallExpression()
-            ?.calleeExpression
-            ?.text
-
-        if (nextCall !in trimFunctions) {
+        if (!expression.isTrimmed()) {
             report(
                 CodeSmell(
                     issue,
@@ -69,6 +62,17 @@ class TrimMultilineRawString(val config: Config) : Rule(config) {
     }
 }
 
-private fun KtExpression.asKtCallExpression(): KtCallExpression? = this as? KtCallExpression
+fun KtStringTemplateExpression.isTrimmed(): Boolean {
+    fun KtExpression.asKtCallExpression(): KtCallExpression? = this as? KtCallExpression
+
+    val nextCall = getQualifiedExpressionForSelectorOrThis()
+        .getQualifiedExpressionForReceiver()
+        ?.selectorExpression
+        ?.asKtCallExpression()
+        ?.calleeExpression
+        ?.text
+
+    return nextCall in trimFunctions
+}
 
 private val trimFunctions = listOf("trimIndent", "trimMargin")

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MultilineRawStringIndentationSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MultilineRawStringIndentationSpec.kt
@@ -1,0 +1,330 @@
+package io.gitlab.arturbosch.detekt.rules.style
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.test.assertThat
+import io.gitlab.arturbosch.detekt.test.compileAndLint
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class MultilineRawStringIndentationSpec {
+    val subject = MultilineRawStringIndentation(Config.empty)
+
+    @Nested
+    inner class IfTheOpeningDoesNotStartTheLine {
+        @Test
+        fun `raise multiline raw string without indentation`() {
+            val code = """
+                val a = $TQ
+                Hello world!
+                $TQ.trimIndent()
+            """
+            subject.compileAndLint(code)
+            assertThat(subject.findings)
+                .hasSize(1)
+                .hasSourceLocation(2 to 1, 2 to 13)
+                .hasTextLocations("Hello world!")
+        }
+
+        @Test
+        fun `raise multiline raw strings without indentation`() {
+            val code = """
+                val a = $TQ
+                Hello world!
+                How are you?
+                $TQ.trimIndent()
+            """
+            subject.compileAndLint(code)
+            assertThat(subject.findings)
+                .hasSize(2)
+                .hasTextLocations("Hello world!", "How are you?")
+        }
+
+        @Test
+        fun `raise multiline raw strings without right indentation`() {
+            val code = """
+                val a = $TQ
+                 Hello world!
+                    How are you?
+                $TQ.trimIndent()
+            """
+            subject.compileAndLint(code)
+            assertThat(subject.findings)
+                .hasSize(1)
+                .hasSourceLocation(2 to 2, 2 to 14)
+                .hasTextLocations("Hello world!")
+        }
+
+        @Test
+        fun `raise multiline raw strings with too much indentation`() {
+            val code = """
+                val a = $TQ
+                     Hello world!
+                     How are you?
+                $TQ.trimIndent()
+            """
+            subject.compileAndLint(code)
+            assertThat(subject.findings)
+                .hasSize(1)
+                .hasSourceLocation(2 to 5, 3 to 18)
+                .hasTextLocations(" Hello world!\n     How are you?")
+        }
+
+        @Test
+        fun `don't raise multiline raw strings if one has correct indentation and the other more`() {
+            val code = """
+                val a = $TQ
+                      Hello world!
+                    How are you?
+                $TQ.trimIndent()
+            """
+            subject.compileAndLint(code)
+            assertThat(subject.findings)
+                .isEmpty()
+        }
+
+        @Test
+        fun `don't raise multiline raw strings if all have the correct indentation`() {
+            val code = """
+                val a = $TQ
+                    Hello world!
+                    
+                    How are you?
+                $TQ.trimIndent()
+            """
+            subject.compileAndLint(code)
+            assertThat(subject.findings)
+                .isEmpty()
+        }
+
+        @Test
+        fun `don't raise multiline raw strings if all have the correct indentation or empty`() {
+            val code = """
+                val a = $TQ
+                    Hello world!
+                
+                    How are you?
+                $TQ.trimIndent()
+            """
+            subject.compileAndLint(code)
+            assertThat(subject.findings)
+                .isEmpty()
+        }
+
+        @Test
+        fun `raise multiline raw strings if a blank line doesn't have the minimum indentation`() {
+            val code = """
+                val a = $TQ
+                    Hello world!
+                  
+                $TQ.trimIndent()
+            """
+            subject.compileAndLint(code)
+            assertThat(subject.findings)
+                .hasSize(1)
+                .hasSourceLocation(3 to 1, 3 to 3)
+        }
+
+        @Test
+        fun `raise multiline raw strings with indentation on closing`() {
+            val code = """
+                val a = $TQ
+                    Hello world!
+                    How are you?
+                    $TQ.trimIndent()
+            """
+            subject.compileAndLint(code)
+            assertThat(subject.findings)
+                .hasSize(1)
+                .hasSourceLocation(4 to 1, 4 to 5)
+        }
+    }
+
+    @Nested
+    inner class IfTheOpeningStartTheLine {
+        @Test
+        fun `raise multiline raw string without indentation`() {
+            val code = """
+                val a = 
+                    $TQ
+                    Hello world!
+                    $TQ.trimIndent()
+            """
+            subject.compileAndLint(code)
+            assertThat(subject.findings)
+                .hasSize(1)
+                .hasSourceLocation(3 to 5, 3 to 17)
+        }
+
+        @Test
+        fun `raise multiline raw strings without indentation`() {
+            val code = """
+                val a = 
+                    $TQ
+                    Hello world!
+                    How are you?
+                    $TQ.trimIndent()
+            """
+            subject.compileAndLint(code)
+            assertThat(subject.findings)
+                .hasSize(2)
+        }
+
+        @Test
+        fun `raise multiline raw strings without right indentation`() {
+            val code = """
+                val a = 
+                    $TQ
+                     Hello world!
+                        How are you?
+                    $TQ.trimIndent()
+            """
+            subject.compileAndLint(code)
+            assertThat(subject.findings)
+                .hasSize(1)
+                .hasSourceLocation(3 to 6, 3 to 18)
+        }
+
+        @Test
+        fun `raise multiline raw strings with too much indentation`() {
+            val code = """
+                val a =
+                    $TQ
+                         Hello world!
+                         How are you?
+                    $TQ.trimIndent()
+            """
+            subject.compileAndLint(code)
+            assertThat(subject.findings)
+                .hasSize(1)
+                .hasSourceLocation(3 to 9, 4 to 22)
+                .hasTextLocations(" Hello world!\n         How are you?")
+        }
+
+        @Test
+        fun `don't raise multiline raw strings if one has correct indentation and the other more`() {
+            val code = """
+                val a = 
+                    $TQ
+                          Hello world!
+                        How are you?
+                    $TQ.trimIndent()
+            """
+            subject.compileAndLint(code)
+            assertThat(subject.findings)
+                .isEmpty()
+        }
+
+        @Test
+        fun `don't raise multiline raw strings if all have the correct indentation`() {
+            val code = """
+                val a = 
+                    $TQ
+                        Hello world!
+                        How are you?
+                    $TQ.trimIndent()
+            """
+            subject.compileAndLint(code)
+            assertThat(subject.findings)
+                .isEmpty()
+        }
+
+        @Test
+        fun `raise multiline raw strings with too much indentation on closing`() {
+            val code = """
+                val a = 
+                    $TQ
+                        Hello world!
+                        How are you?
+                        $TQ.trimIndent()
+            """
+            subject.compileAndLint(code)
+            assertThat(subject.findings)
+                .hasSize(1)
+                .hasSourceLocation(5 to 5, 5 to 9)
+        }
+
+        @Test
+        fun `raise multiline raw strings with too little indentation on closing`() {
+            val code = """
+                val a = 
+                    $TQ
+                        Hello world!
+                        How are you?
+                  $TQ.trimIndent()
+            """
+            subject.compileAndLint(code)
+            assertThat(subject.findings)
+                .hasSize(1)
+                .hasSourceLocation(5 to 3, 5 to 6)
+        }
+    }
+
+    @Nested
+    inner class CasesThatShouldBeIgnored {
+        @Test
+        fun `doesn't raise multiline raw strings without trim`() {
+            val code = """
+                val a = $TQ
+                Hello world!
+                $TQ
+            """
+            subject.compileAndLint(code)
+            assertThat(subject.findings).isEmpty()
+        }
+
+        @Test
+        fun `don't raise one line raw strings`() {
+            val code = """
+                val a = ${TQ}Hello world!$TQ
+            """
+            subject.compileAndLint(code)
+            assertThat(subject.findings).isEmpty()
+        }
+
+        @Test
+        fun `doesn't raise if it is not a raw string`() {
+            val code = """
+                val a = "Hello world!"
+            """
+            subject.compileAndLint(code)
+            assertThat(subject.findings).isEmpty()
+        }
+
+        @Test
+        fun `don't raise if it contains content after the opening triple quote`() {
+            val code = """
+                val a = ${TQ}Hello world!
+                    How are you?
+                $TQ.trimIndent()
+            """
+            subject.compileAndLint(code)
+            assertThat(subject.findings)
+                .isEmpty()
+        }
+
+        @Test
+        fun `don't raise if it contains content before the closing triple quote`() {
+            val code = """
+                val a = $TQ
+                    Hello world!
+                    How are you?$TQ.trimIndent()
+            """
+            subject.compileAndLint(code)
+            assertThat(subject.findings)
+                .isEmpty()
+        }
+
+        @Test
+        fun `don't raise if it isEmpty`() {
+            val code = """
+                val a = $TQ
+                $TQ.trimIndent()
+            """
+            subject.compileAndLint(code)
+            assertThat(subject.findings)
+                .isEmpty()
+        }
+    }
+}
+
+private const val TQ = "\"\"\""

--- a/detekt-test/api/detekt-test.api
+++ b/detekt-test/api/detekt-test.api
@@ -7,6 +7,7 @@ public final class io/gitlab/arturbosch/detekt/test/FindingAssert : org/assertj/
 public final class io/gitlab/arturbosch/detekt/test/FindingsAssert : org/assertj/core/api/AbstractListAssert {
 	public fun <init> (Ljava/util/List;)V
 	public final fun hasSourceLocation (II)Lio/gitlab/arturbosch/detekt/test/FindingsAssert;
+	public final fun hasSourceLocation (Lkotlin/Pair;Lkotlin/Pair;)Lio/gitlab/arturbosch/detekt/test/FindingsAssert;
 	public final fun hasSourceLocations ([Lio/gitlab/arturbosch/detekt/api/SourceLocation;)Lio/gitlab/arturbosch/detekt/test/FindingsAssert;
 	public final fun hasTextLocations ([Ljava/lang/String;)Lio/gitlab/arturbosch/detekt/test/FindingsAssert;
 	public final fun hasTextLocations ([Lkotlin/Pair;)Lio/gitlab/arturbosch/detekt/test/FindingsAssert;

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/FindingsAssertions.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/FindingsAssertions.kt
@@ -42,6 +42,18 @@ class FindingsAssert(actual: List<Finding>) :
         }
     }
 
+    fun hasSourceLocation(start: Pair<Int, Int>, end: Pair<Int, Int>) = apply {
+        val finding = actual.single()
+        val expectedStart = SourceLocation(start.first, start.second)
+        if (finding.location.source != expectedStart) {
+            failWithMessage("Expected source location to be $expectedStart but was ${finding.location.source}")
+        }
+        val expectedEnd = SourceLocation(end.first, end.second)
+        if (finding.location.endSource != expectedEnd) {
+            failWithMessage("Expected source location to be $expectedEnd but was ${finding.location.endSource}")
+        }
+    }
+
     fun hasSourceLocation(line: Int, column: Int) = apply {
         hasSourceLocations(SourceLocation(line, column))
     }


### PR DESCRIPTION
This implements one of the proposed rules in #4705

To be more precise it implements this one:

>  When using `trimIndent()` or `trimMargin()` check that the left-most indentation is indented x characters from the enclosing element

This rule was a complex one. Format is hard >_<.
