### PR TITLE
Configure 'ForbiddenImport' to use value and reason

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -183,8 +183,10 @@ style:
   ForbiddenImport:
     active: true
     imports:
-      - 'org.assertj.core.api.Assertions'
-      - 'org.junit.jupiter.api.Assertions*'
+      - value: 'org.assertj.core.api.Assertions'
+        reason: 'Import Assertions.assertThat instead.'
+      - value: 'org.junit.jupiter.api.Assertions*'
+        reason: 'Use AssertJ assertions instead.'
   ForbiddenMethodCall:
     active: true
     methods:


### PR DESCRIPTION
Now that #4909 is merged, it is possible to define a reason for an import that is forbidden for the detekt code base.