### PR TITLE
Support proper globbing in `ReturnCount`

### DIFF
--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCount.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCount.kt
@@ -124,6 +124,5 @@ class ReturnCount(config: Config = Config.empty) : Rule(config) {
 }
 
 private operator fun Iterable<Regex>.contains(input: String?): Boolean {
-    input ?: return false
-    return any { it.matches(input) }
+    return input != null && any { it.matches(input) }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCountSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCountSpec.kt
@@ -313,7 +313,7 @@ class ReturnCountSpec {
     @Nested
     inner class `a subset of functions are ignored` {
         val code = """
-        fun test1(x: Int): Int {
+        fun factorial(x: Int): Int {
             when (x) {
                 5 -> println("x=5")
                 4 -> return 4
@@ -322,7 +322,7 @@ class ReturnCountSpec {
             return 6
         }
 
-        fun test2(x: Int): Int {
+        fun fac(x: Int): Int {
             when (x) {
                 5 -> println("x=5")
                 4 -> return 4
@@ -331,7 +331,7 @@ class ReturnCountSpec {
             return 6
         }
 
-        fun te_st1(x: Int): Int {
+        fun fansOfFactorial(x: Int): Int {
             when (x) {
                 5 -> println("x=5")
                 4 -> return 4
@@ -347,7 +347,7 @@ class ReturnCountSpec {
                 TestConfig(
                     mapOf(
                         MAX to "2",
-                        EXCLUDED_FUNCTIONS to listOf("test1", "test2")
+                        EXCLUDED_FUNCTIONS to listOf("factorial", "fac"),
                     )
                 )
             ).compileAndLint(code)
@@ -360,7 +360,7 @@ class ReturnCountSpec {
                 TestConfig(
                     mapOf(
                         MAX to "2",
-                        EXCLUDED_FUNCTIONS to listOf("t*1")
+                        EXCLUDED_FUNCTIONS to listOf("fa*ctorial"),
                     )
                 )
             ).compileAndLint(code)

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCountSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCountSpec.kt
@@ -331,7 +331,7 @@ class ReturnCountSpec {
             return 6
         }
 
-        fun test3(x: Int): Int {
+        fun te_st1(x: Int): Int {
             when (x) {
                 5 -> println("x=5")
                 4 -> return 4
@@ -348,6 +348,19 @@ class ReturnCountSpec {
                     mapOf(
                         MAX to "2",
                         EXCLUDED_FUNCTIONS to listOf("test1", "test2")
+                    )
+                )
+            ).compileAndLint(code)
+            assertThat(findings).hasSize(1)
+        }
+
+        @Test
+        fun `should flag none of the ignored functions using globbing`() {
+            val findings = ReturnCount(
+                TestConfig(
+                    mapOf(
+                        MAX to "2",
+                        EXCLUDED_FUNCTIONS to listOf("t*1")
                     )
                 )
             ).compileAndLint(code)


### PR DESCRIPTION
`SplitPattern` has a partial/funky support for glob patterns. This PR changes that to a proper implementation using `simplePatternToRegex`.