### PR TITLE
Ratelimit Codecov for Labeller & Danger

### DIFF
--- a/.github/workflows/danger.yaml
+++ b/.github/workflows/danger.yaml
@@ -17,6 +17,7 @@ permissions:
 
 jobs:
   danger:
+    if: ${{ github.event.sender != 'codecov' }}
     name: Danger JS
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -4,6 +4,7 @@ on:
 
 jobs:
   label-pr:
+    if: ${{ github.event.sender != 'codecov' }}
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
Should solve the issue linked in:
https://github.com/detekt/detekt/pull/5193#issuecomment-1207293593

As those two workflows are on `pull_request_target`, we won't see in action in this PR. Hopefully once we rebase #5193 on top of the merge after this PR, this should solve the issue (it's a best guess fix though, I'm not sure it works 100% - API ref is here https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads).