### PR TITLE
Allow to ignore overloaded methods for the complex interface rule (#5165)

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -98,6 +98,7 @@ complexity:
     threshold: 10
     includeStaticDeclarations: false
     includePrivateDeclarations: false
+    ignoreOverloaded: false
   ComplexMethod:
     active: true
     threshold: 15

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexInterfaceSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexInterfaceSpec.kt
@@ -169,7 +169,7 @@ class ComplexInterfaceSpec {
 
             @Test
             fun `reports complex interface with extension methods with a different receiver`() {
-                val code = """
+                val interfaceWithExtension = """
                     interface I {
                         fun f1()
                         fun String.f1(i: Int)
@@ -178,12 +178,12 @@ class ComplexInterfaceSpec {
                     }
                 """
                 val rule = ComplexInterface(ignoreOverloadedConfig)
-                assertThat(rule.compileAndLint(code)).hasSize(1)
+                assertThat(rule.compileAndLint(interfaceWithExtension)).hasSize(1)
             }
 
             @Test
             fun `does not report simple interface with extension methods with the same receiver`() {
-                val code = """
+                val interfaceWithOverloadedExtensions = """
                     interface I {
                         fun String.f1()
                         fun String.f1(i: Int)
@@ -192,7 +192,7 @@ class ComplexInterfaceSpec {
                     }
                 """
                 val rule = ComplexInterface(ignoreOverloadedConfig)
-                assertThat(rule.compileAndLint(code)).isEmpty()
+                assertThat(rule.compileAndLint(interfaceWithOverloadedExtensions)).isEmpty()
             }
         }
     }

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexInterfaceSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexInterfaceSpec.kt
@@ -14,6 +14,9 @@ private val staticDeclarationsConfig = TestConfig(
 private val privateDeclarationsConfig = TestConfig(
     defaultConfigMap + ("includePrivateDeclarations" to true)
 )
+private val ignoreOverloadedConfig = TestConfig(
+    defaultConfigMap + ("ignoreOverloaded" to true)
+)
 
 class ComplexInterfaceSpec {
 
@@ -139,6 +142,57 @@ class ComplexInterfaceSpec {
             fun `does report complex interface with includePrivateDeclarations config`() {
                 val rule = ComplexInterface(privateDeclarationsConfig)
                 assertThat(rule.compileAndLint(code)).hasSize(1)
+            }
+        }
+
+        @Nested
+        inner class `overloaded methods` {
+            val code = """
+                interface I {
+                    fun f1()
+                    fun f1(i: Int)
+                    val i1: Int
+                    fun fImpl() {}
+                }
+            """
+
+            @Test
+            fun `reports complex interface with overloaded methods`() {
+                assertThat(subject.compileAndLint(code)).hasSize(1)
+            }
+
+            @Test
+            fun `does not report simple interface with ignoreOverloaded`() {
+                val rule = ComplexInterface(ignoreOverloadedConfig)
+                assertThat(rule.compileAndLint(code)).isEmpty()
+            }
+
+            @Test
+            fun `reports complex interface with extension methods with a different receiver`() {
+                val code = """
+                    interface I {
+                        fun f1()
+                        fun String.f1(i: Int)
+                        val i1: Int
+                        fun fImpl() {}
+                    }
+                """
+                val rule = ComplexInterface(ignoreOverloadedConfig)
+                assertThat(rule.compileAndLint(code)).hasSize(1)
+            }
+
+            @Test
+            fun `does not report simple interface with extension methods with the same receiver`() {
+                val code = """
+                    interface I {
+                        fun String.f1()
+                        fun String.f1(i: Int)
+                        val i1: Int
+                        fun fImpl() {}
+                    }
+                """
+                val rule = ComplexInterface(ignoreOverloadedConfig)
+                assertThat(rule.compileAndLint(code)).isEmpty()
             }
         }
     }


### PR DESCRIPTION
Closes #5165

ComplexInterface: do not count method overloads