### PR TITLE
Fix errors with `detektGenerateConfig`

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektGenerateConfigTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektGenerateConfigTask.kt
@@ -9,6 +9,8 @@ import io.gitlab.arturbosch.detekt.invoke.GenerateConfigArgument
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.provider.Provider
+import org.gradle.api.services.BuildService
+import org.gradle.api.services.BuildServiceParameters
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.InputFiles
@@ -72,4 +74,7 @@ abstract class DetektGenerateConfigTask : DefaultTask() {
             taskName = name,
         )
     }
+
+    @Suppress("UnnecessaryAbstractClass")
+    abstract class SingleExecutionBuildService : BuildService<BuildServiceParameters.None>
 }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektGenerateConfigTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektGenerateConfigTask.kt
@@ -8,7 +8,6 @@ import io.gitlab.arturbosch.detekt.invoke.DetektInvoker
 import io.gitlab.arturbosch.detekt.invoke.GenerateConfigArgument
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.ConfigurableFileCollection
-import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Classpath
@@ -21,12 +20,9 @@ import org.gradle.api.tasks.TaskAction
 import org.gradle.language.base.plugins.LifecycleBasePlugin
 import java.io.File
 import java.nio.file.Files
-import javax.inject.Inject
 
 @CacheableTask
-abstract class DetektGenerateConfigTask @Inject constructor(
-    private val objects: ObjectFactory
-) : DefaultTask() {
+abstract class DetektGenerateConfigTask : DefaultTask() {
 
     init {
         description = "Generate a detekt configuration file inside your project."
@@ -48,10 +44,10 @@ abstract class DetektGenerateConfigTask @Inject constructor(
 
     private val configurationToUse: File
         get() = if (config.isEmpty) {
-            objects.fileCollection().from(defaultConfigPath)
+            defaultConfigPath.toFile()
         } else {
-            config
-        }.last()
+            config.last()
+        }
 
     @get:Internal
     internal val arguments: Provider<List<String>> = project.provider {

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
@@ -60,8 +60,16 @@ class DetektPlugin : Plugin<Project> {
     }
 
     private fun Project.registerGenerateConfigTask(extension: DetektExtension) {
+        val detektGenerateConfigSingleExecution = project.gradle.sharedServices.registerIfAbsent(
+            "DetektGenerateConfigSingleExecution",
+            DetektGenerateConfigTask.SingleExecutionBuildService::class.java
+        ) { spec ->
+            spec.maxParallelUsages.set(1)
+        }
+
         tasks.register(GENERATE_CONFIG, DetektGenerateConfigTask::class.java) {
             it.config.setFrom(project.provider { extension.config })
+            it.usesService(detektGenerateConfigSingleExecution)
         }
     }
 


### PR DESCRIPTION
I recomment to read #4843 to understand all the context for this solution.

TL;DR `detektGenerateConfig` runs in a race condition and tries to create the same file multiple times and crashes. With this solution we ansure that this task is always run in serial to avoid it.

This PR also have 2 commits with little refactors over `DetektGenerateConfigTask`. I didn't want to fall into the rabbit hole so I didn't refactor anymore. But if someone wants: It seems that we are doing more work than needed here. The providers and properties are executed multiple times without, I think, a good reason.

Fixes #4843