### PR TITLE
Assert end source locations

### DIFF
--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/IndentationSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/IndentationSpec.kt
@@ -34,7 +34,7 @@ class IndentationSpec {
             @Test
             fun `places finding location to the indentation`() {
                 subject.lint(code).assert()
-                    .hasSourceLocation(2, 1)
+                    .hasStartSourceLocation(2, 1)
                     .hasTextLocations(13 to 14)
             }
         }

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/WrappingSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/WrappingSpec.kt
@@ -31,7 +31,7 @@ class WrappingSpec {
 
         subject.lint(code).assert()
             .hasSize(1)
-            .hasSourceLocation(1, 12)
+            .hasStartSourceLocation(1, 12)
             .hasTextLocations(11 to 12)
     }
 }

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexMethodSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexMethodSpec.kt
@@ -129,7 +129,7 @@ class ComplexMethodSpec {
             )
             val subject = ComplexMethod(config)
 
-            assertThat(subject.lint(path)).hasSourceLocations(SourceLocation(43, 5))
+            assertThat(subject.lint(path)).hasStartSourceLocations(SourceLocation(43, 5))
         }
 
         @Test
@@ -137,7 +137,7 @@ class ComplexMethodSpec {
             val config = TestConfig(mapOf("threshold" to "4"))
             val subject = ComplexMethod(config)
 
-            assertThat(subject.lint(path)).hasSourceLocations(
+            assertThat(subject.lint(path)).hasStartSourceLocations(
                 SourceLocation(6, 5),
                 SourceLocation(15, 5),
                 SourceLocation(25, 5),
@@ -235,7 +235,7 @@ class ComplexMethodSpec {
 private fun assertExpectedComplexityValue(code: String, config: TestConfig, expectedValue: Int) {
     val findings = ComplexMethod(config).lint(code)
 
-    assertThat(findings).hasSourceLocations(SourceLocation(1, 5))
+    assertThat(findings).hasStartSourceLocations(SourceLocation(1, 5))
 
     assertThat(findings.first())
         .isThresholded()

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LargeClassSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LargeClassSpec.kt
@@ -16,7 +16,7 @@ class LargeClassSpec {
     fun `should detect only the nested large class which exceeds threshold 70`() {
         val findings = subject(threshold = 70).lint(resourceAsPath("NestedClasses.kt"))
         assertThat(findings).hasSize(1)
-        assertThat(findings).hasSourceLocations(SourceLocation(12, 15))
+        assertThat(findings).hasStartSourceLocations(SourceLocation(12, 15))
     }
 
     @Test

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedScopeFunctionsSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedScopeFunctionsSpec.kt
@@ -116,7 +116,7 @@ class NestedScopeFunctionsSpec(private val env: KotlinCoreEnvironment) {
     }
 
     private fun expectSourceLocation(location: Pair<Int, Int>) {
-        assertThat(actual).hasSourceLocation(location.first, location.second)
+        assertThat(actual).hasStartSourceLocation(location.first, location.second)
     }
 
     private fun expectFunctionInMsg(scopeFunction: String) {

--- a/detekt-rules-empty/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyFunctionBlockSpec.kt
+++ b/detekt-rules-empty/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyFunctionBlockSpec.kt
@@ -21,7 +21,7 @@ class EmptyFunctionBlockSpec {
                 protected fun stuff() {}
             }
         """
-        assertThat(subject.compileAndLint(code)).hasSourceLocation(2, 27)
+        assertThat(subject.compileAndLint(code)).hasStartSourceLocation(2, 27)
     }
 
     @Test
@@ -51,7 +51,7 @@ class EmptyFunctionBlockSpec {
                 fun b() {}
             }
         """
-        assertThat(subject.compileAndLint(code)).hasSourceLocation(2, 13)
+        assertThat(subject.compileAndLint(code)).hasStartSourceLocation(2, 13)
     }
 
     @Nested
@@ -89,7 +89,7 @@ class EmptyFunctionBlockSpec {
         @Test
         fun `should not flag overridden functions`() {
             val config = TestConfig(mapOf(IGNORE_OVERRIDDEN_FUNCTIONS to "true"))
-            assertThat(EmptyFunctionBlock(config).compileAndLint(code)).hasSourceLocation(1, 13)
+            assertThat(EmptyFunctionBlock(config).compileAndLint(code)).hasStartSourceLocation(1, 13)
         }
     }
 
@@ -115,7 +115,7 @@ class EmptyFunctionBlockSpec {
 
         @Test
         fun `should not flag overridden functions with commented body`() {
-            assertThat(subject.compileAndLint(code)).hasSourceLocation(12, 31)
+            assertThat(subject.compileAndLint(code)).hasStartSourceLocation(12, 31)
         }
 
         @Test

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/CastToNullableTypeSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/CastToNullableTypeSpec.kt
@@ -16,7 +16,7 @@ class CastToNullableTypeSpec {
         """
         val findings = subject.compileAndLint(code)
         assertThat(findings).hasSize(1)
-        assertThat(findings).hasSourceLocation(2, 22)
+        assertThat(findings).hasStartSourceLocation(2, 22)
         assertThat(findings[0]).hasMessage("Use the safe cast ('as? String') instead of 'as String?'.")
     }
 

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DoubleMutabilityForCollectionSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DoubleMutabilityForCollectionSpec.kt
@@ -30,7 +30,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 """
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).hasSize(1)
-                assertThat(result).hasSourceLocation(2, 5)
+                assertThat(result).hasStartSourceLocation(2, 5)
             }
 
             @Test
@@ -42,7 +42,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 """
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).hasSize(1)
-                assertThat(result).hasSourceLocation(2, 5)
+                assertThat(result).hasStartSourceLocation(2, 5)
             }
 
             @Test
@@ -54,7 +54,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 """
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).hasSize(1)
-                assertThat(result).hasSourceLocation(2, 5)
+                assertThat(result).hasStartSourceLocation(2, 5)
             }
 
             @Test
@@ -66,7 +66,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 """
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).hasSize(1)
-                assertThat(result).hasSourceLocation(2, 5)
+                assertThat(result).hasStartSourceLocation(2, 5)
             }
 
             @Test
@@ -78,7 +78,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 """
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).hasSize(1)
-                assertThat(result).hasSourceLocation(2, 5)
+                assertThat(result).hasStartSourceLocation(2, 5)
             }
 
             @Test
@@ -90,7 +90,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 """
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).hasSize(1)
-                assertThat(result).hasSourceLocation(2, 5)
+                assertThat(result).hasStartSourceLocation(2, 5)
             }
 
             @Test
@@ -102,7 +102,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 """
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).hasSize(1)
-                assertThat(result).hasSourceLocation(2, 5)
+                assertThat(result).hasStartSourceLocation(2, 5)
             }
 
             @Test
@@ -114,7 +114,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 """
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).hasSize(1)
-                assertThat(result).hasSourceLocation(2, 5)
+                assertThat(result).hasStartSourceLocation(2, 5)
             }
 
             @Test
@@ -135,7 +135,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 """
                 val result = rule.compileAndLintWithContext(env, code)
                 assertThat(result).hasSize(1)
-                assertThat(result).hasSourceLocation(3, 5)
+                assertThat(result).hasStartSourceLocation(3, 5)
             }
 
             @Test
@@ -157,7 +157,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 """
                 val result = rule.compileAndLintWithContext(env, code)
                 assertThat(result).hasSize(1)
-                assertThat(result).hasSourceLocation(4, 5)
+                assertThat(result).hasStartSourceLocation(4, 5)
             }
 
             @Test
@@ -180,7 +180,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 """
                 val result = rule.compileAndLintWithContext(env, code)
                 assertThat(result).hasSize(1)
-                assertThat(result).hasSourceLocation(5, 5)
+                assertThat(result).hasStartSourceLocation(5, 5)
             }
         }
 
@@ -357,7 +357,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 """
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).hasSize(1)
-                assertThat(result).hasSourceLocation(1, 1)
+                assertThat(result).hasStartSourceLocation(1, 1)
             }
 
             @Test
@@ -367,7 +367,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 """
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).hasSize(1)
-                assertThat(result).hasSourceLocation(1, 1)
+                assertThat(result).hasStartSourceLocation(1, 1)
             }
 
             @Test
@@ -377,7 +377,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 """
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).hasSize(1)
-                assertThat(result).hasSourceLocation(1, 1)
+                assertThat(result).hasStartSourceLocation(1, 1)
             }
 
             @Test
@@ -387,7 +387,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 """
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).hasSize(1)
-                assertThat(result).hasSourceLocation(1, 1)
+                assertThat(result).hasStartSourceLocation(1, 1)
             }
 
             @Test
@@ -397,7 +397,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 """
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).hasSize(1)
-                assertThat(result).hasSourceLocation(1, 1)
+                assertThat(result).hasStartSourceLocation(1, 1)
             }
 
             @Test
@@ -407,7 +407,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 """
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).hasSize(1)
-                assertThat(result).hasSourceLocation(1, 1)
+                assertThat(result).hasStartSourceLocation(1, 1)
             }
 
             @Test
@@ -417,7 +417,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 """
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).hasSize(1)
-                assertThat(result).hasSourceLocation(1, 1)
+                assertThat(result).hasStartSourceLocation(1, 1)
             }
 
             @Test
@@ -427,7 +427,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 """
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).hasSize(1)
-                assertThat(result).hasSourceLocation(1, 1)
+                assertThat(result).hasStartSourceLocation(1, 1)
             }
 
             @Test
@@ -446,7 +446,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 """
                 val result = rule.compileAndLintWithContext(env, code)
                 assertThat(result).hasSize(1)
-                assertThat(result).hasSourceLocation(2, 1)
+                assertThat(result).hasStartSourceLocation(2, 1)
             }
 
             @Test
@@ -466,7 +466,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 """
                 val result = rule.compileAndLintWithContext(env, code)
                 assertThat(result).hasSize(1)
-                assertThat(result).hasSourceLocation(3, 1)
+                assertThat(result).hasStartSourceLocation(3, 1)
             }
 
             @Test
@@ -487,7 +487,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 """
                 val result = rule.compileAndLintWithContext(env, code)
                 assertThat(result).hasSize(1)
-                assertThat(result).hasSourceLocation(4, 1)
+                assertThat(result).hasStartSourceLocation(4, 1)
             }
         }
 
@@ -642,7 +642,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 """
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).hasSize(1)
-                assertThat(result).hasSourceLocation(2, 5)
+                assertThat(result).hasStartSourceLocation(2, 5)
             }
 
             @Test
@@ -654,7 +654,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 """
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).hasSize(1)
-                assertThat(result).hasSourceLocation(2, 5)
+                assertThat(result).hasStartSourceLocation(2, 5)
             }
 
             @Test
@@ -666,7 +666,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 """
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).hasSize(1)
-                assertThat(result).hasSourceLocation(2, 5)
+                assertThat(result).hasStartSourceLocation(2, 5)
             }
 
             @Test
@@ -678,7 +678,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 """
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).hasSize(1)
-                assertThat(result).hasSourceLocation(2, 5)
+                assertThat(result).hasStartSourceLocation(2, 5)
             }
 
             @Test
@@ -690,7 +690,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 """
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).hasSize(1)
-                assertThat(result).hasSourceLocation(2, 5)
+                assertThat(result).hasStartSourceLocation(2, 5)
             }
 
             @Test
@@ -702,7 +702,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 """
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).hasSize(1)
-                assertThat(result).hasSourceLocation(2, 5)
+                assertThat(result).hasStartSourceLocation(2, 5)
             }
 
             @Test
@@ -714,7 +714,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 """
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).hasSize(1)
-                assertThat(result).hasSourceLocation(2, 5)
+                assertThat(result).hasStartSourceLocation(2, 5)
             }
 
             @Test
@@ -726,7 +726,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 """
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).hasSize(1)
-                assertThat(result).hasSourceLocation(2, 5)
+                assertThat(result).hasStartSourceLocation(2, 5)
             }
 
             @Test
@@ -747,7 +747,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 """
                 val result = rule.compileAndLintWithContext(env, code)
                 assertThat(result).hasSize(1)
-                assertThat(result).hasSourceLocation(3, 5)
+                assertThat(result).hasStartSourceLocation(3, 5)
             }
 
             @Test
@@ -769,7 +769,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 """
                 val result = rule.compileAndLintWithContext(env, code)
                 assertThat(result).hasSize(1)
-                assertThat(result).hasSourceLocation(4, 5)
+                assertThat(result).hasStartSourceLocation(4, 5)
             }
 
             @Test
@@ -792,7 +792,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 """
                 val result = rule.compileAndLintWithContext(env, code)
                 assertThat(result).hasSize(1)
-                assertThat(result).hasSourceLocation(5, 5)
+                assertThat(result).hasStartSourceLocation(5, 5)
             }
         }
 

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValueSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValueSpec.kt
@@ -206,7 +206,7 @@ class IgnoredReturnValueSpec(private val env: KotlinCoreEnvironment) {
 
             val findings = subject.lintWithContext(env, code, annotationClass)
             assertThat(findings).hasSize(1)
-            assertThat(findings).hasSourceLocation(7, 5)
+            assertThat(findings).hasStartSourceLocation(7, 5)
             assertThat(findings[0]).hasMessage("The call listOfChecked is returning a value that is ignored.")
         }
 
@@ -227,7 +227,7 @@ class IgnoredReturnValueSpec(private val env: KotlinCoreEnvironment) {
             """
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
-            assertThat(findings).hasSourceLocation(9, 5)
+            assertThat(findings).hasStartSourceLocation(9, 5)
             assertThat(findings[0]).hasMessage("The call listOfChecked is returning a value that is ignored.")
         }
 
@@ -294,7 +294,7 @@ class IgnoredReturnValueSpec(private val env: KotlinCoreEnvironment) {
             """
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
-            assertThat(findings).hasSourceLocation(12, 10)
+            assertThat(findings).hasStartSourceLocation(12, 10)
             assertThat(findings[0]).hasMessage("The call listOfChecked is returning a value that is ignored.")
         }
 
@@ -314,7 +314,7 @@ class IgnoredReturnValueSpec(private val env: KotlinCoreEnvironment) {
             """
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
-            assertThat(findings).hasSourceLocation(9, 5)
+            assertThat(findings).hasStartSourceLocation(9, 5)
             assertThat(findings[0]).hasMessage("The call listOfChecked is returning a value that is ignored.")
         }
 
@@ -335,7 +335,7 @@ class IgnoredReturnValueSpec(private val env: KotlinCoreEnvironment) {
             """
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
-            assertThat(findings).hasSourceLocation(9, 20)
+            assertThat(findings).hasStartSourceLocation(9, 20)
             assertThat(findings[0]).hasMessage("The call listOfChecked is returning a value that is ignored.")
         }
 
@@ -356,7 +356,7 @@ class IgnoredReturnValueSpec(private val env: KotlinCoreEnvironment) {
             """
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
-            assertThat(findings).hasSourceLocation(9, 14)
+            assertThat(findings).hasStartSourceLocation(9, 14)
             assertThat(findings[0]).hasMessage("The call listOfChecked is returning a value that is ignored.")
         }
 
@@ -376,7 +376,7 @@ class IgnoredReturnValueSpec(private val env: KotlinCoreEnvironment) {
             """
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
-            assertThat(findings).hasSourceLocation(8, 11)
+            assertThat(findings).hasStartSourceLocation(8, 11)
             assertThat(findings[0]).hasMessage("The call isTheAnswer is returning a value that is ignored.")
         }
 
@@ -730,7 +730,7 @@ class IgnoredReturnValueSpec(private val env: KotlinCoreEnvironment) {
             """
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
-            assertThat(findings).hasSourceLocation(8, 5)
+            assertThat(findings).hasStartSourceLocation(8, 5)
             assertThat(findings[0]).hasMessage("The call listOfChecked is returning a value that is ignored.")
         }
 
@@ -791,7 +791,7 @@ class IgnoredReturnValueSpec(private val env: KotlinCoreEnvironment) {
             """
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
-            assertThat(findings).hasSourceLocation(9, 5)
+            assertThat(findings).hasStartSourceLocation(9, 5)
             assertThat(findings[0]).hasMessage("The call listOfChecked is returning a value that is ignored.")
         }
 
@@ -807,7 +807,7 @@ class IgnoredReturnValueSpec(private val env: KotlinCoreEnvironment) {
             """
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
-            assertThat(findings).hasSourceLocation(4, 5)
+            assertThat(findings).hasStartSourceLocation(4, 5)
             assertThat(findings[0]).hasMessage("The call listOfChecked is returning a value that is ignored.")
         }
 

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnreachableCatchBlockSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnreachableCatchBlockSpec.kt
@@ -23,7 +23,7 @@ class UnreachableCatchBlockSpec(private val env: KotlinCoreEnvironment) {
         """
         val findings = subject.compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(1)
-        assertThat(findings).hasSourceLocation(4, 7)
+        assertThat(findings).hasStartSourceLocation(4, 7)
     }
 
     @Test
@@ -38,7 +38,7 @@ class UnreachableCatchBlockSpec(private val env: KotlinCoreEnvironment) {
         """
         val findings = subject.compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(1)
-        assertThat(findings).hasSourceLocation(4, 7)
+        assertThat(findings).hasStartSourceLocation(4, 7)
     }
 
     @Test

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnreachableCatchBlockSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnreachableCatchBlockSpec.kt
@@ -54,7 +54,7 @@ class UnreachableCatchBlockSpec(private val env: KotlinCoreEnvironment) {
         """
         val findings = subject.compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(2)
-        assertThat(findings).hasSourceLocations(
+        assertThat(findings).hasStartSourceLocations(
             SourceLocation(4, 7),
             SourceLocation(5, 7)
         )

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnusedUnaryOperatorSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnusedUnaryOperatorSpec.kt
@@ -20,7 +20,7 @@ class UnusedUnaryOperatorSpec(private val env: KotlinCoreEnvironment) {
         """
         val findings = subject.compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(1)
-        assertThat(findings).hasSourceLocation(3, 9)
+        assertThat(findings).hasStartSourceLocation(3, 9)
         assertThat(findings[0]).hasMessage("This '+ 3' is not used")
     }
 
@@ -34,7 +34,7 @@ class UnusedUnaryOperatorSpec(private val env: KotlinCoreEnvironment) {
         """
         val findings = subject.compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(1)
-        assertThat(findings).hasSourceLocation(3, 9)
+        assertThat(findings).hasStartSourceLocation(3, 9)
         assertThat(findings[0]).hasMessage("This '- 3' is not used")
     }
 

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNamingSpec.kt
@@ -48,7 +48,7 @@ class FunctionNamingSpec {
         }
         interface I { fun shouldNotBeFlagged() }
         """
-        assertThat(FunctionNaming().compileAndLint(code)).hasSourceLocation(3, 13)
+        assertThat(FunctionNaming().compileAndLint(code)).hasStartSourceLocation(3, 13)
     }
 
     @Test
@@ -84,7 +84,7 @@ class FunctionNamingSpec {
         }
         interface I { @Suppress("FunctionNaming") fun SHOULD_BE_FLAGGED() }
         """
-        assertThat(FunctionNaming().compileAndLint(code)).hasSourceLocation(3, 13)
+        assertThat(FunctionNaming().compileAndLint(code)).hasStartSourceLocation(3, 13)
     }
 
     @Test

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNamingSpec.kt
@@ -96,7 +96,7 @@ class FunctionNamingSpec {
         interface I { fun SHOULD_BE_FLAGGED() }
         """
         val config = TestConfig(mapOf(FunctionNaming.IGNORE_OVERRIDDEN to "false"))
-        assertThat(FunctionNaming(config).compileAndLint(code)).hasSourceLocations(
+        assertThat(FunctionNaming(config).compileAndLint(code)).hasStartSourceLocations(
             SourceLocation(2, 18),
             SourceLocation(4, 19)
         )
@@ -107,6 +107,6 @@ class FunctionNamingSpec {
         val code = """
             fun `7his is a function name _`() = Unit
         """
-        assertThat(FunctionNaming().compileAndLint(code)).hasSourceLocations(SourceLocation(1, 5))
+        assertThat(FunctionNaming().compileAndLint(code)).hasStartSourceLocations(SourceLocation(1, 5))
     }
 }

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MatchingDeclarationNameSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MatchingDeclarationNameSpec.kt
@@ -132,7 +132,7 @@ class MatchingDeclarationNameSpec {
         fun `should not pass for object declaration`() {
             val ktFile = compileContentForTest("object O", filename = "Objects.kt")
             val findings = MatchingDeclarationName().lint(ktFile)
-            assertThat(findings).hasSourceLocation(1, 8)
+            assertThat(findings).hasStartSourceLocation(1, 8)
         }
 
         @Test
@@ -142,14 +142,14 @@ class MatchingDeclarationNameSpec {
                 filename = "Objects.kt"
             )
             val findings = MatchingDeclarationName().lint(ktFile)
-            assertThat(findings).hasSourceLocation(1, 45)
+            assertThat(findings).hasStartSourceLocation(1, 45)
         }
 
         @Test
         fun `should not pass for class declaration`() {
             val ktFile = compileContentForTest("class C", filename = "Classes.kt")
             val findings = MatchingDeclarationName().lint(ktFile)
-            assertThat(findings).hasSourceLocation(1, 7)
+            assertThat(findings).hasStartSourceLocation(1, 7)
         }
 
         @Test
@@ -163,14 +163,14 @@ class MatchingDeclarationNameSpec {
                 filename = "ClassUtils.kt"
             )
             val findings = MatchingDeclarationName().lint(ktFile)
-            assertThat(findings).hasSourceLocation(1, 7)
+            assertThat(findings).hasStartSourceLocation(1, 7)
         }
 
         @Test
         fun `should not pass for interface declaration`() {
             val ktFile = compileContentForTest("interface I", filename = "Not_I.kt")
             val findings = MatchingDeclarationName().lint(ktFile)
-            assertThat(findings).hasSourceLocation(1, 11)
+            assertThat(findings).hasStartSourceLocation(1, 11)
         }
 
         @Test
@@ -184,7 +184,7 @@ class MatchingDeclarationNameSpec {
                 filename = "E.kt"
             )
             val findings = MatchingDeclarationName().lint(ktFile)
-            assertThat(findings).hasSourceLocation(1, 12)
+            assertThat(findings).hasStartSourceLocation(1, 12)
         }
 
         @Test
@@ -211,7 +211,7 @@ class MatchingDeclarationNameSpec {
             val findings = MatchingDeclarationName(
                 TestConfig("mustBeFirst" to "false")
             ).lint(ktFile)
-            assertThat(findings).hasSourceLocation(3, 7)
+            assertThat(findings).hasStartSourceLocation(3, 7)
         }
     }
 }

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NoNameShadowingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NoNameShadowingSpec.kt
@@ -19,7 +19,7 @@ class NoNameShadowingSpec(val env: KotlinCoreEnvironment) {
         """
         val findings = subject.compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(1)
-        assertThat(findings).hasSourceLocation(2, 9)
+        assertThat(findings).hasStartSourceLocation(2, 9)
         assertThat(findings[0]).hasMessage("Name shadowed: i")
     }
 

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNamingSpec.kt
@@ -64,7 +64,7 @@ class ObjectPropertyNamingSpec {
                     ${PublicConst.positive}
                 }
             """
-            assertThat(subject.compileAndLint(code)).hasSourceLocation(2, 15)
+            assertThat(subject.compileAndLint(code)).hasStartSourceLocation(2, 15)
         }
     }
 
@@ -130,7 +130,7 @@ class ObjectPropertyNamingSpec {
                     }
                 }
             """
-            assertThat(subject.compileAndLint(code)).hasSourceLocation(3, 19)
+            assertThat(subject.compileAndLint(code)).hasStartSourceLocation(3, 19)
         }
     }
 

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableNamingSpec.kt
@@ -18,7 +18,7 @@ class VariableNamingSpec {
             }
         """
         assertThat(VariableNaming().compileAndLint(code))
-            .hasSourceLocations(
+            .hasStartSourceLocations(
                 SourceLocation(2, 17),
                 SourceLocation(3, 9),
                 SourceLocation(4, 9)
@@ -68,7 +68,7 @@ class VariableNamingSpec {
         """
         val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to "false"))
         assertThat(VariableNaming(config).compileAndLint(code))
-            .hasSourceLocations(
+            .hasStartSourceLocations(
                 SourceLocation(2, 18),
                 SourceLocation(5, 18)
             )

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCallSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCallSpec.kt
@@ -26,7 +26,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
 
         assertThat(findings)
             .hasSize(2)
-            .hasSourceLocations(
+            .hasStartSourceLocations(
                 SourceLocation(2, 5),
                 SourceLocation(3, 5),
             )

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCallSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCallSpec.kt
@@ -189,8 +189,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
         val findings = ForbiddenMethodCall(
             TestConfig(mapOf(METHODS to listOf("java.time.LocalDate.now()")))
         ).compileAndLintWithContext(env, code)
-        assertThat(findings).hasSize(1)
-        assertThat(findings).hasSourceLocation(5, 26)
+        assertThat(findings).hasStartSourceLocation(5, 26)
         assertThat(findings[0])
             .hasMessage("The method `java.time.LocalDate.now()` has been forbidden in the detekt config.")
     }
@@ -210,7 +209,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
             TestConfig(mapOf(METHODS to listOf("java.time.LocalDate.now(java.time.Clock)")))
         ).compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(1)
-        assertThat(findings).hasSourceLocation(6, 27)
+        assertThat(findings).hasStartSourceLocation(6, 27)
     }
 
     @Test
@@ -225,7 +224,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
             TestConfig(mapOf(METHODS to listOf("java.time.LocalDate.of(kotlin.Int, kotlin.Int, kotlin.Int)")))
         ).compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(1)
-        assertThat(findings).hasSourceLocation(3, 26)
+        assertThat(findings).hasStartSourceLocation(3, 26)
     }
 
     @Test
@@ -240,7 +239,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
             TestConfig(mapOf(METHODS to listOf("java.time.LocalDate.of(kotlin.Int,kotlin.Int,kotlin.Int)")))
         ).compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(1)
-        assertThat(findings).hasSourceLocation(3, 26)
+        assertThat(findings).hasStartSourceLocation(3, 26)
     }
 
     @Test
@@ -258,7 +257,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
             TestConfig(mapOf(METHODS to listOf("io.gitlab.arturbosch.detekt.rules.style.`some, test`()")))
         ).compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(1)
-        assertThat(findings).hasSourceLocation(6, 13)
+        assertThat(findings).hasStartSourceLocation(6, 13)
     }
 
     @Test
@@ -281,7 +280,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
             )
         ).compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(1)
-        assertThat(findings).hasSourceLocation(6, 13)
+        assertThat(findings).hasStartSourceLocation(6, 13)
     }
 
     @Test
@@ -420,7 +419,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
             ).compileAndLintWithContext(env, code)
             assertThat(findings)
                 .hasSize(1)
-                .hasSourceLocation(5, 16)
+                .hasStartSourceLocation(5, 16)
         }
 
         @Test
@@ -430,7 +429,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
             ).compileAndLintWithContext(env, code)
             assertThat(findings)
                 .hasSize(1)
-                .hasSourceLocation(6, 9)
+                .hasStartSourceLocation(6, 9)
         }
     }
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenSuppressSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenSuppressSpec.kt
@@ -24,7 +24,7 @@ internal class ForbiddenSuppressSpec {
             """
             val findings = subject.compileAndLint(code)
             assertThat(findings).hasSize(1)
-            assertThat(findings).hasSourceLocation(3, 1)
+            assertThat(findings).hasStartSourceLocation(3, 1)
             assertThat(findings.first()).hasMessage(
                 "Cannot @Suppress rule \"ARule\" due to the current configuration."
             )
@@ -38,7 +38,7 @@ internal class ForbiddenSuppressSpec {
             """
             val findings = subject.compileAndLint(code)
             assertThat(findings).hasSize(1)
-            assertThat(findings).hasSourceLocation(1, 1)
+            assertThat(findings).hasStartSourceLocation(1, 1)
             assertThat(findings.first()).hasMessage(
                 "Cannot @Suppress rule \"ARule\" due to the current configuration."
             )
@@ -54,7 +54,7 @@ internal class ForbiddenSuppressSpec {
             """
             val findings = subject.compileAndLint(code)
             assertThat(findings).hasSize(1)
-            assertThat(findings).hasSourceLocation(3, 1)
+            assertThat(findings).hasStartSourceLocation(3, 1)
             assertThat(findings.first()).hasMessage(
                 "Cannot @Suppress rule \"ARule\" due to the current configuration."
             )
@@ -72,7 +72,7 @@ internal class ForbiddenSuppressSpec {
             """
             val findings = subject.compileAndLint(code)
             assertThat(findings).hasSize(1)
-            assertThat(findings).hasSourceLocation(4, 5)
+            assertThat(findings).hasStartSourceLocation(4, 5)
             assertThat(findings.first()).hasMessage(
                 "Cannot @Suppress rule \"ARule\" due to the current configuration."
             )
@@ -133,7 +133,7 @@ internal class ForbiddenSuppressSpec {
             """
             val findings = subject.compileAndLint(code)
             assertThat(findings).hasSize(1)
-            assertThat(findings).hasSourceLocation(1, 1)
+            assertThat(findings).hasStartSourceLocation(1, 1)
             assertThat(findings.first()).hasMessage(
                 "Cannot @Suppress rules \"ARule\", \"BRule\" " +
                     "due to the current configuration."
@@ -150,7 +150,7 @@ internal class ForbiddenSuppressSpec {
             """
             val findings = subject.compileAndLint(code)
             assertThat(findings).hasSize(1)
-            assertThat(findings).hasSourceLocation(3, 1)
+            assertThat(findings).hasStartSourceLocation(3, 1)
             assertThat(findings.first()).hasMessage(
                 "Cannot @Suppress rule \"BRule\" due to the current configuration."
             )

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumberSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumberSpec.kt
@@ -321,7 +321,7 @@ class MagicNumberSpec {
         fun `should be reported`() {
             val findings = MagicNumber().lint(code)
             assertThat(findings)
-                .hasSourceLocations(
+                .hasStartSourceLocations(
                     SourceLocation(1, 17),
                     SourceLocation(1, 21),
                     SourceLocation(1, 24),
@@ -345,7 +345,7 @@ class MagicNumberSpec {
         @Test
         fun `should be reported`() {
             val findings = MagicNumber().lint(code)
-            assertThat(findings).hasSourceLocations(
+            assertThat(findings).hasStartSourceLocations(
                 SourceLocation(3, 9),
                 SourceLocation(3, 21),
                 SourceLocation(4, 9),
@@ -486,7 +486,7 @@ class MagicNumberSpec {
 
             val findings = MagicNumber(config).lint(code)
             assertThat(findings)
-                .hasSourceLocations(
+                .hasStartSourceLocations(
                     SourceLocation(1, 17),
                     SourceLocation(3, 24),
                     SourceLocation(4, 33),
@@ -616,7 +616,7 @@ class MagicNumberSpec {
 
             val findings = MagicNumber(config).lint(code)
             assertThat(findings)
-                .hasSourceLocations(
+                .hasStartSourceLocations(
                     SourceLocation(4, 35),
                     SourceLocation(5, 43)
                 )

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumberSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumberSpec.kt
@@ -39,7 +39,7 @@ class MagicNumberSpec {
         @Test
         fun `should be reported when ignoredNumbers is empty`() {
             val findings = MagicNumber(TestConfig(mapOf(IGNORE_NUMBERS to emptyList<String>()))).lint(code)
-            assertThat(findings).hasSourceLocation(1, 15)
+            assertThat(findings).hasStartSourceLocation(1, 15)
         }
     }
 
@@ -73,7 +73,7 @@ class MagicNumberSpec {
         @Test
         fun `should be reported when ignoredNumbers is empty`() {
             val findings = MagicNumber(TestConfig(mapOf(IGNORE_NUMBERS to emptyList<String>()))).lint(code)
-            assertThat(findings).hasSourceLocation(1, 13)
+            assertThat(findings).hasStartSourceLocation(1, 13)
         }
     }
 
@@ -107,7 +107,7 @@ class MagicNumberSpec {
         @Test
         fun `should be reported when ignoredNumbers is empty`() {
             val findings = MagicNumber(TestConfig(mapOf(IGNORE_NUMBERS to emptyList<String>()))).lint(code)
-            assertThat(findings).hasSourceLocation(1, 14)
+            assertThat(findings).hasStartSourceLocation(1, 14)
         }
     }
 
@@ -124,7 +124,7 @@ class MagicNumberSpec {
         @Test
         fun `should be reported when ignoredNumbers is empty`() {
             val findings = MagicNumber(TestConfig(mapOf(IGNORE_NUMBERS to emptyList<String>()))).lint(code)
-            assertThat(findings).hasSourceLocation(1, 15)
+            assertThat(findings).hasStartSourceLocation(1, 15)
         }
     }
 
@@ -135,7 +135,7 @@ class MagicNumberSpec {
         @Test
         fun `should be reported by default`() {
             val findings = MagicNumber().lint(code)
-            assertThat(findings).hasSourceLocation(1, 15)
+            assertThat(findings).hasStartSourceLocation(1, 15)
         }
 
         @Test
@@ -154,14 +154,14 @@ class MagicNumberSpec {
         fun `should not be ignored when ignoredNumbers contains 2 but not -2`() {
             val findings = MagicNumber(TestConfig(mapOf(IGNORE_NUMBERS to listOf("1", "2", "3", "-1", "0"))))
                 .lint(code)
-            assertThat(findings).hasSourceLocation(1, 15)
+            assertThat(findings).hasStartSourceLocation(1, 15)
         }
 
         @Test
         fun `should not be ignored when ignoredNumbers contains 2 but not -2 config with string`() {
             val findings = MagicNumber(TestConfig(mapOf(IGNORE_NUMBERS to "1,2,3,-1,0")))
                 .lint(code)
-            assertThat(findings).hasSourceLocation(1, 15)
+            assertThat(findings).hasStartSourceLocation(1, 15)
         }
     }
 
@@ -195,7 +195,7 @@ class MagicNumberSpec {
         @Test
         fun `should be reported when ignoredNumbers is empty`() {
             val findings = MagicNumber(TestConfig(mapOf(IGNORE_NUMBERS to emptyList<String>()))).lint(code)
-            assertThat(findings).hasSourceLocation(1, 16)
+            assertThat(findings).hasStartSourceLocation(1, 16)
         }
     }
 
@@ -229,7 +229,7 @@ class MagicNumberSpec {
         @Test
         fun `should be reported when ignoredNumbers is empty`() {
             val findings = MagicNumber(TestConfig(mapOf(IGNORE_NUMBERS to emptyList<String>()))).lint(code)
-            assertThat(findings).hasSourceLocation(1, 13)
+            assertThat(findings).hasStartSourceLocation(1, 13)
         }
     }
 
@@ -291,7 +291,7 @@ class MagicNumberSpec {
         @Test
         fun `should be reported by default`() {
             val findings = MagicNumber().lint(code)
-            assertThat(findings).hasSourceLocation(1, 13)
+            assertThat(findings).hasStartSourceLocation(1, 13)
         }
 
         @Test
@@ -405,7 +405,7 @@ class MagicNumberSpec {
         @Test
         fun `should be reported by default`() {
             val findings = MagicNumber().lint(code)
-            assertThat(findings).hasSourceLocation(1, 12)
+            assertThat(findings).hasStartSourceLocation(1, 12)
         }
 
         @Test
@@ -601,7 +601,7 @@ class MagicNumberSpec {
             )
 
             val findings = MagicNumber(config).lint(code)
-            assertThat(findings).hasSourceLocation(4, 35)
+            assertThat(findings).hasStartSourceLocation(4, 35)
         }
 
         @Test

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLengthSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLengthSpec.kt
@@ -258,7 +258,7 @@ class MaxLineLengthSpec {
 
             rule.visit(fileContent)
             assertThat(rule.findings).hasSize(1)
-            assertThat(rule.findings).hasSourceLocations(SourceLocation(6, 5))
+            assertThat(rule.findings).hasStartSourceLocations(SourceLocation(6, 5))
         }
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MayBeConstSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MayBeConstSpec.kt
@@ -87,7 +87,7 @@ class MayBeConstSpec {
             val x = 1
             """
             subject.compileAndLint(code)
-            assertThat(subject.findings).hasSize(1).hasSourceLocations(
+            assertThat(subject.findings).hasSize(1).hasStartSourceLocations(
                 SourceLocation(1, 5)
             )
         }
@@ -98,7 +98,7 @@ class MayBeConstSpec {
             @JvmField val x = 1
             """
             subject.compileAndLint(code)
-            assertThat(subject.findings).hasSize(1).hasSourceLocations(
+            assertThat(subject.findings).hasSize(1).hasStartSourceLocations(
                 SourceLocation(1, 15)
             )
         }
@@ -111,7 +111,7 @@ class MayBeConstSpec {
             }
             """
             subject.compileAndLint(code)
-            assertThat(subject.findings).hasSize(1).hasSourceLocations(
+            assertThat(subject.findings).hasSize(1).hasStartSourceLocations(
                 SourceLocation(2, 19)
             )
         }
@@ -126,7 +126,7 @@ class MayBeConstSpec {
             }
             """
             subject.compileAndLint(code)
-            assertThat(subject.findings).hasSize(1).hasSourceLocations(
+            assertThat(subject.findings).hasSize(1).hasStartSourceLocations(
                 SourceLocation(3, 13)
             )
         }
@@ -143,7 +143,7 @@ class MayBeConstSpec {
             }
             """
             subject.compileAndLint(code)
-            assertThat(subject.findings).hasSize(1).hasSourceLocations(
+            assertThat(subject.findings).hasSize(1).hasStartSourceLocations(
                 SourceLocation(3, 9)
             )
         }
@@ -159,7 +159,7 @@ class MayBeConstSpec {
             }
             """
             subject.compileAndLint(code)
-            assertThat(subject.findings).hasSize(1).hasSourceLocations(
+            assertThat(subject.findings).hasSize(1).hasStartSourceLocations(
                 SourceLocation(4, 13)
             )
         }
@@ -173,7 +173,7 @@ class MayBeConstSpec {
             }
             """
             subject.compileAndLint(code)
-            assertThat(subject.findings).hasSize(1).hasSourceLocations(
+            assertThat(subject.findings).hasSize(1).hasStartSourceLocations(
                 SourceLocation(3, 9)
             )
         }
@@ -187,7 +187,7 @@ class MayBeConstSpec {
             }
             """
             subject.compileAndLint(code)
-            assertThat(subject.findings).hasSize(1).hasSourceLocations(
+            assertThat(subject.findings).hasSize(1).hasStartSourceLocations(
                 SourceLocation(3, 9)
             )
         }
@@ -203,7 +203,7 @@ class MayBeConstSpec {
             }
             """
             subject.compileAndLint(code)
-            assertThat(subject.findings).hasSize(1).hasSourceLocations(
+            assertThat(subject.findings).hasSize(1).hasStartSourceLocations(
                 SourceLocation(5, 9)
             )
         }
@@ -217,7 +217,7 @@ class MayBeConstSpec {
             }
             """
             subject.compileAndLint(code)
-            assertThat(subject.findings).hasSize(1).hasSourceLocations(
+            assertThat(subject.findings).hasSize(1).hasStartSourceLocations(
                 SourceLocation(3, 17)
             )
         }
@@ -363,7 +363,7 @@ class MayBeConstSpec {
                 }
             """
             subject.compileAndLint(code)
-            assertThat(subject.findings).hasSize(3).hasSourceLocations(
+            assertThat(subject.findings).hasSize(3).hasStartSourceLocations(
                 SourceLocation(4, 13),
                 SourceLocation(7, 17),
                 SourceLocation(11, 13)

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/NewLineAtEndOfFileSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/NewLineAtEndOfFileSpec.kt
@@ -18,7 +18,7 @@ class NewLineAtEndOfFileSpec {
     fun `should flag a kt file not containing new line at the end`() {
         val code = "class Test"
         assertThat(subject.compileAndLint(code)).hasSize(1)
-            .hasSourceLocation(1, 11)
+            .hasStartSourceLocation(1, 11)
     }
 
     @Test

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ObjectLiteralToLambdaSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ObjectLiteralToLambdaSpec.kt
@@ -33,7 +33,7 @@ class ObjectLiteralToLambdaSpec {
                 subject.compileAndLintWithContext(env, code)
                     .assert()
                     .hasSize(1)
-                    .hasSourceLocations(SourceLocation(4, 9))
+                    .hasStartSourceLocations(SourceLocation(4, 9))
             }
 
             @Test
@@ -52,7 +52,7 @@ class ObjectLiteralToLambdaSpec {
                 subject.compileAndLintWithContext(env, code)
                     .assert()
                     .hasSize(1)
-                    .hasSourceLocations(SourceLocation(5, 5))
+                    .hasStartSourceLocations(SourceLocation(5, 5))
             }
 
             @Test
@@ -73,7 +73,7 @@ class ObjectLiteralToLambdaSpec {
                 subject.compileAndLintWithContext(env, code)
                     .assert()
                     .hasSize(1)
-                    .hasSourceLocations(SourceLocation(6, 9))
+                    .hasStartSourceLocations(SourceLocation(6, 9))
             }
 
             @Test
@@ -91,7 +91,7 @@ class ObjectLiteralToLambdaSpec {
                 subject.compileAndLintWithContext(env, code)
                     .assert()
                     .hasSize(1)
-                    .hasSourceLocations(SourceLocation(4, 9))
+                    .hasStartSourceLocations(SourceLocation(4, 9))
             }
 
             @Test
@@ -109,7 +109,7 @@ class ObjectLiteralToLambdaSpec {
                 subject.compileAndLintWithContext(env, code)
                     .assert()
                     .hasSize(1)
-                    .hasSourceLocations(SourceLocation(5, 9))
+                    .hasStartSourceLocations(SourceLocation(5, 9))
             }
 
             @Test
@@ -130,7 +130,7 @@ class ObjectLiteralToLambdaSpec {
                 subject.compileAndLintWithContext(env, code)
                     .assert()
                     .hasSize(1)
-                    .hasSourceLocations(SourceLocation(7, 5))
+                    .hasStartSourceLocations(SourceLocation(7, 5))
             }
 
             @Test
@@ -146,7 +146,7 @@ class ObjectLiteralToLambdaSpec {
                 subject.compileAndLintWithContext(env, code)
                     .assert()
                     .hasSize(1)
-                    .hasSourceLocations(SourceLocation(4, 9))
+                    .hasStartSourceLocations(SourceLocation(4, 9))
             }
         }
 
@@ -337,7 +337,7 @@ class ObjectLiteralToLambdaSpec {
                 subject.compileAndLintWithContext(env, code)
                     .assert()
                     .hasSize(1)
-                    .hasSourceLocations(SourceLocation(1, 9))
+                    .hasStartSourceLocations(SourceLocation(1, 9))
             }
 
             @Test
@@ -353,7 +353,7 @@ class ObjectLiteralToLambdaSpec {
                 subject.compileAndLintWithContext(env, code)
                     .assert()
                     .hasSize(1)
-                    .hasSourceLocations(SourceLocation(2, 9))
+                    .hasStartSourceLocations(SourceLocation(2, 9))
             }
 
             @Test
@@ -466,7 +466,7 @@ class ObjectLiteralToLambdaSpec {
                 subject.compileAndLintWithContext(env, code)
                     .assert()
                     .hasSize(1)
-                    .hasSourceLocations(SourceLocation(6, 5))
+                    .hasStartSourceLocations(SourceLocation(6, 5))
             }
 
             @Test
@@ -489,7 +489,7 @@ class ObjectLiteralToLambdaSpec {
                 subject.compileAndLintWithContext(env, code)
                     .assert()
                     .hasSize(1)
-                    .hasSourceLocations(SourceLocation(7, 9))
+                    .hasStartSourceLocations(SourceLocation(7, 9))
             }
 
             @Test
@@ -534,7 +534,7 @@ class ObjectLiteralToLambdaSpec {
                 subject.compileAndLintWithContext(env, code)
                     .assert()
                     .hasSize(1)
-                    .hasSourceLocations(SourceLocation(5, 19))
+                    .hasStartSourceLocations(SourceLocation(5, 19))
             }
         }
     }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/OptionalWhenBracesSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/OptionalWhenBracesSpec.kt
@@ -66,7 +66,7 @@ class OptionalWhenBracesSpec {
         """
         assertThat(subject.compileAndLint(code))
             .hasSize(2)
-            .hasSourceLocations(SourceLocation(7, 17), SourceLocation(10, 17))
+            .hasStartSourceLocations(SourceLocation(7, 17), SourceLocation(10, 17))
     }
 
     @Test
@@ -87,7 +87,7 @@ class OptionalWhenBracesSpec {
         """
         assertThat(subject.compileAndLint(code))
             .hasSize(1)
-            .hasSourceLocations(SourceLocation(3, 9))
+            .hasStartSourceLocations(SourceLocation(3, 9))
     }
 
     @Nested

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ProtectedMemberInFinalClassSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ProtectedMemberInFinalClassSpec.kt
@@ -22,7 +22,7 @@ class ProtectedMemberInFinalClassSpec {
             """
             val findings = subject.compileAndLint(code)
             assertThat(findings).hasSize(1)
-            assertThat(findings).hasSourceLocation(2, 5)
+            assertThat(findings).hasStartSourceLocation(2, 5)
         }
 
         @Test
@@ -37,7 +37,7 @@ class ProtectedMemberInFinalClassSpec {
             """
             val findings = subject.compileAndLint(code)
             assertThat(findings).hasSize(1)
-            assertThat(findings).hasSourceLocation(3, 5)
+            assertThat(findings).hasStartSourceLocation(3, 5)
         }
 
         @Test
@@ -49,7 +49,7 @@ class ProtectedMemberInFinalClassSpec {
             """
             val findings = subject.compileAndLint(code)
             assertThat(findings).hasSize(1)
-            assertThat(findings).hasSourceLocation(2, 5)
+            assertThat(findings).hasStartSourceLocation(2, 5)
         }
 
         @Test
@@ -63,7 +63,7 @@ class ProtectedMemberInFinalClassSpec {
             """
             val findings = subject.compileAndLint(code)
             assertThat(findings).hasSize(1)
-            assertThat(findings).hasSourceLocation(3, 9)
+            assertThat(findings).hasStartSourceLocation(3, 9)
         }
 
         @Test
@@ -116,7 +116,7 @@ class ProtectedMemberInFinalClassSpec {
             """
             val findings = subject.compileAndLint(code)
             assertThat(findings).hasSize(1)
-            assertThat(findings).hasSourceLocation(4, 13)
+            assertThat(findings).hasStartSourceLocation(4, 13)
         }
 
         @Test
@@ -130,7 +130,7 @@ class ProtectedMemberInFinalClassSpec {
             """
             val findings = subject.compileAndLint(code)
             assertThat(findings).hasSize(1)
-            assertThat(findings).hasSourceLocation(3, 9)
+            assertThat(findings).hasStartSourceLocation(3, 9)
         }
 
         @Test
@@ -140,7 +140,7 @@ class ProtectedMemberInFinalClassSpec {
             """
             val findings = subject.compileAndLint(code)
             assertThat(findings).hasSize(1)
-            assertThat(findings).hasSourceLocation(1, 42)
+            assertThat(findings).hasStartSourceLocation(1, 42)
         }
     }
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ProtectedMemberInFinalClassSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ProtectedMemberInFinalClassSpec.kt
@@ -77,7 +77,7 @@ class ProtectedMemberInFinalClassSpec {
             """
             val findings = subject.compileAndLint(code)
             assertThat(findings).hasSize(2)
-            assertThat(findings).hasSourceLocations(
+            assertThat(findings).hasStartSourceLocations(
                 SourceLocation(2, 5),
                 SourceLocation(3, 9)
             )
@@ -96,7 +96,7 @@ class ProtectedMemberInFinalClassSpec {
             """
             val findings = subject.compileAndLint(code)
             assertThat(findings).hasSize(3)
-            assertThat(findings).hasSourceLocations(
+            assertThat(findings).hasStartSourceLocations(
                 SourceLocation(2, 5),
                 SourceLocation(2, 5),
                 SourceLocation(4, 13)

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantHigherOrderMapUsageSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantHigherOrderMapUsageSpec.kt
@@ -24,7 +24,7 @@ class RedundantHigherOrderMapUsageSpec(val env: KotlinCoreEnvironment) {
             """
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
-            assertThat(findings).hasSourceLocation(4, 10)
+            assertThat(findings).hasStartSourceLocation(4, 10)
             assertThat(findings[0]).hasMessage("This 'map' call can be removed.")
         }
 
@@ -44,7 +44,7 @@ class RedundantHigherOrderMapUsageSpec(val env: KotlinCoreEnvironment) {
             """
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
-            assertThat(findings).hasSourceLocation(5, 10)
+            assertThat(findings).hasStartSourceLocation(5, 10)
             assertThat(findings[0]).hasMessage("This 'map' call can be replaced with 'onEach' or 'forEach'.")
         }
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAbstractClassSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAbstractClassSpec.kt
@@ -31,7 +31,7 @@ class UnnecessaryAbstractClassSpec(val env: KotlinCoreEnvironment) {
             """
             val findings = subject.compileAndLintWithContext(env, code)
             assertFindingMessage(findings, message)
-            assertThat(findings).hasSourceLocation(1, 16)
+            assertThat(findings).hasStartSourceLocation(1, 16)
         }
 
         @Nested
@@ -41,7 +41,7 @@ class UnnecessaryAbstractClassSpec(val env: KotlinCoreEnvironment) {
                 val code = "abstract class A"
                 val findings = subject.compileAndLintWithContext(env, code)
                 assertFindingMessage(findings, message)
-                assertThat(findings).hasSourceLocation(1, 16)
+                assertThat(findings).hasStartSourceLocation(1, 16)
             }
 
             @Test
@@ -204,7 +204,7 @@ class UnnecessaryAbstractClassSpec(val env: KotlinCoreEnvironment) {
             val code = "abstract class A(val i: Int)"
             val findings = subject.compileAndLintWithContext(env, code)
             assertFindingMessage(findings, message)
-            assertThat(findings).hasSourceLocation(1, 16)
+            assertThat(findings).hasStartSourceLocation(1, 16)
         }
 
         @Test
@@ -219,7 +219,7 @@ class UnnecessaryAbstractClassSpec(val env: KotlinCoreEnvironment) {
             val code = "abstract class A(i: Int)"
             val findings = subject.compileAndLintWithContext(env, code)
             assertFindingMessage(findings, message)
-            assertThat(findings).hasSourceLocation(1, 16)
+            assertThat(findings).hasStartSourceLocation(1, 16)
         }
 
         @Test

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateClassSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateClassSpec.kt
@@ -23,7 +23,7 @@ class UnusedPrivateClassSpec {
             val findings = subject.compileAndLint(code)
 
             assertThat(findings).hasSize(1)
-            assertThat(findings).hasSourceLocation(1, 1)
+            assertThat(findings).hasStartSourceLocation(1, 1)
         }
 
         @Nested
@@ -39,7 +39,7 @@ class UnusedPrivateClassSpec {
                 val findings = subject.compileAndLint(code)
 
                 assertThat(findings).hasSize(1)
-                assertThat(findings).hasSourceLocation(1, 1)
+                assertThat(findings).hasStartSourceLocation(1, 1)
             }
 
             @Test
@@ -52,7 +52,7 @@ class UnusedPrivateClassSpec {
                 val findings = subject.compileAndLint(code)
 
                 assertThat(findings).hasSize(1)
-                assertThat(findings).hasSourceLocation(2, 1)
+                assertThat(findings).hasStartSourceLocation(2, 1)
             }
 
             @Test
@@ -435,7 +435,7 @@ class UnusedPrivateClassSpec {
             """
             val findings = UnusedPrivateClass().lint(code)
             assertThat(findings).hasSize(1)
-            assertThat(findings).hasSourceLocation(10, 5)
+            assertThat(findings).hasStartSourceLocation(10, 5)
         }
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMemberSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMemberSpec.kt
@@ -1320,7 +1320,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                 }
             """
             val findings = subject.compileAndLintWithContext(env, code)
-            assertThat(findings).hasSize(1).hasSourceLocations(
+            assertThat(findings).hasSize(1).hasStartSourceLocations(
                 SourceLocation(3, 30)
             )
         }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMemberSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMemberSpec.kt
@@ -1606,7 +1606,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                     private fun foo() = 1
                 }
             """
-            assertThat(subject.lint(code)).hasSize(1).hasSourceLocation(5, 17)
+            assertThat(subject.lint(code)).hasSize(1).hasStartSourceLocation(5, 17)
         }
 
         @Test
@@ -1619,7 +1619,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                     private val foo = 1
                 }
             """
-            assertThat(subject.lint(code)).hasSize(1).hasSourceLocation(5, 17)
+            assertThat(subject.lint(code)).hasSize(1).hasStartSourceLocation(5, 17)
         }
 
         @Test
@@ -1634,7 +1634,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                     ) = 1
                 }
             """
-            assertThat(subject.lint(code)).hasSize(1).hasSourceLocation(6, 9)
+            assertThat(subject.lint(code)).hasSize(1).hasStartSourceLocation(6, 9)
         }
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseCheckOrErrorSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseCheckOrErrorSpec.kt
@@ -22,7 +22,7 @@ class UseCheckOrErrorSpec(val env: KotlinCoreEnvironment) {
                 if (a < 0) throw IllegalStateException()
             }
         """
-        assertThat(subject.lint(code)).hasSourceLocation(3, 16)
+        assertThat(subject.lint(code)).hasStartSourceLocation(3, 16)
     }
 
     @Test
@@ -33,7 +33,7 @@ class UseCheckOrErrorSpec(val env: KotlinCoreEnvironment) {
                 if (a < 0) throw IllegalStateException("More details")
             }
         """
-        assertThat(subject.lint(code)).hasSourceLocation(3, 16)
+        assertThat(subject.lint(code)).hasStartSourceLocation(3, 16)
     }
 
     @Test
@@ -45,7 +45,7 @@ class UseCheckOrErrorSpec(val env: KotlinCoreEnvironment) {
                     else -> throw IllegalStateException()
                 }
         """
-        assertThat(subject.lint(code)).hasSourceLocation(4, 17)
+        assertThat(subject.lint(code)).hasStartSourceLocation(4, 17)
     }
 
     @Test
@@ -56,7 +56,7 @@ class UseCheckOrErrorSpec(val env: KotlinCoreEnvironment) {
                 if (a < 0) throw java.lang.IllegalStateException()
             }
         """
-        assertThat(subject.lint(code)).hasSourceLocation(3, 16)
+        assertThat(subject.lint(code)).hasStartSourceLocation(3, 16)
     }
 
     @Test
@@ -67,7 +67,7 @@ class UseCheckOrErrorSpec(val env: KotlinCoreEnvironment) {
                 if (a < 0) throw kotlin.IllegalStateException()
             }
         """
-        assertThat(subject.lint(code)).hasSourceLocation(3, 16)
+        assertThat(subject.lint(code)).hasStartSourceLocation(3, 16)
     }
 
     @Test
@@ -106,13 +106,13 @@ class UseCheckOrErrorSpec(val env: KotlinCoreEnvironment) {
     @Test
     fun `reports an issue if the exception thrown as the only action in a function`() {
         val code = """fun doThrow() = throw IllegalStateException("message")"""
-        assertThat(subject.lint(code)).hasSourceLocation(1, 17)
+        assertThat(subject.lint(code)).hasStartSourceLocation(1, 17)
     }
 
     @Test
     fun `reports an issue if the exception thrown as the only action in a function block`() {
         val code = """fun doThrow() { throw IllegalStateException("message") }"""
-        assertThat(subject.lint(code)).hasSourceLocation(1, 17)
+        assertThat(subject.lint(code)).hasStartSourceLocation(1, 17)
     }
 
     @Test

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIfEmptyOrIfBlankSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIfEmptyOrIfBlankSpec.kt
@@ -26,7 +26,7 @@ class UseIfEmptyOrIfBlankSpec(val env: KotlinCoreEnvironment) {
             """
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
-            assertThat(findings).hasSourceLocation(4, 29)
+            assertThat(findings).hasStartSourceLocation(4, 29)
             assertThat(findings[0]).hasMessage("This 'isBlank' call can be replaced with 'ifBlank'")
         }
 
@@ -45,7 +45,7 @@ class UseIfEmptyOrIfBlankSpec(val env: KotlinCoreEnvironment) {
             """
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
-            assertThat(findings).hasSourceLocation(4, 29)
+            assertThat(findings).hasStartSourceLocation(4, 29)
             assertThat(findings[0]).hasMessage("This 'isNotBlank' call can be replaced with 'ifBlank'")
         }
 
@@ -61,7 +61,7 @@ class UseIfEmptyOrIfBlankSpec(val env: KotlinCoreEnvironment) {
             """
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
-            assertThat(findings).hasSourceLocation(4, 29)
+            assertThat(findings).hasStartSourceLocation(4, 29)
             assertThat(findings[0]).hasMessage("This 'isEmpty' call can be replaced with 'ifEmpty'")
         }
 
@@ -80,7 +80,7 @@ class UseIfEmptyOrIfBlankSpec(val env: KotlinCoreEnvironment) {
             """
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
-            assertThat(findings).hasSourceLocation(4, 29)
+            assertThat(findings).hasStartSourceLocation(4, 29)
             assertThat(findings[0]).hasMessage("This 'isNotEmpty' call can be replaced with 'ifEmpty'")
         }
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIsNullOrEmptySpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIsNullOrEmptySpec.kt
@@ -24,7 +24,7 @@ class UseIsNullOrEmptySpec(val env: KotlinCoreEnvironment) {
                 """
                 val findings = subject.compileAndLintWithContext(env, code)
                 assertThat(findings).hasSize(1)
-                assertThat(findings).hasSourceLocation(2, 9)
+                assertThat(findings).hasStartSourceLocation(2, 9)
                 assertThat(findings[0]).hasMessage(
                     "This 'x == null || x.isEmpty()' can be replaced with 'isNullOrEmpty()' call"
                 )

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseOrEmptySpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseOrEmptySpec.kt
@@ -22,7 +22,7 @@ class UseOrEmptySpec(val env: KotlinCoreEnvironment) {
             """
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
-            assertThat(findings).hasSourceLocation(2, 13)
+            assertThat(findings).hasStartSourceLocation(2, 13)
             assertThat(findings[0]).hasMessage("This '?: emptyList()' can be replaced with 'orEmpty()' call")
         }
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseRequireSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseRequireSpec.kt
@@ -22,7 +22,7 @@ class UseRequireSpec(val env: KotlinCoreEnvironment) {
                 doSomething()
             }
         """
-        assertThat(subject.lint(code)).hasSourceLocation(2, 16)
+        assertThat(subject.lint(code)).hasStartSourceLocation(2, 16)
     }
 
     @Test
@@ -33,7 +33,7 @@ class UseRequireSpec(val env: KotlinCoreEnvironment) {
                 doSomething()
             }
         """
-        assertThat(subject.lint(code)).hasSourceLocation(2, 16)
+        assertThat(subject.lint(code)).hasStartSourceLocation(2, 16)
     }
 
     @Test
@@ -44,7 +44,7 @@ class UseRequireSpec(val env: KotlinCoreEnvironment) {
                 doSomething()
             }
         """
-        assertThat(subject.lint(code)).hasSourceLocation(2, 16)
+        assertThat(subject.lint(code)).hasStartSourceLocation(2, 16)
     }
 
     @Test
@@ -55,7 +55,7 @@ class UseRequireSpec(val env: KotlinCoreEnvironment) {
                 doSomething()
             }
         """
-        assertThat(subject.lint(code)).hasSourceLocation(2, 16)
+        assertThat(subject.lint(code)).hasStartSourceLocation(2, 16)
     }
 
     @Test

--- a/detekt-test/api/detekt-test.api
+++ b/detekt-test/api/detekt-test.api
@@ -6,8 +6,12 @@ public final class io/gitlab/arturbosch/detekt/test/FindingAssert : org/assertj/
 
 public final class io/gitlab/arturbosch/detekt/test/FindingsAssert : org/assertj/core/api/AbstractListAssert {
 	public fun <init> (Ljava/util/List;)V
+	public final fun hasEndSourceLocation (II)Lio/gitlab/arturbosch/detekt/test/FindingsAssert;
+	public final fun hasEndSourceLocations ([Lio/gitlab/arturbosch/detekt/api/SourceLocation;)Lio/gitlab/arturbosch/detekt/test/FindingsAssert;
 	public final fun hasSourceLocation (II)Lio/gitlab/arturbosch/detekt/test/FindingsAssert;
 	public final fun hasSourceLocations ([Lio/gitlab/arturbosch/detekt/api/SourceLocation;)Lio/gitlab/arturbosch/detekt/test/FindingsAssert;
+	public final fun hasStartSourceLocation (II)Lio/gitlab/arturbosch/detekt/test/FindingsAssert;
+	public final fun hasStartSourceLocations ([Lio/gitlab/arturbosch/detekt/api/SourceLocation;)Lio/gitlab/arturbosch/detekt/test/FindingsAssert;
 	public final fun hasTextLocations ([Ljava/lang/String;)Lio/gitlab/arturbosch/detekt/test/FindingsAssert;
 	public final fun hasTextLocations ([Lkotlin/Pair;)Lio/gitlab/arturbosch/detekt/test/FindingsAssert;
 	public synthetic fun newAbstractIterableAssert (Ljava/lang/Iterable;)Lorg/assertj/core/api/AbstractIterableAssert;

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/FindingsAssertions.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/FindingsAssertions.kt
@@ -6,7 +6,7 @@ import io.gitlab.arturbosch.detekt.api.TextLocation
 import org.assertj.core.api.AbstractAssert
 import org.assertj.core.api.AbstractListAssert
 import org.assertj.core.util.CheckReturnValue
-import java.util.Objects
+import java.util.*
 
 @CheckReturnValue
 fun assertThat(findings: List<Finding>) = FindingsAssert(findings)
@@ -27,7 +27,10 @@ class FindingsAssert(actual: List<Finding>) :
     override fun toAssert(value: Finding?, description: String?): FindingAssert =
         FindingAssert(value).`as`(description)
 
-    fun hasSourceLocations(vararg expected: SourceLocation) = apply {
+    @Deprecated("Use hasStartSourceLocations instead", ReplaceWith("hasStartSourceLocations(*expected)"))
+    fun hasSourceLocations(vararg expected: SourceLocation) = hasStartSourceLocations(*expected)
+
+    fun hasStartSourceLocations(vararg expected: SourceLocation) = apply {
         val actualSources = actual.asSequence()
             .map { it.location.source }
             .sortedWith(compareBy({ it.line }, { it.column }))
@@ -37,13 +40,35 @@ class FindingsAssert(actual: List<Finding>) :
 
         if (!Objects.deepEquals(actualSources.toList(), expectedSources.toList())) {
             failWithMessage(
-                "Expected source locations to be ${expectedSources.toList()} but was ${actualSources.toList()}"
+                "Expected start source locations to be ${expectedSources.toList()} but was ${actualSources.toList()}"
             )
         }
     }
 
-    fun hasSourceLocation(line: Int, column: Int) = apply {
-        hasSourceLocations(SourceLocation(line, column))
+    fun hasEndSourceLocations(vararg expected: SourceLocation) = apply {
+        val actualSources = actual.asSequence()
+            .map { it.location.endSource }
+            .sortedWith(compareBy({ it.line }, { it.column }))
+
+        val expectedSources = expected.asSequence()
+            .sortedWith(compareBy({ it.line }, { it.column }))
+
+        if (!Objects.deepEquals(actualSources.toList(), expectedSources.toList())) {
+            failWithMessage(
+                "Expected end source locations to be ${expectedSources.toList()} but was ${actualSources.toList()}"
+            )
+        }
+    }
+
+    @Deprecated("Use hasStartSourceLocation instead", ReplaceWith("hasStartSourceLocation(line, column)"))
+    fun hasSourceLocation(line: Int, column: Int) = hasStartSourceLocation(line, column)
+
+    fun hasStartSourceLocation(line: Int, column: Int) = apply {
+        hasStartSourceLocations(SourceLocation(line, column))
+    }
+
+    fun hasEndSourceLocation(line: Int, column: Int) = apply {
+        hasEndSourceLocations(SourceLocation(line, column))
     }
 
     fun hasTextLocations(vararg expected: Pair<Int, Int>) = apply {

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/FindingsAssertions.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/FindingsAssertions.kt
@@ -6,7 +6,7 @@ import io.gitlab.arturbosch.detekt.api.TextLocation
 import org.assertj.core.api.AbstractAssert
 import org.assertj.core.api.AbstractListAssert
 import org.assertj.core.util.CheckReturnValue
-import java.util.*
+import java.util.Objects
 
 @CheckReturnValue
 fun assertThat(findings: List<Finding>) = FindingsAssert(findings)


### PR DESCRIPTION
I need this refactor to finish: #5058

The idea behind this PR is in the comment: https://github.com/detekt/detekt/pull/5058/files#r927045468

---

All the changes made outside `FindingsAssertions.kt` where done using the "fix deprecation" feature.