### PR TITLE
Add `UnnecessaryNotNullCheck` rule

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -470,9 +470,9 @@ potential-bugs:
     active: true
   UnconditionalJumpStatementInLoop:
     active: false
-  UnnecessaryNotNullOperator:
-    active: true
   UnnecessaryNotNullCheck:
+    active: false
+  UnnecessaryNotNullOperator:
     active: true
   UnnecessarySafeCall:
     active: true

--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -472,6 +472,8 @@ potential-bugs:
     active: false
   UnnecessaryNotNullOperator:
     active: true
+  UnnecessaryNotNullCheck:
+    active: true
   UnnecessarySafeCall:
     active: true
   UnreachableCatchBlock:

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/PotentialBugProvider.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/PotentialBugProvider.kt
@@ -39,6 +39,7 @@ class PotentialBugProvider : DefaultRuleSetProvider {
             RedundantElseInWhen(config),
             UnconditionalJumpStatementInLoop(config),
             UnnecessaryNotNullOperator(config),
+            UnnecessaryNotNullCheck(config),
             UnnecessarySafeCall(config),
             UnreachableCode(config),
             UnsafeCallOnNullableType(config),

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessaryNotNullCheck.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessaryNotNullCheck.kt
@@ -1,6 +1,7 @@
 package io.gitlab.arturbosch.detekt.rules.bugs
 
 import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
@@ -32,7 +33,7 @@ import org.jetbrains.kotlin.types.typeUtil.nullability
 class UnnecessaryNotNullCheck(config: Config = Config.empty) : Rule(config) {
 
     override val issue = Issue(
-        "UnnecessaryNotNullOperator",
+        "UnnecessaryNotNullCheck",
         Severity.Defect,
         "Unnecessary not-null check detected.",
         Debt.FIVE_MINS,

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessaryNotNullCheck.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessaryNotNullCheck.kt
@@ -1,0 +1,61 @@
+package io.gitlab.arturbosch.detekt.rules.bugs
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtExpression
+import org.jetbrains.kotlin.psi.psiUtil.getCallNameExpression
+import org.jetbrains.kotlin.resolve.BindingContext
+import org.jetbrains.kotlin.resolve.calls.util.getType
+import org.jetbrains.kotlin.types.typeUtil.TypeNullability
+import org.jetbrains.kotlin.types.typeUtil.nullability
+
+/**
+ * Reports unnecessary not-null checks with `requireNotNull` or `checkNotNull` that can be removed by the user.
+ *
+ * <noncompliant>
+ * var string = "foo"
+ * println(requireNotNull(string))
+ * </noncompliant>
+ *
+ * <compliant>
+ * var string : String? = "foo"
+ * println(requireNotNull(string))
+ * </compliant>
+ */
+@RequiresTypeResolution
+class UnnecessaryNotNullCheck(config: Config = Config.empty) : Rule(config) {
+
+    override val issue = Issue(
+        "UnnecessaryNotNullOperator",
+        Severity.Defect,
+        "Unnecessary not-null check detected.",
+        Debt.FIVE_MINS,
+    )
+
+    override fun visitCallExpression(expression: KtCallExpression) {
+        super.visitCallExpression(expression)
+
+        if (bindingContext == BindingContext.EMPTY) return
+
+        val callName = expression.getCallNameExpression()?.text
+        if (callName == "requireNotNull" || callName == "checkNotNull") {
+            val type = (expression.valueArguments[0].lastChild as KtExpression).getType(bindingContext)
+            if (type?.nullability() == TypeNullability.NOT_NULL) {
+                report(
+                    CodeSmell(
+                        issue = issue,
+                        entity = Entity.from(expression),
+                        message = "${expression.text} contains an unnecessary `$callName`",
+                    )
+                )
+            }
+        }
+    }
+
+}

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessaryNotNullCheck.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessaryNotNullCheck.kt
@@ -52,7 +52,7 @@ class UnnecessaryNotNullCheck(config: Config = Config.empty) : Rule(config) {
                     CodeSmell(
                         issue = issue,
                         entity = Entity.from(expression),
-                        message = "${expression.text} contains an unnecessary `$callName`",
+                        message = "`${expression.text}` contains an unnecessary `$callName`",
                     )
                 )
             }

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessaryNotNullCheck.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessaryNotNullCheck.kt
@@ -58,5 +58,4 @@ class UnnecessaryNotNullCheck(config: Config = Config.empty) : Rule(config) {
             }
         }
     }
-
 }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessaryNotNullCheckSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessaryNotNullCheckSpec.kt
@@ -62,7 +62,6 @@ class UnnecessaryNotNullCheckSpec(private val env: KotlinCoreEnvironment) {
             assertThat(findings).hasSize(1)
             assertThat(findings).hasTextLocations(16 to 58)
         }
-
     }
 
     @Nested
@@ -126,6 +125,5 @@ class UnnecessaryNotNullCheckSpec(private val env: KotlinCoreEnvironment) {
             val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
-
     }
 }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessaryNotNullCheckSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessaryNotNullCheckSpec.kt
@@ -1,0 +1,131 @@
+package io.gitlab.arturbosch.detekt.rules.bugs
+
+import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
+import io.gitlab.arturbosch.detekt.test.assertThat
+import io.gitlab.arturbosch.detekt.test.lintWithContext
+import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@KotlinCoreEnvironmentTest
+class UnnecessaryNotNullCheckSpec(private val env: KotlinCoreEnvironment) {
+    private val subject = UnnecessaryNotNullCheck()
+
+    @Nested
+    inner class `check unnecessary not null checks` {
+
+        @Test
+        fun shouldDetectNotNullCallOnVariable() {
+            val code = """
+                val x = 5
+                val y = requireNotNull(x)
+            """.trimIndent()
+            val findings = subject.lintWithContext(env, code)
+            assertThat(findings).hasSize(1)
+            assertThat(findings).hasTextLocations(18 to 35)
+        }
+
+        @Test
+        fun shouldDetectNotNullCallOnVariableUsingCheckNotNull() {
+            val code = """
+                val x = 5
+                val y = checkNotNull(x)
+            """.trimIndent()
+            val findings = subject.lintWithContext(env, code)
+            assertThat(findings).hasSize(1)
+            assertThat(findings).hasTextLocations(18 to 33)
+        }
+
+        @Test
+        fun shouldDetectNotNullCallOnFunctionReturn() {
+            val code = """
+                fun foo(): Int {
+                    return 5
+                }
+                fun bar() {
+                    requireNotNull(foo())
+                }
+            """.trimIndent()
+            val findings = subject.lintWithContext(env, code)
+            assertThat(findings).hasSize(1)
+            assertThat(findings).hasTextLocations(48 to 69)
+        }
+
+        @Test
+        fun shouldDetectWhenCallingPrimitiveJavaMethod() {
+            val code = """
+                fun foo() {
+                    requireNotNull(System.currentTimeMillis())
+                }
+            """.trimIndent()
+            val findings = subject.lintWithContext(env, code)
+            assertThat(findings).hasSize(1)
+            assertThat(findings).hasTextLocations(16 to 58)
+        }
+
+    }
+
+    @Nested
+    inner class `check valid not null check usage` {
+
+        @Test
+        fun shouldIgnoreNotNullCallOnNullableVariableWithValue() {
+            val code = """
+                val x: Int? = 5
+                val y = requireNotNull(x)
+            """.trimIndent()
+            val findings = subject.lintWithContext(env, code)
+            assertThat(findings).isEmpty()
+        }
+
+        @Test
+        fun shouldIgnoreNotNullCallOnNullableVariableWithNull() {
+            val code = """
+                val x: Int? = null
+                val y = requireNotNull(x)
+            """.trimIndent()
+            val findings = subject.lintWithContext(env, code)
+            assertThat(findings).isEmpty()
+        }
+
+        @Test
+        fun shouldIgnoreNotNullCallOnNullableFunctionReturnWithValue() {
+            val code = """
+                fun foo(): Int? {
+                    return 5
+                }
+                fun bar() {
+                    requireNotNull(foo())
+                }
+            """.trimIndent()
+            val findings = subject.lintWithContext(env, code)
+            assertThat(findings).isEmpty()
+        }
+
+        @Test
+        fun shouldIgnoreNotNullCallOnNullableFunctionReturnWithNull() {
+            val code = """
+                fun foo(): Int? {
+                    return null
+                }
+                fun bar() {
+                    requireNotNull(foo())
+                }
+            """.trimIndent()
+            val findings = subject.lintWithContext(env, code)
+            assertThat(findings).isEmpty()
+        }
+
+        @Test
+        fun shouldIgnoreWhenCallingObjectJavaMethod() {
+            val code = """
+                fun foo() {
+                    requireNotNull(System.getLogger())
+                }
+            """.trimIndent()
+            val findings = subject.lintWithContext(env, code)
+            assertThat(findings).isEmpty()
+        }
+
+    }
+}


### PR DESCRIPTION
This adds the `UnnecessaryNotNullCheck` rule as discussed in #5204. It detects usages of `requireNotNull` and `checkNotNull` on non-null values.