### PR TITLE
Don't exclude tests in WildcardImport Rule

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -274,3 +274,6 @@ style:
   VarCouldBeVal:
     active: true
     ignoreAnnotated: ['Parameter']
+  WildcardImport:
+    active: true
+    excludeImports: []

--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -716,6 +716,5 @@ style:
     ignoreLateinitVar: false
   WildcardImport:
     active: true
-    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
     excludeImports:
       - 'java.util.*'

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/KtLintMultiRule.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/KtLintMultiRule.kt
@@ -60,7 +60,7 @@ import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.JavaDummyElement
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.JavaDummyHolder
 import org.jetbrains.kotlin.psi.KtFile
-import java.util.*
+import java.util.LinkedList
 
 /**
  * Runs all KtLint rules.

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/defaultconfig/Exclusion.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/defaultconfig/Exclusion.kt
@@ -27,7 +27,6 @@ private object TestExclusions : Exclusions() {
     override val ruleSets = emptySet<String>()
     override val rules = setOf(
         "FunctionNaming",
-        "WildcardImport",
         "LateinitUsage",
         "StringLiteralDuplication",
         "SpreadOperator",

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/printer/DeprecatedPrinterSpec.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/printer/DeprecatedPrinterSpec.kt
@@ -10,8 +10,8 @@ class DeprecatedPrinterSpec {
     fun `prints the correct properties`() {
         val markdownString = DeprecatedPrinter.print(listOf(createRuleSetPage()))
         val expectedMarkdownString = """
-            style>WildcardImport>conf2=use conf1 instead
-            style>WildcardImport>conf4=use conf3 instead
+            style>MagicNumber>conf2=use conf1 instead
+            style>MagicNumber>conf4=use conf3 instead
             
         """.trimIndent()
         assertThat(markdownString).isEqualTo(expectedMarkdownString)

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/util/RuleSetPageCreator.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/util/RuleSetPageCreator.kt
@@ -59,7 +59,7 @@ internal fun createRuleSetPage(): RuleSetPage {
 
 internal fun createRules(): List<Rule> {
     val rule1 = Rule(
-        name = "WildcardImport",
+        name = "MagicNumber",
         description = "a wildcard import",
         nonCompliantCodeExample = "import foo.*",
         compliantCodeExample = "import foo.bar",

--- a/detekt-generator/src/test/resources/RuleSet.md
+++ b/detekt-generator/src/test/resources/RuleSet.md
@@ -1,6 +1,6 @@
 style rule set
 
-### WildcardImport
+### MagicNumber
 
 a wildcard import
 

--- a/detekt-generator/src/test/resources/RuleSetConfig.yml
+++ b/detekt-generator/src/test/resources/RuleSetConfig.yml
@@ -7,9 +7,9 @@ style:
   rulesetconfig3:
     - 'first'
     - 'se*cond'
-  WildcardImport:
+  MagicNumber:
     active: true
-    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**', '**/*.kts']
     conf1: 'foo'
     conf3:
       - 'a'


### PR DESCRIPTION
Context: https://github.com/detekt/detekt/pull/5116#discussion_r928118070

This PR is also kind of "housekeeping" because I remove the `'java.util.*'` as a valid Wildcard import as we have in the default values.