### PR TITLE
Drop unused Maven Local repo from unit tests

### DIFF
--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektJvmSpec.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektJvmSpec.kt
@@ -19,7 +19,6 @@ class DetektJvmSpec {
             apply<DetektPlugin>()
             repositories {
                 mavenCentral()
-                mavenLocal()
             }
             tasks.withType(Detekt::class.java).configureEach {
                 it.reports { reports ->

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektPlainSpec.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektPlainSpec.kt
@@ -25,7 +25,6 @@ class DetektPlainSpec {
 
                 repositories {
                     mavenCentral()
-                    mavenLocal()
                 }
 
                 configure<DetektExtension> {
@@ -53,7 +52,6 @@ class DetektPlainSpec {
 
                 repositories {
                     mavenCentral()
-                    mavenLocal()
                 }
 
                 tasks.withType(Detekt::class.java).configureEach {


### PR DESCRIPTION
The repo isn't used by these tests as the detekt tasks aren't executed.