### PR TITLE
Fix current indentation

### DIFF
--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/EntitySpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/EntitySpec.kt
@@ -15,14 +15,14 @@ class EntitySpec {
     private val path = Paths.get("/full/path/to/Test.kt")
     private val code = compileContentForTest(
         """
-        package test
+            package test
 
-        class C : Any() {
+            class C : Any() {
 
-            private fun memberFun(): Int = 5
-        }
+                private fun memberFun(): Int = 5
+            }
 
-        fun topLevelFun(number: Int) = Unit
+            fun topLevelFun(number: Int) = Unit
         """.trimIndent(),
         path.toString()
     )

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Analyzer.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Analyzer.kt
@@ -154,11 +154,11 @@ private fun MutableMap<String, List<Finding>>.mergeSmells(other: Map<String, Lis
 
 private fun throwIllegalStateException(file: KtFile, error: Throwable): Nothing {
     val message = """
-    Analyzing ${file.absolutePath()} led to an exception. 
-    Location: ${error.stackTrace.firstOrNull()?.toString()}
-    The original exception message was: ${error.localizedMessage}
-    Running detekt '${whichDetekt() ?: "unknown"}' on Java '${whichJava()}' on OS '${whichOS()}'
-    If the exception message does not help, please feel free to create an issue on our GitHub page.
+        Analyzing ${file.absolutePath()} led to an exception.
+        Location: ${error.stackTrace.firstOrNull()?.toString()}
+        The original exception message was: ${error.localizedMessage}
+        Running detekt '${whichDetekt() ?: "unknown"}' on Java '${whichJava()}' on OS '${whichOS()}'
+        If the exception message does not help, please feel free to create an issue on our GitHub page.
     """.trimIndent()
     throw IllegalStateException(message, error)
 }

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineFacadeSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineFacadeSpec.kt
@@ -49,14 +49,14 @@ class BaselineFacadeSpec {
 
         assertThat(baselineFile).hasContent(
             """
-            <?xml version="1.0" ?>
-            <SmellBaseline>
-              <ManuallySuppressedIssues>
-                <ID>LongParameterList:Signature</ID>
-                <ID>LongMethod:Signature</ID>
-              </ManuallySuppressedIssues>
-              <CurrentIssues></CurrentIssues>
-            </SmellBaseline>
+                <?xml version="1.0" ?>
+                <SmellBaseline>
+                  <ManuallySuppressedIssues>
+                    <ID>LongParameterList:Signature</ID>
+                    <ID>LongMethod:Signature</ID>
+                  </ManuallySuppressedIssues>
+                  <CurrentIssues></CurrentIssues>
+                </SmellBaseline>
             """.trimIndent()
         )
     }
@@ -69,16 +69,16 @@ class BaselineFacadeSpec {
 
         assertThat(baselineFile).hasContent(
             """
-            <?xml version="1.0" ?>
-            <SmellBaseline>
-              <ManuallySuppressedIssues>
-                <ID>LongParameterList:Signature</ID>
-                <ID>LongMethod:Signature</ID>
-              </ManuallySuppressedIssues>
-              <CurrentIssues>
-                <ID>TestSmell:TestEntitySignature</ID>
-              </CurrentIssues>
-            </SmellBaseline>
+                <?xml version="1.0" ?>
+                <SmellBaseline>
+                  <ManuallySuppressedIssues>
+                    <ID>LongParameterList:Signature</ID>
+                    <ID>LongMethod:Signature</ID>
+                  </ManuallySuppressedIssues>
+                  <CurrentIssues>
+                    <ID>TestSmell:TestEntitySignature</ID>
+                  </CurrentIssues>
+                </SmellBaseline>
             """.trimIndent()
         )
     }

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/ValidateConfigSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/ValidateConfigSpec.kt
@@ -205,11 +205,11 @@ class ValidateConfigSpec {
         fun `reports a deprecated property as a warning`(warningsAsErrors: Boolean) {
             val config = yamlConfigFromContent(
                 """
-                config:
-                  warningsAsErrors: $warningsAsErrors
-                naming:
-                  FunctionParameterNaming:
-                    ignoreOverriddenFunctions: ''
+                    config:
+                      warningsAsErrors: $warningsAsErrors
+                    naming:
+                      FunctionParameterNaming:
+                        ignoreOverriddenFunctions: ''
                 """.trimIndent()
             )
 

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/YamlConfigSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/YamlConfigSpec.kt
@@ -193,8 +193,8 @@ class YamlConfigSpec {
             assertThatCode {
                 yamlConfigFromContent(
                     """
-                    map:
-                          {}map
+                        map:
+                              {}map
                     """.trimIndent()
                 )
             }.isInstanceOf(Config.InvalidConfigurationError::class.java)

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/rules/SingleRuleProviderSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/rules/SingleRuleProviderSpec.kt
@@ -37,9 +37,9 @@ class SingleRuleProviderSpec {
     fun `the right sub config is passed to the rule configures rule with active=$value`(value: Boolean) {
         val config = yamlConfigFromContent(
             """
-            style:
-              MagicNumber:
-                active: $value
+                style:
+                  MagicNumber:
+                    active: $value
             """.trimIndent()
         )
 

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/AnnotationSuppressorSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/AnnotationSuppressorSpec.kt
@@ -405,10 +405,10 @@ class AnnotationSuppressorSpec(private val env: KotlinCoreEnvironment) {
         fun `Doesn't mix annotations`() {
             val root = compileContentForTest(
                 """
-                package foo.bar
+                    package foo.bar
 
-                @Composable
-                fun function() = Unit
+                    @Composable
+                    fun function() = Unit
                 """.trimIndent()
             )
 
@@ -426,10 +426,10 @@ class AnnotationSuppressorSpec(private val env: KotlinCoreEnvironment) {
         fun `Works when no using imports`() {
             val root = compileContentForTest(
                 """
-                package foo.bar
+                    package foo.bar
 
-                @androidx.compose.runtime.Composable
-                fun function() = Unit
+                    @androidx.compose.runtime.Composable
+                    fun function() = Unit
                 """.trimIndent()
             )
 
@@ -447,12 +447,12 @@ class AnnotationSuppressorSpec(private val env: KotlinCoreEnvironment) {
         fun `Works when using import alias`() {
             val root = compileContentForTest(
                 """
-                package foo.bar
+                    package foo.bar
 
-                import androidx.compose.runtime.Composable as Bar
+                    import androidx.compose.runtime.Composable as Bar
 
-                @Bar
-                fun function() = Unit
+                    @Bar
+                    fun function() = Unit
                 """.trimIndent()
             )
 

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/SuppressorsSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/SuppressorsSpec.kt
@@ -28,11 +28,11 @@ class SuppressorsSpec {
         entity = Entity.from(
             compileContentForTest(
                 """
-                @file:Composable
+                    @file:Composable
 
-                import androidx.compose.runtime.Composable
+                    import androidx.compose.runtime.Composable
 
-                fun foo() = Unit
+                    fun foo() = Unit
                 """.trimIndent()
             )
         ),

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/CommentWrappingSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/CommentWrappingSpec.kt
@@ -13,22 +13,20 @@ import org.junit.jupiter.api.Test
 class CommentWrappingSpec {
     @Test
     fun `Given a single line block comment that start starts and end on a separate line then report no error`() {
-        val code =
-            """
+        val code = """
             /* Some comment */
-            """.trimIndent()
+        """.trimIndent()
         assertThat(CommentWrapping(Config.empty).lint(code)).isEmpty()
     }
 
     @Test
     fun `Given a block comment followed by a code element on the same line as the block comment ended then report four errors`() {
-        val code =
-            """
+        val code = """
             /* Some comment 1 */ val foo1 = "foo1"
             /* Some comment 2 */val foo2 = "foo2"
             /* Some comment 3 */ fun foo3() = "foo3"
             /* Some comment 4 */fun foo4() = "foo4"
-            """.trimIndent()
+        """.trimIndent()
 
         assertThat(CommentWrapping(Config.empty).lint(code)).hasSize(4)
     }

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/FinalNewlineSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/FinalNewlineSpec.kt
@@ -33,7 +33,7 @@ class FinalNewlineSpec {
         val findings = FinalNewline(TestConfig(INSERT_FINAL_NEWLINE_KEY to "false"))
             .lint(
                 """
-            fun main() = Unit
+                    fun main() = Unit
 
                 """
             )

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingRuleSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingRuleSpec.kt
@@ -25,9 +25,9 @@ class FormattingRuleSpec {
         fun `does support suppression only on file level`() {
             val findings = subject.lint(
                 """
-                @file:Suppress("NoLineBreakBeforeAssignment")
-                fun main() 
-                = Unit
+                    @file:Suppress("NoLineBreakBeforeAssignment")
+                    fun main()
+                    = Unit
                 """.trimIndent()
             )
 
@@ -38,9 +38,9 @@ class FormattingRuleSpec {
         fun `does not support suppression on node level`() {
             val findings = subject.lint(
                 """
-                @Suppress("NoLineBreakBeforeAssignment")
-                fun main() 
-                = Unit
+                    @Suppress("NoLineBreakBeforeAssignment")
+                    fun main()
+                    = Unit
                 """.trimIndent()
             )
 
@@ -55,8 +55,8 @@ class FormattingRuleSpec {
         fun `has no package name`() {
             val findings = subject.lint(
                 """
-                fun main() 
-                = Unit
+                    fun main()
+                    = Unit
                 """.trimIndent()
             )
 
@@ -67,9 +67,9 @@ class FormattingRuleSpec {
         fun `has a package name`() {
             val findings = subject.lint(
                 """
-                package test.test.test
-                fun main() 
-                = Unit
+                    package test.test.test
+                    fun main()
+                    = Unit
                 """.trimIndent()
             )
 

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/ImportOrderingSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/ImportOrderingSpec.kt
@@ -20,17 +20,17 @@ class ImportOrderingSpec {
     fun `defaults to the idea layout`() {
         val findings = ImportOrdering(Config.empty).lint(
             """
-            import android.app.Activity
-            import android.view.View
-            import android.view.ViewGroup
-            import kotlinx.coroutines.CoroutineDispatcher
-            import ru.example.a
-            import java.util.List
-            import javax.net.ssl.SSLHandshakeException
-            import kotlin.concurrent.Thread
-            import kotlin.io.Closeable
-            import android.content.Context as Ctx
-            import androidx.fragment.app.Fragment as F
+                import android.app.Activity
+                import android.view.View
+                import android.view.ViewGroup
+                import kotlinx.coroutines.CoroutineDispatcher
+                import ru.example.a
+                import java.util.List
+                import javax.net.ssl.SSLHandshakeException
+                import kotlin.concurrent.Thread
+                import kotlin.io.Closeable
+                import android.content.Context as Ctx
+                import androidx.fragment.app.Fragment as F
             """.trimIndent()
         )
 
@@ -90,13 +90,13 @@ class ImportOrderingSpec {
         fun `misses a empty line between aliases and other imports`() {
             val findings = ImportOrdering(TestConfig("layout" to "*,|,^*")).lint(
                 """
-                import android.app.Activity
-                import android.view.View
-                import android.view.ViewGroup
-                import java.util.List
-                import kotlin.concurrent.Thread
-                import android.content.Context as Ctx
-                import androidx.fragment.app.Fragment as F
+                    import android.app.Activity
+                    import android.view.View
+                    import android.view.ViewGroup
+                    import java.util.List
+                    import kotlin.concurrent.Thread
+                    import android.content.Context as Ctx
+                    import androidx.fragment.app.Fragment as F
                 """.trimIndent()
             )
 
@@ -107,14 +107,14 @@ class ImportOrderingSpec {
         fun `passes for empty line between aliases and other imports`() {
             val findings = ImportOrdering(TestConfig("layout" to "*,|,^*")).lint(
                 """
-                import android.app.Activity
-                import android.view.View
-                import android.view.ViewGroup
-                import java.util.List
-                import kotlin.concurrent.Thread
+                    import android.app.Activity
+                    import android.view.View
+                    import android.view.ViewGroup
+                    import java.util.List
+                    import kotlin.concurrent.Thread
 
-                import android.content.Context as Ctx
-                import androidx.fragment.app.Fragment as F
+                    import android.content.Context as Ctx
+                    import androidx.fragment.app.Fragment as F
                 """.trimIndent()
             )
 

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/KdocWrappingSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/KdocWrappingSpec.kt
@@ -13,23 +13,21 @@ import org.junit.jupiter.api.Test
 class KdocWrappingSpec {
     @Test
     fun `Given a single line KDoc comment that start starts and end on a separate line then do not reformat`() {
-        val code =
-            """
+        val code = """
             /** Some KDoc comment */
-            """.trimIndent()
+        """.trimIndent()
 
         assertThat(KdocWrapping(Config.empty).lint(code)).isEmpty()
     }
 
     @Test
     fun `Given a KDoc comment followed by a code element on the same line as the block comment ended then report four errors`() {
-        val code =
-            """
+        val code = """
             /** Some comment 1 */ val foo1 = "foo1"
             /** Some comment 2 */val foo2 = "foo2"
             /** Some comment 3 */ fun foo3() = "foo3"
             /** Some comment 4 */fun foo4() = "foo4"
-            """.trimIndent()
+        """.trimIndent()
 
         assertThat(KdocWrapping(Config.empty).lint(code)).hasSize(4)
     }

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/NoWildcardImportsSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/NoWildcardImportsSpec.kt
@@ -21,24 +21,22 @@ class NoWildcardImportsSpec {
 
         @Test
         fun `Wildcard imports are detected`() {
-            val code =
-                """
+            val code = """
                 import a.*
                 import a.b.c.*
                 import a.b
                 import foo.bar.`**`
-                """.trimIndent()
+            """.trimIndent()
 
             assertThat(subject.lint(code)).hasSize(2)
         }
 
         @Test
         fun `Wildcard imports on packages which are accepted by IntelliJ Default are not detected`() {
-            val code =
-                """
+            val code = """
                 import a.b
                 import kotlinx.android.synthetic.main.layout_name.*
-                """.trimIndent()
+            """.trimIndent()
             assertThat(subject.lint(code)).isEmpty()
         }
     }
@@ -47,13 +45,12 @@ class NoWildcardImportsSpec {
     inner class PackagesToUseImportOnDemandPropertySet {
         @Test
         fun `Given that the property is set with value 'unset' then packages which are accepted by IntelliJ Default are not detected`() {
-            val code =
-                """
+            val code = """
                 import a.b
                 import kotlinx.android.synthetic.main.layout_name.*
                 import react.*
                 import react.dom.*
-                """.trimIndent()
+            """.trimIndent()
 
             assertThat(
                 NoWildcardImports(TestConfig("packagesToUseImportOnDemandProperty" to "unset")).lint(
@@ -64,13 +61,12 @@ class NoWildcardImportsSpec {
 
         @Test
         fun `Given that the property is set to some packages exclusive subpackages then wildcard imports for those directories are not detected`() {
-            val code =
-                """
+            val code = """
                 import a.b
                 import kotlinx.android.synthetic.main.layout_name.*
                 import react.*
                 import react.dom.*
-                """.trimIndent()
+            """.trimIndent()
             assertThat(
                 NoWildcardImports(TestConfig("packagesToUseImportOnDemandProperty" to "react.*,react.dom.*")).lint(
                     code
@@ -80,13 +76,12 @@ class NoWildcardImportsSpec {
 
         @Test
         fun `Given that the property is set to some packages inclusive subpackages then wildcard imports for those directories are not detected`() {
-            val code =
-                """
+            val code = """
                 import a.b
                 import kotlinx.android.synthetic.main.layout_name.*
                 import react.*
                 import react.dom.*
-                """.trimIndent()
+            """.trimIndent()
 
             assertThat(
                 NoWildcardImports(TestConfig("packagesToUseImportOnDemandProperty" to "react.**")).lint(
@@ -97,11 +92,10 @@ class NoWildcardImportsSpec {
 
         @Test
         fun `Given that property is set without a value then the packages which otherwise would be accepted by IntelliJ Default are detected`() {
-            val code =
-                """
+            val code = """
                 import a.b
                 import kotlinx.android.synthetic.main.layout_name.*
-                """.trimIndent()
+            """.trimIndent()
 
             assertThat(
                 NoWildcardImports(TestConfig("packagesToUseImportOnDemandProperty" to "")).lint(

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/TestFiles.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/TestFiles.kt
@@ -23,75 +23,75 @@ fun loadFileContent(resourceName: String) =
     StringUtilRt.convertLineSeparators(File(resource(resourceName)).readText())
 
 val contentAfterChainWrapping = """
-fun main() {
-    val anchor = owner.firstChild!!
-        .siblings(forward = true)
-        .dropWhile { it is PsiComment || it is PsiWhiteSpace }
-    val s = foo()
-        ?: bar
-    val s = foo()
-        ?.bar
-    val s = 1
-        + 2
-    val s = true &&
-        false
-    val s = b.equals(o.b) &&
-        g == o.g
-    val d = 1 +
-        -1
-    val d = 1
-        + -1
-    when (foo){
-        0 -> {
+    fun main() {
+        val anchor = owner.firstChild!!
+            .siblings(forward = true)
+            .dropWhile { it is PsiComment || it is PsiWhiteSpace }
+        val s = foo()
+            ?: bar
+        val s = foo()
+            ?.bar
+        val s = 1
+            + 2
+        val s = true &&
+            false
+        val s = b.equals(o.b) &&
+            g == o.g
+        val d = 1 +
+            -1
+        val d = 1
+            + -1
+        when (foo){
+            0 -> {
+            }
+            1 -> {
+            }
+            -2 -> {
+            }
         }
-        1 -> {
+        if (
+          -3 == a()
+        ) {}
+        if (
+          // comment
+          -3 == a()
+        ) {}
+        if (
+          /* comment */
+          -3 == a()
+        ) {}
+        if (c)
+          -7
+        else
+          -8
+        try {
+          fn()
+        } catch(e: Exception) {
+          -9
         }
-        -2 -> {
-        }
+        var x =
+            -2 >
+            (2 + 2)
+        -3
     }
-    if (
-      -3 == a()
-    ) {}
-    if (
-      // comment
-      -3 == a()
-    ) {}
-    if (
-      /* comment */
-      -3 == a()
-    ) {}
-    if (c)
-      -7
-    else
-      -8
-    try {
-      fn()
-    } catch(e: Exception) {
-      -9
-    }
-    var x =
-        -2 >
-        (2 + 2)
-    -3
-}
 
 """.trimIndent()
 
 val longLines = """
-/**
- * These are class docs.
- */
-class C {
     /**
-     * These are function docs.
+     * These are class docs.
      */
-    fun getLoremIpsum() = "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua."
-
-    companion object {
+    class C {
         /**
-         * This is a constant for "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua."
+         * These are function docs.
          */
-        val LOREM_IPSUM = "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua."
+        fun getLoremIpsum() = "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua."
+
+        companion object {
+            /**
+             * This is a constant for "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua."
+             */
+            val LOREM_IPSUM = "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua."
+        }
     }
-}
 """.trimIndent()

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/TrailingCommaSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/TrailingCommaSpec.kt
@@ -21,52 +21,47 @@ class TrailingCommaSpec {
 
         @Test
         fun `reports unnecessary comma on function call`() {
-            val code =
-                """
+            val code = """
                 val foo1 = listOf("a", "b",)
-                """.trimIndent()
+            """.trimIndent()
             val findings = TrailingComma(TestConfig(mapOf(ALLOW_TRAILING_COMMA to false))).lint(code)
             assertThat(findings).hasSize(1)
         }
 
         @Test
         fun `reports unnecessary comma on constructor call`() {
-            val code =
-                """
+            val code = """
                 val foo2 = Pair(1, 2,)
-                """.trimIndent()
+            """.trimIndent()
             val findings = TrailingComma(TestConfig(mapOf(ALLOW_TRAILING_COMMA to false))).lint(code)
             assertThat(findings).hasSize(1)
         }
 
         @Test
         fun `reports unnecessary comma on generic type definition`() {
-            val code =
-                """
+            val code = """
                 val foo3: List<String,> = emptyList()
-                """.trimIndent()
+            """.trimIndent()
             val findings = TrailingComma(TestConfig(mapOf(ALLOW_TRAILING_COMMA to false))).lint(code)
             assertThat(findings).hasSize(1)
         }
 
         @Test
         fun `reports unnecessary comma on array get`() {
-            val code =
-                """
+            val code = """
                 val foo4 = Array(2) { 42 }
                 val bar4 = foo4[1,]
-                """.trimIndent()
+            """.trimIndent()
             val findings = TrailingComma(TestConfig(mapOf(ALLOW_TRAILING_COMMA to false))).lint(code)
             assertThat(findings).hasSize(1)
         }
 
         @Test
         fun `reports unnecessary comma on annotation`() {
-            val code =
-                """
+            val code = """
                 @Foo5([1, 2,])
                 val foo5: Int = 0
-                """.trimIndent()
+            """.trimIndent()
             val findings = TrailingComma(TestConfig(mapOf(ALLOW_TRAILING_COMMA to false))).lint(code)
             assertThat(findings).hasSize(1)
         }
@@ -77,41 +72,38 @@ class TrailingCommaSpec {
 
         @Test
         fun `reports missing comma on field definition`() {
-            val code =
-                """
+            val code = """
                 data class Foo1(val bar: Int)
                 data class Foo2(
                    val bar: Int
                 )
-                """.trimIndent()
+            """.trimIndent()
             val findings = TrailingComma(TestConfig(mapOf(ALLOW_TRAILING_COMMA to true))).lint(code)
             assertThat(findings).hasSize(1)
         }
 
         @Test
         fun `reports missing comma on function call`() {
-            val code =
-                """
+            val code = """
                 val foo1 = listOf("a", "b")
                 val foo2 = listOf(
                     "a", 
                     "b"
                 )
-                """.trimIndent()
+            """.trimIndent()
             val findings = TrailingComma(TestConfig(mapOf(ALLOW_TRAILING_COMMA_ON_CALL_SITE to true))).lint(code)
             assertThat(findings).hasSize(1)
         }
 
         @Test
         fun `reports missing comma on constructor call`() {
-            val code =
-                """
+            val code = """
                 val foo2 = Pair(1, 2)
                 val foo2 = Pair(
                     1, 
                     2
                 )
-                """.trimIndent()
+            """.trimIndent()
             val findings = TrailingComma(TestConfig(mapOf(ALLOW_TRAILING_COMMA_ON_CALL_SITE to true))).lint(code)
             assertThat(findings).hasSize(1)
         }

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/WrappingSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/WrappingSpec.kt
@@ -17,17 +17,16 @@ class WrappingSpec {
 
     @Test
     fun `Given a wrong wrapping in the class definition`() {
-        val code =
-            """
+        val code = """
             class A() : B, 
                 C {
             }
-            
+
             interface B
 
             interface C
 
-            """.trimIndent()
+        """.trimIndent()
 
         subject.lint(code).assert()
             .hasSize(1)

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/defaultconfig/ConfigPrinter.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/defaultconfig/ConfigPrinter.kt
@@ -25,62 +25,62 @@ object ConfigPrinter : DocumentationPrinter<List<RuleSetPage>> {
     }
 
     private fun defaultBuildConfiguration(): String = """
-      build:
-        maxIssues: 0
-        excludeCorrectable: false
-        weights:
-          # complexity: 2
-          # LongParameterList: 1
-          # style: 1
-          # comments: 1
+        build:
+          maxIssues: 0
+          excludeCorrectable: false
+          weights:
+            # complexity: 2
+            # LongParameterList: 1
+            # style: 1
+            # comments: 1
     """.trimIndent()
 
     private fun defaultConfigConfiguration(): String = """
-      config:
-        validation: true
-        warningsAsErrors: false
-        # when writing own rules with new properties, exclude the property path e.g.: 'my_rule_set,.*>.*>[my_property]'
-        excludes: ''
+        config:
+          validation: true
+          warningsAsErrors: false
+          # when writing own rules with new properties, exclude the property path e.g.: 'my_rule_set,.*>.*>[my_property]'
+          excludes: ''
     """.trimIndent()
 
     private fun defaultProcessorsConfiguration(): String = """
-      processors:
-        active: true
-        exclude:
-          - 'DetektProgressListener'
-        # - 'KtFileCountProcessor'
-        # - 'PackageCountProcessor'
-        # - 'ClassCountProcessor'
-        # - 'FunctionCountProcessor'
-        # - 'PropertyCountProcessor'
-        # - 'ProjectComplexityProcessor'
-        # - 'ProjectCognitiveComplexityProcessor'
-        # - 'ProjectLLOCProcessor'
-        # - 'ProjectCLOCProcessor'
-        # - 'ProjectLOCProcessor'
-        # - 'ProjectSLOCProcessor'
-        # - 'LicenseHeaderLoaderExtension'
+        processors:
+          active: true
+          exclude:
+            - 'DetektProgressListener'
+          # - 'KtFileCountProcessor'
+          # - 'PackageCountProcessor'
+          # - 'ClassCountProcessor'
+          # - 'FunctionCountProcessor'
+          # - 'PropertyCountProcessor'
+          # - 'ProjectComplexityProcessor'
+          # - 'ProjectCognitiveComplexityProcessor'
+          # - 'ProjectLLOCProcessor'
+          # - 'ProjectCLOCProcessor'
+          # - 'ProjectLOCProcessor'
+          # - 'ProjectSLOCProcessor'
+          # - 'LicenseHeaderLoaderExtension'
     """.trimIndent()
 
     private fun defaultConsoleReportsConfiguration(): String = """
-      console-reports:
-        active: true
-        exclude:
-           - 'ProjectStatisticsReport'
-           - 'ComplexityReport'
-           - 'NotificationReport'
-           - 'FindingsReport'
-           - 'FileBasedFindingsReport'
-        #  - 'LiteFindingsReport'
+        console-reports:
+          active: true
+          exclude:
+             - 'ProjectStatisticsReport'
+             - 'ComplexityReport'
+             - 'NotificationReport'
+             - 'FindingsReport'
+             - 'FileBasedFindingsReport'
+          #  - 'LiteFindingsReport'
     """.trimIndent()
 
     private fun defaultOutputReportsConfiguration(): String = """
-      output-reports:
-        active: true
-        exclude:
-        # - 'TxtOutputReport'
-        # - 'XmlOutputReport'
-        # - 'HtmlOutputReport'
-        # - 'MdOutputReport'
+        output-reports:
+          active: true
+          exclude:
+          # - 'TxtOutputReport'
+          # - 'XmlOutputReport'
+          # - 'HtmlOutputReport'
+          # - 'MdOutputReport'
     """.trimIndent()
 }

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleSetProviderCollectorSpec.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleSetProviderCollectorSpec.kt
@@ -321,13 +321,13 @@ class RuleSetProviderCollectorSpec {
     @Nested
     inner class `a RuleSetProvider with configurations in kdoc` {
         val code = """
-        package foo
+            package foo
 
-        /**
-         * description
-         * @configuration android - if android style guides should be preferred (default: `false`)
-         */
-        class TestProvider: RuleSetProvider {
+            /**
+             * description
+             * @configuration android - if android style guides should be preferred (default: `false`)
+             */
+            class TestProvider: RuleSetProvider {
         """.trimIndent()
 
         @Test

--- a/detekt-psi-utils/src/test/kotlin/io/github/detekt/psi/internal/FullQualifiedNameGuesserSpec.kt
+++ b/detekt-psi-utils/src/test/kotlin/io/github/detekt/psi/internal/FullQualifiedNameGuesserSpec.kt
@@ -12,11 +12,11 @@ class FullQualifiedNameGuesserSpec {
         private val sut = FullQualifiedNameGuesser(
             compileContentForTest(
                 """
-                package foo
+                    package foo
 
-                import kotlin.jvm.JvmField
-                import kotlin.jvm.JvmStatic as Static
-                import java.io.*
+                    import kotlin.jvm.JvmField
+                    import kotlin.jvm.JvmStatic as Static
+                    import java.io.*
                 """.trimIndent()
             )
         )

--- a/detekt-report-html/src/main/kotlin/io/github/detekt/report/html/HtmlUtils.kt
+++ b/detekt-report-html/src/main/kotlin/io/github/detekt/report/html/HtmlUtils.kt
@@ -83,15 +83,15 @@ private fun createReportUrl(ruleName: String, throwable: Throwable): String {
         .take(STACK_TRACE_LINES_TO_SHOW)
         .joinToString("\n")
     val bodyMessage = """
-            |I found an error in the html report:
-            |- Rule: $ruleName
-            |- Detekt version: ${whichDetekt() ?: "<WRITE HERE THE VERSION OF DETEKT THAT YOU ARE USING>"}
-            |- Stacktrace:
-            |```
-            |$stackTrace
-            |```
-            |- How to reproduce it: <WRITE HERE HOW TO REPRODUCE THIS ISSUE. A CODE SNIPPET IS THE BEST WAY.>
-            |
+        |I found an error in the html report:
+        |- Rule: $ruleName
+        |- Detekt version: ${whichDetekt() ?: "<WRITE HERE THE VERSION OF DETEKT THAT YOU ARE USING>"}
+        |- Stacktrace:
+        |```
+        |$stackTrace
+        |```
+        |- How to reproduce it: <WRITE HERE HOW TO REPRODUCE THIS ISSUE. A CODE SNIPPET IS THE BEST WAY.>
+        |
     """.trimMargin()
     val body = URLEncoder.encode(bodyMessage, "UTF8")
 

--- a/detekt-report-html/src/test/kotlin/io/github/detekt/report/html/HtmlUtilsSpec.kt
+++ b/detekt-report-html/src/test/kotlin/io/github/detekt/report/html/HtmlUtilsSpec.kt
@@ -35,16 +35,16 @@ class HtmlUtilsSpec {
 
         assertThat(snippet).isEqualTo(
             """
-            <div>
-              <pre><code><span class="lineno">   4 </span>// reports 1 - a comment with trailing space
-            <span class="lineno">   5 </span>// A comment
-            <span class="lineno">   6 </span>// reports 1
-            <span class="lineno">   7 </span><span class="error">class TrailingWhitespacePositive {</span>
-            <span class="lineno">   8 </span>    // reports 1 - line with just one tab
-            <span class="lineno">   9 </span>
-            <span class="lineno">  10 </span>    // reports 1
-            </code></pre>
-            </div>
+                <div>
+                  <pre><code><span class="lineno">   4 </span>// reports 1 - a comment with trailing space
+                <span class="lineno">   5 </span>// A comment
+                <span class="lineno">   6 </span>// reports 1
+                <span class="lineno">   7 </span><span class="error">class TrailingWhitespacePositive {</span>
+                <span class="lineno">   8 </span>    // reports 1 - line with just one tab
+                <span class="lineno">   9 </span>
+                <span class="lineno">  10 </span>    // reports 1
+                </code></pre>
+                </div>
 
             """.trimIndent()
         )
@@ -58,16 +58,16 @@ class HtmlUtilsSpec {
 
         assertThat(snippet).isEqualTo(
             """
-            <div>
-              <pre><code><span class="lineno">   4 </span>// reports 1 - a comment with trailing space
-            <span class="lineno">   5 </span>// A comment
-            <span class="lineno">   6 </span>// reports 1
-            <span class="lineno">   7 </span>class <span class="error">TrailingWhitespacePositive</span> {
-            <span class="lineno">   8 </span>    // reports 1 - line with just one tab
-            <span class="lineno">   9 </span>
-            <span class="lineno">  10 </span>    // reports 1
-            </code></pre>
-            </div>
+                <div>
+                  <pre><code><span class="lineno">   4 </span>// reports 1 - a comment with trailing space
+                <span class="lineno">   5 </span>// A comment
+                <span class="lineno">   6 </span>// reports 1
+                <span class="lineno">   7 </span>class <span class="error">TrailingWhitespacePositive</span> {
+                <span class="lineno">   8 </span>    // reports 1 - line with just one tab
+                <span class="lineno">   9 </span>
+                <span class="lineno">  10 </span>    // reports 1
+                </code></pre>
+                </div>
 
             """.trimIndent()
         )
@@ -81,16 +81,16 @@ class HtmlUtilsSpec {
 
         assertThat(snippet).isEqualTo(
             """
-            <div>
-              <pre><code><span class="lineno">   4 </span>// reports 1 - a comment with trailing space
-            <span class="lineno">   5 </span>// A comment
-            <span class="lineno">   6 </span>// reports 1
-            <span class="lineno">   7 </span>class <span class="error">TrailingWhitespacePositive {</span>
-            <span class="lineno">   8 </span><span class="error">    // reports 1 - line with just one</span> tab
-            <span class="lineno">   9 </span>
-            <span class="lineno">  10 </span>    // reports 1
-            </code></pre>
-            </div>
+                <div>
+                  <pre><code><span class="lineno">   4 </span>// reports 1 - a comment with trailing space
+                <span class="lineno">   5 </span>// A comment
+                <span class="lineno">   6 </span>// reports 1
+                <span class="lineno">   7 </span>class <span class="error">TrailingWhitespacePositive {</span>
+                <span class="lineno">   8 </span><span class="error">    // reports 1 - line with just one</span> tab
+                <span class="lineno">   9 </span>
+                <span class="lineno">  10 </span>    // reports 1
+                </code></pre>
+                </div>
 
             """.trimIndent()
         )

--- a/detekt-report-md/src/test/kotlin/io/github/detekt/report/md/MdOutputReportSpec.kt
+++ b/detekt-report-md/src/test/kotlin/io/github/detekt/report/md/MdOutputReportSpec.kt
@@ -148,10 +148,10 @@ private fun mockKtElement(): KtElement {
         package com.example.test
         
         import io.github.*
-       
+        
         class Test() {
             val greeting: String = "Hello, World!"
-        
+
             init {
                 println(greetings)
             }

--- a/detekt-report-xml/src/test/kotlin/io/github/detekt/report/xml/XmlOutputFormatSpec.kt
+++ b/detekt-report-xml/src/test/kotlin/io/github/detekt/report/xml/XmlOutputFormatSpec.kt
@@ -52,9 +52,9 @@ class XmlOutputFormatSpec {
 
         assertThat(result).isEqualTo(
             """
-            <?xml version="1.0" encoding="UTF-8"?>
-            <checkstyle version="4.3">
-            </checkstyle>
+                <?xml version="1.0" encoding="UTF-8"?>
+                <checkstyle version="4.3">
+                </checkstyle>
             """.trimIndent()
         )
     }
@@ -67,12 +67,12 @@ class XmlOutputFormatSpec {
 
         assertThat(result).isEqualTo(
             """
-            <?xml version="1.0" encoding="UTF-8"?>
-            <checkstyle version="4.3">
-            <file name="src/main/com/sample/Sample1.kt">
-            $TAB<error line="11" column="1" severity="warning" message="" source="detekt.id_a" />
-            </file>
-            </checkstyle>
+                <?xml version="1.0" encoding="UTF-8"?>
+                <checkstyle version="4.3">
+                <file name="src/main/com/sample/Sample1.kt">
+                $TAB<error line="11" column="1" severity="warning" message="" source="detekt.id_a" />
+                </file>
+                </checkstyle>
             """.trimIndent()
         )
     }
@@ -86,13 +86,13 @@ class XmlOutputFormatSpec {
 
         assertThat(result).isEqualTo(
             """
-            <?xml version="1.0" encoding="UTF-8"?>
-            <checkstyle version="4.3">
-            <file name="src/main/com/sample/Sample1.kt">
-            $TAB<error line="11" column="1" severity="warning" message="" source="detekt.id_a" />
-            $TAB<error line="11" column="1" severity="warning" message="" source="detekt.id_b" />
-            </file>
-            </checkstyle>
+                <?xml version="1.0" encoding="UTF-8"?>
+                <checkstyle version="4.3">
+                <file name="src/main/com/sample/Sample1.kt">
+                $TAB<error line="11" column="1" severity="warning" message="" source="detekt.id_a" />
+                $TAB<error line="11" column="1" severity="warning" message="" source="detekt.id_b" />
+                </file>
+                </checkstyle>
             """.trimIndent()
         )
     }
@@ -106,15 +106,15 @@ class XmlOutputFormatSpec {
 
         assertThat(result).isEqualTo(
             """
-            <?xml version="1.0" encoding="UTF-8"?>
-            <checkstyle version="4.3">
-            <file name="src/main/com/sample/Sample1.kt">
-            $TAB<error line="11" column="1" severity="warning" message="" source="detekt.id_a" />
-            </file>
-            <file name="src/main/com/sample/Sample2.kt">
-            $TAB<error line="22" column="2" severity="warning" message="" source="detekt.id_a" />
-            </file>
-            </checkstyle>
+                <?xml version="1.0" encoding="UTF-8"?>
+                <checkstyle version="4.3">
+                <file name="src/main/com/sample/Sample1.kt">
+                $TAB<error line="11" column="1" severity="warning" message="" source="detekt.id_a" />
+                </file>
+                <file name="src/main/com/sample/Sample2.kt">
+                $TAB<error line="22" column="2" severity="warning" message="" source="detekt.id_a" />
+                </file>
+                </checkstyle>
             """.trimIndent()
         )
     }
@@ -136,15 +136,15 @@ class XmlOutputFormatSpec {
 
         assertThat(result).isEqualTo(
             """
-            <?xml version="1.0" encoding="UTF-8"?>
-            <checkstyle version="4.3">
-            <file name="Sample1.kt">
-            $TAB<error line="1" column="1" severity="warning" message="TestMessage" source="detekt.id_a" />
-            </file>
-            <file name="Sample2.kt">
-            $TAB<error line="1" column="1" severity="warning" message="TestMessage" source="detekt.id_b" />
-            </file>
-            </checkstyle>
+                <?xml version="1.0" encoding="UTF-8"?>
+                <checkstyle version="4.3">
+                <file name="Sample1.kt">
+                $TAB<error line="1" column="1" severity="warning" message="TestMessage" source="detekt.id_a" />
+                </file>
+                <file name="Sample2.kt">
+                $TAB<error line="1" column="1" severity="warning" message="TestMessage" source="detekt.id_b" />
+                </file>
+                </checkstyle>
             """.trimIndent()
         )
     }
@@ -167,17 +167,17 @@ class XmlOutputFormatSpec {
 
         assertThat(result).isEqualTo(
             """
-            <?xml version="1.0" encoding="UTF-8"?>
-            <checkstyle version="4.3">
-            <file name="src/main/com/sample/Sample1.kt">
-            $TAB<error line="11" column="1" severity="warning" message="" source="detekt.id_a" />
-            $TAB<error line="11" column="1" severity="warning" message="" source="detekt.id_b" />
-            </file>
-            <file name="src/main/com/sample/Sample2.kt">
-            $TAB<error line="22" column="2" severity="warning" message="" source="detekt.id_a" />
-            $TAB<error line="22" column="2" severity="warning" message="" source="detekt.id_b" />
-            </file>
-            </checkstyle>
+                <?xml version="1.0" encoding="UTF-8"?>
+                <checkstyle version="4.3">
+                <file name="src/main/com/sample/Sample1.kt">
+                $TAB<error line="11" column="1" severity="warning" message="" source="detekt.id_a" />
+                $TAB<error line="11" column="1" severity="warning" message="" source="detekt.id_b" />
+                </file>
+                <file name="src/main/com/sample/Sample2.kt">
+                $TAB<error line="22" column="2" severity="warning" message="" source="detekt.id_a" />
+                $TAB<error line="22" column="2" severity="warning" message="" source="detekt.id_b" />
+                </file>
+                </checkstyle>
             """.trimIndent()
         )
     }
@@ -205,11 +205,11 @@ class XmlOutputFormatSpec {
                 $TAB<error line="${finding.location.source.line}" column="${finding.location.source.column}" severity="$xmlSeverity" message="${finding.messageOrDescription()}" source="detekt.${finding.id}" />
                 </file>
                 </checkstyle>
-            """
+            """.trimIndent()
 
             val actual = outputFormat.render(TestDetektion(finding))
 
-            assertThat(actual).isEqualTo(expected.trimIndent())
+            assertThat(actual).isEqualTo(expected)
         }
     }
 }

--- a/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/LicenceHeaderLoaderExtension.kt
+++ b/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/LicenceHeaderLoaderExtension.kt
@@ -52,8 +52,8 @@ class LicenceHeaderLoaderExtension : FileProcessListener {
 
             require(Files.exists(templateFile)) {
                 """
-                Rule '$RULE_NAME': License template file not found at `${templateFile.toAbsolutePath()}`.
-                Create file license header file or check your running path.
+                    Rule '$RULE_NAME': License template file not found at `${templateFile.toAbsolutePath()}`.
+                    Create file license header file or check your running path.
                 """.trimIndent()
             }
 

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/AbsentOrWrongFileLicenseSpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/AbsentOrWrongFileLicenseSpec.kt
@@ -60,13 +60,13 @@ class AbsentOrWrongFileLicenseSpec {
         fun `reports nothing for 2016`() {
             val findings = checkLicence(
                 """
-                //
-                // Copyright 2016 Artur Bosch & Contributors
-                //     http://www.apache.org/licenses/LICENSE-2.0
-                // See the License for the specific language governing permissions and
-                // limitations under the License.
-                //
-                package cases
+                    //
+                    // Copyright 2016 Artur Bosch & Contributors
+                    //     http://www.apache.org/licenses/LICENSE-2.0
+                    // See the License for the specific language governing permissions and
+                    // limitations under the License.
+                    //
+                    package cases
                 """.trimIndent(),
                 isRegexLicense = true
             )
@@ -78,13 +78,13 @@ class AbsentOrWrongFileLicenseSpec {
         fun `reports nothing for 2021`() {
             val findings = checkLicence(
                 """
-                //
-                // Copyright 2021 Artur Bosch & Contributors
-                //     http://www.apache.org/licenses/LICENSE-2.0
-                // See the License for the specific language governing permissions and
-                // limitations under the License.
-                //
-                package cases
+                    //
+                    // Copyright 2021 Artur Bosch & Contributors
+                    //     http://www.apache.org/licenses/LICENSE-2.0
+                    // See the License for the specific language governing permissions and
+                    // limitations under the License.
+                    //
+                    package cases
                 """.trimIndent(),
                 isRegexLicense = true
             )
@@ -100,7 +100,7 @@ class AbsentOrWrongFileLicenseSpec {
         fun `file with missing license header`() {
             val findings = checkLicence(
                 """
-                package cases
+                    package cases
                 """.trimIndent(),
                 isRegexLicense = true
             )
@@ -112,13 +112,13 @@ class AbsentOrWrongFileLicenseSpec {
         fun `file with license header not on the first line`() {
             val findings = checkLicence(
                 """
-                package cases
-                //
-                // Copyright 2021 Artur Bosch & Contributors
-                //     http://www.apache.org/licenses/LICENSE-2.0
-                // See the License for the specific language governing permissions and
-                // limitations under the License.
-                //
+                    package cases
+                    //
+                    // Copyright 2021 Artur Bosch & Contributors
+                    //     http://www.apache.org/licenses/LICENSE-2.0
+                    // See the License for the specific language governing permissions and
+                    // limitations under the License.
+                    //
                 """.trimIndent(),
                 isRegexLicense = true
             )
@@ -130,10 +130,10 @@ class AbsentOrWrongFileLicenseSpec {
         fun `file with incomplete license header`() {
             val findings = checkLicence(
                 """
-                //
-                // Copyright 2021 Artur Bosch & Contributors
-                //
-                package cases
+                    //
+                    // Copyright 2021 Artur Bosch & Contributors
+                    //
+                    package cases
                 """.trimIndent(),
                 isRegexLicense = true
             )
@@ -145,14 +145,14 @@ class AbsentOrWrongFileLicenseSpec {
         fun `file with too many empty likes in license header`() {
             val findings = checkLicence(
                 """
-                //
-                //
-                // Copyright 2021 Artur Bosch & Contributors
-                //     http://www.apache.org/licenses/LICENSE-2.0
-                // See the License for the specific language governing permissions and
-                // limitations under the License.
-                //
-                package cases
+                    //
+                    //
+                    // Copyright 2021 Artur Bosch & Contributors
+                    //     http://www.apache.org/licenses/LICENSE-2.0
+                    // See the License for the specific language governing permissions and
+                    // limitations under the License.
+                    //
+                    package cases
                 """.trimIndent(),
                 isRegexLicense = true
             )
@@ -164,13 +164,13 @@ class AbsentOrWrongFileLicenseSpec {
         fun `file with incorrect year in license header`() {
             val findings = checkLicence(
                 """
-                //
-                // Copyright 202 Artur Bosch & Contributors
-                //     http://www.apache.org/licenses/LICENSE-2.0
-                // See the License for the specific language governing permissions and
-                // limitations under the License.
-                //
-                package cases
+                    //
+                    // Copyright 202 Artur Bosch & Contributors
+                    //     http://www.apache.org/licenses/LICENSE-2.0
+                    // See the License for the specific language governing permissions and
+                    // limitations under the License.
+                    //
+                    package cases
                 """.trimIndent(),
                 isRegexLicense = true
             )

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/KDocReferencesNonPublicPropertySpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/KDocReferencesNonPublicPropertySpec.kt
@@ -10,16 +10,16 @@ class KDocReferencesNonPublicPropertySpec {
     @Test
     fun `reports referenced non-public properties`() {
         val code = """ 
-        /**
-         * Comment
-         * [prop1] - non-public property
-         * [prop2] - public property
-         */
-        class Test {
-            private val nonReferencedProp = 0
-            private val prop1 = 0
-            val prop2 = 0
-        }
+            /**
+             * Comment
+             * [prop1] - non-public property
+             * [prop2] - public property
+             */
+            class Test {
+                private val nonReferencedProp = 0
+                private val prop1 = 0
+                val prop2 = 0
+            }
         """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
@@ -27,16 +27,16 @@ class KDocReferencesNonPublicPropertySpec {
     @Test
     fun `reports referenced non-public properties in private class`() {
         val code = """ 
-        /**
-         * Comment
-         * [prop1] - non-public property
-         * [prop2] - public property
-         */
-        private class Test {
-            private val nonReferencedProp = 0
-            private val prop1 = 0
-            val prop2 = 0
-        }
+            /**
+             * Comment
+             * [prop1] - non-public property
+             * [prop2] - public property
+             */
+            private class Test {
+                private val nonReferencedProp = 0
+                private val prop1 = 0
+                val prop2 = 0
+            }
         """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
@@ -45,27 +45,27 @@ class KDocReferencesNonPublicPropertySpec {
     fun `reports referenced non-public properties in nested objects`() {
         val code = """ 
         /**
-         * Comment
-         * [prop1] - non-public property
-         * [A.prop2] - non-public property
-         * [A.B.prop3] - non-public property
-         * [A.C.prop4] - non-public property
-         */
-        class Test {
-            private val prop1 = 0
-            
-            object A {
-                private val nonReferencedProp = 0
-                private val prop2 = 0
+             * Comment
+             * [prop1] - non-public property
+             * [A.prop2] - non-public property
+             * [A.B.prop3] - non-public property
+             * [A.C.prop4] - non-public property
+             */
+            class Test {
+                private val prop1 = 0
                 
-                private object B {
-                    val prop3 = 0
-                }
-                object C {
-                    private val prop4 = 0
+                object A {
+                    private val nonReferencedProp = 0
+                    private val prop2 = 0
+
+                    private object B {
+                        val prop3 = 0
+                    }
+                    object C {
+                        private val prop4 = 0
+                    }
                 }
             }
-        }
         """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(4)
     }
@@ -73,10 +73,10 @@ class KDocReferencesNonPublicPropertySpec {
     @Test
     fun `does not report properties with no KDoc`() {
         val code = """ 
-        class Test {
-            private val prop1 = 0
-            val prop2 = 0
-        }
+            class Test {
+                private val prop1 = 0
+                val prop2 = 0
+            }
         """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
@@ -84,12 +84,12 @@ class KDocReferencesNonPublicPropertySpec {
     @Test
     fun `does not report properties with empty comments`() {
         val code = """
-        /**
-        */
-        class Test {
-            private val prop1 = 0
-            val prop2 = 0
-        }
+            /**
+            */
+            class Test {
+                private val prop1 = 0
+                val prop2 = 0
+            }
         """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
@@ -97,12 +97,12 @@ class KDocReferencesNonPublicPropertySpec {
     @Test
     fun `does not report properties not enclosed in a class`() {
         val code = """
-        /**
-        * [prop1]
-        * [prop2]
-        */
-        private val prop1 = 0
-        val prop2 = 0
+            /**
+            * [prop1]
+            * [prop2]
+            */
+            private val prop1 = 0
+            val prop2 = 0
         """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
@@ -110,24 +110,24 @@ class KDocReferencesNonPublicPropertySpec {
     @Test
     fun `does not report referenced public properties in nested objects`() {
         val code = """ 
-        /**
-         * Comment
-         * [prop1] - public property
-         * [A.B.prop2] - public property
-         * [C.prop3] - public property
-         */
-        open class Test {
-            protected val prop1 = 0
-            object A {
-                object B {
-                    val nonReferencedProp = 0
-                    val prop2 = 0
+            /**
+             * Comment
+             * [prop1] - public property
+             * [A.B.prop2] - public property
+             * [C.prop3] - public property
+             */
+            open class Test {
+                protected val prop1 = 0
+                object A {
+                    object B {
+                        val nonReferencedProp = 0
+                        val prop2 = 0
+                    }
+                }
+                object C {
+                    val prop3 = 0
                 }
             }
-            object C {
-                val prop3 = 0
-            }
-        }
         """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MatchingDeclarationNameSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MatchingDeclarationNameSpec.kt
@@ -156,9 +156,9 @@ class MatchingDeclarationNameSpec {
         fun `should not pass for class declaration as first declaration with utility functions`() {
             val ktFile = compileContentForTest(
                 """
-                class C
-                fun a() = 5
-                fun C.b() = 5
+                    class C
+                    fun a() = 5
+                    fun C.b() = 5
                 """.trimIndent(),
                 filename = "ClassUtils.kt"
             )
@@ -177,9 +177,9 @@ class MatchingDeclarationNameSpec {
         fun `should not pass for enum declaration`() {
             val ktFile = compileContentForTest(
                 """
-                enum class NOT_E {
-                    ONE, TWO, THREE
-                }
+                    enum class NOT_E {
+                        ONE, TWO, THREE
+                    }
                 """.trimIndent(),
                 filename = "E.kt"
             )
@@ -202,9 +202,9 @@ class MatchingDeclarationNameSpec {
         fun `should not pass for class declaration not as first declaration with utility functions when mustBeFirst is false`() {
             val ktFile = compileContentForTest(
                 """
-                fun a() = 5
-                fun C.b() = 5
-                class C
+                    fun a() = 5
+                    fun C.b() = 5
+                    class C
                 """.trimIndent(),
                 filename = "Classes.kt"
             )

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/DestructuringDeclarationWithTooManyEntriesSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/DestructuringDeclarationWithTooManyEntriesSpec.kt
@@ -17,16 +17,16 @@ class DestructuringDeclarationWithTooManyEntriesSpec {
         @Test
         fun `does not report destructuring declarations with 2 or 3 entries`() {
             val code = """
-            fun testFun() {
-                val (x, y) = Pair(3, 4)
-                println(x)
-                println(y)
-                
-                val (a, b, c) = Triple(1, 2, 3)
-                println(a)
-                println(b)
-                println(c)
-            }
+                fun testFun() {
+                    val (x, y) = Pair(3, 4)
+                    println(x)
+                    println(y)
+
+                    val (a, b, c) = Triple(1, 2, 3)
+                    println(a)
+                    println(b)
+                    println(c)
+                }
             """.trimIndent()
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
@@ -34,15 +34,15 @@ class DestructuringDeclarationWithTooManyEntriesSpec {
         @Test
         fun `reports destructuring declarations with more than 3 entries`() {
             val code = """
-            fun testFun() {
-                data class ManyElements(val a: Int, val b: Int, val c: Int, val d: Int)
+                fun testFun() {
+                    data class ManyElements(val a: Int, val b: Int, val c: Int, val d: Int)
 
-                val (a, b, c, d) = ManyElements(1, 2, 3, 4)
-                println(a)
-                println(b)
-                println(c)
-                println(d)
-            }
+                    val (a, b, c, d) = ManyElements(1, 2, 3, 4)
+                    println(a)
+                    println(b)
+                    println(c)
+                    println(d)
+                }
             """.trimIndent()
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
@@ -50,14 +50,14 @@ class DestructuringDeclarationWithTooManyEntriesSpec {
         @Test
         fun `does not report destructuring declarations in lambdas with 2 or 3 entries`() {
             val code = """
-            fun testFun() {
-                val items = listOf(Pair(3, 4))
+                fun testFun() {
+                    val items = listOf(Pair(3, 4))
 
-                items.forEach { (a, b) ->
-                    println(a)
-                    println(b)
+                    items.forEach { (a, b) ->
+                        println(a)
+                        println(b)
+                    }
                 }
-            }
             """.trimIndent()
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
@@ -65,17 +65,17 @@ class DestructuringDeclarationWithTooManyEntriesSpec {
         @Test
         fun `reports destructuring declarations in lambdas with more than 3 entries`() {
             val code = """
-            fun testFun() {
-                data class ManyElements(val a: Int, val b: Int, val c: Int, val d: Int)
+                fun testFun() {
+                    data class ManyElements(val a: Int, val b: Int, val c: Int, val d: Int)
 
-                val items = listOf(ManyElements(1, 2, 3, 4))
-                items.forEach { (a, b, c, d) ->
-                    println(a)
-                    println(b)
-                    println(c)
-                    println(d)
+                    val items = listOf(ManyElements(1, 2, 3, 4))
+                    items.forEach { (a, b, c, d) ->
+                        println(a)
+                        println(b)
+                        println(c)
+                        println(d)
+                    }
                 }
-            }
             """.trimIndent()
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
@@ -92,11 +92,11 @@ class DestructuringDeclarationWithTooManyEntriesSpec {
         @Test
         fun `does not report destructuring declarations with 2 entries`() {
             val code = """
-            fun testFun() {
-                val (x, y) = Pair(3, 4)
-                println(x)
-                println(y)
-            }
+                fun testFun() {
+                    val (x, y) = Pair(3, 4)
+                    println(x)
+                    println(y)
+                }
             """.trimIndent()
             assertThat(configuredRule.compileAndLint(code)).isEmpty()
         }
@@ -104,12 +104,12 @@ class DestructuringDeclarationWithTooManyEntriesSpec {
         @Test
         fun `reports destructuring declarations with more than 2 entries`() {
             val code = """
-            fun testFun() {
-                val (a, b, c) = Triple(1, 2, 3)
-                println(a)
-                println(b)
-                println(c)
-            }
+                fun testFun() {
+                    val (a, b, c) = Triple(1, 2, 3)
+                    println(a)
+                    println(b)
+                    println(c)
+                }
             """.trimIndent()
             assertThat(configuredRule.compileAndLint(code)).hasSize(1)
         }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLengthSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLengthSpec.kt
@@ -75,12 +75,12 @@ class MaxLineLengthSpec {
     @Nested
     inner class `a kt file with a long package name and long import statements` {
         val code = """
-        package anIncrediblyLongAndComplexPackageNameThatProbablyShouldBeMuchShorterButForTheSakeOfTheTestItsNot
+            package anIncrediblyLongAndComplexPackageNameThatProbablyShouldBeMuchShorterButForTheSakeOfTheTestItsNot
 
-        import anIncrediblyLongAndComplexImportNameThatProbablyShouldBeMuchShorterButForTheSakeOfTheTestItsNot
+            import anIncrediblyLongAndComplexImportNameThatProbablyShouldBeMuchShorterButForTheSakeOfTheTestItsNot
 
-        class Test {
-        }
+            class Test {
+            }
         """
 
         private val file = compileContentForTest(code)
@@ -182,13 +182,13 @@ class MaxLineLengthSpec {
     @Nested
     inner class `a kt file with a long package name, long import statements and a long line` {
         val code = """
-        package anIncrediblyLongAndComplexPackageNameThatProbablyShouldBeMuchShorterButForTheSakeOfTheTestItsNot
+            package anIncrediblyLongAndComplexPackageNameThatProbablyShouldBeMuchShorterButForTheSakeOfTheTestItsNot
 
-        import anIncrediblyLongAndComplexImportNameThatProbablyShouldBeMuchShorterButForTheSakeOfTheTestItsNot
+            import anIncrediblyLongAndComplexImportNameThatProbablyShouldBeMuchShorterButForTheSakeOfTheTestItsNot
 
-        class Test {
-            fun anIncrediblyLongAndComplexMethodNameThatProbablyShouldBeMuchShorterButForTheSakeOfTheTestItsNot() {}
-        }
+            class Test {
+                fun anIncrediblyLongAndComplexMethodNameThatProbablyShouldBeMuchShorterButForTheSakeOfTheTestItsNot() {}
+            }
         """.trimIndent()
 
         private val file = compileContentForTest(code)

--- a/detekt-sample-extensions/src/test/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/SampleConfigValidatorSpec.kt
+++ b/detekt-sample-extensions/src/test/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/SampleConfigValidatorSpec.kt
@@ -10,9 +10,9 @@ class SampleConfigValidatorSpec {
     fun `it warns if active property is not a boolean`() {
         val config = yamlConfigFromContent(
             """
-            sample:
-              TooManyFunctions:
-                active: 1
+                sample:
+                  TooManyFunctions:
+                    active: 1
             """.trimIndent()
         )
 


### PR DESCRIPTION
This PR fixes the issues that #5058 found on our code base. I did to ensure that the rule works properly.

If you think about it these cahnges are really few. We have way more bad formatted raw strings. The point is that the rule implemented on #5058 only flags raw-strings that call `.trimMargin()` or `.trimIndent()` and we don't call those functions. I think that we should change that and always call `.trimIndent()` (#5051 will help with that). Then the rule will flag way more bad formatted raw-strings and we will be able to fix them.