### PR TITLE
Don't run rules annotated with `@RequiresTypeResolution` when running plain detekt

### DIFF
--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/RequiresTypeResolution.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/RequiresTypeResolution.kt
@@ -2,6 +2,9 @@ package io.gitlab.arturbosch.detekt.api.internal
 
 /**
  * Annotated [io.gitlab.arturbosch.detekt.api.Rule] requires type resolution to work.
+ *
+ * The detekt core will honor this annotation and it will not run any rule with this annotation if the bindingContext
+ * is empty.
  */
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/RequiresTypeResolution.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/RequiresTypeResolution.kt
@@ -4,5 +4,5 @@ package io.gitlab.arturbosch.detekt.api.internal
  * Annotated [io.gitlab.arturbosch.detekt.api.Rule] requires type resolution to work.
  */
 @Target(AnnotationTarget.CLASS)
-@Retention(AnnotationRetention.SOURCE)
+@Retention(AnnotationRetention.RUNTIME)
 annotation class RequiresTypeResolution

--- a/detekt-core/build.gradle.kts
+++ b/detekt-core/build.gradle.kts
@@ -7,6 +7,7 @@ dependencies {
     api(projects.detektParser)
     api(projects.detektTooling)
     implementation(libs.snakeyaml)
+    implementation(libs.kotlin.reflection)
     implementation(projects.detektMetrics)
     implementation(projects.detektPsiUtils)
     implementation(projects.detektReportHtml)

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Analyzer.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Analyzer.kt
@@ -115,12 +115,8 @@ internal class Analyzer(
 
         val (correctableRules, otherRules) = activeRuleSetsToRuleSetConfigs
             .flatMap { (ruleSet, _) -> ruleSet.rules.asSequence() }
-            .let { sequence ->
-                if (bindingContext == BindingContext.EMPTY) {
-                    sequence.filterNot { rule -> rule::class.hasAnnotation<RequiresTypeResolution>() }
-                } else {
-                    sequence
-                }
+            .filter { rule ->
+                bindingContext != BindingContext.EMPTY || !rule::class.hasAnnotation<RequiresTypeResolution>()
             }
             .partition { isCorrectable(it) }
 

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Analyzer.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Analyzer.kt
@@ -10,6 +10,7 @@ import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.RuleSetId
 import io.gitlab.arturbosch.detekt.api.RuleSetProvider
 import io.gitlab.arturbosch.detekt.api.internal.CompilerResources
+import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.internal.whichDetekt
 import io.gitlab.arturbosch.detekt.api.internal.whichJava
 import io.gitlab.arturbosch.detekt.api.internal.whichOS
@@ -24,6 +25,7 @@ import org.jetbrains.kotlin.config.languageVersionSettings
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.calls.smartcasts.DataFlowValueFactoryImpl
+import kotlin.reflect.full.hasAnnotation
 
 private typealias FindingsResult = List<Map<RuleSetId, List<Finding>>>
 
@@ -113,6 +115,13 @@ internal class Analyzer(
 
         val (correctableRules, otherRules) = activeRuleSetsToRuleSetConfigs
             .flatMap { (ruleSet, _) -> ruleSet.rules.asSequence() }
+            .let { sequence ->
+                if (bindingContext == BindingContext.EMPTY) {
+                    sequence.filterNot { rule -> rule::class.hasAnnotation<RequiresTypeResolution>() }
+                } else {
+                    sequence
+                }
+            }
             .partition { isCorrectable(it) }
 
         val result = HashMap<RuleSetId, MutableList<Finding>>()

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/AnalyzerSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/AnalyzerSpec.kt
@@ -63,16 +63,16 @@ class AnalyzerSpec {
             val settings = createProcessingSettings(testFile, yamlConfig("configs/config-value-type-correct.yml"))
             val analyzer = Analyzer(settings, listOf(StyleRuleSetProvider()), emptyList())
 
-            assertThat(settings.use { analyzer.run(listOf(compileForTest(testFile))) }).isEmpty()
+            assertThat(settings.use { analyzer.run(listOf(compileForTest(testFile))) }.values.flatten()).isEmpty()
         }
 
         @Test
         fun `with findings`() {
             val testFile = path.resolve("Test.kt")
             val settings = createProcessingSettings(testFile, yamlConfig("configs/config-value-type-correct.yml"))
-            val analyzer = Analyzer(settings, listOf(StyleRuleSetProvider(18)), emptyList())
+            val analyzer = Analyzer(settings, listOf(StyleRuleSetProvider(30)), emptyList())
 
-            assertThat(settings.use { analyzer.run(listOf(compileForTest(testFile))) }).hasSize(1)
+            assertThat(settings.use { analyzer.run(listOf(compileForTest(testFile))) }.values.flatten()).hasSize(1)
         }
 
         @Test
@@ -84,7 +84,7 @@ class AnalyzerSpec {
             )
             val analyzer = Analyzer(settings, listOf(StyleRuleSetProvider(18)), emptyList())
 
-            assertThat(settings.use { analyzer.run(listOf(compileForTest(testFile))) }).isEmpty()
+            assertThat(settings.use { analyzer.run(listOf(compileForTest(testFile))) }.values.flatten()).isEmpty()
         }
 
         @Test

--- a/detekt-core/src/test/resources/cases/Test.kt
+++ b/detekt-core/src/test/resources/cases/Test.kt
@@ -5,5 +5,5 @@ package cases
 @Suppress("Unused")
 class Test
 
-@Target(AnnotationTarget.FILE)
+@Target(AnnotationTarget.FILE, AnnotationTarget.FUNCTION)
 annotation class AnAnnotation

--- a/detekt-core/src/test/resources/configs/config-value-type-correct.yml
+++ b/detekt-core/src/test/resources/configs/config-value-type-correct.yml
@@ -2,6 +2,9 @@ style:
   MaxLineLength:
     active: true
     maxLineLength: 120
+  RequiresTypeResolutionMaxLineLength:
+    active: true
+    maxLineLength: 120
   FaultyRule:
     active: true
   FaultyRuleNoStackTrace:

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NamedArguments.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NamedArguments.kt
@@ -12,7 +12,6 @@ import io.gitlab.arturbosch.detekt.api.internal.Configuration
 import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtLambdaArgument
-import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.calls.util.getParameterForArgument
 import org.jetbrains.kotlin.resolve.calls.util.getResolvedCall
 
@@ -49,7 +48,6 @@ class NamedArguments(config: Config = Config.empty) : Rule(config) {
     private val ignoreArgumentsMatchingNames: Boolean by config(defaultValue = false)
 
     override fun visitCallExpression(expression: KtCallExpression) {
-        if (bindingContext == BindingContext.EMPTY) return
         val valueArguments = expression.valueArguments.filterNot { it is KtLambdaArgument }
         if (valueArguments.size > threshold && expression.canNameArguments()) {
             val message = "This function call has ${valueArguments.size} arguments. To call a function with more " +

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedScopeFunctions.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedScopeFunctions.kt
@@ -16,7 +16,6 @@ import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import org.jetbrains.kotlin.descriptors.CallableDescriptor
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtNamedFunction
-import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.calls.util.getResolvedCall
 
 /**
@@ -66,7 +65,6 @@ class NestedScopeFunctions(config: Config = Config.empty) : Rule(config) {
     }
 
     override fun visitNamedFunction(function: KtNamedFunction) {
-        if (bindingContext == BindingContext.EMPTY) return
         function.accept(FunctionDepthVisitor())
     }
 

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ReplaceSafeCallChainWithRun.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ReplaceSafeCallChainWithRun.kt
@@ -9,7 +9,6 @@ import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import org.jetbrains.kotlin.psi.KtSafeQualifiedExpression
-import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.calls.util.getResolvedCall
 import org.jetbrains.kotlin.types.isNullable
 
@@ -51,8 +50,6 @@ class ReplaceSafeCallChainWithRun(config: Config = Config.empty) : Rule(config) 
 
     override fun visitSafeQualifiedExpression(expression: KtSafeQualifiedExpression) {
         super.visitSafeQualifiedExpression(expression)
-
-        if (bindingContext == BindingContext.EMPTY) return
 
         /* We want the last safe qualified expression in the chain, so if there are more in this chain then there's no
         need to run checks on this one */

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedScopeFunctionsSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedScopeFunctionsSpec.kt
@@ -4,7 +4,6 @@ import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLint
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
@@ -94,25 +93,8 @@ class NestedScopeFunctionsSpec(private val env: KotlinCoreEnvironment) {
         expectNoFindings()
     }
 
-    @Test
-    fun `should not report when binding context is empty`() {
-        givenCode = """
-            fun f() {
-                1.run {
-                    1.run { }
-                }
-            }
-        """.trimIndent()
-        whenLintRunsWithoutContext()
-        expectNoFindings()
-    }
-
     private fun whenLintRuns() {
         actual = subject.compileAndLintWithContext(env, givenCode)
-    }
-
-    private fun whenLintRunsWithoutContext() {
-        actual = subject.compileAndLint(givenCode)
     }
 
     private fun expectSourceLocation(location: Pair<Int, Int>) {

--- a/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/InjectDispatcher.kt
+++ b/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/InjectDispatcher.kt
@@ -17,7 +17,6 @@ import org.jetbrains.kotlin.psi.KtConstructorDelegationCall
 import org.jetbrains.kotlin.psi.KtParameter
 import org.jetbrains.kotlin.psi.KtSimpleNameExpression
 import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
-import org.jetbrains.kotlin.resolve.BindingContext.EMPTY
 import org.jetbrains.kotlin.resolve.calls.util.getType
 import org.jetbrains.kotlin.types.typeUtil.supertypes
 
@@ -57,7 +56,7 @@ class InjectDispatcher(config: Config) : Rule(config) {
 
     override fun visitSimpleNameExpression(expression: KtSimpleNameExpression) {
         super.visitSimpleNameExpression(expression)
-        if (bindingContext == EMPTY || expression.getReferencedName() !in dispatcherNames) return
+        if (expression.getReferencedName() !in dispatcherNames) return
         val type = expression.getType(bindingContext) ?: return
         val isCoroutineDispatcher = type.fqNameOrNull() == COROUTINE_DISPATCHER_FQCN ||
             type.supertypes().any { it.fqNameOrNull() == COROUTINE_DISPATCHER_FQCN }

--- a/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/RedundantSuspendModifier.kt
+++ b/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/RedundantSuspendModifier.kt
@@ -66,7 +66,6 @@ class RedundantSuspendModifier(config: Config) : Rule(config) {
     )
 
     override fun visitNamedFunction(function: KtNamedFunction) {
-        if (bindingContext == BindingContext.EMPTY) return
         val suspendModifier = function.modifierList?.getModifier(KtTokens.SUSPEND_KEYWORD) ?: return
         if (!function.hasBody()) return
         if (function.hasModifier(KtTokens.OVERRIDE_KEYWORD)) return

--- a/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SleepInsteadOfDelay.kt
+++ b/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SleepInsteadOfDelay.kt
@@ -16,7 +16,6 @@ import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.KtQualifiedExpression
 import org.jetbrains.kotlin.psi.psiUtil.forEachDescendantOfType
 import org.jetbrains.kotlin.psi.psiUtil.hasSuspendModifier
-import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.calls.util.getResolvedCall
 import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameOrNull
 
@@ -50,7 +49,6 @@ class SleepInsteadOfDelay(config: Config = Config.empty) : Rule(config) {
     )
 
     override fun visitNamedFunction(function: KtNamedFunction) {
-        if (bindingContext == BindingContext.EMPTY) return
         if (function.modifierList?.hasSuspendModifier() == true) {
             function.checkDescendants(SUSPEND_FUN_MESSAGE)
         }

--- a/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunWithCoroutineScopeReceiver.kt
+++ b/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunWithCoroutineScopeReceiver.kt
@@ -60,7 +60,6 @@ class SuspendFunWithCoroutineScopeReceiver(config: Config) : Rule(config) {
     )
 
     override fun visitNamedFunction(function: KtNamedFunction) {
-        if (bindingContext == BindingContext.EMPTY) return
         checkReceiver(function)
     }
 

--- a/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunWithFlowReturnType.kt
+++ b/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunWithFlowReturnType.kt
@@ -73,7 +73,6 @@ class SuspendFunWithFlowReturnType(config: Config) : Rule(config) {
     )
 
     override fun visitNamedFunction(function: KtNamedFunction) {
-        if (bindingContext == BindingContext.EMPTY) return
         val suspendModifier = function.modifierList?.getModifier(KtTokens.SUSPEND_KEYWORD) ?: return
         bindingContext[BindingContext.FUNCTION, function]
             ?.returnType

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/AvoidReferentialEquality.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/AvoidReferentialEquality.kt
@@ -16,7 +16,6 @@ import io.gitlab.arturbosch.detekt.rules.fqNameOrNull
 import org.jetbrains.kotlin.lexer.KtTokens.EQEQEQ
 import org.jetbrains.kotlin.lexer.KtTokens.EXCLEQEQEQ
 import org.jetbrains.kotlin.psi.KtBinaryExpression
-import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.calls.util.getType
 
 /**
@@ -62,7 +61,6 @@ class AvoidReferentialEquality(config: Config) : Rule(config) {
     }
 
     private fun checkBinaryExpression(expression: KtBinaryExpression) {
-        if (bindingContext == BindingContext.EMPTY) return
         if (expression.operationToken != EQEQEQ && expression.operationToken != EXCLEQEQEQ) return
 
         val checkedType = expression.left?.getType(bindingContext)?.fqNameOrNull() ?: return

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/Deprecation.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/Deprecation.kt
@@ -11,7 +11,6 @@ import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.diagnostics.Errors
 import org.jetbrains.kotlin.psi.KtNamedDeclaration
-import org.jetbrains.kotlin.resolve.BindingContext
 
 /**
  * Deprecated elements are expected to be removed in the future. Alternatives should be found if possible.
@@ -30,7 +29,6 @@ class Deprecation(config: Config) : Rule(config) {
     override val defaultRuleIdAliases = setOf("DEPRECATION")
 
     override fun visitElement(element: PsiElement) {
-        if (bindingContext == BindingContext.EMPTY) return
         if (hasDeprecationCompilerWarnings(element)) {
             val entity = if (element is KtNamedDeclaration) Entity.atName(element) else Entity.from(element)
             report(CodeSmell(issue, entity, "${element.text} is deprecated."))

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DontDowncastCollectionTypes.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DontDowncastCollectionTypes.kt
@@ -15,7 +15,6 @@ import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.psi.KtIsExpression
 import org.jetbrains.kotlin.psi.KtTypeReference
 import org.jetbrains.kotlin.psi.KtUserType
-import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.calls.util.getType
 
 /**
@@ -50,15 +49,12 @@ class DontDowncastCollectionTypes(config: Config) : Rule(config) {
 
     override fun visitIsExpression(expression: KtIsExpression) {
         super.visitIsExpression(expression)
-        if (bindingContext == BindingContext.EMPTY) return
 
         checkForDowncast(expression, expression.leftHandSide, expression.typeReference)
     }
 
     override fun visitBinaryWithTypeRHSExpression(expression: KtBinaryExpressionWithTypeRHS) {
         super.visitBinaryWithTypeRHSExpression(expression)
-
-        if (bindingContext == BindingContext.EMPTY) return
 
         checkForDowncast(expression, expression.left, expression.right)
     }

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DoubleMutabilityForCollection.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DoubleMutabilityForCollection.kt
@@ -65,8 +65,6 @@ class DoubleMutabilityForCollection(config: Config = Config.empty) : Rule(config
     override fun visitProperty(property: KtProperty) {
         super.visitProperty(property)
 
-        if (bindingContext == BindingContext.EMPTY) return
-
         val type = (bindingContext[BindingContext.VARIABLE, property])?.type ?: return
         val standardType = type.fqNameOrNull()
         if (property.isVar && standardType in mutableTypes) {

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ElseCaseInsteadOfExhaustiveWhen.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ElseCaseInsteadOfExhaustiveWhen.kt
@@ -10,7 +10,6 @@ import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import org.jetbrains.kotlin.cfg.WhenChecker
 import org.jetbrains.kotlin.psi.KtWhenExpression
-import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.calls.util.getType
 import org.jetbrains.kotlin.types.KotlinType
 import org.jetbrains.kotlin.types.typeUtil.isBooleanOrNullableBoolean
@@ -63,7 +62,6 @@ class ElseCaseInsteadOfExhaustiveWhen(config: Config = Config.empty) : Rule(conf
     override fun visitWhenExpression(whenExpression: KtWhenExpression) {
         super.visitWhenExpression(whenExpression)
 
-        if (bindingContext == BindingContext.EMPTY) return
         checkForElseCaseInsteadOfExhaustiveWhenExpression(whenExpression)
     }
 

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ExitOutsideMain.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ExitOutsideMain.kt
@@ -12,7 +12,6 @@ import io.gitlab.arturbosch.detekt.rules.isMainFunction
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
-import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.calls.util.getResolvedCall
 import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameOrNull
 
@@ -57,8 +56,6 @@ class ExitOutsideMain(config: Config = Config.empty) : Rule(config) {
     @Suppress("ReturnCount")
     override fun visitCallExpression(expression: KtCallExpression) {
         super.visitCallExpression(expression)
-
-        if (bindingContext == BindingContext.EMPTY) return
 
         if (expression.getStrictParentOfType<KtNamedFunction>()?.isMainFunction() == true) return
         val fqName = expression.getResolvedCall(bindingContext)?.resultingDescriptor?.fqNameOrNull() ?: return

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/HasPlatformType.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/HasPlatformType.kt
@@ -51,7 +51,6 @@ class HasPlatformType(config: Config) : Rule(config) {
 
     override fun visitKtElement(element: KtElement) {
         super.visitKtElement(element)
-        if (bindingContext == BindingContext.EMPTY) return
 
         if (element is KtCallableDeclaration && element.hasImplicitPlatformType()) {
             report(

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValue.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValue.kt
@@ -15,7 +15,6 @@ import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.simplePatternToRegex
 import org.jetbrains.kotlin.descriptors.annotations.AnnotationDescriptor
 import org.jetbrains.kotlin.psi.KtCallExpression
-import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.bindingContextUtil.isUsedAsExpression
 import org.jetbrains.kotlin.resolve.calls.util.getResolvedCall
 import org.jetbrains.kotlin.types.typeUtil.isUnit
@@ -75,7 +74,6 @@ class IgnoredReturnValue(config: Config = Config.empty) : Rule(config) {
     @Suppress("ReturnCount")
     override fun visitCallExpression(expression: KtCallExpression) {
         super.visitCallExpression(expression)
-        if (bindingContext == BindingContext.EMPTY) return
 
         if (expression.isUsedAsExpression(bindingContext)) return
 

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ImplicitUnitReturnType.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ImplicitUnitReturnType.kt
@@ -13,7 +13,6 @@ import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import org.jetbrains.kotlin.builtins.StandardNames
 import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.psi.KtNamedFunction
-import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.calls.util.getResolvedCall
 import org.jetbrains.kotlin.types.typeUtil.isUnit
 
@@ -58,9 +57,6 @@ class ImplicitUnitReturnType(config: Config) : Rule(config) {
     @Suppress("ReturnCount")
     override fun visitNamedFunction(function: KtNamedFunction) {
         super.visitNamedFunction(function)
-        if (BindingContext.EMPTY == bindingContext) {
-            return
-        }
 
         if (allowExplicitReturnType && function.hasDeclaredReturnType()) {
             return

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingWhenCase.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingWhenCase.kt
@@ -14,7 +14,6 @@ import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import org.jetbrains.kotlin.cfg.WhenChecker
 import org.jetbrains.kotlin.diagnostics.WhenMissingCase
 import org.jetbrains.kotlin.psi.KtWhenExpression
-import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.bindingContextUtil.isUsedAsExpression
 import org.jetbrains.kotlin.resolve.calls.util.getType
 
@@ -83,7 +82,6 @@ class MissingWhenCase(config: Config = Config.empty) : Rule(config) {
 
     override fun visitWhenExpression(expression: KtWhenExpression) {
         super.visitWhenExpression(expression)
-        if (bindingContext == BindingContext.EMPTY) return
         if (allowElseExpression && expression.elseExpression != null) return
         checkMissingWhenExpression(expression)
     }

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/NullCheckOnMutableProperty.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/NullCheckOnMutableProperty.kt
@@ -22,7 +22,6 @@ import org.jetbrains.kotlin.psi.KtNameReferenceExpression
 import org.jetbrains.kotlin.psi.KtPrimaryConstructor
 import org.jetbrains.kotlin.psi.KtProperty
 import org.jetbrains.kotlin.psi.KtReferenceExpression
-import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.calls.util.getResolvedCall
 import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameOrNull
 
@@ -62,7 +61,6 @@ class NullCheckOnMutableProperty(config: Config) : Rule(config) {
     )
 
     override fun visitKtFile(file: KtFile) {
-        if (bindingContext == BindingContext.EMPTY) return
         super.visitKtFile(file)
         NullCheckVisitor().visitKtFile(file)
     }

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/NullableToStringCall.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/NullableToStringCall.kt
@@ -61,7 +61,6 @@ class NullableToStringCall(config: Config = Config.empty) : Rule(config) {
 
     override fun visitSimpleNameExpression(expression: KtSimpleNameExpression) {
         super.visitSimpleNameExpression(expression)
-        if (bindingContext == BindingContext.EMPTY) return
 
         val simpleOrCallExpression = expression.parent.safeAs<KtCallExpression>() ?: expression
         val targetExpression = simpleOrCallExpression.targetExpression() ?: return

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/RedundantElseInWhen.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/RedundantElseInWhen.kt
@@ -11,7 +11,6 @@ import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
 import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import org.jetbrains.kotlin.diagnostics.Errors
 import org.jetbrains.kotlin.psi.KtWhenExpression
-import org.jetbrains.kotlin.resolve.BindingContext
 
 /**
  * Turn on this rule to flag `when` expressions that contain a redundant `else` case. This occurs when it can be
@@ -72,7 +71,6 @@ class RedundantElseInWhen(config: Config = Config.empty) : Rule(config) {
     override fun visitWhenExpression(whenExpression: KtWhenExpression) {
         super.visitWhenExpression(whenExpression)
 
-        if (bindingContext == BindingContext.EMPTY) return
         val elseEntry = whenExpression.entries.lastOrNull { it.isElse } ?: return
         val compilerReports = bindingContext.diagnostics.forElement(elseEntry)
         if (compilerReports.any { it.factory == Errors.REDUNDANT_ELSE_IN_WHEN }) {

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessaryNotNullOperator.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessaryNotNullOperator.kt
@@ -11,7 +11,6 @@ import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
 import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import org.jetbrains.kotlin.diagnostics.Errors
 import org.jetbrains.kotlin.psi.KtUnaryExpression
-import org.jetbrains.kotlin.resolve.BindingContext
 
 /**
  * Reports unnecessary not-null operator usage (!!) that can be removed by the user.
@@ -39,7 +38,6 @@ class UnnecessaryNotNullOperator(config: Config = Config.empty) : Rule(config) {
 
     override fun visitUnaryExpression(expression: KtUnaryExpression) {
         super.visitUnaryExpression(expression)
-        if (bindingContext == BindingContext.EMPTY) return
 
         val compilerReports = bindingContext.diagnostics.forElement(expression.operationReference)
         if (compilerReports.any { it.factory == Errors.UNNECESSARY_NOT_NULL_ASSERTION }) {

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessarySafeCall.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessarySafeCall.kt
@@ -14,7 +14,6 @@ import org.jetbrains.kotlin.diagnostics.Errors
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtSafeQualifiedExpression
 import org.jetbrains.kotlin.psi.psiUtil.getChildOfType
-import org.jetbrains.kotlin.resolve.BindingContext
 
 /**
  * Reports unnecessary safe call operators (`?.`) that can be removed by the user.
@@ -43,8 +42,6 @@ class UnnecessarySafeCall(config: Config = Config.empty) : Rule(config) {
     @Suppress("ReturnCount")
     override fun visitSafeQualifiedExpression(expression: KtSafeQualifiedExpression) {
         super.visitSafeQualifiedExpression(expression)
-
-        if (bindingContext == BindingContext.EMPTY) return
 
         val safeAccessElement = expression.getChildOfType<LeafPsiElement>()
         if (safeAccessElement == null || safeAccessElement.elementType != KtTokens.SAFE_ACCESS) {

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnreachableCatchBlock.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnreachableCatchBlock.kt
@@ -60,7 +60,6 @@ class UnreachableCatchBlock(config: Config = Config.empty) : Rule(config) {
     @Suppress("ReturnCount")
     override fun visitCatchSection(catchClause: KtCatchClause) {
         super.visitCatchSection(catchClause)
-        if (bindingContext == BindingContext.EMPTY) return
 
         val tryExpression = catchClause.getStrictParentOfType<KtTryExpression>() ?: return
         val prevCatchClauses = tryExpression.catchClauses.takeWhile { it != catchClause }

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnreachableCode.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnreachableCode.kt
@@ -11,7 +11,6 @@ import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
 import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import org.jetbrains.kotlin.diagnostics.Errors
 import org.jetbrains.kotlin.psi.KtExpression
-import org.jetbrains.kotlin.resolve.BindingContext
 
 /**
  * Reports unreachable code.
@@ -46,9 +45,7 @@ class UnreachableCode(config: Config = Config.empty) : Rule(config) {
 
     override fun visitExpression(expression: KtExpression) {
         super.visitExpression(expression)
-        if (bindingContext != BindingContext.EMPTY &&
-            bindingContext.diagnostics.forElement(expression).any { it.factory == Errors.UNREACHABLE_CODE }
-        ) {
+        if (bindingContext.diagnostics.forElement(expression).any { it.factory == Errors.UNREACHABLE_CODE }) {
             report(
                 CodeSmell(
                     issue,

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCallOnNullableType.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCallOnNullableType.kt
@@ -11,7 +11,6 @@ import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
 import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtPostfixExpression
-import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.calls.util.getType
 import org.jetbrains.kotlin.types.typeUtil.TypeNullability
 import org.jetbrains.kotlin.types.typeUtil.nullability
@@ -46,7 +45,6 @@ class UnsafeCallOnNullableType(config: Config = Config.empty) : Rule(config) {
 
     override fun visitPostfixExpression(expression: KtPostfixExpression) {
         super.visitPostfixExpression(expression)
-        if (bindingContext == BindingContext.EMPTY) return
         if (expression.operationToken == KtTokens.EXCLEXCL &&
             expression.baseExpression?.getType(bindingContext)?.nullability() == TypeNullability.NULLABLE
         ) {

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCast.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCast.kt
@@ -11,7 +11,6 @@ import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
 import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import org.jetbrains.kotlin.diagnostics.Errors
 import org.jetbrains.kotlin.psi.KtBinaryExpressionWithTypeRHS
-import org.jetbrains.kotlin.resolve.BindingContext
 
 /**
  * Reports casts that will never succeed.
@@ -46,8 +45,6 @@ class UnsafeCast(config: Config = Config.empty) : Rule(config) {
     )
 
     override fun visitBinaryWithTypeRHSExpression(expression: KtBinaryExpressionWithTypeRHS) {
-        if (bindingContext == BindingContext.EMPTY) return
-
         if (bindingContext.diagnostics.forElement(expression.operationReference)
             .any { it.factory == Errors.CAST_NEVER_SUCCEEDS }
         ) {

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnusedUnaryOperator.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnusedUnaryOperator.kt
@@ -19,7 +19,6 @@ import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.psi.KtPrefixExpression
 import org.jetbrains.kotlin.psi.psiUtil.leaves
 import org.jetbrains.kotlin.psi.psiUtil.parents
-import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.bindingContextUtil.isUsedAsExpression
 import org.jetbrains.kotlin.resolve.calls.util.getResolvedCall
 
@@ -51,7 +50,6 @@ class UnusedUnaryOperator(config: Config = Config.empty) : Rule(config) {
     @Suppress("ReturnCount")
     override fun visitPrefixExpression(expression: KtPrefixExpression) {
         super.visitPrefixExpression(expression)
-        if (bindingContext == BindingContext.EMPTY) return
 
         if (expression.baseExpression == null) return
         val operationToken = expression.operationToken

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ObjectExtendsThrowable.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ObjectExtendsThrowable.kt
@@ -55,7 +55,6 @@ class ObjectExtendsThrowable(config: Config = Config.empty) : Rule(config) {
 
     override fun visitObjectDeclaration(declaration: KtObjectDeclaration) {
         super.visitObjectDeclaration(declaration)
-        if (bindingContext == BindingContext.EMPTY) return
         if (!declaration.isObjectLiteral() && declaration.isSubtypeOfThrowable()) {
             report(
                 CodeSmell(

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ReturnFromFinally.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ReturnFromFinally.kt
@@ -18,7 +18,6 @@ import org.jetbrains.kotlin.psi.KtTryExpression
 import org.jetbrains.kotlin.psi.psiUtil.blockExpressionsOrSingle
 import org.jetbrains.kotlin.psi.psiUtil.collectDescendantsOfType
 import org.jetbrains.kotlin.psi.psiUtil.isInsideOf
-import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.bindingContextUtil.getTargetFunction
 import org.jetbrains.kotlin.resolve.bindingContextUtil.isUsedAsExpression
 import org.jetbrains.kotlin.resolve.calls.util.getType
@@ -57,7 +56,6 @@ class ReturnFromFinally(config: Config = Config.empty) : Rule(config) {
 
     override fun visitTryExpression(expression: KtTryExpression) {
         super.visitTryExpression(expression)
-        if (bindingContext == BindingContext.EMPTY) return
 
         val finallyBlock = expression.finallyBlock ?: return
 

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/BooleanPropertyNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/BooleanPropertyNaming.kt
@@ -17,7 +17,6 @@ import io.gitlab.arturbosch.detekt.rules.isOverride
 import org.jetbrains.kotlin.psi.KtCallableDeclaration
 import org.jetbrains.kotlin.psi.KtParameter
 import org.jetbrains.kotlin.psi.KtProperty
-import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.typeBinding.createTypeBindingForReturnType
 
 /**
@@ -62,10 +61,6 @@ class BooleanPropertyNaming(config: Config = Config.empty) : Rule(config) {
     }
 
     private fun validateDeclaration(declaration: KtCallableDeclaration) {
-        if (bindingContext == BindingContext.EMPTY) {
-            return
-        }
-
         val name = declaration.identifierName()
         val typeName = getTypeName(declaration)
         val isBooleanType =

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NoNameShadowing.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NoNameShadowing.kt
@@ -18,7 +18,6 @@ import org.jetbrains.kotlin.psi.KtNamedDeclaration
 import org.jetbrains.kotlin.psi.KtParameter
 import org.jetbrains.kotlin.psi.KtProperty
 import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
-import org.jetbrains.kotlin.resolve.BindingContext
 
 /**
  * Disallows shadowing variable declarations.
@@ -76,16 +75,13 @@ class NoNameShadowing(config: Config = Config.empty) : Rule(config) {
 
     private fun checkNameShadowing(declaration: KtNamedDeclaration) {
         val nameIdentifier = declaration.nameIdentifier ?: return
-        if (bindingContext != BindingContext.EMPTY &&
-            bindingContext.diagnostics.forElement(declaration).any { it.factory == Errors.NAME_SHADOWING }
-        ) {
+        if (bindingContext.diagnostics.forElement(declaration).any { it.factory == Errors.NAME_SHADOWING }) {
             report(CodeSmell(issue, Entity.from(nameIdentifier), "Name shadowed: ${nameIdentifier.text}"))
         }
     }
 
     override fun visitLambdaExpression(lambdaExpression: KtLambdaExpression) {
         super.visitLambdaExpression(lambdaExpression)
-        if (bindingContext == BindingContext.EMPTY) return
         val implicitParameter = lambdaExpression.implicitParameter(bindingContext) ?: return
         if (lambdaExpression.hasImplicitParameterReference(implicitParameter, bindingContext) &&
             lambdaExpression.hasParentImplicitParameterLambda()

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NonBooleanPropertyPrefixedWithIs.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NonBooleanPropertyPrefixedWithIs.kt
@@ -14,7 +14,6 @@ import org.jetbrains.kotlin.builtins.isFunctionOrKFunctionTypeWithAnySuspendabil
 import org.jetbrains.kotlin.psi.KtCallableDeclaration
 import org.jetbrains.kotlin.psi.KtParameter
 import org.jetbrains.kotlin.psi.KtProperty
-import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.typeBinding.createTypeBindingForReturnType
 import org.jetbrains.kotlin.types.KotlinType
 import org.jetbrains.kotlin.types.typeUtil.isBoolean
@@ -59,10 +58,6 @@ class NonBooleanPropertyPrefixedWithIs(config: Config = Config.empty) : Rule(con
     }
 
     private fun validateDeclaration(declaration: KtCallableDeclaration) {
-        if (bindingContext == BindingContext.EMPTY) {
-            return
-        }
-
         val name = declaration.identifierName()
 
         if (name.startsWith("is") && name.length > 2 && !name[2].isLowerCase()) {

--- a/detekt-rules-performance/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/ArrayPrimitive.kt
+++ b/detekt-rules-performance/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/ArrayPrimitive.kt
@@ -15,11 +15,9 @@ import org.jetbrains.kotlin.descriptors.CallableDescriptor
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtCallableDeclaration
-import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtNamedDeclaration
 import org.jetbrains.kotlin.psi.KtTypeReference
 import org.jetbrains.kotlin.psi.psiUtil.collectDescendantsOfType
-import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.calls.util.getResolvedCall
 import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameOrNull
 
@@ -51,11 +49,6 @@ class ArrayPrimitive(config: Config = Config.empty) : Rule(config) {
         "Using `Array<Primitive>` leads to implicit boxing and a performance hit.",
         Debt.FIVE_MINS
     )
-
-    override fun visitKtFile(file: KtFile) {
-        if (bindingContext == BindingContext.EMPTY) return
-        super.visitKtFile(file)
-    }
 
     override fun visitCallExpression(expression: KtCallExpression) {
         super.visitCallExpression(expression)

--- a/detekt-rules-performance/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/CouldBeSequence.kt
+++ b/detekt-rules-performance/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/CouldBeSequence.kt
@@ -15,7 +15,6 @@ import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.psi.psiUtil.getQualifiedExpressionForReceiver
 import org.jetbrains.kotlin.psi.psiUtil.getQualifiedExpressionForSelectorOrThis
-import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.calls.util.getResolvedCall
 import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameOrNull
 
@@ -50,8 +49,6 @@ class CouldBeSequence(config: Config = Config.empty) : Rule(config) {
     @Suppress("ReturnCount")
     override fun visitCallExpression(expression: KtCallExpression) {
         super.visitCallExpression(expression)
-
-        if (bindingContext == BindingContext.EMPTY) return
 
         if (visitedCallExpressions.contains(expression)) return
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitCollectionElementAccessMethod.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitCollectionElementAccessMethod.kt
@@ -16,7 +16,6 @@ import org.jetbrains.kotlin.psi.KtBlockExpression
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
 import org.jetbrains.kotlin.psi.psiUtil.getQualifiedExpressionForSelector
-import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.calls.util.getResolvedCall
 import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
 import org.jetbrains.kotlin.types.error.ErrorType
@@ -52,7 +51,6 @@ class ExplicitCollectionElementAccessMethod(config: Config = Config.empty) : Rul
 
     override fun visitDotQualifiedExpression(expression: KtDotQualifiedExpression) {
         super.visitDotQualifiedExpression(expression)
-        if (bindingContext == BindingContext.EMPTY) return
         val call = expression.selectorExpression as? KtCallExpression ?: return
         if (isIndexGetterRecommended(call) || isIndexSetterRecommended(call)) {
             report(CodeSmell(issue, Entity.from(expression), issue.description))

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCall.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCall.kt
@@ -25,7 +25,6 @@ import org.jetbrains.kotlin.psi.KtPrefixExpression
 import org.jetbrains.kotlin.psi.psiUtil.isDotSelector
 import org.jetbrains.kotlin.psi2ir.unwrappedGetMethod
 import org.jetbrains.kotlin.psi2ir.unwrappedSetMethod
-import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.calls.util.getCalleeExpressionIfAny
 import org.jetbrains.kotlin.resolve.calls.util.getResolvedCall
 
@@ -106,8 +105,6 @@ class ForbiddenMethodCall(config: Config = Config.empty) : Rule(config) {
     }
 
     private fun check(expression: KtExpression) {
-        if (bindingContext == BindingContext.EMPTY) return
-
         val descriptors = expression.getResolvedCall(bindingContext)?.resultingDescriptor?.let {
             val foundDescriptors = if (it is PropertyDescriptor) {
                 listOfNotNull(it.unwrappedGetMethod, it.unwrappedSetMethod)

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenVoid.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenVoid.kt
@@ -20,7 +20,6 @@ import org.jetbrains.kotlin.psi.KtTypeArgumentList
 import org.jetbrains.kotlin.psi.KtTypeReference
 import org.jetbrains.kotlin.psi.psiUtil.anyDescendantOfType
 import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
-import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.bindingContextUtil.getAbbreviatedTypeOrType
 
 /**
@@ -57,7 +56,6 @@ class ForbiddenVoid(config: Config = Config.empty) : Rule(config) {
 
     @Suppress("ReturnCount")
     override fun visitTypeReference(typeReference: KtTypeReference) {
-        if (bindingContext == BindingContext.EMPTY) return
         val kotlinType = typeReference.getAbbreviatedTypeOrType(bindingContext) ?: return
 
         if (kotlinType.fqNameOrNull() == VOID_FQ_NAME) {

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/LibraryCodeMustSpecifyReturnType.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/LibraryCodeMustSpecifyReturnType.kt
@@ -54,9 +54,6 @@ class LibraryCodeMustSpecifyReturnType(config: Config = Config.empty) : Rule(con
     )
 
     override fun visitProperty(property: KtProperty) {
-        if (bindingContext == BindingContext.EMPTY) {
-            return
-        }
         if (property.explicitReturnTypeRequired()) {
             report(
                 CodeSmell(

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxChainedCallsOnSameLine.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxChainedCallsOnSameLine.kt
@@ -47,8 +47,6 @@ class MaxChainedCallsOnSameLine(config: Config = Config.empty) : Rule(config) {
     override fun visitQualifiedExpression(expression: KtQualifiedExpression) {
         super.visitQualifiedExpression(expression)
 
-        if (bindingContext == BindingContext.EMPTY) return
-
         val parent = expression.parent
 
         // skip if the parent is also a call on the same line to avoid duplicated warnings

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MultilineLambdaItParameter.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MultilineLambdaItParameter.kt
@@ -12,7 +12,6 @@ import io.gitlab.arturbosch.detekt.rules.IT_LITERAL
 import io.gitlab.arturbosch.detekt.rules.hasImplicitParameterReference
 import io.gitlab.arturbosch.detekt.rules.implicitParameter
 import org.jetbrains.kotlin.psi.KtLambdaExpression
-import org.jetbrains.kotlin.resolve.BindingContext
 
 /**
  * Lambda expressions are very useful in a lot of cases, and they often include very small chunks of
@@ -75,7 +74,6 @@ class MultilineLambdaItParameter(val config: Config) : Rule(config) {
 
     override fun visitLambdaExpression(lambdaExpression: KtLambdaExpression) {
         super.visitLambdaExpression(lambdaExpression)
-        if (bindingContext == BindingContext.EMPTY) return
         val size = lambdaExpression.bodyExpression?.statements?.size
         if (size == null || size <= 1) return
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ObjectLiteralToLambda.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ObjectLiteralToLambda.kt
@@ -96,7 +96,6 @@ class ObjectLiteralToLambda(config: Config = Config.empty) : Rule(config) {
 
     override fun visitObjectLiteralExpression(expression: KtObjectLiteralExpression) {
         super.visitObjectLiteralExpression(expression)
-        if (bindingContext == BindingContext.EMPTY) return
         val declaration = expression.objectDeclaration
 
         if (

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantExplicitType.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantExplicitType.kt
@@ -56,7 +56,6 @@ class RedundantExplicitType(config: Config) : Rule(config) {
 
     @Suppress("ReturnCount", "ComplexMethod")
     override fun visitProperty(property: KtProperty) {
-        if (bindingContext == BindingContext.EMPTY) return
         if (!property.isLocal) return
         val typeReference = property.typeReference ?: return
         val type =

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantHigherOrderMapUsage.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantHigherOrderMapUsage.kt
@@ -86,7 +86,6 @@ class RedundantHigherOrderMapUsage(config: Config = Config.empty) : Rule(config)
 
     override fun visitCallExpression(expression: KtCallExpression) {
         super.visitCallExpression(expression)
-        if (bindingContext == BindingContext.EMPTY) return
 
         val calleeExpression = expression.calleeExpression
         if (calleeExpression?.text != "map") return

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryApply.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryApply.kt
@@ -56,8 +56,6 @@ class UnnecessaryApply(config: Config) : Rule(config) {
     override fun visitCallExpression(expression: KtCallExpression) {
         super.visitCallExpression(expression)
 
-        if (bindingContext == BindingContext.EMPTY) return
-
         if (expression.isApplyExpr() &&
             expression.hasOnlyOneMemberAccessStatement() &&
             !expression.receiverIsUsed(bindingContext)

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryFilter.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryFilter.kt
@@ -16,7 +16,6 @@ import org.jetbrains.kotlin.psi.KtLambdaExpression
 import org.jetbrains.kotlin.psi.psiUtil.getQualifiedExpressionForReceiver
 import org.jetbrains.kotlin.psi.psiUtil.getQualifiedExpressionForSelectorOrThis
 import org.jetbrains.kotlin.psi.unpackFunctionLiteral
-import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.calls.util.getResolvedCall
 import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameOrNull
 
@@ -57,7 +56,6 @@ class UnnecessaryFilter(config: Config = Config.empty) : Rule(config) {
     @Suppress("ReturnCount")
     override fun visitCallExpression(expression: KtCallExpression) {
         super.visitCallExpression(expression)
-        if (bindingContext == BindingContext.EMPTY) return
 
         if (!expression.isCalling(filterFqNames)) return
         val lambdaArgumentText = expression.lambda()?.text ?: return

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryInnerClass.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryInnerClass.kt
@@ -13,7 +13,6 @@ import org.jetbrains.kotlin.backend.common.pop
 import org.jetbrains.kotlin.descriptors.ClassifierDescriptor
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.psi.KtClass
-import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtReferenceExpression
 import org.jetbrains.kotlin.psi.KtThisExpression
 import org.jetbrains.kotlin.psi.psiUtil.containingClass
@@ -53,11 +52,6 @@ class UnnecessaryInnerClass(config: Config = Config.empty) : Rule(config) {
         "The 'inner' qualifier is unnecessary.",
         Debt.FIVE_MINS
     )
-
-    override fun visit(root: KtFile) {
-        if (bindingContext == BindingContext.EMPTY) return
-        super.visit(root)
-    }
 
     override fun visitClass(klass: KtClass) {
         classChain.add(klass)

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLet.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLet.kt
@@ -59,8 +59,6 @@ class UnnecessaryLet(config: Config) : Rule(config) {
     override fun visitCallExpression(expression: KtCallExpression) {
         super.visitCallExpression(expression)
 
-        if (bindingContext == BindingContext.EMPTY) return
-
         if (!expression.isLetExpr()) return
 
         val lambdaExpr = expression.firstLambdaArg

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseAnyOrNoneInsteadOfFind.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseAnyOrNoneInsteadOfFind.kt
@@ -17,7 +17,6 @@ import org.jetbrains.kotlin.psi.KtBinaryExpression
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtQualifiedExpression
 import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
-import org.jetbrains.kotlin.resolve.BindingContext
 
 /**
  * Turn on this rule to flag `find` calls for null check that can be replaced with a `any` or `none` call.
@@ -45,7 +44,6 @@ class UseAnyOrNoneInsteadOfFind(config: Config = Config.empty) : Rule(config) {
     @Suppress("ReturnCount")
     override fun visitCallExpression(expression: KtCallExpression) {
         super.visitCallExpression(expression)
-        if (bindingContext == BindingContext.EMPTY) return
 
         val functionName = expression.calleeExpression?.text ?: return
         val qualifiedOrThis = expression.getStrictParentOfType<KtQualifiedExpression>() ?: expression

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseCheckNotNull.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseCheckNotNull.kt
@@ -12,7 +12,6 @@ import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.rules.isCallingWithNonNullCheckArgument
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.psi.KtCallExpression
-import org.jetbrains.kotlin.resolve.BindingContext
 
 /**
  * Turn on this rule to flag `check` calls for not-null check that can be replaced with a `checkNotNull` call.
@@ -37,7 +36,6 @@ class UseCheckNotNull(config: Config = Config.empty) : Rule(config) {
 
     override fun visitCallExpression(expression: KtCallExpression) {
         super.visitCallExpression(expression)
-        if (bindingContext == BindingContext.EMPTY) return
         if (expression.isCallingWithNonNullCheckArgument(checkFunctionFqName, bindingContext)) {
             report(CodeSmell(issue, Entity.from(expression), issue.description))
         }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIfEmptyOrIfBlank.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIfEmptyOrIfBlank.kt
@@ -20,7 +20,6 @@ import org.jetbrains.kotlin.psi.KtPrefixExpression
 import org.jetbrains.kotlin.psi.KtThisExpression
 import org.jetbrains.kotlin.psi.psiUtil.blockExpressionsOrSingle
 import org.jetbrains.kotlin.psi.psiUtil.getPossiblyQualifiedCallExpression
-import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.calls.util.getResolvedCall
 import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameOrNull
 
@@ -59,7 +58,6 @@ class UseIfEmptyOrIfBlank(config: Config = Config.empty) : Rule(config) {
 
     override fun visitIfExpression(expression: KtIfExpression) {
         super.visitIfExpression(expression)
-        if (bindingContext == BindingContext.EMPTY) return
 
         if (expression.isElseIf()) return
         val thenExpression = expression.then ?: return

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIsNullOrEmpty.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIsNullOrEmpty.kt
@@ -19,7 +19,6 @@ import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
 import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.psi.KtSimpleNameExpression
-import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.calls.util.getResolvedCall
 import org.jetbrains.kotlin.resolve.calls.util.getType
 import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameOrNull
@@ -59,7 +58,6 @@ class UseIsNullOrEmpty(config: Config = Config.empty) : Rule(config) {
     @Suppress("ReturnCount")
     override fun visitBinaryExpression(expression: KtBinaryExpression) {
         super.visitBinaryExpression(expression)
-        if (bindingContext == BindingContext.EMPTY) return
 
         if (expression.operationToken != KtTokens.OROR) return
         val left = expression.left as? KtBinaryExpression ?: return

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseOrEmpty.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseOrEmpty.kt
@@ -18,7 +18,6 @@ import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.psi.KtStringTemplateExpression
 import org.jetbrains.kotlin.psi2ir.deparenthesize
-import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.calls.util.getResolvedCall
 import org.jetbrains.kotlin.resolve.calls.util.getType
 import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameOrNull
@@ -57,7 +56,6 @@ class UseOrEmpty(config: Config = Config.empty) : Rule(config) {
     @Suppress("ReturnCount")
     override fun visitBinaryExpression(expression: KtBinaryExpression) {
         super.visitBinaryExpression(expression)
-        if (bindingContext == BindingContext.EMPTY) return
 
         if (expression.operationToken != KtTokens.ELVIS) return
         val left = expression.left ?: return

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseRequireNotNull.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseRequireNotNull.kt
@@ -12,7 +12,6 @@ import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.rules.isCallingWithNonNullCheckArgument
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.psi.KtCallExpression
-import org.jetbrains.kotlin.resolve.BindingContext
 
 /**
  * Turn on this rule to flag `require` calls for not-null check that can be replaced with a `requireNotNull` call.
@@ -37,7 +36,6 @@ class UseRequireNotNull(config: Config = Config.empty) : Rule(config) {
 
     override fun visitCallExpression(expression: KtCallExpression) {
         super.visitCallExpression(expression)
-        if (bindingContext == BindingContext.EMPTY) return
         if (expression.isCallingWithNonNullCheckArgument(requireFunctionFqName, bindingContext)) {
             report(CodeSmell(issue, Entity.from(expression), issue.description))
         }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UselessCallOnNotNull.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UselessCallOnNotNull.kt
@@ -14,7 +14,6 @@ import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtQualifiedExpression
 import org.jetbrains.kotlin.psi.KtSafeQualifiedExpression
 import org.jetbrains.kotlin.psi.ValueArgument
-import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.calls.util.getResolvedCall
 import org.jetbrains.kotlin.resolve.calls.util.getType
 import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameOrNull
@@ -61,7 +60,6 @@ class UselessCallOnNotNull(config: Config = Config.empty) : Rule(config) {
     @Suppress("ReturnCount")
     override fun visitQualifiedExpression(expression: KtQualifiedExpression) {
         super.visitQualifiedExpression(expression)
-        if (bindingContext == BindingContext.EMPTY) return
 
         val safeExpression = expression as? KtSafeQualifiedExpression
         val notNullType = expression.receiverExpression.getType(bindingContext)?.isNullable() == false

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/VarCouldBeVal.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/VarCouldBeVal.kt
@@ -76,7 +76,6 @@ class VarCouldBeVal(config: Config = Config.empty) : Rule(config) {
 
     override fun visitKtFile(file: KtFile) {
         super.visitKtFile(file)
-        if (bindingContext == BindingContext.EMPTY) return
         val assignmentVisitor = AssignmentVisitor(bindingContext, ignoreLateinitVar)
         file.accept(assignmentVisitor)
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/PreferToOverPairSyntax.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/PreferToOverPairSyntax.kt
@@ -12,7 +12,6 @@ import io.gitlab.arturbosch.detekt.rules.safeAs
 import org.jetbrains.kotlin.descriptors.ClassConstructorDescriptor
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.psi.KtCallExpression
-import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.calls.util.getResolvedCall
 import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameOrNull
 
@@ -42,7 +41,6 @@ class PreferToOverPairSyntax(config: Config = Config.empty) : Rule(config) {
     override fun visitCallExpression(expression: KtCallExpression) {
         super.visitCallExpression(expression)
 
-        if (bindingContext == BindingContext.EMPTY) return
         if (expression.isPairConstructor()) {
             val arg = expression.valueArguments.joinToString(" to ") { it.text }
             report(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,7 @@ kotlin-gradlePluginApi = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin-a
 kotlin-scriptUtil = { module = "org.jetbrains.kotlin:kotlin-script-util", version.ref = "kotlin" }
 kotlin-scriptingCompilerEmbeddable = { module = "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable", version.ref = "kotlin" }
 kotlin-stdlibJdk8 = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlin" }
+kotlin-reflection = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
 
 kotlinx-html = "org.jetbrains.kotlinx:kotlinx-html-jvm:0.8.0"
 kotlinx-coroutines = "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4"
@@ -26,7 +27,7 @@ android-gradle = "com.android.tools.build:gradle:7.2.2"
 ktlint-core = { module = "com.pinterest.ktlint:ktlint-core", version.ref = "ktlint" }
 ktlint-rulesetStandard = { module = "com.pinterest.ktlint:ktlint-ruleset-standard", version.ref = "ktlint" }
 ktlint-rulesetExperimental = { module = "com.pinterest.ktlint:ktlint-ruleset-experimental", version.ref = "ktlint" }
-slf4j-nop = { module = "org.slf4j:slf4j-nop", version = "1.7.36"  }
+slf4j-nop = { module = "org.slf4j:slf4j-nop", version = "1.7.36" }
 
 spek-dsl = { module = "org.spekframework.spek2:spek-dsl-jvm", version = "2.0.19" }
 

--- a/website/docs/gettingstarted/type-resolution.md
+++ b/website/docs/gettingstarted/type-resolution.md
@@ -100,19 +100,9 @@ Rules that are using type resolution, access the [bindingContext](https://github
 
 By default, the `bindingContext` is initialized as `BindingContext.EMPTY`. This is the **default value** that the rule receives if type resolution is **not enabled**.
 
-Therefore, is generally advised to wrap your rules with a check for an empty binding context ([source](https://github.com/detekt/detekt/blob/cd659ce8737fb177caf140f46f73a1a86b22be56/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseCheckNotNull.kt#L37-L39)):
+Therefore, is generally advised to annotate your `Rule` with `@RequiresTypeResolution` to ensure that your rule doesn't run if you don't have a proper `BindingContext`.
 
-```kotlin
-    override fun visitCallExpression(expression: KtCallExpression) {
-        super.visitCallExpression(expression)
-    
-        if (bindingContext == BindingContext.EMPTY) return
-    
-        // Rest of the rule that will run only with type resolution enabled.
-    }
-```
-
-If the `bindingContext` is not `EMPTY`, you are free to use it to resolve types and get access to all the information needed for your rules. As a rule of thumb, we recommend to get inspiration from other rules on how they're using the `bindingContext`.
+If your rule is annotated with `@RequiresTypeResolution` you are free to use it to resolve types and get access to all the information needed for your rules. As a rule of thumb, we recommend to get inspiration from other rules on how they're using the `bindingContext`.
 
 ## Testing a rule that uses type resolution
 


### PR DESCRIPTION
This is an alternative for #5130. To be more precise this was proposed by @marschwar here: https://github.com/detekt/detekt/pull/5130#issuecomment-1197932497

I implemented this in `:detekt-core` because I think it should be the one that decides if a rule should or should not be runned. But to be more consistent with the current code we could move this check to the `Rule` inside `:detekt-api`. What do you think?

---

~This PR isn't finish yet. I need to remove all the `if (bindingContext == BindingContext.EMPTY) return` that we have in our code now but I want feedback to know if this is what we want.~