### PR TITLE
Allow parentheses for unclear precedence with range operator

### DIFF
--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryParentheses.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryParentheses.kt
@@ -99,8 +99,13 @@ class UnnecessaryParentheses(config: Config = Config.empty) : Rule(config) {
                 Precedence.SIMPLE_NAME, // (a to b) to c
             ),
 
-            // (a * b) + c
-            Precedence.MULTIPLICATIVE to arrayOf(Precedence.ADDITIVE),
+            Precedence.MULTIPLICATIVE to arrayOf(
+                Precedence.ADDITIVE, // (a * b) + c
+                Precedence.RANGE, // (a / b)..(c * d)
+            ),
+
+            // (a + b)..(c + d)
+            Precedence.ADDITIVE to arrayOf(Precedence.RANGE),
 
             // (a && b) || c
             Precedence.CONJUNCTION to arrayOf(Precedence.DISJUNCTION),

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryParenthesesSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryParenthesesSpec.kt
@@ -308,6 +308,19 @@ class UnnecessaryParenthesesSpec {
 
     @ParameterizedTest
     @MethodSource("cases")
+    fun `range operator when precedence is unclear`(testCase: RuleTestCase) {
+        val code = """
+            val a = (1 - 2)..(3 + 4)
+            val b = (1 / 2)..(3 * 4)
+            val c = (1 ?: 2)..(3 ?: 4) // parens required
+            val d = (1 to 2)..(3 to 4) // parens required
+        """
+
+        assertThat(testCase.rule.lint(code)).hasSize(if (testCase.allowForUnclearPrecedence) 0 else 4)
+    }
+
+    @ParameterizedTest
+    @MethodSource("cases")
     fun `multiple wrapping parentheses`(testCase: RuleTestCase) {
         val code = """
             val a = ((false || (((true && false)))))


### PR DESCRIPTION
Follow-up to #4881 to allow parentheses clarifying usage of the range operator (`..`). Since for example `IntRange` has a `plus(Int)` operator function, the expression `a..b +c` could be ambiguous (but is interpreted as `a..(b + c)`). We can allow clarifying parentheses for such cases.