### PR TITLE
Remove redundant null check

### DIFF
--- a/detekt-parser/build.gradle.kts
+++ b/detekt-parser/build.gradle.kts
@@ -14,7 +14,7 @@ dependencies {
 }
 
 tasks.withType<Test> {
-    systemProperty("kotlinVersion", getKotlinPluginVersion() ?: embeddedKotlinVersion)
+    systemProperty("kotlinVersion", getKotlinPluginVersion())
 
     doFirst {
         systemProperty("testClasspath", classpath.joinToString(";"))


### PR DESCRIPTION
`getKotlinPluginVersion()` never returns `null`