### PR TITLE
Get Android variant compile classpath from compileConfiguration

### DIFF
--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektAndroidSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektAndroidSpec.kt
@@ -3,7 +3,6 @@ package io.gitlab.arturbosch.detekt
 import io.gitlab.arturbosch.detekt.testkit.DslGradleRunner
 import io.gitlab.arturbosch.detekt.testkit.ProjectLayout
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -274,7 +273,6 @@ class DetektAndroidSpec {
 
         @Test
         @DisplayName("task :android_lib:detektMain")
-        @Disabled("https://github.com/detekt/detekt/issues/5150")
         fun libDetektMain() {
             gradleRunner.runTasksAndCheckResult(
                 "--configuration-cache",

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektAndroidSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektAndroidSpec.kt
@@ -291,6 +291,31 @@ class DetektAndroidSpec {
                 )
             }
         }
+
+        @Test
+        @DisplayName("task :android_lib:detektTest")
+        fun libDetektTest() {
+            gradleRunner.runTasksAndCheckResult(
+                "--configuration-cache",
+                ":android_lib:detektTest",
+            ) { buildResult ->
+                assertThat(buildResult.output).contains("Configuration cache")
+                assertThat(buildResult.output).containsPattern(
+                    """--baseline \S*[/\\]detekt-baseline-debugUnitTest.xml """
+                )
+                assertThat(buildResult.output).containsPattern(
+                    """--baseline \S*[/\\]detekt-baseline-debugAndroidTest.xml """
+                )
+                assertThat(buildResult.output).contains("--report xml:")
+                assertThat(buildResult.output).contains("--report sarif:")
+                assertThat(buildResult.output).doesNotContain("--report txt:")
+                assertThat(buildResult.tasks.map { it.path }).containsAll(
+                    listOf(
+                        ":android_lib:detektTest",
+                    )
+                )
+            }
+        }
     }
 
     @Nested

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektAndroid.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektAndroid.kt
@@ -14,6 +14,7 @@ import io.gitlab.arturbosch.detekt.extensions.DetektExtension
 import org.gradle.api.DomainObjectSet
 import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.api.attributes.Attribute
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.FileCollection
 import org.gradle.api.tasks.TaskProvider
@@ -117,7 +118,11 @@ internal fun Project.registerAndroidDetektTask(
         setSource(variant.sourceSets.map { it.javaDirectories + it.kotlinDirectories })
         extraInputSource?.let { source(it) }
         classpath.setFrom(
-            variant.getCompileClasspath(null).filter { it.exists() },
+            variant.compileConfiguration.incoming.artifactView { view ->
+                view.attributes {
+                    it.attribute(Attribute.of("artifactType", String::class.java), "jar")
+                }
+            }.files,
             bootClasspath,
             javaCompileDestination(variant),
         )
@@ -141,7 +146,11 @@ internal fun Project.registerAndroidCreateBaselineTask(
         setSource(variant.sourceSets.map { it.javaDirectories + it.kotlinDirectories })
         extraInputSource?.let { source(it) }
         classpath.setFrom(
-            variant.getCompileClasspath(null).filter { it.exists() },
+            variant.compileConfiguration.incoming.artifactView { view ->
+                view.attributes {
+                    it.attribute(Attribute.of("artifactType", String::class.java), "jar")
+                }
+            }.files,
             bootClasspath,
             javaCompileDestination(variant),
         )


### PR DESCRIPTION
Fixes #5150

We don't have good functional test coverage for Android so we're not guarded against introducing new issues. However the implementation of `getCompileConfiguration()` calls `getVariantData().getVariantDependencies().getCompileClasspath()`, so without digging further into AGP internals this should provide equivalent results to the previous `variant.getCompileClasspath(null)` method.