### PR TITLE
Introduce baseline tooling api

### DIFF
--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineFacade.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineFacade.kt
@@ -11,7 +11,7 @@ class BaselineFacade {
 
     fun transformResult(baselineFile: Path, result: Detektion): Detektion {
         return if (baselineExists(baselineFile)) {
-            BaselineFilteredResult(result, Baseline.load(baselineFile))
+            BaselineFilteredResult(result, DefaultBaseline.load(baselineFile))
         } else {
             result
         }
@@ -20,14 +20,15 @@ class BaselineFacade {
     fun createOrUpdate(baselineFile: Path, findings: List<Finding>) {
         val ids = findings.map { it.baselineId }.toSortedSet()
         val oldBaseline = if (baselineExists(baselineFile)) {
-            Baseline.load(baselineFile)
+            DefaultBaseline.load(baselineFile)
         } else {
-            Baseline(emptySet(), emptySet())
+            DefaultBaseline(emptySet(), emptySet())
         }
-        val baseline = oldBaseline.copy(currentIssues = ids)
+        val baselineFormat = BaselineFormat()
+        val baseline = baselineFormat.of(oldBaseline.manuallySuppressedIssues, ids)
         if (oldBaseline != baseline) {
             baselineFile.parent?.let { Files.createDirectories(it) }
-            BaselineFormat().write(baseline, baselineFile)
+            baselineFormat.write(baselineFile, baseline)
         }
     }
 

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineFilteredResult.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineFilteredResult.kt
@@ -1,12 +1,13 @@
 package io.gitlab.arturbosch.detekt.core.baseline
 
+import io.github.detekt.tooling.api.Baseline
 import io.gitlab.arturbosch.detekt.api.Detektion
 import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.api.RuleSetId
 
 internal class BaselineFilteredResult(
     result: Detektion,
-    private val baseline: Baseline
+    private val baseline: Baseline,
 ) : Detektion by result {
 
     override val findings: Map<RuleSetId, List<Finding>> = result.findings

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineHandler.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineHandler.kt
@@ -11,7 +11,7 @@ internal class BaselineHandler : DefaultHandler() {
     private val currentIssues = mutableSetOf<String>()
     private val manuallySuppressedIssues = mutableSetOf<String>()
 
-    internal fun createBaseline() = Baseline(manuallySuppressedIssues, currentIssues)
+    internal fun createBaseline() = DefaultBaseline(manuallySuppressedIssues, currentIssues)
 
     override fun startElement(uri: String, localName: String, qName: String, attributes: Attributes) {
         when (qName) {

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/DefaultBaseline.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/DefaultBaseline.kt
@@ -1,19 +1,19 @@
 package io.gitlab.arturbosch.detekt.core.baseline
 
+import io.github.detekt.tooling.api.Baseline
+import io.github.detekt.tooling.api.FindingId
+import io.github.detekt.tooling.api.FindingsIdList
 import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.core.exists
 import io.gitlab.arturbosch.detekt.core.isFile
 import java.nio.file.Path
 
-internal typealias FindingsIdList = Set<String>
-internal typealias FindingId = String
+internal data class DefaultBaseline(
+    override val manuallySuppressedIssues: FindingsIdList,
+    override val currentIssues: FindingsIdList,
+) : Baseline {
 
-internal data class Baseline(
-    val manuallySuppressedIssues: FindingsIdList,
-    val currentIssues: FindingsIdList
-) {
-
-    fun contains(id: FindingId): Boolean =
+    override fun contains(id: FindingId): Boolean =
         currentIssues.contains(id) || manuallySuppressedIssues.contains(id)
 
     companion object {

--- a/detekt-core/src/main/resources/META-INF/services/io.github.detekt.tooling.api.BaselineProvider
+++ b/detekt-core/src/main/resources/META-INF/services/io.github.detekt.tooling.api.BaselineProvider
@@ -1,0 +1,1 @@
+io.gitlab.arturbosch.detekt.core.baseline.BaselineFormat

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineFilteredResultSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineFilteredResultSpec.kt
@@ -28,13 +28,13 @@ class BaselineFilteredResultSpec {
 
     @Test
     fun `does return the same finding on empty baseline`() {
-        val actual = BaselineFilteredResult(result, Baseline(emptySet(), emptySet()))
+        val actual = BaselineFilteredResult(result, DefaultBaseline(emptySet(), emptySet()))
         assertThat(actual.findings).hasSize(3)
     }
 
     @Test
     fun `filters with an existing baseline file`() {
-        val baseline = Baseline.load(baselineFile)
+        val baseline = DefaultBaseline.load(baselineFile)
         val actual = BaselineFilteredResult(result, baseline)
         // Note: Detektion works with Map<RuleSetId, List<Finding>
         // but the TestDetektion maps the RuleId as RuleSetId

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineResultMappingSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineResultMappingSpec.kt
@@ -55,7 +55,7 @@ class BaselineResultMappingSpec {
 
     @Test
     fun `should not update an existing baseline file if option configured as false`() {
-        val existing = Baseline.load(existingBaselineFile)
+        val existing = DefaultBaseline.load(existingBaselineFile)
         val mapping = resultMapping(
             baselineFile = existingBaselineFile,
             createBaseline = false,
@@ -63,13 +63,13 @@ class BaselineResultMappingSpec {
 
         mapping.transformFindings(findings)
 
-        val changed = Baseline.load(existingBaselineFile)
+        val changed = DefaultBaseline.load(existingBaselineFile)
         assertThat(existing).isEqualTo(changed)
     }
 
     @Test
     fun `should not update an existing baseline file if option is not configured`() {
-        val existing = Baseline.load(existingBaselineFile)
+        val existing = DefaultBaseline.load(existingBaselineFile)
         val mapping = resultMapping(
             baselineFile = existingBaselineFile,
             createBaseline = null,
@@ -77,7 +77,7 @@ class BaselineResultMappingSpec {
 
         mapping.transformFindings(findings)
 
-        val changed = Baseline.load(existingBaselineFile)
+        val changed = DefaultBaseline.load(existingBaselineFile)
         assertThat(existing).isEqualTo(changed)
     }
 
@@ -108,7 +108,7 @@ class BaselineResultMappingSpec {
     @Test
     fun `should update an existing baseline file if a file is configured`() {
         Files.copy(existingBaselineFile, baselineFile)
-        val existing = Baseline.load(baselineFile)
+        val existing = DefaultBaseline.load(baselineFile)
         val mapping = resultMapping(
             baselineFile = baselineFile,
             createBaseline = true,
@@ -116,7 +116,7 @@ class BaselineResultMappingSpec {
 
         mapping.transformFindings(findings)
 
-        val changed = Baseline.load(baselineFile)
+        val changed = DefaultBaseline.load(baselineFile)
         assertThat(existing).isNotEqualTo(changed)
     }
 }

--- a/detekt-tooling/api/detekt-tooling.api
+++ b/detekt-tooling/api/detekt-tooling.api
@@ -7,6 +7,25 @@ public final class io/github/detekt/tooling/api/AnalysisResultKt {
 	public static final fun exitCode (Lio/github/detekt/tooling/api/AnalysisResult;)I
 }
 
+public abstract interface class io/github/detekt/tooling/api/Baseline {
+	public abstract fun contains (Ljava/lang/String;)Z
+	public abstract fun getCurrentIssues ()Ljava/util/Set;
+	public abstract fun getManuallySuppressedIssues ()Ljava/util/Set;
+}
+
+public abstract interface class io/github/detekt/tooling/api/BaselineProvider {
+	public static final field Companion Lio/github/detekt/tooling/api/BaselineProvider$Companion;
+	public abstract fun id (Lio/gitlab/arturbosch/detekt/api/Finding;)Ljava/lang/String;
+	public abstract fun of (Ljava/util/Set;Ljava/util/Set;)Lio/github/detekt/tooling/api/Baseline;
+	public abstract fun read (Ljava/nio/file/Path;)Lio/github/detekt/tooling/api/Baseline;
+	public abstract fun write (Ljava/nio/file/Path;Lio/github/detekt/tooling/api/Baseline;)V
+}
+
+public final class io/github/detekt/tooling/api/BaselineProvider$Companion {
+	public final fun load (Ljava/lang/ClassLoader;)Lio/github/detekt/tooling/api/BaselineProvider;
+	public static synthetic fun load$default (Lio/github/detekt/tooling/api/BaselineProvider$Companion;Ljava/lang/ClassLoader;ILjava/lang/Object;)Lio/github/detekt/tooling/api/BaselineProvider;
+}
+
 public abstract interface class io/github/detekt/tooling/api/DefaultConfigurationProvider {
 	public static final field Companion Lio/github/detekt/tooling/api/DefaultConfigurationProvider$Companion;
 	public abstract fun copy (Ljava/nio/file/Path;)V

--- a/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/api/BaselineProvider.kt
+++ b/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/api/BaselineProvider.kt
@@ -1,0 +1,31 @@
+package io.github.detekt.tooling.api
+
+import io.gitlab.arturbosch.detekt.api.Finding
+import java.nio.file.Path
+import java.util.ServiceLoader
+
+interface BaselineProvider {
+
+    fun id(finding: Finding): FindingId
+    fun of(manuallySuppressedIssues: FindingsIdList, currentIssues: FindingsIdList): Baseline
+    fun read(sourcePath: Path): Baseline
+    fun write(targetPath: Path, baseline: Baseline)
+
+    companion object {
+
+        fun load(
+            classLoader: ClassLoader = BaselineProvider::class.java.classLoader,
+        ): BaselineProvider = ServiceLoader.load(BaselineProvider::class.java, classLoader).first()
+    }
+}
+
+typealias FindingsIdList = Set<String>
+typealias FindingId = String
+
+interface Baseline {
+
+    val manuallySuppressedIssues: FindingsIdList
+    val currentIssues: FindingsIdList
+
+    fun contains(id: FindingId): Boolean
+}


### PR DESCRIPTION
This PR introduces tooling for our baseline format.
The Intellij plugin for example can use this api to automatically suppress findings in code:

https://github.com/detekt/detekt-intellij-plugin/pull/270/files#diff-c03a54359751513b4259bc0203878035d5081ab928f22b639ddbb206f9eef2ecR34-R41