### PR TITLE
Switch custom Gradle data plugin coordinates to correct version identifier

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -42,7 +42,7 @@ enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 // build scan plugin can only be applied in settings file
 plugins {
     id("com.gradle.enterprise") version "3.11.1"
-    id("com.gradle.common-custom-user-data-gradle-plugin") version "1.8.0"
+    id("com.gradle.common-custom-user-data-gradle-plugin") version "1.8"
 }
 
 val isCiBuild = System.getenv("CI") != null


### PR DESCRIPTION
Something funky seems to have happened with the release versioning and this is having an impact on Vercel deployments in new PRs.

This change should hopefully address that.

https://plugins.gradle.org/plugin/com.gradle.common-custom-user-data-gradle-plugin