### PR TITLE
`RedundantExplicitType` add annotation `@RequiresTypeResolution`

### DIFF
--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantExplicitType.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantExplicitType.kt
@@ -7,6 +7,7 @@ import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import org.jetbrains.kotlin.KtNodeTypes
 import org.jetbrains.kotlin.builtins.KotlinBuiltIns
 import org.jetbrains.kotlin.psi.KtCallExpression
@@ -43,6 +44,7 @@ import org.jetbrains.kotlin.types.typeUtil.isLong
  * }
  * </compliant>
  */
+@RequiresTypeResolution
 class RedundantExplicitType(config: Config) : Rule(config) {
 
     override val issue = Issue(


### PR DESCRIPTION
`RedundantExplicitType` uses type solving but it wasn't annotated with `@RequiresTypeResolution`