### PR TITLE
Run build-logic Kotlin compilation out of process on CI

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -13,3 +13,10 @@ dependencies {
     implementation(libs.semver4j.gradle)
     implementation(libs.nexusStaging.gradle)
 }
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+    val isCiBuild = System.getenv("CI") != null
+    if (isCiBuild) {
+        compilerExecutionStrategy.set(org.jetbrains.kotlin.gradle.tasks.KotlinCompilerExecutionStrategy.OUT_OF_PROCESS)
+    }
+}


### PR DESCRIPTION
Kotlin uses a compilation daemon by default. This is the fastest execution mode and usually preferred, because the Kotlin compilation environment can be setup once and reused.

However, it leaves the compilation daemon running for the lifetime of the Gradle daemon. Again, usually what we want, but in the case of the `build-logic` project which depends on `kotlin-dsl`, it will launch a Kotlin 1.6.21 daemon (matching Gradle's embedded Kotlin version) if the `build-logic:compileKotlin` task has to run, which cannot be reused by other compilation tasks (which use Kotlin 1.7.10). The 1.6.21 compilation daemon then remains in memory, unused.

This PR changes the compilation strategy to be out of process when running on CI. This means the 1.6.21 compilation environment is terminated as soon as the `build-logic:compileKotlin` task completes, which will free that memory for the remainder of the build.

I actually think this is a good trade off for all builds, not just on CI, but happy to hear thoughts on this.