### PR TITLE
Use Gradle's configuration cache by default

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,5 +4,5 @@ systemProp.dependency.analysis.test.analysis=false
 org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8
-org.gradle.unsafe.configuration-cache=false
+org.gradle.unsafe.configuration-cache=true
 systemProp.org.gradle.kotlin.dsl.precompiled.accessors.strict=true


### PR DESCRIPTION
`./gradlew publishToMavenLocal` works OK since Gradle 7.5 (https://github.com/detekt/detekt/issues/4598)

Relates to https://github.com/detekt/detekt/pull/4669 and https://github.com/detekt/detekt/pull/4668.

Configuration cache is still incubating but between the fixes in Gradle 7.5 and the use of `notCompatibleWithConfigurationCache` for incompatible tasks we should be able to use this now without causing build instability.