### PR TITLE
Limit Kotlin version warning suppression scope in build

### DIFF
--- a/build-logic/src/main/kotlin/module.gradle.kts
+++ b/build-logic/src/main/kotlin/module.gradle.kts
@@ -51,17 +51,10 @@ tasks.withType<Test>().configureEach {
 tasks.withType<KotlinCompile>().configureEach {
     kotlinOptions {
         jvmTarget = Versions.JVM_TARGET
-        apiVersion = "1.4"
-        freeCompilerArgs = listOf(
+        freeCompilerArgs += listOf(
             "-progressive",
-            "-Xsuppress-version-warnings",
         )
-        // Note: Currently there are warnings for detekt-gradle-plugin that seemingly can't be fixed
-        //       until Gradle releases an update (https://github.com/gradle/gradle/issues/16345)
-        allWarningsAsErrors = when (project.name) {
-            "detekt-gradle-plugin" -> false
-            else -> project.findProperty("warningsAsErrors") == "true"
-        }
+        allWarningsAsErrors = project.findProperty("warningsAsErrors") == "true"
     }
 }
 

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Rule.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Rule.kt
@@ -72,7 +72,7 @@ abstract class Rule(
     private fun computeSeverity(): SeverityLevel {
         val configValue: String = valueOrNull(SEVERITY_KEY)
             ?: ruleSetConfig.valueOrDefault(SEVERITY_KEY, "warning")
-        return enumValueOf(configValue.toUpperCase(Locale.US))
+        return enumValueOf(configValue.uppercase(Locale.US))
     }
 
     /**

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/DetektPrinter.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/DetektPrinter.kt
@@ -42,7 +42,7 @@ class DetektPrinter(private val arguments: GeneratorArgs) {
         check(ruleSet.length > 1) { "Rule set name must be not empty or less than two symbols." }
         return """
             |---
-            |title: ${ruleSet[0].toUpperCase()}${ruleSet.substring(1)} Rule Set
+            |title: ${ruleSet[0].uppercaseChar()}${ruleSet.substring(1)} Rule Set
             |sidebar: home_sidebar
             |keywords: [rules, $ruleSet]
             |permalink: $ruleSet.html

--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -154,6 +154,18 @@ tasks.withType<Sign>().configureEach {
     notCompatibleWithConfigurationCache("https://github.com/gradle/gradle/issues/13470")
 }
 
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+    kotlinOptions {
+        apiVersion = "1.4"
+        freeCompilerArgs += listOf(
+            "-Xsuppress-version-warnings",
+        )
+        // Note: Currently there are warnings for detekt-gradle-plugin that seemingly can't be fixed
+        //       until Gradle releases an update (https://github.com/gradle/gradle/issues/16345)
+        allWarningsAsErrors = false
+    }
+}
+
 afterEvaluate {
     publishing {
         publications.filterIsInstance<MavenPublication>().forEach {

--- a/detekt-report-html/src/main/kotlin/io/github/detekt/report/html/HtmlOutputReport.kt
+++ b/detekt-report-html/src/main/kotlin/io/github/detekt/report/html/HtmlOutputReport.kt
@@ -123,7 +123,7 @@ class HtmlOutputReport : OutputReport() {
                 span("description") { text(findings.first().issue.description) }
             }
 
-            a("$DETEKT_WEBSITE_BASE_URL/docs/rules/${group.toLowerCase(Locale.US)}#${rule.toLowerCase(Locale.US)}") {
+            a("$DETEKT_WEBSITE_BASE_URL/docs/rules/${group.lowercase(Locale.US)}#${rule.lowercase(Locale.US)}") {
                 +"Documentation"
             }
 

--- a/detekt-report-md/src/main/kotlin/io/github/detekt/report/md/MdOutputReport.kt
+++ b/detekt-report-md/src/main/kotlin/io/github/detekt/report/md/MdOutputReport.kt
@@ -97,7 +97,7 @@ private fun MarkdownContent.renderRule(rule: String, group: String, findings: Li
     paragraph {
         link(
             "Documentation",
-            "$DETEKT_WEBSITE_BASE_URL/docs/rules/${group.toLowerCase(Locale.US)}#${rule.toLowerCase(Locale.US)}"
+            "$DETEKT_WEBSITE_BASE_URL/docs/rules/${group.lowercase(Locale.US)}#${rule.lowercase(Locale.US)}"
         )
     }
 

--- a/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/RuleDescriptors.kt
+++ b/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/RuleDescriptors.kt
@@ -36,8 +36,8 @@ private fun MultiRule.toDescriptors(ruleSetId: RuleSetId): List<ReportingDescrip
     this.rules.map { it.toDescriptor(ruleSetId) }
 
 private fun Rule.toDescriptor(ruleSetId: RuleSetId): ReportingDescriptor {
-    val formattedRuleSetId = ruleSetId.toLowerCase(Locale.US)
-    val formattedRuleId = ruleId.toLowerCase(Locale.US)
+    val formattedRuleSetId = ruleSetId.lowercase(Locale.US)
+    val formattedRuleId = ruleId.lowercase(Locale.US)
 
     return ReportingDescriptor(
         id = "detekt.$ruleSetId.$ruleId",

--- a/detekt-report-xml/src/main/kotlin/io/github/detekt/report/xml/XmlEscape.kt
+++ b/detekt-report-xml/src/main/kotlin/io/github/detekt/report/xml/XmlEscape.kt
@@ -276,7 +276,7 @@ private object Xml10EscapeSymbolsInitializer {
     }
 
     private operator fun ByteArray.set(c: Char, value: Byte) {
-        set(c.toInt(), value)
+        set(c.code, value)
     }
 
     /**

--- a/detekt-report-xml/src/main/kotlin/io/github/detekt/report/xml/XmlOutputReport.kt
+++ b/detekt-report-xml/src/main/kotlin/io/github/detekt/report/xml/XmlOutputReport.kt
@@ -17,7 +17,7 @@ class XmlOutputReport : OutputReport() {
     override val name = "Checkstyle XML report"
 
     private val Finding.severityLabel: String
-        get() = severity.name.toLowerCase(Locale.US)
+        get() = severity.name.lowercase(Locale.US)
 
     override fun render(detektion: Detektion): String {
         val smells = detektion.findings.flatMap { it.value }

--- a/detekt-report-xml/src/test/kotlin/io/github/detekt/report/xml/XmlOutputFormatSpec.kt
+++ b/detekt-report-xml/src/test/kotlin/io/github/detekt/report/xml/XmlOutputFormatSpec.kt
@@ -188,7 +188,7 @@ class XmlOutputFormatSpec {
         @ParameterizedTest
         @EnumSource(SeverityLevel::class)
         fun `renders detektion with severity as XML with severity`(severity: SeverityLevel) {
-            val xmlSeverity = severity.name.toLowerCase(Locale.US)
+            val xmlSeverity = severity.name.lowercase(Locale.US)
             val finding = object : CodeSmell(
                 issue = Issue("issue_id", Severity.CodeSmell, "issue description", Debt.FIVE_MINS),
                 entity = entity1,

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumber.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumber.kt
@@ -178,7 +178,7 @@ class MagicNumber(config: Config = Config.empty) : Rule(config) {
 
     private fun normalizeForParsingAsDouble(text: String): String {
         return text.trim()
-            .toLowerCase(Locale.US)
+            .lowercase(Locale.US)
             .replace("_", "")
             .removeSuffix("l")
             .removeSuffix("d")

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiterals.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiterals.kt
@@ -105,7 +105,7 @@ class UnderscoresInNumericLiterals(config: Config = Config.empty) : Rule(config)
 
     private fun normalizeForMatching(text: String): String {
         return text.trim()
-            .toLowerCase(Locale.ROOT)
+            .lowercase(Locale.ROOT)
             .removeSuffix("l")
             .removeSuffix("d")
             .removeSuffix("f")


### PR DESCRIPTION
The Gradle plugin requires a lower API version to maintain compatibility with [older Gradle versions](https://docs.gradle.org/current/userguide/compatibility.html#kotlin).

detekt itself doesn't need to limit itself to older API versions as it uses its own Kotlin dependency to execute, which is different from the version Gradle embeds. This PR updates the build configuration to align - now other modules can use the current Kotlin API and don't need to suppress version warnings. This is now applied only to the Gradle plugin.