### PR TITLE
Enable Predictive Test Selection for local builds

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,6 +44,14 @@ allprojects {
     }
 }
 
+subprojects {
+    tasks.withType<Test> {
+        predictiveSelection {
+            enabled.set(System.getenv("CI") == null)
+        }
+    }
+}
+
 val analysisDir = file(projectDir)
 val baselineFile = file("$rootDir/config/detekt/baseline.xml")
 val configFile = file("$rootDir/config/detekt/detekt.yml")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -44,6 +44,7 @@ plugins {
     // check https://gradle.com/enterprise/releases with new versions. GE plugin version should not lag behind Gradle version
     id("com.gradle.enterprise") version "3.10.3"
     id("com.gradle.common-custom-user-data-gradle-plugin") version "1.7.2"
+    id("com.gradle.enterprise.test-distribution") version "2.3.5"
 }
 
 val isCiBuild = System.getenv("CI") != null


### PR DESCRIPTION
Closes #4992

Example results: https://ge.detekt.dev/s/zw2mley3hbwz6/tests/overview. The build was run simply with `./gradlew test` on the main branch.

This enables PTS only for local builds. Gradle recommends enabling PTS for local builds and PRs, however it's simpler and lower risk to leave disabled on CI entirely. Maybe we can enable on PRs too once we have some experience with it.

This doesn't apply to detekt-gradle-plugin, which is unfortunate because it's the slowest test suite, but currently included builds are not supported so this is a technical limitation. Config can be updated in future if this changes.

This is an `@Internal` property so the different value in CI & non-CI builds doesn't impact remote build cache hits.