### PR TITLE
Get actual absolute path in compilation PsiFiles

### DIFF
--- a/detekt-psi-utils/src/main/kotlin/io/github/detekt/psi/KtFiles.kt
+++ b/detekt-psi-utils/src/main/kotlin/io/github/detekt/psi/KtFiles.kt
@@ -19,7 +19,7 @@ fun PsiFile.fileNameWithoutSuffix(): String {
     return fileName.removeSuffix(KOTLIN_SUFFIX)
 }
 
-fun PsiFile.absolutePath(): Path = Paths.get(name)
+fun PsiFile.absolutePath(): Path = Paths.get(virtualFile.presentableUrl)
 
 fun PsiFile.relativePath(): Path? = getUserData(RELATIVE_PATH)?.let { Paths.get(it) }
 


### PR DESCRIPTION
When the psi-utils are used by the Detekt Compiler Plugin, the Kotlin Compiler constructs PsiFiles slightly differently. The difference in PsiFile causes the Detekt Location object to present a relative path, even when an absolute path is requested.

Reports show just the file's name, and not it's path. For example `Foo.kt` rather than `/Users/tim.oltjenbruns/foo-app/src/main/kotlin/Foo.kt` Not a huge issue, but it does mean that reports generated from the compiler plugin cannot be merged and de-duplicated with reports from the traditional gradle plugin. It also means that the Sonar integration would not work with compiler plugin generated reports.

From my manual tests on:
* Mac OSX 11.6.1
* Gradle 7.4.2
* Kotlin 1.6.10
* Detekt 1.20.0
* Latest main branch of Compiler Plugin (unreleased), with the Detekt version updated from 1.18.1 to 1.20.0

The traditional gradle plugin, with and without type resolution produces the absolute paths as intended.
The compiler plugin produces just the name of the file, without a path.

Changing the implementation of `PsiFile.absolutePath()` to use `PsiFile.virtualFile.presentableUrl` rather than `PsiFile.name` fixed the compiler plugin reports, and the reports with the traditional gradle plugin were unchanged.

I did not manually test the Detekt CLI but I looked into the unit tests and those seem to adequately cover the report path.
I'm not sure how well the traditional gradle plugin is unit tested in this way (or if the CLI tests are sufficient enough in this way). I think some tests should be added to the compiler plugin to catch this though.

I still feel like I haven't tested this adequately enough, mainly because I'm not sure what all this might affect down the line.