### PR TITLE
ReturnCount: Make configuration parameter more explicit

### DIFF
--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCount.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCount.kt
@@ -59,7 +59,7 @@ class ReturnCount(config: Config = Config.empty) : Rule(config) {
     @Configuration("define the maximum number of return statements allowed per function")
     private val max: Int by config(2)
 
-    @Configuration("define comma separated list of function names to be ignored by this check")
+    @Configuration("define a free-form comma separated list of function names to be ignored by this check")
     private val excludedFunctions: SplitPattern by config("equals") { SplitPattern(it) }
 
     @Configuration("if labeled return statements should be ignored")

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCount.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCount.kt
@@ -59,7 +59,7 @@ class ReturnCount(config: Config = Config.empty) : Rule(config) {
     @Configuration("define the maximum number of return statements allowed per function")
     private val max: Int by config(2)
 
-    @Configuration("define functions to be ignored by this check")
+    @Configuration("define comma separated list of function names to be ignored by this check")
     private val excludedFunctions: SplitPattern by config("equals") { SplitPattern(it) }
 
     @Configuration("if labeled return statements should be ignored")


### PR DESCRIPTION
## Background
I want to configure `ReturnCount` to ignore Android's onMenuItemSelected and onOptionsItemSelected because they should have many returns to prevent bugs and strange behavior.

## Problem
In the JSON-schema we have this definition:
```
            "excludedFunctions": {
              "type": "string"
            },
```
Stringly typed items are hard to use, because they don't define structure.
It's not clear if this string is a regex, or a pipe separated list, or a comma separated list, or even a semi-colon separated regex list.

## Investigation
Note: this investigation has to be done by anyone who wants to use this configuration, and they might not know how to navigate the code or not have will.

### Docs
https://detekt.dev/docs/rules/style/#returncount

| <img src=https://user-images.githubusercontent.com/2906988/178217883-3491bde0-805d-4029-b6e2-25af6dcb07bc.png width=25% /> |
| - |

No conclusive result.

### Source code
https://github.com/detekt/detekt/blob/1b330e9e42a385a588c9f61021f2da6ae7495a92/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCount.kt#L62-L63

Now I know it's split somehow.

### Tests
https://github.com/detekt/detekt/blob/a2734b18c133020520183292c9d2ff0593040a1c/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCountSpec.kt#L350

Now I know it's split by comma.

### Deeper look
https://github.com/detekt/detekt/blob/1b330e9e42a385a588c9f61021f2da6ae7495a92/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCount.kt#L93

calls

https://github.com/detekt/detekt/blob/1b330e9e42a385a588c9f61021f2da6ae7495a92/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/SplitPattern.kt#L31

also

https://github.com/detekt/detekt/blob/1b330e9e42a385a588c9f61021f2da6ae7495a92/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/SplitPattern.kt#L65-L70

Now I know it's definitely comma separated (from constructor default parameter), and that it's case insensitive (which is strange in a strongly typed case sensitive language), I also know the comma separated list is free-from because of trim and resilient in case there are multiple or trailing commas.

## Solution
Update docs to reflect this.

## Note
Obviously a more explicit way of doing this would be ideal:
```yaml
    excludedFunctions:
      # Ignore MenuProvider.onMenuItemSelected,
      # because it has a special structure for bug prevention.
      - onMenuItemSelected
      # Ignore Activity.onOptionsItemSelected and Fragment.onOptionsItemSelected,
      # because they has a special structure for bug prevention.
      - onOptionsItemSelected
```
but for now, this will do:
```yaml
    excludedFunctions:
      # Ignore MenuProvider.onMenuItemSelected, Activity.onOptionsItemSelected,
      # and Fragment.onOptionsItemSelected, because they have a special structure for bug prevention.
      '
        onMenuItemSelected,
        onOptionsItemSelected,
      '
```