### PR TITLE
Update `UnnecessaryAbstractClass` issue description to be less verbose

### DIFF
--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAbstractClass.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAbstractClass.kt
@@ -54,9 +54,7 @@ class UnnecessaryAbstractClass(config: Config = Config.empty) : Rule(config) {
         Issue(
             "UnnecessaryAbstractClass",
             Severity.Style,
-            "An abstract class is unnecessary and can be refactored. " +
-                "An abstract class should have both abstract and concrete properties or functions. " +
-                noConcreteMember + " " + noAbstractMember,
+            "An abstract class is unnecessary. May be refactored to an interface or to a concrete class.",
             Debt.FIVE_MINS
         )
 


### PR DESCRIPTION
This PR closes https://github.com/detekt/detekt/issues/4750.

It updates the description of the `UnnecessaryAbstractClass` issue into something less verbose according to the project guidelines https://github.com/detekt/detekt/blob/main/.github/CONTRIBUTING.md#rule-descriptions

