### PR TITLE
Re-enable warnings as errors for detekt-gradle-plugin

### DIFF
--- a/build-logic/src/main/kotlin/module.gradle.kts
+++ b/build-logic/src/main/kotlin/module.gradle.kts
@@ -56,12 +56,7 @@ tasks.withType<KotlinCompile>().configureEach {
             "-progressive",
             "-Xsuppress-version-warnings",
         )
-        // Note: Currently there are warnings for detekt-gradle-plugin that seemingly can't be fixed
-        //       until Gradle releases an update (https://github.com/gradle/gradle/issues/16345)
-        allWarningsAsErrors = when (project.name) {
-            "detekt-gradle-plugin" -> false
-            else -> project.findProperty("warningsAsErrors") == "true"
-        }
+        allWarningsAsErrors = project.findProperty("warningsAsErrors") == "true"
     }
 }
 

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektAndroid.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektAndroid.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package io.gitlab.arturbosch.detekt.internal
 
 import com.android.build.gradle.AppExtension

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektJvm.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektJvm.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package io.gitlab.arturbosch.detekt.internal
 
 import io.gitlab.arturbosch.detekt.DetektPlugin

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/SharedTasks.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/SharedTasks.kt
@@ -12,6 +12,7 @@ internal fun Project.registerDetektTask(
     configuration: Detekt.() -> Unit
 ): TaskProvider<Detekt> =
     tasks.register(name, Detekt::class.java) {
+        @Suppress("DEPRECATION")
         with(extension.reports) {
             if (xml.outputLocation.isPresent) {
                 logger.warn(


### PR DESCRIPTION
Fixes #5037

We currently have:
* Kotlin 1.7.10
* Gradle 7.5, which embeds Kotlin 1.6.21
* API version 1.4

Everything happily works together with warnings as errors now - but this is because we're now using `-Xsuppress-version-warnings`. So this PR will re-enable warnings as errors, and I've opened #5156 which limits usage of the suppression to only where it is needed.