### PR TITLE
Allow secondary constructors to reference CoroutineDispatchers

### DIFF
--- a/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/InjectDispatcher.kt
+++ b/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/InjectDispatcher.kt
@@ -13,6 +13,7 @@ import io.gitlab.arturbosch.detekt.api.internal.Configuration
 import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.rules.fqNameOrNull
 import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.psi.KtConstructorDelegationCall
 import org.jetbrains.kotlin.psi.KtParameter
 import org.jetbrains.kotlin.psi.KtSimpleNameExpression
 import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
@@ -60,7 +61,8 @@ class InjectDispatcher(config: Config) : Rule(config) {
         val type = expression.getType(bindingContext) ?: return
         val isCoroutineDispatcher = type.fqNameOrNull() == COROUTINE_DISPATCHER_FQCN ||
             type.supertypes().any { it.fqNameOrNull() == COROUTINE_DISPATCHER_FQCN }
-        val isUsedAsParameter = expression.getStrictParentOfType<KtParameter>() != null
+        val isUsedAsParameter = expression.getStrictParentOfType<KtParameter>() != null ||
+            expression.getStrictParentOfType<KtConstructorDelegationCall>() != null
         if (isCoroutineDispatcher && !isUsedAsParameter) {
             report(
                 CodeSmell(

--- a/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/InjectDispatcherSpec.kt
+++ b/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/InjectDispatcherSpec.kt
@@ -62,6 +62,19 @@ class InjectDispatcherSpec(val env: KotlinCoreEnvironment) {
         }
 
         @Test
+        fun `does not report when dispatcher is used as a secondary constructor parameter`() {
+            val code = """
+                import kotlinx.coroutines.CoroutineDispatcher
+                import kotlinx.coroutines.Dispatchers
+
+                class MyRepository(dispatcher: CoroutineDispatcher) {
+                    constructor() : this(Dispatchers.IO)
+                }
+            """
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        }
+
+        @Test
         fun `does not report when dispatcher is used as a property`() {
             val code = """
                 import kotlinx.coroutines.CoroutineDispatcher


### PR DESCRIPTION
Allow constructor delegation elements to refer to dispatchers
directly, similar to how default parameters are allowed to.

Fixes #5225