### PR TITLE
Use getter when determining whether custom config path is set in DetektGenerateConfigTask

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektGenerateConfigTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektGenerateConfigTask.kt
@@ -48,11 +48,12 @@ open class DetektGenerateConfigTask @Inject constructor(
 
     private val defaultConfigPath = project.rootDir.toPath().resolve(CONFIG_DIR_NAME).resolve(CONFIG_FILE)
 
-    private val configurationToUse = if (config.isEmpty) {
-        objects.fileCollection().from(defaultConfigPath)
-    } else {
-        config
-    }
+    private val configurationToUse: ConfigurableFileCollection
+        get() = if (config.isEmpty) {
+            objects.fileCollection().from(defaultConfigPath)
+        } else {
+            config
+        }
 
     @get:Internal
     internal val arguments: Provider<List<String>> = project.provider {


### PR DESCRIPTION
Fixes #5097

Before this change, this task:
```kotlin
tasks.register("customDetektConfig", io.gitlab.arturbosch.detekt.DetektGenerateConfigTask::class) {
    config.setFrom("custom/location.yml")
    doLast {
        logger.warn("Configured path: ${config.asPath}")
    }
}
```

Would produce this output:
```
> Task :detekt-api:customDetektConfig
Skipping config file generation; file already exists at C:\<projectPath>\config\detekt\detekt.yml
Configured path: C:\<projectPath>\detekt-api\custom\location.yml
```

You can see the task was setting the config path and despite what was configured in the build file, the config wasn't being calculated correctly by the task.

With this PR, it will successfully generate the file:
```
> Task :detekt-api:customDetektConfig
Successfully copied default config to C:\<projectPath>\detekt-api\custom\location.yml
Configured path: C:\<projectPath>\detekt-api\custom\location.yml
```

And subsequent invocations will product the expected output:
```
> Task :detekt-api:customDetektConfig
Skipping config file generation; file already exists at C:\<projectPath>\detekt-api\custom\location.yml
Configured path: C:\<projectPath>\detekt-api\custom\location.yml
```