### PR TITLE
Enable trim multiline raw string

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -229,6 +229,8 @@ style:
     excludeGuardClauses: true
   SpacingBetweenPackageAndImports:
     active: true
+  TrimMultilineRawString:
+    active: true
   UnderscoresInNumericLiterals:
     active: true
   UnnecessaryAnnotationUseSiteTarget:

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Location.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Location.kt
@@ -51,10 +51,7 @@ constructor(
 
     @Suppress("DEPRECATION")
     @Deprecated(
-        """
-        locationString was removed and won't get passed to the main constructor.
-        Use queries on 'ktElement' instead.
-        """,
+        "locationString was removed and won't get passed to the main constructor. Use queries on 'ktElement' instead.",
         ReplaceWith(
             "Location(source, text, file)",
             "io.gitlab.arturbosch.detekt.api.Location"

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/SuppressionSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/SuppressionSpec.kt
@@ -169,7 +169,7 @@ class SuppressionSpec {
                     println("FAILED TEST")
                 }
             }
-                """
+                """.trimIndent()
             )
             val rule = TestRule()
             rule.visitFile(ktFile)
@@ -187,7 +187,7 @@ class SuppressionSpec {
                     println("FAILED TEST")
                 }
             }
-                """
+                """.trimIndent()
             )
             val rule = TestRule()
             rule.visitFile(ktFile)
@@ -205,7 +205,7 @@ class SuppressionSpec {
                     println("FAILED TEST")
                 }
             }
-                """
+                """.trimIndent()
             )
             val rule = TestRule()
             rule.visitFile(ktFile)
@@ -227,7 +227,7 @@ class SuppressionSpec {
                     println("FAILED TEST")
                 }
             }
-                """
+                """.trimIndent()
             )
             val rule = TestRule(TestConfig(mutableMapOf("aliases" to "[MyTest]")))
             rule.visitFile(ktFile)
@@ -314,7 +314,7 @@ private fun isSuppressedBy(annotation: String, argument: String): Boolean {
     val annotated = """
             @$annotation("$argument")
             class Test
-    """
+    """.trimIndent()
     val file = compileContentForTest(annotated)
     val annotatedClass = file.children.first { it is KtClass } as KtAnnotated
     return annotatedClass.isSuppressedBy("Test", setOf("alias"))

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/validation/CheckConfigurationSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/validation/CheckConfigurationSpec.kt
@@ -26,7 +26,7 @@ class CheckConfigurationSpec {
             """
             unknown_property:
               unknown_var: ""
-            """
+            """.trimIndent()
         )
         createProcessingSettings(
             testDir,
@@ -55,7 +55,7 @@ class CheckConfigurationSpec {
             my_additional_properties:
               magic_number: 7
               magic_string: 'Hello World'
-            """
+            """.trimIndent()
         )
         createProcessingSettings(testDir, config).use {
             assertThatCode { checkConfiguration(it, spec.getDefaultConfiguration()) }
@@ -74,7 +74,7 @@ class CheckConfigurationSpec {
               TooManyFunctions:
                 # This property is tested via the SampleConfigValidator
                 active: 1 # should be true
-            """
+            """.trimIndent()
         )
         createProcessingSettings(testDir, config).use {
             assertThatCode { checkConfiguration(it, spec.getDefaultConfiguration()) }
@@ -104,7 +104,7 @@ class CheckConfigurationSpec {
            my_additional_properties:
              magic_number: 7
              magic_string: 'Hello World'
-            """
+            """.trimIndent()
         )
         createProcessingSettings(testDir, config).use {
             assertThatCode { checkConfiguration(it, spec.getDefaultConfiguration()) }

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/FinalNewlineSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/FinalNewlineSpec.kt
@@ -22,7 +22,7 @@ class FinalNewlineSpec {
             """
                 fun main() = Unit
 
-            """
+            """.trimIndent()
         )
 
         assertThat(findings).isEmpty()
@@ -35,7 +35,7 @@ class FinalNewlineSpec {
                 """
                     fun main() = Unit
 
-                """
+                """.trimIndent()
             )
 
         assertThat(findings).hasSize(1)

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingRuleSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingRuleSpec.kt
@@ -85,7 +85,7 @@ class FormattingRuleSpec {
             """
                 fun main()
                 = Unit
-            """,
+            """.trimIndent(),
             expectedPath
         )
 

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/MultiRuleCollectorSpec.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/MultiRuleCollectorSpec.kt
@@ -50,7 +50,7 @@ class MultiRuleCollectorSpec {
                     p2
                 )
             }
-        """
+        """.trimIndent()
         val items = subject.run(code)
         assertThat(items[0].rules).hasSize(4)
         assertThat(items[0].rules).contains("Rule1", "Rule2", "Rule3", "Rule4")

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleCollectorSpec.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleCollectorSpec.kt
@@ -54,7 +54,7 @@ class RuleCollectorSpec {
              * description
              */
             class $name : Rule
-        """
+        """.trimIndent()
         val items = subject.run(code)
         assertThat(items[0].name).isEqualTo(name)
     }
@@ -67,7 +67,7 @@ class RuleCollectorSpec {
              * $description
              */
             class SomeRandomClass : Rule
-        """
+        """.trimIndent()
         val items = subject.run(code)
         assertThat(items[0].description).isEqualTo(description)
     }
@@ -82,7 +82,7 @@ class RuleCollectorSpec {
              * more...
              */
             class SomeRandomClass : Rule
-        """
+        """.trimIndent()
         val items = subject.run(code)
         assertThat(items[0].description).startsWith(description)
         assertThat(items[0].description).contains("more...")
@@ -95,7 +95,7 @@ class RuleCollectorSpec {
              * description
              */
             class SomeRandomClass : Rule
-        """
+        """.trimIndent()
         val items = subject.run(code)
         assertThat(items[0].defaultActivationStatus.active).isFalse()
     }
@@ -108,7 +108,7 @@ class RuleCollectorSpec {
              */
             @ActiveByDefault("1.12.123")
             class SomeRandomClass : Rule
-        """
+        """.trimIndent()
         val items = subject.run(code)
         val defaultActivationStatus = items[0].defaultActivationStatus as Active
         assertThat(defaultActivationStatus.since).isEqualTo("1.12.123")
@@ -122,7 +122,7 @@ class RuleCollectorSpec {
              */
             @ActiveByDefault(since = "1.2.3")
             class SomeRandomClass : Rule
-        """
+        """.trimIndent()
         val items = subject.run(code)
         val defaultActivationStatus = items[0].defaultActivationStatus as Active
         assertThat(defaultActivationStatus.since).isEqualTo("1.2.3")
@@ -136,7 +136,7 @@ class RuleCollectorSpec {
              */
             @ActiveByDefault("1.2.x")
             class SomeRandomClass : Rule
-        """
+        """.trimIndent()
         assertThatExceptionOfType(InvalidDocumentationException::class.java).isThrownBy { subject.run(code) }
     }
 
@@ -149,7 +149,7 @@ class RuleCollectorSpec {
              */
             @AutoCorrectable(since = "1.0.0")
             class SomeRandomClass : Rule
-        """
+        """.trimIndent()
         val items = subject.run(code)
         assertThat(items[0].autoCorrect).isTrue()
     }
@@ -164,7 +164,7 @@ class RuleCollectorSpec {
                 override val defaultRuleIdAliases = setOf("RULE", "RULE2")
                 override val issue = Issue(javaClass.simpleName, Severity.Style, "", Debt.TEN_MINS)
             }
-        """
+        """.trimIndent()
         val items = subject.run(code)
         assertThat(items[0].severity).isEqualTo("Style")
         assertThat(items[0].debt).isEqualTo("10min")
@@ -180,7 +180,7 @@ class RuleCollectorSpec {
                  * description
                  */
                 class SomeRandomClass : Rule
-            """
+            """.trimIndent()
             val items = subject.run(code)
             assertThat(items[0].configuration).isEmpty()
         }
@@ -195,7 +195,7 @@ class RuleCollectorSpec {
                     @Configuration("description")
                     private val config: String by config("[A-Z$]")
                 }                        
-            """
+            """.trimIndent()
             val items = subject.run(code)
             assertThat(items[0].configuration).hasSize(1)
             val expectedConfiguration = Configuration(
@@ -218,7 +218,7 @@ class RuleCollectorSpec {
                     @Configuration("description")
                     private val config: Int by config(1_999_000)
                 }                        
-            """
+            """.trimIndent()
             val items = subject.run(code)
             assertThat(items[0].configuration).hasSize(1)
             assertThat(items[0].configuration[0].defaultValue).isEqualTo(of(1_999_000))
@@ -234,7 +234,7 @@ class RuleCollectorSpec {
                     @Configuration("description")
                     private val config: String by config(""${"\""}abcd""${"\""})
                 }                        
-            """
+            """.trimIndent()
             val items = subject.run(code)
             assertThat(items[0].configuration[0].defaultValue).isEqualTo(of("abcd"))
         }
@@ -249,7 +249,7 @@ class RuleCollectorSpec {
                     @Configuration("description")
                     private val config: Int by config(defaultValue = 99)
                 }                        
-            """
+            """.trimIndent()
             val items = subject.run(code)
             assertThat(items[0].configuration[0].defaultValue).isEqualTo(of(99))
         }
@@ -269,7 +269,7 @@ class RuleCollectorSpec {
                         )
                     )
                 }                        
-            """
+            """.trimIndent()
             val items = subject.run(code)
             val expected = of(listOf("a", "b"))
             assertThat(items[0].configuration[0].defaultValue).isEqualTo(expected)
@@ -288,7 +288,7 @@ class RuleCollectorSpec {
                     @Configuration("description")
                     private val config2: String by config("")
                 }                        
-            """
+            """.trimIndent()
             val items = subject.run(code)
             assertThat(items[0].configuration).hasSize(2)
         }
@@ -306,7 +306,7 @@ class RuleCollectorSpec {
                         "description")
                     private val config: String by config("a")
                 }                        
-            """
+            """.trimIndent()
             val items = subject.run(code)
             assertThat(items[0].configuration[0].description).isEqualTo("This is a multi line description")
             assertThat(items[0].configuration[0].defaultValue).isEqualTo(of("a"))
@@ -326,7 +326,7 @@ class RuleCollectorSpec {
                         private const val DEFAULT_CONFIG_VALUE = 99
                     }
                 }                        
-            """
+            """.trimIndent()
             val items = subject.run(code)
             assertThat(items[0].configuration[0].defaultValue).isEqualTo(of(99))
         }
@@ -345,7 +345,7 @@ class RuleCollectorSpec {
                         private const val DEFAULT_CONFIG_VALUE = 99
                     }
                 }                        
-            """
+            """.trimIndent()
             val items = subject.run(code)
             assertThat(items[0].configuration[0].defaultValue).isEqualTo(of(99))
         }
@@ -364,7 +364,7 @@ class RuleCollectorSpec {
                         private const val DEFAULT_CONFIG_VALUE = "a"
                     }
                 }                        
-            """
+            """.trimIndent()
             val items = subject.run(code)
             assertThat(items[0].configuration[0].defaultValue).isEqualTo(of("a"))
         }
@@ -387,7 +387,7 @@ class RuleCollectorSpec {
                         private val DEFAULT_CONFIG_VALUE_A = "a"
                     }
                 }                        
-            """
+            """.trimIndent()
             val items = subject.run(code)
             val expected = of(listOf("a", "b"))
             assertThat(items[0].configuration[0].defaultValue).isEqualTo(expected)
@@ -407,7 +407,7 @@ class RuleCollectorSpec {
                     @Configuration("description")
                     private val config2: List<String> by config(emptyList())
                 }                        
-            """
+            """.trimIndent()
             val items = subject.run(code)
             val expected = of(emptyList())
             assertThat(items[0].configuration[0].defaultValue).isEqualTo(expected)
@@ -431,7 +431,7 @@ class RuleCollectorSpec {
                         private val DEFAULT_CONFIG_VALUE: List<String> = emptyList()
                     }
                 }                        
-            """
+            """.trimIndent()
             val items = subject.run(code)
             val expected = of(emptyList())
             assertThat(items[0].configuration[0].defaultValue).isEqualTo(expected)
@@ -449,7 +449,7 @@ class RuleCollectorSpec {
                     @Configuration("description")
                     private val config: String by config("")
                 }                        
-            """
+            """.trimIndent()
             val items = subject.run(code)
             assertThat(items[0].configuration[0].deprecated).isEqualTo("use config1 instead")
         }
@@ -463,7 +463,7 @@ class RuleCollectorSpec {
                  */
                 class SomeRandomClass() : Rule {
                 }                        
-            """
+            """.trimIndent()
             assertThatExceptionOfType(InvalidDocumentationException::class.java).isThrownBy { subject.run(code) }
         }
 
@@ -477,7 +477,7 @@ class RuleCollectorSpec {
                     @Configuration("description")
                     private val config: String = "foo"
                 }                        
-            """
+            """.trimIndent()
             assertThatExceptionOfType(InvalidDocumentationException::class.java).isThrownBy { subject.run(code) }
         }
 
@@ -491,7 +491,7 @@ class RuleCollectorSpec {
                     @Configuration("description")
                     private val config: String by lazy { "foo" }
                 }                        
-            """
+            """.trimIndent()
             assertThatExceptionOfType(InvalidDocumentationException::class.java).isThrownBy { subject.run(code) }
         }
 
@@ -504,7 +504,7 @@ class RuleCollectorSpec {
                 class SomeRandomClass() : Rule {
                     private val config: String by config("")
                 }                        
-            """
+            """.trimIndent()
             assertThatExceptionOfType(InvalidDocumentationException::class.java).isThrownBy { subject.run(code) }
         }
 
@@ -520,7 +520,7 @@ class RuleCollectorSpec {
                         @Configuration("description")
                         private val maxLineLength: Int by configWithAndroidVariants(120, 100)
                     }                        
-                """
+                """.trimIndent()
                 val items = subject.run(code)
                 assertThat(items[0].configuration[0]).isEqualTo(
                     Configuration(
@@ -544,7 +544,7 @@ class RuleCollectorSpec {
                         private val maxLineLength: Int by
                             configWithAndroidVariants(defaultValue = 120, defaultAndroidValue = 100)
                     }                        
-                """
+                """.trimIndent()
                 val items = subject.run(code)
                 assertThat(items[0].configuration[0]).isEqualTo(
                     Configuration(
@@ -576,7 +576,7 @@ class RuleCollectorSpec {
                         @Configuration("description")
                         private val config3: Int by configWithFallback(defaultValue = 99, fallbackProperty = ::prop)
                     }                        
-                """
+                """.trimIndent()
                 val items = subject.run(code)
                 val fallbackProperties = items[0].configuration.filter { it.name.startsWith("config") }
                 assertThat(fallbackProperties).hasSize(3)
@@ -594,7 +594,7 @@ class RuleCollectorSpec {
                         @Configuration("description")
                         private val config: Int by configWithFallback(::prop, 99)
                     }                        
-                """
+                """.trimIndent()
                 assertThatThrownBy { subject.run(code) }
                     .isInstanceOf(InvalidDocumentationException::class.java)
                     .hasMessageContaining("delegate")
@@ -613,7 +613,7 @@ class RuleCollectorSpec {
                     @Configuration("description")
                     private val config2: String by config(false, Boolean::toString)
                 }                        
-            """
+            """.trimIndent()
 
             @Test
             fun `extracts default value with transformer function`() {
@@ -658,7 +658,7 @@ class RuleCollectorSpec {
                                 private val DEFAULT_VALUE = valuesWithReason("value" to "reason")
                             }
                         }
-            """
+            """.trimIndent()
 
             @Test
             fun `parse options of type ValuesWithReason`() {
@@ -711,7 +711,7 @@ class RuleCollectorSpec {
                  * description
                  */
                 class SomeRandomClass : Rule
-            """
+            """.trimIndent()
             val items = subject.run(code)
             assertThat(items[0].requiresTypeResolution).isFalse()
         }
@@ -724,7 +724,7 @@ class RuleCollectorSpec {
                  */
                 @RequiresTypeResolution
                 class SomeRandomClass : Rule
-            """
+            """.trimIndent()
             val items = subject.run(code)
             assertThat(items[0].requiresTypeResolution).isTrue()
         }
@@ -737,7 +737,7 @@ class RuleCollectorSpec {
                  */
                 @io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
                 class SomeRandomClass : Rule
-            """
+            """.trimIndent()
             val items = subject.run(code)
             assertThat(items[0].requiresTypeResolution).isTrue()
         }
@@ -758,7 +758,7 @@ class RuleCollectorSpec {
              * </compliant>
              */
             class RandomClass : Rule
-        """
+        """.trimIndent()
         val items = subject.run(code)
         assertThat(items[0].nonCompliantCodeExample).isEqualTo("val one = 2")
         assertThat(items[0].compliantCodeExample).isEqualTo("val one = 1")
@@ -773,7 +773,7 @@ class RuleCollectorSpec {
              * <noncompliant>
              */
             class RandomClass : Rule
-        """
+        """.trimIndent()
         assertThatExceptionOfType(InvalidCodeExampleDocumentationException::class.java)
             .isThrownBy { subject.run(code) }
     }
@@ -790,7 +790,7 @@ class RuleCollectorSpec {
              * <compliant>
              */
             class RandomClass : Rule
-        """
+        """.trimIndent()
         assertThatExceptionOfType(InvalidCodeExampleDocumentationException::class.java)
             .isThrownBy { subject.run(code) }
     }
@@ -806,7 +806,7 @@ class RuleCollectorSpec {
              * </compliant>
              */
             class RandomClass : Rule
-        """
+        """.trimIndent()
         assertThatExceptionOfType(InvalidCodeExampleDocumentationException::class.java)
             .isThrownBy { subject.run(code) }
     }
@@ -825,7 +825,7 @@ class RuleCollectorSpec {
                         "",
                         debt = Debt.TEN_MINS)
             }
-        """
+        """.trimIndent()
         assertThatExceptionOfType(InvalidIssueDeclaration::class.java).isThrownBy { subject.run(code) }
     }
 
@@ -844,7 +844,7 @@ class RuleCollectorSpec {
                         "",
                         debt = Debt.TEN_MINS)
             }
-        """
+        """.trimIndent()
         assertThatExceptionOfType(InvalidAliasesDeclaration::class.java).isThrownBy { subject.run(code) }
     }
 
@@ -856,7 +856,7 @@ class RuleCollectorSpec {
              * $description
              */
             class SomeRandomClass : Rule
-        """
+        """.trimIndent()
         assertThatExceptionOfType(InvalidDocumentationException::class.java).isThrownBy { subject.run(code) }
     }
 }

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleSetProviderCollectorSpec.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleSetProviderCollectorSpec.kt
@@ -29,7 +29,7 @@ class RuleSetProviderCollectorSpec {
                 println(message)
             }
         }
-        """
+        """.trimIndent()
 
         @Test
         fun `collects no rulesets`() {
@@ -48,7 +48,7 @@ class RuleSetProviderCollectorSpec {
                 println(message)
             }
         }
-        """
+        """.trimIndent()
 
         @Test
         fun `collects no rulesets`() {
@@ -67,7 +67,7 @@ class RuleSetProviderCollectorSpec {
                 println(message)
             }
         }
-        """
+        """.trimIndent()
 
         @Test
         fun `throws an exception`() {
@@ -86,7 +86,7 @@ class RuleSetProviderCollectorSpec {
                 println(message)
             }
         }
-        """
+        """.trimIndent()
 
         @Test
         fun `throws an exception`() {
@@ -118,7 +118,7 @@ class RuleSetProviderCollectorSpec {
                 ))
             }
         }
-        """
+        """.trimIndent()
 
         @Test
         fun `collects a RuleSetProvider`() {
@@ -176,7 +176,7 @@ class RuleSetProviderCollectorSpec {
                 ))
             }
         }
-        """
+        """.trimIndent()
 
         @Test
         fun `is not active`() {
@@ -203,7 +203,7 @@ class RuleSetProviderCollectorSpec {
                 ))
             }
         }
-        """
+        """.trimIndent()
 
         @Test
         fun `throws an exception`() {
@@ -228,7 +228,7 @@ class RuleSetProviderCollectorSpec {
                 ))
             }
         }
-        """
+        """.trimIndent()
 
         @Test
         fun `throws an exception`() {
@@ -255,7 +255,7 @@ class RuleSetProviderCollectorSpec {
                 ))
             }
         }
-        """
+        """.trimIndent()
 
         @Test
         fun `throws an exception`() {
@@ -277,7 +277,7 @@ class RuleSetProviderCollectorSpec {
                 return RuleSet(ruleSetId, emptyListOf())
             }
         }
-        """
+        """.trimIndent()
 
         @Test
         fun `throws an exception`() {
@@ -309,7 +309,7 @@ class RuleSetProviderCollectorSpec {
                 ))
             }
         }
-        """
+        """.trimIndent()
 
         @Test
         fun `collects multiple rules`() {
@@ -364,7 +364,7 @@ class RuleSetProviderCollectorSpec {
                 val aString by ruleSetConfig("a")
             }
         }
-        """
+        """.trimIndent()
         private val items = subject.run(code)
 
         @Test
@@ -414,7 +414,7 @@ class RuleSetProviderCollectorSpec {
                 val aConfig by ruleSetConfig(listOf("a"))
             }
         }
-        """
+        """.trimIndent()
 
         @Test
         fun `fails`() {

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/ConfigurationCacheSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/ConfigurationCacheSpec.kt
@@ -23,6 +23,7 @@ class ConfigurationCacheSpec {
     inner class `Create baseline task` {
         @Test
         fun `can be loaded from the configuration cache`() {
+            @Suppress("TrimMultilineRawString")
             val detektConfig = """
                 |detekt {
                 |   baseline = file("build/baseline.xml")

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/ConfigurationCacheSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/ConfigurationCacheSpec.kt
@@ -24,9 +24,9 @@ class ConfigurationCacheSpec {
         @Test
         fun `can be loaded from the configuration cache`() {
             val detektConfig = """
-                        |detekt {
-                        |   baseline = file("build/baseline.xml")
-                        |}
+                |detekt {
+                |   baseline = file("build/baseline.xml")
+                |}
             """
             val gradleRunner = DslTestBuilder.kotlin()
                 .withDetektConfig(detektConfig)

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/CreateBaselineTaskDslSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/CreateBaselineTaskDslSpec.kt
@@ -11,6 +11,7 @@ class CreateBaselineTaskDslSpec {
     fun `detektBaseline task can be executed when baseline file is specified`() {
         val baselineFilename = "baseline.xml"
 
+        @Suppress("TrimMultilineRawString")
         val detektConfig = """
             |detekt {
             |   baseline = file("$baselineFilename")
@@ -35,6 +36,7 @@ class CreateBaselineTaskDslSpec {
 
     @Test
     fun `detektBaseline task can be executed when baseline file is not specified`() {
+        @Suppress("TrimMultilineRawString")
         val detektConfig = """
             |detekt {
             |}
@@ -57,6 +59,7 @@ class CreateBaselineTaskDslSpec {
 
     @Test
     fun `detektBaseline task can not be executed when baseline file is specified null`() {
+        @Suppress("TrimMultilineRawString")
         val detektConfig = """
             |detekt {
             |   baseline = null

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektReportMergeSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektReportMergeSpec.kt
@@ -61,15 +61,15 @@ class DetektReportMergeSpec {
             assertThat(result.output).contains("FAILURE: Build completed with 2 failures.")
             assertThat(result.output).containsIgnoringWhitespaces(
                 """
-                Execution failed for task ':child1:detekt'.
-                > Analysis failed with 2 weighted issues.
-                """
+                    Execution failed for task ':child1:detekt'.
+                    > Analysis failed with 2 weighted issues.
+                """.trimIndent()
             )
             assertThat(result.output).containsIgnoringWhitespaces(
                 """
-                Execution failed for task ':child2:detekt'.
-                > Analysis failed with 4 weighted issues.
-                """
+                    Execution failed for task ':child2:detekt'.
+                    > Analysis failed with 4 weighted issues.
+                """.trimIndent()
             )
             assertThat(projectFile("build/reports/detekt/detekt.sarif")).doesNotExist()
             assertThat(projectFile("build/reports/detekt/merge.sarif")).exists()
@@ -134,15 +134,15 @@ class DetektReportMergeSpec {
             assertThat(result.output).contains("FAILURE: Build completed with 2 failures.")
             assertThat(result.output).containsIgnoringWhitespaces(
                 """
-                Execution failed for task ':child1:detekt'.
-                > Analysis failed with 2 weighted issues.
-                """
+                    Execution failed for task ':child1:detekt'.
+                    > Analysis failed with 2 weighted issues.
+                """.trimIndent()
             )
             assertThat(result.output).containsIgnoringWhitespaces(
                 """
-                Execution failed for task ':child2:detekt'.
-                > Analysis failed with 4 weighted issues.
-                """
+                    Execution failed for task ':child2:detekt'.
+                    > Analysis failed with 4 weighted issues.
+                """.trimIndent()
             )
             assertThat(projectFile("build/reports/detekt/detekt.xml")).doesNotExist()
             assertThat(projectFile("build/reports/detekt/merge.xml")).exists()

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektReportMergeSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektReportMergeSpec.kt
@@ -13,33 +13,33 @@ class DetektReportMergeSpec {
         val builder = DslTestBuilder.kotlin()
         val buildFileContent =
             """
-            |${builder.gradlePlugins}
-            |
-            |allprojects {
-            |  ${builder.gradleRepositories}
-            |}
-            |
-            |val sarifReportMerge by tasks.registering(io.gitlab.arturbosch.detekt.report.ReportMergeTask::class) {
-            |  output.set(project.layout.buildDirectory.file("reports/detekt/merge.sarif"))
-            |}
-            |
-            |subprojects {
-            |  ${builder.gradleSubprojectsApplyPlugins}
-            |  
-            |  detekt {
-            |    reports.sarif.enabled = true
-            |  }
-            |  
-            |  plugins.withType(io.gitlab.arturbosch.detekt.DetektPlugin::class) {
-            |    tasks.withType(io.gitlab.arturbosch.detekt.Detekt::class) detekt@{
-            |       sarifReportMerge.configure {
-            |         this.mustRunAfter(this@detekt)
-            |         input.from(this@detekt.sarifReportFile)
-            |       }
-            |    }
-            |  }
-            |}
-            |
+                |${builder.gradlePlugins}
+                |
+                |allprojects {
+                |  ${builder.gradleRepositories}
+                |}
+                |
+                |val sarifReportMerge by tasks.registering(io.gitlab.arturbosch.detekt.report.ReportMergeTask::class) {
+                |  output.set(project.layout.buildDirectory.file("reports/detekt/merge.sarif"))
+                |}
+                |
+                |subprojects {
+                |  ${builder.gradleSubprojectsApplyPlugins}
+                |  
+                |  detekt {
+                |    reports.sarif.enabled = true
+                |  }
+                |  
+                |  plugins.withType(io.gitlab.arturbosch.detekt.DetektPlugin::class) {
+                |    tasks.withType(io.gitlab.arturbosch.detekt.Detekt::class) detekt@{
+                |       sarifReportMerge.configure {
+                |         this.mustRunAfter(this@detekt)
+                |         input.from(this@detekt.sarifReportFile)
+                |       }
+                |    }
+                |  }
+                |}
+                |
             """.trimMargin()
 
         val projectLayout = ProjectLayout(numberOfSourceFilesInRootPerSourceDir = 0).apply {
@@ -98,11 +98,11 @@ class DetektReportMergeSpec {
             |
             |subprojects {
             |  ${builder.gradleSubprojectsApplyPlugins}
-            |  
+            |
             |  detekt {
             |    reports.xml.enabled = true
             |  }
-            |  
+            |
             |  plugins.withType(io.gitlab.arturbosch.detekt.DetektPlugin::class) {
             |    tasks.withType(io.gitlab.arturbosch.detekt.Detekt::class) detekt@{
             |       xmlReportMerge.configure {

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektTaskDslSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektTaskDslSpec.kt
@@ -77,9 +77,9 @@ class DetektTaskDslSpec {
         @BeforeAll
         fun beforeGroup() {
             val config = """
-                    |detekt {
-                    |    config.setFrom(files("firstConfig.yml", "secondConfig.yml"))
-                    |}
+                |detekt {
+                |    config.setFrom(files("firstConfig.yml", "secondConfig.yml"))
+                |}
             """
 
             gradleRunner = builder.withDetektConfig(config).build()
@@ -104,9 +104,9 @@ class DetektTaskDslSpec {
         @BeforeAll
         fun beforeGroup() {
             val config = """
-                    |detekt {
-                    |   baseline = file("$baselineFilename")
-                    |}
+                |detekt {
+                |   baseline = file("$baselineFilename")
+                |}
             """
 
             gradleRunner = builder
@@ -131,9 +131,9 @@ class DetektTaskDslSpec {
         @BeforeAll
         fun beforeGroup() {
             val config = """
-                    |detekt {
-                    |   baseline = file("$baselineFilename")
-                    |}
+                |detekt {
+                |   baseline = file("$baselineFilename")
+                |}
             """
 
             gradleRunner = builder
@@ -157,9 +157,9 @@ class DetektTaskDslSpec {
         @BeforeAll
         fun beforeGroup() {
             val config = """
-                    |detekt {
-                    |    input = files("$customSrc1", "$customSrc2", "folder_that_does_not_exist")
-                    |}
+                |detekt {
+                |    input = files("$customSrc1", "$customSrc2", "folder_that_does_not_exist")
+                |}
             """
 
             val projectLayout = ProjectLayout(1, srcDirs = listOf(customSrc1, customSrc2))
@@ -192,9 +192,9 @@ class DetektTaskDslSpec {
         @BeforeAll
         fun beforeGroup() {
             val config = """
-                    |detekt {
-                    |    source = files("$customSrc1", "$customSrc2", "folder_that_does_not_exist")
-                    |}
+                |detekt {
+                |    source = files("$customSrc1", "$customSrc2", "folder_that_does_not_exist")
+                |}
             """
 
             val projectLayout = ProjectLayout(1, srcDirs = listOf(customSrc1, customSrc2))
@@ -225,9 +225,9 @@ class DetektTaskDslSpec {
         @BeforeAll
         fun beforeGroup() {
             val config = """
-                    |detekt {
-                    |    reportsDir = file("build/detekt-reports")
-                    |}
+                |detekt {
+                |    reportsDir = file("build/detekt-reports")
+                |}
             """
 
             gradleRunner = builder
@@ -267,15 +267,15 @@ class DetektTaskDslSpec {
         @BeforeAll
         fun beforeGroup() {
             val config = """
-                    |detekt {
-                    |    reportsDir = file("build/detekt-reports")
-                    |}
-                    |
-                    |tasks.detekt {
-                    |    reports {
-                    |        xml.destination = file("build/xml-reports/custom-detekt.xml")
-                    |    }
-                    |}
+                |detekt {
+                |    reportsDir = file("build/detekt-reports")
+                |}
+                |
+                |tasks.detekt {
+                |    reports {
+                |        xml.destination = file("build/xml-reports/custom-detekt.xml")
+                |    }
+                |}
             """
 
             gradleRunner = builder
@@ -309,23 +309,23 @@ class DetektTaskDslSpec {
         @BeforeAll
         fun beforeGroup() {
             val config = """
-                    |tasks.detekt {
-                    |    reports {
-                    |        xml.enabled = false
-                    |        html {
-                    |            enabled = false
-                    |        }
-                    |        txt {
-                    |            enabled = false
-                    |        }
-                    |        sarif {
-                    |            enabled = false
-                    |        }
-                    |        md {
-                    |            enabled = false
-                    |        }
-                    |    }
-                    |}
+                |tasks.detekt {
+                |    reports {
+                |        xml.enabled = false
+                |        html {
+                |            enabled = false
+                |        }
+                |        txt {
+                |            enabled = false
+                |        }
+                |        sarif {
+                |            enabled = false
+                |        }
+                |        md {
+                |            enabled = false
+                |        }
+                |    }
+                |}
             """
 
             gradleRunner = builder
@@ -347,18 +347,18 @@ class DetektTaskDslSpec {
             @BeforeAll
             fun beforeGroup() {
                 val config = """
-                            |tasks.detekt {
-                            |    reports {
-                            |        custom {
-                            |           reportId = "customXml"
-                            |           destination = file("build/reports/custom.xml")
-                            |       }
-                            |        custom {
-                            |           reportId = "customJson"
-                            |           destination = file("build/reports/custom.json")
-                            |       }
-                            |    }
-                            |}
+                    |tasks.detekt {
+                    |    reports {
+                    |        custom {
+                    |           reportId = "customXml"
+                    |           destination = file("build/reports/custom.xml")
+                    |       }
+                    |        custom {
+                    |           reportId = "customJson"
+                    |           destination = file("build/reports/custom.json")
+                    |       }
+                    |    }
+                    |}
                 """
 
                 gradleRunner = builder.withDetektConfig(config).build()
@@ -383,13 +383,13 @@ class DetektTaskDslSpec {
             @BeforeAll
             fun beforeGroup() {
                 val config = """
-                            |tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
-                            |    reports {
-                            |        custom {
-                            |           destination = file("build/reports/custom.xml")
-                            |       }
-                            |    }
-                            |}
+                    |tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
+                    |    reports {
+                    |        custom {
+                    |           destination = file("build/reports/custom.xml")
+                    |       }
+                    |    }
+                    |}
                 """
 
                 gradleRunner = builder.withDetektConfig(config).build()
@@ -409,13 +409,13 @@ class DetektTaskDslSpec {
             @BeforeAll
             fun beforeGroup() {
                 val config = """
-                            |tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
-                            |    reports {
-                            |        custom {
-                            |           reportId = "customJson"
-                            |       }
-                            |    }
-                            |}
+                    |tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
+                    |    reports {
+                    |        custom {
+                    |           reportId = "customJson"
+                    |       }
+                    |    }
+                    |}
                 """
 
                 gradleRunner = builder.withDetektConfig(config).build()
@@ -437,14 +437,14 @@ class DetektTaskDslSpec {
                 val aDirectory = "\${rootDir}/src"
 
                 val config = """
-                            |tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
-                            |    reports {
-                            |        custom {
-                            |           reportId = "foo"
-                            |           destination = file("$aDirectory")
-                            |       }
-                            |    }
-                            |}
+                    |tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
+                    |    reports {
+                    |        custom {
+                    |           reportId = "foo"
+                    |           destination = file("$aDirectory")
+                    |       }
+                    |    }
+                    |}
                 """
 
                 gradleRunner = builder.withDetektConfig(config).build()
@@ -464,14 +464,14 @@ class DetektTaskDslSpec {
             @EnumSource(DetektReportType::class)
             fun `fails the build`(wellKnownType: DetektReportType) {
                 val config = """
-                                    |tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
-                                    |    reports {
-                                    |        custom {
-                                    |            reportId = "${wellKnownType.reportId}"
-                                    |            destination = file("build/reports/custom.xml")
-                                    |        }
-                                    |    }
-                                    |}
+                    |tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
+                    |    reports {
+                    |        custom {
+                    |            reportId = "${wellKnownType.reportId}"
+                    |            destination = file("build/reports/custom.xml")
+                    |        }
+                    |    }
+                    |}
                 """
 
                 gradleRunner = builder.withDetektConfig(config).build()
@@ -489,16 +489,16 @@ class DetektTaskDslSpec {
         @BeforeAll
         fun beforeGroup() {
             val config = """
-                    |detekt {
-                    |    debug = true
-                    |    parallel = true
-                    |    disableDefaultRuleSets = true
-                    |    failFast = true
-                    |    allRules = true
-                    |    autoCorrect = true
-                    |    buildUponDefaultConfig = true
-                    |    ignoreFailures = true
-                    |}
+                |detekt {
+                |    debug = true
+                |    parallel = true
+                |    disableDefaultRuleSets = true
+                |    failFast = true
+                |    allRules = true
+                |    autoCorrect = true
+                |    buildUponDefaultConfig = true
+                |    ignoreFailures = true
+                |}
             """
 
             gradleRunner = builder
@@ -568,9 +568,9 @@ class DetektTaskDslSpec {
         @BeforeAll
         fun beforeGroup() {
             val config = """
-                        |dependencies {
-                        |   detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:$defaultDetektVersion")
-                        |}
+                |dependencies {
+                |   detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:$defaultDetektVersion")
+                |}
             """
 
             gradleRunner = builder
@@ -597,9 +597,9 @@ class DetektTaskDslSpec {
         @BeforeAll
         fun beforeGroup() {
             val config = """
-                        |detekt {
-                        |    toolVersion = "$customVersion"
-                        |}
+                |detekt {
+                |    toolVersion = "$customVersion"
+                |}
             """
 
             gradleRunner = builder

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektTaskDslSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektTaskDslSpec.kt
@@ -76,6 +76,7 @@ class DetektTaskDslSpec {
 
         @BeforeAll
         fun beforeGroup() {
+            @Suppress("TrimMultilineRawString")
             val config = """
                 |detekt {
                 |    config.setFrom(files("firstConfig.yml", "secondConfig.yml"))
@@ -103,6 +104,7 @@ class DetektTaskDslSpec {
 
         @BeforeAll
         fun beforeGroup() {
+            @Suppress("TrimMultilineRawString")
             val config = """
                 |detekt {
                 |   baseline = file("$baselineFilename")
@@ -130,6 +132,7 @@ class DetektTaskDslSpec {
 
         @BeforeAll
         fun beforeGroup() {
+            @Suppress("TrimMultilineRawString")
             val config = """
                 |detekt {
                 |   baseline = file("$baselineFilename")
@@ -156,6 +159,7 @@ class DetektTaskDslSpec {
 
         @BeforeAll
         fun beforeGroup() {
+            @Suppress("TrimMultilineRawString")
             val config = """
                 |detekt {
                 |    input = files("$customSrc1", "$customSrc2", "folder_that_does_not_exist")
@@ -191,6 +195,7 @@ class DetektTaskDslSpec {
 
         @BeforeAll
         fun beforeGroup() {
+            @Suppress("TrimMultilineRawString")
             val config = """
                 |detekt {
                 |    source = files("$customSrc1", "$customSrc2", "folder_that_does_not_exist")
@@ -224,6 +229,7 @@ class DetektTaskDslSpec {
 
         @BeforeAll
         fun beforeGroup() {
+            @Suppress("TrimMultilineRawString")
             val config = """
                 |detekt {
                 |    reportsDir = file("build/detekt-reports")
@@ -266,6 +272,7 @@ class DetektTaskDslSpec {
 
         @BeforeAll
         fun beforeGroup() {
+            @Suppress("TrimMultilineRawString")
             val config = """
                 |detekt {
                 |    reportsDir = file("build/detekt-reports")
@@ -308,6 +315,7 @@ class DetektTaskDslSpec {
 
         @BeforeAll
         fun beforeGroup() {
+            @Suppress("TrimMultilineRawString")
             val config = """
                 |tasks.detekt {
                 |    reports {
@@ -346,6 +354,7 @@ class DetektTaskDslSpec {
         inner class `configured correctly` {
             @BeforeAll
             fun beforeGroup() {
+                @Suppress("TrimMultilineRawString")
                 val config = """
                     |tasks.detekt {
                     |    reports {
@@ -382,6 +391,7 @@ class DetektTaskDslSpec {
         inner class `report id is missing` {
             @BeforeAll
             fun beforeGroup() {
+                @Suppress("TrimMultilineRawString")
                 val config = """
                     |tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
                     |    reports {
@@ -408,6 +418,7 @@ class DetektTaskDslSpec {
         inner class `report filename is missing` {
             @BeforeAll
             fun beforeGroup() {
+                @Suppress("TrimMultilineRawString")
                 val config = """
                     |tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
                     |    reports {
@@ -436,6 +447,7 @@ class DetektTaskDslSpec {
             fun beforeGroup() {
                 val aDirectory = "\${rootDir}/src"
 
+                @Suppress("TrimMultilineRawString")
                 val config = """
                     |tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
                     |    reports {
@@ -463,6 +475,7 @@ class DetektTaskDslSpec {
             @ParameterizedTest
             @EnumSource(DetektReportType::class)
             fun `fails the build`(wellKnownType: DetektReportType) {
+                @Suppress("TrimMultilineRawString")
                 val config = """
                     |tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
                     |    reports {
@@ -488,6 +501,7 @@ class DetektTaskDslSpec {
 
         @BeforeAll
         fun beforeGroup() {
+            @Suppress("TrimMultilineRawString")
             val config = """
                 |detekt {
                 |    debug = true
@@ -567,6 +581,7 @@ class DetektTaskDslSpec {
     inner class `with an additional plugin` {
         @BeforeAll
         fun beforeGroup() {
+            @Suppress("TrimMultilineRawString")
             val config = """
                 |dependencies {
                 |   detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:$defaultDetektVersion")
@@ -596,6 +611,7 @@ class DetektTaskDslSpec {
 
         @BeforeAll
         fun beforeGroup() {
+            @Suppress("TrimMultilineRawString")
             val config = """
                 |detekt {
                 |    toolVersion = "$customVersion"
@@ -623,6 +639,7 @@ class DetektTaskDslSpec {
     inner class `and creating a custom task` {
         @BeforeAll
         fun beforeGroup() {
+            @Suppress("TrimMultilineRawString")
             val config = """
                 |task<io.gitlab.arturbosch.detekt.Detekt>("myDetekt") {
                 |    description = "Runs a custom detekt build."

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektTaskGroovyDslSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektTaskGroovyDslSpec.kt
@@ -9,6 +9,7 @@ class DetektTaskGroovyDslSpec {
 
     @Test
     fun `detekt extension can be configured without errors`() {
+        @Suppress("TrimMultilineRawString")
         val config = """
             |detekt {
             |    toolVersion = "1.0.0.RC8"
@@ -36,6 +37,7 @@ class DetektTaskGroovyDslSpec {
 
     @Test
     fun `detekt task can be fully configured without errors`() {
+        @Suppress("TrimMultilineRawString")
         val config = """
             |tasks.create("customDetektTask", io.gitlab.arturbosch.detekt.Detekt) {
             |    source = files("${"$"}projectDir")
@@ -81,6 +83,7 @@ class DetektTaskGroovyDslSpec {
 
     @Test
     fun `detekt create baseline task can be configured without errors`() {
+        @Suppress("TrimMultilineRawString")
         val config = """
             |tasks.create("customDetektCreateBaselineTask", io.gitlab.arturbosch.detekt.DetektCreateBaselineTask) {
             |    source = files("${"$"}projectDir")
@@ -110,6 +113,7 @@ class DetektTaskGroovyDslSpec {
 
     @Test
     fun `detekt generate config task can be configured without errors`() {
+        @Suppress("TrimMultilineRawString")
         val config = """
             |tasks.create("customDetektGenerateConfigTask", io.gitlab.arturbosch.detekt.DetektGenerateConfigTask) {
             |    detektClasspath.setFrom(files("config.yml"))

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektTaskSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektTaskSpec.kt
@@ -15,6 +15,7 @@ class DetektTaskSpec {
 
     @Test
     fun `build succeeds with more issues than threshold if ignoreFailures = true`() {
+        @Suppress("TrimMultilineRawString")
         val config = """
             |detekt {
             |   ignoreFailures = true
@@ -33,6 +34,7 @@ class DetektTaskSpec {
 
     @Test
     fun `build fails with more issues than threshold successfully if ignoreFailures = false`() {
+        @Suppress("TrimMultilineRawString")
         val config = """
             |detekt {
             |   ignoreFailures = false

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/GenerateConfigTaskSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/GenerateConfigTaskSpec.kt
@@ -23,9 +23,9 @@ class GenerateConfigTaskSpec {
         val builder = DslTestBuilder.kotlin()
         val gradleRunner = builder.withDetektConfig(
             """
-                    |detekt {
-                    |   config = files("config/detekt/detekt.yml", "config/other/detekt.yml")
-                    |}
+                |detekt {
+                |   config = files("config/detekt/detekt.yml", "config/other/detekt.yml")
+                |}
             """
         ).withConfigFile("config/detekt/detekt.yml").build()
         gradleRunner.writeProjectFile("config/other/detekt.yml", content = "")

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/GenerateConfigTaskSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/GenerateConfigTaskSpec.kt
@@ -22,6 +22,7 @@ class GenerateConfigTaskSpec {
     fun `chooses the last config file when configured`() {
         val builder = DslTestBuilder.kotlin()
         val gradleRunner = builder.withDetektConfig(
+            @Suppress("TrimMultilineRawString")
             """
                 |detekt {
                 |   config = files("config/detekt/detekt.yml", "config/other/detekt.yml")

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/PluginTaskBehaviorSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/PluginTaskBehaviorSpec.kt
@@ -16,6 +16,7 @@ class PluginTaskBehaviorSpec {
     val configFileName = "config.yml"
     val baselineFileName = "baseline.xml"
 
+    @Suppress("TrimMultilineRawString")
     val detektConfig = """
         |detekt {
         |    config = files("$configFileName")

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/PluginTaskBehaviorSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/PluginTaskBehaviorSpec.kt
@@ -17,10 +17,10 @@ class PluginTaskBehaviorSpec {
     val baselineFileName = "baseline.xml"
 
     val detektConfig = """
-                    |detekt {
-                    |    config = files("$configFileName")
-                    |    baseline = file("$baselineFileName")
-                    |}
+        |detekt {
+        |    config = files("$configFileName")
+        |    baseline = file("$baselineFileName")
+        |}
     """
 
     lateinit var gradleRunner: DslGradleRunner

--- a/detekt-gradle-plugin/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/testkit/DslTestBuilder.kt
+++ b/detekt-gradle-plugin/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/testkit/DslTestBuilder.kt
@@ -76,6 +76,8 @@ abstract class DslTestBuilder {
 
 private class GroovyBuilder : DslTestBuilder() {
     override val gradleBuildName: String = "build.gradle"
+
+    @Suppress("TrimMultilineRawString")
     override val gradlePlugins = """
         |plugins {
         |  id 'java-library'
@@ -94,6 +96,7 @@ private class GroovyBuilder : DslTestBuilder() {
         |}
     """.trimMargin()
 
+    @Suppress("TrimMultilineRawString")
     override val gradleSubprojectsApplyPlugins = """
         |apply plugin: "io.gitlab.arturbosch.detekt"
         |
@@ -105,6 +108,7 @@ private class GroovyBuilder : DslTestBuilder() {
 private class KotlinBuilder : DslTestBuilder() {
     override val gradleBuildName: String = "build.gradle.kts"
 
+    @Suppress("TrimMultilineRawString")
     override val gradlePlugins = """
         |plugins {
         |   `java-library`
@@ -123,6 +127,7 @@ private class KotlinBuilder : DslTestBuilder() {
         |}
     """.trimMargin()
 
+    @Suppress("TrimMultilineRawString")
     override val gradleSubprojectsApplyPlugins = """
         |plugins.apply("io.gitlab.arturbosch.detekt")
         |

--- a/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/CognitiveComplexitySpec.kt
+++ b/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/CognitiveComplexitySpec.kt
@@ -24,7 +24,7 @@ class CognitiveComplexitySpec {
                 }
                 return total
             }
-            """
+            """.trimIndent()
         )
 
         assertThat(CognitiveComplexity.calculate(code)).isEqualTo(7)
@@ -40,7 +40,7 @@ class CognitiveComplexitySpec {
                  3 -> "a few"
                  else -> "lots"
              }
-            """
+            """.trimIndent()
         )
 
         assertThat(CognitiveComplexity.calculate(code)).isEqualTo(1)
@@ -57,7 +57,7 @@ class CognitiveComplexitySpec {
                     fun factorial(n: Int): Int =
                         if (n >= 1) n * this.factorial(n - 1) else 1
                 }
-                """
+                """.trimIndent()
             )
 
             assertThat(CognitiveComplexity.calculate(code)).isEqualTo(2)
@@ -69,7 +69,7 @@ class CognitiveComplexitySpec {
                 """
                 fun factorial(n: Int): Int =
                     if (n >= 1) n * factorial(n - 1) else 1
-                """
+                """.trimIndent()
             )
 
             assertThat(CognitiveComplexity.calculate(code)).isEqualTo(2)
@@ -82,7 +82,7 @@ class CognitiveComplexitySpec {
                 object O { fun factorial(i: Int): Int = i - 1 }
                 fun factorial(n: Int): Int =
                     if (n >= 1) n * O.factorial(n - 1) else 1
-                """
+                """.trimIndent()
             )
 
             assertThat(CognitiveComplexity.calculate(code)).isEqualTo(1)
@@ -97,7 +97,7 @@ class CognitiveComplexitySpec {
             fun main(args: Array<String>) {
                args.takeIf { it.size > 3 }?.let(::parse) ?: error("not enough arguments")
             }
-            """
+            """.trimIndent()
         )
 
         assertThat(CognitiveComplexity.calculate(code)).isEqualTo(0)
@@ -113,7 +113,7 @@ class CognitiveComplexitySpec {
                 } catch (e: IllegalStateException) {
                 } catch (e: Throwable) {}
             }
-            """
+            """.trimIndent()
         )
 
         assertThat(CognitiveComplexity.calculate(code)).isEqualTo(3)
@@ -136,7 +136,7 @@ class CognitiveComplexitySpec {
                     do {} while(true) // +2
                 }
             }
-            """
+            """.trimIndent()
         )
 
         assertThat(CognitiveComplexity.calculate(code)).isEqualTo(9)
@@ -147,7 +147,7 @@ class CognitiveComplexitySpec {
         val code = compileContentForTest(
             """
             fun main() { run { if (true) {} } }
-            """
+            """.trimIndent()
         )
 
         assertThat(CognitiveComplexity.calculate(code)).isEqualTo(2)
@@ -158,7 +158,7 @@ class CognitiveComplexitySpec {
         val code = compileContentForTest(
             """
             fun main() { fun run() { if (true) {} } }
-            """
+            """.trimIndent()
         )
 
         assertThat(CognitiveComplexity.calculate(code)).isEqualTo(2)
@@ -172,7 +172,7 @@ class CognitiveComplexitySpec {
             val code = compileContentForTest(
                 """
                 fun test(cond_ Boolean) = !cond
-                """
+                """.trimIndent()
             )
 
             assertThat(CognitiveComplexity.calculate(code)).isEqualTo(0)
@@ -186,7 +186,7 @@ class CognitiveComplexitySpec {
                 val code = compileContentForTest(
                     """
                     fun test(cond_ Boolean) = !cond && !cond
-                    """
+                    """.trimIndent()
                 )
 
                 assertThat(CognitiveComplexity.calculate(code)).isEqualTo(1)
@@ -197,7 +197,7 @@ class CognitiveComplexitySpec {
                 val code = compileContentForTest(
                     """
                     fun test(cond_ Boolean) = !cond && !cond && !cond
-                    """
+                    """.trimIndent()
                 )
 
                 assertThat(CognitiveComplexity.calculate(code)).isEqualTo(1)
@@ -208,7 +208,7 @@ class CognitiveComplexitySpec {
                 val code = compileContentForTest(
                     """
                     fun test(cond_ Boolean) = !cond && !cond || cond
-                    """
+                    """.trimIndent()
                 )
 
                 assertThat(CognitiveComplexity.calculate(code)).isEqualTo(2)
@@ -226,7 +226,7 @@ class CognitiveComplexitySpec {
                             && cond             // +1
                         ) {}
                     }
-                    """
+                    """.trimIndent()
                 )
 
                 assertThat(CognitiveComplexity.calculate(code)).isEqualTo(4)
@@ -242,7 +242,7 @@ class CognitiveComplexitySpec {
                             && !(cond && cond)  // +2
                         ) {}
                     }
-                    """
+                    """.trimIndent()
                 )
 
                 assertThat(CognitiveComplexity.calculate(code)).isEqualTo(3)
@@ -258,7 +258,7 @@ class CognitiveComplexitySpec {
                             && !(cond && cond && cond)  // +2
                         ) {}
                     }
-                    """
+                    """.trimIndent()
                 )
 
                 assertThat(CognitiveComplexity.calculate(code)).isEqualTo(3)
@@ -275,7 +275,7 @@ class CognitiveComplexitySpec {
                             || !(cond || cond)          // +2
                         ) {}
                     }
-                    """
+                    """.trimIndent()
                 )
 
                 assertThat(CognitiveComplexity.calculate(code)).isEqualTo(5)

--- a/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/CyclomaticComplexitySpec.kt
+++ b/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/CyclomaticComplexitySpec.kt
@@ -22,7 +22,7 @@ class CyclomaticComplexitySpec {
             val code = compileContentForTest(
                 """
                     fun test() = null as? String ?: ""
-                """
+                """.trimIndent()
             )
 
             val actual = CyclomaticComplexity.calculate(code)
@@ -35,7 +35,7 @@ class CyclomaticComplexitySpec {
             val code = compileContentForTest(
                 """
                     fun test() = if (true || true && false) 1 else 0
-                """
+                """.trimIndent()
             )
 
             val actual = CyclomaticComplexity.calculate(code)
@@ -60,7 +60,7 @@ class CyclomaticComplexitySpec {
                         }
                         println("finished")
                     }
-                """
+                """.trimIndent()
             )
 
             val actual = CyclomaticComplexity.calculate(code)
@@ -77,7 +77,7 @@ class CyclomaticComplexitySpec {
                     fun test(i: Int) {
                         (1..10).forEach { println(it) }
                     }
-            """
+            """.trimIndent()
         )
 
         @Test
@@ -129,7 +129,7 @@ class CyclomaticComplexitySpec {
                         else -> println("Meh")
                     }
                 }
-                """
+                """.trimIndent()
             ).getFunctionByName("test")
 
             val actual = CyclomaticComplexity.calculate(function) {
@@ -152,7 +152,7 @@ class CyclomaticComplexitySpec {
                         else -> println("Meh")
                     }
                 }
-                """
+                """.trimIndent()
             ).getFunctionByName("test")
 
             val actual = CyclomaticComplexity.calculate(function) {
@@ -177,7 +177,7 @@ class CyclomaticComplexitySpec {
                         else -> println("Meh")
                     }
                 }
-                """
+                """.trimIndent()
             ).getFunctionByName("test")
 
             val actual = CyclomaticComplexity.calculate(function) {
@@ -203,7 +203,7 @@ class CyclomaticComplexitySpec {
                         else -> println("Meh")
                     }
                 }
-                """
+                """.trimIndent()
             ).getFunctionByName("test")
 
             val actual = CyclomaticComplexity.calculate(function) {
@@ -231,7 +231,7 @@ class CyclomaticComplexitySpec {
                         else -> println("Meh")
                     }
                 }
-                """
+                """.trimIndent()
             ).getFunctionByName("test")
 
             val actual = CyclomaticComplexity.calculate(function) {

--- a/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/processors/LOCVisitorSpec.kt
+++ b/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/processors/LOCVisitorSpec.kt
@@ -13,6 +13,6 @@ class LOCVisitorSpec {
             accept(LOCVisitor())
             getUserData(linesKey)
         }
-        assertThat(loc).isEqualTo(8)
+        assertThat(loc).isEqualTo(7)
     }
 }

--- a/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/processors/package.kt
+++ b/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/processors/package.kt
@@ -8,21 +8,21 @@ package cases
  */
 @Suppress("Unused")
 class Default
-""".trimStart()
+""".trimIndent()
 
 val emptyEnum = """
 package empty
 
 @Suppress("Unused")
 enum class EmptyEnum
-""".trimStart()
+""".trimIndent()
 
 val emptyInterface = """
 package empty
 
 @Suppress("Unused")
 interface EmptyInterface
-""".trimStart()
+""".trimIndent()
 
 val classWithFields = """
 package fields
@@ -33,7 +33,7 @@ class ClassWithFields {
     private var x = 0
     val y = 0
 }
-""".trimStart()
+""".trimIndent()
 
 val commentsClass = """
 package comments
@@ -58,7 +58,7 @@ class CommentsClass {
         println("// no comment //")
     }
 }
-""".trimStart()
+""".trimIndent()
 
 val complexClass = """
 package cases
@@ -206,4 +206,4 @@ class ComplexClass {// McCabe: 44, LLOC: 20 + 20 + 4x4
         }
     }
 }
-""".trimStart()
+""".trimIndent()

--- a/detekt-psi-utils/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/ThrowExtensionsSpec.kt
+++ b/detekt-psi-utils/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/ThrowExtensionsSpec.kt
@@ -18,7 +18,7 @@ internal class ThrowExtensionsSpec {
                 fun test() {
                     if (i == 1) throw IllegalArgumentException()
                 }
-            """
+            """.trimIndent()
 
             verifyThrowExpression(code) {
                 assertThat(isEnclosedByConditionalStatement()).isTrue()
@@ -32,7 +32,7 @@ internal class ThrowExtensionsSpec {
                     if (i == 1) 
                         throw IllegalArgumentException()
                 }
-            """
+            """.trimIndent()
 
             verifyThrowExpression(code) {
                 assertThat(isEnclosedByConditionalStatement()).isTrue()
@@ -48,7 +48,7 @@ internal class ThrowExtensionsSpec {
                         throw IllegalArgumentException()
                     }
                 }
-            """
+            """.trimIndent()
 
             verifyThrowExpression(code) {
                 assertThat(isEnclosedByConditionalStatement()).isTrue()
@@ -61,7 +61,7 @@ internal class ThrowExtensionsSpec {
                 fun test() {
                     throw IllegalArgumentException()
                 }
-            """
+            """.trimIndent()
 
             verifyThrowExpression(code) {
                 assertThat(isEnclosedByConditionalStatement()).isFalse()
@@ -78,7 +78,7 @@ internal class ThrowExtensionsSpec {
                         else -> println("other")
                     }
                 }
-            """
+            """.trimIndent()
 
             verifyThrowExpression(code) {
                 assertThat(isEnclosedByConditionalStatement()).isFalse()
@@ -91,7 +91,7 @@ internal class ThrowExtensionsSpec {
                 fun test(a: Int) {
                     if (a == 2) println("2") else throw IllegalArgumentException()
                 }
-            """
+            """.trimIndent()
 
             verifyThrowExpression(code) {
                 assertThat(isEnclosedByConditionalStatement()).isTrue()
@@ -108,7 +108,7 @@ internal class ThrowExtensionsSpec {
                         throw IllegalArgumentException()
                     }
                 }
-            """
+            """.trimIndent()
 
             verifyThrowExpression(code) {
                 assertThat(isEnclosedByConditionalStatement()).isTrue()

--- a/detekt-report-sarif/src/test/kotlin/io/github/detekt/report/sarif/SarifOutputReportSpec.kt
+++ b/detekt-report-sarif/src/test/kotlin/io/github/detekt/report/sarif/SarifOutputReportSpec.kt
@@ -171,7 +171,7 @@ private fun constrainRegion(startLine: Int, startColumn: Int, endLine: Int, endC
       "startColumn": $startColumn,
       "startLine": $startLine
     }            
-"""
+""".trimIndent()
 
 class TestRule : Rule() {
     override val issue = Issue(javaClass.simpleName, Severity.Warning, "", Debt.FIVE_MINS)

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexConditionSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexConditionSpec.kt
@@ -13,7 +13,7 @@ class ComplexConditionSpec {
             while (5 > 4 && 4 < 6 || (3 < 5 || 2 < 5)) {}
             do { } while (5 > 4 && 4 < 6 || (3 < 5 || 2 < 5))
         }
-    """
+    """.trimIndent()
 
     @Test
     fun `reports some complex conditions`() {

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexInterfaceSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexInterfaceSpec.kt
@@ -34,7 +34,7 @@ class ComplexInterfaceSpec {
                     val i1: Int
                     fun fImpl() {}
                 }
-            """
+            """.trimIndent()
 
             @Test
             fun `reports complex interface`() {
@@ -59,7 +59,7 @@ class ComplexInterfaceSpec {
                         fun fImpl() {}
                     }
                 }
-            """
+            """.trimIndent()
 
             @Test
             fun `reports complex interface`() {
@@ -84,7 +84,7 @@ class ComplexInterfaceSpec {
                         val v = 0
                     }
                 }
-            """
+            """.trimIndent()
 
             @Test
             fun `does not report static declarations per default`() {
@@ -107,7 +107,7 @@ class ComplexInterfaceSpec {
                     val i1: Int
                     private fun fImpl() {}
                 }
-            """
+            """.trimIndent()
 
             @Test
             fun `does not report complex interface`() {
@@ -131,7 +131,7 @@ class ComplexInterfaceSpec {
                         get() = 42
                     fun fImpl() {}
                 }
-            """
+            """.trimIndent()
 
             @Test
             fun `does not report complex interface`() {
@@ -154,7 +154,7 @@ class ComplexInterfaceSpec {
                     val i1: Int
                     fun fImpl() {}
                 }
-            """
+            """.trimIndent()
 
             @Test
             fun `reports complex interface with overloaded methods`() {
@@ -176,7 +176,7 @@ class ComplexInterfaceSpec {
                         val i1: Int
                         fun fImpl() {}
                     }
-                """
+                """.trimIndent()
                 val rule = ComplexInterface(ignoreOverloadedConfig)
                 assertThat(rule.compileAndLint(interfaceWithExtension)).hasSize(1)
             }
@@ -190,7 +190,7 @@ class ComplexInterfaceSpec {
                         val i1: Int
                         fun fImpl() {}
                     }
-                """
+                """.trimIndent()
                 val rule = ComplexInterface(ignoreOverloadedConfig)
                 assertThat(rule.compileAndLint(interfaceWithOverloadedExtensions)).isEmpty()
             }
@@ -212,7 +212,7 @@ class ComplexInterfaceSpec {
                     val i: Int
                     // a comment shouldn't be detected
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
@@ -227,7 +227,7 @@ class ComplexInterfaceSpec {
                         const val c = 0
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexMethodSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexMethodSpec.kt
@@ -29,7 +29,7 @@ class ComplexMethodSpec {
                     do {} while(true)
                     (1..10).forEach {}
                 }
-                """
+                """.trimIndent()
             )
 
             assertThat(findings.first()).isThresholded().withValue(defaultComplexity + 4)
@@ -42,7 +42,7 @@ class ComplexMethodSpec {
                 fun test() {
                     try {} catch(e: IllegalArgumentException) {} catch(e: Exception) {} finally {}
                 }
-                """
+                """.trimIndent()
             )
 
             assertThat(findings.first()).isThresholded().withValue(defaultComplexity + 2)
@@ -66,7 +66,7 @@ class ComplexMethodSpec {
                         // only catches count
                     }
                 }
-                """
+                """.trimIndent()
             )
 
             assertThat(findings.first()).isThresholded().withValue(defaultComplexity + 4)
@@ -81,7 +81,7 @@ class ComplexMethodSpec {
                     for (i in 1..10) {}
                     (1..10).forEach {}
                 }
-        """
+        """.trimIndent()
 
         @Test
         fun `counts three with nesting function 'forEach'`() {
@@ -167,7 +167,7 @@ class ComplexMethodSpec {
                         }
                     }
                 }
-            """
+            """.trimIndent()
 
             val findings = subject.compileAndLint(code)
             assertThat(findings).isEmpty()
@@ -223,7 +223,7 @@ class ComplexMethodSpec {
                 }
             }
         }
-        """
+        """.trimIndent()
 
         @Test
         fun `should not count these overridden functions to base functions complexity`() {

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LabeledExpressionSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LabeledExpressionSpec.kt
@@ -20,7 +20,7 @@ class LabeledExpressionSpec {
                     }
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(3)
     }
 
@@ -33,7 +33,7 @@ class LabeledExpressionSpec {
                     println(it)
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 
@@ -46,7 +46,7 @@ class LabeledExpressionSpec {
                     println(it)
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(2)
     }
 
@@ -65,7 +65,7 @@ class LabeledExpressionSpec {
                     }
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(3)
     }
 
@@ -79,7 +79,7 @@ class LabeledExpressionSpec {
                 }
             }
         }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -94,7 +94,7 @@ class LabeledExpressionSpec {
                 }
             }
         }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -108,7 +108,7 @@ class LabeledExpressionSpec {
                 }
             }
         }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -129,7 +129,7 @@ class LabeledExpressionSpec {
                 }
             }
         }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -139,7 +139,7 @@ class LabeledExpressionSpec {
             fun f() {
                 loop@ for (i in 1..5) {}
             }
-        """
+        """.trimIndent()
         val config = TestConfig(mapOf("ignoredLabels" to listOf("loop")))
         val findings = LabeledExpression(config).compileAndLint(code)
         assertThat(findings).isEmpty()
@@ -151,7 +151,7 @@ class LabeledExpressionSpec {
             fun f() {
                 loop@ for (i in 1..5) {}
             }
-        """
+        """.trimIndent()
         val config = TestConfig(mapOf("ignoredLabels" to "loop"))
         val findings = LabeledExpression(config).compileAndLint(code)
         assertThat(findings).isEmpty()
@@ -163,7 +163,7 @@ class LabeledExpressionSpec {
             fun f() {
                 loop@ for (i in 1..5) {}
             }
-        """
+        """.trimIndent()
         val config = TestConfig(mapOf("ignoredLabels" to "*loop*,other"))
         val findings = LabeledExpression(config).compileAndLint(code)
         assertThat(findings).isEmpty()

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LargeClassSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LargeClassSpec.kt
@@ -28,7 +28,7 @@ class LargeClassSpec {
                 println()
                 println()
             }
-        """
+        """.trimIndent()
         val rule = subject(threshold = 2)
         assertThat(rule.compileAndLint(code)).isEmpty()
     }

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongMethodSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongMethodSpec.kt
@@ -24,7 +24,7 @@ class LongMethodSpec {
                     println()
                 }
             }
-        """
+        """.trimIndent()
         val findings = subject.compileAndLint(code)
 
         assertThat(findings).hasSize(2)
@@ -41,7 +41,7 @@ class LongMethodSpec {
                     println()
                 }
             }
-        """
+        """.trimIndent()
 
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
@@ -55,7 +55,7 @@ class LongMethodSpec {
                 println()
                 println()
             }
-        """
+        """.trimIndent()
 
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
@@ -70,7 +70,7 @@ class LongMethodSpec {
                 println()
                 println()
             }
-        """
+        """.trimIndent()
 
         val findings = subject.compileAndLint(code)
 
@@ -94,7 +94,7 @@ class LongMethodSpec {
                     y2
                 )
             }
-        """
+        """.trimIndent()
 
         val findings = subject.compileAndLint(code)
 
@@ -120,7 +120,7 @@ class LongMethodSpec {
                     println()
                 }
             }
-        """
+        """.trimIndent()
 
         val findings = subject.compileAndLint(code)
 
@@ -145,7 +145,7 @@ class LongMethodSpec {
                     println()
                 }
             }
-        """
+        """.trimIndent()
 
         val findings = subject.compileAndLint(code)
 

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterListSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterListSpec.kt
@@ -127,7 +127,7 @@ class LongParameterListSpec {
                 annotation class CustomAnnotation
 
                 class Data constructor(@CustomAnnotation val a: Int)
-            """
+            """.trimIndent()
             assertThat(rule.compileAndLint(code)).hasSize(1)
         }
 
@@ -138,7 +138,7 @@ class LongParameterListSpec {
                 annotation class CustomAnnotation
 
                 class Data { fun foo(@CustomAnnotation a: Int) {} }
-            """
+            """.trimIndent()
             assertThat(rule.compileAndLint(code)).hasSize(1)
         }
 
@@ -154,7 +154,7 @@ class LongParameterListSpec {
                 class Data {
                     fun foo(@kotlin.Suppress("") a: Int) {}
                 }
-            """
+            """.trimIndent()
             assertThat(rule.compileAndLint(code)).isEmpty()
         }
     }

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/MethodOverloadingSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/MethodOverloadingSpec.kt
@@ -23,7 +23,7 @@ class MethodOverloadingSpec {
                     fun x(i: Int) {}
                     fun x(i: Int, j: Int) {}
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLint(code)
             assertThat(findings).hasSize(1)
             assertThat(findings[0].message).isEqualTo("The method 'x' is overloaded 3 times.")
@@ -35,7 +35,7 @@ class MethodOverloadingSpec {
                 fun x() {}
                 fun x(i: Int) {}
                 fun x(i: Int, j: Int) {}
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
@@ -47,7 +47,7 @@ class MethodOverloadingSpec {
                 fun x() { }
                 fun x(i: Int) { }
             }
-                """
+                """.trimIndent()
             )
             assertThat(subject.findings.size).isZero()
         }
@@ -63,7 +63,7 @@ class MethodOverloadingSpec {
             fun Boolean.foo() {}
             fun Int.foo() {}
             fun Long.foo() {}
-                """
+                """.trimIndent()
             )
             assertThat(subject.findings.size).isZero()
         }
@@ -75,7 +75,7 @@ class MethodOverloadingSpec {
             fun Int.foo() {}
             fun Int.foo(i: Int) {}
             fun Int.foo(i: String) {}
-                """
+                """.trimIndent()
             )
             assertThat(subject.findings.size).isEqualTo(1)
         }
@@ -94,7 +94,7 @@ class MethodOverloadingSpec {
                         fun f(i: Int, j: Int) {}
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
@@ -110,7 +110,7 @@ class MethodOverloadingSpec {
                         fun f(i: Int, j: Int) {}
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
     }
@@ -126,7 +126,7 @@ class MethodOverloadingSpec {
                     fun f(i: Int) {}
                     fun f(i: Int, j: Int) {}
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
@@ -137,7 +137,7 @@ class MethodOverloadingSpec {
                     fun f() {}
                     fun f(i: Int) {}
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
@@ -151,7 +151,7 @@ class MethodOverloadingSpec {
                         fun f(i: Int, j: Int) {}
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
@@ -164,7 +164,7 @@ class MethodOverloadingSpec {
                         fun f(i: Int) {}
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
@@ -180,7 +180,7 @@ class MethodOverloadingSpec {
                         fun f(i: Int) {}
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
@@ -197,7 +197,7 @@ class MethodOverloadingSpec {
                         }
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
     }
@@ -221,7 +221,7 @@ class MethodOverloadingSpec {
 
                     abstract fun f()
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
@@ -235,7 +235,7 @@ class MethodOverloadingSpec {
                     };
                     fun f() {}
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
@@ -249,7 +249,7 @@ class MethodOverloadingSpec {
                     fun f(i: Int) {}
                     fun f(i: Int, j: Int) {}
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
     }
@@ -268,7 +268,7 @@ class MethodOverloadingSpec {
                 fun f(i: Int) {}
                 fun f(i: Int, j: Int) {}
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 }

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NamedArgumentsSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NamedArgumentsSpec.kt
@@ -203,7 +203,7 @@ class NamedArgumentsSpec(val env: KotlinCoreEnvironment) {
             fun test(n: Int) {
                 require(n == 2) { "N is not 2" }
             }
-        """
+            """
             val subject = NamedArguments(TestConfig(mapOf("threshold" to 1)))
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(0)

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NamedArgumentsSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NamedArgumentsSpec.kt
@@ -23,7 +23,7 @@ class NamedArgumentsSpec(val env: KotlinCoreEnvironment) {
             fun call() {
                 sum(1, 2, 3)
             }
-        """
+        """.trimIndent()
         val findings = subject.compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(1)
     }
@@ -37,7 +37,7 @@ class NamedArgumentsSpec(val env: KotlinCoreEnvironment) {
             fun call() {
                 sum(a = 1, b = 2, c = 3)
             }
-        """
+        """.trimIndent()
         val findings = subject.compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(0)
     }
@@ -51,7 +51,7 @@ class NamedArgumentsSpec(val env: KotlinCoreEnvironment) {
             fun call() {
                 sum(1, b = 2, c = 3)
             }
-        """
+        """.trimIndent()
         val findings = subject.compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(1)
     }
@@ -65,7 +65,7 @@ class NamedArgumentsSpec(val env: KotlinCoreEnvironment) {
             fun call() {
                 sum(1, 2)
             }
-        """
+        """.trimIndent()
         val findings = subject.compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(0)
     }
@@ -79,7 +79,7 @@ class NamedArgumentsSpec(val env: KotlinCoreEnvironment) {
             fun call() {
                 sum(a = 1, b = 2)
             }
-        """
+        """.trimIndent()
         val findings = subject.compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(0)
     }
@@ -90,7 +90,7 @@ class NamedArgumentsSpec(val env: KotlinCoreEnvironment) {
             class C(val a: Int, val b:Int, val c:Int)
             
             val obj = C(1, 2, 3)
-        """
+        """.trimIndent()
         val findings = subject.compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(1)
     }
@@ -101,7 +101,7 @@ class NamedArgumentsSpec(val env: KotlinCoreEnvironment) {
             class C(val a: Int, val b:Int, val c:Int)
             
             val obj = C(a = 1, b = 2, c= 3)
-        """
+        """.trimIndent()
         val findings = subject.compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(0)
     }
@@ -112,7 +112,7 @@ class NamedArgumentsSpec(val env: KotlinCoreEnvironment) {
             class C(val a: Int, val b:Int)
             
             val obj = C(1, 2)
-        """
+        """.trimIndent()
         val findings = subject.compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(0)
     }
@@ -125,7 +125,7 @@ class NamedArgumentsSpec(val env: KotlinCoreEnvironment) {
             fun test() {
                 LocalDateTime.of(2020, 3, 13, 14, 0, 0)
             }
-        """
+        """.trimIndent()
         val findings = subject.compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(0)
     }
@@ -139,7 +139,7 @@ class NamedArgumentsSpec(val env: KotlinCoreEnvironment) {
                 foo(1, 2, 3, 4, 5)
                 bar(1, 2, 3, "a")
             }
-        """
+        """.trimIndent()
         val findings = subject.compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(0)
     }
@@ -151,7 +151,7 @@ class NamedArgumentsSpec(val env: KotlinCoreEnvironment) {
             fun test() {
                 bar(1, 2, 3, *arrayOf("a"))
             }
-        """
+        """.trimIndent()
         val findings = subject.compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(1)
     }
@@ -166,7 +166,7 @@ class NamedArgumentsSpec(val env: KotlinCoreEnvironment) {
             fun test() {
                 foo(a = 1, b = 2, c = 3, { it })
             }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
@@ -179,7 +179,7 @@ class NamedArgumentsSpec(val env: KotlinCoreEnvironment) {
             fun test() {
                 foo(a = 1, b = 2, c = 3) { it }
             }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(0)
         }
@@ -192,7 +192,7 @@ class NamedArgumentsSpec(val env: KotlinCoreEnvironment) {
             fun test() {
                 foo(a = 1, b = 2, 3) { it }
             }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
@@ -203,7 +203,7 @@ class NamedArgumentsSpec(val env: KotlinCoreEnvironment) {
             fun test(n: Int) {
                 require(n == 2) { "N is not 2" }
             }
-            """
+            """.trimIndent()
             val subject = NamedArguments(TestConfig(mapOf("threshold" to 1)))
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(0)
@@ -224,7 +224,7 @@ class NamedArgumentsSpec(val env: KotlinCoreEnvironment) {
                     fun bar(a: Int, b: Int, c: Int) {
                         foo(a, b, c)
                     }
-                """
+                """.trimIndent()
                 val findings = subject.compileAndLintWithContext(env, code)
                 assertThat(findings).hasSize(0)
             }
@@ -236,7 +236,7 @@ class NamedArgumentsSpec(val env: KotlinCoreEnvironment) {
                     fun bar(a: Int, b: Int, c: Int) {
                         foo(a, c, b)
                     }
-                """
+                """.trimIndent()
                 val findings = subject.compileAndLintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }
@@ -251,7 +251,7 @@ class NamedArgumentsSpec(val env: KotlinCoreEnvironment) {
                             foo(a, this.b, c)
                         }
                     }
-                """
+                """.trimIndent()
                 val findings = subject.compileAndLintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }
@@ -264,7 +264,7 @@ class NamedArgumentsSpec(val env: KotlinCoreEnvironment) {
                     fun bar(a: Int, c: Int, baz: Baz?) {
                         baz?.let { foo(a, it.b, c) }
                     }
-                """
+                """.trimIndent()
                 val findings = subject.compileAndLintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }
@@ -279,7 +279,7 @@ class NamedArgumentsSpec(val env: KotlinCoreEnvironment) {
                     fun bar(a: Int, b: Int, c: Int) {
                         foo(a, b, c)
                     }
-                """
+                """.trimIndent()
                 val findings = subject.compileAndLintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedBlockDepthSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedBlockDepthSpec.kt
@@ -35,7 +35,7 @@ class NestedBlockDepthSpec {
                     }
                 }
             }
-        """
+        """.trimIndent()
         val findings = subject.compileAndLint(code)
 
         assertThat(findings).hasSize(1)
@@ -53,7 +53,7 @@ class NestedBlockDepthSpec {
                     }
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -69,7 +69,7 @@ class NestedBlockDepthSpec {
                     }
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -87,7 +87,7 @@ class NestedBlockDepthSpec {
                     }
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 }

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedScopeFunctionsSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedScopeFunctionsSpec.kt
@@ -31,7 +31,7 @@ class NestedScopeFunctionsSpec(private val env: KotlinCoreEnvironment) {
                     1.run { }
                 }
             }
-        """
+        """.trimIndent()
         whenLintRuns()
         expectSourceLocation(3 to 11)
         expectFunctionInMsg("run")
@@ -45,7 +45,7 @@ class NestedScopeFunctionsSpec(private val env: KotlinCoreEnvironment) {
                     with(1) { }
                 }
             }
-        """
+        """.trimIndent()
         whenLintRuns()
         expectSourceLocation(3 to 9)
         expectFunctionInMsg("with")
@@ -61,7 +61,7 @@ class NestedScopeFunctionsSpec(private val env: KotlinCoreEnvironment) {
                     }
                 }
             }
-        """
+        """.trimIndent()
         whenLintRuns()
         expectSourceLocation(4 to 13)
     }
@@ -75,7 +75,7 @@ class NestedScopeFunctionsSpec(private val env: KotlinCoreEnvironment) {
                     with(1) { }
                 }
             }
-        """
+        """.trimIndent()
         whenLintRuns()
         expectNoFindings()
     }
@@ -89,7 +89,7 @@ class NestedScopeFunctionsSpec(private val env: KotlinCoreEnvironment) {
                 with(1) {}
                 with(1) {}
             }
-        """
+        """.trimIndent()
         whenLintRuns()
         expectNoFindings()
     }
@@ -102,7 +102,7 @@ class NestedScopeFunctionsSpec(private val env: KotlinCoreEnvironment) {
                     1.run { }
                 }
             }
-        """
+        """.trimIndent()
         whenLintRunsWithoutContext()
         expectNoFindings()
     }

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ReplaceSafeCallChainWithRunSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ReplaceSafeCallChainWithRunSpec.kt
@@ -22,7 +22,7 @@ class ReplaceSafeCallChainWithRunSpec(val env: KotlinCoreEnvironment) {
                 ?.distinctBy { it }
                 ?.iterator()
                 ?.forEach(::println)
-        """
+        """.trimIndent()
 
         assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
     }
@@ -35,7 +35,7 @@ class ReplaceSafeCallChainWithRunSpec(val env: KotlinCoreEnvironment) {
             val y = x
                 ?.asSequence()
                 ?.map { it }
-        """
+        """.trimIndent()
 
         assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
     }
@@ -47,7 +47,7 @@ class ReplaceSafeCallChainWithRunSpec(val env: KotlinCoreEnvironment) {
 
             val y = x
                 ?.asSequence()
-        """
+        """.trimIndent()
 
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
@@ -66,7 +66,7 @@ class ReplaceSafeCallChainWithRunSpec(val env: KotlinCoreEnvironment) {
             fun modifyList() {
                 z?.element?.list = listOf("strings")
             }
-        """
+        """.trimIndent()
 
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/StringLiteralDuplicationSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/StringLiteralDuplicationSpec.kt
@@ -28,7 +28,7 @@ class StringLiteralDuplicationSpec {
                     s1.equals("lorem")
                 }
             }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
@@ -49,7 +49,7 @@ class StringLiteralDuplicationSpec {
             class B
             @Suppress("unused")
             class C
-        """
+        """.trimIndent()
 
         @Test
         fun `does not report strings in annotations`() {
@@ -86,14 +86,14 @@ class StringLiteralDuplicationSpec {
         val regexTestingCode = """
             val str1 = "lorem" + "lorem" + "lorem"
             val str2 = "ipsum" + "ipsum" + "ipsum"
-        """
+        """.trimIndent()
 
         @Test
         fun `does not report lorem or ipsum according to config in regex`() {
             val code = """
                 val str1 = "lorem" + "lorem" + "lorem"
                 val str2 = "ipsum" + "ipsum" + "ipsum"
-            """
+            """.trimIndent()
             val config = TestConfig(mapOf(IGNORE_STRINGS_REGEX to "(lorem|ipsum)"))
             assertFindingWithConfig(code, config, 0)
         }
@@ -129,7 +129,7 @@ class StringLiteralDuplicationSpec {
                     s1.equals("lorem")
                 }
             }
-            """
+            """.trimIndent()
             val finding = subject.compileAndLint(code)[0]
             val locations = finding.references.map { it.location } + finding.entity.location
             assertThat(locations).hasSize(3)
@@ -148,7 +148,7 @@ class StringLiteralDuplicationSpec {
                     |
                     |
                     ""${'"'}
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
     }

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/TooManyFunctionsSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/TooManyFunctionsSpec.kt
@@ -35,7 +35,7 @@ class TooManyFunctionsSpec {
             class A {
                 fun a() = Unit
             }
-        """
+        """.trimIndent()
 
         val findings = rule.compileAndLint(code)
         assertThat(findings).hasSize(1)
@@ -48,7 +48,7 @@ class TooManyFunctionsSpec {
             object O {
                 fun o() = Unit
             }
-        """
+        """.trimIndent()
 
         val findings = rule.compileAndLint(code)
         assertThat(findings).hasSize(1)
@@ -61,7 +61,7 @@ class TooManyFunctionsSpec {
             interface I {
                 fun i()
             }
-        """
+        """.trimIndent()
 
         val findings = rule.compileAndLint(code)
         assertThat(findings).hasSize(1)
@@ -75,7 +75,7 @@ class TooManyFunctionsSpec {
                 A;
                 fun e() {}
             }
-        """
+        """.trimIndent()
 
         val findings = rule.compileAndLint(code)
         assertThat(findings).hasSize(1)
@@ -99,7 +99,7 @@ class TooManyFunctionsSpec {
             interface I
             enum class E
             fun f3() = Unit
-        """
+        """.trimIndent()
 
         assertThat(rule.compileAndLint(code)).hasSize(1)
     }
@@ -112,7 +112,7 @@ class TooManyFunctionsSpec {
                     fun a() = Unit
                 }
             }
-        """
+        """.trimIndent()
 
         val findings = rule.compileAndLint(code)
         assertThat(findings).hasSize(1)
@@ -131,7 +131,7 @@ class TooManyFunctionsSpec {
                 fun f() {
                 }
             }
-        """
+        """.trimIndent()
 
         @Test
         fun `finds all deprecated functions per default`() {
@@ -160,7 +160,7 @@ class TooManyFunctionsSpec {
             class A {
                 private fun f() {}
             }
-        """
+        """.trimIndent()
 
         @Test
         fun `finds the private function per default`() {
@@ -204,7 +204,7 @@ class TooManyFunctionsSpec {
                     override fun a() = Unit
                     override fun b() = Unit
                 }
-            """
+            """.trimIndent()
             val configuredRule = TooManyFunctions(
                 TestConfig(
                     mapOf(
@@ -233,7 +233,7 @@ class TooManyFunctionsSpec {
                     override fun func1() = Unit
                     override fun func2() = Unit
                 }
-        """
+        """.trimIndent()
 
         @Test
         fun `should not report class with overridden functions, if ignoreOverridden is enabled`() {

--- a/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/GlobalCoroutineUsageSpec.kt
+++ b/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/GlobalCoroutineUsageSpec.kt
@@ -20,7 +20,7 @@ class GlobalCoroutineUsageSpec {
             fun foo() {
                 GlobalScope.launch { delay(1_000L) }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 
@@ -35,7 +35,7 @@ class GlobalCoroutineUsageSpec {
             fun foo() {
                 GlobalScope.async { delay(1_000L) }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 
@@ -50,7 +50,7 @@ class GlobalCoroutineUsageSpec {
             fun foo() {
                 bar(GlobalScope)
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -66,7 +66,7 @@ class GlobalCoroutineUsageSpec {
                 val scope = GlobalScope
                 bar(scope)
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 }

--- a/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/InjectDispatcherSpec.kt
+++ b/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/InjectDispatcherSpec.kt
@@ -29,7 +29,7 @@ class InjectDispatcherSpec(val env: KotlinCoreEnvironment) {
                         launch(Dispatchers.IO) { }
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
@@ -46,7 +46,7 @@ class InjectDispatcherSpec(val env: KotlinCoreEnvironment) {
                         launch(dispatcher) { }
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -57,7 +57,7 @@ class InjectDispatcherSpec(val env: KotlinCoreEnvironment) {
                 import kotlinx.coroutines.Dispatchers
 
                 class MyRepository(dispatcher: CoroutineDispatcher = Dispatchers.IO)
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -70,7 +70,7 @@ class InjectDispatcherSpec(val env: KotlinCoreEnvironment) {
                 class MyRepository(dispatcher: CoroutineDispatcher) {
                     constructor() : this(Dispatchers.IO)
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -81,7 +81,7 @@ class InjectDispatcherSpec(val env: KotlinCoreEnvironment) {
                 import kotlinx.coroutines.Dispatchers
 
                 class MyRepository(private val dispatcher: CoroutineDispatcher = Dispatchers.IO)
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -97,7 +97,7 @@ class InjectDispatcherSpec(val env: KotlinCoreEnvironment) {
                         launch(Dispatchers.Main) { }
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
     }
@@ -119,7 +119,7 @@ class InjectDispatcherSpec(val env: KotlinCoreEnvironment) {
                         launch(Dispatchers.Main) { }
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
     }

--- a/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/RedundantSuspendModifierSpec.kt
+++ b/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/RedundantSuspendModifierSpec.kt
@@ -28,7 +28,7 @@ class RedundantSuspendModifierSpec(val env: KotlinCoreEnvironment) {
                     println("hello world")
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
     }
 
@@ -46,7 +46,7 @@ class RedundantSuspendModifierSpec(val env: KotlinCoreEnvironment) {
             suspend fun doesSuspend() {
                 suspendCoroutine()
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 
@@ -58,7 +58,7 @@ class RedundantSuspendModifierSpec(val env: KotlinCoreEnvironment) {
                     println("hello world")
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 
@@ -68,7 +68,7 @@ class RedundantSuspendModifierSpec(val env: KotlinCoreEnvironment) {
             interface SuspendInterface {
                 suspend fun empty()
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 
@@ -84,7 +84,7 @@ class RedundantSuspendModifierSpec(val env: KotlinCoreEnvironment) {
                     println("hello world")
                 }
             }                                
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 
@@ -100,7 +100,7 @@ class RedundantSuspendModifierSpec(val env: KotlinCoreEnvironment) {
                     println(x)
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 
@@ -121,7 +121,7 @@ class RedundantSuspendModifierSpec(val env: KotlinCoreEnvironment) {
                     "Hello"
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 }

--- a/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SleepInsteadOfDelaySpec.kt
+++ b/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SleepInsteadOfDelaySpec.kt
@@ -22,7 +22,7 @@ class SleepInsteadOfDelaySpec(val env: KotlinCoreEnvironment) {
             suspend fun foo() {
                 delay(1000L)
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).hasSize(0)
     }
 
@@ -33,7 +33,7 @@ class SleepInsteadOfDelaySpec(val env: KotlinCoreEnvironment) {
             suspend fun foo() {
                 Thread.sleep(1000L)
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
     }
 
@@ -50,7 +50,7 @@ class SleepInsteadOfDelaySpec(val env: KotlinCoreEnvironment) {
                     Thread.sleep(1000L)
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
     }
 
@@ -68,7 +68,7 @@ class SleepInsteadOfDelaySpec(val env: KotlinCoreEnvironment) {
                     Thread.sleep(1000L)
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
     }
 }

--- a/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunWithCoroutineScopeReceiverSpec.kt
+++ b/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunWithCoroutineScopeReceiverSpec.kt
@@ -28,7 +28,7 @@ class SuspendFunWithCoroutineScopeReceiverSpec(val env: KotlinCoreEnvironment) {
                         delay(timeMillis = 1000)
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
@@ -42,7 +42,7 @@ class SuspendFunWithCoroutineScopeReceiverSpec(val env: KotlinCoreEnvironment) {
                         delay(timeMillis = 1000)
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
@@ -57,7 +57,7 @@ class SuspendFunWithCoroutineScopeReceiverSpec(val env: KotlinCoreEnvironment) {
                         delay(timeMillis = 1000)
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
@@ -75,7 +75,7 @@ class SuspendFunWithCoroutineScopeReceiverSpec(val env: KotlinCoreEnvironment) {
                         delay(timeMillis = 1000)
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
@@ -91,7 +91,7 @@ class SuspendFunWithCoroutineScopeReceiverSpec(val env: KotlinCoreEnvironment) {
                         delay(timeMillis = 1000)
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -107,7 +107,7 @@ class SuspendFunWithCoroutineScopeReceiverSpec(val env: KotlinCoreEnvironment) {
                         delay(timeMillis = 1000)
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -121,7 +121,7 @@ class SuspendFunWithCoroutineScopeReceiverSpec(val env: KotlinCoreEnvironment) {
                         delay(timeMillis = this@foo)
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
     }
@@ -140,7 +140,7 @@ class SuspendFunWithCoroutineScopeReceiverSpec(val env: KotlinCoreEnvironment) {
                 suspend fun CoroutineScope.foo(action: suspend CoroutineScope.() -> Unit) {
                     action()
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
     }

--- a/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunWithFlowReturnTypeSpec.kt
+++ b/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunWithFlowReturnTypeSpec.kt
@@ -35,7 +35,7 @@ class SuspendFunWithFlowReturnTypeSpec(val env: KotlinCoreEnvironment) {
                 yield()
                 return MutableStateFlow(value = 1L)
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).hasSize(3)
     }
 
@@ -59,7 +59,7 @@ class SuspendFunWithFlowReturnTypeSpec(val env: KotlinCoreEnvironment) {
                 yield()
                 return MutableStateFlow(value = 1L)
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).hasSize(3)
     }
 
@@ -82,7 +82,7 @@ class SuspendFunWithFlowReturnTypeSpec(val env: KotlinCoreEnvironment) {
                 yield()
                 return kotlinx.coroutines.flow.MutableStateFlow(value = 1L)
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).hasSize(3)
     }
 
@@ -94,7 +94,7 @@ class SuspendFunWithFlowReturnTypeSpec(val env: KotlinCoreEnvironment) {
 
             suspend fun flowValues() = flowOf(1L, 2L, 3L)
             suspend fun mutableStateFlowValues() = MutableStateFlow(value = 1L)
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).hasSize(2)
     }
 
@@ -110,7 +110,7 @@ class SuspendFunWithFlowReturnTypeSpec(val env: KotlinCoreEnvironment) {
                 suspend fun stateFlowValues(): StateFlow<Long>
                 suspend fun mutableStateFlowValues(): MutableStateFlow<Long>
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).hasSize(3)
     }
 
@@ -139,7 +139,7 @@ class SuspendFunWithFlowReturnTypeSpec(val env: KotlinCoreEnvironment) {
                     return MutableStateFlow(value = 1L)
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).hasSize(3)
     }
 
@@ -153,7 +153,7 @@ class SuspendFunWithFlowReturnTypeSpec(val env: KotlinCoreEnvironment) {
                 suspend fun flowValues() = flowOf(1L, 2L, 3L)
                 suspend fun mutableStateFlowValues() = MutableStateFlow(value = 1L)
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).hasSize(2)
     }
 
@@ -180,7 +180,7 @@ class SuspendFunWithFlowReturnTypeSpec(val env: KotlinCoreEnvironment) {
                 yield()
                 return MutableStateFlow(value = this)
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).hasSize(3)
     }
 
@@ -192,7 +192,7 @@ class SuspendFunWithFlowReturnTypeSpec(val env: KotlinCoreEnvironment) {
 
             suspend fun Long.flowValues() = (0..this).asFlow()
             suspend fun Long.mutableStateFlowValues() = MutableStateFlow(value = this)
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).hasSize(2)
     }
 
@@ -213,7 +213,7 @@ class SuspendFunWithFlowReturnTypeSpec(val env: KotlinCoreEnvironment) {
             fun doSomething3(block: suspend () -> MutableStateFlow<Long>) {
                 TODO()
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 
@@ -250,7 +250,7 @@ class SuspendFunWithFlowReturnTypeSpec(val env: KotlinCoreEnvironment) {
             class ValueRepository3 {
                 suspend fun getValue() = 5L.apply { delay(1_000L) }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 
@@ -273,7 +273,7 @@ class SuspendFunWithFlowReturnTypeSpec(val env: KotlinCoreEnvironment) {
             fun mutableStateFlowValues(): MutableStateFlow<Long> {
                 return MutableStateFlow(value = 1L)
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 }

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/AbsentOrWrongFileLicenseSpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/AbsentOrWrongFileLicenseSpec.kt
@@ -24,7 +24,7 @@ class AbsentOrWrongFileLicenseSpec {
             """
             /* LICENSE */
             package cases
-            """
+            """.trimIndent()
         )
 
         assertThat(findings).isEmpty()
@@ -36,7 +36,7 @@ class AbsentOrWrongFileLicenseSpec {
             """
             /* WRONG LICENSE */
             package cases
-            """
+            """.trimIndent()
         )
 
         assertThat(findings).hasSize(1)
@@ -47,7 +47,7 @@ class AbsentOrWrongFileLicenseSpec {
         val findings = checkLicence(
             """
             package cases
-            """
+            """.trimIndent()
         )
 
         assertThat(findings).hasSize(1)

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentOverPrivateMethodSpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentOverPrivateMethodSpec.kt
@@ -16,7 +16,7 @@ class CommentOverPrivateMethodSpec {
                  */
                 private fun f() {}
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 
@@ -27,7 +27,7 @@ class CommentOverPrivateMethodSpec {
              * asdf
              */
             fun f() {}
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -40,7 +40,7 @@ class CommentOverPrivateMethodSpec {
                  */
                 fun f() {}
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 }

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentOverPrivatePropertiesSpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentOverPrivatePropertiesSpec.kt
@@ -14,7 +14,7 @@ class CommentOverPrivatePropertiesSpec {
              * asdf
              */
             private val v = 1
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 
@@ -25,7 +25,7 @@ class CommentOverPrivatePropertiesSpec {
              * asdf
              */
             val v = 1
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -38,7 +38,7 @@ class CommentOverPrivatePropertiesSpec {
                  */
                 private val v = 1
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 
@@ -51,7 +51,7 @@ class CommentOverPrivatePropertiesSpec {
                  */
                 val v = 1
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 }

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/DeprecatedBlockTagSpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/DeprecatedBlockTagSpec.kt
@@ -17,7 +17,7 @@ class DeprecatedBlockTagSpec {
              * Nothing to see here...
              */
             val v = 2
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(0)
     }
 
@@ -30,7 +30,7 @@ class DeprecatedBlockTagSpec {
              * @deprecated oh no, this should not be here
              */
             fun ohNo() { }
-        """
+        """.trimIndent()
 
         @Test
         fun `has found something`() {
@@ -58,7 +58,7 @@ class DeprecatedBlockTagSpec {
              * @deprecated This thing is deprecated
              */
             class Thing { }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
@@ -73,7 +73,7 @@ class DeprecatedBlockTagSpec {
                  */
                 val doNotUseMe = 0
             }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
@@ -86,7 +86,7 @@ class DeprecatedBlockTagSpec {
                  * @deprecated Do not use that
                  */
                 annotation class Thing()
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
@@ -101,7 +101,7 @@ class DeprecatedBlockTagSpec {
                      */
                     constructor(something: String)
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
@@ -118,7 +118,7 @@ class DeprecatedBlockTagSpec {
                          */
                         set(value) { println(value) }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
@@ -135,7 +135,7 @@ class DeprecatedBlockTagSpec {
                         get() = 10
                         set(value) { println(value) }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
@@ -148,7 +148,7 @@ class DeprecatedBlockTagSpec {
                  * @deprecated Do not use this typealias
                  */
                 typealias VeryString = String
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
     }

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/EndOfSentenceFormatSpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/EndOfSentenceFormatSpec.kt
@@ -13,7 +13,7 @@ class EndOfSentenceFormatSpec {
         /** Some doc */
         class Test {
         }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 
@@ -23,7 +23,7 @@ class EndOfSentenceFormatSpec {
             /** Some doc */
             fun f(x: Int, y: Int, z: Int) = 
                 if (x == 0) y + z else x + y
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 
@@ -34,7 +34,7 @@ class EndOfSentenceFormatSpec {
             /** Some doc */
             val test = 3
         }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 
@@ -43,7 +43,7 @@ class EndOfSentenceFormatSpec {
         val code = """
         /** Some doc */
         fun test() = 3
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 
@@ -54,7 +54,7 @@ class EndOfSentenceFormatSpec {
             /** Some doc */
             fun test() = 3
         }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 
@@ -65,7 +65,7 @@ class EndOfSentenceFormatSpec {
             /** Some doc-- */
             fun test() = 3
         }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 
@@ -77,7 +77,7 @@ class EndOfSentenceFormatSpec {
          */
         class Test {
         }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 
@@ -91,7 +91,7 @@ class EndOfSentenceFormatSpec {
          */
         class Test {
         }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -102,7 +102,7 @@ class EndOfSentenceFormatSpec {
          */
         class Test {
         }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -116,7 +116,7 @@ class EndOfSentenceFormatSpec {
          */
         class Test {
         }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -136,7 +136,7 @@ class EndOfSentenceFormatSpec {
          */
         class Test {
         }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -148,7 +148,7 @@ class EndOfSentenceFormatSpec {
          */
         class Test {
         }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -160,7 +160,7 @@ class EndOfSentenceFormatSpec {
          */
         class Test {
         }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -172,7 +172,7 @@ class EndOfSentenceFormatSpec {
          */
         class Test {
         }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -184,7 +184,7 @@ class EndOfSentenceFormatSpec {
          */
         class Test {
         }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -199,7 +199,7 @@ class EndOfSentenceFormatSpec {
         http://google.com */
         class Test2 {
         }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 }

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/OutdatedDocumentationSpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/OutdatedDocumentationSpec.kt
@@ -15,7 +15,7 @@ class OutdatedDocumentationSpec {
         fun `should not report when doc is missing`() {
             val withoutDoc = """
             class MyClass(someParam: String, val someProp: String)
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(withoutDoc)).isEmpty()
         }
 
@@ -26,7 +26,7 @@ class OutdatedDocumentationSpec {
              * Some class description without referring to tags or properties
              */
             class MyClass(someParam: String, val someProp: String)
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(docWithoutParamAndPropertyTags)).isEmpty()
         }
     }
@@ -40,7 +40,7 @@ class OutdatedDocumentationSpec {
              * @param someParam Description of param
              */
             class MyClass(someParam: String)
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(correctParam)).isEmpty()
         }
 
@@ -51,7 +51,7 @@ class OutdatedDocumentationSpec {
              * @param someParam Description of param
              */
             class MyClass(otherParam: String)
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(incorrectParamName)).hasSize(1)
         }
 
@@ -63,7 +63,7 @@ class OutdatedDocumentationSpec {
              * @param someSecondParam Description of param
              */
             class MyClass(someParam: String)
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(incorrectListOfParams)).hasSize(1)
         }
 
@@ -75,7 +75,7 @@ class OutdatedDocumentationSpec {
              * @param otherParam Description of param
              */
             class MyClass(otherParam: String, someParam: String)
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(incorrectParamOrder)).hasSize(1)
         }
 
@@ -87,7 +87,7 @@ class OutdatedDocumentationSpec {
              * @property someProp Description of property
              */
             class MyClass(someParam: String, val someProp: String)
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(correctParamAndProp)).isEmpty()
         }
 
@@ -99,7 +99,7 @@ class OutdatedDocumentationSpec {
              * @property someProp Description of property
              */
             class MyClass(someParam: String, val otherProp: String)
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(correctParamIncorrectProp)).hasSize(1)
         }
 
@@ -111,7 +111,7 @@ class OutdatedDocumentationSpec {
              * @property someProp Description of property
              */
             class MyClass(otherParam: String, val someProp: String)
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(incorrectParamCorrectProp)).hasSize(1)
         }
 
@@ -124,7 +124,7 @@ class OutdatedDocumentationSpec {
                  */
                 constructor(otherParam: String)
             }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(incorrectConstructorDoc)).hasSize(1)
         }
 
@@ -136,7 +136,7 @@ class OutdatedDocumentationSpec {
                  * @param someProp Description of property
                  */
                 class MyClass(someParam: String, val someProp: String)
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(propertyAsParam)).hasSize(1)
         }
 
@@ -148,7 +148,7 @@ class OutdatedDocumentationSpec {
              * @param someParam Description of param
              */
             class MyClass(someParam: String, val someProp: String)
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(incorrectDeclarationsOrder)).hasSize(1)
         }
     }
@@ -164,7 +164,7 @@ class OutdatedDocumentationSpec {
              * @param someParam Description of param
              */
             class MyClass<T>(someParam: String)
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(correctTypeParam)).isEmpty()
         }
 
@@ -176,7 +176,7 @@ class OutdatedDocumentationSpec {
              * @param T Description of type param
              */
             class MyClass<T>
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(correctTypeParam)).isEmpty()
         }
 
@@ -187,7 +187,7 @@ class OutdatedDocumentationSpec {
              * @param someParam Description of param
              */
             class MyClass<T>(someParam: String)
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(missingTypeParam)).hasSize(1)
         }
 
@@ -199,7 +199,7 @@ class OutdatedDocumentationSpec {
              * @param someParam Description of param
              */
             class MyClass<T>(someParam: String)
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(incorrectTypeParamName)).hasSize(1)
         }
 
@@ -211,7 +211,7 @@ class OutdatedDocumentationSpec {
              * @param someParam Description of param
              */
             class MyClass<T, S>(someParam: String)
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(incorrectTypeParamList)).hasSize(1)
         }
     }
@@ -226,7 +226,7 @@ class OutdatedDocumentationSpec {
              * @param someParam Description of param
              */
             fun myFun(someParam: String) {}
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(correctDoc)).isEmpty()
         }
 
@@ -237,7 +237,7 @@ class OutdatedDocumentationSpec {
              * @param someParam Description of param
              */
             fun myFun(otherParam: String) {}
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(incorrectParamName)).hasSize(1)
         }
     }
@@ -253,7 +253,7 @@ class OutdatedDocumentationSpec {
              * @param someParam Description of param
              */
             fun <T> myFun(someParam: String) {}
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(correctTypeParam)).isEmpty()
         }
 
@@ -264,7 +264,7 @@ class OutdatedDocumentationSpec {
              * @param someParam Description of param
              */
             fun <T> myFun(someParam: String) {}
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(missingTypeParam)).hasSize(1)
         }
 
@@ -276,7 +276,7 @@ class OutdatedDocumentationSpec {
              * @param someParam Description of param
              */
             fun <T> myFun(someParam: String) {}
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(incorrectTypeParamName)).hasSize(1)
         }
 
@@ -288,7 +288,7 @@ class OutdatedDocumentationSpec {
              * @param someParam Description of param
              */
             fun <T, S> myFun(someParam: String) {}
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(incorrectTypeParamList)).hasSize(1)
         }
 
@@ -301,7 +301,7 @@ class OutdatedDocumentationSpec {
                  * @param S Description of type param
                  */
                 fun <T, S> myFun(someParam: String) {}
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(incorrectTypeParamsOrder)).hasSize(1)
         }
     }
@@ -321,7 +321,7 @@ class OutdatedDocumentationSpec {
                 */
                 fun myFun(someParam: String) {}
             }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(correctClassWithFunction)).isEmpty()
         }
 
@@ -345,7 +345,7 @@ class OutdatedDocumentationSpec {
                 */
                 class MyNestedClass(otherParam: String)
             }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(incorrectClassWithTwoIncorrectFunctions)).hasSize(4)
         }
     }
@@ -362,7 +362,7 @@ class OutdatedDocumentationSpec {
              * @param someParam Description of param
              */
             class MyClass<T, S>(someParam: String)
-            """
+            """.trimIndent()
             assertThat(configuredSubject.compileAndLint(incorrectClassTypeParams)).isEmpty()
         }
 
@@ -373,7 +373,7 @@ class OutdatedDocumentationSpec {
              * @param someParam Description of param
              */
             fun <T, S> myFun(someParam: String) {}
-            """
+            """.trimIndent()
             assertThat(configuredSubject.compileAndLint(incorrectFunctionTypeParams)).isEmpty()
         }
     }
@@ -391,7 +391,7 @@ class OutdatedDocumentationSpec {
              * @param otherParam Description of param
              */
             class MyClass(otherParam: String, someParam: String)
-            """
+            """.trimIndent()
             assertThat(configuredSubject.compileAndLint(incorrectDeclarationsOrder)).isEmpty()
         }
 
@@ -405,7 +405,7 @@ class OutdatedDocumentationSpec {
              * @param T Description of param
              */
             fun <T, S> myFun(otherParam: String, someParam: String) {}
-            """
+            """.trimIndent()
             assertThat(configuredSubject.compileAndLint(incorrectDeclarationsOrderWithType)).isEmpty()
         }
     }
@@ -423,7 +423,7 @@ class OutdatedDocumentationSpec {
                  * @param someProp Description of property
                  */
                 class MyClass(someParam: String, val someProp: String)
-            """
+            """.trimIndent()
             assertThat(configuredSubject.compileAndLint(propertyAsParam)).isEmpty()
         }
 
@@ -435,7 +435,7 @@ class OutdatedDocumentationSpec {
                  * @property someProp Description of property
                  */
                 class MyClass(someParam: String, val someProp: String)
-            """
+            """.trimIndent()
             assertThat(configuredSubject.compileAndLint(propertyAsParam)).isEmpty()
         }
     }
@@ -460,7 +460,7 @@ class OutdatedDocumentationSpec {
                  * @param someProp Description of property
                  */
                 class MyClass(someParam: String, val someProp: String)
-            """
+            """.trimIndent()
             assertThat(configuredSubject.compileAndLint(propertyAsParam)).isEmpty()
         }
 
@@ -472,7 +472,7 @@ class OutdatedDocumentationSpec {
                  * @property someProp Description of property
                  */
                 class MyClass(someParam: String, val someProp: String)
-            """
+            """.trimIndent()
             assertThat(configuredSubject.compileAndLint(propertyAsParam)).isEmpty()
         }
     }

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicClassSpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicClassSpec.kt
@@ -19,42 +19,42 @@ class UndocumentedPublicClassSpec {
         class TestInner {
             inner class Inner
         }
-    """
+    """.trimIndent()
 
     val innerObject = """
         /** Some doc */
         class TestInner {
             object Inner
         }
-    """
+    """.trimIndent()
 
     val innerInterface = """
         /** Some doc */
         class TestInner {
             interface Something
         }
-    """
+    """.trimIndent()
 
     val nested = """
         /** Some doc */
         class TestNested {
             class Nested
         }
-    """
+    """.trimIndent()
 
     val nestedPublic = """
         /** Some doc */
         class TestNested {
             public class Nested
         }
-    """
+    """.trimIndent()
 
     val nestedPrivate = """
         /** Some doc */
         class TestNested {
             private class Nested
         }
-    """
+    """.trimIndent()
 
     val privateClass = "private class TestNested {}"
     val internalClass = "internal class TestNested {}"
@@ -141,7 +141,7 @@ class UndocumentedPublicClassSpec {
             class Nested
             inner class Inner
         }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -151,7 +151,7 @@ class UndocumentedPublicClassSpec {
         internal class Outer {
             interface Inner
         }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -161,7 +161,7 @@ class UndocumentedPublicClassSpec {
         internal class Outer {
             object Inner
         }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -181,7 +181,7 @@ class UndocumentedPublicClassSpec {
             fun main(args: Array<String>) {
             }
         }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -194,7 +194,7 @@ class UndocumentedPublicClassSpec {
                 override fun next() = 1
             }
         }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -204,7 +204,7 @@ class UndocumentedPublicClassSpec {
         enum class Enum {
             CONSTANT
         }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 
@@ -215,7 +215,7 @@ class UndocumentedPublicClassSpec {
         enum class Enum {
             CONSTANT
         }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -231,7 +231,7 @@ class UndocumentedPublicClassSpec {
              */
             fun onComplete()
         }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -240,7 +240,7 @@ class UndocumentedPublicClassSpec {
         val code = """
         protected class Test {
         }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -249,7 +249,7 @@ class UndocumentedPublicClassSpec {
         val code = """
         protected class Test {
         }
-        """
+        """.trimIndent()
         val subject = UndocumentedPublicClass(TestConfig(mapOf(SEARCH_IN_PROTECTED_CLASS to "true")))
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicFunctionSpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicFunctionSpec.kt
@@ -15,7 +15,7 @@ class UndocumentedPublicFunctionSpec {
     fun `reports undocumented public functions`() {
         val code = """
             fun noComment1() {}
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 
@@ -25,7 +25,7 @@ class UndocumentedPublicFunctionSpec {
             object Test {
                 fun noComment1() {}
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 
@@ -37,7 +37,7 @@ class UndocumentedPublicFunctionSpec {
                     fun noComment1() {}
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 
@@ -50,7 +50,7 @@ class UndocumentedPublicFunctionSpec {
                     public fun noComment2() {}
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(2)
     }
 
@@ -60,7 +60,7 @@ class UndocumentedPublicFunctionSpec {
             interface Test {
                 fun noComment1()
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 
@@ -71,7 +71,7 @@ class UndocumentedPublicFunctionSpec {
              * Comment
              */
             fun commented1() {}
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -84,7 +84,7 @@ class UndocumentedPublicFunctionSpec {
             */
             fun commented() {}
         }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -95,7 +95,7 @@ class UndocumentedPublicFunctionSpec {
                 internal fun no1(){}
                 private fun no2(){}
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -108,7 +108,7 @@ class UndocumentedPublicFunctionSpec {
             fun commented() {
                 fun iDontNeedDoc() {}
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -119,7 +119,7 @@ class UndocumentedPublicFunctionSpec {
                 fun nope1() {}
                 public fun nope2() {}
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -130,7 +130,7 @@ class UndocumentedPublicFunctionSpec {
                 fun nope1() {}
                 public fun nope2() {}
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -140,7 +140,7 @@ class UndocumentedPublicFunctionSpec {
             private object Test {
                 fun noComment1() {}
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -150,7 +150,7 @@ class UndocumentedPublicFunctionSpec {
             open class Test {
                 protected fun noComment1() {}
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -160,7 +160,7 @@ class UndocumentedPublicFunctionSpec {
             open class Test {
                 protected fun noComment1() {}
             }
-        """
+        """.trimIndent()
         val subject = UndocumentedPublicFunction(TestConfig(mapOf(SEARCH_PROTECTED_FUN to "true")))
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
@@ -176,7 +176,7 @@ class UndocumentedPublicFunctionSpec {
                         }
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
@@ -191,7 +191,7 @@ class UndocumentedPublicFunctionSpec {
                         }
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
@@ -204,7 +204,7 @@ class UndocumentedPublicFunctionSpec {
                         }
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
     }

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicPropertySpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicPropertySpec.kt
@@ -23,7 +23,7 @@ class UndocumentedPublicPropertySpec {
             object Test {
                 val a = 1
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 
@@ -35,7 +35,7 @@ class UndocumentedPublicPropertySpec {
                     val a = 1 
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 
@@ -48,7 +48,7 @@ class UndocumentedPublicPropertySpec {
                     public val b = 1
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(2)
     }
 
@@ -58,7 +58,7 @@ class UndocumentedPublicPropertySpec {
             interface Test {
                 val a: Int
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 
@@ -81,7 +81,7 @@ class UndocumentedPublicPropertySpec {
              * Comment
              */
             val a = 1
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -94,7 +94,7 @@ class UndocumentedPublicPropertySpec {
                 */
                 val a = 1
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -111,7 +111,7 @@ class UndocumentedPublicPropertySpec {
             class Test : I {
                 override val a = 1
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -122,7 +122,7 @@ class UndocumentedPublicPropertySpec {
                 internal val a = 1
                 private val b = 1
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -132,7 +132,7 @@ class UndocumentedPublicPropertySpec {
             fun commented(x: Int) {
                 var a = x
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -143,7 +143,7 @@ class UndocumentedPublicPropertySpec {
                 public val a = 1
                 val b = 1
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -154,7 +154,7 @@ class UndocumentedPublicPropertySpec {
                 public val a = 1
                 val b = 1
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -164,7 +164,7 @@ class UndocumentedPublicPropertySpec {
             class Test() {
                 constructor(a: Int) : this()
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -173,7 +173,7 @@ class UndocumentedPublicPropertySpec {
         val code = """
             class Test1(internal val a: Int)
             class Test2(b: Int)
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -202,7 +202,7 @@ class UndocumentedPublicPropertySpec {
                  */
                 val e: Int                    
             )
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -212,7 +212,7 @@ class UndocumentedPublicPropertySpec {
             private object Test {
                 val a = 1
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -222,7 +222,7 @@ class UndocumentedPublicPropertySpec {
             open class Test {
                 protected val a = 1
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -232,7 +232,7 @@ class UndocumentedPublicPropertySpec {
             open class Test {
                 protected val a = 1
             }
-        """
+        """.trimIndent()
         val subject = UndocumentedPublicProperty(TestConfig(mapOf(SEARCH_PROTECTED_PROPERTY to "true")))
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
@@ -252,7 +252,7 @@ class UndocumentedPublicPropertySpec {
                     }
                 }
             }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).hasSize(2)
         }
 
@@ -264,7 +264,7 @@ class UndocumentedPublicPropertySpec {
                     val i = 0
                 }
             }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
@@ -276,7 +276,7 @@ class UndocumentedPublicPropertySpec {
                     val i = 0
                 }
             }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
@@ -288,7 +288,7 @@ class UndocumentedPublicPropertySpec {
                     val i = 0
                 }
             }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
@@ -300,7 +300,7 @@ class UndocumentedPublicPropertySpec {
                     val i = 0
                 }
             }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
     }
@@ -316,7 +316,7 @@ class UndocumentedPublicPropertySpec {
                     class InnerInner(val c: Int)
                 }
             }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).hasSize(3)
         }
 
@@ -326,7 +326,7 @@ class UndocumentedPublicPropertySpec {
             class Outer(val a: Int) {
                 inner class Inner(val b: Int)
             }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).hasSize(2)
         }
 
@@ -336,7 +336,7 @@ class UndocumentedPublicPropertySpec {
             object Outer {
                 class Inner(val a: Int)
             }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
@@ -346,7 +346,7 @@ class UndocumentedPublicPropertySpec {
             internal class Outer(val a: Int) {
                 class Inner(val b: Int)
             }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
@@ -356,7 +356,7 @@ class UndocumentedPublicPropertySpec {
             internal class Outer(val a: Int) {
                 inner class Inner(val b: Int)
             }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
     }

--- a/detekt-rules-empty/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyClassBlockSpec.kt
+++ b/detekt-rules-empty/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyClassBlockSpec.kt
@@ -21,7 +21,7 @@ class EmptyClassBlockSpec {
             class SomeClass {
                 // Some comment to explain what this class is supposed to do
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -33,7 +33,7 @@ class EmptyClassBlockSpec {
                 Some comment to explain what this class is supposed to do
                 */
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -43,7 +43,7 @@ class EmptyClassBlockSpec {
             class SomeClass {
                 class EmptyClass {}
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 
@@ -63,7 +63,7 @@ class EmptyClassBlockSpec {
             fun f() {
                  object : Open() {}
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 }

--- a/detekt-rules-empty/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyCodeSpec.kt
+++ b/detekt-rules-empty/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyCodeSpec.kt
@@ -22,7 +22,7 @@ class EmptyCodeSpec {
                 } catch (foo: Exception) {
                 }
             }
-    """
+    """.trimIndent()
 
     @Test
     fun `findsEmptyCatch`() {
@@ -40,7 +40,7 @@ class EmptyCodeSpec {
                 }
             }
         }
-        """
+        """.trimIndent()
         assertThat(EmptyCatchBlock(Config.empty).compileAndLint(code)).hasSize(1)
     }
 
@@ -53,7 +53,7 @@ class EmptyCodeSpec {
             } catch (expected: Exception) {
             }
         }
-        """
+        """.trimIndent()
         assertThat(EmptyCatchBlock(Config.empty).compileAndLint(code)).isEmpty()
     }
 
@@ -65,7 +65,7 @@ class EmptyCodeSpec {
             } catch (foo: Exception) {
             }
         }
-        """
+        """.trimIndent()
         val config = TestConfig(mapOf(ALLOWED_EXCEPTION_NAME_REGEX to "foo"))
         assertThat(EmptyCatchBlock(config).compileAndLint(code)).isEmpty()
     }

--- a/detekt-rules-empty/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyDefaultConstructorSpec.kt
+++ b/detekt-rules-empty/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyDefaultConstructorSpec.kt
@@ -12,7 +12,7 @@ internal class EmptyDefaultConstructorSpec {
     fun `EmptyConstructor`() {
         val code = """
             class EmptyConstructor()
-        """
+        """.trimIndent()
         assertThat(EmptyDefaultConstructor(Config.empty).compileAndLint(code)).hasSize(1)
     }
 
@@ -20,7 +20,7 @@ internal class EmptyDefaultConstructorSpec {
     fun `EmptyPrimaryConstructor`() {
         val code = """
             class EmptyPrimaryConstructor constructor()
-        """
+        """.trimIndent()
         assertThat(EmptyDefaultConstructor(Config.empty).compileAndLint(code)).hasSize(1)
     }
 
@@ -28,7 +28,7 @@ internal class EmptyDefaultConstructorSpec {
     fun `EmptyPublicPrimaryConstructor`() {
         val code = """
             class EmptyPublicPrimaryConstructor public constructor()
-        """
+        """.trimIndent()
         assertThat(EmptyDefaultConstructor(Config.empty).compileAndLint(code)).hasSize(1)
     }
 
@@ -36,7 +36,7 @@ internal class EmptyDefaultConstructorSpec {
     fun `PrimaryConstructorWithParameter`() {
         val code = """
             class PrimaryConstructorWithParameter constructor(x: Int)
-        """
+        """.trimIndent()
         assertThat(EmptyDefaultConstructor(Config.empty).compileAndLint(code)).isEmpty()
     }
 
@@ -44,7 +44,7 @@ internal class EmptyDefaultConstructorSpec {
     fun `PrimaryConstructorWithAnnotation`() {
         val code = """
             class PrimaryConstructorWithAnnotation @SafeVarargs constructor()
-        """
+        """.trimIndent()
         assertThat(EmptyDefaultConstructor(Config.empty).compileAndLint(code)).isEmpty()
     }
 
@@ -52,7 +52,7 @@ internal class EmptyDefaultConstructorSpec {
     fun `PrivatePrimaryConstructor`() {
         val code = """
             class PrivatePrimaryConstructor private constructor()
-        """
+        """.trimIndent()
         assertThat(EmptyDefaultConstructor(Config.empty).compileAndLint(code)).isEmpty()
     }
 
@@ -63,7 +63,7 @@ internal class EmptyDefaultConstructorSpec {
 
                 constructor(i: Int) : this()
             }
-        """
+        """.trimIndent()
         assertThat(EmptyDefaultConstructor(Config.empty).compileAndLint(code)).isEmpty()
     }
 
@@ -71,7 +71,7 @@ internal class EmptyDefaultConstructorSpec {
     fun `should not report empty constructors for classes with expect keyword - #1362`() {
         val code = """
             expect class NeedsConstructor()
-        """
+        """.trimIndent()
         assertThat(EmptyDefaultConstructor(Config.empty).lint(code)).isEmpty()
     }
 
@@ -79,7 +79,7 @@ internal class EmptyDefaultConstructorSpec {
     fun `should not report empty constructors for classes with actual - #1362`() {
         val code = """
             actual class NeedsConstructor actual constructor()
-        """
+        """.trimIndent()
         assertThat(EmptyDefaultConstructor(Config.empty).lint(code)).isEmpty()
     }
 
@@ -87,7 +87,7 @@ internal class EmptyDefaultConstructorSpec {
     fun `should not report empty constructors for annotation classes with expect keyword - #1362`() {
         val code = """
             expect annotation class NeedsConstructor()
-        """
+        """.trimIndent()
         assertThat(EmptyDefaultConstructor(Config.empty).lint(code)).isEmpty()
     }
 
@@ -95,7 +95,7 @@ internal class EmptyDefaultConstructorSpec {
     fun `should not report empty constructors for annotation classes with actual - #1362`() {
         val code = """
             actual annotation class NeedsConstructor actual constructor()
-        """
+        """.trimIndent()
         assertThat(EmptyDefaultConstructor(Config.empty).lint(code)).isEmpty()
     }
 }

--- a/detekt-rules-empty/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyElseBlockSpec.kt
+++ b/detekt-rules-empty/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyElseBlockSpec.kt
@@ -20,7 +20,7 @@ class EmptyElseBlockSpec {
                     
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 
@@ -33,7 +33,7 @@ class EmptyElseBlockSpec {
                     println(i)
                 } else ;
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 
@@ -48,7 +48,7 @@ class EmptyElseBlockSpec {
                 ;
                 i++
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 
@@ -63,7 +63,7 @@ class EmptyElseBlockSpec {
                 }
                 i++
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 
@@ -78,7 +78,7 @@ class EmptyElseBlockSpec {
                     i++
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -91,7 +91,7 @@ class EmptyElseBlockSpec {
                     println(i)
                 } else i++
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -104,7 +104,7 @@ class EmptyElseBlockSpec {
                     println(i)
                 } else i++;
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 }

--- a/detekt-rules-empty/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyFunctionBlockSpec.kt
+++ b/detekt-rules-empty/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyFunctionBlockSpec.kt
@@ -20,7 +20,7 @@ class EmptyFunctionBlockSpec {
             class A {
                 protected fun stuff() {}
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasStartSourceLocation(2, 27)
     }
 
@@ -30,7 +30,7 @@ class EmptyFunctionBlockSpec {
             open class A {
                 open fun stuff() {}
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -40,7 +40,7 @@ class EmptyFunctionBlockSpec {
             interface I {
                 fun stuff() {}
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -50,7 +50,7 @@ class EmptyFunctionBlockSpec {
             fun a() {
                 fun b() {}
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasStartSourceLocation(2, 13)
     }
 
@@ -79,7 +79,7 @@ class EmptyFunctionBlockSpec {
                     // this is necessary...
                 }
             }
-        """
+        """.trimIndent()
 
         @Test
         fun `should flag empty block in overridden function`() {
@@ -111,7 +111,7 @@ class EmptyFunctionBlockSpec {
 
                 }
             }
-        """
+        """.trimIndent()
 
         @Test
         fun `should not flag overridden functions with commented body`() {

--- a/detekt-rules-empty/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyIfBlockSpec.kt
+++ b/detekt-rules-empty/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyIfBlockSpec.kt
@@ -17,7 +17,7 @@ class EmptyIfBlockSpec {
                 if (i == 0);
                 i++
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 
@@ -30,7 +30,7 @@ class EmptyIfBlockSpec {
                 ;
                 i++
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 
@@ -43,7 +43,7 @@ class EmptyIfBlockSpec {
                 }
                 i++
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 
@@ -56,7 +56,7 @@ class EmptyIfBlockSpec {
                     i++
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -67,7 +67,7 @@ class EmptyIfBlockSpec {
                 var i = 0
                 if (i == 0) i++
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -78,7 +78,7 @@ class EmptyIfBlockSpec {
                 var i = 0
                 if (i == 0) i++;
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -90,7 +90,7 @@ class EmptyIfBlockSpec {
                 if (i == 0) ;
                 else i++
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -103,7 +103,7 @@ class EmptyIfBlockSpec {
                 else if (i == 1) ;
                 else i++
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/CastToNullableTypeSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/CastToNullableTypeSpec.kt
@@ -13,7 +13,7 @@ class CastToNullableTypeSpec {
             fun foo(a: Any?) {
                 val x: String? = a as String?
             } 
-        """
+        """.trimIndent()
         val findings = subject.compileAndLint(code)
         assertThat(findings).hasSize(1)
         assertThat(findings).hasStartSourceLocation(2, 22)
@@ -26,7 +26,7 @@ class CastToNullableTypeSpec {
             fun foo(a: Any?) {
                 val x: String? = a as? String
             } 
-        """
+        """.trimIndent()
         val findings = subject.compileAndLint(code)
         assertThat(findings).isEmpty()
     }
@@ -37,7 +37,7 @@ class CastToNullableTypeSpec {
             fun foo(a: Any?) {
                 val x = a is String?
             } 
-        """
+        """.trimIndent()
         val findings = subject.compileAndLint(code)
         assertThat(findings).isEmpty()
     }
@@ -48,7 +48,7 @@ class CastToNullableTypeSpec {
             fun foo(a: Any?) {
                 val x = null as String?
             }
-        """
+        """.trimIndent()
         val findings = subject.compileAndLint(code)
         assertThat(findings).isEmpty()
     }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DeprecationSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DeprecationSpec.kt
@@ -26,7 +26,7 @@ class DeprecationSpec(private val env: KotlinCoreEnvironment) {
                 fun spam() {
                 }
             }
-        """
+        """.trimIndent()
         val findings = subject.compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(1)
         assertThat(findings.first().message).isEqualTo("Foo is deprecated.")
@@ -45,7 +45,7 @@ class DeprecationSpec(private val env: KotlinCoreEnvironment) {
                 fun baz() {
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DontDowncastCollectionTypesSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DontDowncastCollectionTypesSpec.kt
@@ -22,7 +22,7 @@ class DontDowncastCollectionTypesSpec(private val env: KotlinCoreEnvironment) {
                 val myList = listOf(1,2,3)
                 val mutList = myList as MutableList<Int>
             }
-            """
+            """.trimIndent()
             val result = subject.compileAndLintWithContext(env, code)
             assertThat(result).hasSize(1)
             assertThat(result.first().message).isEqualTo(
@@ -37,7 +37,7 @@ class DontDowncastCollectionTypesSpec(private val env: KotlinCoreEnvironment) {
                 val myList : List<Int>? = null
                 val mutList = myList as? MutableList<Int>
             }
-            """
+            """.trimIndent()
             val result = subject.compileAndLintWithContext(env, code)
             assertThat(result).hasSize(1)
             assertThat(result.first().message).isEqualTo(
@@ -54,7 +54,7 @@ class DontDowncastCollectionTypesSpec(private val env: KotlinCoreEnvironment) {
                     myList.add(4)
                 }
             }
-            """
+            """.trimIndent()
             val result = subject.compileAndLintWithContext(env, code)
             assertThat(result).hasSize(1)
             assertThat(result.first().message).isEqualTo(
@@ -69,7 +69,7 @@ class DontDowncastCollectionTypesSpec(private val env: KotlinCoreEnvironment) {
                 val mySet = setOf(1,2,3)
                 val mutSet = mySet as MutableSet<Int>
             }
-            """
+            """.trimIndent()
             val result = subject.compileAndLintWithContext(env, code)
             assertThat(result).hasSize(1)
             assertThat(result.first().message).isEqualTo(
@@ -84,7 +84,7 @@ class DontDowncastCollectionTypesSpec(private val env: KotlinCoreEnvironment) {
                 val mySet : Set<Int>? = null
                 val mutSet = mySet as? MutableSet<Int>
             }
-            """
+            """.trimIndent()
             val result = subject.compileAndLintWithContext(env, code)
             assertThat(result).hasSize(1)
             assertThat(result.first().message).isEqualTo(
@@ -101,7 +101,7 @@ class DontDowncastCollectionTypesSpec(private val env: KotlinCoreEnvironment) {
                     mySet.add(4)
                 }
             }
-            """
+            """.trimIndent()
             val result = subject.compileAndLintWithContext(env, code)
             assertThat(result).hasSize(1)
             assertThat(result.first().message).isEqualTo(
@@ -116,7 +116,7 @@ class DontDowncastCollectionTypesSpec(private val env: KotlinCoreEnvironment) {
                 val myMap = mapOf(1 to 2)
                 val mutMap = myMap as MutableMap<Int, Int>
             }
-            """
+            """.trimIndent()
             val result = subject.compileAndLintWithContext(env, code)
             assertThat(result).hasSize(1)
             assertThat(result.first().message).isEqualTo(
@@ -131,7 +131,7 @@ class DontDowncastCollectionTypesSpec(private val env: KotlinCoreEnvironment) {
                 val myMap : Map<Int, Int>? = null
                 val mutMap = myMap as? MutableMap<Int, Int>
             }
-            """
+            """.trimIndent()
             val result = subject.compileAndLintWithContext(env, code)
             assertThat(result).hasSize(1)
             assertThat(result.first().message).isEqualTo(
@@ -148,7 +148,7 @@ class DontDowncastCollectionTypesSpec(private val env: KotlinCoreEnvironment) {
                     myMap[3] = 4
                 }
             }
-            """
+            """.trimIndent()
             val result = subject.compileAndLintWithContext(env, code)
             assertThat(result).hasSize(1)
             assertThat(result.first().message).isEqualTo(
@@ -167,7 +167,7 @@ class DontDowncastCollectionTypesSpec(private val env: KotlinCoreEnvironment) {
                 val myList = mutableListOf(1,2,3)
                 val mutList = myList as MutableList<Int>
             }
-            """
+            """.trimIndent()
             val result = subject.compileAndLintWithContext(env, code)
             assertThat(result).isEmpty()
         }
@@ -179,7 +179,7 @@ class DontDowncastCollectionTypesSpec(private val env: KotlinCoreEnvironment) {
                 val mySet = mutableSetOf(1,2,3)
                 val mutSet = mySet as MutableSet<Int>
             }
-            """
+            """.trimIndent()
             val result = subject.compileAndLintWithContext(env, code)
             assertThat(result).isEmpty()
         }
@@ -191,7 +191,7 @@ class DontDowncastCollectionTypesSpec(private val env: KotlinCoreEnvironment) {
                 val myMap = mutableMapOf(1 to 2)
                 val mutMap = myMap as MutableMap<Int, Int>
             }
-            """
+            """.trimIndent()
             val result = subject.compileAndLintWithContext(env, code)
             assertThat(result).isEmpty()
         }
@@ -203,7 +203,7 @@ class DontDowncastCollectionTypesSpec(private val env: KotlinCoreEnvironment) {
             fun main() {
                 val params = tooltip_guide.layoutParams as LayoutParams
             }
-            """
+            """.trimIndent()
             val result = subject.lintWithContext(env, code)
             assertThat(result).isEmpty()
         }
@@ -219,7 +219,7 @@ class DontDowncastCollectionTypesSpec(private val env: KotlinCoreEnvironment) {
                 val myList = listOf(1,2,3)
                 val mutList = myList as ArrayList<Int>
             }
-            """
+            """.trimIndent()
             val result = subject.compileAndLintWithContext(env, code)
             assertThat(result).hasSize(1)
             assertThat(result.first().message).isEqualTo(
@@ -234,7 +234,7 @@ class DontDowncastCollectionTypesSpec(private val env: KotlinCoreEnvironment) {
                 val myList : List<Int>? = null
                 val mutList = myList as? ArrayList<Int>
             }
-            """
+            """.trimIndent()
             val result = subject.compileAndLintWithContext(env, code)
             assertThat(result).hasSize(1)
             assertThat(result.first().message).isEqualTo(
@@ -251,7 +251,7 @@ class DontDowncastCollectionTypesSpec(private val env: KotlinCoreEnvironment) {
                     myList.add(4)
                 }
             }
-            """
+            """.trimIndent()
             val result = subject.compileAndLintWithContext(env, code)
             assertThat(result).hasSize(1)
             assertThat(result.first().message).isEqualTo(
@@ -266,7 +266,7 @@ class DontDowncastCollectionTypesSpec(private val env: KotlinCoreEnvironment) {
                 val mySet = setOf(1,2,3)
                 val mutSet = mySet as LinkedHashSet<Int>
             }
-            """
+            """.trimIndent()
             val result = subject.compileAndLintWithContext(env, code)
             assertThat(result).hasSize(1)
             assertThat(result.first().message).isEqualTo(
@@ -281,7 +281,7 @@ class DontDowncastCollectionTypesSpec(private val env: KotlinCoreEnvironment) {
                 val mySet : Set<Int>? = null
                 val mutSet = mySet as? LinkedHashSet<Int>
             }
-            """
+            """.trimIndent()
             val result = subject.compileAndLintWithContext(env, code)
             assertThat(result).hasSize(1)
             assertThat(result.first().message).isEqualTo(
@@ -298,7 +298,7 @@ class DontDowncastCollectionTypesSpec(private val env: KotlinCoreEnvironment) {
                     mySet.add(4)
                 }
             }
-            """
+            """.trimIndent()
             val result = subject.compileAndLintWithContext(env, code)
             assertThat(result).hasSize(1)
             assertThat(result.first().message).isEqualTo(
@@ -313,7 +313,7 @@ class DontDowncastCollectionTypesSpec(private val env: KotlinCoreEnvironment) {
                 val mySet = setOf(1,2,3)
                 val mutSet = mySet as HashSet<Int>
             }
-            """
+            """.trimIndent()
             val result = subject.compileAndLintWithContext(env, code)
             assertThat(result).hasSize(1)
             assertThat(result.first().message).isEqualTo(
@@ -328,7 +328,7 @@ class DontDowncastCollectionTypesSpec(private val env: KotlinCoreEnvironment) {
                 val mySet : Set<Int>? = null
                 val mutSet = mySet as? HashSet<Int>
             }
-            """
+            """.trimIndent()
             val result = subject.compileAndLintWithContext(env, code)
             assertThat(result).hasSize(1)
             assertThat(result.first().message).isEqualTo(
@@ -345,7 +345,7 @@ class DontDowncastCollectionTypesSpec(private val env: KotlinCoreEnvironment) {
                     mySet.add(4)
                 }
             }
-            """
+            """.trimIndent()
             val result = subject.compileAndLintWithContext(env, code)
             assertThat(result).hasSize(1)
             assertThat(result.first().message).isEqualTo(
@@ -360,7 +360,7 @@ class DontDowncastCollectionTypesSpec(private val env: KotlinCoreEnvironment) {
                 val myMap = mapOf(1 to 2)
                 val mutMap = myMap as HashMap<Int, Int>
             }
-            """
+            """.trimIndent()
             val result = subject.compileAndLintWithContext(env, code)
             assertThat(result).hasSize(1)
             assertThat(result.first().message).isEqualTo(
@@ -375,7 +375,7 @@ class DontDowncastCollectionTypesSpec(private val env: KotlinCoreEnvironment) {
                 val myMap : Map<Int, Int>? = null
                 val mutMap = myMap as? HashMap<Int, Int>
             }
-            """
+            """.trimIndent()
             val result = subject.compileAndLintWithContext(env, code)
             assertThat(result).hasSize(1)
             assertThat(result.first().message).isEqualTo(
@@ -392,7 +392,7 @@ class DontDowncastCollectionTypesSpec(private val env: KotlinCoreEnvironment) {
                     myMap[3] = 4
                 }
             }
-            """
+            """.trimIndent()
             val result = subject.compileAndLintWithContext(env, code)
             assertThat(result).hasSize(1)
             assertThat(result.first().message).isEqualTo(
@@ -407,7 +407,7 @@ class DontDowncastCollectionTypesSpec(private val env: KotlinCoreEnvironment) {
                 val myMap = mapOf(1 to 2)
                 val mutMap = myMap as LinkedHashMap<Int, Int>
             }
-            """
+            """.trimIndent()
             val result = subject.compileAndLintWithContext(env, code)
             assertThat(result).hasSize(1)
             assertThat(result.first().message).isEqualTo(
@@ -422,7 +422,7 @@ class DontDowncastCollectionTypesSpec(private val env: KotlinCoreEnvironment) {
                 val myMap : Map<Int, Int>? = null
                 val mutMap = myMap as? LinkedHashMap<Int, Int>
             }
-            """
+            """.trimIndent()
             val result = subject.compileAndLintWithContext(env, code)
             assertThat(result).hasSize(1)
             assertThat(result.first().message).isEqualTo(
@@ -439,7 +439,7 @@ class DontDowncastCollectionTypesSpec(private val env: KotlinCoreEnvironment) {
                     myMap[3] = 4
                 }
             }
-            """
+            """.trimIndent()
             val result = subject.compileAndLintWithContext(env, code)
             assertThat(result).hasSize(1)
             assertThat(result.first().message).isEqualTo(

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DoubleMutabilityForCollectionSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DoubleMutabilityForCollectionSpec.kt
@@ -27,7 +27,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 fun main() {
                     var myList = mutableListOf(1,2,3)
                 }
-                """
+                """.trimIndent()
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).hasSize(1)
                 assertThat(result).hasStartSourceLocation(2, 5)
@@ -39,7 +39,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 fun main() {
                     var mySet = mutableSetOf(1,2,3)
                 }
-                """
+                """.trimIndent()
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).hasSize(1)
                 assertThat(result).hasStartSourceLocation(2, 5)
@@ -51,7 +51,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 fun main() {
                     var myMap = mutableMapOf("answer" to 42)
                 }
-                """
+                """.trimIndent()
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).hasSize(1)
                 assertThat(result).hasStartSourceLocation(2, 5)
@@ -63,7 +63,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 fun main() {
                     var myArrayList = ArrayList<Int>()
                 }
-                """
+                """.trimIndent()
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).hasSize(1)
                 assertThat(result).hasStartSourceLocation(2, 5)
@@ -75,7 +75,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 fun main() {
                     var myLinkedHashSet = LinkedHashSet<Int>()
                 }
-                """
+                """.trimIndent()
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).hasSize(1)
                 assertThat(result).hasStartSourceLocation(2, 5)
@@ -87,7 +87,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 fun main() {
                     var myHashSet = HashSet<Int>()
                 }
-                """
+                """.trimIndent()
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).hasSize(1)
                 assertThat(result).hasStartSourceLocation(2, 5)
@@ -99,7 +99,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 fun main() {
                     var myLinkedHashMap = LinkedHashMap<String, Int>()
                 }
-                """
+                """.trimIndent()
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).hasSize(1)
                 assertThat(result).hasStartSourceLocation(2, 5)
@@ -111,7 +111,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 fun main() {
                     var myHashMap = HashMap<String, Int>()
                 }
-                """
+                """.trimIndent()
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).hasSize(1)
                 assertThat(result).hasStartSourceLocation(2, 5)
@@ -132,7 +132,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 fun main() {
                     var myState = MutableState("foo")
                 }
-                """
+                """.trimIndent()
                 val result = rule.compileAndLintWithContext(env, code)
                 assertThat(result).hasSize(1)
                 assertThat(result).hasStartSourceLocation(3, 5)
@@ -154,7 +154,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 fun main() {
                     var myState = mutableStateOf("foo")
                 }
-                """
+                """.trimIndent()
                 val result = rule.compileAndLintWithContext(env, code)
                 assertThat(result).hasSize(1)
                 assertThat(result).hasStartSourceLocation(4, 5)
@@ -177,7 +177,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 fun main() {
                     var myState = remember { mutableStateOf("foo") }
                 }
-                """
+                """.trimIndent()
                 val result = rule.compileAndLintWithContext(env, code)
                 assertThat(result).hasSize(1)
                 assertThat(result).hasStartSourceLocation(5, 5)
@@ -193,7 +193,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 fun main() {
                     val myList = mutableListOf(1,2,3)
                 }
-                """
+                """.trimIndent()
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).isEmpty()
             }
@@ -204,7 +204,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 fun main() {
                     val mySet = mutableSetOf(1,2,3)
                 }
-                """
+                """.trimIndent()
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).isEmpty()
             }
@@ -215,7 +215,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 fun main() {
                     val myMap = mutableMapOf("answer" to 42)
                 }
-                """
+                """.trimIndent()
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).isEmpty()
             }
@@ -226,7 +226,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 fun main() {
                     val myArrayList = ArrayList<Int>()
                 }
-                """
+                """.trimIndent()
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).isEmpty()
             }
@@ -237,7 +237,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 fun main() {
                     val myLinkedHashSet = LinkedHashSet<Int>()
                 }
-                """
+                """.trimIndent()
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).isEmpty()
             }
@@ -248,7 +248,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 fun main() {
                     val myHashSet = HashSet<Int>()
                 }
-                """
+                """.trimIndent()
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).isEmpty()
             }
@@ -259,7 +259,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 fun main() {
                     val myLinkedHashMap = LinkedHashMap<String, Int>()
                 }
-                """
+                """.trimIndent()
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).isEmpty()
             }
@@ -270,7 +270,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 fun main() {
                     val myHashMap = HashMap<String, Int>()
                 }
-                """
+                """.trimIndent()
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).isEmpty()
             }
@@ -285,7 +285,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 fun main() {
                     val myList = listOf(1,2,3)
                 }
-                """
+                """.trimIndent()
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).isEmpty()
             }
@@ -296,7 +296,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 fun main() {
                     val mySet = setOf(1,2,3)
                 }
-                """
+                """.trimIndent()
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).isEmpty()
             }
@@ -307,7 +307,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 fun main() {
                     val myMap = mapOf("answer" to 42)
                 }
-                """
+                """.trimIndent()
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).isEmpty()
             }
@@ -337,7 +337,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 fun main() {
                     var myState by remember { mutableStateOf("foo") }
                 }
-                """
+                """.trimIndent()
                 val result = rule.compileAndLintWithContext(env, code)
                 assertThat(result).isEmpty()
             }
@@ -354,7 +354,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
             fun `detects var declaration with mutable list`() {
                 val code = """
                 var myList = mutableListOf(1,2,3)
-                """
+                """.trimIndent()
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).hasSize(1)
                 assertThat(result).hasStartSourceLocation(1, 1)
@@ -364,7 +364,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
             fun `detects var declaration with mutable set`() {
                 val code = """
                 var mySet = mutableSetOf(1,2,3)
-                """
+                """.trimIndent()
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).hasSize(1)
                 assertThat(result).hasStartSourceLocation(1, 1)
@@ -374,7 +374,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
             fun `detects var declaration with mutable map`() {
                 val code = """
                 var myMap = mutableMapOf("answer" to 42)
-                """
+                """.trimIndent()
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).hasSize(1)
                 assertThat(result).hasStartSourceLocation(1, 1)
@@ -384,7 +384,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
             fun `detects var declaration with ArrayList`() {
                 val code = """
                 var myArrayList = ArrayList<Int>()
-                """
+                """.trimIndent()
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).hasSize(1)
                 assertThat(result).hasStartSourceLocation(1, 1)
@@ -394,7 +394,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
             fun `detects var declaration with LinkedHashSet`() {
                 val code = """
                 var myLinkedHashSet = LinkedHashSet<Int>()
-                """
+                """.trimIndent()
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).hasSize(1)
                 assertThat(result).hasStartSourceLocation(1, 1)
@@ -404,7 +404,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
             fun `detects var declaration with HashSet`() {
                 val code = """
                 var myHashSet = HashSet<Int>()
-                """
+                """.trimIndent()
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).hasSize(1)
                 assertThat(result).hasStartSourceLocation(1, 1)
@@ -414,7 +414,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
             fun `detects var declaration with LinkedHashMap`() {
                 val code = """
                 var myLinkedHashMap = LinkedHashMap<String, Int>()
-                """
+                """.trimIndent()
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).hasSize(1)
                 assertThat(result).hasStartSourceLocation(1, 1)
@@ -424,7 +424,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
             fun `detects var declaration with HashMap`() {
                 val code = """
                 var myHashMap = HashMap<String, Int>()
-                """
+                """.trimIndent()
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).hasSize(1)
                 assertThat(result).hasStartSourceLocation(1, 1)
@@ -443,7 +443,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 val code = """
                 data class MutableState<T>(var state: T)
                 var myState = MutableState("foo")
-                """
+                """.trimIndent()
                 val result = rule.compileAndLintWithContext(env, code)
                 assertThat(result).hasSize(1)
                 assertThat(result).hasStartSourceLocation(2, 1)
@@ -463,7 +463,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 data class MutableState<T>(var state: T)
                 fun <T> mutableStateOf(value: T): MutableState<T> = MutableState(value)
                 var myState = mutableStateOf("foo")
-                """
+                """.trimIndent()
                 val result = rule.compileAndLintWithContext(env, code)
                 assertThat(result).hasSize(1)
                 assertThat(result).hasStartSourceLocation(3, 1)
@@ -484,7 +484,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 fun <T> mutableStateOf(value: T): MutableState<T> = MutableState(value)
                 fun <T> remember(calculation: () -> T): T = calculation()
                 var myState = remember { mutableStateOf("foo") }
-                """
+                """.trimIndent()
                 val result = rule.compileAndLintWithContext(env, code)
                 assertThat(result).hasSize(1)
                 assertThat(result).hasStartSourceLocation(4, 1)
@@ -498,7 +498,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
             fun `does not detect val declaration with mutable list`() {
                 val code = """
                 val myList = mutableListOf(1,2,3)
-                """
+                """.trimIndent()
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).isEmpty()
             }
@@ -507,7 +507,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
             fun `does not detect val declaration with mutable set`() {
                 val code = """
                 val mySet = mutableSetOf(1,2,3)
-                """
+                """.trimIndent()
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).isEmpty()
             }
@@ -516,7 +516,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
             fun `does not detect val declaration with mutable map`() {
                 val code = """
                 val myMap = mutableMapOf("answer" to 42)
-                """
+                """.trimIndent()
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).isEmpty()
             }
@@ -525,7 +525,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
             fun `does not detect val declaration with ArrayList`() {
                 val code = """
                 val myArrayList = ArrayList<Int>()
-                """
+                """.trimIndent()
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).isEmpty()
             }
@@ -534,7 +534,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
             fun `does not detect val declaration with LinkedHashSet`() {
                 val code = """
                 val myLinkedHashSet = LinkedHashSet<Int>()
-                """
+                """.trimIndent()
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).isEmpty()
             }
@@ -543,7 +543,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
             fun `does not detect val declaration with HashSet`() {
                 val code = """
                 val myHashSet = HashSet<Int>()
-                """
+                """.trimIndent()
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).isEmpty()
             }
@@ -552,7 +552,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
             fun `does not detect val declaration with LinkedHashMap`() {
                 val code = """
                 val myLinkedHashMap = LinkedHashMap<String, Int>()
-                """
+                """.trimIndent()
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).isEmpty()
             }
@@ -561,7 +561,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
             fun `does not detect val declaration with HashMap`() {
                 val code = """
                 val myHashMap = HashMap<String, Int>()
-                """
+                """.trimIndent()
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).isEmpty()
             }
@@ -574,7 +574,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
             fun `does not detect var declaration with immutable list`() {
                 val code = """
                 val myList = listOf(1,2,3)
-                """
+                """.trimIndent()
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).isEmpty()
             }
@@ -583,7 +583,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
             fun `does not detect var declaration with immutable set`() {
                 val code = """
                 val mySet = setOf(1,2,3)
-                """
+                """.trimIndent()
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).isEmpty()
             }
@@ -592,7 +592,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
             fun `does not detect var declaration with immutable map`() {
                 val code = """
                 val myMap = mapOf("answer" to 42)
-                """
+                """.trimIndent()
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).isEmpty()
             }
@@ -620,7 +620,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                     this.state = value
                 }
                 var myState by remember { mutableStateOf("foo") }
-                """
+                """.trimIndent()
                 val result = rule.compileAndLintWithContext(env, code)
                 assertThat(result).isEmpty()
             }
@@ -639,7 +639,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 class MyClass {
                     var myOtherList = mutableListOf(1,2,3)
                 }
-                """
+                """.trimIndent()
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).hasSize(1)
                 assertThat(result).hasStartSourceLocation(2, 5)
@@ -651,7 +651,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 class MyClass {
                     var mySet = mutableSetOf(1,2,3)
                 }
-                """
+                """.trimIndent()
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).hasSize(1)
                 assertThat(result).hasStartSourceLocation(2, 5)
@@ -663,7 +663,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 class MyClass {
                     var myMap = mutableMapOf("answer" to 42)
                 }
-                """
+                """.trimIndent()
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).hasSize(1)
                 assertThat(result).hasStartSourceLocation(2, 5)
@@ -675,7 +675,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 class MyClass {
                     var myArrayList = ArrayList<Int>()
                 }
-                """
+                """.trimIndent()
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).hasSize(1)
                 assertThat(result).hasStartSourceLocation(2, 5)
@@ -687,7 +687,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 class MyClass {
                     var myLinkedHashSet = LinkedHashSet<Int>()
                 }
-                """
+                """.trimIndent()
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).hasSize(1)
                 assertThat(result).hasStartSourceLocation(2, 5)
@@ -699,7 +699,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 class MyClass {
                     var myHashSet = HashSet<Int>()
                 }
-                """
+                """.trimIndent()
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).hasSize(1)
                 assertThat(result).hasStartSourceLocation(2, 5)
@@ -711,7 +711,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 class MyClass {
                     var myLinkedHashMap = LinkedHashMap<String, Int>()
                 }
-                """
+                """.trimIndent()
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).hasSize(1)
                 assertThat(result).hasStartSourceLocation(2, 5)
@@ -723,7 +723,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 class MyClass {
                     var myHashMap = HashMap<String, Int>()
                 }
-                """
+                """.trimIndent()
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).hasSize(1)
                 assertThat(result).hasStartSourceLocation(2, 5)
@@ -744,7 +744,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 class MyClass {
                     var myState = MutableState("foo")
                 }
-                """
+                """.trimIndent()
                 val result = rule.compileAndLintWithContext(env, code)
                 assertThat(result).hasSize(1)
                 assertThat(result).hasStartSourceLocation(3, 5)
@@ -766,7 +766,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 class MyClass {
                     var myState = mutableStateOf("foo")
                 }
-                """
+                """.trimIndent()
                 val result = rule.compileAndLintWithContext(env, code)
                 assertThat(result).hasSize(1)
                 assertThat(result).hasStartSourceLocation(4, 5)
@@ -789,7 +789,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 class MyClass {
                     var myState = remember { mutableStateOf("foo") }
                 }
-                """
+                """.trimIndent()
                 val result = rule.compileAndLintWithContext(env, code)
                 assertThat(result).hasSize(1)
                 assertThat(result).hasStartSourceLocation(5, 5)
@@ -805,7 +805,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 class MyClass {
                     val myList = mutableListOf(1,2,3)
                 }
-                """
+                """.trimIndent()
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).isEmpty()
             }
@@ -816,7 +816,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 class MyClass {
                     val mySet = mutableSetOf(1,2,3)
                 }
-                """
+                """.trimIndent()
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).isEmpty()
             }
@@ -827,7 +827,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 class MyClass {
                     val myMap = mutableMapOf("answer" to 42)
                 }
-                """
+                """.trimIndent()
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).isEmpty()
             }
@@ -838,7 +838,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 class MyClass {
                     val myArrayList = ArrayList<Int>()
                 }
-                """
+                """.trimIndent()
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).isEmpty()
             }
@@ -849,7 +849,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 class MyClass {
                     val myLinkedHashSet = LinkedHashSet<Int>()
                 }
-                """
+                """.trimIndent()
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).isEmpty()
             }
@@ -860,7 +860,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 class MyClass {
                     val myHashSet = HashSet<Int>()
                 }
-                """
+                """.trimIndent()
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).isEmpty()
             }
@@ -871,7 +871,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 class MyClass {
                     val myLinkedHashMap = LinkedHashMap<String, Int>()
                 }
-                """
+                """.trimIndent()
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).isEmpty()
             }
@@ -882,7 +882,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 class MyClass {
                     val myHashMap = HashMap<String, Int>()
                 }
-                """
+                """.trimIndent()
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).isEmpty()
             }
@@ -897,7 +897,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 class MyClass {
                     val myList = listOf(1,2,3)
                 }
-                """
+                """.trimIndent()
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).isEmpty()
             }
@@ -908,7 +908,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 class MyClass {
                     val mySet = setOf(1,2,3)
                 }
-                """
+                """.trimIndent()
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).isEmpty()
             }
@@ -919,7 +919,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 class MyClass {
                     val myMap = mapOf("answer" to 42)
                 }
-                """
+                """.trimIndent()
                 val result = subject.compileAndLintWithContext(env, code)
                 assertThat(result).isEmpty()
             }
@@ -949,7 +949,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 class MyClass {
                     var myState by remember { mutableStateOf("foo") }
                 }
-                """
+                """.trimIndent()
                 val result = rule.compileAndLintWithContext(env, code)
                 assertThat(result).isEmpty()
             }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DuplicateCaseInWhenExpressionSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DuplicateCaseInWhenExpressionSpec.kt
@@ -20,7 +20,7 @@ class DuplicateCaseInWhenExpressionSpec {
                     else -> println()
                 }
             }
-        """
+        """.trimIndent()
         val result = subject.compileAndLint(code)
         assertThat(result).hasSize(1)
         assertThat(result.first().message).isEqualTo("When expression has multiple case statements for 1; 1, 2.")
@@ -35,7 +35,7 @@ class DuplicateCaseInWhenExpressionSpec {
                     else -> println()
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ElseCaseInsteadOfExhaustiveWhenSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ElseCaseInsteadOfExhaustiveWhenSpec.kt
@@ -30,7 +30,7 @@ class ElseCaseInsteadOfExhaustiveWhenSpec(private val env: KotlinCoreEnvironment
                     else -> {}
                 }
             }
-            """
+            """.trimIndent()
             val actual = subject.compileAndLintWithContext(env, code)
             assertThat(actual).hasSize(1)
         }
@@ -51,7 +51,7 @@ class ElseCaseInsteadOfExhaustiveWhenSpec(private val env: KotlinCoreEnvironment
                     else -> 100
                 }
             }
-            """
+            """.trimIndent()
             val actual = subject.compileAndLintWithContext(env, code)
             assertThat(actual).hasSize(1)
         }
@@ -85,7 +85,7 @@ class ElseCaseInsteadOfExhaustiveWhenSpec(private val env: KotlinCoreEnvironment
                     Color.GREEN -> {}
                 }
             }
-            """
+            """.trimIndent()
             assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
     }
@@ -108,7 +108,7 @@ class ElseCaseInsteadOfExhaustiveWhenSpec(private val env: KotlinCoreEnvironment
                         else -> {}
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
@@ -128,7 +128,7 @@ class ElseCaseInsteadOfExhaustiveWhenSpec(private val env: KotlinCoreEnvironment
                         else -> "other"
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
@@ -147,7 +147,7 @@ class ElseCaseInsteadOfExhaustiveWhenSpec(private val env: KotlinCoreEnvironment
                         is Variant.VariantB -> {}
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
     }
@@ -170,7 +170,7 @@ class ElseCaseInsteadOfExhaustiveWhenSpec(private val env: KotlinCoreEnvironment
                         else -> {}
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
@@ -190,7 +190,7 @@ class ElseCaseInsteadOfExhaustiveWhenSpec(private val env: KotlinCoreEnvironment
                         else -> "other"
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
     }
@@ -206,7 +206,7 @@ class ElseCaseInsteadOfExhaustiveWhenSpec(private val env: KotlinCoreEnvironment
                     else -> {}
                 }
             }
-            """
+            """.trimIndent()
             val actual = subject.compileAndLintWithContext(env, code)
             assertThat(actual).hasSize(1)
         }
@@ -221,7 +221,7 @@ class ElseCaseInsteadOfExhaustiveWhenSpec(private val env: KotlinCoreEnvironment
                     else -> 100
                 }
             }
-            """
+            """.trimIndent()
             val actual = subject.compileAndLintWithContext(env, code)
             assertThat(actual).hasSize(1)
         }
@@ -240,7 +240,7 @@ class ElseCaseInsteadOfExhaustiveWhenSpec(private val env: KotlinCoreEnvironment
                     false -> 2
                 }
             }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -260,7 +260,7 @@ class ElseCaseInsteadOfExhaustiveWhenSpec(private val env: KotlinCoreEnvironment
                     null -> 100
                 }
             }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
     }
@@ -301,7 +301,7 @@ class ElseCaseInsteadOfExhaustiveWhenSpec(private val env: KotlinCoreEnvironment
                         else -> print("x is funny")
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
     }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsAlwaysReturnsTrueOrFalseSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsAlwaysReturnsTrueOrFalseSpec.kt
@@ -29,7 +29,7 @@ class EqualsAlwaysReturnsTrueOrFalseSpec {
                     return true
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 
@@ -42,7 +42,7 @@ class EqualsAlwaysReturnsTrueOrFalseSpec {
                 override fun equals(other: Any?): Boolean = (other as? Item)?.text == this.text
                 override fun hashCode(): Int = text.hashCode()
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsWithHashCodeExistSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsWithHashCodeExistSpec.kt
@@ -18,7 +18,7 @@ class EqualsWithHashCodeExistSpec {
             class A {
                 override fun hashCode(): Int { return super.hashCode() }
             }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
@@ -28,7 +28,7 @@ class EqualsWithHashCodeExistSpec {
             class A {
                 override fun equals(other: Any?): Boolean { return super.equals(other) }
             }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
@@ -39,7 +39,7 @@ class EqualsWithHashCodeExistSpec {
                 fun equals(other: Any?, i: Int): Boolean { return super.equals(other) }
                 override fun hashCode(): Int { return super.hashCode() }
             }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
@@ -50,7 +50,7 @@ class EqualsWithHashCodeExistSpec {
                 override fun equals(other: Any?): Boolean { return super.equals(other) }
                 fun hashCode(i: Int): Int { return super.hashCode() }
             }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
@@ -65,7 +65,7 @@ class EqualsWithHashCodeExistSpec {
                 override fun equals(other: Any?, i: Int): Boolean { return super.equals(other) }
                 override fun hashCode(): Int { return super.hashCode() }
             }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
@@ -80,7 +80,7 @@ class EqualsWithHashCodeExistSpec {
                 override fun equals(other: Any?): Boolean { return super.equals(other) }
                 override fun hashCode(i: Int): Int { return super.hashCode() }
             }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
@@ -91,7 +91,7 @@ class EqualsWithHashCodeExistSpec {
                 override fun equals(other: Any?): Boolean { return super.equals(other) }
                 override fun hashCode(): Int { return super.hashCode() }
             }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
@@ -102,7 +102,7 @@ class EqualsWithHashCodeExistSpec {
                 override fun equals(other: kotlin.Any?): Boolean { return super.equals(other) }
                 override fun hashCode(): Int { return super.hashCode() }
             }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
     }
@@ -118,7 +118,7 @@ class EqualsWithHashCodeExistSpec {
                     return super.equals(other)
                 }
             }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
     }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ExitOutsideMainSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ExitOutsideMainSpec.kt
@@ -17,7 +17,7 @@ class ExitOutsideMainSpec(private val env: KotlinCoreEnvironment) {
             fun f() {
                 exitProcess(0)
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
     }
 
@@ -27,7 +27,7 @@ class ExitOutsideMainSpec(private val env: KotlinCoreEnvironment) {
             fun f() {
                 System.exit(0)
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
     }
 
@@ -38,7 +38,7 @@ class ExitOutsideMainSpec(private val env: KotlinCoreEnvironment) {
             fun main() {
                 exitProcess(0)
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 
@@ -48,7 +48,7 @@ class ExitOutsideMainSpec(private val env: KotlinCoreEnvironment) {
             fun main() {
                 System.exit(0)
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 
@@ -61,7 +61,7 @@ class ExitOutsideMainSpec(private val env: KotlinCoreEnvironment) {
                     exitProcess(0)
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
     }
 
@@ -73,7 +73,7 @@ class ExitOutsideMainSpec(private val env: KotlinCoreEnvironment) {
                     System.exit(0)
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
     }
 }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ExplicitGarbageCollectionCallSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ExplicitGarbageCollectionCallSpec.kt
@@ -16,7 +16,7 @@ class ExplicitGarbageCollectionCallSpec {
                 Runtime.getRuntime().gc()
                 System.runFinalization()
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(3)
     }
 }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/HasPlatformTypeSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/HasPlatformTypeSpec.kt
@@ -17,7 +17,7 @@ class HasPlatformTypeSpec(private val env: KotlinCoreEnvironment) {
             class Person {
                 fun apiCall() = System.getProperty("propertyName")
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
     }
 
@@ -27,7 +27,7 @@ class HasPlatformTypeSpec(private val env: KotlinCoreEnvironment) {
             class Person {
                 private fun apiCall() = System.getProperty("propertyName")
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 
@@ -37,7 +37,7 @@ class HasPlatformTypeSpec(private val env: KotlinCoreEnvironment) {
             class Person {
                 fun apiCall(): String = System.getProperty("propertyName")
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 
@@ -47,7 +47,7 @@ class HasPlatformTypeSpec(private val env: KotlinCoreEnvironment) {
             class Person {
                 val name = System.getProperty("name")
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
     }
 
@@ -57,7 +57,7 @@ class HasPlatformTypeSpec(private val env: KotlinCoreEnvironment) {
             class Person {
                 private val name = System.getProperty("name")
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 
@@ -67,7 +67,7 @@ class HasPlatformTypeSpec(private val env: KotlinCoreEnvironment) {
             class Person {
                 val name: String = System.getProperty("name")
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValueSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValueSpec.kt
@@ -22,7 +22,7 @@ class IgnoredReturnValueSpec(private val env: KotlinCoreEnvironment) {
                 fun foo() {
                     listOf("hello")
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
@@ -34,7 +34,7 @@ class IgnoredReturnValueSpec(private val env: KotlinCoreEnvironment) {
                     listOf("hello")
                     return 42
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
@@ -45,7 +45,7 @@ class IgnoredReturnValueSpec(private val env: KotlinCoreEnvironment) {
                 fun foo() {
                     listOf("hello").isEmpty().not()
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
@@ -56,7 +56,7 @@ class IgnoredReturnValueSpec(private val env: KotlinCoreEnvironment) {
                 fun foo() {
                     listOf("hello");println("foo")
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
@@ -67,7 +67,7 @@ class IgnoredReturnValueSpec(private val env: KotlinCoreEnvironment) {
                 fun foo() {
                     println("foo");listOf("hello")
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
@@ -78,7 +78,7 @@ class IgnoredReturnValueSpec(private val env: KotlinCoreEnvironment) {
                 fun foo() {
                     listOf("hello")//foo
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
@@ -90,7 +90,7 @@ class IgnoredReturnValueSpec(private val env: KotlinCoreEnvironment) {
                 fun foo(input: Int) {
                     input.isTheAnswer()
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
@@ -110,7 +110,7 @@ class IgnoredReturnValueSpec(private val env: KotlinCoreEnvironment) {
                     var x: List<String>
                     x = listA()
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
@@ -123,7 +123,7 @@ class IgnoredReturnValueSpec(private val env: KotlinCoreEnvironment) {
                 fun foo() {
                     noReturnValue()
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
@@ -136,7 +136,7 @@ class IgnoredReturnValueSpec(private val env: KotlinCoreEnvironment) {
                 fun f() {
                     if (returnsBoolean()) {}
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
@@ -149,7 +149,7 @@ class IgnoredReturnValueSpec(private val env: KotlinCoreEnvironment) {
                 fun f() {
                     if (42 == returnsInt()) {}
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
@@ -162,7 +162,7 @@ class IgnoredReturnValueSpec(private val env: KotlinCoreEnvironment) {
                 fun f() {
                     println(returnsInt())
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
@@ -175,7 +175,7 @@ class IgnoredReturnValueSpec(private val env: KotlinCoreEnvironment) {
                 fun f() {
                     println(message = returnsInt())
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
@@ -197,12 +197,12 @@ class IgnoredReturnValueSpec(private val env: KotlinCoreEnvironment) {
                     listOfChecked("hello")
                     println("foo")
                 }
-            """
+            """.trimIndent()
             val annotationClass = """
                 package annotation
 
                 annotation class CheckReturnValue
-            """
+            """.trimIndent()
 
             val findings = subject.lintWithContext(env, code, annotationClass)
             assertThat(findings).hasSize(1)
@@ -224,7 +224,7 @@ class IgnoredReturnValueSpec(private val env: KotlinCoreEnvironment) {
                     listOfChecked("hello")
                     return 42
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasStartSourceLocation(9, 5)
@@ -245,7 +245,7 @@ class IgnoredReturnValueSpec(private val env: KotlinCoreEnvironment) {
                     listOfChecked("hello").isEmpty().not()
                     return 42
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
@@ -269,7 +269,7 @@ class IgnoredReturnValueSpec(private val env: KotlinCoreEnvironment) {
                         .not()
                     return 42
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
@@ -291,7 +291,7 @@ class IgnoredReturnValueSpec(private val env: KotlinCoreEnvironment) {
                         .listOfChecked()
                     return 42
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasStartSourceLocation(12, 10)
@@ -311,7 +311,7 @@ class IgnoredReturnValueSpec(private val env: KotlinCoreEnvironment) {
                 fun foo() {
                     listOfChecked("hello");println("foo")
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasStartSourceLocation(9, 5)
@@ -332,7 +332,7 @@ class IgnoredReturnValueSpec(private val env: KotlinCoreEnvironment) {
                     println("foo");listOfChecked("hello")
                     return 42
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasStartSourceLocation(9, 20)
@@ -353,7 +353,7 @@ class IgnoredReturnValueSpec(private val env: KotlinCoreEnvironment) {
                     /* foo */listOfChecked("hello")//foo
                     return 42
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasStartSourceLocation(9, 14)
@@ -373,7 +373,7 @@ class IgnoredReturnValueSpec(private val env: KotlinCoreEnvironment) {
                     input.isTheAnswer()
                     return 42
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasStartSourceLocation(8, 11)
@@ -395,7 +395,7 @@ class IgnoredReturnValueSpec(private val env: KotlinCoreEnvironment) {
                     x = listOfChecked("hello")
                     return 42
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
@@ -414,7 +414,7 @@ class IgnoredReturnValueSpec(private val env: KotlinCoreEnvironment) {
                     noReturnValue()
                     return 42
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
@@ -432,7 +432,7 @@ class IgnoredReturnValueSpec(private val env: KotlinCoreEnvironment) {
                 fun f() {
                     if (returnsBoolean()) {}
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
@@ -450,7 +450,7 @@ class IgnoredReturnValueSpec(private val env: KotlinCoreEnvironment) {
                 fun f() {
                     if (42 == returnsInt()) {}
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
@@ -468,7 +468,7 @@ class IgnoredReturnValueSpec(private val env: KotlinCoreEnvironment) {
                 fun f() {
                     println(returnsInt())
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
@@ -486,7 +486,7 @@ class IgnoredReturnValueSpec(private val env: KotlinCoreEnvironment) {
                 fun f() {
                     println(message = returnsInt())
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
@@ -506,7 +506,7 @@ class IgnoredReturnValueSpec(private val env: KotlinCoreEnvironment) {
                 } else {
                     returnsInt()
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
@@ -527,7 +527,7 @@ class IgnoredReturnValueSpec(private val env: KotlinCoreEnvironment) {
                     returnsInt()
                     2
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
@@ -549,7 +549,7 @@ class IgnoredReturnValueSpec(private val env: KotlinCoreEnvironment) {
                         returnsInt()
                     }.plus(1)
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
@@ -572,7 +572,7 @@ class IgnoredReturnValueSpec(private val env: KotlinCoreEnvironment) {
                         2
                     }.plus(1)
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
@@ -594,7 +594,7 @@ class IgnoredReturnValueSpec(private val env: KotlinCoreEnvironment) {
                         returnsInt()
                     }
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
@@ -618,7 +618,7 @@ class IgnoredReturnValueSpec(private val env: KotlinCoreEnvironment) {
                         .print()
                     return 42
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
@@ -638,7 +638,7 @@ class IgnoredReturnValueSpec(private val env: KotlinCoreEnvironment) {
                 fun main() {
                     Assertions().listOfChecked("hello")
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
@@ -658,7 +658,7 @@ class IgnoredReturnValueSpec(private val env: KotlinCoreEnvironment) {
                 fun main() {
                     Assertions.listOfChecked("hello")
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
@@ -680,7 +680,7 @@ class IgnoredReturnValueSpec(private val env: KotlinCoreEnvironment) {
                 fun main() {
                     Assertions().listOfChecked("hello")
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
@@ -702,7 +702,7 @@ class IgnoredReturnValueSpec(private val env: KotlinCoreEnvironment) {
                 fun main() {
                     Parent.Child().listOfChecked("hello")
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
@@ -727,7 +727,7 @@ class IgnoredReturnValueSpec(private val env: KotlinCoreEnvironment) {
                     listOfChecked("hello")
                     return 42
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasStartSourceLocation(8, 5)
@@ -748,7 +748,7 @@ class IgnoredReturnValueSpec(private val env: KotlinCoreEnvironment) {
                     listOfChecked("hello")
                     return 42
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
@@ -764,7 +764,7 @@ class IgnoredReturnValueSpec(private val env: KotlinCoreEnvironment) {
                     listOfChecked("hello")
                     return 42
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
@@ -788,7 +788,7 @@ class IgnoredReturnValueSpec(private val env: KotlinCoreEnvironment) {
                     listOfChecked("hello")
                     return 42
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasStartSourceLocation(9, 5)
@@ -804,7 +804,7 @@ class IgnoredReturnValueSpec(private val env: KotlinCoreEnvironment) {
                     listOfChecked("hello")
                     return 42
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasStartSourceLocation(4, 5)
@@ -825,7 +825,7 @@ class IgnoredReturnValueSpec(private val env: KotlinCoreEnvironment) {
                     listOfChecked("hello")
                     return 42
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
@@ -844,7 +844,7 @@ class IgnoredReturnValueSpec(private val env: KotlinCoreEnvironment) {
                     listOfChecked("hello")
                     return 42
                 }
-            """
+            """.trimIndent()
             val rule = IgnoredReturnValue(
                 TestConfig(
                     mapOf(
@@ -868,7 +868,7 @@ class IgnoredReturnValueSpec(private val env: KotlinCoreEnvironment) {
                     listOfChecked("hello")
                     return 42
                 }
-            """
+            """.trimIndent()
             val rule = IgnoredReturnValue(
                 TestConfig(
                     mapOf(

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ImplicitDefaultLocaleSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ImplicitDefaultLocaleSpec.kt
@@ -17,7 +17,7 @@ class ImplicitDefaultLocaleSpec(private val env: KotlinCoreEnvironment) {
             fun x() {
                 String.format("%d", 1)
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
     }
 
@@ -28,7 +28,7 @@ class ImplicitDefaultLocaleSpec(private val env: KotlinCoreEnvironment) {
             fun x() {
                 String.format(Locale.US, "%d", 1)
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 
@@ -39,7 +39,7 @@ class ImplicitDefaultLocaleSpec(private val env: KotlinCoreEnvironment) {
                 val s = "deadbeef"
                 s.toUpperCase()
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
     }
 
@@ -51,7 +51,7 @@ class ImplicitDefaultLocaleSpec(private val env: KotlinCoreEnvironment) {
                 val s = "deadbeef"
                 s.toUpperCase(Locale.US)
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 
@@ -62,7 +62,7 @@ class ImplicitDefaultLocaleSpec(private val env: KotlinCoreEnvironment) {
                 val s = "deadbeef"
                 s.toLowerCase()
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
     }
 
@@ -74,7 +74,7 @@ class ImplicitDefaultLocaleSpec(private val env: KotlinCoreEnvironment) {
                 val s = "deadbeef"
                 s.toLowerCase(Locale.US)
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 
@@ -85,7 +85,7 @@ class ImplicitDefaultLocaleSpec(private val env: KotlinCoreEnvironment) {
                 val s: String? = "deadbeef"
                 s?.toUpperCase()
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
     }
 
@@ -96,7 +96,7 @@ class ImplicitDefaultLocaleSpec(private val env: KotlinCoreEnvironment) {
                 val s: String? = "deadbeef"
                 s?.toLowerCase()
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
     }
 }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ImplicitUnitReturnTypeSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ImplicitUnitReturnTypeSpec.kt
@@ -18,7 +18,7 @@ class ImplicitUnitReturnTypeSpec(private val env: KotlinCoreEnvironment) {
             fun errorProneUnit() = println("Hello Unit")
             fun errorProneUnitWithParam(param: String) = param.run { println(this) }
             fun String.errorProneUnitWithReceiver() = run { println(this) }
-        """
+        """.trimIndent()
 
         val findings = subject.compileAndLintWithContext(env, code)
 
@@ -50,7 +50,7 @@ class ImplicitUnitReturnTypeSpec(private val env: KotlinCoreEnvironment) {
             fun blockUnitReturn() { 
                 println("Hello Unit")
             }
-        """
+        """.trimIndent()
 
         val findings = subject.compileAndLintWithContext(env, code)
 
@@ -61,7 +61,7 @@ class ImplicitUnitReturnTypeSpec(private val env: KotlinCoreEnvironment) {
     fun `does not report for Unit expression`() {
         val code = """
             fun foo() = Unit
-        """
+        """.trimIndent()
         val findings = subject.compileAndLintWithContext(env, code)
         assertThat(findings).isEmpty()
     }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/InvalidRangeSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/InvalidRangeSpec.kt
@@ -22,7 +22,7 @@ class InvalidRangeSpec {
                     for (i in 2 until 4 step 2) {}
                     for (i in (1+1)..3) { }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
@@ -35,7 +35,7 @@ class InvalidRangeSpec {
                     for (i in 2 until 2) { }
                     for (i in 2 until 1 step 2) { }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).hasSize(4)
         }
 
@@ -47,7 +47,7 @@ class InvalidRangeSpec {
                         for (i in 2..1) { }
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
     }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/LateinitUsageSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/LateinitUsageSpec.kt
@@ -17,7 +17,7 @@ class LateinitUsageSpec {
             lateinit var v1: String
             @SinceKotlin("1.0.0") lateinit var v2: String
         }
-    """
+    """.trimIndent()
 
     @Test
     fun `should report lateinit usages`() {

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MapGetWithNotNullAssertionOperatorSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MapGetWithNotNullAssertionOperatorSpec.kt
@@ -18,7 +18,7 @@ class MapGetWithNotNullAssertionOperatorSpec(private val env: KotlinCoreEnvironm
                     val map = emptyMap<Any, Any>()
                     val value = map["key"]!!
                 }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
     }
 
@@ -29,7 +29,7 @@ class MapGetWithNotNullAssertionOperatorSpec(private val env: KotlinCoreEnvironm
                     val map = emptyMap<Any, Any>()
                     val value = map.get("key")!!
                 }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
     }
 
@@ -40,7 +40,7 @@ class MapGetWithNotNullAssertionOperatorSpec(private val env: KotlinCoreEnvironm
                     val map = emptyMap<String, String>()
                     map["key"]
                 }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 
@@ -51,7 +51,7 @@ class MapGetWithNotNullAssertionOperatorSpec(private val env: KotlinCoreEnvironm
                     val map = emptyMap<String, String>()
                     map.getValue("key")
                 }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 
@@ -62,7 +62,7 @@ class MapGetWithNotNullAssertionOperatorSpec(private val env: KotlinCoreEnvironm
                     val map = emptyMap<String, String>()
                     map.getOrDefault("key", "")
                 }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 
@@ -73,7 +73,7 @@ class MapGetWithNotNullAssertionOperatorSpec(private val env: KotlinCoreEnvironm
                     val map = emptyMap<String, String>()
                     map.getOrElse("key", { "" })
                 }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingPackageDeclarationSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingPackageDeclarationSpec.kt
@@ -12,7 +12,7 @@ internal class MissingPackageDeclarationSpec {
             package foo.bar
 
             class C
-        """
+        """.trimIndent()
         val findings = MissingPackageDeclaration().compileAndLint(code)
 
         assertThat(findings).isEmpty()

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingWhenCaseSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingWhenCaseSpec.kt
@@ -33,7 +33,7 @@ class MissingWhenCaseSpec(private val env: KotlinCoreEnvironment) {
                         Color.GREEN -> {}
                     }
                 }
-                """
+                """.trimIndent()
                 val actual = subject.lintWithContext(env, code)
                 assertThat(actual).hasSize(1)
                 assertThat(actual.first().issue.id).isEqualTo("MissingWhenCase")
@@ -57,7 +57,7 @@ class MissingWhenCaseSpec(private val env: KotlinCoreEnvironment) {
                         Color.GREEN -> {}
                     }
                 }
-                """
+                """.trimIndent()
                 val actual = subject.lintWithContext(env, code)
                 assertThat(actual).hasSize(1)
                 assertThat(actual.first().issue.id).isEqualTo("MissingWhenCase")
@@ -82,7 +82,7 @@ class MissingWhenCaseSpec(private val env: KotlinCoreEnvironment) {
                         Color.RED -> {}
                     }
                 }
-                """
+                """.trimIndent()
                 val actual = subject.lintWithContext(env, code)
                 assertThat(actual).hasSize(1)
                 assertThat(actual.first().issue.id).isEqualTo("MissingWhenCase")
@@ -108,7 +108,7 @@ class MissingWhenCaseSpec(private val env: KotlinCoreEnvironment) {
                         Color.RED -> {}
                     }
                 }
-                """
+                """.trimIndent()
                 assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
             }
 
@@ -135,7 +135,7 @@ class MissingWhenCaseSpec(private val env: KotlinCoreEnvironment) {
                         else -> {}
                     }
                 }
-                """
+                """.trimIndent()
                 assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
             }
         }
@@ -157,7 +157,7 @@ class MissingWhenCaseSpec(private val env: KotlinCoreEnvironment) {
                             is Variant.VariantB -> {}
                         }
                     }
-                """
+                """.trimIndent()
                 val actual = subject.lintWithContext(env, code)
                 assertThat(actual).hasSize(1)
                 assertThat(actual.first().issue.id).isEqualTo("MissingWhenCase")
@@ -182,7 +182,7 @@ class MissingWhenCaseSpec(private val env: KotlinCoreEnvironment) {
                             is Variant.VariantC -> {}
                         }
                     }
-                """
+                """.trimIndent()
                 val actual = subject.lintWithContext(env, code)
                 assertThat(actual).hasSize(1)
                 assertThat(actual.first().issue.id).isEqualTo("MissingWhenCase")
@@ -206,7 +206,7 @@ class MissingWhenCaseSpec(private val env: KotlinCoreEnvironment) {
                             is Variant.VariantB -> {}
                         }
                     }
-                """
+                """.trimIndent()
                 val actual = subject.lintWithContext(env, code)
                 assertThat(actual).hasSize(1)
                 assertThat(actual.first().issue.id).isEqualTo("MissingWhenCase")
@@ -232,7 +232,7 @@ class MissingWhenCaseSpec(private val env: KotlinCoreEnvironment) {
                             is Variant.VariantC -> {}
                         }
                     }
-                """
+                """.trimIndent()
                 assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
             }
 
@@ -260,7 +260,7 @@ class MissingWhenCaseSpec(private val env: KotlinCoreEnvironment) {
                             is Variant.VariantC -> {}
                         }
                     }
-                """
+                """.trimIndent()
                 assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
             }
         }
@@ -301,7 +301,7 @@ class MissingWhenCaseSpec(private val env: KotlinCoreEnvironment) {
                             else -> print("x is funny")
                         }
                     }
-                """
+                """.trimIndent()
                 assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
             }
         }
@@ -331,7 +331,7 @@ class MissingWhenCaseSpec(private val env: KotlinCoreEnvironment) {
                         else -> {}
                     }
                 }
-                """
+                """.trimIndent()
                 val actual = subject.compileAndLintWithContext(env, code)
                 assertThat(actual).hasSize(1)
                 assertThat(actual.first().issue.id).isEqualTo("MissingWhenCase")
@@ -355,7 +355,7 @@ class MissingWhenCaseSpec(private val env: KotlinCoreEnvironment) {
                         else -> {}
                     }
                 }
-                """
+                """.trimIndent()
                 val actual = subject.compileAndLintWithContext(env, code)
                 assertThat(actual).hasSize(1)
                 assertThat(actual.first().issue.id).isEqualTo("MissingWhenCase")
@@ -378,7 +378,7 @@ class MissingWhenCaseSpec(private val env: KotlinCoreEnvironment) {
                         Color.RED -> {}
                     }
                 }
-                """
+                """.trimIndent()
                 val actual = subject.compileAndLintWithContext(env, code)
                 assertThat(actual).isEmpty()
             }
@@ -402,7 +402,7 @@ class MissingWhenCaseSpec(private val env: KotlinCoreEnvironment) {
                             else -> {}
                         }
                     }
-                """
+                """.trimIndent()
                 val actual = subject.compileAndLintWithContext(env, code)
                 assertThat(actual).hasSize(1)
                 assertThat(actual.first().issue.id).isEqualTo("MissingWhenCase")
@@ -425,7 +425,7 @@ class MissingWhenCaseSpec(private val env: KotlinCoreEnvironment) {
                             is Variant.VariantC -> {}
                         }
                     }
-                """
+                """.trimIndent()
                 assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
             }
         }
@@ -443,7 +443,7 @@ class MissingWhenCaseSpec(private val env: KotlinCoreEnvironment) {
                             else -> print("otherwise")
                         }
                     }
-                """
+                """.trimIndent()
                 assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
             }
         }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/NullCheckOnMutablePropertySpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/NullCheckOnMutablePropertySpec.kt
@@ -22,7 +22,7 @@ class NullCheckOnMutablePropertySpec(private val env: KotlinCoreEnvironment) {
                     } 
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
     }
 
@@ -36,7 +36,7 @@ class NullCheckOnMutablePropertySpec(private val env: KotlinCoreEnvironment) {
                     } 
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
     }
 
@@ -50,7 +50,7 @@ class NullCheckOnMutablePropertySpec(private val env: KotlinCoreEnvironment) {
                     } 
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
     }
 
@@ -64,7 +64,7 @@ class NullCheckOnMutablePropertySpec(private val env: KotlinCoreEnvironment) {
                     } 
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
     }
 
@@ -81,7 +81,7 @@ class NullCheckOnMutablePropertySpec(private val env: KotlinCoreEnvironment) {
                     } 
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
     }
 
@@ -95,7 +95,7 @@ class NullCheckOnMutablePropertySpec(private val env: KotlinCoreEnvironment) {
                     } 
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 
@@ -110,7 +110,7 @@ class NullCheckOnMutablePropertySpec(private val env: KotlinCoreEnvironment) {
                     } 
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 
@@ -124,7 +124,7 @@ class NullCheckOnMutablePropertySpec(private val env: KotlinCoreEnvironment) {
                     } 
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 
@@ -139,7 +139,7 @@ class NullCheckOnMutablePropertySpec(private val env: KotlinCoreEnvironment) {
                     } 
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
     }
 
@@ -154,7 +154,7 @@ class NullCheckOnMutablePropertySpec(private val env: KotlinCoreEnvironment) {
                     } 
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 
@@ -176,7 +176,7 @@ class NullCheckOnMutablePropertySpec(private val env: KotlinCoreEnvironment) {
                     return if (randInt % 2 == 0) randInt else null
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
     }
 
@@ -192,7 +192,7 @@ class NullCheckOnMutablePropertySpec(private val env: KotlinCoreEnvironment) {
                     }
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
     }
 
@@ -214,7 +214,7 @@ class NullCheckOnMutablePropertySpec(private val env: KotlinCoreEnvironment) {
                     } 
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
     }
 
@@ -230,7 +230,7 @@ class NullCheckOnMutablePropertySpec(private val env: KotlinCoreEnvironment) {
                     } 
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
     }
 
@@ -246,7 +246,7 @@ class NullCheckOnMutablePropertySpec(private val env: KotlinCoreEnvironment) {
                     } 
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 
@@ -260,7 +260,7 @@ class NullCheckOnMutablePropertySpec(private val env: KotlinCoreEnvironment) {
                     } 
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -274,7 +274,7 @@ class NullCheckOnMutablePropertySpec(private val env: KotlinCoreEnvironment) {
                     } 
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
     }
 
@@ -289,7 +289,7 @@ class NullCheckOnMutablePropertySpec(private val env: KotlinCoreEnvironment) {
                     } 
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 
@@ -306,7 +306,7 @@ class NullCheckOnMutablePropertySpec(private val env: KotlinCoreEnvironment) {
                     } 
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/NullableToStringCallSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/NullableToStringCallSpec.kt
@@ -16,7 +16,7 @@ class NullableToStringCallSpec(private val env: KotlinCoreEnvironment) {
             fun test(a: Any?) {
                 println(a.toString())
             }
-        """
+        """.trimIndent()
         val actual = subject.compileAndLintWithContext(env, code)
         assertThat(actual).hasSize(1)
         assertThat(actual.first().message).isEqualTo("This call 'a.toString()' may return the string \"null\".")
@@ -28,7 +28,7 @@ class NullableToStringCallSpec(private val env: KotlinCoreEnvironment) {
             fun test(a: Any?) {
                 println("${'$'}a")
             }
-        """
+        """.trimIndent()
         val actual = subject.compileAndLintWithContext(env, code)
         assertThat(actual).hasSize(1)
         assertThat(actual.first().message).isEqualTo("This call '\$a' may return the string \"null\".")
@@ -40,7 +40,7 @@ class NullableToStringCallSpec(private val env: KotlinCoreEnvironment) {
             fun test(a: Any?) {
                 println("${'$'}{a}")
             }
-        """
+        """.trimIndent()
         val actual = subject.compileAndLintWithContext(env, code)
         assertThat(actual).hasSize(1)
         assertThat(actual.first().message).isEqualTo("This call '\${a}' may return the string \"null\".")
@@ -52,7 +52,7 @@ class NullableToStringCallSpec(private val env: KotlinCoreEnvironment) {
             fun test(a: Any?) {
                 println(${'"'}""${'$'}a""${'"'})
             }
-        """
+        """.trimIndent()
         val actual = subject.compileAndLintWithContext(env, code)
         assertThat(actual).hasSize(1)
         assertThat(actual.first().message).isEqualTo("This call '\$a' may return the string \"null\".")
@@ -71,7 +71,7 @@ class NullableToStringCallSpec(private val env: KotlinCoreEnvironment) {
                 val y = foo.bar().toString()
                 val z = baz().toString()
             }
-        """
+        """.trimIndent()
         val actual = subject.compileAndLintWithContext(env, code)
         assertThat(actual).hasSize(3)
         assertThat(actual[0].message).isEqualTo("This call 'foo.a.toString()' may return the string \"null\".")
@@ -92,7 +92,7 @@ class NullableToStringCallSpec(private val env: KotlinCoreEnvironment) {
                 val y = "${'$'}{foo.bar()}"
                 val z = "${'$'}{baz()}"
             }
-        """
+        """.trimIndent()
         val actual = subject.compileAndLintWithContext(env, code)
         assertThat(actual).hasSize(3)
         assertThat(actual[0].message).isEqualTo("This call '\${foo.a}' may return the string \"null\".")
@@ -108,7 +108,7 @@ class NullableToStringCallSpec(private val env: KotlinCoreEnvironment) {
             fun test(foo: Foo?) {
                 val y = "${'$'}{foo?.a}"
             }
-        """
+        """.trimIndent()
         val actual = subject.compileAndLintWithContext(env, code)
         assertThat(actual).hasSize(1)
         assertThat(actual[0].message).isEqualTo("This call '\${foo?.a}' may return the string \"null\".")
@@ -155,7 +155,7 @@ class NullableToStringCallSpec(private val env: KotlinCoreEnvironment) {
                 if (bar == null) return
                 val y = "${'$'}{bar?.a}"
             }
-        """
+        """.trimIndent()
         val actual = subject.compileAndLintWithContext(env, code)
         assertThat(actual).isEmpty()
     }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/RedundantElseInWhenSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/RedundantElseInWhenSpec.kt
@@ -31,7 +31,7 @@ class RedundantElseInWhenSpec(private val env: KotlinCoreEnvironment) {
                     else -> {}
                 }
             }
-            """
+            """.trimIndent()
             val actual = subject.compileAndLintWithContext(env, code)
             assertThat(actual).hasSize(1)
         }
@@ -53,7 +53,7 @@ class RedundantElseInWhenSpec(private val env: KotlinCoreEnvironment) {
                     else -> 100
                 }
             }
-            """
+            """.trimIndent()
             val actual = subject.compileAndLintWithContext(env, code)
             assertThat(actual).hasSize(1)
         }
@@ -80,7 +80,7 @@ class RedundantElseInWhenSpec(private val env: KotlinCoreEnvironment) {
                     else -> 100
                 }
             }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -113,7 +113,7 @@ class RedundantElseInWhenSpec(private val env: KotlinCoreEnvironment) {
                     Color.GREEN -> {}
                 }
             }
-            """
+            """.trimIndent()
             assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
     }
@@ -137,7 +137,7 @@ class RedundantElseInWhenSpec(private val env: KotlinCoreEnvironment) {
                         else -> {}
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
@@ -158,7 +158,7 @@ class RedundantElseInWhenSpec(private val env: KotlinCoreEnvironment) {
                         else -> "other"
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
@@ -184,7 +184,7 @@ class RedundantElseInWhenSpec(private val env: KotlinCoreEnvironment) {
                         else -> "other"
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -203,7 +203,7 @@ class RedundantElseInWhenSpec(private val env: KotlinCoreEnvironment) {
                         is Variant.VariantB -> {}
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
     }
@@ -244,7 +244,7 @@ class RedundantElseInWhenSpec(private val env: KotlinCoreEnvironment) {
                         else -> print("x is funny")
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
     }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnconditionalJumpStatementInLoopSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnconditionalJumpStatementInLoopSpec.kt
@@ -13,7 +13,7 @@ class UnconditionalJumpStatementInLoopSpec {
             fun f() {
                 for (i in 1..2) return
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 
@@ -23,7 +23,7 @@ class UnconditionalJumpStatementInLoopSpec {
             fun f() {
                 while (true) { return } 
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 
@@ -33,7 +33,7 @@ class UnconditionalJumpStatementInLoopSpec {
             fun f() {
                 do { return } while(true) 
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 
@@ -43,7 +43,7 @@ class UnconditionalJumpStatementInLoopSpec {
             fun f() {
                 for (i in 1..2) continue
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 
@@ -53,7 +53,7 @@ class UnconditionalJumpStatementInLoopSpec {
             fun f() {
                 while (true) { continue } 
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 
@@ -63,7 +63,7 @@ class UnconditionalJumpStatementInLoopSpec {
             fun f() {
                 do { continue } while(true) 
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 
@@ -73,7 +73,7 @@ class UnconditionalJumpStatementInLoopSpec {
             fun f() {
                 for (i in 1..2) break
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 
@@ -83,7 +83,7 @@ class UnconditionalJumpStatementInLoopSpec {
             fun f() {
                 while (true) { break } 
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 
@@ -93,7 +93,7 @@ class UnconditionalJumpStatementInLoopSpec {
             fun f() {
                 do { break } while(true) 
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 
@@ -107,7 +107,7 @@ class UnconditionalJumpStatementInLoopSpec {
                     }
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 
@@ -121,7 +121,7 @@ class UnconditionalJumpStatementInLoopSpec {
                     }
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 
@@ -135,7 +135,7 @@ class UnconditionalJumpStatementInLoopSpec {
                     }
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 
@@ -150,7 +150,7 @@ class UnconditionalJumpStatementInLoopSpec {
                     if (i > 1) println() else return
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -165,7 +165,7 @@ class UnconditionalJumpStatementInLoopSpec {
                     if (i > 1) println() else continue
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -180,7 +180,7 @@ class UnconditionalJumpStatementInLoopSpec {
                     if (i > 1) println() else break
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -192,7 +192,7 @@ class UnconditionalJumpStatementInLoopSpec {
                 for (i in 1..5)
                     return compute(i) ?: return
             }
-        """
+        """.trimIndent()
 
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
@@ -207,7 +207,7 @@ class UnconditionalJumpStatementInLoopSpec {
                 }
                 return 0
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -221,7 +221,7 @@ class UnconditionalJumpStatementInLoopSpec {
                 }
                 return 0
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -236,7 +236,7 @@ class UnconditionalJumpStatementInLoopSpec {
                 }
                 return 0
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -251,7 +251,7 @@ class UnconditionalJumpStatementInLoopSpec {
                 }
                 return 0
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -266,7 +266,7 @@ class UnconditionalJumpStatementInLoopSpec {
                 }
                 return 0
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -279,7 +279,7 @@ class UnconditionalJumpStatementInLoopSpec {
                     compute(i) ?: return
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -292,7 +292,7 @@ class UnconditionalJumpStatementInLoopSpec {
                     compute(i) ?: continue
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -305,7 +305,7 @@ class UnconditionalJumpStatementInLoopSpec {
                     compute(i) ?: break
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -320,7 +320,7 @@ class UnconditionalJumpStatementInLoopSpec {
                     }
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -347,7 +347,7 @@ class UnconditionalJumpStatementInLoopSpec {
                 }
                 return 0
             }
-            """
+            """.trimIndent()
         )
 
         assertThat(findings).isEmpty()

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessaryNotNullOperatorSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessaryNotNullOperatorSpec.kt
@@ -19,7 +19,7 @@ class UnnecessaryNotNullOperatorSpec(private val env: KotlinCoreEnvironment) {
             val code = """
                 val a = 1
                 val b = a!!
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasTextLocations(18 to 21)
@@ -30,7 +30,7 @@ class UnnecessaryNotNullOperatorSpec(private val env: KotlinCoreEnvironment) {
             val code = """
                 val a = 1
                 val b = a!!.plus(42)
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasTextLocations(18 to 21)
@@ -41,7 +41,7 @@ class UnnecessaryNotNullOperatorSpec(private val env: KotlinCoreEnvironment) {
             val code = """
                 val a = 1
                 val b = a!!.plus(42)!!
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(2)
             assertThat(findings).hasTextLocations(18 to 21, 18 to 32)
@@ -56,7 +56,7 @@ class UnnecessaryNotNullOperatorSpec(private val env: KotlinCoreEnvironment) {
             val code = """
                 val a : Int? = 1
                 val b = a!!
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessarySafeCallSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessarySafeCallSpec.kt
@@ -22,7 +22,7 @@ class UnnecessarySafeCallSpec(private val env: KotlinCoreEnvironment) {
                     val a = 1
                     val b = a?.toString()
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasTextLocations(48 to 61)
@@ -35,7 +35,7 @@ class UnnecessarySafeCallSpec(private val env: KotlinCoreEnvironment) {
                     val a = 1
                     val b = a?.plus(42)
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasTextLocations(48 to 59)
@@ -48,7 +48,7 @@ class UnnecessarySafeCallSpec(private val env: KotlinCoreEnvironment) {
                     val a = 1
                     val b = a?.plus(42)?.minus(24)
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasTextLocations(48 to 59)
@@ -65,7 +65,7 @@ class UnnecessarySafeCallSpec(private val env: KotlinCoreEnvironment) {
                     val a : Int? = 1
                     val b = a?.plus(42)
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
@@ -83,7 +83,7 @@ class UnnecessarySafeCallSpec(private val env: KotlinCoreEnvironment) {
                     val a = outside()
                     val b = a?.plus(42)
                 }
-            """
+            """.trimIndent()
             val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
@@ -97,7 +97,7 @@ class UnnecessarySafeCallSpec(private val env: KotlinCoreEnvironment) {
                     val a : Int? = outside()
                     val b = a?.plus(42)
                 }
-            """
+            """.trimIndent()
             val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
@@ -111,7 +111,7 @@ class UnnecessarySafeCallSpec(private val env: KotlinCoreEnvironment) {
                     val a : Int = outside()
                     val b = a?.plus(42)
                 }
-            """
+            """.trimIndent()
             val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasTextLocations(103 to 114)

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnreachableCatchBlockSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnreachableCatchBlockSpec.kt
@@ -20,7 +20,7 @@ class UnreachableCatchBlockSpec(private val env: KotlinCoreEnvironment) {
                 } catch (e: Exception) {
                 }
             }
-        """
+        """.trimIndent()
         val findings = subject.compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(1)
         assertThat(findings).hasStartSourceLocation(4, 7)
@@ -35,7 +35,7 @@ class UnreachableCatchBlockSpec(private val env: KotlinCoreEnvironment) {
                 } catch (e: Exception) {
                 }
             }
-        """
+        """.trimIndent()
         val findings = subject.compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(1)
         assertThat(findings).hasStartSourceLocation(4, 7)
@@ -51,7 +51,7 @@ class UnreachableCatchBlockSpec(private val env: KotlinCoreEnvironment) {
                 } catch (e: IllegalStateException) {
                 }
             }
-        """
+        """.trimIndent()
         val findings = subject.compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(2)
         assertThat(findings).hasStartSourceLocations(
@@ -70,7 +70,7 @@ class UnreachableCatchBlockSpec(private val env: KotlinCoreEnvironment) {
                 } catch (e: RuntimeException) {
                 }
             }
-        """
+        """.trimIndent()
         val findings = subject.compileAndLintWithContext(env, code)
         assertThat(findings).isEmpty()
     }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnreachableCodeSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnreachableCodeSpec.kt
@@ -20,7 +20,7 @@ class UnreachableCodeSpec(private val env: KotlinCoreEnvironment) {
                     println()
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
     }
 
@@ -34,7 +34,7 @@ class UnreachableCodeSpec(private val env: KotlinCoreEnvironment) {
                 }
                 return false
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).hasSize(2)
     }
 
@@ -50,7 +50,7 @@ class UnreachableCodeSpec(private val env: KotlinCoreEnvironment) {
                     return@f 1
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
     }
 
@@ -63,7 +63,7 @@ class UnreachableCodeSpec(private val env: KotlinCoreEnvironment) {
                     println()
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
     }
 
@@ -80,7 +80,7 @@ class UnreachableCodeSpec(private val env: KotlinCoreEnvironment) {
                     println()
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).hasSize(2)
     }
 
@@ -93,7 +93,7 @@ class UnreachableCodeSpec(private val env: KotlinCoreEnvironment) {
                     println()
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 
@@ -106,7 +106,7 @@ class UnreachableCodeSpec(private val env: KotlinCoreEnvironment) {
                 }
                 throw IllegalArgumentException()
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 
@@ -120,7 +120,7 @@ class UnreachableCodeSpec(private val env: KotlinCoreEnvironment) {
                 }
                 println()
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 
@@ -135,7 +135,7 @@ class UnreachableCodeSpec(private val env: KotlinCoreEnvironment) {
                 }
                 return 0
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
     }
 
@@ -151,7 +151,7 @@ class UnreachableCodeSpec(private val env: KotlinCoreEnvironment) {
                 }
                 return 0
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
     }
 
@@ -166,7 +166,7 @@ class UnreachableCodeSpec(private val env: KotlinCoreEnvironment) {
                 }
                 return 0
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
     }
 }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCallOnNullableTypeSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCallOnNullableTypeSpec.kt
@@ -16,7 +16,7 @@ class UnsafeCallOnNullableTypeSpec(private val env: KotlinCoreEnvironment) {
                 fun test(str: String?) {
                     println(str!!.length)
                 }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
     }
 
@@ -26,7 +26,7 @@ class UnsafeCallOnNullableTypeSpec(private val env: KotlinCoreEnvironment) {
                 import java.util.UUID
 
                 val version = UUID.randomUUID()!!
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 
@@ -36,7 +36,7 @@ class UnsafeCallOnNullableTypeSpec(private val env: KotlinCoreEnvironment) {
                 fun test(str: String?) {
                     println(str?.length)
                 }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 
@@ -46,7 +46,7 @@ class UnsafeCallOnNullableTypeSpec(private val env: KotlinCoreEnvironment) {
                 fun test(str: String?) {
                     println(str?.length ?: 0)
                 }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCastSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCastSpec.kt
@@ -16,7 +16,7 @@ class UnsafeCastSpec(private val env: KotlinCoreEnvironment) {
             fun test(s: String) {
                 println(s as Int)
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
     }
 
@@ -26,7 +26,7 @@ class UnsafeCastSpec(private val env: KotlinCoreEnvironment) {
             fun test(s: String) {
                 println((s as? Int) ?: 0)
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
     }
 
@@ -36,7 +36,7 @@ class UnsafeCastSpec(private val env: KotlinCoreEnvironment) {
             fun test(s: Any) {
                 println(s as Int)
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 
@@ -46,7 +46,7 @@ class UnsafeCastSpec(private val env: KotlinCoreEnvironment) {
             fun test(s: Any) {
                 println((s as? Int) ?: 0)
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnusedUnaryOperatorSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnusedUnaryOperatorSpec.kt
@@ -17,7 +17,7 @@ class UnusedUnaryOperatorSpec(private val env: KotlinCoreEnvironment) {
                 val x = 1 + 2
                     + 3
             }
-        """
+        """.trimIndent()
         val findings = subject.compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(1)
         assertThat(findings).hasStartSourceLocation(3, 9)
@@ -31,7 +31,7 @@ class UnusedUnaryOperatorSpec(private val env: KotlinCoreEnvironment) {
                 val x = 1 + 2
                     - 3
             }
-        """
+        """.trimIndent()
         val findings = subject.compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(1)
         assertThat(findings).hasStartSourceLocation(3, 9)
@@ -45,7 +45,7 @@ class UnusedUnaryOperatorSpec(private val env: KotlinCoreEnvironment) {
                 val x = 1 + 2
                     + 3 + 4 + 5
             }
-        """
+        """.trimIndent()
         val findings = subject.compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(1)
         assertThat(findings[0]).hasMessage("This '+ 3 + 4 + 5' is not used")
@@ -58,7 +58,7 @@ class UnusedUnaryOperatorSpec(private val env: KotlinCoreEnvironment) {
                 val x = (1 + 2
                     + 3 + 4 + 5)
             }
-        """
+        """.trimIndent()
         val findings = subject.compileAndLintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
@@ -69,7 +69,7 @@ class UnusedUnaryOperatorSpec(private val env: KotlinCoreEnvironment) {
             fun test() {
                 val x = -1
             }
-        """
+        """.trimIndent()
         val findings = subject.compileAndLintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
@@ -80,7 +80,7 @@ class UnusedUnaryOperatorSpec(private val env: KotlinCoreEnvironment) {
             fun test(): Int {
                 return -1
             }
-        """
+        """.trimIndent()
         val findings = subject.compileAndLintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
@@ -92,7 +92,7 @@ class UnusedUnaryOperatorSpec(private val env: KotlinCoreEnvironment) {
             fun test() {
                 foo(x = -1)
             }
-        """
+        """.trimIndent()
         val findings = subject.compileAndLintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
@@ -103,7 +103,7 @@ class UnusedUnaryOperatorSpec(private val env: KotlinCoreEnvironment) {
             annotation class Ann(val x: Int)
             @Ann(x = -1)
             val y = 2
-        """
+        """.trimIndent()
         val findings = subject.compileAndLintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
@@ -118,7 +118,7 @@ class UnusedUnaryOperatorSpec(private val env: KotlinCoreEnvironment) {
                 val p = Foo(1) + Foo(2)
                     - Foo(3)
             } 
-        """
+        """.trimIndent()
         val findings = subject.compileAndLintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
@@ -134,7 +134,7 @@ class UnusedUnaryOperatorSpec(private val env: KotlinCoreEnvironment) {
                     1
                 }
             }
-        """
+        """.trimIndent()
         val findings = subject.compileAndLintWithContext(env, code)
         assertThat(findings).isEmpty()
     }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UselessPostfixExpressionSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UselessPostfixExpressionSpec.kt
@@ -20,7 +20,7 @@ class UselessPostfixExpressionSpec {
                     i = 1 + i++ // invalid
                     i = i++ + 1 // invalid
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).hasSize(3)
         }
 
@@ -32,7 +32,7 @@ class UselessPostfixExpressionSpec {
                     var j = 0
                     j = i++
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
@@ -45,7 +45,7 @@ class UselessPostfixExpressionSpec {
                     if (i == 0) return 1 + j++
                     return i++
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).hasSize(2)
         }
 
@@ -69,7 +69,7 @@ class UselessPostfixExpressionSpec {
                         return i++
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
@@ -91,7 +91,7 @@ class UselessPostfixExpressionSpec {
                         return i++
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).hasSize(2)
         }
     }
@@ -111,7 +111,7 @@ class UselessPostfixExpressionSpec {
                 fun f2(): Int {
                     return str!!.count()
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
@@ -122,7 +122,7 @@ class UselessPostfixExpressionSpec {
                     val str: String? = ""
                     str!!
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
     }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/WrongEqualsTypeParameterSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/WrongEqualsTypeParameterSpec.kt
@@ -16,7 +16,7 @@ class WrongEqualsTypeParameterSpec {
                     return super.equals(other)
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -28,7 +28,7 @@ class WrongEqualsTypeParameterSpec {
                     return super.equals(other)
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 
@@ -40,7 +40,7 @@ class WrongEqualsTypeParameterSpec {
                     return super.equals(other)
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -59,7 +59,7 @@ class WrongEqualsTypeParameterSpec {
                 
                 override fun equals() = true
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -69,7 +69,7 @@ class WrongEqualsTypeParameterSpec {
             interface I {
                 fun equals(other: String)
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -78,7 +78,7 @@ class WrongEqualsTypeParameterSpec {
         val code = """
             fun equals(other: String) {}
             fun equals(other: Any?) {}
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 }

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ExceptionRaisedInUnexpectedLocationSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ExceptionRaisedInUnexpectedLocationSpec.kt
@@ -30,7 +30,7 @@ class ExceptionRaisedInUnexpectedLocationSpec {
         fun toDo() {
             throw IllegalStateException()
         }
-            """
+            """.trimIndent()
         )
         assertThat(findings).hasSize(1)
     }
@@ -43,7 +43,7 @@ class ExceptionRaisedInUnexpectedLocationSpec {
         fun toDo() {
             throw IllegalStateException()
         }
-            """
+            """.trimIndent()
         )
         assertThat(findings).hasSize(1)
     }

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/InstanceOfCheckForExceptionSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/InstanceOfCheckForExceptionSpec.kt
@@ -21,7 +21,7 @@ class InstanceOfCheckForExceptionSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).hasSize(2)
     }
 
@@ -36,7 +36,7 @@ class InstanceOfCheckForExceptionSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).hasSize(2)
     }
 
@@ -53,7 +53,7 @@ class InstanceOfCheckForExceptionSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 
@@ -69,7 +69,7 @@ class InstanceOfCheckForExceptionSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 }

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/NotImplementedDeclarationSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/NotImplementedDeclarationSpec.kt
@@ -14,7 +14,7 @@ class NotImplementedDeclarationSpec {
             if (1 == 1) throw NotImplementedError()
             throw NotImplementedError()
         }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(2)
     }
 
@@ -25,7 +25,7 @@ class NotImplementedDeclarationSpec {
             TODO("not implemented")
             TODO()
         }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(2)
     }
 
@@ -35,7 +35,7 @@ class NotImplementedDeclarationSpec {
         fun f() {
             // TODO
         }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 }

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ObjectExtendsThrowableSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ObjectExtendsThrowableSpec.kt
@@ -18,7 +18,7 @@ class ObjectExtendsThrowableSpec(val env: KotlinCoreEnvironment) {
         object AuthException : RuntimeException()
         object ReportedException : Exception()
         object FatalException : Error()
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).hasSize(4)
     }
 
@@ -30,7 +30,7 @@ class ObjectExtendsThrowableSpec(val env: KotlinCoreEnvironment) {
             class Exception2 : DomainException()
             object Exception3 : DomainException()
         }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
     }
 
@@ -40,7 +40,7 @@ class ObjectExtendsThrowableSpec(val env: KotlinCoreEnvironment) {
         object ObjectCustomException : CustomException("singleton custom exception")
 
         open class CustomException(message: String) : RuntimeException(message)
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
     }
 
@@ -70,7 +70,7 @@ class ObjectExtendsThrowableSpec(val env: KotlinCoreEnvironment) {
                 const val NAME = "Test 4"
             }
         }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).hasSize(4)
     }
 
@@ -87,7 +87,7 @@ class ObjectExtendsThrowableSpec(val env: KotlinCoreEnvironment) {
         }
 
         open class CustomException(message: String) 
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 
@@ -105,7 +105,7 @@ class ObjectExtendsThrowableSpec(val env: KotlinCoreEnvironment) {
                 const val NAME = "Test 3"
             }
         }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 
@@ -125,7 +125,7 @@ class ObjectExtendsThrowableSpec(val env: KotlinCoreEnvironment) {
         }
 
         open class CustomException(message: String) 
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 
@@ -135,7 +135,7 @@ class ObjectExtendsThrowableSpec(val env: KotlinCoreEnvironment) {
         val exception = object : AbstractCustomException() {}
 
         abstract class AbstractCustomException : RuntimeException()
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 }

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/PrintStackTraceSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/PrintStackTraceSpec.kt
@@ -20,7 +20,7 @@ class PrintStackTraceSpec {
                     e.printStackTrace()
                 }
             }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
@@ -36,7 +36,7 @@ class PrintStackTraceSpec {
                     printStackTrace()
                 }
             }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
     }
@@ -53,7 +53,7 @@ class PrintStackTraceSpec {
                 fun dumpStack() {}
                 dumpStack()
             }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
     }

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/RethrowCaughtExceptionSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/RethrowCaughtExceptionSpec.kt
@@ -16,7 +16,7 @@ class RethrowCaughtExceptionSpec {
                     throw e
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 
@@ -32,7 +32,7 @@ class RethrowCaughtExceptionSpec {
                     }
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -46,7 +46,7 @@ class RethrowCaughtExceptionSpec {
                     print("log")
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 
@@ -62,7 +62,7 @@ class RethrowCaughtExceptionSpec {
                     }
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 
@@ -75,7 +75,7 @@ class RethrowCaughtExceptionSpec {
                     throw IllegalArgumentException(e)
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -90,7 +90,7 @@ class RethrowCaughtExceptionSpec {
                     throw IllegalArgumentException("msg", f)
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -106,7 +106,7 @@ class RethrowCaughtExceptionSpec {
                     throw IllegalArgumentException("msg", f)
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -125,7 +125,7 @@ class RethrowCaughtExceptionSpec {
                     throw e
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -140,7 +140,7 @@ class RethrowCaughtExceptionSpec {
                     print(e)
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -156,7 +156,7 @@ class RethrowCaughtExceptionSpec {
                     throw e
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -168,7 +168,7 @@ class RethrowCaughtExceptionSpec {
                 } finally {
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -183,7 +183,7 @@ class RethrowCaughtExceptionSpec {
                     throw e
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 
@@ -199,7 +199,7 @@ class RethrowCaughtExceptionSpec {
                     throw e
                 }
             }
-        """
+        """.trimIndent()
         val result = subject.compileAndLint(code)
         assertThat(result).hasSize(2)
         // ensure correct violation order

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ReturnFromFinallySpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ReturnFromFinallySpec.kt
@@ -21,7 +21,7 @@ class ReturnFromFinallySpec(val env: KotlinCoreEnvironment) {
                     return
                 }
             }
-        """
+        """.trimIndent()
 
         @Test
         fun `should report`() {
@@ -38,7 +38,7 @@ class ReturnFromFinallySpec(val env: KotlinCoreEnvironment) {
                 } finally {
                 }
             }
-        """
+        """.trimIndent()
 
         @Test
         fun `should not report`() {
@@ -58,7 +58,7 @@ class ReturnFromFinallySpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             }
-        """
+        """.trimIndent()
 
         @Test
         fun `should report`() {
@@ -79,7 +79,7 @@ class ReturnFromFinallySpec(val env: KotlinCoreEnvironment) {
                     y()
                 }
             }
-        """
+        """.trimIndent()
 
         @Test
         fun `should not report`() {
@@ -99,7 +99,7 @@ class ReturnFromFinallySpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             }
-        """
+        """.trimIndent()
 
         @Test
         fun `should report when ignoreLabeled is false`() {
@@ -127,7 +127,7 @@ class ReturnFromFinallySpec(val env: KotlinCoreEnvironment) {
                 } finally {
                     "finally"
                 }
-            """
+            """.trimIndent()
 
             val finding = subject.compileAndLintWithContext(env, code)
 
@@ -147,7 +147,7 @@ class ReturnFromFinallySpec(val env: KotlinCoreEnvironment) {
                 } finally {
                     "finally"
                 }
-            """
+            """.trimIndent()
 
             val finding = subject.compileAndLintWithContext(env, code)
 
@@ -169,7 +169,7 @@ class ReturnFromFinallySpec(val env: KotlinCoreEnvironment) {
                 }
                 
                 fun compute(): String = "value"
-            """
+            """.trimIndent()
 
             val finding = subject.compileAndLintWithContext(env, code)
 
@@ -187,7 +187,7 @@ class ReturnFromFinallySpec(val env: KotlinCoreEnvironment) {
                 } catch (e: Exception) {
                     "exception"
                 } 
-            """
+            """.trimIndent()
 
             val finding = subject.compileAndLintWithContext(env, code)
 
@@ -206,7 +206,7 @@ class ReturnFromFinallySpec(val env: KotlinCoreEnvironment) {
                 } catch (e: Exception) {
                     "exception"
                 }
-            """
+            """.trimIndent()
 
             val finding = subject.compileAndLintWithContext(env, code)
 
@@ -228,7 +228,7 @@ class ReturnFromFinallySpec(val env: KotlinCoreEnvironment) {
                        "finally"
                    }
                }
-            """
+            """.trimIndent()
 
             val finding = subject.compileAndLintWithContext(env, code)
 
@@ -248,7 +248,7 @@ class ReturnFromFinallySpec(val env: KotlinCoreEnvironment) {
                 } finally {
                     println("finally")
                 }
-            """
+            """.trimIndent()
 
             val finding = subject.compileAndLintWithContext(env, code)
 
@@ -270,7 +270,7 @@ class ReturnFromFinallySpec(val env: KotlinCoreEnvironment) {
                     println("finally")
                     property
                 }
-            """
+            """.trimIndent()
 
             val finding = subject.compileAndLintWithContext(env, code)
 

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedExceptionSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedExceptionSpec.kt
@@ -20,7 +20,7 @@ class SwallowedExceptionSpec {
                     throw IllegalArgumentException()
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 
@@ -35,7 +35,7 @@ class SwallowedExceptionSpec {
                     throw Exception(IllegalArgumentException(f.toString()))
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(2)
     }
 
@@ -52,7 +52,7 @@ class SwallowedExceptionSpec {
                     throw Exception(IllegalArgumentException(message))
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(2)
     }
 
@@ -73,7 +73,7 @@ class SwallowedExceptionSpec {
                     }
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(2)
     }
 
@@ -90,7 +90,7 @@ class SwallowedExceptionSpec {
                     throw IllegalArgumentException(e)
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 
@@ -107,7 +107,7 @@ class SwallowedExceptionSpec {
                     throw IllegalArgumentException(e.message)
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 
@@ -125,7 +125,7 @@ class SwallowedExceptionSpec {
                     throw IllegalArgumentException(e)
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 
@@ -138,7 +138,7 @@ class SwallowedExceptionSpec {
                     println()
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 
@@ -159,7 +159,7 @@ class SwallowedExceptionSpec {
                 } catch (e: IllegalArgumentException) {
                 }
             }
-            """
+            """.trimIndent()
             assertThat(rule.compileAndLint(code)).isEmpty()
         }
 
@@ -171,7 +171,7 @@ class SwallowedExceptionSpec {
                 } catch (e: Exception) {
                 }
             }
-            """
+            """.trimIndent()
             assertThat(rule.compileAndLint(code)).hasSize(1)
         }
     }
@@ -193,7 +193,7 @@ class SwallowedExceptionSpec {
                 } catch (e: IllegalArgumentException) {
                 }
             }
-            """
+            """.trimIndent()
             assertThat(rule.compileAndLint(code)).isEmpty()
         }
 
@@ -205,7 +205,7 @@ class SwallowedExceptionSpec {
                 } catch (e: Exception) {
                 }
             }
-            """
+            """.trimIndent()
             assertThat(rule.compileAndLint(code)).hasSize(1)
         }
     }
@@ -224,7 +224,7 @@ class SwallowedExceptionSpec {
                     } catch (myIgnore: IllegalArgumentException) {
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(rule.compileAndLint(code)).isEmpty()
         }
 
@@ -236,7 +236,7 @@ class SwallowedExceptionSpec {
                     } catch (e: IllegalArgumentException) {
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(rule.compileAndLint(code)).hasSize(1)
         }
     }
@@ -252,7 +252,7 @@ class SwallowedExceptionSpec {
                     throw IllegalArgumentException(e)
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -267,7 +267,7 @@ class SwallowedExceptionSpec {
                     print(e.message)
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -284,7 +284,7 @@ class SwallowedExceptionSpec {
                     throw Exception()
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -307,7 +307,7 @@ class SwallowedExceptionSpec {
                     throw $exceptionInstantiation
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 }

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionFromFinallySpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionFromFinallySpec.kt
@@ -18,7 +18,7 @@ class ThrowingExceptionFromFinallySpec {
                     }
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 
@@ -31,7 +31,7 @@ class ThrowingExceptionFromFinallySpec {
                     throw IllegalArgumentException()
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 
@@ -44,7 +44,7 @@ class ThrowingExceptionFromFinallySpec {
                     println()
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 }

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionInMainSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionInMainSpec.kt
@@ -14,7 +14,7 @@ class ThrowingExceptionInMainSpec {
             fun main(args: Array<String>) { throw IllegalArgumentException() }
             fun main(vararg args: String) { throw IllegalArgumentException() }
             fun main() { throw IllegalArgumentException() }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(3)
     }
 
@@ -39,7 +39,7 @@ class ThrowingExceptionInMainSpec {
                 @JvmStatic
                 fun main(args: Array<String>) { throw IllegalArgumentException() }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(3)
     }
 
@@ -51,7 +51,7 @@ class ThrowingExceptionInMainSpec {
             fun mai() { throw IllegalArgumentException() }
             fun main(args: String) { throw IllegalArgumentException() }
             fun main(args: Array<String>, i: Int) { throw IllegalArgumentException() }
-        """
+        """.trimIndent()
         assertThat(subject.lint(code)).isEmpty()
     }
 
@@ -62,7 +62,7 @@ class ThrowingExceptionInMainSpec {
             fun main() { }
             fun mai() { }
             fun main(args: String) { }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -71,7 +71,7 @@ class ThrowingExceptionInMainSpec {
         val code = """
             fun main(args: Array<String>) = ""
             fun main() = Unit
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -85,7 +85,7 @@ class ThrowingExceptionInMainSpec {
                 fun main(args: Array<String>) { throw IllegalArgumentException() }
             }
         }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 }

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionsWithoutMessageOrCauseSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionsWithoutMessageOrCauseSpec.kt
@@ -21,7 +21,7 @@ class ThrowingExceptionsWithoutMessageOrCauseSpec {
                 IllegalArgumentException("foo")
                 throw IllegalArgumentException()
             }
-        """
+        """.trimIndent()
 
         @Test
         fun `reports calls to the default constructor`() {
@@ -45,7 +45,7 @@ class ThrowingExceptionsWithoutMessageOrCauseSpec {
             fun test() {
                 org.assertj.core.api.Assertions.assertThatIllegalArgumentException().isThrownBy { println() }
             }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
     }

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingNewInstanceOfSameExceptionSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingNewInstanceOfSameExceptionSpec.kt
@@ -18,7 +18,7 @@ class ThrowingNewInstanceOfSameExceptionSpec {
                 throw IllegalStateException(e)
             }
         }
-        """
+        """.trimIndent()
 
         @Test
         fun `should report`() {
@@ -36,7 +36,7 @@ class ThrowingNewInstanceOfSameExceptionSpec {
                 throw IllegalArgumentException(e)
             }
         }
-        """
+        """.trimIndent()
 
         @Test
         fun `should not report`() {
@@ -57,7 +57,7 @@ class ThrowingNewInstanceOfSameExceptionSpec {
                 throw IllegalStateException()
             }
         }
-        """
+        """.trimIndent()
 
         @Test
         fun `should not report`() {

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionCaughtSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionCaughtSpec.kt
@@ -40,7 +40,7 @@ class TooGenericExceptionCaughtSpec {
                     throw Error()
                 }
             }
-        """
+        """.trimIndent()
 
         @Test
         fun `should not report an ignored catch blocks because of its exception name`() {

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionSpec.kt
@@ -20,7 +20,7 @@ class TooGenericExceptionSpec {
     }
 }
 
-const val tooGenericExceptionCode = """
+val tooGenericExceptionCode = """
     fun main() {
         try {
             throw Throwable()
@@ -39,4 +39,4 @@ const val tooGenericExceptionCode = """
 
         }
     }
-"""
+""".trimIndent()

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionThrownSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionThrownSpec.kt
@@ -45,7 +45,7 @@ class TooGenericExceptionThrownSpec {
                     throw Error()
                 }
             }
-        """
+        """.trimIndent()
         val findings = rule.compileAndLint(code)
 
         assertThat(findings).isEmpty()

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/BooleanPropertyNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/BooleanPropertyNamingSpec.kt
@@ -31,7 +31,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                 }
 
                 data class TestImpl (override var default: Boolean) : Test
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
 
             assertThat(findings).hasSize(1)
@@ -45,7 +45,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                 }
 
                 data class TestImpl (override var default: Boolean) : Test
-            """
+            """.trimIndent()
             val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to false))
             val findings = BooleanPropertyNaming(config).compileAndLintWithContext(env, code)
 
@@ -60,7 +60,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                 }
 
                 data class TestImpl (override var default: Boolean) : Test
-            """
+            """.trimIndent()
             val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to true))
             val findings = BooleanPropertyNaming(config).compileAndLintWithContext(env, code)
 
@@ -83,7 +83,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                 }
 
                 data class TestImpl (override var default: Boolean?) : Test
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
 
             assertThat(findings).hasSize(1)
@@ -97,7 +97,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                 }
 
                 data class TestImpl (override var default: Boolean?) : Test
-            """
+            """.trimIndent()
             val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to false))
             val findings = BooleanPropertyNaming(config).compileAndLintWithContext(env, code)
 
@@ -112,7 +112,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                 }
 
                 data class TestImpl (override var default: Boolean?) : Test
-            """
+            """.trimIndent()
             val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to true))
             val findings = BooleanPropertyNaming(config).compileAndLintWithContext(env, code)
 
@@ -135,7 +135,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                 }
 
                 data class TestImpl (override var default: Boolean = false) : Test
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
 
             assertThat(findings).hasSize(1)
@@ -149,7 +149,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                 }
 
                 data class TestImpl (override var default: Boolean = false) : Test
-            """
+            """.trimIndent()
             val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to false))
             val findings = BooleanPropertyNaming(config).compileAndLintWithContext(env, code)
 
@@ -164,7 +164,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                 }
 
                 data class TestImpl (override var default: Boolean = false) : Test
-            """
+            """.trimIndent()
             val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to true))
             val findings = BooleanPropertyNaming(config).compileAndLintWithContext(env, code)
 
@@ -187,7 +187,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                 }
 
                 data class TestImpl (override var default: java.lang.Boolean) : Test
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
 
             assertThat(findings).hasSize(1)
@@ -201,7 +201,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                 }
 
                 data class TestImpl (override var default: java.lang.Boolean) : Test
-            """
+            """.trimIndent()
             val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to false))
             val findings = BooleanPropertyNaming(config).compileAndLintWithContext(env, code)
 
@@ -216,7 +216,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                 }
 
                 data class TestImpl (override var default: java.lang.Boolean) : Test
-            """
+            """.trimIndent()
             val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to true))
             val findings = BooleanPropertyNaming(config).compileAndLintWithContext(env, code)
 
@@ -248,7 +248,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                 class Test {
                     var default: Boolean = true
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
 
             assertThat(findings).hasSize(1)
@@ -264,7 +264,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                 class TestImpl : Test {
                     override var default: Boolean = true
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
 
             assertThat(findings).hasSize(1)
@@ -276,7 +276,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                 object Test {
                     const val CONSTANT_VAL_BOOLEAN = true
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
 
             assertThat(findings).hasSize(0)
@@ -292,7 +292,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                 class TestImpl : Test {
                     override var default: Boolean = true
                 }
-            """
+            """.trimIndent()
             val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to false))
             val findings = BooleanPropertyNaming(config).compileAndLintWithContext(env, code)
 
@@ -309,7 +309,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                 class TestImpl : Test {
                     override var default: Boolean = true
                 }
-            """
+            """.trimIndent()
             val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to true))
             val findings = BooleanPropertyNaming(config).compileAndLintWithContext(env, code)
 
@@ -322,7 +322,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                 class Test {
                     var default: Boolean? = null
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
 
             assertThat(findings).hasSize(1)
@@ -338,7 +338,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                 class TestImpl : Test {
                     override var default: Boolean? = null
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
 
             assertThat(findings).hasSize(1)
@@ -354,7 +354,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                 class TestImpl : Test {
                     override var default: Boolean? = null
                 }
-            """
+            """.trimIndent()
             val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to false))
             val findings = BooleanPropertyNaming(config).compileAndLintWithContext(env, code)
 
@@ -371,7 +371,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                 class TestImpl : Test {
                     override var default: Boolean? = null
                 }
-            """
+            """.trimIndent()
             val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to true))
             val findings = BooleanPropertyNaming(config).compileAndLintWithContext(env, code)
 
@@ -384,7 +384,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                 class Test {
                     var default: Boolean = false
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
 
             assertThat(findings).hasSize(1)
@@ -400,7 +400,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                 class TestImpl : Test {
                     override var default: Boolean = false
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
 
             assertThat(findings).hasSize(1)
@@ -416,7 +416,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                 class TestImpl : Test {
                     override var default: Boolean = false
                 }
-            """
+            """.trimIndent()
             val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to false))
             val findings = BooleanPropertyNaming(config).compileAndLintWithContext(env, code)
 
@@ -433,7 +433,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                 class TestImpl : Test {
                     override var default: Boolean = false
                 }
-            """
+            """.trimIndent()
             val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to true))
             val findings = BooleanPropertyNaming(config).compileAndLintWithContext(env, code)
 
@@ -446,7 +446,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                 class Test {
                     var default = true
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
 
             assertThat(findings).hasSize(1)
@@ -462,7 +462,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                 class TestImpl : Test {
                     override var default = true
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
 
             assertThat(findings).hasSize(1)
@@ -478,7 +478,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                 class TestImpl : Test {
                     override var default = true
                 }
-            """
+            """.trimIndent()
             val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to false))
             val findings = BooleanPropertyNaming(config).compileAndLintWithContext(env, code)
 
@@ -495,7 +495,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                 class TestImpl : Test {
                     override var default = true
                 }
-            """
+            """.trimIndent()
             val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to true))
             val findings = BooleanPropertyNaming(config).compileAndLintWithContext(env, code)
 
@@ -508,7 +508,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                 class Test {
                     var default: java.lang.Boolean = java.lang.Boolean(true)
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
 
             assertThat(findings).hasSize(1)
@@ -524,7 +524,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                 class TestImpl : Test {
                     override var default: java.lang.Boolean = java.lang.Boolean(true)
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
 
             assertThat(findings).hasSize(1)
@@ -540,7 +540,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                 class TestImpl : Test {
                     override var default: java.lang.Boolean = java.lang.Boolean(true)
                 }
-            """
+            """.trimIndent()
             val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to false))
             val findings = BooleanPropertyNaming(config).compileAndLintWithContext(env, code)
 
@@ -557,7 +557,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                 class TestImpl : Test {
                     override var default: java.lang.Boolean = java.lang.Boolean(true)
                 }
-            """
+            """.trimIndent()
             val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to true))
             val findings = BooleanPropertyNaming(config).compileAndLintWithContext(env, code)
 
@@ -570,7 +570,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                 class Test {
                     var count: Int = 0
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
 
             assertThat(findings).isEmpty()
@@ -583,7 +583,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                     var isEnabled: Boolean = true
                     var hasDefault: Boolean = true
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
 
             assertThat(findings).isEmpty()
@@ -595,7 +595,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                 class Test {
                     var needReload: Boolean = true
                 }
-            """
+            """.trimIndent()
 
             val config = TestConfig(mapOf(ALLOWED_PATTERN to "^(is|has|are|need)"))
             assertThat(BooleanPropertyNaming(config).compileAndLint(code))

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ClassNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ClassNamingSpec.kt
@@ -10,7 +10,7 @@ class ClassNamingSpec {
     fun `should detect no violations class with numbers`() {
         val code = """
             class MyClassWithNumbers5
-        """
+        """.trimIndent()
 
         assertThat(ClassNaming().compileAndLint(code)).isEmpty()
     }
@@ -20,7 +20,7 @@ class ClassNamingSpec {
         val code = """
             class NamingConventions {
             }
-        """
+        """.trimIndent()
 
         assertThat(ClassNaming().compileAndLint(code)).isEmpty()
     }
@@ -29,7 +29,7 @@ class ClassNamingSpec {
     fun `should detect no violations with class using backticks`() {
         val code = """
             class `NamingConventions`
-        """
+        """.trimIndent()
 
         assertThat(ClassNaming().compileAndLint(code)).isEmpty()
     }
@@ -38,7 +38,7 @@ class ClassNamingSpec {
     fun `should detect because it have a _`() {
         val code = """
             class _NamingConventions
-        """
+        """.trimIndent()
 
         assertThat(ClassNaming().compileAndLint(code))
             .hasSize(1)
@@ -49,7 +49,7 @@ class ClassNamingSpec {
     fun `should detect because it have starts with lowercase`() {
         val code = """
             class namingConventions {}
-        """
+        """.trimIndent()
 
         assertThat(ClassNaming().compileAndLint(code))
             .hasSize(1)
@@ -61,7 +61,7 @@ class ClassNamingSpec {
         val code = """
             @Suppress("ClassName")
             class namingConventions {}
-        """
+        """.trimIndent()
         assertThat(ClassNaming().compileAndLint(code)).isEmpty()
     }
 }

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ConstructorParameterNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ConstructorParameterNamingSpec.kt
@@ -16,7 +16,7 @@ class ConstructorParameterNamingSpec {
                 constructor(param: String) {}
                 constructor(param: String, privateParam: String) {}
             }
-        """
+        """.trimIndent()
         assertThat(ConstructorParameterNaming().compileAndLint(code)).isEmpty()
     }
 
@@ -29,7 +29,7 @@ class ConstructorParameterNamingSpec {
                 constructor(PARAM: String) {}
                 constructor(PARAM: String, PRIVATE_PARAM: String) {}
             }
-        """
+        """.trimIndent()
         assertThat(ConstructorParameterNaming().compileAndLint(code)).hasSize(5)
     }
 
@@ -37,7 +37,7 @@ class ConstructorParameterNamingSpec {
     fun `should find a violation in the correct text location`() {
         val code = """
             class C(val PARAM: String)
-        """
+        """.trimIndent()
         assertThat(ConstructorParameterNaming().compileAndLint(code)).hasTextLocations(8 to 25)
     }
 
@@ -47,7 +47,7 @@ class ConstructorParameterNamingSpec {
             class C(override val PARAM: String) : I
 
             interface I { val PARAM: String }
-        """
+        """.trimIndent()
         assertThat(ConstructorParameterNaming().compileAndLint(code)).isEmpty()
     }
 
@@ -57,7 +57,7 @@ class ConstructorParameterNamingSpec {
             class C(override val PARAM: String) : I
 
             interface I { val PARAM: String }
-        """
+        """.trimIndent()
         val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to "false"))
         assertThat(ConstructorParameterNaming(config).compileAndLint(code)).hasTextLocations(8 to 34)
     }

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/EnumNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/EnumNamingSpec.kt
@@ -13,7 +13,7 @@ class EnumNamingSpec {
             enum class WorkFlow {
                 ACTIVE, NOT_ACTIVE, Unknown, Number1
             }
-            """
+            """.trimIndent()
         )
         assertThat(findings).isEmpty()
     }
@@ -24,7 +24,7 @@ class EnumNamingSpec {
             enum class WorkFlow {
                 default
             }
-        """
+        """.trimIndent()
         assertThat(NamingRules().compileAndLint(code)).hasSize(1)
     }
 
@@ -34,7 +34,7 @@ class EnumNamingSpec {
             enum class WorkFlow {
                 _Default
             }
-        """
+        """.trimIndent()
         assertThat(EnumNaming().compileAndLint(code)).hasSize(1)
     }
 
@@ -44,7 +44,7 @@ class EnumNamingSpec {
             enum class WorkFlow {
                 @Suppress("EnumNaming") _Default
             }
-        """
+        """.trimIndent()
         assertThat(EnumNaming().compileAndLint(code)).isEmpty()
     }
 
@@ -54,7 +54,7 @@ class EnumNamingSpec {
             enum class WorkFlow {
                 _Default,
             }
-        """
+        """.trimIndent()
         val findings = EnumNaming().compileAndLint(code)
         assertThat(findings).hasTextLocations(26 to 34)
     }

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ForbiddenClassNameSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ForbiddenClassNameSpec.kt
@@ -15,7 +15,7 @@ class ForbiddenClassNameSpec {
             class TestManager {} // violation
             class TestProvider {} // violation
             class TestHolder
-        """
+        """.trimIndent()
         assertThat(
             ForbiddenClassName(TestConfig(mapOf(FORBIDDEN_NAME to listOf("Manager", "Provider"))))
                 .compileAndLint(code)
@@ -39,7 +39,7 @@ class ForbiddenClassNameSpec {
             class TestManager {} // violation
             class TestProvider {} // violation
             class TestHolder
-        """
+        """.trimIndent()
         assertThat(
             ForbiddenClassName(TestConfig(mapOf(FORBIDDEN_NAME to "Manager, Provider")))
                 .compileAndLint(code)
@@ -53,7 +53,7 @@ class ForbiddenClassNameSpec {
             class TestManager {} // violation
             class TestProvider {} // violation
             class TestHolder
-        """
+        """.trimIndent()
         assertThat(
             ForbiddenClassName(TestConfig(mapOf(FORBIDDEN_NAME to "*Manager*, *Provider*")))
                 .compileAndLint(code)
@@ -65,7 +65,7 @@ class ForbiddenClassNameSpec {
     fun `should report all forbidden names in message`() {
         val code = """
             class TestManager {}
-        """
+        """.trimIndent()
         val actual = ForbiddenClassName(TestConfig(mapOf(FORBIDDEN_NAME to "Test, Manager, Provider")))
             .compileAndLint(code)
         assertThat(actual.first().message)

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNamingSpec.kt
@@ -13,7 +13,7 @@ class FunctionNamingSpec {
         val code = """
         @Suppress("FunctionName")
         fun MY_FUN() {}
-        """
+        """.trimIndent()
         assertThat(FunctionNaming().compileAndLint(code)).isEmpty()
     }
 
@@ -23,7 +23,7 @@ class FunctionNamingSpec {
         val f: (Int) -> Int = fun(i: Int): Int {
             return i + i
         }
-        """
+        """.trimIndent()
         assertThat(FunctionNaming().compileAndLint(code)).isEmpty()
     }
 
@@ -33,7 +33,7 @@ class FunctionNamingSpec {
         class WhateverTest {
             fun SHOULD_NOT_BE_FLAGGED() {}
         }
-        """
+        """.trimIndent()
         val config = TestConfig(mapOf(FunctionNaming.EXCLUDE_CLASS_PATTERN to ".*Test$"))
         assertThat(FunctionNaming(config).compileAndLint(code)).isEmpty()
     }
@@ -47,7 +47,7 @@ class FunctionNamingSpec {
             }
         }
         interface I { fun shouldNotBeFlagged() }
-        """
+        """.trimIndent()
         assertThat(FunctionNaming().compileAndLint(code)).hasStartSourceLocation(3, 13)
     }
 
@@ -58,7 +58,7 @@ class FunctionNamingSpec {
             override fun SHOULD_NOT_BE_FLAGGED() {}
         }
         interface I { @Suppress("FunctionNaming") fun SHOULD_NOT_BE_FLAGGED() }
-        """
+        """.trimIndent()
         assertThat(FunctionNaming().compileAndLint(code)).isEmpty()
     }
 
@@ -69,7 +69,7 @@ class FunctionNamingSpec {
         private class FooImpl : Foo
 
         fun Foo(): Foo = FooImpl()
-        """
+        """.trimIndent()
         val config = TestConfig(mapOf(FunctionNaming.IGNORE_OVERRIDDEN to "false"))
         assertThat(FunctionNaming(config).compileAndLint(code)).isEmpty()
     }
@@ -83,7 +83,7 @@ class FunctionNamingSpec {
             }
         }
         interface I { @Suppress("FunctionNaming") fun SHOULD_BE_FLAGGED() }
-        """
+        """.trimIndent()
         assertThat(FunctionNaming().compileAndLint(code)).hasStartSourceLocation(3, 13)
     }
 
@@ -94,7 +94,7 @@ class FunctionNamingSpec {
             override fun SHOULD_BE_FLAGGED() {}
         }
         interface I { fun SHOULD_BE_FLAGGED() }
-        """
+        """.trimIndent()
         val config = TestConfig(mapOf(FunctionNaming.IGNORE_OVERRIDDEN to "false"))
         assertThat(FunctionNaming(config).compileAndLint(code)).hasStartSourceLocations(
             SourceLocation(2, 18),
@@ -106,7 +106,7 @@ class FunctionNamingSpec {
     fun `doesn't allow functions with backtick`() {
         val code = """
             fun `7his is a function name _`() = Unit
-        """
+        """.trimIndent()
         assertThat(FunctionNaming().compileAndLint(code)).hasStartSourceLocations(SourceLocation(1, 5))
     }
 }

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionParameterNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionParameterNamingSpec.kt
@@ -20,7 +20,7 @@ class FunctionParameterNamingSpec {
                 class C {
                     fun someStuff(param: String) {}
                 }
-            """
+            """.trimIndent()
             assertThat(FunctionParameterNaming().compileAndLint(code)).isEmpty()
         }
 
@@ -31,7 +31,7 @@ class FunctionParameterNamingSpec {
                     override fun someStuff(`object`: String) {}
                 }
                 interface I { fun someStuff(@Suppress("FunctionParameterNaming") `object`: String) }
-            """
+            """.trimIndent()
             assertThat(FunctionParameterNaming().compileAndLint(code)).isEmpty()
         }
 
@@ -42,7 +42,7 @@ class FunctionParameterNamingSpec {
                     override fun someStuff(`object`: String) {}
                 }
                 interface I { fun someStuff(`object`: String) }
-            """
+            """.trimIndent()
             val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to "false"))
             assertThat(FunctionParameterNaming(config).compileAndLint(code)).hasSize(2)
         }
@@ -53,7 +53,7 @@ class FunctionParameterNamingSpec {
                 class C {
                     fun someStuff(PARAM: String) {}
                 }
-            """
+            """.trimIndent()
             assertThat(FunctionParameterNaming().compileAndLint(code)).hasSize(1)
         }
     }
@@ -69,7 +69,7 @@ class FunctionParameterNamingSpec {
                 class Excluded {
                     fun f(PARAM: Int) {}
                 }
-            """
+            """.trimIndent()
             assertThat(FunctionParameterNaming(config).compileAndLint(code)).isEmpty()
         }
 

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/InvalidPackageDeclarationSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/InvalidPackageDeclarationSpec.kt
@@ -20,7 +20,7 @@ class InvalidPackageDeclarationSpec {
             package foo.bar
 
             class C
-        """
+        """.trimIndent()
 
         val ktFile = compileContentForTest(source, createPath("project/src/foo/bar/File.kt"))
         val findings = InvalidPackageDeclaration().lint(ktFile)
@@ -50,7 +50,7 @@ class InvalidPackageDeclarationSpec {
                 package com.example
 
                 class C
-            """
+            """.trimIndent()
 
             val ktFile = compileContentForTest(source, createPath("src/File.kt"))
             val findings = InvalidPackageDeclaration(config).lint(ktFile)
@@ -64,7 +64,7 @@ class InvalidPackageDeclarationSpec {
                 package com.example.foo.bar
 
                 class C
-            """
+            """.trimIndent()
 
             val ktFile = compileContentForTest(source, createPath("src/foo/bar/File.kt"))
             val findings = InvalidPackageDeclaration(config).lint(ktFile)
@@ -78,7 +78,7 @@ class InvalidPackageDeclarationSpec {
                 package com.example.foo.bar
 
                 class C
-            """
+            """.trimIndent()
 
             val ktFile = compileContentForTest(source, createPath("src/com/example/foo/bar/File.kt"))
             val findings = InvalidPackageDeclaration(config).lint(ktFile)
@@ -92,7 +92,7 @@ class InvalidPackageDeclarationSpec {
                 package com.example.foo.baz
 
                 class C
-            """
+            """.trimIndent()
 
             val ktFile = compileContentForTest(source, createPath("src/foo/bar/File.kt"))
             val findings = InvalidPackageDeclaration(config).lint(ktFile)
@@ -106,7 +106,7 @@ class InvalidPackageDeclarationSpec {
                 package io.foo.bar
 
                 class C
-            """
+            """.trimIndent()
 
             val ktFile = compileContentForTest(source, createPath("src/com/example/File.kt"))
             val findings = InvalidPackageDeclaration(config).lint(ktFile)
@@ -126,7 +126,7 @@ class InvalidPackageDeclarationSpec {
                 package com.example.foo.bar
 
                 class C
-            """
+            """.trimIndent()
 
             val ktFileWithRelativePath = compileContentForTest(source, createPath("src/foo/bar/File.kt"))
             val findingsForRelativePath = InvalidPackageDeclaration(config).lint(ktFileWithRelativePath)
@@ -145,7 +145,7 @@ class InvalidPackageDeclarationSpec {
                 package foo.bar
 
                 class C
-            """
+            """.trimIndent()
 
             val ktFile = compileContentForTest(source, createPath("src/foo/bar/File.kt"))
             val findings = InvalidPackageDeclaration(config).lint(ktFile)

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/LambdaParameterNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/LambdaParameterNamingSpec.kt
@@ -10,7 +10,7 @@ class LambdaParameterNamingSpec {
     fun `Reports no supported parameter names`() {
         val code = """
             val a: (String) -> Unit = { HELLO_THERE -> Unit }
-        """
+        """.trimIndent()
         assertThat(LambdaParameterNaming().compileAndLint(code))
             .hasSize(1)
             .hasTextLocations("HELLO_THERE")
@@ -20,7 +20,7 @@ class LambdaParameterNamingSpec {
     fun `Reports no supported parameter names when there are multiple`() {
         val code = """
             val a: (String, Int) -> Unit = { HI, HELLO_THERE -> Unit }
-        """
+        """.trimIndent()
         assertThat(LambdaParameterNaming().compileAndLint(code))
             .hasSize(2)
             .hasTextLocations("HI", "HELLO_THERE")
@@ -30,7 +30,7 @@ class LambdaParameterNamingSpec {
     fun `Doesn't report a valid parameter`() {
         val code = """
             val a: (String) -> Unit = { helloThere -> Unit }
-        """
+        """.trimIndent()
         assertThat(LambdaParameterNaming().compileAndLint(code))
             .isEmpty()
     }
@@ -39,7 +39,7 @@ class LambdaParameterNamingSpec {
     fun `Doesn't report a valid parameter when define type`() {
         val code = """
             val a = { helloThere: String -> Unit }
-        """
+        """.trimIndent()
         assertThat(LambdaParameterNaming().compileAndLint(code))
             .isEmpty()
     }
@@ -48,7 +48,7 @@ class LambdaParameterNamingSpec {
     fun `Doesn't report _`() {
         val code = """
             val a: (String) -> Unit = { _ -> Unit }
-        """
+        """.trimIndent()
         assertThat(LambdaParameterNaming().compileAndLint(code))
             .isEmpty()
     }
@@ -57,7 +57,7 @@ class LambdaParameterNamingSpec {
     fun `Doesn't report by using implicit name`() {
         val code = """
             val a: (String) -> Unit = { Unit }
-        """
+        """.trimIndent()
         assertThat(LambdaParameterNaming().compileAndLint(code))
             .isEmpty()
     }
@@ -66,7 +66,7 @@ class LambdaParameterNamingSpec {
     fun `Doesn't report if there aren't parameters`() {
         val code = """
             val a: () -> Unit = { Unit }
-        """
+        """.trimIndent()
         assertThat(LambdaParameterNaming().compileAndLint(code))
             .isEmpty()
     }
@@ -76,7 +76,7 @@ class LambdaParameterNamingSpec {
         val code = """
             data class Bar(val a: String)
             val a: (Bar) -> Unit = { (HELLO_THERE) -> Unit }
-        """
+        """.trimIndent()
         assertThat(LambdaParameterNaming().compileAndLint(code))
             .hasSize(1)
             .hasTextLocations("HELLO_THERE")
@@ -87,7 +87,7 @@ class LambdaParameterNamingSpec {
         val code = """
             data class Bar(val a: String, val b: String)
             val a: (Bar) -> Unit = { (HI, HELLO_THERE) -> Unit }
-        """
+        """.trimIndent()
         assertThat(LambdaParameterNaming().compileAndLint(code))
             .hasSize(2)
             .hasTextLocations("HI", "HELLO_THERE")
@@ -98,7 +98,7 @@ class LambdaParameterNamingSpec {
         val code = """
             data class Bar(val a: String, val b: String)
             val a: (Bar) -> Unit = { (a, b) -> Unit }
-        """
+        """.trimIndent()
         assertThat(LambdaParameterNaming().compileAndLint(code))
             .isEmpty()
     }
@@ -108,7 +108,7 @@ class LambdaParameterNamingSpec {
         val code = """
             data class Bar(val a: String, val b: String)
             val a: (Bar) -> Unit = { (a: String, b) -> Unit }
-        """
+        """.trimIndent()
         assertThat(LambdaParameterNaming().compileAndLint(code))
             .isEmpty()
     }
@@ -118,7 +118,7 @@ class LambdaParameterNamingSpec {
         val code = """
             data class Bar(val a: String, val b: String)
             val a: (Bar) -> Unit = { (_, b) -> Unit }
-        """
+        """.trimIndent()
         assertThat(LambdaParameterNaming().compileAndLint(code))
             .isEmpty()
     }

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MatchingDeclarationNameSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MatchingDeclarationNameSpec.kt
@@ -50,7 +50,7 @@ class MatchingDeclarationNameSpec {
                 enum class E {
                     ONE, TWO, THREE
                 }
-                """,
+                """.trimIndent(),
                 filename = "E.kt"
             )
             val findings = MatchingDeclarationName().lint(ktFile)
@@ -64,7 +64,7 @@ class MatchingDeclarationNameSpec {
                 class C
                 object O
                 fun a() = 5
-                """,
+                """.trimIndent(),
                 filename = "MultiDeclarations.kt"
             )
             val findings = MatchingDeclarationName().lint(ktFile)
@@ -78,7 +78,7 @@ class MatchingDeclarationNameSpec {
                 class C
                 fun a() = 5
                 fun C.b() = 5
-                """,
+                """.trimIndent(),
                 filename = "C.kt"
             )
             val findings = MatchingDeclarationName().lint(ktFile)
@@ -92,7 +92,7 @@ class MatchingDeclarationNameSpec {
                 fun a() = 5
                 fun C.b() = 5
                 class C
-                """,
+                """.trimIndent(),
                 filename = "Classes.kt"
             )
             val findings = MatchingDeclarationName().lint(ktFile)
@@ -105,7 +105,7 @@ class MatchingDeclarationNameSpec {
                 """
             private class C
             fun a() = 5
-                """,
+                """.trimIndent(),
                 filename = "b.kt"
             )
             val findings = MatchingDeclarationName().lint(ktFile)
@@ -118,7 +118,7 @@ class MatchingDeclarationNameSpec {
             typealias Foo = FooImpl
 
             class FooImpl {}
-            """
+            """.trimIndent()
             val ktFile = compileContentForTest(code, filename = "Foo.kt")
             val findings = MatchingDeclarationName().lint(ktFile)
             assertThat(findings).isEmpty()
@@ -192,7 +192,7 @@ class MatchingDeclarationNameSpec {
             val code = """
                 class FooImpl {}
                 typealias Bar = FooImpl
-            """
+            """.trimIndent()
             val ktFile = compileContentForTest(code, filename = "Foo.kt")
             val findings = MatchingDeclarationName().lint(ktFile)
             assertThat(findings).hasSize(1)

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MemberNameEqualsClassNameSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MemberNameEqualsClassNameSpec.kt
@@ -35,7 +35,7 @@ class MemberNameEqualsClassNameSpec(val env: KotlinCoreEnvironment) {
                         fun MethodNameNotEqualsClassName() {}
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -47,7 +47,7 @@ class MemberNameEqualsClassNameSpec(val env: KotlinCoreEnvironment) {
                         fun MethodNameNotEqualsClassName() {}
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -59,7 +59,7 @@ class MemberNameEqualsClassNameSpec(val env: KotlinCoreEnvironment) {
                         fun A() {}
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
     }
@@ -73,7 +73,7 @@ class MemberNameEqualsClassNameSpec(val env: KotlinCoreEnvironment) {
                 class MethodNameEqualsClassName {
                     fun methodNameEqualsClassName() {}
                 }
-            """
+            """.trimIndent()
             assertThat(MemberNameEqualsClassName().compileAndLint(code)).hasSize(1)
         }
 
@@ -83,7 +83,7 @@ class MemberNameEqualsClassNameSpec(val env: KotlinCoreEnvironment) {
                 object MethodNameEqualsObjectName {
                     fun MethodNameEqualsObjectName() {}
                 }
-            """
+            """.trimIndent()
             assertThat(MemberNameEqualsClassName().compileAndLint(code)).hasSize(1)
         }
 
@@ -93,7 +93,7 @@ class MemberNameEqualsClassNameSpec(val env: KotlinCoreEnvironment) {
                 class PropertyNameEqualsClassName {
                     val propertyNameEqualsClassName = 0
                 }
-            """
+            """.trimIndent()
             assertThat(MemberNameEqualsClassName().compileAndLint(code)).hasSize(1)
         }
 
@@ -103,7 +103,7 @@ class MemberNameEqualsClassNameSpec(val env: KotlinCoreEnvironment) {
                 object PropertyNameEqualsObjectName {
                     val propertyNameEqualsObjectName = 0
                 }
-            """
+            """.trimIndent()
             assertThat(MemberNameEqualsClassName().compileAndLint(code)).hasSize(1)
         }
 
@@ -115,7 +115,7 @@ class MemberNameEqualsClassNameSpec(val env: KotlinCoreEnvironment) {
                         fun StaticMethodNameEqualsClassName() {}
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(MemberNameEqualsClassName().compileAndLint(code)).hasSize(1)
         }
 
@@ -127,7 +127,7 @@ class MemberNameEqualsClassNameSpec(val env: KotlinCoreEnvironment) {
                         fun MethodNameEqualsNestedClassName() {}
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(MemberNameEqualsClassName().compileAndLint(code)).hasSize(1)
         }
 
@@ -140,7 +140,7 @@ class MemberNameEqualsClassNameSpec(val env: KotlinCoreEnvironment) {
                 abstract class BaseClassForMethodNameEqualsClassName {
                     abstract fun AbstractMethodNameEqualsClassName()
                 }
-            """
+            """.trimIndent()
             assertThat(MemberNameEqualsClassName().compileAndLint(code)).isEmpty()
         }
 
@@ -150,7 +150,7 @@ class MemberNameEqualsClassNameSpec(val env: KotlinCoreEnvironment) {
                 interface MethodNameEqualsInterfaceName {
                     fun MethodNameEqualsInterfaceName() {}
                 }
-            """
+            """.trimIndent()
             assertThat(MemberNameEqualsClassName().compileAndLint(code)).isEmpty()
         }
 
@@ -163,7 +163,7 @@ class MemberNameEqualsClassNameSpec(val env: KotlinCoreEnvironment) {
                 abstract class BaseClassForMethodNameEqualsClassName {
                     abstract fun AbstractMethodNameEqualsClassName()
                 }
-            """
+            """.trimIndent()
             assertThat(MemberNameEqualsClassName(noIgnoreOverridden).compileAndLint(code)).hasSize(1)
         }
 
@@ -176,7 +176,7 @@ class MemberNameEqualsClassNameSpec(val env: KotlinCoreEnvironment) {
                 abstract class BaseClassForMethodNameEqualsClassName {
                     abstract val AbstractMethodNameEqualsClassName: String
                 }
-            """
+            """.trimIndent()
             assertThat(MemberNameEqualsClassName().compileAndLint(code)).isEmpty()
         }
 
@@ -189,7 +189,7 @@ class MemberNameEqualsClassNameSpec(val env: KotlinCoreEnvironment) {
                 abstract class BaseClassForMethodNameEqualsClassName {
                     abstract val AbstractMethodNameEqualsClassName: String
                 }
-            """
+            """.trimIndent()
             assertThat(MemberNameEqualsClassName(noIgnoreOverridden).compileAndLint(code)).hasSize(1)
         }
     }
@@ -206,7 +206,7 @@ class MemberNameEqualsClassNameSpec(val env: KotlinCoreEnvironment) {
                         fun wrongFactoryClass1() {}
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(MemberNameEqualsClassName().compileAndLint(code)).hasSize(1)
         }
 
@@ -221,7 +221,7 @@ class MemberNameEqualsClassNameSpec(val env: KotlinCoreEnvironment) {
                         }
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(MemberNameEqualsClassName().compileAndLint(code)).hasSize(1)
         }
 
@@ -234,7 +234,7 @@ class MemberNameEqualsClassNameSpec(val env: KotlinCoreEnvironment) {
                         fun wrongFactoryClass3() = 0
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(MemberNameEqualsClassName().compileAndLintWithContext(env, code)).hasSize(1)
         }
 
@@ -252,7 +252,7 @@ class MemberNameEqualsClassNameSpec(val env: KotlinCoreEnvironment) {
                 class B: A()
                 
                 class C: A()
-            """
+            """.trimIndent()
             assertThat(MemberNameEqualsClassName().compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -269,7 +269,7 @@ class MemberNameEqualsClassNameSpec(val env: KotlinCoreEnvironment) {
                         }
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(MemberNameEqualsClassName().compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -286,7 +286,7 @@ class MemberNameEqualsClassNameSpec(val env: KotlinCoreEnvironment) {
                 class B: A()
 
                 class C: A()
-            """
+            """.trimIndent()
 
             @Test
             fun `with type solving`() {

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingConventionCustomPatternSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingConventionCustomPatternSpec.kt
@@ -52,7 +52,7 @@ class NamingConventionCustomPatternSpec {
             object Foo {
                 val MYVar = 3
             }
-    """
+    """.trimIndent()
 
     val excludeClassPatternFunctionRegexCode = """
             class Bar {
@@ -62,7 +62,7 @@ class NamingConventionCustomPatternSpec {
             object Foo {
                 fun MYFun() {}
             }
-    """
+    """.trimIndent()
 
     @Test
     fun `should use custom name for method and class`() {
@@ -79,7 +79,7 @@ class NamingConventionCustomPatternSpec {
               const val lowerCaseConst = ""
             }
         }
-                """
+                """.trimIndent()
             )
         ).isEmpty()
     }
@@ -95,7 +95,7 @@ class NamingConventionCustomPatternSpec {
               const val lowerCaseConst = ""
             }
         }
-                """
+                """.trimIndent()
             )
         ).isEmpty()
     }
@@ -111,7 +111,7 @@ class NamingConventionCustomPatternSpec {
                 enum1, enum2
             }
         }
-                """
+                """.trimIndent()
             )
         ).isEmpty()
     }
@@ -132,7 +132,7 @@ class NamingConventionCustomPatternSpec {
         object Foo {
             val MYVar = 3
         }
-        """
+        """.trimIndent()
         val config = TestConfig(mapOf(VariableNaming.EXCLUDE_CLASS_PATTERN to "Foo|Bar"))
         assertThat(VariableNaming(config).compileAndLint(code)).isEmpty()
     }
@@ -165,7 +165,7 @@ class NamingConventionCustomPatternSpec {
         object Foo {
             fun MYFun() {}
         }
-        """
+        """.trimIndent()
         val config = TestConfig(mapOf(FunctionNaming.EXCLUDE_CLASS_PATTERN to "Foo|Bar"))
         assertThat(FunctionNaming(config).compileAndLint(code)).isEmpty()
     }

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingConventionLengthSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingConventionLengthSpec.kt
@@ -16,7 +16,7 @@ class NamingConventionLengthSpec {
             fun function() {
                 val (_, status) = getResult()
             }
-        """
+        """.trimIndent()
         subject.compileAndLint(code)
         assertThat(subject.findings).isEmpty()
     }
@@ -47,7 +47,7 @@ class NamingConventionLengthSpec {
                 class C {
                     val prop: (Int) -> Unit = { _ -> Unit }
             }
-            """
+            """.trimIndent()
             assertThat(variableMinLength.compileAndLint(code)).isEmpty()
         }
     }

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingRulesSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingRulesSpec.kt
@@ -13,7 +13,7 @@ class NamingRulesSpec {
             fun doStuff() {
                 val (_, HOLY_GRAIL) = D(5, 4)
             }
-        """
+        """.trimIndent()
         assertThat(NamingRules().compileAndLint(code)).isEmpty()
     }
 }

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NoNameShadowingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NoNameShadowingSpec.kt
@@ -16,7 +16,7 @@ class NoNameShadowingSpec(val env: KotlinCoreEnvironment) {
             fun test(i: Int) {
                 val i = 1
             }
-        """
+        """.trimIndent()
         val findings = subject.compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(1)
         assertThat(findings).hasStartSourceLocation(2, 9)
@@ -29,7 +29,7 @@ class NoNameShadowingSpec(val env: KotlinCoreEnvironment) {
             fun test(j: Int) {
                 val (j, _) = 1 to 2
             }
-        """
+        """.trimIndent()
         val findings = subject.compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(1)
         assertThat(findings[0]).hasMessage("Name shadowed: j")
@@ -42,7 +42,7 @@ class NoNameShadowingSpec(val env: KotlinCoreEnvironment) {
                 listOf(1).map { k ->
                 }
             }
-        """
+        """.trimIndent()
         val findings = subject.compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(1)
         assertThat(findings[0]).hasMessage("Name shadowed: k")
@@ -57,7 +57,7 @@ class NoNameShadowingSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             }
-        """
+        """.trimIndent()
         val findings = subject.compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(1)
         assertThat(findings[0]).hasMessage("Name shadowed: it")
@@ -72,7 +72,7 @@ class NoNameShadowingSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             }
-        """
+        """.trimIndent()
         val findings = subject.compileAndLintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
@@ -83,7 +83,7 @@ class NoNameShadowingSpec(val env: KotlinCoreEnvironment) {
             fun test(i: Int) {
                 val j = i
             }
-        """
+        """.trimIndent()
         val findings = subject.compileAndLintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
@@ -106,7 +106,7 @@ class NoNameShadowingSpec(val env: KotlinCoreEnvironment) {
                     list.map { it + "x" }
                 }
             }
-        """
+        """.trimIndent()
         val findings = subject.compileAndLintWithContext(env, code)
         assertThat(findings).isEmpty()
     }

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NonBooleanPropertyWithPrefixIsSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NonBooleanPropertyWithPrefixIsSpec.kt
@@ -60,7 +60,7 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinCoreEnvironment) {
                 data class O (var isDefault: Inner) {
                     class Inner
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
 
             assertThat(findings).hasSize(1)
@@ -91,7 +91,7 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinCoreEnvironment) {
                 class O {
                     var isDefault = false
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
 
             assertThat(findings).isEmpty()
@@ -107,7 +107,7 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinCoreEnvironment) {
                         isDefault = true
                     }
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
 
             assertThat(findings).isEmpty()
@@ -119,7 +119,7 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinCoreEnvironment) {
                 class O {
                     var isDefault: Boolean? = null
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
 
             assertThat(findings).isEmpty()
@@ -131,7 +131,7 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinCoreEnvironment) {
                 class O {
                     var isDefault: java.lang.Boolean = java.lang.Boolean(false)
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
 
             assertThat(findings).isEmpty()
@@ -147,7 +147,7 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinCoreEnvironment) {
                         isDefault = java.lang.Boolean(false)
                     }
                }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
 
             assertThat(findings).isEmpty()
@@ -159,7 +159,7 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinCoreEnvironment) {
                 class O {
                     var isDefault: java.lang.Boolean? = null
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
 
             assertThat(findings).isEmpty()
@@ -171,7 +171,7 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinCoreEnvironment) {
                 class O {
                     var isDefault: Int = 0
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
 
             assertThat(findings).hasSize(1)
@@ -183,7 +183,7 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinCoreEnvironment) {
                 class O {
                     var isDefault = 0
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
 
             assertThat(findings).hasSize(1)
@@ -195,7 +195,7 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinCoreEnvironment) {
                 class O {
                     var isDefault = listOf(1, 2, 3)
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
 
             assertThat(findings).hasSize(1)
@@ -209,7 +209,7 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinCoreEnvironment) {
                     
                     class Inner
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
 
             assertThat(findings).hasSize(1)
@@ -221,7 +221,7 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinCoreEnvironment) {
                 class O {
                     var `is`: Int = 0
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
 
             assertThat(findings).isEmpty()
@@ -233,7 +233,7 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinCoreEnvironment) {
                 class O {
                     var isengardTowerHeightInFeet: Int = 500
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
 
             assertThat(findings).isEmpty()
@@ -245,7 +245,7 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinCoreEnvironment) {
                 fun f() {
                     var isDefault: Int = 0
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
 
             assertThat(findings).hasSize(1)
@@ -260,7 +260,7 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinCoreEnvironment) {
             class Test {
                 val isDebuggable get() = BuildConfig.DEBUG
             }
-            """
+            """.trimIndent()
 
             // BuildConfig is missing in this test so we can't compile it
             val findings = subject.lintWithContext(env, code)
@@ -275,7 +275,7 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinCoreEnvironment) {
 
                 fun trueFun() = true
                 val isReferenceBoolean = ::trueFun
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
 
             assertThat(findings).isEmpty()

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNamingSpec.kt
@@ -23,7 +23,7 @@ class ObjectPropertyNamingSpec {
                 object O {
                     ${PublicConst.negative}
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
@@ -33,7 +33,7 @@ class ObjectPropertyNamingSpec {
                 object O {
                     ${PublicConst.positive}
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
@@ -43,7 +43,7 @@ class ObjectPropertyNamingSpec {
                 object O {
                     ${PrivateConst.negative}
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
@@ -53,7 +53,7 @@ class ObjectPropertyNamingSpec {
                 object O {
                     ${PrivateConst.positive}
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
@@ -63,7 +63,7 @@ class ObjectPropertyNamingSpec {
                 object O {
                     ${PublicConst.positive}
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).hasStartSourceLocation(2, 15)
         }
     }
@@ -81,7 +81,7 @@ class ObjectPropertyNamingSpec {
                         ${PublicConst.negative}
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
@@ -93,7 +93,7 @@ class ObjectPropertyNamingSpec {
                         ${PublicConst.positive}
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
@@ -105,7 +105,7 @@ class ObjectPropertyNamingSpec {
                         ${PrivateConst.negative}
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
@@ -117,7 +117,7 @@ class ObjectPropertyNamingSpec {
                         ${PrivateConst.positive}
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
@@ -129,7 +129,7 @@ class ObjectPropertyNamingSpec {
                         ${PublicConst.positive}
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).hasStartSourceLocation(3, 19)
         }
     }
@@ -145,7 +145,7 @@ class ObjectPropertyNamingSpec {
                 object O {
                     ${PublicVal.negative}
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
@@ -155,7 +155,7 @@ class ObjectPropertyNamingSpec {
                 object O {
                     ${PublicVal.positive}
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
@@ -165,7 +165,7 @@ class ObjectPropertyNamingSpec {
                 object O {
                     ${PrivateVal.negative}
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
@@ -175,7 +175,7 @@ class ObjectPropertyNamingSpec {
                 object O {
                     private val __NAME = "Artur"
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
     }
@@ -199,7 +199,7 @@ class ObjectPropertyNamingSpec {
                     const val _NAME = "Artur"
                     const val _name = "Artur"
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
@@ -210,7 +210,7 @@ class ObjectPropertyNamingSpec {
                     private val __NAME = "Artur"
                     private val _1234 = "Artur"
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
     }
@@ -232,7 +232,7 @@ class ObjectPropertyNamingSpec {
                         val somethingElse = 1
                     }
                 }
-            """
+            """.trimIndent()
 
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
@@ -249,7 +249,7 @@ abstract class NamingSnippet(private val isPrivate: Boolean, private val isConst
                     ${visibility()}${const()}val name = "Artur"
                     ${visibility()}${const()}val nAme = "Artur"
                     ${visibility()}${const()}val serialVersionUID = 42L
-    """
+    """.trimIndent()
     val positive = """${visibility()}${const()}val _nAme = "Artur""""
 
     private fun visibility() = if (isPrivate) "private " else ""

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/PackageNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/PackageNamingSpec.kt
@@ -13,7 +13,7 @@ class PackageNamingSpec {
                 """
                 @file:Suppress("PackageDirectoryMismatch")
                 package FOO.BAR
-                """
+                """.trimIndent()
             )
         ).isEmpty()
     }

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/TopLevelPropertyNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/TopLevelPropertyNamingSpec.kt
@@ -17,7 +17,7 @@ class TopLevelPropertyNamingSpec {
             val code = """
                 const val MY_NAME_8 = "Artur"
                 const val MYNAME = "Artur"
-            """
+            """.trimIndent()
             assertThat(subject.lint(code)).isEmpty()
         }
 
@@ -29,7 +29,7 @@ class TopLevelPropertyNamingSpec {
                 const val nAme = "Artur"
                 private const val _nAme = "Artur"
                 const val serialVersionUID = 42L
-            """
+            """.trimIndent()
             assertThat(subject.lint(code)).hasSize(5)
         }
     }
@@ -50,7 +50,7 @@ class TopLevelPropertyNamingSpec {
                 private val NAME = "Artur"
                 val s_d_d_1 = listOf("")
                 private val INTERNAL_VERSION = "1.0.0"
-            """
+            """.trimIndent()
             assertThat(subject.lint(code)).isEmpty()
         }
 
@@ -58,7 +58,7 @@ class TopLevelPropertyNamingSpec {
         fun `should report non private top level property using underscore`() {
             val code = """
                 val _nAme = "Artur"
-            """
+            """.trimIndent()
             assertThat(subject.lint(code)).hasSize(1)
         }
 
@@ -66,7 +66,7 @@ class TopLevelPropertyNamingSpec {
         fun `should report private top level property using two underscores`() {
             val code = """
                 private val __NAME = "Artur"
-            """
+            """.trimIndent()
             io.gitlab.arturbosch.detekt.test.assertThat(subject.lint(code)).hasSize(1)
         }
     }

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableNamingSpec.kt
@@ -16,7 +16,7 @@ class VariableNamingSpec {
                 val FIELD get() = _FIELD
                 val camel_Case_Property = 5
             }
-        """
+        """.trimIndent()
         assertThat(VariableNaming().compileAndLint(code))
             .hasStartSourceLocations(
                 SourceLocation(2, 17),
@@ -33,7 +33,7 @@ class VariableNamingSpec {
                 val field get() = _field
                 val camelCaseProperty = 5
             }
-        """
+        """.trimIndent()
         assertThat(VariableNaming().compileAndLint(code)).isEmpty()
     }
 
@@ -49,7 +49,7 @@ class VariableNamingSpec {
             interface I2 {
                 @Suppress("VariableNaming") val SHOULD_NOT_BE_FLAGGED: String
             }
-        """
+        """.trimIndent()
         assertThat(VariableNaming().compileAndLint(code)).isEmpty()
     }
 
@@ -65,7 +65,7 @@ class VariableNamingSpec {
             interface I2 {
                 @Suppress("VariableNaming") val SHOULD_BE_FLAGGED: String
             }
-        """
+        """.trimIndent()
         val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to "false"))
         assertThat(VariableNaming(config).compileAndLint(code))
             .hasStartSourceLocations(

--- a/detekt-rules-performance/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/CouldBeSequenceSpec.kt
+++ b/detekt-rules-performance/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/CouldBeSequenceSpec.kt
@@ -22,7 +22,7 @@ class CouldBeSequenceSpec(val env: KotlinCoreEnvironment) {
         }.filter {
             it > 5
         }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
     }
 
@@ -33,7 +33,7 @@ class CouldBeSequenceSpec(val env: KotlinCoreEnvironment) {
         val processed = myCollection.filter {
             it % 2 == 0
         }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 
@@ -48,7 +48,7 @@ class CouldBeSequenceSpec(val env: KotlinCoreEnvironment) {
         }.filter {
             it > 5
         }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 
@@ -63,7 +63,7 @@ class CouldBeSequenceSpec(val env: KotlinCoreEnvironment) {
         }.filter {
             it > 5
         }.toList()
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 }

--- a/detekt-rules-performance/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/ForEachOnRangeSpec.kt
+++ b/detekt-rules-performance/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/ForEachOnRangeSpec.kt
@@ -26,7 +26,7 @@ class ForEachOnRangeSpec {
                 println(it)
             }
         }
-        """
+        """.trimIndent()
 
         @Test
         fun `should report the forEach usage`() {
@@ -41,7 +41,7 @@ class ForEachOnRangeSpec {
         fun test() {
             (1..10).isEmpty()
         }
-        """
+        """.trimIndent()
 
         @Test
         fun `should not report any issues`() {
@@ -58,7 +58,7 @@ class ForEachOnRangeSpec {
                 println(it)
             }
         }
-        """
+        """.trimIndent()
 
         @Test
         fun `should not report any issues`() {

--- a/detekt-rules-performance/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/SpreadOperatorSpec.kt
+++ b/detekt-rules-performance/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/SpreadOperatorSpec.kt
@@ -30,7 +30,7 @@ class SpreadOperatorSpec(val env: KotlinCoreEnvironment) {
                 val xsArray = intArrayOf(1)
                 fun foo(vararg xs: Int) {}
                 val testVal = foo(xs = *xsArray)
-            """
+            """.trimIndent()
             val actual = subject.compileAndLintWithContext(env, code)
             assertThat(actual).hasSize(1)
             assertThat(actual.first().message).isEqualTo(typeResolutionEnabledMessage)
@@ -42,7 +42,7 @@ class SpreadOperatorSpec(val env: KotlinCoreEnvironment) {
                 val xsArray = intArrayOf(1)
                 fun foo(vararg xs: Int) {}
                 val testVal = foo(*xsArray)
-            """
+            """.trimIndent()
             val actual = subject.compileAndLintWithContext(env, code)
             assertThat(actual).hasSize(1)
             assertThat(actual.first().message).isEqualTo(typeResolutionEnabledMessage)
@@ -53,7 +53,7 @@ class SpreadOperatorSpec(val env: KotlinCoreEnvironment) {
             val code = """
                 fun foo(vararg xs: Int) {}
                 val testVal = foo(xs = *intArrayOf(1))
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -62,7 +62,7 @@ class SpreadOperatorSpec(val env: KotlinCoreEnvironment) {
             val code = """
                 fun <T> asList(vararg ts: T, stringValue: String): List<Int> = listOf(1,2,3)
                 val list = asList(-1, 0, *arrayOf(1, 2, 3), 4, stringValue = "5")
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -71,7 +71,7 @@ class SpreadOperatorSpec(val env: KotlinCoreEnvironment) {
             val code = """
                 fun <T> asList(vararg ts: T, stringValue: String): List<Int> = listOf(1,2,3)
                 val list = asList(-1, 0, 1, 2, 3, 4, stringValue = "5")
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -85,7 +85,7 @@ class SpreadOperatorSpec(val env: KotlinCoreEnvironment) {
             fun test(strs: Array<String>) {
                 strs.forEach { println(it) }
             }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -99,7 +99,7 @@ class SpreadOperatorSpec(val env: KotlinCoreEnvironment) {
             fun test(test : Int) {
                 println(test)
             }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -110,7 +110,7 @@ class SpreadOperatorSpec(val env: KotlinCoreEnvironment) {
                 fun a(vararg bla: Int) { 
                     b(*bla) 
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -123,7 +123,7 @@ class SpreadOperatorSpec(val env: KotlinCoreEnvironment) {
                     val bla = arrayOf("")
                     b(*bla)
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
     }
@@ -140,7 +140,7 @@ class SpreadOperatorSpec(val env: KotlinCoreEnvironment) {
                 val xsArray = intArrayOf(1)
                 fun foo(vararg xs: Int) {}
                 val testVal = foo(xs = *xsArray)
-            """
+            """.trimIndent()
             val actual = subject.compileAndLint(code)
             assertThat(actual).hasSize(1)
             assertThat(actual.first().message).isEqualTo(typeResolutionDisabledMessage)
@@ -152,7 +152,7 @@ class SpreadOperatorSpec(val env: KotlinCoreEnvironment) {
                 val xsArray = intArrayOf(1)
                 fun foo(vararg xs: Int) {}
                 val testVal = foo(*xsArray)
-            """
+            """.trimIndent()
             val actual = subject.compileAndLint(code)
             assertThat(actual).hasSize(1)
             assertThat(actual.first().message).isEqualTo(typeResolutionDisabledMessage)
@@ -163,7 +163,7 @@ class SpreadOperatorSpec(val env: KotlinCoreEnvironment) {
             val code = """
                 fun foo(vararg xs: Int) {}
                 val testVal = foo(xs = *intArrayOf(1))
-            """
+            """.trimIndent()
             val actual = subject.compileAndLint(code)
             assertThat(actual).hasSize(1)
             assertThat(actual.first().message).isEqualTo(typeResolutionDisabledMessage)
@@ -174,7 +174,7 @@ class SpreadOperatorSpec(val env: KotlinCoreEnvironment) {
             val code = """
                 fun <T> asList(vararg ts: T, stringValue: String): List<Int> = listOf(1,2,3)
                 val list = asList(-1, 0, *arrayOf(1, 2, 3), 4, stringValue = "5")
-            """
+            """.trimIndent()
             val actual = subject.compileAndLint(code)
             assertThat(actual).hasSize(1)
             assertThat(actual.first().message).isEqualTo(typeResolutionDisabledMessage)
@@ -185,7 +185,7 @@ class SpreadOperatorSpec(val env: KotlinCoreEnvironment) {
             val code = """
                 fun <T> asList(vararg ts: T, stringValue: String): List<Int> = listOf(1,2,3)
                 val list = asList(-1, 0, 1, 2, 3, 4, stringValue = "5")
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
@@ -199,7 +199,7 @@ class SpreadOperatorSpec(val env: KotlinCoreEnvironment) {
             fun test(strs: Array<String>) {
                 strs.forEach { println(it) }
             }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
@@ -213,7 +213,7 @@ class SpreadOperatorSpec(val env: KotlinCoreEnvironment) {
             fun test(test : Int) {
                 println(test)
             }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
@@ -224,7 +224,7 @@ class SpreadOperatorSpec(val env: KotlinCoreEnvironment) {
                 fun a(vararg bla: Int) { 
                     b(*bla)
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
@@ -237,7 +237,7 @@ class SpreadOperatorSpec(val env: KotlinCoreEnvironment) {
                     val bla = arrayOf("")
                     b(*bla)
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
     }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/CanBeNonNullableSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/CanBeNonNullableSpec.kt
@@ -22,7 +22,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                     a = 6
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -46,7 +46,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                     return b
                 }
             }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(2)
         }
 
@@ -77,7 +77,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                         }
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(2)
         }
 
@@ -90,7 +90,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
             fun fileFoo() {
                 fileB = 6
             }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(2)
         }
 
@@ -123,7 +123,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                     return if (bizz % 2 == 0) null else bizz
                 }
             }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -133,7 +133,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                 class A(private var aDelegate: Int?) {
                     private var a: Int? by this::aDelegate
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -155,7 +155,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                     fileA = null
                 }
             }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -169,7 +169,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                     a = 6
                 }
             }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
@@ -183,7 +183,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                     a = null
                 }
             }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -196,7 +196,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                     a = 6
                 }
             }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -210,7 +210,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                         a = 6
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -222,7 +222,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                     a = 6
                 }
             }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
     }
@@ -242,7 +242,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                     c = cVal
                 }
             }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(3)
         }
 
@@ -254,7 +254,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                     5
                 }
             }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
@@ -262,7 +262,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
         fun `reports when file-level vals are set to non-nullable values`() {
             val code = """
             val fileA: Int? = 5
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
@@ -281,7 +281,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                     c = cVal
                 }
             }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -296,7 +296,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                     if (randVal % 2 == 0) randVal else null
                 }
             }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -304,7 +304,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
         fun `does not report when file-level vals are assigned a nullable value`() {
             val code = """
             val fileA: Int? = null
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -314,7 +314,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
             class A {
                 val a: Int = 5
             }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -322,7 +322,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
         fun `does not report when vals are declared in the constructor`() {
             val code = """
             class A(private val a: Int?)
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -343,7 +343,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                     return 5
                 }
             }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(3)
         }
 
@@ -367,7 +367,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                         return if (randInt % 2 == 0) randInt else null
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -452,7 +452,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                 open val a: Int? = 5
                 open var b: Int? = 5
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 
@@ -463,7 +463,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                 abstract val a: Int?
                 abstract var b: Int?
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 
@@ -477,7 +477,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                 // as non-null in Kotlin code.
                 private var a: String? = e.localizedMessage
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 
@@ -488,7 +488,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                 val a: Int?
                 var b: Int?
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/CascadingCallWrappingSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/CascadingCallWrappingSpec.kt
@@ -15,7 +15,7 @@ class CascadingCallWrappingSpec {
         val code = """
             val a = 0
                 .plus(0).plus(0).plus(0)
-        """
+        """.trimIndent()
 
         assertThat(subject.compileAndLint(code))
             .hasSize(1)
@@ -28,7 +28,7 @@ class CascadingCallWrappingSpec {
     fun `does not report when chained calls are on a single line`() {
         val code = """
             val a = 0.plus(0).plus(0)
-        """
+        """.trimIndent()
 
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
@@ -39,7 +39,7 @@ class CascadingCallWrappingSpec {
             val a = 0
                 .plus(0)
                 .plus(0)
-        """
+        """.trimIndent()
 
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
@@ -50,7 +50,7 @@ class CascadingCallWrappingSpec {
             val a = 0.plus(0).plus(0)
                 .plus(0)
                 .plus(0)
-        """
+        """.trimIndent()
 
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
@@ -60,7 +60,7 @@ class CascadingCallWrappingSpec {
         val code = """
             val a = 0
                 ?.plus(0)?.plus(0)
-        """
+        """.trimIndent()
 
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
@@ -70,7 +70,7 @@ class CascadingCallWrappingSpec {
         val code = """
             val a = 0!!
                 .plus(0)!!.plus(0)
-        """
+        """.trimIndent()
 
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
@@ -83,7 +83,7 @@ class CascadingCallWrappingSpec {
 
             val b = ""
                 .length.plus(0)
-        """
+        """.trimIndent()
 
         assertThat(subject.compileAndLint(code)).hasSize(2)
     }
@@ -100,7 +100,7 @@ class CascadingCallWrappingSpec {
                     .let { 
                         0
                     }
-            """
+            """.trimIndent()
 
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
@@ -117,7 +117,7 @@ class CascadingCallWrappingSpec {
                     }.plus(
                         0
                     )
-            """
+            """.trimIndent()
 
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
@@ -130,7 +130,7 @@ class CascadingCallWrappingSpec {
                 ).let {
                     0
                 }
-            """
+            """.trimIndent()
 
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
@@ -141,7 +141,7 @@ class CascadingCallWrappingSpec {
                 val a = 0.plus(
                     0
                 )
-            """
+            """.trimIndent()
 
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
@@ -158,7 +158,7 @@ class CascadingCallWrappingSpec {
                 val a = 0
                     .plus(0)
                     ?: 0
-            """
+            """.trimIndent()
 
             assertThat(subjectIncludingElvis.compileAndLint(code)).isEmpty()
             assertThat(subjectExcludingElvis.compileAndLint(code)).isEmpty()
@@ -169,7 +169,7 @@ class CascadingCallWrappingSpec {
             val code = """
                 val a = 0
                     .plus(0) ?: 0
-            """
+            """.trimIndent()
 
             assertThat(subjectIncludingElvis.compileAndLint(code)).hasSize(1)
             assertThat(subjectExcludingElvis.compileAndLint(code)).isEmpty()

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ClassOrderingSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ClassOrderingSpec.kt
@@ -26,7 +26,7 @@ class ClassOrderingSpec {
                     const val IMPORTANT_VALUE = 3
                 }
             }
-        """
+        """.trimIndent()
 
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
@@ -49,7 +49,7 @@ class ClassOrderingSpec {
                     const val IMPORTANT_VALUE = 3
                 }
             }
-        """
+        """.trimIndent()
 
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
@@ -72,7 +72,7 @@ class ClassOrderingSpec {
                     const val IMPORTANT_VALUE = 3
                 }
             }
-        """
+        """.trimIndent()
 
         val findings = subject.compileAndLint(code)
         assertThat(findings).hasSize(1)
@@ -99,7 +99,7 @@ class ClassOrderingSpec {
                     const val IMPORTANT_VALUE = 3
                 }
             }
-        """
+        """.trimIndent()
 
         val findings = subject.compileAndLint(code)
         assertThat(findings).hasSize(2)
@@ -129,7 +129,7 @@ class ClassOrderingSpec {
                     const val IMPORTANT_VALUE = 3
                 }
             }
-        """
+        """.trimIndent()
 
         val findings = subject.compileAndLint(code)
         assertThat(findings).hasSize(3)
@@ -159,7 +159,7 @@ class ClassOrderingSpec {
 
                 fun returnX() = x
             }
-        """
+        """.trimIndent()
 
         val findings = subject.compileAndLint(code)
         assertThat(findings).hasSize(1)
@@ -184,7 +184,7 @@ class ClassOrderingSpec {
 
                 fun returnX() = x
             }
-        """
+        """.trimIndent()
 
         assertThat(subject.compileAndLint(code)).hasSize(0)
     }
@@ -207,7 +207,7 @@ class ClassOrderingSpec {
 
                 fun returnX() = x
             }
-        """
+        """.trimIndent()
 
         assertThat(subject.compileAndLint(code)).hasSize(0)
     }
@@ -232,7 +232,7 @@ class ClassOrderingSpec {
                 
                 val y = x
             }
-        """
+        """.trimIndent()
 
         val findings = subject.compileAndLint(code)
         assertThat(findings).hasSize(3)
@@ -258,7 +258,7 @@ class ClassOrderingSpec {
                 
                 val y = x
             }
-        """
+        """.trimIndent()
 
         val findings = subject.compileAndLint(code)
         assertThat(findings).hasSize(3)

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/CollapsibleIfStatementsSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/CollapsibleIfStatementsSpec.kt
@@ -17,7 +17,7 @@ class CollapsibleIfStatementsSpec {
                     // a comment
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 
@@ -32,7 +32,7 @@ class CollapsibleIfStatementsSpec {
                     println()
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 
@@ -45,7 +45,7 @@ class CollapsibleIfStatementsSpec {
                     if (true) {}
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -57,7 +57,7 @@ class CollapsibleIfStatementsSpec {
                     if (1 == 1) {}
                 } else {}
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -70,7 +70,7 @@ class CollapsibleIfStatementsSpec {
                 } else if (false) {}
                 else {}
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -83,7 +83,7 @@ class CollapsibleIfStatementsSpec {
                     println()
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -96,7 +96,7 @@ class CollapsibleIfStatementsSpec {
                     } else {}
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -109,7 +109,7 @@ class CollapsibleIfStatementsSpec {
                     } else if (2 == 2) {}
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/DataClassContainsFunctionsSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/DataClassContainsFunctionsSpec.kt
@@ -21,7 +21,7 @@ class DataClassContainsFunctionsSpec {
                     fun toConversion() = C(i.toString())
                 }
             }
-        """
+        """.trimIndent()
 
         @Test
         fun `reports valid data class with conversion function`() {
@@ -55,7 +55,7 @@ class DataClassContainsFunctionsSpec {
             class C {
                 fun f() {}
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -76,7 +76,7 @@ class DataClassContainsFunctionsSpec {
                     return super.toString()
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/DataClassShouldBeImmutableSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/DataClassShouldBeImmutableSpec.kt
@@ -19,7 +19,7 @@ class DataClassShouldBeImmutableSpec {
             data class C(val i: Int) {
                 var s: String? = null
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 
@@ -30,7 +30,7 @@ class DataClassShouldBeImmutableSpec {
                 var s: String = ""
                     private set
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 
@@ -40,7 +40,7 @@ class DataClassShouldBeImmutableSpec {
             data class C(val i: Int) {
                 lateinit var s: String
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 
@@ -56,7 +56,7 @@ class DataClassShouldBeImmutableSpec {
             data class C(val i: Int) {
                 val s: String? = null
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -66,7 +66,7 @@ class DataClassShouldBeImmutableSpec {
             data class C(val i: Int) {
                 val s: String by lazy { "" }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -76,7 +76,7 @@ class DataClassShouldBeImmutableSpec {
             class C(var i: Int) {
                 val s: String by lazy { "" }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/EqualsNullCallSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/EqualsNullCallSpec.kt
@@ -14,7 +14,7 @@ class EqualsNullCallSpec {
             fun x(a: String) {
                 a.equals(null)
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code).size).isEqualTo(1)
     }
 
@@ -24,7 +24,7 @@ class EqualsNullCallSpec {
             fun x(a: String, b: String) {
                 a.equals(b.equals(null))
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code).size).isEqualTo(1)
     }
 
@@ -34,7 +34,7 @@ class EqualsNullCallSpec {
             fun x(a: String, b: String) {
                 a.equals(b)
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code).size).isEqualTo(0)
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/EqualsOnSignatureLineSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/EqualsOnSignatureLineSpec.kt
@@ -17,7 +17,7 @@ class EqualsOnSignatureLineSpec {
                 """
                 fun foo()
                     = 1
-                """
+                """.trimIndent()
             )
             assertThat(findings).hasSize(1)
         }
@@ -30,7 +30,7 @@ class EqualsOnSignatureLineSpec {
 
             fun bar() =
                 2
-                """
+                """.trimIndent()
             )
             assertThat(findings).isEmpty()
         }
@@ -54,7 +54,7 @@ class EqualsOnSignatureLineSpec {
                 foo: String
             ): Int
                 = 3
-                """
+                """.trimIndent()
             )
             assertThat(findings).hasSize(3)
         }
@@ -91,7 +91,7 @@ class EqualsOnSignatureLineSpec {
             :
             Int =
                 6
-                """
+                """.trimIndent()
             )
             assertThat(findings).isEmpty()
         }
@@ -116,7 +116,7 @@ class EqualsOnSignatureLineSpec {
             ): Int
                 where V : Number
                 = 3
-                """
+                """.trimIndent()
             )
             assertThat(findings).hasSize(3)
         }
@@ -132,7 +132,7 @@ class EqualsOnSignatureLineSpec {
                 where V : Number =
                 2
 
-                """
+                """.trimIndent()
             )
             assertThat(findings).isEmpty()
         }
@@ -154,7 +154,7 @@ class EqualsOnSignatureLineSpec {
         Unit
         {
         }
-            """
+            """.trimIndent()
         )
         assertThat(findings).isEmpty()
     }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitCollectionElementAccessMethodSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitCollectionElementAccessMethodSpec.kt
@@ -26,7 +26,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                         val map = mapOf<String, String>() 
                         val value = map.get("key") 
                     }
-                """
+                """.trimIndent()
                 assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
             }
 
@@ -37,7 +37,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                         val map = mapOf<String, String>() 
                         val value = map?.get("key") 
                     }
-                """
+                """.trimIndent()
                 assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
             }
 
@@ -48,7 +48,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                         val map = mutableMapOf<String, String>() 
                         map.set("key", "value") 
                     }
-                """
+                """.trimIndent()
                 assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
             }
 
@@ -59,7 +59,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                         val map = mutableMapOf<String, String>()
                         map.put("key", "val") 
                     }
-                """
+                """.trimIndent()
                 assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
             }
 
@@ -70,7 +70,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                         val map = mutableMapOf<String, String>() 
                         val oldValue = map.put("key", "val") 
                     }
-                """
+                """.trimIndent()
                 assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
             }
 
@@ -81,7 +81,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                         val map = mutableMapOf<String, String>()
                         return map.put("key", "val") == null
                     }
-                """
+                """.trimIndent()
                 assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
             }
 
@@ -92,7 +92,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                         val map = hashMapOf<String, String>() 
                         val value = map.get("key") 
                     }
-                """
+                """.trimIndent()
                 assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
             }
 
@@ -103,7 +103,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                         val map = hashMapOf<String, String>() 
                         map.put("key", "value") 
                     }
-                """
+                """.trimIndent()
                 assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
             }
 
@@ -115,7 +115,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                         val map = mapOf<String, String>()
                         val value = map["key"] 
                     }
-                """
+                """.trimIndent()
                 assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
             }
 
@@ -127,7 +127,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                         val map = mutableMapOf<String, String>()
                         map["key"] = "value" 
                     }
-                """
+                """.trimIndent()
                 assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
             }
 
@@ -138,7 +138,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                         val map = mapOf<String, String>()
                         val value = listOf("1", "2").associateBy { it }.get("1")
                     }
-                """
+                """.trimIndent()
                 assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
             }
 
@@ -149,7 +149,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                         val map = linkedMapOf<String, String>()
                         val value = map.get("key") 
                     }
-                """
+                """.trimIndent()
                 assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
             }
 
@@ -160,7 +160,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                         val map = mapOf<String, Int>()
                         with(map) { get("a") }
                     }
-                """
+                """.trimIndent()
                 assertThat(subject.compileAndLintWithContext(env, code)).hasSize(0)
             }
         }
@@ -174,7 +174,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                         val list = listOf<String>() 
                         val value = list.get(0) 
                     }
-                """
+                """.trimIndent()
                 assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
             }
 
@@ -185,7 +185,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                         val list = mutableListOf<String>()
                         val value = list.get(0) 
                     }
-                """
+                """.trimIndent()
                 assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
             }
 
@@ -197,7 +197,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                         val list = listOf<String>() 
                         val value = list[0] 
                     }
-                """
+                """.trimIndent()
                 assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
             }
 
@@ -208,7 +208,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                         val list = arrayListOf<String>() 
                         val value = list.get(0) 
                     }
-                """
+                """.trimIndent()
                 assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
             }
 
@@ -219,7 +219,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                         val list = listOf<String>()
                         val value = with(list) { get(0) }
                     }
-                """
+                """.trimIndent()
                 assertThat(subject.compileAndLintWithContext(env, code)).hasSize(0)
             }
         }
@@ -234,7 +234,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                         val map = java.util.HashMap<String, String>() 
                         val value = map.get("key") 
                     }
-                """
+                """.trimIndent()
                 assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
             }
 
@@ -245,7 +245,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                         val map = java.util.HashMap<String, String>() 
                         map.set("key", "val") 
                     }
-                """
+                """.trimIndent()
                 assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
             }
 
@@ -256,7 +256,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                         val map = java.util.HashMap<String, String>() 
                         map.put("key", "val") 
                     }
-                """
+                """.trimIndent()
                 assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
             }
 
@@ -268,7 +268,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                         val map = java.util.HashMap<String, String>() 
                         val value = map["key"] 
                     }
-                """
+                """.trimIndent()
                 assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
             }
 
@@ -280,7 +280,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                         val map = java.util.HashMap<String, String>() 
                         map["key"] = "value" 
                     }
-                """
+                """.trimIndent()
                 assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
             }
 
@@ -291,7 +291,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                         val map = java.util.HashMap<String, String>() 
                         val value = listOf("1", "2").associateBy { it }.get("1") 
                     }
-                """
+                """.trimIndent()
                 assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
             }
         }
@@ -305,7 +305,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                         val buffer = java.nio.ByteBuffer()
                         buffer.get(byteArrayOf(0x42))
                     }
-                """
+                """.trimIndent()
                 assertThat(subject.lintWithContext(env, code)).isEmpty()
             }
 
@@ -315,7 +315,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                     fun f(field: java.lang.reflect.Field) {
                         val value = field.get(null) // access static field
                     }
-                """
+                """.trimIndent()
                 assertThat(subject.lintWithContext(env, code)).isEmpty()
             }
         }
@@ -331,7 +331,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                         val custom = Custom()
                         val value = custom.get(0)
                     }
-                """
+                """.trimIndent()
                 assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
             }
 
@@ -343,7 +343,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                         val custom = Custom()
                         val value = custom.get(0)
                     }
-                """
+                """.trimIndent()
                 assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
             }
 
@@ -355,7 +355,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                         val custom = Custom()
                         custom.set("key", "value")
                     }
-                """
+                """.trimIndent()
                 assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
             }
 
@@ -367,7 +367,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                         val custom = Custom()
                         custom.set("key", "value")
                     }
-                """
+                """.trimIndent()
                 assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
             }
 
@@ -380,7 +380,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                     fun test(c: C) {
                         c.get<Int>("key")
                     }
-                """
+                """.trimIndent()
                 assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
             }
         }
@@ -395,7 +395,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                         val list = java.util.ArrayList<String>() 
                         val value = list.get(0) 
                     }
-                """
+                """.trimIndent()
                 assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
             }
 
@@ -407,7 +407,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                         val list = java.util.ArrayList<String>() 
                         val value = list[0] 
                     }
-                """
+                """.trimIndent()
                 assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
             }
         }
@@ -422,7 +422,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                         val i: Int get() = 1 + 2
                         val c: Char? get() = "".first() ?: throw IllegalArgumentException("getter")
                     }
-                """
+                """.trimIndent()
                 assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
             }
 
@@ -431,7 +431,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                 val code = """
                     val string = ""
                         .toString()
-                """
+                """.trimIndent()
                 assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
             }
 
@@ -442,7 +442,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                         val unknownType = UnknownType()
                         val value = unknownType.put("answer", 42)
                      }
-                """
+                """.trimIndent()
                 assertThat(subject.lintWithContext(env, code)).isEmpty()
             }
 
@@ -453,7 +453,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                     fun f() {
                         put()
                     }
-                """
+                """.trimIndent()
                 assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
             }
         }
@@ -472,7 +472,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                     rect.set(0, 1)
                     rect.set(0, 1, 2)
                 }
-            """
+            """.trimIndent()
             assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
     }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitItLambdaParameterSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitItLambdaParameterSpec.kt
@@ -18,7 +18,7 @@ class ExplicitItLambdaParameterSpec {
             fun f() {
                 val digits = 1234.let { it -> listOf(it) }
             }
-                """
+                """.trimIndent()
             )
             assertThat(findings).hasSize(1)
         }
@@ -30,7 +30,7 @@ class ExplicitItLambdaParameterSpec {
             fun f() {
                 val lambda = { it: Int -> it.toString() }
             }
-                """
+                """.trimIndent()
             )
             assertThat(findings).hasSize(1)
         }
@@ -47,7 +47,7 @@ class ExplicitItLambdaParameterSpec {
                 val digits = 1234.let { lambda(it) }.toList()
                 val flat = listOf(listOf(1), listOf(2)).flatMap { it }
             }
-                """
+                """.trimIndent()
             )
             assertThat(findings).isEmpty()
         }
@@ -62,7 +62,7 @@ class ExplicitItLambdaParameterSpec {
             fun f() {
                 val flat = listOf(listOf(1), listOf(2)).mapIndexed { index, it -> it + index }
             }
-                """
+                """.trimIndent()
             )
             assertThat(findings).hasSize(1)
         }
@@ -74,7 +74,7 @@ class ExplicitItLambdaParameterSpec {
             fun f() {
                 val lambda = { it: Int, that: String -> it.toString() + that }
             }
-                """
+                """.trimIndent()
             )
             assertThat(findings).hasSize(1)
         }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExpressionBodySyntaxSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExpressionBodySyntaxSpec.kt
@@ -23,7 +23,7 @@ class ExpressionBodySyntaxSpec {
                 fun stuff(): Int {
                     return 5
                 }
-                    """
+                    """.trimIndent()
                 )
             ).hasSize(1)
         }
@@ -36,7 +36,7 @@ class ExpressionBodySyntaxSpec {
                 fun stuff(): String {
                     return StringBuilder().append(0).toString()
                 }
-                    """
+                    """.trimIndent()
                 )
             ).hasSize(1)
         }
@@ -52,7 +52,7 @@ class ExpressionBodySyntaxSpec {
                 fun stuff(): Int {
                     return try { return 5 } catch (e: Exception) { return 3 }
                 }
-                    """
+                    """.trimIndent()
                 )
             ).hasSize(2)
         }
@@ -66,7 +66,7 @@ class ExpressionBodySyntaxSpec {
                     if (true) return true
                     return false
                 }
-                    """
+                    """.trimIndent()
                 )
             ).isEmpty()
         }
@@ -81,7 +81,7 @@ class ExpressionBodySyntaxSpec {
                 }
 
                 fun callee(a: String): String = ""
-                    """
+                    """.trimIndent()
                 )
             ).isEmpty()
         }
@@ -96,7 +96,7 @@ class ExpressionBodySyntaxSpec {
                     .append(1)
                     .toString()
             }
-        """
+        """.trimIndent()
 
         @Test
         fun `does not report with the default configuration`() {
@@ -120,7 +120,7 @@ class ExpressionBodySyntaxSpec {
                     else -> 1
                 }
             }
-        """
+        """.trimIndent()
 
         @Test
         fun `does not report with the default configuration`() {
@@ -142,7 +142,7 @@ class ExpressionBodySyntaxSpec {
                 return if (arg == 0) 0
                 else 1
             }
-        """
+        """.trimIndent()
 
         @Test
         fun `does not report with the default configuration`() {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenCommentSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenCommentSpec.kt
@@ -70,7 +70,7 @@ class ForbiddenCommentSpec {
                /*
                 TODO: I need to fix this.
                 */
-            """
+            """.trimIndent()
             val findings = ForbiddenComment().compileAndLint(code)
             assertThat(findings).hasSize(1)
         }
@@ -86,7 +86,7 @@ class ForbiddenCommentSpec {
                      * TODO: I need to fix this.
                      */
                 }
-            """
+            """.trimIndent()
             val findings = ForbiddenComment().compileAndLint(code)
             assertThat(findings).hasSize(2)
         }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenImportSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenImportSpec.kt
@@ -21,7 +21,7 @@ class ForbiddenImportSpec {
         import com.example.R.string
         import net.example.R.dimen
         import net.example.R.dimension
-    """
+    """.trimIndent()
 
     @Test
     fun `should report nothing by default`() {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCallSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCallSpec.kt
@@ -482,7 +482,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
                     val calendar = Calendar.getInstance()
                     calendar.firstDayOfWeek = 1
                 }
-            """
+        """
         val findings =
             ForbiddenMethodCall(TestConfig(mapOf(METHODS to listOf("java.util.Calendar.setFirstDayOfWeek")))).compileAndLintWithContext(
                 env,
@@ -500,7 +500,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
                     val calendar = Calendar.getInstance()
                     calendar.let(calendar::compareTo)
                 }
-            """
+        """
         val findings =
             ForbiddenMethodCall(TestConfig(mapOf(METHODS to listOf("java.util.Calendar.compareTo")))).compileAndLintWithContext(
                 env,

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCallSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCallSpec.kt
@@ -21,7 +21,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
             print("3")
             println("4")
         }
-        """
+        """.trimIndent()
         val findings = ForbiddenMethodCall(TestConfig()).compileAndLintWithContext(env, code)
 
         assertThat(findings)
@@ -44,7 +44,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
         fun main() {
             System.out.println("hello")
         }
-        """
+        """.trimIndent()
         val findings = ForbiddenMethodCall(
             TestConfig(mapOf(METHODS to listOf("  ")))
         ).compileAndLintWithContext(env, code)
@@ -58,7 +58,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
         fun main() {
             System.out.println("hello")
         }
-        """
+        """.trimIndent()
         val findings = ForbiddenMethodCall(
             TestConfig(mapOf(METHODS to listOf("java.lang.System.gc")))
         ).compileAndLintWithContext(env, code)
@@ -71,7 +71,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
         fun main() {
             java.lang.System.out.println("hello")
         }
-        """
+        """.trimIndent()
         val findings = ForbiddenMethodCall(
             TestConfig(mapOf(METHODS to listOf("java.io.PrintStream.println")))
         ).compileAndLintWithContext(env, code)
@@ -86,7 +86,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
         fun main() {
             out.println("hello")
         }
-        """
+        """.trimIndent()
         val findings = ForbiddenMethodCall(
             TestConfig(mapOf(METHODS to listOf("java.io.PrintStream.println")))
         ).compileAndLintWithContext(env, code)
@@ -102,7 +102,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
         System.out.println("hello")
             System.gc()
         }
-        """
+        """.trimIndent()
         val findings = ForbiddenMethodCall(
             TestConfig(
                 mapOf(
@@ -123,7 +123,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
             fun main() {
                 java.math.BigDecimal(5.5) == java.math.BigDecimal(5.5)
             }
-        """
+        """.trimIndent()
         val findings = ForbiddenMethodCall(
             TestConfig(mapOf(METHODS to listOf("java.math.BigDecimal.equals")))
         ).compileAndLintWithContext(env, code)
@@ -137,7 +137,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
                 var i = 1
                 ++i
             }
-        """
+        """.trimIndent()
         val findings = ForbiddenMethodCall(
             TestConfig(mapOf(METHODS to listOf("kotlin.Int.inc")))
         ).compileAndLintWithContext(env, code)
@@ -151,7 +151,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
                 var i = 1
                 i--
             }
-        """
+        """.trimIndent()
         val findings = ForbiddenMethodCall(
             TestConfig(mapOf(METHODS to listOf("kotlin.Int.dec")))
         ).compileAndLintWithContext(env, code)
@@ -168,7 +168,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
                 val date = LocalDate.now()
                 val date2 = LocalDate.now(clock)
             }
-        """
+        """.trimIndent()
         val findings = ForbiddenMethodCall(
             TestConfig(mapOf(METHODS to listOf("java.time.LocalDate.now")))
         ).compileAndLintWithContext(env, code)
@@ -185,7 +185,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
                 val date = LocalDate.now()
                 val date2 = LocalDate.now(clock)
             }
-        """
+        """.trimIndent()
         val findings = ForbiddenMethodCall(
             TestConfig(mapOf(METHODS to listOf("java.time.LocalDate.now()")))
         ).compileAndLintWithContext(env, code)
@@ -204,7 +204,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
                 val date = LocalDate.now()
                 val date2 = LocalDate.now(clock)
             }
-        """
+        """.trimIndent()
         val findings = ForbiddenMethodCall(
             TestConfig(mapOf(METHODS to listOf("java.time.LocalDate.now(java.time.Clock)")))
         ).compileAndLintWithContext(env, code)
@@ -219,7 +219,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
             fun test() {
                 val date = LocalDate.of(2020, 1, 1)
             }
-        """
+        """.trimIndent()
         val findings = ForbiddenMethodCall(
             TestConfig(mapOf(METHODS to listOf("java.time.LocalDate.of(kotlin.Int, kotlin.Int, kotlin.Int)")))
         ).compileAndLintWithContext(env, code)
@@ -234,7 +234,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
             fun test() {
                 val date = LocalDate.of(2020, 1, 1)
             }
-        """
+        """.trimIndent()
         val findings = ForbiddenMethodCall(
             TestConfig(mapOf(METHODS to listOf("java.time.LocalDate.of(kotlin.Int,kotlin.Int,kotlin.Int)")))
         ).compileAndLintWithContext(env, code)
@@ -252,7 +252,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
             fun test() {
                 val s = `some, test`()
             }
-        """
+        """.trimIndent()
         val findings = ForbiddenMethodCall(
             TestConfig(mapOf(METHODS to listOf("io.gitlab.arturbosch.detekt.rules.style.`some, test`()")))
         ).compileAndLintWithContext(env, code)
@@ -270,7 +270,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
             fun test() {
                 val s = defaultParamsMethod("test")
             }
-        """
+        """.trimIndent()
         val findings = ForbiddenMethodCall(
             TestConfig(
                 mapOf(
@@ -300,7 +300,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
                 i.f()
                 c.f()
             }
-        """
+        """.trimIndent()
         val findings = ForbiddenMethodCall(
             TestConfig(mapOf(METHODS to listOf("org.example.com.I.f")))
         ).compileAndLintWithContext(env, code)
@@ -317,7 +317,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
             fun foo() {
                 bar { "" }
             }
-        """
+        """.trimIndent()
         val findings = ForbiddenMethodCall(
             TestConfig(mapOf(METHODS to listOf("org.example.bar((kotlin.String) -> kotlin.String)")))
         ).compileAndLintWithContext(env, code)
@@ -334,7 +334,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
             fun foo() {
                 "".bar()
             }
-        """
+        """.trimIndent()
         val findings = ForbiddenMethodCall(
             TestConfig(mapOf(METHODS to listOf("org.example.bar(kotlin.String)")))
         ).compileAndLintWithContext(env, code)
@@ -351,7 +351,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
             fun foo() {
                 bar(1, "", "")
             }
-        """
+        """.trimIndent()
 
         @Test
         fun `raise the issue`() {
@@ -380,7 +380,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
             fun foo() {
                 1.bar("")
             }
-        """
+        """.trimIndent()
 
         @Test
         fun `raise the issue`() {
@@ -410,7 +410,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
                     runCatching {}
                 }
             }
-        """
+        """.trimIndent()
 
         @Test
         fun `forbid the one without receiver`() {
@@ -445,7 +445,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
                     val calendar = Calendar.getInstance()
                     val day = calendar.getFirstDayOfWeek()
                 }
-            """
+            """.trimIndent()
             val findings =
                 ForbiddenMethodCall(TestConfig(mapOf(METHODS to listOf("java.util.Calendar.getFirstDayOfWeek")))).compileAndLintWithContext(
                     env,
@@ -463,7 +463,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
                     val calendar = Calendar.getInstance()
                     val day = calendar.firstDayOfWeek
                 }
-            """
+            """.trimIndent()
             val findings =
                 ForbiddenMethodCall(TestConfig(mapOf(METHODS to listOf("java.util.Calendar.getFirstDayOfWeek")))).compileAndLintWithContext(
                     env,
@@ -482,7 +482,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
                     val calendar = Calendar.getInstance()
                     calendar.firstDayOfWeek = 1
                 }
-        """
+        """.trimIndent()
         val findings =
             ForbiddenMethodCall(TestConfig(mapOf(METHODS to listOf("java.util.Calendar.setFirstDayOfWeek")))).compileAndLintWithContext(
                 env,
@@ -500,7 +500,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
                     val calendar = Calendar.getInstance()
                     calendar.let(calendar::compareTo)
                 }
-        """
+        """.trimIndent()
         val findings =
             ForbiddenMethodCall(TestConfig(mapOf(METHODS to listOf("java.util.Calendar.compareTo")))).compileAndLintWithContext(
                 env,

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenPublicDataClassSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenPublicDataClassSpec.kt
@@ -13,7 +13,7 @@ class ForbiddenPublicDataClassSpec {
     fun `public data class should pass without explicit filters set`() {
         val code = """
             data class C(val a: String)                
-        """
+        """.trimIndent()
 
         assertThat(ForbiddenPublicDataClass(TestConfig(Config.EXCLUDES_KEY to "**")).compileAndLint(code)).isEmpty()
     }
@@ -22,7 +22,7 @@ class ForbiddenPublicDataClassSpec {
     fun `public data class should fail`() {
         val code = """
             data class C(val a: String)                
-        """
+        """.trimIndent()
 
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
@@ -31,7 +31,7 @@ class ForbiddenPublicDataClassSpec {
     fun `private data class should pass`() {
         val code = """
             private data class C(val a: String)                
-        """
+        """.trimIndent()
 
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
@@ -40,7 +40,7 @@ class ForbiddenPublicDataClassSpec {
     fun `internal data class should pass`() {
         val code = """
             internal data class C(val a: String)                
-        """
+        """.trimIndent()
 
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
@@ -49,7 +49,7 @@ class ForbiddenPublicDataClassSpec {
     fun `public class should pass`() {
         val code = """
             class C(val a: String) 
-        """
+        """.trimIndent()
 
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
@@ -60,7 +60,7 @@ class ForbiddenPublicDataClassSpec {
             class C {
                 private data class D(val a: String)   
             }
-        """
+        """.trimIndent()
 
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
@@ -71,7 +71,7 @@ class ForbiddenPublicDataClassSpec {
             class C {
                 data class D(val a: String)   
             }
-        """
+        """.trimIndent()
 
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
@@ -82,7 +82,7 @@ class ForbiddenPublicDataClassSpec {
             open class C {
                 protected data class D(val a: String)   
             }
-        """
+        """.trimIndent()
 
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
@@ -93,7 +93,7 @@ class ForbiddenPublicDataClassSpec {
             internal class C {
                 data class D(val a: String)   
             }
-        """
+        """.trimIndent()
 
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
@@ -104,7 +104,7 @@ class ForbiddenPublicDataClassSpec {
             package com.example.internal
 
             data class C(val a: String)                
-        """
+        """.trimIndent()
 
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
@@ -115,7 +115,7 @@ class ForbiddenPublicDataClassSpec {
             package com.example.internal.other
 
             data class C(val a: String)                
-        """
+        """.trimIndent()
 
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
@@ -126,7 +126,7 @@ class ForbiddenPublicDataClassSpec {
             package com.example.internalise
 
             data class C(val a: String)                
-        """
+        """.trimIndent()
 
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
@@ -137,7 +137,7 @@ class ForbiddenPublicDataClassSpec {
             package com.random
 
             data class C(val a: String)                
-        """
+        """.trimIndent()
 
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
@@ -148,7 +148,7 @@ class ForbiddenPublicDataClassSpec {
             package com.example
 
             data class C(val a: String)                
-        """
+        """.trimIndent()
 
         val config = TestConfig("ignorePackages" to listOf("*.hello", "com.example"))
         assertThat(ForbiddenPublicDataClass(config).compileAndLint(code)).isEmpty()
@@ -160,7 +160,7 @@ class ForbiddenPublicDataClassSpec {
             package org.example
 
             data class C(val a: String)                
-        """
+        """.trimIndent()
 
         val config = TestConfig("ignorePackages" to "*.hello,org.example")
         assertThat(ForbiddenPublicDataClass(config).compileAndLint(code)).isEmpty()

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenSuppressSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenSuppressSpec.kt
@@ -21,7 +21,7 @@ internal class ForbiddenSuppressSpec {
                 
                 @SuppressWarnings("ARule")
                 class Foo
-            """
+            """.trimIndent()
             val findings = subject.compileAndLint(code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasStartSourceLocation(3, 1)
@@ -35,7 +35,7 @@ internal class ForbiddenSuppressSpec {
             val code = """
                 @file:Suppress("ARule")
                 package config
-            """
+            """.trimIndent()
             val findings = subject.compileAndLint(code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasStartSourceLocation(1, 1)
@@ -51,7 +51,7 @@ internal class ForbiddenSuppressSpec {
                 
                 @Suppress("ARule")
                 fun foo() { }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLint(code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasStartSourceLocation(3, 1)
@@ -69,7 +69,7 @@ internal class ForbiddenSuppressSpec {
                     @Suppress("ARule")
                     println("bar")
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLint(code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasStartSourceLocation(4, 5)
@@ -85,7 +85,7 @@ internal class ForbiddenSuppressSpec {
                 
                 @Suppress("UNCHECKED_CAST")
                 fun foo() { }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLint(code)
             assertThat(findings).isEmpty()
         }
@@ -97,7 +97,7 @@ internal class ForbiddenSuppressSpec {
                 
                 @Suppress("UNCHECKED_CAST", "ARule")
                 fun foo() { }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLint(code)
             assertThat(findings).hasSize(1)
             assertThat(findings.first()).hasMessage(
@@ -113,7 +113,7 @@ internal class ForbiddenSuppressSpec {
                 
                 @Suppress
                 fun foo() { }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLint(code)
             assertThat(findings).hasSize(0)
         }
@@ -130,7 +130,7 @@ internal class ForbiddenSuppressSpec {
             val code = """
                 @file:Suppress("ARule", "BRule")
                 package config
-            """
+            """.trimIndent()
             val findings = subject.compileAndLint(code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasStartSourceLocation(1, 1)
@@ -147,7 +147,7 @@ internal class ForbiddenSuppressSpec {
                 
                 @Suppress("BRule")
                 fun foo() { }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLint(code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasStartSourceLocation(3, 1)
@@ -168,7 +168,7 @@ internal class ForbiddenSuppressSpec {
             val code = """
                 @file:Suppress("ForbiddenSuppress")
                 package config
-            """
+            """.trimIndent()
             val findings = subject.compileAndLint(code)
             assertThat(findings).hasSize(0)
         }
@@ -178,7 +178,7 @@ internal class ForbiddenSuppressSpec {
             val code = """
                 @file:Suppress("ForbiddenSuppress", "ARule")
                 package config
-            """
+            """.trimIndent()
             val findings = subject.compileAndLint(code)
             assertThat(findings).hasSize(0)
         }
@@ -193,7 +193,7 @@ internal class ForbiddenSuppressSpec {
             val code = """
                 @file:Suppress("ARule")
                 package config
-            """
+            """.trimIndent()
             val findings = subject.compileAndLint(code)
             assertThat(findings).hasSize(0)
         }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenVoidSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenVoidSpec.kt
@@ -26,7 +26,7 @@ class ForbiddenVoidSpec(val env: KotlinCoreEnvironment) {
                 val a: Void? = null
                 val b: Void = null!!
             }
-        """
+        """.trimIndent()
 
         assertThat(subject.compileAndLintWithContext(env, code)).hasSize(4)
     }
@@ -36,7 +36,7 @@ class ForbiddenVoidSpec(val env: KotlinCoreEnvironment) {
         val code = """
             val clazz = java.lang.Void::class
             val klass = Void::class
-        """
+        """.trimIndent()
 
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
@@ -55,7 +55,7 @@ class ForbiddenVoidSpec(val env: KotlinCoreEnvironment) {
                 fun myFun2(): E = E.Void
                 abstract fun myFun(): Void
             }
-        """
+        """.trimIndent()
 
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
@@ -78,7 +78,7 @@ class ForbiddenVoidSpec(val env: KotlinCoreEnvironment) {
                         throw IllegalStateException()
                     }
                 }
-            """
+            """.trimIndent()
 
             val findings = ForbiddenVoid(config).compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
@@ -99,7 +99,7 @@ class ForbiddenVoidSpec(val env: KotlinCoreEnvironment) {
                         throw IllegalStateException()
                     }
                 }
-            """
+            """.trimIndent()
 
             val findings = ForbiddenVoid(config).compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
@@ -117,7 +117,7 @@ class ForbiddenVoidSpec(val env: KotlinCoreEnvironment) {
                         val a: Void? = null
                     }
                 }
-            """
+            """.trimIndent()
 
             val findings = ForbiddenVoid(config).compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
@@ -129,7 +129,7 @@ class ForbiddenVoidSpec(val env: KotlinCoreEnvironment) {
                 fun method(param: Void) : Void {
                     return param
                 }
-            """
+            """.trimIndent()
 
             val findings = ForbiddenVoid(config).compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(2)
@@ -157,7 +157,7 @@ class ForbiddenVoidSpec(val env: KotlinCoreEnvironment) {
                 }
 
                 class D : A<Void>
-            """
+            """.trimIndent()
 
             val findings = ForbiddenVoid(config).compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
@@ -169,7 +169,7 @@ class ForbiddenVoidSpec(val env: KotlinCoreEnvironment) {
                 interface A<T>
                 interface B<T>
                 class C : A<B<Void>>
-            """
+            """.trimIndent()
 
             val findings = ForbiddenVoid(config).compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
@@ -179,7 +179,7 @@ class ForbiddenVoidSpec(val env: KotlinCoreEnvironment) {
         fun `should not report Void in definition with multiple generic parameters`() {
             val code = """
                 val foo = mutableMapOf<Int, Void>()
-            """
+            """.trimIndent()
 
             val findings = ForbiddenVoid(config).compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
@@ -194,7 +194,7 @@ class ForbiddenVoidSpec(val env: KotlinCoreEnvironment) {
                     val a: Void? = null
                     val b: Void = null!!
                 }
-            """
+            """.trimIndent()
 
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(4)
         }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/FunctionOnlyReturningConstantSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/FunctionOnlyReturningConstantSpec.kt
@@ -26,7 +26,7 @@ class FunctionOnlyReturningConstantSpec {
             actual class ActualFunctionReturningConstant {
                 actual fun f() = 1
             }
-        """
+        """.trimIndent()
 
         val code = """
             import kotlin.SinceKotlin
@@ -36,7 +36,7 @@ class FunctionOnlyReturningConstantSpec {
                     return "I am a constant"
                 }
             }
-        """
+        """.trimIndent()
 
         @Test
         fun `reports functions which return constants`() {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/LibraryCodeMustSpecifyReturnTypeSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/LibraryCodeMustSpecifyReturnTypeSpec.kt
@@ -26,7 +26,7 @@ class LibraryCodeMustSpecifyReturnTypeSpec(val env: KotlinCoreEnvironment) {
                 fun b() = 2
                 val c = 2
             }
-                """
+                """.trimIndent()
             )
         ).isEmpty()
     }
@@ -42,7 +42,7 @@ class LibraryCodeMustSpecifyReturnTypeSpec(val env: KotlinCoreEnvironment) {
                     env,
                     """
                 fun foo() = 5
-                    """
+                    """.trimIndent()
                 )
             ).hasSize(1)
         }
@@ -54,7 +54,7 @@ class LibraryCodeMustSpecifyReturnTypeSpec(val env: KotlinCoreEnvironment) {
                     env,
                     """
                 val foo = 5
-                    """
+                    """.trimIndent()
                 )
             ).hasSize(1)
         }
@@ -69,7 +69,7 @@ class LibraryCodeMustSpecifyReturnTypeSpec(val env: KotlinCoreEnvironment) {
                     val foo = 5
                     fun bar() = 5
                 }
-                    """
+                    """.trimIndent()
                 )
             ).hasSize(2)
         }
@@ -84,7 +84,7 @@ class LibraryCodeMustSpecifyReturnTypeSpec(val env: KotlinCoreEnvironment) {
                     protected val foo = 5
                     protected fun bar() = 5
                 }
-                    """
+                    """.trimIndent()
                 )
             ).hasSize(2)
         }
@@ -101,7 +101,7 @@ class LibraryCodeMustSpecifyReturnTypeSpec(val env: KotlinCoreEnvironment) {
                     env,
                     """
                 fun foo(): Int = 5
-                    """
+                    """.trimIndent()
                 )
             ).isEmpty()
         }
@@ -113,7 +113,7 @@ class LibraryCodeMustSpecifyReturnTypeSpec(val env: KotlinCoreEnvironment) {
                     env,
                     """
                 fun foo() {}
-                    """
+                    """.trimIndent()
                 )
             ).isEmpty()
         }
@@ -125,7 +125,7 @@ class LibraryCodeMustSpecifyReturnTypeSpec(val env: KotlinCoreEnvironment) {
                     env,
                     """
                 val foo: Int = 5
-                    """
+                    """.trimIndent()
                 )
             ).isEmpty()
         }
@@ -140,7 +140,7 @@ class LibraryCodeMustSpecifyReturnTypeSpec(val env: KotlinCoreEnvironment) {
                     val foo: Int = 5
                     fun bar(): Int = 5
                 }
-                    """
+                    """.trimIndent()
                 )
             ).isEmpty()
         }
@@ -158,7 +158,7 @@ class LibraryCodeMustSpecifyReturnTypeSpec(val env: KotlinCoreEnvironment) {
                     """
                 internal fun bar() = 5
                 private fun foo() = 5
-                    """
+                    """.trimIndent()
                 )
             ).isEmpty()
         }
@@ -170,7 +170,7 @@ class LibraryCodeMustSpecifyReturnTypeSpec(val env: KotlinCoreEnvironment) {
                     env,
                     """
                 internal val foo = 5
-                    """
+                    """.trimIndent()
                 )
             ).isEmpty()
         }
@@ -188,7 +188,7 @@ class LibraryCodeMustSpecifyReturnTypeSpec(val env: KotlinCoreEnvironment) {
                         val a = 5
                     }
                 }
-                    """
+                    """.trimIndent()
                 )
             ).isEmpty()
         }
@@ -203,7 +203,7 @@ class LibraryCodeMustSpecifyReturnTypeSpec(val env: KotlinCoreEnvironment) {
                     fun baz() = 5
                     val qux = 5
                 }
-                    """
+                    """.trimIndent()
                 )
             ).isEmpty()
         }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/LibraryEntitiesShouldNotBePublicSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/LibraryEntitiesShouldNotBePublicSpec.kt
@@ -16,7 +16,7 @@ class LibraryEntitiesShouldNotBePublicSpec {
             subject.compileAndLint(
                 """
                 class A 
-                """
+                """.trimIndent()
             )
         ).isEmpty()
     }
@@ -31,7 +31,7 @@ class LibraryEntitiesShouldNotBePublicSpec {
                 subject.compileAndLint(
                     """
                 class A
-                    """
+                    """.trimIndent()
                 )
             ).hasSize(1)
         }
@@ -46,7 +46,7 @@ class LibraryEntitiesShouldNotBePublicSpec {
                         return 1
                     }
                 }
-                    """
+                    """.trimIndent()
                 )
             ).hasSize(1)
         }
@@ -57,7 +57,7 @@ class LibraryEntitiesShouldNotBePublicSpec {
                 subject.compileAndLint(
                     """
                 typealias A = List<String>
-                    """
+                    """.trimIndent()
                 )
             ).hasSize(1)
         }
@@ -69,7 +69,7 @@ class LibraryEntitiesShouldNotBePublicSpec {
                     """
                 typealias A = List<String>
                 fun foo() = Unit
-                    """
+                    """.trimIndent()
                 )
             ).hasSize(2)
         }
@@ -80,7 +80,7 @@ class LibraryEntitiesShouldNotBePublicSpec {
                 subject.compileAndLint(
                     """
                 fun foo() = Unit
-                    """
+                    """.trimIndent()
                 )
             ).hasSize(1)
         }
@@ -100,7 +100,7 @@ class LibraryEntitiesShouldNotBePublicSpec {
                         return 1
                     }
                 }
-                    """
+                    """.trimIndent()
                 )
             ).isEmpty()
         }
@@ -111,7 +111,7 @@ class LibraryEntitiesShouldNotBePublicSpec {
                 subject.compileAndLint(
                     """
                 internal class A
-                    """
+                    """.trimIndent()
                 )
             ).isEmpty()
         }
@@ -122,7 +122,7 @@ class LibraryEntitiesShouldNotBePublicSpec {
                 subject.compileAndLint(
                     """
                 internal typealias A = List<String>
-                    """
+                    """.trimIndent()
                 )
             ).isEmpty()
         }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumberSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumberSpec.kt
@@ -340,7 +340,7 @@ class MagicNumberSpec {
                 3 -> return 3
             }
         }
-        """
+        """.trimIndent()
 
         @Test
         fun `should be reported`() {
@@ -362,7 +362,7 @@ class MagicNumberSpec {
         fun test(x: Int) {
             val i = 5
         }
-        """
+        """.trimIndent()
 
         @Test
         fun `should be reported`() {
@@ -377,7 +377,7 @@ class MagicNumberSpec {
         fun test() : Boolean {
             return true;
         }
-        """
+        """.trimIndent()
 
         @Test
         fun `should not be reported`() {
@@ -469,7 +469,7 @@ class MagicNumberSpec {
         }
 
         data class Color(val color: Int)
-        """
+        """.trimIndent()
 
         @Test
         fun `should report all without ignore flags`() {
@@ -526,7 +526,7 @@ class MagicNumberSpec {
                 const val anotherBoringConstant = 93872
             }
         }
-        """
+        """.trimIndent()
 
         @Test
         fun `should not report any issues by default`() {
@@ -645,7 +645,7 @@ class MagicNumberSpec {
             )
 
             var model = Model(someVal = $numberString)
-            """
+            """.trimIndent()
 
             @Test
             fun `should not ignore int`() {
@@ -687,7 +687,7 @@ class MagicNumberSpec {
                 abstract class A(n: Int)
 
                 object B : A(n = 5)
-                """
+                """.trimIndent()
                 assertThat(MagicNumber().compileAndLint(code)).isEmpty()
             }
 
@@ -709,7 +709,7 @@ class MagicNumberSpec {
             )
 
             var model = Model($numberString)
-            """
+            """.trimIndent()
 
             @Test
             fun `should detect the argument by default`() {
@@ -723,7 +723,7 @@ class MagicNumberSpec {
             fun tested(someVal: Int, other: String = "default")
 
             val t = tested(someVal = $number)
-            """
+            """.trimIndent()
 
             @Test
             fun `should ignore int by default`() {
@@ -753,7 +753,7 @@ class MagicNumberSpec {
                 SMALL(1),
                 EXTRA_LARGE(5)
             }
-            """
+            """.trimIndent()
 
             @Test
             fun `should be reported by default`() {
@@ -774,7 +774,7 @@ class MagicNumberSpec {
                 SMALL(id = 1),
                 EXTRA_LARGE(id = 5)
             }
-            """
+            """.trimIndent()
 
             @Test
             fun `should be reported`() {
@@ -805,7 +805,7 @@ class MagicNumberSpec {
             val code = """
             fun x() = 9
             fun y(): Int { return 9 }
-            """
+            """.trimIndent()
             assertThat(MagicNumber().compileAndLint(code)).isEmpty()
         }
 
@@ -814,7 +814,7 @@ class MagicNumberSpec {
             val code = """
             fun x() = 9 + 1
             fun y(): Int { return 9 + 1 }
-            """
+            """.trimIndent()
             assertThat(MagicNumber().compileAndLint(code)).hasSize(2)
         }
     }
@@ -851,7 +851,7 @@ class MagicNumberSpec {
             class SomeClassWithDefault {
                 constructor(val defaultValue: Int = 10) { }
             }
-            """
+            """.trimIndent()
             assertThat(MagicNumber().lint(code)).isEmpty()
         }
 
@@ -861,7 +861,7 @@ class MagicNumberSpec {
             class SomeClassWithDefault {
                 constructor(val defaultValue: Duration = 10.toDuration(DurationUnit.MILLISECONDS)) { }
             }
-            """
+            """.trimIndent()
             assertThat(MagicNumber().lint(code)).isEmpty()
         }
     }
@@ -994,7 +994,7 @@ class MagicNumberSpec {
                 fun Int.dp() = this + 1
 
                 val a = 500.dp()
-            """
+            """.trimIndent()
 
             assertThat(rule.compileAndLint(code)).isEmpty()
         }
@@ -1006,7 +1006,7 @@ class MagicNumberSpec {
                   get() = this + 1
 
                 val a = 500.dp
-            """
+            """.trimIndent()
 
             assertThat(rule.compileAndLint(code)).isEmpty()
         }
@@ -1017,7 +1017,7 @@ class MagicNumberSpec {
                 fun Int.dp(a: Int) = this + a
 
                 val a = 500.dp(400)
-            """
+            """.trimIndent()
 
             assertThat(rule.compileAndLint(code)).hasSize(1)
         }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxChainedCallsOnSameLineSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxChainedCallsOnSameLineSpec.kt
@@ -67,7 +67,7 @@ class MaxChainedCallsOnSameLineSpec(private val env: KotlinCoreEnvironment) {
                 .plus(0)
                 .plus(0)
                 .plus(0)
-        """
+        """.trimIndent()
 
         assertThat(rule.compileAndLintWithContext(env, code)).isEmpty()
     }
@@ -79,7 +79,7 @@ class MaxChainedCallsOnSameLineSpec(private val env: KotlinCoreEnvironment) {
             val a = 0.plus(0).plus(0)
                 .plus(0).plus(0).plus(0)
                 .plus(0).plus(0).plus(0)
-        """
+        """.trimIndent()
 
         assertThat(rule.compileAndLintWithContext(env, code)).isEmpty()
     }
@@ -91,7 +91,7 @@ class MaxChainedCallsOnSameLineSpec(private val env: KotlinCoreEnvironment) {
             val a = 0.plus(0).plus(0).plus(0)
                 .plus(0)
                 .plus(0)
-        """
+        """.trimIndent()
 
         assertThat(rule.compileAndLintWithContext(env, code)).hasSize(1)
     }
@@ -104,7 +104,7 @@ class MaxChainedCallsOnSameLineSpec(private val env: KotlinCoreEnvironment) {
                 .plus(0)
                 .plus(0).plus(0).plus(0).plus(0)
                 .plus(0)
-        """
+        """.trimIndent()
 
         assertThat(rule.compileAndLintWithContext(env, code)).hasSize(1)
     }
@@ -130,7 +130,7 @@ class MaxChainedCallsOnSameLineSpec(private val env: KotlinCoreEnvironment) {
         val rule = MaxChainedCallsOnSameLine(TestConfig(mapOf("maxChainedCalls" to 3)))
         val code = """
             val x = kotlin.math.floor(1.0).plus(1).plus(1)
-        """
+        """.trimIndent()
         assertThat(rule.compileAndLintWithContext(env, code)).isEmpty()
     }
 
@@ -139,7 +139,7 @@ class MaxChainedCallsOnSameLineSpec(private val env: KotlinCoreEnvironment) {
         val rule = MaxChainedCallsOnSameLine(TestConfig(mapOf("maxChainedCalls" to 3)))
         val code = """
             val x = kotlin.run { 1 }.plus(1).plus(1)
-        """
+        """.trimIndent()
         assertThat(rule.compileAndLintWithContext(env, code)).isEmpty()
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLengthSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLengthSpec.kt
@@ -77,7 +77,7 @@ class MaxLineLengthSpec {
 
             class Test {
             }
-        """
+        """.trimIndent()
 
         private val file = compileContentForTest(code)
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MayBeConstSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MayBeConstSpec.kt
@@ -19,7 +19,7 @@ class MayBeConstSpec {
                 object Something {
                     const val X = 42
                 }
-            """
+            """.trimIndent()
             subject.compileAndLint(code)
             assertThat(subject.findings).isEmpty()
         }
@@ -30,7 +30,7 @@ class MayBeConstSpec {
             object Test {
                 const val TEST = "Test"
             }
-            """
+            """.trimIndent()
             subject.compileAndLint(code)
             assertThat(subject.findings).isEmpty()
         }
@@ -43,7 +43,7 @@ class MayBeConstSpec {
                     const val B = 1
                 }
             }
-            """
+            """.trimIndent()
             subject.compileAndLint(code)
             assertThat(subject.findings).isEmpty()
         }
@@ -60,7 +60,7 @@ class MayBeConstSpec {
                     const val B = Something.A + 1
                 }
             }
-            """
+            """.trimIndent()
             subject.compileAndLint(code)
             assertThat(subject.findings).isEmpty()
         }
@@ -73,7 +73,7 @@ class MayBeConstSpec {
             }
             val p = Pair(Something.a, Something.a + Something.a)
             val p2 = emptyList<Int>().plus(Something.a)
-            """
+            """.trimIndent()
             subject.compileAndLint(code)
             assertThat(subject.findings).isEmpty()
         }
@@ -85,7 +85,7 @@ class MayBeConstSpec {
         fun `is a simple val`() {
             val code = """
             val x = 1
-            """
+            """.trimIndent()
             subject.compileAndLint(code)
             assertThat(subject.findings).hasSize(1).hasStartSourceLocations(
                 SourceLocation(1, 5)
@@ -96,7 +96,7 @@ class MayBeConstSpec {
         fun `is a simple JvmField val`() {
             val code = """
             @JvmField val x = 1
-            """
+            """.trimIndent()
             subject.compileAndLint(code)
             assertThat(subject.findings).hasSize(1).hasStartSourceLocations(
                 SourceLocation(1, 15)
@@ -109,7 +109,7 @@ class MayBeConstSpec {
             object Test {
                 @JvmField val test = "Test"
             }
-            """
+            """.trimIndent()
             subject.compileAndLint(code)
             assertThat(subject.findings).hasSize(1).hasStartSourceLocations(
                 SourceLocation(2, 19)
@@ -124,7 +124,7 @@ class MayBeConstSpec {
                     val b = 1
                 }
             }
-            """
+            """.trimIndent()
             subject.compileAndLint(code)
             assertThat(subject.findings).hasSize(1).hasStartSourceLocations(
                 SourceLocation(3, 13)
@@ -141,7 +141,7 @@ class MayBeConstSpec {
                 const val one = 1
                 val two = one * 2
             }
-            """
+            """.trimIndent()
             subject.compileAndLint(code)
             assertThat(subject.findings).hasSize(1).hasStartSourceLocations(
                 SourceLocation(3, 9)
@@ -157,7 +157,7 @@ class MayBeConstSpec {
                     val two = one * 2
                 }
             }
-            """
+            """.trimIndent()
             subject.compileAndLint(code)
             assertThat(subject.findings).hasSize(1).hasStartSourceLocations(
                 SourceLocation(4, 13)
@@ -171,7 +171,7 @@ class MayBeConstSpec {
                 const val one = 1
                 val two = one * 2 + 1
             }
-            """
+            """.trimIndent()
             subject.compileAndLint(code)
             assertThat(subject.findings).hasSize(1).hasStartSourceLocations(
                 SourceLocation(3, 9)
@@ -185,7 +185,7 @@ class MayBeConstSpec {
                 const val one = 1
                 val two = one * (2 + 1)
             }
-            """
+            """.trimIndent()
             subject.compileAndLint(code)
             assertThat(subject.findings).hasSize(1).hasStartSourceLocations(
                 SourceLocation(3, 9)
@@ -201,7 +201,7 @@ class MayBeConstSpec {
                 @JvmField
                 val b = a + 1
             }
-            """
+            """.trimIndent()
             subject.compileAndLint(code)
             assertThat(subject.findings).hasSize(1).hasStartSourceLocations(
                 SourceLocation(5, 9)
@@ -215,7 +215,7 @@ class MayBeConstSpec {
                 private const val A = "a"
                 private val B = A + "b"
             }
-            """
+            """.trimIndent()
             subject.compileAndLint(code)
             assertThat(subject.findings).hasSize(1).hasStartSourceLocations(
                 SourceLocation(3, 17)
@@ -259,7 +259,7 @@ class MayBeConstSpec {
             class Test {
                 @JvmField val a = 3
             }
-            """
+            """.trimIndent()
             subject.compileAndLint(code)
             assertThat(subject.findings).isEmpty()
         }
@@ -270,7 +270,7 @@ class MayBeConstSpec {
             annotation class A
 
             @A val a = 55
-            """
+            """.trimIndent()
             subject.compileAndLint(code)
             assertThat(subject.findings).isEmpty()
         }
@@ -285,7 +285,7 @@ class MayBeConstSpec {
             object Derived : Base {
                 override val property = 1
             }
-            """
+            """.trimIndent()
             subject.compileAndLint(code)
             assertThat(subject.findings).isEmpty()
         }
@@ -314,7 +314,7 @@ class MayBeConstSpec {
                 }
                 var test_var = "test"
                 var code = $innerCode
-            """
+            """.trimIndent()
             subject.compileAndLint(code)
             assertThat(subject.findings).isEmpty()
         }
@@ -328,7 +328,7 @@ class MayBeConstSpec {
                         val prop = ""
                     }
                 }
-                """
+                """.trimIndent()
             )
 
             assertThat(subject.findings).isEmpty()
@@ -361,7 +361,7 @@ class MayBeConstSpec {
                         val ACONST = ROOT_CONST + 1
                     }
                 }
-            """
+            """.trimIndent()
             subject.compileAndLint(code)
             assertThat(subject.findings).hasSize(3).hasStartSourceLocations(
                 SourceLocation(4, 13),

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ModifierOrderSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ModifierOrderSpec.kt
@@ -68,7 +68,7 @@ class ModifierOrderSpec {
                 abstract class Test : A() {
                     override open fun test() {}
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
@@ -81,7 +81,7 @@ class ModifierOrderSpec {
                 abstract class Test : A() {
                     override fun test() {}
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
     }
@@ -95,7 +95,7 @@ class ModifierOrderSpec {
                 public class A {
                     tailrec private fun foo(x: Double = 1.0): Double = 1.0
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
@@ -105,7 +105,7 @@ class ModifierOrderSpec {
                 public class A {
                     private tailrec fun foo(x: Double = 1.0): Double = 1.0
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
     }
@@ -135,7 +135,7 @@ class ModifierOrderSpec {
                 private fun interface LoadMoreCallback {
                     fun loadMore(): Boolean
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
     }
@@ -148,7 +148,7 @@ class ModifierOrderSpec {
             val code = """
                 @JvmInline
                 private value class Foo(val bar: Int)
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
     }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MultilineLambdaItParameterSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MultilineLambdaItParameterSpec.kt
@@ -23,7 +23,7 @@ class MultilineLambdaItParameterSpec(val env: KotlinCoreEnvironment) {
                     println(it)
                 }
             }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
@@ -37,7 +37,7 @@ class MultilineLambdaItParameterSpec(val env: KotlinCoreEnvironment) {
                     println(it)
                 }
             }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
@@ -51,7 +51,7 @@ class MultilineLambdaItParameterSpec(val env: KotlinCoreEnvironment) {
                     println(param)
                 }
             }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
@@ -68,7 +68,7 @@ class MultilineLambdaItParameterSpec(val env: KotlinCoreEnvironment) {
                     println(it)
                 }
             }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
@@ -84,7 +84,7 @@ class MultilineLambdaItParameterSpec(val env: KotlinCoreEnvironment) {
                     listOf(it)
                 }
             }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
@@ -97,7 +97,7 @@ class MultilineLambdaItParameterSpec(val env: KotlinCoreEnvironment) {
                     listOf(it)
                 }
             }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
@@ -110,7 +110,7 @@ class MultilineLambdaItParameterSpec(val env: KotlinCoreEnvironment) {
                     listOf(param)
                 }
             }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
@@ -124,7 +124,7 @@ class MultilineLambdaItParameterSpec(val env: KotlinCoreEnvironment) {
             fun f() {
                 val digits = 1234.let { listOf(it) }
             }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
@@ -135,7 +135,7 @@ class MultilineLambdaItParameterSpec(val env: KotlinCoreEnvironment) {
             fun f() {
                 val digits = 1234.let { listOf(it) }
             }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
@@ -146,7 +146,7 @@ class MultilineLambdaItParameterSpec(val env: KotlinCoreEnvironment) {
             fun f() {
                 val digits = 1234.let { it -> listOf(it) }
             }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
@@ -157,7 +157,7 @@ class MultilineLambdaItParameterSpec(val env: KotlinCoreEnvironment) {
             fun f() {
                 val digits = 1234.let { param -> listOf(param) }
             }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
@@ -174,7 +174,7 @@ class MultilineLambdaItParameterSpec(val env: KotlinCoreEnvironment) {
                     it + index 
                 }
             }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
@@ -188,7 +188,7 @@ class MultilineLambdaItParameterSpec(val env: KotlinCoreEnvironment) {
                     item.toString() + that 
                 }
             }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
@@ -205,7 +205,7 @@ class MultilineLambdaItParameterSpec(val env: KotlinCoreEnvironment) {
                     append("b")
                 }
             }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MultilineRawStringIndentationSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MultilineRawStringIndentationSpec.kt
@@ -17,7 +17,7 @@ class MultilineRawStringIndentationSpec {
                 val a = $TQ
                 Hello world!
                 $TQ.trimIndent()
-            """
+            """.trimIndent()
             subject.compileAndLint(code)
             assertThat(subject.findings)
                 .hasSize(1)
@@ -33,7 +33,7 @@ class MultilineRawStringIndentationSpec {
                 Hello world!
                 How are you?
                 $TQ.trimIndent()
-            """
+            """.trimIndent()
             subject.compileAndLint(code)
             assertThat(subject.findings)
                 .hasSize(2)
@@ -47,7 +47,7 @@ class MultilineRawStringIndentationSpec {
                  Hello world!
                     How are you?
                 $TQ.trimIndent()
-            """
+            """.trimIndent()
             subject.compileAndLint(code)
             assertThat(subject.findings)
                 .hasSize(1)
@@ -63,7 +63,7 @@ class MultilineRawStringIndentationSpec {
                      Hello world!
                      How are you?
                 $TQ.trimIndent()
-            """
+            """.trimIndent()
             subject.compileAndLint(code)
             assertThat(subject.findings)
                 .hasSize(1)
@@ -79,7 +79,7 @@ class MultilineRawStringIndentationSpec {
                       Hello world!
                     How are you?
                 $TQ.trimIndent()
-            """
+            """.trimIndent()
             subject.compileAndLint(code)
             assertThat(subject.findings)
                 .isEmpty()
@@ -93,7 +93,7 @@ class MultilineRawStringIndentationSpec {
                     
                     How are you?
                 $TQ.trimIndent()
-            """
+            """.trimIndent()
             subject.compileAndLint(code)
             assertThat(subject.findings)
                 .isEmpty()
@@ -107,7 +107,7 @@ class MultilineRawStringIndentationSpec {
                 
                     How are you?
                 $TQ.trimIndent()
-            """
+            """.trimIndent()
             subject.compileAndLint(code)
             assertThat(subject.findings)
                 .isEmpty()
@@ -120,7 +120,7 @@ class MultilineRawStringIndentationSpec {
                     Hello world!
                   
                 $TQ.trimIndent()
-            """
+            """.trimIndent()
             subject.compileAndLint(code)
             assertThat(subject.findings)
                 .hasSize(1)
@@ -135,7 +135,7 @@ class MultilineRawStringIndentationSpec {
                     Hello world!
                     How are you?
                     $TQ.trimIndent()
-            """
+            """.trimIndent()
             subject.compileAndLint(code)
             assertThat(subject.findings)
                 .hasSize(1)
@@ -153,7 +153,7 @@ class MultilineRawStringIndentationSpec {
                     $TQ
                     Hello world!
                     $TQ.trimIndent()
-            """
+            """.trimIndent()
             subject.compileAndLint(code)
             assertThat(subject.findings)
                 .hasSize(1)
@@ -169,7 +169,7 @@ class MultilineRawStringIndentationSpec {
                     Hello world!
                     How are you?
                     $TQ.trimIndent()
-            """
+            """.trimIndent()
             subject.compileAndLint(code)
             assertThat(subject.findings)
                 .hasSize(2)
@@ -183,7 +183,7 @@ class MultilineRawStringIndentationSpec {
                      Hello world!
                         How are you?
                     $TQ.trimIndent()
-            """
+            """.trimIndent()
             subject.compileAndLint(code)
             assertThat(subject.findings)
                 .hasSize(1)
@@ -199,7 +199,7 @@ class MultilineRawStringIndentationSpec {
                          Hello world!
                          How are you?
                     $TQ.trimIndent()
-            """
+            """.trimIndent()
             subject.compileAndLint(code)
             assertThat(subject.findings)
                 .hasSize(1)
@@ -216,7 +216,7 @@ class MultilineRawStringIndentationSpec {
                           Hello world!
                         How are you?
                     $TQ.trimIndent()
-            """
+            """.trimIndent()
             subject.compileAndLint(code)
             assertThat(subject.findings)
                 .isEmpty()
@@ -230,7 +230,7 @@ class MultilineRawStringIndentationSpec {
                         Hello world!
                         How are you?
                     $TQ.trimIndent()
-            """
+            """.trimIndent()
             subject.compileAndLint(code)
             assertThat(subject.findings)
                 .isEmpty()
@@ -244,7 +244,7 @@ class MultilineRawStringIndentationSpec {
                         Hello world!
                         How are you?
                         $TQ.trimIndent()
-            """
+            """.trimIndent()
             subject.compileAndLint(code)
             assertThat(subject.findings)
                 .hasSize(1)
@@ -260,7 +260,7 @@ class MultilineRawStringIndentationSpec {
                         Hello world!
                         How are you?
                   $TQ.trimIndent()
-            """
+            """.trimIndent()
             subject.compileAndLint(code)
             assertThat(subject.findings)
                 .hasSize(1)
@@ -277,7 +277,7 @@ class MultilineRawStringIndentationSpec {
                 val a = $TQ
                 Hello world!
                 $TQ
-            """
+            """.trimIndent()
             subject.compileAndLint(code)
             assertThat(subject.findings).isEmpty()
         }
@@ -286,7 +286,7 @@ class MultilineRawStringIndentationSpec {
         fun `don't raise one line raw strings`() {
             val code = """
                 val a = ${TQ}Hello world!$TQ
-            """
+            """.trimIndent()
             subject.compileAndLint(code)
             assertThat(subject.findings).isEmpty()
         }
@@ -295,7 +295,7 @@ class MultilineRawStringIndentationSpec {
         fun `doesn't raise if it is not a raw string`() {
             val code = """
                 val a = "Hello world!"
-            """
+            """.trimIndent()
             subject.compileAndLint(code)
             assertThat(subject.findings).isEmpty()
         }
@@ -306,7 +306,7 @@ class MultilineRawStringIndentationSpec {
                 val a = ${TQ}Hello world!
                     How are you?
                 $TQ.trimIndent()
-            """
+            """.trimIndent()
             subject.compileAndLint(code)
             assertThat(subject.findings)
                 .isEmpty()
@@ -318,7 +318,7 @@ class MultilineRawStringIndentationSpec {
                 val a = $TQ
                     Hello world!
                     How are you?$TQ.trimIndent()
-            """
+            """.trimIndent()
             subject.compileAndLint(code)
             assertThat(subject.findings)
                 .isEmpty()
@@ -329,7 +329,7 @@ class MultilineRawStringIndentationSpec {
             val code = """
                 val a = $TQ
                 $TQ.trimIndent()
-            """
+            """.trimIndent()
             subject.compileAndLint(code)
             assertThat(subject.findings)
                 .isEmpty()

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/NestedClassesVisibilitySpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/NestedClassesVisibilitySpec.kt
@@ -15,7 +15,7 @@ class NestedClassesVisibilitySpec {
                 public object B
                 public class C
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(3)
     }
 
@@ -26,7 +26,7 @@ class NestedClassesVisibilitySpec {
                 A;
                 public class C
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 
@@ -39,7 +39,7 @@ class NestedClassesVisibilitySpec {
                  enum class E { One }
                  internal interface I
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -49,7 +49,7 @@ class NestedClassesVisibilitySpec {
             internal class Outer {
                 private class A
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -59,7 +59,7 @@ class NestedClassesVisibilitySpec {
             internal class Outer {
                 public enum class E { E1; }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -69,7 +69,7 @@ class NestedClassesVisibilitySpec {
             internal class Outer {
                 public companion object C
             } 
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -79,7 +79,7 @@ class NestedClassesVisibilitySpec {
             internal class Outer {
                 companion object C
             } 
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -89,7 +89,7 @@ class NestedClassesVisibilitySpec {
             private class Outer {
                  class A
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -99,7 +99,7 @@ class NestedClassesVisibilitySpec {
             internal interface Outer {
                  class A
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -111,7 +111,7 @@ class NestedClassesVisibilitySpec {
                     public class C2
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/NullableBooleanCheckSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/NullableBooleanCheckSpec.kt
@@ -32,7 +32,7 @@ class NullableBooleanCheckSpec(val env: KotlinCoreEnvironment) {
             fun foo(): Boolean {
                 return nullableBoolean() ?: $bool
             }
-        """
+        """.trimIndent()
 
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
@@ -48,7 +48,7 @@ class NullableBooleanCheckSpec(val env: KotlinCoreEnvironment) {
             fun foo(): Boolean {
                 return nullableBoolean() ?: $bool
             }
-        """
+        """.trimIndent()
 
         val findings = subject.compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(1)
@@ -69,7 +69,7 @@ class NullableBooleanCheckSpec(val env: KotlinCoreEnvironment) {
             fun foo() {
                 if (nullableBoolean() ?: $bool) println("foo")
             }
-        """
+        """.trimIndent()
 
         val findings = subject.compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(1)
@@ -89,7 +89,7 @@ class NullableBooleanCheckSpec(val env: KotlinCoreEnvironment) {
             fun foo(): Boolean {
                 return nullableBoolean() ?: Random.nextBoolean()
             }
-        """
+        """.trimIndent()
 
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
@@ -105,7 +105,7 @@ class NullableBooleanCheckSpec(val env: KotlinCoreEnvironment) {
             fun foo(): Any {
                 return nullableAny() ?: $bool
             }
-        """
+        """.trimIndent()
 
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
@@ -120,7 +120,7 @@ class NullableBooleanCheckSpec(val env: KotlinCoreEnvironment) {
             fun foo(): Int {
                 return nullableInt() ?: 0
             }
-        """
+        """.trimIndent()
 
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
@@ -133,7 +133,7 @@ class NullableBooleanCheckSpec(val env: KotlinCoreEnvironment) {
             fun foo(): Boolean {
                 return Random.nextBoolean() || false
             }
-        """
+        """.trimIndent()
 
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ObjectLiteralToLambdaSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ObjectLiteralToLambdaSpec.kt
@@ -29,7 +29,7 @@ class ObjectLiteralToLambdaSpec {
                         override fun foo() {
                         }
                     }   
-                """
+                """.trimIndent()
                 subject.compileAndLintWithContext(env, code)
                     .assert()
                     .hasSize(1)
@@ -48,7 +48,7 @@ class ObjectLiteralToLambdaSpec {
                             }
                         }
                     }
-                """
+                """.trimIndent()
                 subject.compileAndLintWithContext(env, code)
                     .assert()
                     .hasSize(1)
@@ -69,7 +69,7 @@ class ObjectLiteralToLambdaSpec {
                             }
                         }
                     }
-                """
+                """.trimIndent()
                 subject.compileAndLintWithContext(env, code)
                     .assert()
                     .hasSize(1)
@@ -87,7 +87,7 @@ class ObjectLiteralToLambdaSpec {
                             return 1
                         }
                     }   
-                """
+                """.trimIndent()
                 subject.compileAndLintWithContext(env, code)
                     .assert()
                     .hasSize(1)
@@ -105,7 +105,7 @@ class ObjectLiteralToLambdaSpec {
                         override fun foo() {
                         }
                     }   
-                """
+                """.trimIndent()
                 subject.compileAndLintWithContext(env, code)
                     .assert()
                     .hasSize(1)
@@ -126,7 +126,7 @@ class ObjectLiteralToLambdaSpec {
                             }
                         }
                     }
-                """
+                """.trimIndent()
                 subject.compileAndLintWithContext(env, code)
                     .assert()
                     .hasSize(1)
@@ -142,7 +142,7 @@ class ObjectLiteralToLambdaSpec {
                     val a = object : Sam {
                         override fun foo() = 3
                     }
-                """
+                """.trimIndent()
                 subject.compileAndLintWithContext(env, code)
                     .assert()
                     .hasSize(1)
@@ -162,7 +162,7 @@ class ObjectLiteralToLambdaSpec {
                         override fun foo() {
                         }
                     }
-                """
+                """.trimIndent()
                 subject.compileAndLint(code).assert().isEmpty()
             }
 
@@ -171,7 +171,7 @@ class ObjectLiteralToLambdaSpec {
                 val code = """
                     interface Sam
                     val a = object : Sam {}
-                """
+                """.trimIndent()
                 subject.compileAndLintWithContext(env, code).assert().isEmpty()
             }
 
@@ -183,7 +183,7 @@ class ObjectLiteralToLambdaSpec {
                         fun foo() {
                         }
                     }
-                """
+                """.trimIndent()
                 subject.compileAndLintWithContext(env, code).assert().isEmpty()
             }
 
@@ -196,7 +196,7 @@ class ObjectLiteralToLambdaSpec {
                     val a = object : Sam {
                         override val foo = 1
                     }
-                """
+                """.trimIndent()
                 subject.compileAndLintWithContext(env, code).assert().isEmpty()
             }
 
@@ -207,7 +207,7 @@ class ObjectLiteralToLambdaSpec {
                     val a = object : Sam {
                         val b = 1
                     }
-                """
+                """.trimIndent()
                 subject.compileAndLintWithContext(env, code).assert().isEmpty()
             }
 
@@ -221,7 +221,7 @@ class ObjectLiteralToLambdaSpec {
                         override fun foo() {
                         }
                     }
-                """
+                """.trimIndent()
                 subject.compileAndLintWithContext(env, code).assert().isEmpty()
             }
 
@@ -235,7 +235,7 @@ class ObjectLiteralToLambdaSpec {
                         override fun foo() {
                         }
                     }
-                """
+                """.trimIndent()
                 subject.compileAndLintWithContext(env, code).assert().isEmpty()
             }
 
@@ -251,7 +251,7 @@ class ObjectLiteralToLambdaSpec {
                         override fun foo() {
                         }
                     }
-                """
+                """.trimIndent()
                 subject.compileAndLintWithContext(env, code).assert().isEmpty()
             }
 
@@ -269,7 +269,7 @@ class ObjectLiteralToLambdaSpec {
                         override fun foo() {
                         }
                     }
-                """
+                """.trimIndent()
                 subject.compileAndLintWithContext(env, code).assert().isEmpty()
             }
         }
@@ -288,7 +288,7 @@ class ObjectLiteralToLambdaSpec {
                         fun bar() {
                         }
                     }
-                """
+                """.trimIndent()
                 subject.compileAndLintWithContext(env, code).assert().isEmpty()
             }
 
@@ -303,7 +303,7 @@ class ObjectLiteralToLambdaSpec {
                         override fun foo() {
                         }
                     }
-                """
+                """.trimIndent()
                 subject.compileAndLintWithContext(env, code).assert().isEmpty()
             }
 
@@ -319,7 +319,7 @@ class ObjectLiteralToLambdaSpec {
                         override fun foo() {
                         }
                     }
-                """
+                """.trimIndent()
                 subject.compileAndLintWithContext(env, code).assert().isEmpty()
             }
         }
@@ -333,7 +333,7 @@ class ObjectLiteralToLambdaSpec {
                         override fun run(){
                         }
                     }
-                """
+                """.trimIndent()
                 subject.compileAndLintWithContext(env, code)
                     .assert()
                     .hasSize(1)
@@ -349,7 +349,7 @@ class ObjectLiteralToLambdaSpec {
                             return 1
                         }
                     }
-                """
+                """.trimIndent()
                 subject.compileAndLintWithContext(env, code)
                     .assert()
                     .hasSize(1)
@@ -364,7 +364,7 @@ class ObjectLiteralToLambdaSpec {
                         fun foo() {
                         }
                     }
-                """
+                """.trimIndent()
                 subject.compileAndLintWithContext(env, code).assert().isEmpty()
             }
 
@@ -381,7 +381,7 @@ class ObjectLiteralToLambdaSpec {
                             return 1
                         }
                     }
-                """
+                """.trimIndent()
                 subject.compileAndLintWithContext(env, code).assert().isEmpty()
             }
         }
@@ -402,7 +402,7 @@ class ObjectLiteralToLambdaSpec {
                             }
                         }
                     }
-                """
+                """.trimIndent()
                 subject.compileAndLintWithContext(env, code).assert().isEmpty()
             }
 
@@ -422,7 +422,7 @@ class ObjectLiteralToLambdaSpec {
                             }
                         }
                     }
-                """
+                """.trimIndent()
                 subject.compileAndLintWithContext(env, code).assert().isEmpty()
             }
 
@@ -440,7 +440,7 @@ class ObjectLiteralToLambdaSpec {
                             }
                         }
                     }
-                """
+                """.trimIndent()
                 subject.compileAndLintWithContext(env, code).assert().isEmpty()
             }
 
@@ -462,7 +462,7 @@ class ObjectLiteralToLambdaSpec {
                             }
                         }
                     }
-                """
+                """.trimIndent()
                 subject.compileAndLintWithContext(env, code)
                     .assert()
                     .hasSize(1)
@@ -485,7 +485,7 @@ class ObjectLiteralToLambdaSpec {
                             }
                         }
                     }
-                """
+                """.trimIndent()
                 subject.compileAndLintWithContext(env, code)
                     .assert()
                     .hasSize(1)
@@ -506,7 +506,7 @@ class ObjectLiteralToLambdaSpec {
                             }
                         }
                     }
-                """
+                """.trimIndent()
                 subject.compileAndLintWithContext(env, code).assert().isEmpty()
             }
         }
@@ -530,7 +530,7 @@ class ObjectLiteralToLambdaSpec {
         
                     val a = newObject() === newObject() // false
                     val b = lambda() === lambda() // true
-                """
+                """.trimIndent()
                 subject.compileAndLintWithContext(env, code)
                     .assert()
                     .hasSize(1)
@@ -555,7 +555,7 @@ class ObjectLiteralToLambdaSpec {
                         }
                     }
                 } 
-            """
+            """.trimIndent()
 
             subject.lintWithContext(env, code).assert().hasSize(1)
         }
@@ -569,7 +569,7 @@ class ObjectLiteralToLambdaSpec {
                     val x = object : OnlyDefaultMethods {
                     }
                 } 
-            """
+            """.trimIndent()
             subject.lintWithContext(env, code).assert().isEmpty()
         }
 
@@ -585,7 +585,7 @@ class ObjectLiteralToLambdaSpec {
                         }
                     }
                 } 
-            """
+            """.trimIndent()
             subject.lintWithContext(env, code).assert().isEmpty()
         }
     }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/OptionalAbstractKeywordSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/OptionalAbstractKeywordSpec.kt
@@ -36,7 +36,7 @@ class OptionalAbstractKeywordSpec {
                     abstract fun x()
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(2)
     }
 
@@ -54,7 +54,7 @@ class OptionalAbstractKeywordSpec {
                     abstract fun dependency()
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/OptionalWhenBracesSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/OptionalWhenBracesSpec.kt
@@ -25,7 +25,7 @@ class OptionalWhenBracesSpec {
                     }
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -38,7 +38,7 @@ class OptionalWhenBracesSpec {
                     else -> println()
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 
@@ -63,7 +63,7 @@ class OptionalWhenBracesSpec {
                     false -> println("false")
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code))
             .hasSize(2)
             .hasStartSourceLocations(SourceLocation(7, 17), SourceLocation(10, 17))
@@ -84,7 +84,7 @@ class OptionalWhenBracesSpec {
                     }
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code))
             .hasSize(1)
             .hasStartSourceLocations(SourceLocation(3, 9))
@@ -101,7 +101,7 @@ class OptionalWhenBracesSpec {
                         false -> { { it + 200  } }
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
@@ -114,7 +114,7 @@ class OptionalWhenBracesSpec {
                         false -> { { i -> i + 200  } }
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).hasSize(2)
         }
     }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ProtectedMemberInFinalClassSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ProtectedMemberInFinalClassSpec.kt
@@ -19,7 +19,7 @@ class ProtectedMemberInFinalClassSpec {
                 class Foo {
                     protected var i1 = 0
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLint(code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasStartSourceLocation(2, 5)
@@ -34,7 +34,7 @@ class ProtectedMemberInFinalClassSpec {
                         this.i1 = i1
                     }
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLint(code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasStartSourceLocation(3, 5)
@@ -46,7 +46,7 @@ class ProtectedMemberInFinalClassSpec {
                 class Foo {
                     protected fun function() {}
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLint(code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasStartSourceLocation(2, 5)
@@ -60,7 +60,7 @@ class ProtectedMemberInFinalClassSpec {
                         protected val i = 0
                     }
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLint(code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasStartSourceLocation(3, 9)
@@ -74,7 +74,7 @@ class ProtectedMemberInFinalClassSpec {
                         protected val i = 0
                     }
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLint(code)
             assertThat(findings).hasSize(2)
             assertThat(findings).hasStartSourceLocations(
@@ -93,7 +93,7 @@ class ProtectedMemberInFinalClassSpec {
                         }
                     }
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLint(code)
             assertThat(findings).hasSize(3)
             assertThat(findings).hasStartSourceLocations(
@@ -113,7 +113,7 @@ class ProtectedMemberInFinalClassSpec {
                         }
                     }
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLint(code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasStartSourceLocation(4, 13)
@@ -127,7 +127,7 @@ class ProtectedMemberInFinalClassSpec {
                         protected val i = 0
                     }
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLint(code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasStartSourceLocation(3, 9)
@@ -137,7 +137,7 @@ class ProtectedMemberInFinalClassSpec {
         fun `reports a protected primary constructor in a final class`() {
             val code = """
                 class FinalClassWithProtectedConstructor protected constructor()
-            """
+            """.trimIndent()
             val findings = subject.compileAndLint(code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasStartSourceLocation(1, 42)
@@ -154,7 +154,7 @@ class ProtectedMemberInFinalClassSpec {
                 class Foo : BaseClass() {
                     private val i = 0
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
@@ -168,7 +168,7 @@ class ProtectedMemberInFinalClassSpec {
                     // should not report protected = private visibility
                     protected override val abstractProp = 0
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
@@ -183,7 +183,7 @@ class ProtectedMemberInFinalClassSpec {
                     protected override fun abstractFunction() {
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
@@ -196,7 +196,7 @@ class ProtectedMemberInFinalClassSpec {
                 
                     protected object InnerObject
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
@@ -206,7 +206,7 @@ class ProtectedMemberInFinalClassSpec {
                 sealed class SealedClass {
                     protected fun a() {}
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
@@ -217,7 +217,7 @@ class ProtectedMemberInFinalClassSpec {
                     ;   
                     protected fun foo() {}
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
     }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantExplicitTypeSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantExplicitTypeSpec.kt
@@ -17,7 +17,7 @@ class RedundantExplicitTypeSpec(val env: KotlinCoreEnvironment) {
             fun function() {
                 val x: Boolean = true
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
     }
 
@@ -27,7 +27,7 @@ class RedundantExplicitTypeSpec(val env: KotlinCoreEnvironment) {
             fun function() {
                 val x: Int = 3
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
     }
 
@@ -37,7 +37,7 @@ class RedundantExplicitTypeSpec(val env: KotlinCoreEnvironment) {
             fun function() {
                 val x: Long = 3L
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
     }
 
@@ -47,7 +47,7 @@ class RedundantExplicitTypeSpec(val env: KotlinCoreEnvironment) {
             fun function() {
                 val x: Float = 3.0f
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
     }
 
@@ -57,7 +57,7 @@ class RedundantExplicitTypeSpec(val env: KotlinCoreEnvironment) {
             fun function() {
                 val x: Double = 3.0
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
     }
 
@@ -67,7 +67,7 @@ class RedundantExplicitTypeSpec(val env: KotlinCoreEnvironment) {
             fun function() {
                 val x: Char = 'f'
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
     }
 
@@ -79,7 +79,7 @@ class RedundantExplicitTypeSpec(val env: KotlinCoreEnvironment) {
                 val x = 3
                 val y: String = "$substitute"
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
     }
 
@@ -91,7 +91,7 @@ class RedundantExplicitTypeSpec(val env: KotlinCoreEnvironment) {
             fun foo() {
                 val o: Test = Test
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
     }
 
@@ -107,7 +107,7 @@ class RedundantExplicitTypeSpec(val env: KotlinCoreEnvironment) {
             fun tallPerson() {
                 val t: TallPerson = TallPerson("first", 3)
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
     }
 
@@ -123,7 +123,7 @@ class RedundantExplicitTypeSpec(val env: KotlinCoreEnvironment) {
             fun tallPerson() {
                 val t: Person = TallPerson("first", 3)
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantHigherOrderMapUsageSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantHigherOrderMapUsageSpec.kt
@@ -21,7 +21,7 @@ class RedundantHigherOrderMapUsageSpec(val env: KotlinCoreEnvironment) {
                         .filter { it > 1 }
                         .map { it }
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasStartSourceLocation(4, 10)
@@ -41,7 +41,7 @@ class RedundantHigherOrderMapUsageSpec(val env: KotlinCoreEnvironment) {
                         }
                         .filter { it > 1 }
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasStartSourceLocation(5, 10)
@@ -54,7 +54,7 @@ class RedundantHigherOrderMapUsageSpec(val env: KotlinCoreEnvironment) {
                 fun test() {
                     listOf(1, 2, 3).map { foo -> foo }
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
@@ -65,7 +65,7 @@ class RedundantHigherOrderMapUsageSpec(val env: KotlinCoreEnvironment) {
                 fun test() {
                     listOf(1).map({ it })
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
@@ -80,7 +80,7 @@ class RedundantHigherOrderMapUsageSpec(val env: KotlinCoreEnvironment) {
                         it
                     }
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
@@ -97,7 +97,7 @@ class RedundantHigherOrderMapUsageSpec(val env: KotlinCoreEnvironment) {
                         it
                     }
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
@@ -113,7 +113,7 @@ class RedundantHigherOrderMapUsageSpec(val env: KotlinCoreEnvironment) {
                         }.joinToString("") + s
                     }
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
@@ -124,7 +124,7 @@ class RedundantHigherOrderMapUsageSpec(val env: KotlinCoreEnvironment) {
                 fun List<Int>.test() {
                     map { it }
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
@@ -135,7 +135,7 @@ class RedundantHigherOrderMapUsageSpec(val env: KotlinCoreEnvironment) {
                 fun List<Int>.test() {
                     this.map { it }
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
@@ -146,7 +146,7 @@ class RedundantHigherOrderMapUsageSpec(val env: KotlinCoreEnvironment) {
                 fun test() {
                     mutableListOf(1).map { it }
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
@@ -157,7 +157,7 @@ class RedundantHigherOrderMapUsageSpec(val env: KotlinCoreEnvironment) {
                 fun test() {
                     val x:Sequence<Int> = sequenceOf(1).map { it }
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
@@ -168,7 +168,7 @@ class RedundantHigherOrderMapUsageSpec(val env: KotlinCoreEnvironment) {
                 fun test() {
                     setOf(1).map { it }
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
             assertThat(findings[0]).hasMessage("This 'map' call can be replaced with 'toList'.")
@@ -185,7 +185,7 @@ class RedundantHigherOrderMapUsageSpec(val env: KotlinCoreEnvironment) {
                         .filter { it > 1 }
                         .map { it + 1 }
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
@@ -199,7 +199,7 @@ class RedundantHigherOrderMapUsageSpec(val env: KotlinCoreEnvironment) {
                         it
                     }
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
@@ -210,7 +210,7 @@ class RedundantHigherOrderMapUsageSpec(val env: KotlinCoreEnvironment) {
                 fun test() {
                     listOf(1 to 2).map { (a, b) -> a }
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
@@ -221,7 +221,7 @@ class RedundantHigherOrderMapUsageSpec(val env: KotlinCoreEnvironment) {
                 fun test() {
                     val x: List<Map.Entry<Int, String>> = mapOf(1 to "a").map { it }
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantVisibilityModifierRuleSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantVisibilityModifierRuleSpec.kt
@@ -26,7 +26,7 @@ class RedundantVisibilityModifierRuleSpec {
             class Test : A() {
                 override public fun f() {}
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -40,7 +40,7 @@ class RedundantVisibilityModifierRuleSpec {
             class Test : A() {
                 override fun f() {}
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -54,7 +54,7 @@ class RedundantVisibilityModifierRuleSpec {
             class Test : A {
                 override public fun f() {}
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -65,7 +65,7 @@ class RedundantVisibilityModifierRuleSpec {
                 @Suppress("RedundantVisibilityModifier")
                 public fun f() {}
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -75,7 +75,7 @@ class RedundantVisibilityModifierRuleSpec {
             class Test {
                 public fun f() {}
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 
@@ -85,7 +85,7 @@ class RedundantVisibilityModifierRuleSpec {
             class Test {
                 fun f() {}
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -95,7 +95,7 @@ class RedundantVisibilityModifierRuleSpec {
             public class Test {
                 fun f() {}
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 
@@ -105,7 +105,7 @@ class RedundantVisibilityModifierRuleSpec {
             public interface Test {
                 public fun f()
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(2)
     }
 
@@ -115,7 +115,7 @@ class RedundantVisibilityModifierRuleSpec {
             class Test {
                 public val str : String = "test"
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 
@@ -125,7 +125,7 @@ class RedundantVisibilityModifierRuleSpec {
             class Test {
                 val str : String = "test"
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -139,7 +139,7 @@ class RedundantVisibilityModifierRuleSpec {
             class B : A() {
                 override val test: String = "valid"
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -153,7 +153,7 @@ class RedundantVisibilityModifierRuleSpec {
             class B : A() {
                 override public val test: String = "valid"
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -163,7 +163,7 @@ class RedundantVisibilityModifierRuleSpec {
             private object A {
                 internal class InternalClass
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 
@@ -173,7 +173,7 @@ class RedundantVisibilityModifierRuleSpec {
             private object A {
                 internal fun internalFunction() {}
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 
@@ -186,7 +186,7 @@ class RedundantVisibilityModifierRuleSpec {
                 public class A() {
                     fun f()
                 }
-                """
+                """.trimIndent()
             )
 
         val rule = RedundantVisibilityModifierRule()

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCountSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCountSpec.kt
@@ -20,7 +20,7 @@ class ReturnCountSpec {
     inner class `a function without a body` {
         val code = """
             fun func() = Unit
-        """
+        """.trimIndent()
 
         @Test
         fun `does not report violation by default`() {
@@ -32,7 +32,7 @@ class ReturnCountSpec {
     inner class `a function with an empty body` {
         val code = """
             fun func() {}
-        """
+        """.trimIndent()
 
         @Test
         fun `does not report violation by default`() {
@@ -51,7 +51,7 @@ class ReturnCountSpec {
             }
             return 6
         }
-        """
+        """.trimIndent()
 
         @Test
         fun `should not get flagged for if condition guard clauses`() {
@@ -75,7 +75,7 @@ class ReturnCountSpec {
             }
             return 6
         }
-        """
+        """.trimIndent()
 
         @Test
         fun `should not get flagged for if condition guard clauses`() {
@@ -110,7 +110,7 @@ class ReturnCountSpec {
             }
             return 6
         }
-        """
+        """.trimIndent()
 
         @Test
         fun `should report a too-complicated if statement for being a guard clause, with EXCLUDE_GUARD_CLAUSES on`() {
@@ -131,7 +131,7 @@ class ReturnCountSpec {
             }
             return 6
         }
-        """
+        """.trimIndent()
 
         @Test
         fun `should not get flagged for ELVIS operator guard clauses`() {
@@ -152,7 +152,7 @@ class ReturnCountSpec {
             if (x < 4) return 0
             return 6
         }
-        """
+        """.trimIndent()
 
         @Test
         fun `should get flagged for an if condition guard clause which is not the first statement`() {
@@ -173,7 +173,7 @@ class ReturnCountSpec {
             val y = x ?: return 0
             return 6
         }
-        """
+        """.trimIndent()
 
         @Test
         fun `should get flagged for an ELVIS guard clause which is not the first statement`() {
@@ -197,7 +197,7 @@ class ReturnCountSpec {
 
                 return
             }
-        """
+        """.trimIndent()
 
         @Test
         fun `should not count all four guard clauses`() {
@@ -231,7 +231,7 @@ class ReturnCountSpec {
             }
             return 6
         }
-        """
+        """.trimIndent()
 
         @Test
         fun `should get flagged by default`() {
@@ -262,7 +262,7 @@ class ReturnCountSpec {
             }
             return 6
         }
-        """
+        """.trimIndent()
 
         @Test
         fun `should not get flagged by default`() {
@@ -294,7 +294,7 @@ class ReturnCountSpec {
             }
             return 6
         }
-        """
+        """.trimIndent()
 
         @Test
         fun `should not get flagged`() {
@@ -339,7 +339,7 @@ class ReturnCountSpec {
             }
             return 6
         }
-        """
+        """.trimIndent()
 
         @Test
         fun `should flag none of the ignored functions`() {
@@ -387,7 +387,7 @@ class ReturnCountSpec {
             }
             return 6
         }
-        """
+        """.trimIndent()
 
         @Test
         fun `should not get flag when returns is in inner object`() {
@@ -424,7 +424,7 @@ class ReturnCountSpec {
             }
             return 6
         }
-        """
+        """.trimIndent()
 
         @Test
         fun `should not get flag when returns is in inner object`() {
@@ -463,7 +463,7 @@ class ReturnCountSpec {
             }
             return 6
         }
-        """
+        """.trimIndent()
 
         @Test
         fun `should get flagged when returns is in inner object`() {
@@ -483,7 +483,7 @@ class ReturnCountSpec {
                 return@flatMap Flowable.just(it[0])
             }
         }
-        """
+        """.trimIndent()
 
         @Test
         fun `should not count labeled returns from lambda by default`() {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/SafeCastSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/SafeCastSpec.kt
@@ -17,7 +17,7 @@ class SafeCastSpec {
                     element
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 
@@ -31,7 +31,7 @@ class SafeCastSpec {
                     null
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 
@@ -46,7 +46,7 @@ class SafeCastSpec {
                     null
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -60,7 +60,7 @@ class SafeCastSpec {
                     String()
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/SerialVersionUIDInSerializableClassSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/SerialVersionUIDInSerializableClassSpec.kt
@@ -14,7 +14,7 @@ class SerialVersionUIDInSerializableClassSpec {
             import java.io.Serializable
 
             class C : Serializable
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 
@@ -28,7 +28,7 @@ class SerialVersionUIDInSerializableClassSpec {
                     const val serialVersionUID = 1
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 
@@ -42,7 +42,7 @@ class SerialVersionUIDInSerializableClassSpec {
                     const val serialVersionUID: Int = 1
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 
@@ -60,7 +60,7 @@ class SerialVersionUIDInSerializableClassSpec {
                     val serialVersionUUID = 1L
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(2)
     }
 
@@ -76,7 +76,7 @@ class SerialVersionUIDInSerializableClassSpec {
             import java.io.Serializable
 
             interface I : Serializable
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -90,7 +90,7 @@ class SerialVersionUIDInSerializableClassSpec {
                     const val serialVersionUID = 1L
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -104,7 +104,7 @@ class SerialVersionUIDInSerializableClassSpec {
                     const val serialVersionUID = -1L
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -118,7 +118,7 @@ class SerialVersionUIDInSerializableClassSpec {
                     const val serialVersionUID: Long = 1
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/SpacingBetweenPackageAndImportsSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/SpacingBetweenPackageAndImportsSpec.kt
@@ -110,7 +110,7 @@ class SpacingBetweenPackageAndImportsSpec {
             import kotlin.collections.Set
 
             class A { }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -121,7 +121,7 @@ class SpacingBetweenPackageAndImportsSpec {
 
             import kotlin.collections.List
             import kotlin.collections.Set
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ThrowsCountSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ThrowsCountSpec.kt
@@ -16,7 +16,7 @@ class ThrowsCountSpec {
     inner class `a function with an empty body` {
         val code = """
             fun func() {}
-        """
+        """.trimIndent()
 
         @Test
         fun `does not report violation by default`() {
@@ -28,7 +28,7 @@ class ThrowsCountSpec {
     inner class `a function without a body` {
         val code = """
             fun func() = Unit
-        """
+        """.trimIndent()
 
         @Test
         fun `does not report violation by default`() {
@@ -45,7 +45,7 @@ class ThrowsCountSpec {
                     2 -> throw IOException()
                 }
             }
-        """
+        """.trimIndent()
         val subject = ThrowsCount(Config.empty)
 
         @Test
@@ -64,7 +64,7 @@ class ThrowsCountSpec {
                     3 -> throw IOException()
                 }
             }
-        """
+        """.trimIndent()
         val subject = ThrowsCount(Config.empty)
 
         @Test
@@ -83,7 +83,7 @@ class ThrowsCountSpec {
                     3 -> throw IOException()
                 }
             }
-        """
+        """.trimIndent()
         val subject = ThrowsCount(Config.empty)
 
         @Test
@@ -107,7 +107,7 @@ class ThrowsCountSpec {
                 }
                 return bar(x)
             }
-        """
+        """.trimIndent()
         val subject = ThrowsCount(Config.empty)
 
         @Test
@@ -126,7 +126,7 @@ class ThrowsCountSpec {
                 val int = x?.toInt() ?: throw IOException()
                 val double = x?.toDouble() ?: throw IOException()
             }
-        """
+        """.trimIndent()
 
         @Test
         fun `does not report when max parameter is 3`() {
@@ -154,7 +154,7 @@ class ThrowsCountSpec {
                 }
                 throw Exception()
             }
-        """
+        """.trimIndent()
 
         @Test
         fun `should not report violation with EXCLUDE_GUARD_CLAUSES as true`() {
@@ -182,7 +182,7 @@ class ThrowsCountSpec {
                 }
                 throw Exception()
             }
-        """
+        """.trimIndent()
 
         @Test
         fun `should not report violation with EXCLUDE_GUARD_CLAUSES as true`() {
@@ -217,7 +217,7 @@ class ThrowsCountSpec {
                 }
                 throw Exception()
             }
-        """
+        """.trimIndent()
 
         @Test
         fun `should report violation even with EXCLUDE_GUARD_CLAUSES as true`() {
@@ -238,7 +238,7 @@ class ThrowsCountSpec {
                 if (x < 4) throw Exception()
                 throw Exception()
             }
-        """
+        """.trimIndent()
 
         @Test
         fun `should report the violation even with EXCLUDE_GUARD_CLAUSES as true`() {
@@ -259,7 +259,7 @@ class ThrowsCountSpec {
                 val y = x ?: throw Exception()
                 throw Exception()
             }
-        """
+        """.trimIndent()
 
         @Test
         fun `should report the violation even with EXCLUDE_GUARD_CLAUSES as true`() {
@@ -283,7 +283,7 @@ class ThrowsCountSpec {
 
                 throw Exception()
             }
-        """
+        """.trimIndent()
 
         @Test
         fun `should not report violation with EXCLUDE_GUARD_CLAUSES as true`() {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/TrailingWhitespaceSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/TrailingWhitespaceSpec.kt
@@ -78,7 +78,7 @@ class TrailingWhitespaceSpec {
                     
                     Should ignore indent on the previous line
                 ""${'"'}
-            """.trim()
+            """.trimIndent()
             val findings = compileAndLintWithoutTrim(code)
             assertThat(findings).isEmpty()
         }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/TrimMultilineRawStringSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/TrimMultilineRawStringSpec.kt
@@ -16,7 +16,7 @@ class TrimMultilineRawStringSpec {
                 val a = ${TQ}
                 Hello world!
                 ${TQ}
-            """
+        """
         subject.compileAndLint(code)
         assertThat(subject.findings).hasSize(1)
     }
@@ -27,7 +27,7 @@ class TrimMultilineRawStringSpec {
                 val a = ${TQ}
                 Hello world!
                 ${TQ}.length
-            """
+        """
         subject.compileAndLint(code)
         assertThat(subject.findings).hasSize(1)
     }
@@ -38,7 +38,7 @@ class TrimMultilineRawStringSpec {
                 val a = ${TQ}
                 Hello world!
                 ${TQ}.trimIndent()
-            """
+        """
         subject.compileAndLint(code)
         assertThat(subject.findings).isEmpty()
     }
@@ -49,7 +49,7 @@ class TrimMultilineRawStringSpec {
                 val a = ${TQ}
                 |Hello world!
                 ${TQ}.trimMargin()
-            """
+        """
         subject.compileAndLint(code)
         assertThat(subject.findings).isEmpty()
     }
@@ -60,7 +60,7 @@ class TrimMultilineRawStringSpec {
                 val a = ${TQ}
                 >Hello world!
                 ${TQ}.trimMargin(">")
-            """
+        """
         subject.compileAndLint(code)
         assertThat(subject.findings).isEmpty()
     }
@@ -69,7 +69,7 @@ class TrimMultilineRawStringSpec {
     fun `don't raise one line raw strings`() {
         val code = """
                 val a = ${TQ}Hello world!${TQ}
-            """
+        """
         subject.compileAndLint(code)
         assertThat(subject.findings).isEmpty()
     }
@@ -78,7 +78,7 @@ class TrimMultilineRawStringSpec {
     fun `doesn't raise if it is not a raw string`() {
         val code = """
                 val a = "Hello world!"
-            """
+        """
         subject.compileAndLint(code)
         assertThat(subject.findings).isEmpty()
     }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/TrimMultilineRawStringSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/TrimMultilineRawStringSpec.kt
@@ -16,7 +16,7 @@ class TrimMultilineRawStringSpec {
                 val a = ${TQ}
                 Hello world!
                 ${TQ}
-        """
+        """.trimIndent()
         subject.compileAndLint(code)
         assertThat(subject.findings).hasSize(1)
     }
@@ -27,7 +27,7 @@ class TrimMultilineRawStringSpec {
                 val a = ${TQ}
                 Hello world!
                 ${TQ}.length
-        """
+        """.trimIndent()
         subject.compileAndLint(code)
         assertThat(subject.findings).hasSize(1)
     }
@@ -38,7 +38,7 @@ class TrimMultilineRawStringSpec {
                 val a = ${TQ}
                 Hello world!
                 ${TQ}.trimIndent()
-        """
+        """.trimIndent()
         subject.compileAndLint(code)
         assertThat(subject.findings).isEmpty()
     }
@@ -49,7 +49,7 @@ class TrimMultilineRawStringSpec {
                 val a = ${TQ}
                 |Hello world!
                 ${TQ}.trimMargin()
-        """
+        """.trimIndent()
         subject.compileAndLint(code)
         assertThat(subject.findings).isEmpty()
     }
@@ -60,7 +60,7 @@ class TrimMultilineRawStringSpec {
                 val a = ${TQ}
                 >Hello world!
                 ${TQ}.trimMargin(">")
-        """
+        """.trimIndent()
         subject.compileAndLint(code)
         assertThat(subject.findings).isEmpty()
     }
@@ -69,7 +69,7 @@ class TrimMultilineRawStringSpec {
     fun `don't raise one line raw strings`() {
         val code = """
                 val a = ${TQ}Hello world!${TQ}
-        """
+        """.trimIndent()
         subject.compileAndLint(code)
         assertThat(subject.findings).isEmpty()
     }
@@ -78,7 +78,7 @@ class TrimMultilineRawStringSpec {
     fun `doesn't raise if it is not a raw string`() {
         val code = """
                 val a = "Hello world!"
-        """
+        """.trimIndent()
         subject.compileAndLint(code)
         assertThat(subject.findings).isEmpty()
     }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiteralsSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiteralsSpec.kt
@@ -260,7 +260,7 @@ class UnderscoresInNumericLiteralsSpec {
             object TestSerializable : Serializable {
                 private val serialVersionUID = 314159L
             }
-        """
+        """.trimIndent()
 
         @Test
         fun `should not be reported`() {
@@ -275,7 +275,7 @@ class UnderscoresInNumericLiteralsSpec {
             object TestSerializable {
                 private val serialVersionUID = 314159L
             }
-        """
+        """.trimIndent()
 
         @Test
         fun `should be reported by default`() {
@@ -290,7 +290,7 @@ class UnderscoresInNumericLiteralsSpec {
             object TestSerializable {
                 private val serialVersionUID = 314_159L
             }
-        """
+        """.trimIndent()
 
         @Test
         fun `should not be reported`() {
@@ -312,7 +312,7 @@ class UnderscoresInNumericLiteralsSpec {
                         private const val serialVersionUID = -43857148126114372L
                     }
                 }
-            """
+            """.trimIndent()
             val findings = UnderscoresInNumericLiterals().compileAndLint(code)
             assertThat(findings).hasSize(0)
         }
@@ -327,7 +327,7 @@ class UnderscoresInNumericLiteralsSpec {
                         private const val serialVersionUID = 43857148126114372L
                     }
                 }
-            """
+            """.trimIndent()
             val findings = UnderscoresInNumericLiterals().compileAndLint(code)
             assertThat(findings).hasSize(0)
         }
@@ -344,7 +344,7 @@ class UnderscoresInNumericLiteralsSpec {
                 class Test : Serializable {
                     private val serialVersionUID = -43857148126114372L
                 }
-            """
+            """.trimIndent()
             val findings = UnderscoresInNumericLiterals().compileAndLint(code)
             assertThat(findings).hasSize(0)
         }
@@ -357,7 +357,7 @@ class UnderscoresInNumericLiteralsSpec {
                 class Test : Serializable {
                     private val serialVersionUID = 43857148126114372L
                 }
-            """
+            """.trimIndent()
             val findings = UnderscoresInNumericLiterals().compileAndLint(code)
             assertThat(findings).hasSize(0)
         }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAbstractClassSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAbstractClassSpec.kt
@@ -28,7 +28,7 @@ class UnnecessaryAbstractClassSpec(val env: KotlinCoreEnvironment) {
                     abstract fun f()
                     public abstract fun f2()
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertFindingMessage(findings, message)
             assertThat(findings).hasStartSourceLocation(1, 16)
@@ -72,7 +72,7 @@ class UnnecessaryAbstractClassSpec(val env: KotlinCoreEnvironment) {
                         val i: Int
                     }
                     abstract class B : A
-                """
+                """.trimIndent()
                 val findings = subject.compileAndLintWithContext(env, code)
                 assertFindingMessage(findings, message)
             }
@@ -85,7 +85,7 @@ class UnnecessaryAbstractClassSpec(val env: KotlinCoreEnvironment) {
                         abstract val i: Int
                     }
                     abstract class B : A()
-                """
+                """.trimIndent()
                 assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
             }
 
@@ -99,7 +99,7 @@ class UnnecessaryAbstractClassSpec(val env: KotlinCoreEnvironment) {
                     abstract val i: Int
                 }
                 abstract class B: A(), I
-                """
+                """.trimIndent()
                 val findings = subject.compileAndLintWithContext(env, code)
                 assertThat(findings).isEmpty()
             }
@@ -114,7 +114,7 @@ class UnnecessaryAbstractClassSpec(val env: KotlinCoreEnvironment) {
                     abstract val i: Int
                 }
                 abstract class B: I, A()
-                """
+                """.trimIndent()
                 val findings = subject.compileAndLintWithContext(env, code)
                 assertThat(findings).isEmpty()
             }
@@ -131,7 +131,7 @@ class UnnecessaryAbstractClassSpec(val env: KotlinCoreEnvironment) {
                 abstract class B : A() {
                     abstract fun g()
                 } 
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -141,7 +141,7 @@ class UnnecessaryAbstractClassSpec(val env: KotlinCoreEnvironment) {
                 abstract class A {
                     internal abstract fun f()
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -151,7 +151,7 @@ class UnnecessaryAbstractClassSpec(val env: KotlinCoreEnvironment) {
                 abstract class A {
                     protected abstract fun f()
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
     }
@@ -168,7 +168,7 @@ class UnnecessaryAbstractClassSpec(val env: KotlinCoreEnvironment) {
                     val i: Int = 0
                     fun f() {}
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertFindingMessage(findings, message)
         }
@@ -181,7 +181,7 @@ class UnnecessaryAbstractClassSpec(val env: KotlinCoreEnvironment) {
                         fun f() {}
                     }
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertFindingMessage(findings, message)
         }
@@ -194,7 +194,7 @@ class UnnecessaryAbstractClassSpec(val env: KotlinCoreEnvironment) {
                         fun f() {}
                     }
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertFindingMessage(findings, message)
         }
@@ -239,7 +239,7 @@ class UnnecessaryAbstractClassSpec(val env: KotlinCoreEnvironment) {
                 
                     fun g() {}
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertFindingMessage(findings, message)
         }
@@ -259,7 +259,7 @@ class UnnecessaryAbstractClassSpec(val env: KotlinCoreEnvironment) {
                 abstract class B : A() {
                     fun g() {}
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -273,7 +273,7 @@ class UnnecessaryAbstractClassSpec(val env: KotlinCoreEnvironment) {
                 abstract class B : A(0) {
                     fun g() {}
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -287,7 +287,7 @@ class UnnecessaryAbstractClassSpec(val env: KotlinCoreEnvironment) {
                 interface Interface {
                     fun f()
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -303,7 +303,7 @@ class UnnecessaryAbstractClassSpec(val env: KotlinCoreEnvironment) {
                 abstract class B {
                     abstract fun f()
                 } 
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -314,7 +314,7 @@ class UnnecessaryAbstractClassSpec(val env: KotlinCoreEnvironment) {
                     fun test(): Int
                 }
                 abstract class Test(val x: Int) : I
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
     }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAbstractClassSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAbstractClassSpec.kt
@@ -99,7 +99,7 @@ class UnnecessaryAbstractClassSpec(val env: KotlinCoreEnvironment) {
                     abstract val i: Int
                 }
                 abstract class B: A(), I
-            """
+                """
                 val findings = subject.compileAndLintWithContext(env, code)
                 assertThat(findings).isEmpty()
             }
@@ -114,7 +114,7 @@ class UnnecessaryAbstractClassSpec(val env: KotlinCoreEnvironment) {
                     abstract val i: Int
                 }
                 abstract class B: I, A()
-            """
+                """
                 val findings = subject.compileAndLintWithContext(env, code)
                 assertThat(findings).isEmpty()
             }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAnnotationUseSiteTargetSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAnnotationUseSiteTargetSpec.kt
@@ -14,7 +14,7 @@ class UnnecessaryAnnotationUseSiteTargetSpec {
             class C(@param:Asdf private val foo: String)
 
             annotation class Asdf
-        """
+        """.trimIndent()
         assertThat(UnnecessaryAnnotationUseSiteTarget().compileAndLint(code)).hasTextLocations("param:")
     }
 
@@ -25,7 +25,7 @@ class UnnecessaryAnnotationUseSiteTargetSpec {
             class C(@param:Asdf foo: String)
 
             annotation class Asdf
-        """
+        """.trimIndent()
         assertThat(UnnecessaryAnnotationUseSiteTarget().compileAndLint(code)).hasTextLocations("param:")
     }
 
@@ -36,7 +36,7 @@ class UnnecessaryAnnotationUseSiteTargetSpec {
             class C(@get:Asdf private val foo: String)
 
             annotation class Asdf
-        """
+        """.trimIndent()
         assertThat(UnnecessaryAnnotationUseSiteTarget().compileAndLint(code)).isEmpty()
     }
 
@@ -47,7 +47,7 @@ class UnnecessaryAnnotationUseSiteTargetSpec {
             class C(@property:Asdf private val foo: String)
 
             annotation class Asdf
-        """
+        """.trimIndent()
         assertThat(UnnecessaryAnnotationUseSiteTarget().compileAndLint(code)).isEmpty()
     }
 
@@ -60,7 +60,7 @@ class UnnecessaryAnnotationUseSiteTargetSpec {
             }
 
             annotation class Asdf
-        """
+        """.trimIndent()
         assertThat(UnnecessaryAnnotationUseSiteTarget().compileAndLint(code)).hasTextLocations("property:")
     }
 
@@ -71,7 +71,7 @@ class UnnecessaryAnnotationUseSiteTargetSpec {
             @property:Asdf private val foo: String = "bar"
 
             annotation class Asdf
-        """
+        """.trimIndent()
         assertThat(UnnecessaryAnnotationUseSiteTarget().compileAndLint(code)).hasTextLocations("property:")
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryApplySpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryApplySpec.kt
@@ -28,7 +28,7 @@ class UnnecessaryApplySpec(val env: KotlinCoreEnvironment) {
                         plus(1)
                     }
                 }
-                """
+                """.trimIndent()
             )
             assertThat(findings).hasSize(1)
             assertThat(findings.first().message).isEqualTo("apply expression can be omitted")
@@ -47,7 +47,7 @@ class UnnecessaryApplySpec(val env: KotlinCoreEnvironment) {
                         plus(1)
                     }
                 }
-                """
+                """.trimIndent()
             )
             assertThat(findings).hasSize(1)
             assertThat(findings.first().message).isEqualTo("apply can be replaced with let or an if")
@@ -67,7 +67,7 @@ class UnnecessaryApplySpec(val env: KotlinCoreEnvironment) {
                         b()
                     }
                 }
-                    """
+                    """.trimIndent()
                 )
             ).hasSize(1)
         }
@@ -84,7 +84,7 @@ class UnnecessaryApplySpec(val env: KotlinCoreEnvironment) {
                         plus(1)
                     })
                 }
-                    """
+                    """.trimIndent()
                 )
             ).isEmpty()
         }
@@ -103,7 +103,7 @@ class UnnecessaryApplySpec(val env: KotlinCoreEnvironment) {
                         toString()
                     })
                 }
-                    """
+                    """.trimIndent()
                 )
             ).isEmpty()
         }
@@ -130,7 +130,7 @@ class UnnecessaryApplySpec(val env: KotlinCoreEnvironment) {
                         }
                     )
                 }
-                    """
+                    """.trimIndent()
                 )
             ).isEmpty()
         }
@@ -144,7 +144,7 @@ class UnnecessaryApplySpec(val env: KotlinCoreEnvironment) {
                     val a = listOf(mutableListOf(""))
                                 .map { it.apply { add("") } }
                 }
-                    """
+                    """.trimIndent()
                 )
             ).isEmpty()
         }
@@ -172,7 +172,7 @@ class UnnecessaryApplySpec(val env: KotlinCoreEnvironment) {
                         plus(2)
                     })
                 }
-                    """
+                    """.trimIndent()
                 )
             ).isEmpty()
         }
@@ -193,7 +193,7 @@ class UnnecessaryApplySpec(val env: KotlinCoreEnvironment) {
                 class Bar {
                     fun bar() {}
                 }
-                """
+                """.trimIndent()
             )
             assertThat(findings).hasSize(1)
         }
@@ -214,7 +214,7 @@ class UnnecessaryApplySpec(val env: KotlinCoreEnvironment) {
                 class Bar {
                     fun bar() {}
                 }
-                """
+                """.trimIndent()
             )
             assertThat(findings).hasSize(1)
         }
@@ -229,7 +229,7 @@ class UnnecessaryApplySpec(val env: KotlinCoreEnvironment) {
                         this
                     }
                 }
-                """
+                """.trimIndent()
             )
             assertThat(findings).hasSize(1)
         }
@@ -253,7 +253,7 @@ class UnnecessaryApplySpec(val env: KotlinCoreEnvironment) {
                         prop = 1
                     }
                 }
-                    """
+                    """.trimIndent()
                 )
             ).hasSize(1)
         }
@@ -273,7 +273,7 @@ class UnnecessaryApplySpec(val env: KotlinCoreEnvironment) {
                         prop = 1
                     }
                 }
-                    """
+                    """.trimIndent()
                 )
             ).isEmpty()
         }
@@ -293,7 +293,7 @@ class UnnecessaryApplySpec(val env: KotlinCoreEnvironment) {
                 }
                 
                 val a = C().apply { f() }
-                    """
+                    """.trimIndent()
                 )
             ).isEmpty()
         }
@@ -307,7 +307,7 @@ class UnnecessaryApplySpec(val env: KotlinCoreEnvironment) {
                 class C(var prop: Int)
                 
                 fun Int.f() = C(5).apply { prop = 10 }
-                    """
+                    """.trimIndent()
                 )
             ).isEmpty()
         }
@@ -323,7 +323,7 @@ class UnnecessaryApplySpec(val env: KotlinCoreEnvironment) {
                         C(1).apply { prop = 3 }
                     }
                 }
-                    """
+                    """.trimIndent()
                 )
             ).isEmpty()
         }
@@ -337,7 +337,7 @@ class UnnecessaryApplySpec(val env: KotlinCoreEnvironment) {
                 class C(var prop: Int)
                 
                 fun f() = (C(5)).apply { prop = 10 }
-                    """
+                    """.trimIndent()
                 )
             ).isEmpty()
         }
@@ -354,7 +354,7 @@ class UnnecessaryApplySpec(val env: KotlinCoreEnvironment) {
                         ?.apply { if (true) 4 }
                         ?: listOf(0)
                 }
-                    """
+                    """.trimIndent()
                 )
             ).isEmpty()
         }
@@ -380,7 +380,7 @@ class UnnecessaryApplySpec(val env: KotlinCoreEnvironment) {
                         }
                     }
                 }
-                    """
+                    """.trimIndent()
                 )
             ).isEmpty()
         }
@@ -404,7 +404,7 @@ class UnnecessaryApplySpec(val env: KotlinCoreEnvironment) {
                         this.prop
                     }
                 }
-                    """
+                    """.trimIndent()
                 )
             ).hasSize(2)
         }
@@ -430,7 +430,7 @@ class UnnecessaryApplySpec(val env: KotlinCoreEnvironment) {
                         C()
                     }
                 }
-                    """
+                    """.trimIndent()
                 )
             ).isEmpty()
         }
@@ -455,7 +455,7 @@ class UnnecessaryApplySpec(val env: KotlinCoreEnvironment) {
                         C().apply { f() }
                     }
                 }
-                    """
+                    """.trimIndent()
                 )
             ).isEmpty()
         }
@@ -484,7 +484,7 @@ class UnnecessaryApplySpec(val env: KotlinCoreEnvironment) {
                         var baz = 1
                     }
 
-                    """
+                    """.trimIndent()
                 )
             ).isEmpty()
         }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryFilterSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryFilterSpec.kt
@@ -20,7 +20,7 @@ class UnnecessaryFilterSpec(val env: KotlinCoreEnvironment) {
                 val x = listOf(1, 2, 3)
                     .filter { it > 1 }
                     .size
-            """
+            """.trimIndent()
 
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
@@ -33,7 +33,7 @@ class UnnecessaryFilterSpec(val env: KotlinCoreEnvironment) {
                 val x = listOf(1, 2, 3)
                     .filter { it > 1 }
                     .count()
-            """
+            """.trimIndent()
 
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
@@ -47,7 +47,7 @@ class UnnecessaryFilterSpec(val env: KotlinCoreEnvironment) {
                     .map { it * 2 }
                     .filter { it > 1 }
                     .count()
-            """
+            """.trimIndent()
 
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
@@ -59,7 +59,7 @@ class UnnecessaryFilterSpec(val env: KotlinCoreEnvironment) {
                 val x = listOf(1, 2, 3)
                     .filter { it > 2 }
                     .isEmpty()
-            """
+            """.trimIndent()
 
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
@@ -71,7 +71,7 @@ class UnnecessaryFilterSpec(val env: KotlinCoreEnvironment) {
                 val x = listOf(1, 2, 3)
                     .filter { it > 2 }
                     .isNotEmpty()
-            """
+            """.trimIndent()
 
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
@@ -89,7 +89,7 @@ class UnnecessaryFilterSpec(val env: KotlinCoreEnvironment) {
                 
                 val x = listOf<Int>().count()
                 val y = listOf<Int>().filter { it > 0 }.count()
-            """
+            """.trimIndent()
 
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
@@ -104,7 +104,7 @@ class UnnecessaryFilterSpec(val env: KotlinCoreEnvironment) {
                 
                 val x = listOf<Int>().asSequence().count()
                 val y = listOf<Int>().asSequence().filter { it > 0 }.count()
-            """
+            """.trimIndent()
 
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
@@ -118,7 +118,7 @@ class UnnecessaryFilterSpec(val env: KotlinCoreEnvironment) {
                 }
                 
                 val x = filter().size
-            """
+            """.trimIndent()
 
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
@@ -129,7 +129,7 @@ class UnnecessaryFilterSpec(val env: KotlinCoreEnvironment) {
             val code = """
                 val x = listOf(1, 2, 3)
                     .count { it > 2 }
-            """
+            """.trimIndent()
 
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
@@ -140,7 +140,7 @@ class UnnecessaryFilterSpec(val env: KotlinCoreEnvironment) {
             val code = """
                 val x = listOf(1, 2, 3)
                     .none { it > 2 }
-            """
+            """.trimIndent()
 
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
@@ -151,7 +151,7 @@ class UnnecessaryFilterSpec(val env: KotlinCoreEnvironment) {
             val code = """
                 val x = listOf(1, 2, 3)
                     .any { it > 2 }
-            """
+            """.trimIndent()
 
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
@@ -164,7 +164,7 @@ class UnnecessaryFilterSpec(val env: KotlinCoreEnvironment) {
                     .asSequence()
                     .map { it * 2 }
                     .count { it > 1 }
-            """
+            """.trimIndent()
 
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
@@ -182,7 +182,7 @@ class UnnecessaryFilterSpec(val env: KotlinCoreEnvironment) {
                         println("more than two")
                     }
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
@@ -198,7 +198,7 @@ class UnnecessaryFilterSpec(val env: KotlinCoreEnvironment) {
                     b.isEmpty()
                     c.isNotEmpty()
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryInheritanceSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryInheritanceSpec.kt
@@ -14,7 +14,7 @@ class UnnecessaryInheritanceSpec {
             """
             class A : Any()
             class B : Object()
-            """
+            """.trimIndent()
         )
         assertThat(findings).hasSize(2)
     }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLetSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLetSpec.kt
@@ -22,7 +22,7 @@ class UnnecessaryLetSpec(val env: KotlinCoreEnvironment) {
                 a.let { it.plus(1) }
                 a.let { that -> that.plus(1) }
             }
-            """
+            """.trimIndent()
         )
         assertThat(findings).hasSize(2)
         assertThat(findings).allMatch { it.message == MESSAGE_OMIT_LET }
@@ -38,7 +38,7 @@ class UnnecessaryLetSpec(val env: KotlinCoreEnvironment) {
                 a?.let { it.plus(1) }
                 a?.let { that -> that.plus(1) }
             }
-            """
+            """.trimIndent()
         )
         assertThat(findings).hasSize(2)
         assertThat(findings).allMatch { it.message == MESSAGE_OMIT_LET }
@@ -54,7 +54,7 @@ class UnnecessaryLetSpec(val env: KotlinCoreEnvironment) {
                 a?.let { it?.plus(1) }
                 a?.let { that -> that?.plus(1) }
             }
-            """
+            """.trimIndent()
         )
         assertThat(findings).hasSize(2)
         assertThat(findings).allMatch { it.message == MESSAGE_OMIT_LET }
@@ -69,7 +69,7 @@ class UnnecessaryLetSpec(val env: KotlinCoreEnvironment) {
                 val a: Int? = null
                 a?.let { that -> that.plus(1) }?.let { it.plus(1) }
             }
-            """
+            """.trimIndent()
         )
         assertThat(findings).hasSize(2)
         assertThat(findings).allMatch { it.message == MESSAGE_OMIT_LET }
@@ -85,7 +85,7 @@ class UnnecessaryLetSpec(val env: KotlinCoreEnvironment) {
                 a.let { 1.plus(1) }
                 a.let { that -> 1.plus(1) }
             }
-            """
+            """.trimIndent()
         )
         assertThat(findings).hasSize(2)
         assertThat(findings).allMatch { it.message == MESSAGE_OMIT_LET }
@@ -101,7 +101,7 @@ class UnnecessaryLetSpec(val env: KotlinCoreEnvironment) {
                 val x = a.let { 1.plus(1) }
                 val y = a.let { that -> 1.plus(1) }
             }
-            """
+            """.trimIndent()
         )
         assertThat(findings).hasSize(2)
         assertThat(findings).allMatch { it.message == MESSAGE_OMIT_LET }
@@ -117,7 +117,7 @@ class UnnecessaryLetSpec(val env: KotlinCoreEnvironment) {
                 a?.let { 1.plus(1) }
                 a?.let { that -> 1.plus(1) }
             }
-            """
+            """.trimIndent()
         )
         assertThat(findings).hasSize(2)
         assertThat(findings).allMatch { it.message == MESSAGE_USE_IF }
@@ -133,7 +133,7 @@ class UnnecessaryLetSpec(val env: KotlinCoreEnvironment) {
                 a.let { print(it) }
                 a.let { that -> print(that) }
             }
-            """
+            """.trimIndent()
         )
         assertThat(findings).hasSize(2)
         assertThat(findings).allMatch { it.message == MESSAGE_OMIT_LET }
@@ -149,7 +149,7 @@ class UnnecessaryLetSpec(val env: KotlinCoreEnvironment) {
                 val a: Int? = null
                 a.let(f)
             }
-            """
+            """.trimIndent()
         )
         assertThat(findings).hasSize(1)
         assertThat(findings).allMatch { it.message == MESSAGE_OMIT_LET }
@@ -165,7 +165,7 @@ class UnnecessaryLetSpec(val env: KotlinCoreEnvironment) {
                 a?.let { print(it) }
                 a?.let { that -> 1.plus(that) }
             }
-            """
+            """.trimIndent()
         )
         assertThat(findings).isEmpty()
     }
@@ -179,7 +179,7 @@ class UnnecessaryLetSpec(val env: KotlinCoreEnvironment) {
                 val a: Int? = null
                 a?.let { that -> 1.plus(that) }?.let { print(it) }
             }
-            """
+            """.trimIndent()
         )
         assertThat(findings).isEmpty()
     }
@@ -194,7 +194,7 @@ class UnnecessaryLetSpec(val env: KotlinCoreEnvironment) {
                 val x = a?.let { 1.plus(1) }
                 val y = a?.let { that -> 1.plus(1) }
             }
-            """
+            """.trimIndent()
         )
         assertThat(findings).isEmpty()
     }
@@ -208,7 +208,7 @@ class UnnecessaryLetSpec(val env: KotlinCoreEnvironment) {
                 val a = listOf<List<String>?>(listOf(""))
                     .map { list -> list?.let { it + it } }
             }
-            """
+            """.trimIndent()
         )
         assertThat(findings).isEmpty()
     }
@@ -223,7 +223,7 @@ class UnnecessaryLetSpec(val env: KotlinCoreEnvironment) {
                 val a: Int? = null
                 a?.let(f)
             }
-            """
+            """.trimIndent()
         )
         assertThat(findings).hasSize(0)
     }
@@ -260,7 +260,7 @@ class UnnecessaryLetSpec(val env: KotlinCoreEnvironment) {
                     it.plus(2)
                 }
             }
-            """
+            """.trimIndent()
         )
         assertThat(findings).isEmpty()
     }
@@ -278,7 +278,7 @@ class UnnecessaryLetSpec(val env: KotlinCoreEnvironment) {
                 a?.let { foo -> foo.plus(foo) }
                 b.let { foo -> foo.plus(foo) }
             }
-            """
+            """.trimIndent()
         )
         assertThat(findings).isEmpty()
     }
@@ -293,7 +293,7 @@ class UnnecessaryLetSpec(val env: KotlinCoreEnvironment) {
             fun test(foo: Foo) {
                 foo.let { (a, b) -> a + b }
             }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, content)
             assertThat(findings).isEmpty()
         }
@@ -306,7 +306,7 @@ class UnnecessaryLetSpec(val env: KotlinCoreEnvironment) {
             fun test(foo: Foo) {
                 foo.let { (a, _) -> a + a }
             }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, content)
             assertThat(findings).isEmpty()
         }
@@ -319,7 +319,7 @@ class UnnecessaryLetSpec(val env: KotlinCoreEnvironment) {
             fun test(foo: Foo) {
                 foo.let { (a: Int, b: Int) -> a + b }
             }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, content)
             assertThat(findings).isEmpty()
         }
@@ -332,7 +332,7 @@ class UnnecessaryLetSpec(val env: KotlinCoreEnvironment) {
             fun test(foo: Foo) {
                 foo.let { (a, _) -> a }
             }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, content)
             assertThat(findings).hasSize(1)
             assertThat(findings).allMatch { it.message == MESSAGE_OMIT_LET }
@@ -346,7 +346,7 @@ class UnnecessaryLetSpec(val env: KotlinCoreEnvironment) {
             fun test(foo: Foo?) {
                 foo?.let { (_, b) -> b.plus(1) }
             }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, content)
             assertThat(findings).hasSize(1)
             assertThat(findings).allMatch { it.message == MESSAGE_OMIT_LET }
@@ -360,7 +360,7 @@ class UnnecessaryLetSpec(val env: KotlinCoreEnvironment) {
             fun test(foo: Foo) {
                 foo.let { (_, _) -> 0 }
             }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, content)
             assertThat(findings).hasSize(1)
             assertThat(findings).allMatch { it.message == MESSAGE_OMIT_LET }
@@ -374,7 +374,7 @@ class UnnecessaryLetSpec(val env: KotlinCoreEnvironment) {
             fun test(foo: Foo?) {
                 foo?.let { (_, _) -> 0 }
             }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, content)
             assertThat(findings).hasSize(1)
             assertThat(findings).allMatch { it.message == MESSAGE_USE_IF }
@@ -389,7 +389,7 @@ class UnnecessaryLetSpec(val env: KotlinCoreEnvironment) {
                     listOf(1).map { it }
                 }
             }
-        """
+        """.trimIndent()
         val findings = subject.compileAndLintWithContext(env, content)
         assertThat(findings).hasSize(1)
         assertThat(findings).allMatch { it.message == MESSAGE_USE_IF }
@@ -409,7 +409,7 @@ class UnnecessaryLetSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             }
-        """
+        """.trimIndent()
         val findings = subject.compileAndLintWithContext(env, content)
         assertThat(findings).isEmpty()
     }
@@ -424,7 +424,7 @@ class UnnecessaryLetSpec(val env: KotlinCoreEnvironment) {
                     that(42)
                 }
             }
-            """
+            """.trimIndent()
         )
         assertThat(findings).isEmpty()
     }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryParenthesesSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryParenthesesSpec.kt
@@ -43,7 +43,7 @@ class UnnecessaryParenthesesSpec {
                     println("Test")
                 }
             }
-        """
+        """.trimIndent()
 
         assertThat(testCase.rule.lint(code)).hasSize(1)
     }
@@ -59,7 +59,7 @@ class UnnecessaryParenthesesSpec {
             fun test() {
                 function({ input -> println(input) })
             }
-        """
+        """.trimIndent()
 
         assertThat(testCase.rule.lint(code)).isEmpty()
     }
@@ -75,7 +75,7 @@ class UnnecessaryParenthesesSpec {
             fun test() {
                 function(1, { input -> println(input) })
             }
-        """
+        """.trimIndent()
 
         assertThat(testCase.rule.lint(code)).isEmpty()
     }
@@ -87,7 +87,7 @@ class UnnecessaryParenthesesSpec {
             fun f() {
                 instance.copy(value = { false })
             }
-        """
+        """.trimIndent()
 
         assertThat(testCase.rule.lint(code)).isEmpty()
     }
@@ -101,7 +101,7 @@ class UnnecessaryParenthesesSpec {
                     println("Test")
                 }
             }
-        """
+        """.trimIndent()
 
         assertThat(testCase.rule.lint(code)).isEmpty()
     }
@@ -116,7 +116,7 @@ class UnnecessaryParenthesesSpec {
                     }
                 }
             })
-        """
+        """.trimIndent()
 
         assertThat(testCase.rule.lint(code)).isEmpty()
     }
@@ -131,7 +131,7 @@ class UnnecessaryParenthesesSpec {
                     }
                 }
             })
-        """
+        """.trimIndent()
 
         assertThat(testCase.rule.lint(code)).isEmpty()
     }
@@ -145,7 +145,7 @@ class UnnecessaryParenthesesSpec {
             ) {
                 constructor() : this({ first, second -> true })
             }
-        """
+        """.trimIndent()
 
         assertThat(testCase.rule.lint(code)).isEmpty()
     }
@@ -164,7 +164,7 @@ class UnnecessaryParenthesesSpec {
                     test({ println(it) }) { println(it) }
                 }
             }
-        """
+        """.trimIndent()
 
         assertThat(testCase.rule.lint(code)).isEmpty()
     }
@@ -183,7 +183,7 @@ class UnnecessaryParenthesesSpec {
                     test({ println(it) }, { println(it) })
                 }
             }
-        """
+        """.trimIndent()
 
         assertThat(testCase.rule.lint(code)).isEmpty()
     }
@@ -204,7 +204,7 @@ class UnnecessaryParenthesesSpec {
                     test("hello", { println(it) }) { println(it) }
                 }
             }
-        """
+        """.trimIndent()
 
         assertThat(testCase.rule.lint(code)).isEmpty()
     }
@@ -214,7 +214,7 @@ class UnnecessaryParenthesesSpec {
     fun `should not report interface delegation with parenthesis - #3851`(testCase: RuleTestCase) {
         val code = """
             class Clazz: Comparable<String> by ("hello".filter { it != 'l' })
-        """
+        """.trimIndent()
 
         assertThat(testCase.rule.lint(code)).isEmpty()
     }
@@ -232,7 +232,7 @@ class UnnecessaryParenthesesSpec {
             val b3 = 3 + (1 % 2)
 
             val c = (4 + 5) * 3 // parens required
-        """
+        """.trimIndent()
 
         assertThat(testCase.rule.lint(code)).hasSize(if (testCase.allowForUnclearPrecedence) 0 else 6)
     }
@@ -246,7 +246,7 @@ class UnnecessaryParenthesesSpec {
             val a3 = (1 + 2 * 3)
             val b1 = (1 + 2) + 3
             val b2 = (1 * 2) * 3
-        """
+        """.trimIndent()
 
         assertThat(testCase.rule.lint(code)).hasSize(5)
     }
@@ -259,7 +259,7 @@ class UnnecessaryParenthesesSpec {
             val a2 = (true && false) || (false && true) // 2 warnings when disallowed
             val b = false || (true && false)
             val c = (true || false) && false // parens required
-        """
+        """.trimIndent()
 
         assertThat(testCase.rule.lint(code)).hasSize(if (testCase.allowForUnclearPrecedence) 0 else 4)
     }
@@ -273,7 +273,7 @@ class UnnecessaryParenthesesSpec {
             val a3 = (true && false || false)
             val b1 = (true && false) && false
             val b2 = (true || false) || false
-        """
+        """.trimIndent()
 
         assertThat(testCase.rule.lint(code)).hasSize(5)
     }
@@ -284,7 +284,7 @@ class UnnecessaryParenthesesSpec {
         val code = """
             val d = (true and false) or false
             val e = false or (true and false) // parens required
-        """
+        """.trimIndent()
 
         assertThat(testCase.rule.lint(code)).hasSize(if (testCase.allowForUnclearPrecedence) 0 else 1)
     }
@@ -304,7 +304,7 @@ class UnnecessaryParenthesesSpec {
 
             val d1 = null ?: (1 in 2) // parens required
             val d2 = (null ?: 1) in 2
-        """
+        """.trimIndent()
 
         assertThat(testCase.rule.lint(code)).hasSize(if (testCase.allowForUnclearPrecedence) 0 else 4)
     }
@@ -317,7 +317,7 @@ class UnnecessaryParenthesesSpec {
             val b = (1 / 2)..(3 * 4)
             val c = (1 ?: 2)..(3 ?: 4) // parens required
             val d = (1 to 2)..(3 to 4) // parens required
-        """
+        """.trimIndent()
 
         assertThat(testCase.rule.lint(code)).hasSize(if (testCase.allowForUnclearPrecedence) 0 else 4)
     }
@@ -327,7 +327,7 @@ class UnnecessaryParenthesesSpec {
     fun `multiple wrapping parentheses`(testCase: RuleTestCase) {
         val code = """
             val a = ((false || (((true && false)))))
-        """
+        """.trimIndent()
 
         assertThat(testCase.rule.lint(code)).hasSize(if (testCase.allowForUnclearPrecedence) 4 else 5)
     }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UntilInsteadOfRangeToSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UntilInsteadOfRangeToSpec.kt
@@ -16,7 +16,7 @@ class UntilInsteadOfRangeToSpec {
             fun f() {
                 for (i in 0 .. 10 - 1) {}
             }
-        """
+        """.trimIndent()
         val findings = subject.lint(code)
         assertThat(findings).hasSize(1)
         assertThat(findings[0]).hasMessage("'..' call can be replaced with 'until'")
@@ -29,7 +29,7 @@ class UntilInsteadOfRangeToSpec {
                 for (i in 0 until 10 - 1) {}
                 for (i in 10 downTo 2 - 1) {}
             }
-        """
+        """.trimIndent()
         assertThat(subject.lint(code)).isEmpty()
     }
 
@@ -39,7 +39,7 @@ class UntilInsteadOfRangeToSpec {
             fun f() {
                 for (i in 0 .. 10) {}
             }
-        """
+        """.trimIndent()
         assertThat(subject.lint(code)).isEmpty()
     }
 
@@ -50,7 +50,7 @@ class UntilInsteadOfRangeToSpec {
                 for (i in 0 .. 10 + 1) {}
                 for (i in 0 .. 10 - 2) {}
             }
-        """
+        """.trimIndent()
         assertThat(subject.lint(code)).isEmpty()
     }
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedImportsSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedImportsSpec.kt
@@ -23,12 +23,12 @@ class UnusedImportsSpec(val env: KotlinCoreEnvironment) {
                 } success {
                 }
             }
-        """
+        """.trimIndent()
         val additional = """
             package tasks
 
             infix fun Int.success(f: () -> Unit) {}
-        """
+        """.trimIndent()
         assertThat(subject.lintWithContext(env, main, additional)).isEmpty()
     }
 
@@ -52,14 +52,14 @@ class UnusedImportsSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             }
-        """
+        """.trimIndent()
         val additional = """
             package tasks
 
             infix fun Int.success(f: () -> Unit) {}
             infix fun Int.failure(f: () -> Unit) {}
             infix fun Int.undefined(f: () -> Unit) {}
-        """
+        """.trimIndent()
         assertThat(subject.lintWithContext(env, main, additional)).isEmpty()
     }
 
@@ -80,14 +80,14 @@ class UnusedImportsSpec(val env: KotlinCoreEnvironment) {
                 } success {
                 }
             }                
-        """
+        """.trimIndent()
         val additional = """
             package tasks
             
             infix fun Int.success(f: () -> Unit) {}
             infix fun Int.failure(f: () -> Unit) {}
             infix fun Int.undefined(f: () -> Unit) {}
-        """
+        """.trimIndent()
         val lint = subject.lintWithContext(env, main, additional)
         with(lint) {
             assertThat(this).hasSize(1)
@@ -102,12 +102,12 @@ class UnusedImportsSpec(val env: KotlinCoreEnvironment) {
             import test.SomeClass
 
             val a: SomeClass? = null
-        """
+        """.trimIndent()
         val additional = """
             package test
 
             class SomeClass
-        """
+        """.trimIndent()
         val lint = subject.lintWithContext(env, main, additional)
         with(lint) {
             assertThat(this).hasSize(1)
@@ -130,14 +130,14 @@ class UnusedImportsSpec(val env: KotlinCoreEnvironment) {
                     TODO()
                 }
             }
-        """
+        """.trimIndent()
         val additional = """
             package android.text
 
             class TextWatcher {
                 fun beforeTextChanged() {}
             }                
-        """
+        """.trimIndent()
         assertThat(subject.lintWithContext(env, main, additional)).isEmpty()
     }
 
@@ -162,7 +162,7 @@ class UnusedImportsSpec(val env: KotlinCoreEnvironment) {
             }
 
             fun fn(s: String) {}
-        """
+        """.trimIndent()
         val p = """
             package p
 
@@ -173,20 +173,20 @@ class UnusedImportsSpec(val env: KotlinCoreEnvironment) {
                 fun call() {}
             }
             class D
-        """
+        """.trimIndent()
         val p2 = """
             package p2
 
             object B {
                 const val NAME = ""
             }
-        """
+        """.trimIndent()
         val escaped = """
             package escaped
 
             fun `when`() {}
             fun `foo`() {}
-        """
+        """.trimIndent()
         val lint = subject.lintWithContext(env, main, p, p2, escaped)
         with(lint) {
             assertThat(this).hasSize(3)
@@ -206,14 +206,14 @@ class UnusedImportsSpec(val env: KotlinCoreEnvironment) {
             open class Something<T>
             
             class Foo : Something<Inner>()                
-        """
+        """.trimIndent()
         val additional = """
             package test
             
             class Outer {
                 class Inner
             }
-        """
+        """.trimIndent()
         val lint = subject.lintWithContext(env, main, additional)
         with(lint) {
             assertThat(this).isEmpty()
@@ -230,12 +230,12 @@ class UnusedImportsSpec(val env: KotlinCoreEnvironment) {
              * @see success
              */
             fun doSomething()
-        """
+        """.trimIndent()
         val additional = """
             package tasks
 
             fun success() {}
-        """
+        """.trimIndent()
         assertThat(subject.lintWithContext(env, main, additional)).isEmpty()
     }
 
@@ -249,12 +249,12 @@ class UnusedImportsSpec(val env: KotlinCoreEnvironment) {
              * @see success something
              */
             fun doSomething() {}
-        """
+        """.trimIndent()
         val additional = """
             package tasks
 
             fun success() {}
-        """
+        """.trimIndent()
         assertThat(subject.lintWithContext(env, main, additional)).isEmpty()
     }
 
@@ -268,12 +268,12 @@ class UnusedImportsSpec(val env: KotlinCoreEnvironment) {
              * @see something
              */
             fun doSomething() {}
-        """
+        """.trimIndent()
         val additional = """
             package tasks
 
             fun success() {}
-        """
+        """.trimIndent()
         assertThat(subject.lintWithContext(env, main, additional)).hasSize(1)
     }
 
@@ -287,12 +287,12 @@ class UnusedImportsSpec(val env: KotlinCoreEnvironment) {
              * @see something success
              */
             fun doSomething() {}
-        """
+        """.trimIndent()
         val additional = """
             package tasks
 
             fun success() {}
-        """
+        """.trimIndent()
         assertThat(subject.lintWithContext(env, main, additional)).hasSize(1)
     }
 
@@ -310,13 +310,13 @@ class UnusedImportsSpec(val env: KotlinCoreEnvironment) {
              * @sample success when ...
              */
             fun doSomething() {}
-        """
+        """.trimIndent()
         val additional = """
             package tasks
 
             fun success() {}
             fun undefined() {}
-        """
+        """.trimIndent()
         assertThat(subject.lintWithContext(env, main, additional)).isEmpty()
     }
 
@@ -325,11 +325,11 @@ class UnusedImportsSpec(val env: KotlinCoreEnvironment) {
         val main = """
             import test.forEach as foreach
             fun foo() = listOf().iterator().foreach {}
-        """
+        """.trimIndent()
         val additional = """
             package test
             fun Iterator<Int>.forEach(f: () -> Unit) {}
-        """
+        """.trimIndent()
         assertThat(subject.lintWithContext(env, main, additional)).isEmpty()
     }
 
@@ -344,15 +344,15 @@ class UnusedImportsSpec(val env: KotlinCoreEnvironment) {
             fun f(): Boolean {
                 return myFoo() == otherFoo()
             }
-        """
+        """.trimIndent()
         val additional1 = """
             package com.example
             fun foo() = 1                
-        """
+        """.trimIndent()
         val additional2 = """
             package com.example.other
             fun foo() = 1                
-        """
+        """.trimIndent()
         assertThat(subject.lintWithContext(env, main, additional1, additional2)).isEmpty()
     }
 
@@ -365,7 +365,7 @@ class UnusedImportsSpec(val env: KotlinCoreEnvironment) {
             class DumpVersionProperties {
                 private val dumpVersionProperties by Foo()
             }                
-        """
+        """.trimIndent()
         val additional = """
             package org.gradle.kotlin.dsl
             
@@ -377,7 +377,7 @@ class UnusedImportsSpec(val env: KotlinCoreEnvironment) {
                 thisRef: T,
                 prop: KProperty<*>
             ) = lazy { "" }                
-        """
+        """.trimIndent()
         assertThat(subject.lintWithContext(env, main, additional)).isEmpty()
     }
 
@@ -391,11 +391,11 @@ class UnusedImportsSpec(val env: KotlinCoreEnvironment) {
             fun test() {
                 val (a, b) = MyClass(1, 2)
             }
-        """
+        """.trimIndent()
         val additional = """
             package com.example
             data class MyClass(val a: Int, val b: Int)                
-        """
+        """.trimIndent()
 
         assertThat(subject.lintWithContext(env, main, additional)).isEmpty()
     }
@@ -411,17 +411,17 @@ class UnusedImportsSpec(val env: KotlinCoreEnvironment) {
             fun test() {
                 println("Testing")
             }
-        """
+        """.trimIndent()
         val additional1 = """
             package com.example
             class TestComponent
             fun components() {}
             fun component1AndSomethingElse() {}
-        """
+        """.trimIndent()
         val additional2 = """
             package com.example.component1
             class Unused
-        """
+        """.trimIndent()
         val lint = subject.lintWithContext(env, main, additional1, additional2)
 
         with(lint) {
@@ -441,15 +441,15 @@ class UnusedImportsSpec(val env: KotlinCoreEnvironment) {
             fun main() {
                 test(1)
             }      
-        """
+        """.trimIndent()
         val additionalFile1 = """
             package foo
             fun test(i: Int) {}
-        """
+        """.trimIndent()
         val additionalFile2 = """
             package bar
             fun test(s: String) {}
-        """
+        """.trimIndent()
         val findings = subject.lintWithContext(env, mainFile, additionalFile1, additionalFile2)
         assertThat(findings).hasSize(1)
         assertThat(findings[0].entity.signature).endsWith("import bar.test")
@@ -462,7 +462,7 @@ class UnusedImportsSpec(val env: KotlinCoreEnvironment) {
             
             fun doesNothing(thing: HashMap<String, String>) {
             }
-        """
+        """.trimIndent()
         val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
@@ -477,7 +477,7 @@ class UnusedImportsSpec(val env: KotlinCoreEnvironment) {
             
             @Ann(HashMap::class)
             fun foo() {}
-        """
+        """.trimIndent()
         val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
@@ -488,12 +488,12 @@ class UnusedImportsSpec(val env: KotlinCoreEnvironment) {
             import x.y.z.Foo
             
             val foo = Foo()
-        """
+        """.trimIndent()
         val additionalFile = """
             package x.y.z
             
             class Foo
-        """
+        """.trimIndent()
         val findings = subject.lintWithContext(env, mainFile, additionalFile)
         assertThat(findings).isEmpty()
     }
@@ -505,12 +505,12 @@ class UnusedImportsSpec(val env: KotlinCoreEnvironment) {
 
             @Ann
             fun foo() {}
-        """
+        """.trimIndent()
         val additionalFile = """
             package x.y.z
             
             annotation class Ann
-        """
+        """.trimIndent()
         val findings = subject.lintWithContext(env, mainFile, additionalFile)
         assertThat(findings).isEmpty()
     }
@@ -521,14 +521,14 @@ class UnusedImportsSpec(val env: KotlinCoreEnvironment) {
             import x.y.z.Foo
             
             val x = Foo
-        """
+        """.trimIndent()
         val additionalFile = """
             package x.y.z
             
             class Foo {
                 companion object
             }
-        """
+        """.trimIndent()
         val findings = subject.lintWithContext(env, mainFile, additionalFile)
         assertThat(findings).isEmpty()
     }
@@ -539,7 +539,7 @@ class UnusedImportsSpec(val env: KotlinCoreEnvironment) {
             import x.y.z.Foo
             
             val x = Foo.create()
-        """
+        """.trimIndent()
         val additionalFile = """
             package x.y.z
             
@@ -548,7 +548,7 @@ class UnusedImportsSpec(val env: KotlinCoreEnvironment) {
                     fun create(): Foo = Foo()
                 }
             }
-        """
+        """.trimIndent()
         val findings = subject.lintWithContext(env, mainFile, additionalFile)
         assertThat(findings).isEmpty()
     }
@@ -559,7 +559,7 @@ class UnusedImportsSpec(val env: KotlinCoreEnvironment) {
             import x.y.z.Foo
             
             val x = Foo.BAR
-        """
+        """.trimIndent()
         val additionalFile = """
             package x.y.z
             
@@ -568,7 +568,7 @@ class UnusedImportsSpec(val env: KotlinCoreEnvironment) {
                     const val BAR = 1
                 }
             }
-        """
+        """.trimIndent()
         val findings = subject.lintWithContext(env, mainFile, additionalFile)
         assertThat(findings).isEmpty()
     }
@@ -579,14 +579,14 @@ class UnusedImportsSpec(val env: KotlinCoreEnvironment) {
             import x.y.z.FetchType
             
             val x = FetchType.LAZY
-        """
+        """.trimIndent()
         val additionalFile = """
             package x.y.z
             
             enum class FetchType {
                 LAZY
             }
-        """
+        """.trimIndent()
         assertThat(subject.lintWithContext(env, mainFile, additionalFile)).isEmpty()
     }
 
@@ -600,13 +600,13 @@ class UnusedImportsSpec(val env: KotlinCoreEnvironment) {
                 @AnnotationB(attribute = AnnotationA())
                 val someProp: Int = 42
             }
-        """
+        """.trimIndent()
         val additionalFile = """
             package x.y.z
             
             annotation class AnnotationA
             annotation class AnnotationB(val attribute: AnnotationA)
-        """
+        """.trimIndent()
         assertThat(subject.lintWithContext(env, mainFile, additionalFile)).isEmpty()
     }
 
@@ -624,13 +624,13 @@ class UnusedImportsSpec(val env: KotlinCoreEnvironment) {
          * @property someVal Someval for [SomeClass]
          */
          data class StyleClass(val someVal: String)
-        """
+        """.trimIndent()
 
         val additionalFile = """
         package x.y.z
 
         class SomeClass
-        """
+        """.trimIndent()
 
         assertThat(subject.lintWithContext(env, mainFile, additionalFile)).isEmpty()
     }
@@ -648,7 +648,7 @@ class UnusedImportsSpec(val env: KotlinCoreEnvironment) {
 
             Bar().baz()
         }
-        """
+        """.trimIndent()
 
         assertThat(subject.lintWithContext(env, mainFile)).isEmpty()
     }
@@ -662,7 +662,7 @@ class UnusedImportsSpec(val env: KotlinCoreEnvironment) {
         fun test() {
             2 + 3
         }
-        """
+        """.trimIndent()
 
         assertThat(subject.lintWithContext(env, mainFile)).hasSize(2)
     }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateClassSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateClassSpec.kt
@@ -18,7 +18,7 @@ class UnusedPrivateClassSpec {
             val code = """
                 private interface Foo
                 class Bar
-            """
+            """.trimIndent()
 
             val findings = subject.compileAndLint(code)
 
@@ -34,7 +34,7 @@ class UnusedPrivateClassSpec {
                 val code = """
                 private class Foo
                 class Bar
-                """
+                """.trimIndent()
 
                 val findings = subject.compileAndLint(code)
 
@@ -47,7 +47,7 @@ class UnusedPrivateClassSpec {
                 val code = """
                 private open class Foo
                 private class Bar : Foo()
-                """
+                """.trimIndent()
 
                 val findings = subject.compileAndLint(code)
 
@@ -66,7 +66,7 @@ class UnusedPrivateClassSpec {
                 data class FooOne(val b: Bar) : Foo<Bar> {
                     override fun invoke(b: Bar): Unit = Unit
                 }
-                """
+                """.trimIndent()
 
                 val findings = subject.compileAndLint(code)
 
@@ -81,7 +81,7 @@ class UnusedPrivateClassSpec {
                 fun something() {
                     val foo: Foo = Foo()
                 }
-            """
+            """.trimIndent()
 
             val findings = subject.compileAndLint(code)
 
@@ -95,7 +95,7 @@ class UnusedPrivateClassSpec {
                 private object Bar {
                   fun bar(foo: Foo) = Unit
                 }
-            """
+            """.trimIndent()
 
             val findings = subject.compileAndLint(code)
 
@@ -107,7 +107,7 @@ class UnusedPrivateClassSpec {
             val code = """
                 private class Foo
                 private val a: Foo? = null
-            """
+            """.trimIndent()
 
             val findings = subject.compileAndLint(code)
 
@@ -119,7 +119,7 @@ class UnusedPrivateClassSpec {
             val code = """
                 private class Foo
                 private lateinit var a: Foo
-            """
+            """.trimIndent()
 
             val findings = subject.compileAndLint(code)
 
@@ -131,7 +131,7 @@ class UnusedPrivateClassSpec {
             val code = """
                 private class Foo
                 private lateinit var foos: List<Foo>
-            """
+            """.trimIndent()
 
             val findings = subject.compileAndLint(code)
 
@@ -143,7 +143,7 @@ class UnusedPrivateClassSpec {
             val code = """
                 private val elements = listOf(42).filterIsInstance<Set<Item>>()
                 private class Item
-            """
+            """.trimIndent()
 
             val findings = subject.compileAndLint(code)
 
@@ -155,7 +155,7 @@ class UnusedPrivateClassSpec {
             val code = """
                 private val elements = listOf(42).filterIsInstance<Something<Int>>()
                 private abstract class Something<E>: Collection<E>
-            """
+            """.trimIndent()
 
             val findings = subject.compileAndLint(code)
 
@@ -171,7 +171,7 @@ class UnusedPrivateClassSpec {
                 fun <T> bar(): T {
                     throw Exception()
                 }
-            """
+            """.trimIndent()
 
             val findings = subject.compileAndLint(code)
 
@@ -183,7 +183,7 @@ class UnusedPrivateClassSpec {
             val code = """
                 private class Foo
                 private lateinit var foos: List<List<Foo>>
-            """
+            """.trimIndent()
 
             val findings = subject.compileAndLint(code)
 
@@ -195,7 +195,7 @@ class UnusedPrivateClassSpec {
             val code = """
                 private class Foo<T>
                 private lateinit var foos: Foo<String>
-            """
+            """.trimIndent()
 
             val findings = subject.compileAndLint(code)
 
@@ -207,7 +207,7 @@ class UnusedPrivateClassSpec {
             val code = """
                 private class Foo<T>
                 private var foos: Foo<String>? = Foo()
-            """
+            """.trimIndent()
 
             val findings = subject.compileAndLint(code)
 
@@ -219,7 +219,7 @@ class UnusedPrivateClassSpec {
             val code = """
                 private class Foo
                 private val a = Foo()
-            """
+            """.trimIndent()
 
             val findings = subject.compileAndLint(code)
 
@@ -231,7 +231,7 @@ class UnusedPrivateClassSpec {
             val code = """
                 private class Foo(val a: String)
                 private val a = Foo("test")
-            """
+            """.trimIndent()
 
             val findings = subject.compileAndLint(code)
 
@@ -245,7 +245,7 @@ class UnusedPrivateClassSpec {
                 private object Bar {
                   fun foo(): Foo? = null
                 }
-            """
+            """.trimIndent()
 
             val findings = subject.compileAndLint(code)
 
@@ -257,7 +257,7 @@ class UnusedPrivateClassSpec {
             val code = """
                 private class Foo
                 private val lambda: ((Foo) -> Unit)? = null
-            """
+            """.trimIndent()
 
             val findings = subject.compileAndLint(code)
 
@@ -269,7 +269,7 @@ class UnusedPrivateClassSpec {
             val code = """
                 private class Foo
                 private val lambda: (() -> Foo)? = null
-            """
+            """.trimIndent()
 
             val findings = subject.compileAndLint(code)
 
@@ -281,7 +281,7 @@ class UnusedPrivateClassSpec {
             val code = """
                 private class Foo
                 private val lambda: (() -> List<Foo>)? = null
-            """
+            """.trimIndent()
 
             val findings = subject.compileAndLint(code)
 
@@ -300,7 +300,7 @@ class UnusedPrivateClassSpec {
                         override fun bar() = Unit
                     }
                 }
-            """
+            """.trimIndent()
 
             val findings = subject.compileAndLint(code)
 
@@ -318,7 +318,7 @@ class UnusedPrivateClassSpec {
                 
                 private class Foo
                 fun bar(clazz: KClass<*>) = Unit
-            """
+            """.trimIndent()
 
             val findings = UnusedPrivateClass().compileAndLint(code)
 
@@ -338,7 +338,7 @@ class UnusedPrivateClassSpec {
                         B("B"),
                         C("C")
                     }
-            """
+            """.trimIndent()
 
             val findings = UnusedPrivateClass().compileAndLint(code)
 
@@ -363,7 +363,7 @@ class UnusedPrivateClassSpec {
                         fun getSomeObject(): ((String) -> Any) = ::InternalClass
                         private class InternalClass(val param: String)
                     }
-            """
+            """.trimIndent()
 
             val findings = UnusedPrivateClass().compileAndLint(code)
 
@@ -382,7 +382,7 @@ class UnusedPrivateClassSpec {
                     @Test3 val property = ""
                     @Test4 fun function() {}
                 }
-            """
+            """.trimIndent()
 
             val findings = UnusedPrivateClass().compileAndLint(code)
 
@@ -407,7 +407,7 @@ class UnusedPrivateClassSpec {
                         E3
                     }
                 }
-            """
+            """.trimIndent()
             val findings = UnusedPrivateClass().lint(code)
             assertThat(findings).isEmpty()
         }
@@ -432,7 +432,7 @@ class UnusedPrivateClassSpec {
                         EFG1
                     }
                 }
-            """
+            """.trimIndent()
             val findings = UnusedPrivateClass().lint(code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasStartSourceLocation(10, 5)

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMemberSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMemberSpec.kt
@@ -30,7 +30,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                         println(used)
                     }
                 }
-    """
+    """.trimIndent()
 
     @Nested
     inner class `interface functions` {
@@ -42,7 +42,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                     fun plug(application: Application)
                     fun unplug()
                 }
-            """
+            """.trimIndent()
             assertThat(subject.lint(code)).isEmpty()
         }
     }
@@ -57,7 +57,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                     fun bar(i: Int)
                     fun baz(i: Int, s: String)
                 }
-            """
+            """.trimIndent()
             assertThat(subject.lint(code)).isEmpty()
         }
 
@@ -68,7 +68,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                     fun bar(i: Int)
                     fun baz(i: Int, s: String)
                 }
-            """
+            """.trimIndent()
             assertThat(subject.lint(code)).isEmpty()
         }
 
@@ -77,7 +77,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
             val code = """
                 expect fun bar(i: Int)
                 expect fun baz(i: Int, s: String)
-            """
+            """.trimIndent()
             assertThat(subject.lint(code)).isEmpty()
         }
 
@@ -86,7 +86,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
             val code = """
                 expect class Foo1(private val bar: String) {}
                 expect class Foo2(bar: String) {}
-            """
+            """.trimIndent()
             assertThat(subject.lint(code)).isEmpty()
         }
     }
@@ -101,7 +101,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                     actual fun bar(i: Int) {}
                     actual fun baz(i: Int, s: String) {}
                 }
-            """
+            """.trimIndent()
             assertThat(subject.lint(code)).isEmpty()
         }
 
@@ -109,7 +109,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
         fun `should not report unused parameters in actual constructors`() {
             val code = """
                 actual class Foo actual constructor(bar: String) {}
-            """
+            """.trimIndent()
             assertThat(subject.lint(code)).isEmpty()
         }
 
@@ -117,7 +117,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
         fun `should not report unused actual fields defined as parameters of primary constructors`() {
             val code = """
                 actual class Foo actual constructor(actual val bar: String) {}
-            """
+            """.trimIndent()
             assertThat(subject.lint(code)).isEmpty()
         }
 
@@ -125,7 +125,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
         fun `reports unused private fields defined as parameters of primary constructors`() {
             val code = """
                 actual class Foo actual constructor(private val bar: String) {}
-            """
+            """.trimIndent()
             assertThat(subject.lint(code)).hasSize(1)
         }
     }
@@ -152,7 +152,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                         fun notify(error: String)
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.lint(code)).isEmpty()
         }
     }
@@ -184,7 +184,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                         }
                     })
                 }
-            """
+            """.trimIndent()
             assertThat(subject.lint(code)).isEmpty()
         }
 
@@ -206,7 +206,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                         return 1
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.lint(code)).isEmpty()
         }
     }
@@ -217,7 +217,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
         fun `should not report internal classes`() {
             val code = """
                 internal class IC // unused but internal
-            """
+            """.trimIndent()
             assertThat(subject.lint(code)).isEmpty()
         }
     }
@@ -238,7 +238,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                                 .subscribe()
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.lint(code)).isEmpty()
         }
     }
@@ -256,7 +256,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                         println("This is not using a property")
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.lint(code)).hasSize(1)
         }
 
@@ -270,7 +270,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                         println("This is not using a property")
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.lint(code)).isEmpty()
         }
 
@@ -284,7 +284,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                         println(used)
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.lint(code)).isEmpty()
         }
 
@@ -299,7 +299,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                         println(used)
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.lint(code)).hasSize(1)
         }
 
@@ -336,7 +336,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                         val unusedLocal = 5
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.lint(code)).hasSize(5)
         }
 
@@ -351,7 +351,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                         println(used)
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.lint(code)).hasSize(1)
         }
 
@@ -366,7 +366,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                         println(text)
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.lint(code)).isEmpty()
         }
 
@@ -403,7 +403,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                         private fun doubleColonObjectReferenced() {}
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.lint(code)).isEmpty()
         }
 
@@ -443,7 +443,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                         println(used)
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.lint(code)).hasSize(1)
         }
     }
@@ -464,7 +464,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                         private val unusedNestedVal = 1
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.lint(code)).hasSize(4)
         }
 
@@ -478,7 +478,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                 private object PO { // private, but constants may be used
                     const val TEXT = "text"
                 }
-            """
+            """.trimIndent()
             assertThat(subject.lint(code)).isEmpty()
         }
     }
@@ -493,7 +493,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
 
                 val defaultRuleSetIds = listOf("comments", "complexity", "empty-blocks",
                         "exceptions", "potential-bugs", "performance", "style")
-            """
+            """.trimIndent()
             assertThat(subject.lint(code)).isEmpty()
         }
 
@@ -507,7 +507,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                         }
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.lint(code)).isEmpty()
         }
 
@@ -520,7 +520,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                         }
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.lint(code)).hasSize(1)
         }
 
@@ -535,7 +535,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                         }
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.lint(code)).hasSize(1)
         }
 
@@ -549,7 +549,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                         }
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.lint(code)).hasSize(2)
         }
 
@@ -565,7 +565,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                         }
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.lint(code)).isEmpty()
         }
     }
@@ -584,7 +584,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                         println(text)
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.lint(code)).isEmpty()
         }
 
@@ -598,7 +598,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                         val test = unused
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.lint(code)).isEmpty()
         }
     }
@@ -610,7 +610,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
         fun `reports top-level unused functions`() {
             val code = """
                 private fun unusedTopLevelFunction() = 5
-            """
+            """.trimIndent()
             assertThat(subject.lint(code)).hasSize(1)
         }
 
@@ -622,7 +622,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                 fun main(args: Array<String>) {
                     calledFromMain()
                 }
-            """
+            """.trimIndent()
             assertThat(subject.lint(code)).isEmpty()
         }
     }
@@ -635,7 +635,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                 private val usedTopLevelVal = 1
                 private const val unusedTopLevelConst = 1
                 private val unusedTopLevelVal = usedTopLevelVal
-            """
+            """.trimIndent()
             assertThat(subject.lint(code)).hasSize(2)
         }
 
@@ -662,7 +662,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                     println(stuff.next())
                     calledFromMain()
                 }
-            """
+            """.trimIndent()
             assertThat(subject.lint(code)).isEmpty()
         }
     }
@@ -679,7 +679,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                     return 5
                 }
             }
-            """
+            """.trimIndent()
 
             assertThat(subject.lint(code)).isEmpty()
         }
@@ -692,7 +692,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                     return 5
                 }
             }
-            """
+            """.trimIndent()
 
             assertThat(subject.lint(code)).hasSize(1)
         }
@@ -706,7 +706,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
                 private fun doSomethingElse() {}
-            """
+            """.trimIndent()
 
             assertThat(subject.lint(code)).isEmpty()
         }
@@ -727,7 +727,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                     println("Never used")
                 }
             }
-            """
+            """.trimIndent()
 
             assertThat(subject.lint(code)).hasSize(1)
         }
@@ -742,7 +742,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                 class Test {
                     private val ignored = ""
                 }
-            """
+            """.trimIndent()
             assertThat(subject.lint(code)).isEmpty()
         }
 
@@ -752,7 +752,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                 class Test {
                     private fun ignored(ignored: Int) {}
                 }
-            """
+            """.trimIndent()
             assertThat(subject.lint(code)).isEmpty()
         }
     }
@@ -768,7 +768,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                         private val unused = 1
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.lint(code)).hasSize(1)
         }
 
@@ -781,7 +781,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                         fun someFunction() = used
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.lint(code)).isEmpty()
         }
     }
@@ -792,7 +792,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
         fun `reports unused private property`() {
             val code = """
                 class Test(private val unused: Any)
-            """
+            """.trimIndent()
             assertThat(subject.lint(code)).hasSize(1)
         }
 
@@ -800,7 +800,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
         fun `does not report public property`() {
             val code = """
                 class Test(val unused: Any)
-            """
+            """.trimIndent()
             assertThat(subject.lint(code)).isEmpty()
         }
 
@@ -810,7 +810,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                 class Test(private val used: Any) {
                     init { used.toString() }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.lint(code)).isEmpty()
         }
 
@@ -822,7 +822,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                         used.toString()
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.lint(code)).isEmpty()
         }
     }
@@ -833,7 +833,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
         fun `are specific for function parameters`() {
             val code = """
                 fun foo(unused: Int){}
-            """
+            """.trimIndent()
 
             val lint = subject.lint(code)
 
@@ -844,7 +844,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
         fun `are specific for local variables`() {
             val code = """
                 fun foo(){ val unused = 1 }
-            """
+            """.trimIndent()
 
             val lint = subject.lint(code)
 
@@ -859,7 +859,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                     return 5
                 }
             }
-            """
+            """.trimIndent()
 
             val lint = subject.lint(code)
 
@@ -873,7 +873,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
         fun `does not report annotated private constructor properties`() {
             val code = """
                 class Test(@Suppress("unused") private val foo: String) {}
-            """
+            """.trimIndent()
 
             assertThat(subject.lint(code)).isEmpty()
         }
@@ -885,7 +885,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                     @Suppress("unused") private val foo: String,
                     private val bar: String
                 ) {}
-            """
+            """.trimIndent()
 
             val lint = subject.lint(code)
 
@@ -901,7 +901,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                     private val foo: String,
                     private val bar: String
                 ) {}
-            """
+            """.trimIndent()
 
             assertThat(subject.lint(code)).isEmpty()
         }
@@ -918,7 +918,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                         private val baz: String
                     ) {}
                 }
-            """
+            """.trimIndent()
 
             assertThat(subject.lint(code)).isEmpty()
         }
@@ -936,7 +936,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                         private val baz: String
                     ) {}
                 }
-            """
+            """.trimIndent()
 
             assertThat(subject.lint(code)).isEmpty()
         }
@@ -947,7 +947,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                 class Test {
                     @Suppress("unused") private val foo: String
                 }
-            """
+            """.trimIndent()
 
             assertThat(subject.lint(code)).isEmpty()
         }
@@ -959,7 +959,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                     @Suppress("unused") private val foo: String
                     private val bar: String
                 }
-            """
+            """.trimIndent()
 
             val lint = subject.lint(code)
 
@@ -975,7 +975,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                     private val foo: String
                     private val bar: String
                 }
-            """
+            """.trimIndent()
 
             assertThat(subject.lint(code)).isEmpty()
         }
@@ -992,7 +992,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                         private val baz: String
                     }
                 }
-            """
+            """.trimIndent()
 
             assertThat(subject.lint(code)).isEmpty()
         }
@@ -1010,7 +1010,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                         private val baz: String
                     }
                 }
-            """
+            """.trimIndent()
 
             assertThat(subject.lint(code)).isEmpty()
         }
@@ -1023,7 +1023,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
             val code = """
                 @Suppress("unused")
                 private fun foo(): String = ""
-            """
+            """.trimIndent()
 
             assertThat(subject.lint(code)).isEmpty()
         }
@@ -1032,7 +1032,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
         fun `reports private functions without annotation`() {
             val code = """
                 private fun foo(): String = ""
-            """
+            """.trimIndent()
 
             val findings = subject.lint(code)
 
@@ -1047,7 +1047,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                 class Test {
                     private fun foo(): String = ""
                 }
-            """
+            """.trimIndent()
 
             assertThat(subject.lint(code)).isEmpty()
         }
@@ -1064,7 +1064,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                         private fun baz(): String = ""
                     }
                 }
-            """
+            """.trimIndent()
 
             assertThat(subject.lint(code)).isEmpty()
         }
@@ -1081,7 +1081,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                         private fun baz(): String = ""
                     }
                 }
-            """
+            """.trimIndent()
 
             assertThat(subject.lint(code)).isEmpty()
         }
@@ -1100,7 +1100,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                         println("b")
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.lint(code)).isEmpty()
         }
 
@@ -1110,7 +1110,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                 fun main(args: Array<String>) {
                     println("b")
                 }
-            """
+            """.trimIndent()
             assertThat(subject.lint(code)).isEmpty()
         }
     }
@@ -1128,7 +1128,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                         private operator fun Date.plus(diff: Long): Date = Date(this.time + diff)
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -1142,7 +1142,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                         private operator fun Date.plus(diff: Long): Date = Date(this.time + diff)
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
@@ -1156,7 +1156,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                 }
 
                 val answer = Test.answer()
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
@@ -1178,7 +1178,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                     private operator fun Int?.div(other: Int) = 4
                     private operator fun Int?.rem(other: Int) = 5
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -1192,7 +1192,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                         return any { it.matches(a) }
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -1206,7 +1206,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                         return any { it.matches(a) }
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -1219,7 +1219,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                         private operator fun Date.minus(diff: Long): Date = Date(this.time - diff)
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
     }
@@ -1241,7 +1241,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                         return 5
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(2)
         }
 
@@ -1263,7 +1263,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                         return num.toInt()
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(2)
         }
 
@@ -1285,7 +1285,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                         return toInt()
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(2)
         }
     }
@@ -1303,7 +1303,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                         fun double(): Foo = this + this
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(0)
         }
 
@@ -1318,7 +1318,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                         fun double(): Foo = this + this
                     }
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1).hasStartSourceLocations(
                 SourceLocation(3, 30)
@@ -1353,7 +1353,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                         aInstance.someMethod(setOf(B(), B()), false)
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(0)
         }
     }
@@ -1377,7 +1377,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                         error("setValue")
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(0)
         }
 
@@ -1395,7 +1395,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                     operator fun setValue(thisRef: Any?, property: KProperty<*>, value: String) {
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(0)
         }
 
@@ -1413,7 +1413,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                         error("setValue")
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(2)
         }
     }
@@ -1427,7 +1427,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                 fun main() {
                     val `in` = "foo"
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
@@ -1439,7 +1439,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                     val expected = "foo"
                     println(expected == `in`)
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -1451,7 +1451,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                     val expected = "foo"
                     println(expected == `actual`)
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -1463,7 +1463,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                     val expected = "foo"
                     println(expected == actual)
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
     }
@@ -1474,7 +1474,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
         fun `does not report used backtick parameters`() {
             val code = """
                 fun test(`foo bar`: Int) = `foo bar`
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
     }
@@ -1492,7 +1492,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                     private operator fun List<StringWrapper>.get(s: String) =
                         this.firstOrNull { it.s == s }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
@@ -1511,7 +1511,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                     private operator fun List<StringWrapper>.get(s: String) =
                         this.firstOrNull { it.s == s }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(0)
         }
 
@@ -1530,7 +1530,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                     private operator fun List<StringWrapper>.get(a: String, b: String) =
                         this.firstOrNull { it.s == b }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(0)
         }
 
@@ -1549,7 +1549,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                     private operator fun List<StringWrapper>.get(s: String) =
                         this.firstOrNull { it.s == s }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(0)
         }
 
@@ -1562,7 +1562,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
 
                 private operator fun List<StringWrapper>.get(s: String) =
                     this.firstOrNull { it.s == s }
-            """
+            """.trimIndent()
             assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
 
@@ -1581,7 +1581,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
 
                 private operator fun List<StringWrapper>.get(s: String) =
                     this.firstOrNull { it.s == s }
-            """
+            """.trimIndent()
             assertThat(subject.lintWithContext(env, code)).hasSize(0)
         }
 
@@ -1600,7 +1600,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
 
                 private operator fun List<StringWrapper>.get(s: String) =
                     this.firstOrNull { it.s == s }
-            """
+            """.trimIndent()
             assertThat(subject.lintWithContext(env, code)).hasSize(0)
         }
     }
@@ -1616,7 +1616,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                      */
                     private fun foo() = 1
                 }
-            """
+            """.trimIndent()
             assertThat(subject.lint(code)).hasSize(1).hasStartSourceLocation(5, 17)
         }
 
@@ -1629,7 +1629,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                      */
                     private val foo = 1
                 }
-            """
+            """.trimIndent()
             assertThat(subject.lint(code)).hasSize(1).hasStartSourceLocation(5, 17)
         }
 
@@ -1644,7 +1644,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                         x: Int
                     ) = 1
                 }
-            """
+            """.trimIndent()
             assertThat(subject.lint(code)).hasSize(1).hasStartSourceLocation(6, 9)
         }
     }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateParameterSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateParameterSpec.kt
@@ -20,7 +20,7 @@ class UnusedPrivateParameterSpec(val env: KotlinCoreEnvironment) {
             fun function(unusedParameter: Int): Int {
                 return 5
             }
-            """
+            """.trimIndent()
 
             assertThat(subject.lint(code)).hasSize(1)
         }
@@ -31,7 +31,7 @@ class UnusedPrivateParameterSpec(val env: KotlinCoreEnvironment) {
             fun function(used: Int): Int {
                 return used
             }
-            """
+            """.trimIndent()
 
             assertThat(subject.lint(code)).isEmpty()
         }
@@ -42,7 +42,7 @@ class UnusedPrivateParameterSpec(val env: KotlinCoreEnvironment) {
             fun function(used: Int) {
                 println(used)
             }
-            """
+            """.trimIndent()
 
             assertThat(subject.lint(code)).isEmpty()
         }
@@ -53,7 +53,7 @@ class UnusedPrivateParameterSpec(val env: KotlinCoreEnvironment) {
             fun function(unusedParameter: Int, usedParameter: Int): Int {
                 return usedParameter
             }
-            """
+            """.trimIndent()
 
             assertThat(subject.lint(code)).hasSize(1)
         }
@@ -64,7 +64,7 @@ class UnusedPrivateParameterSpec(val env: KotlinCoreEnvironment) {
             fun function(unusedParameter: Int, usedParameter: Int) {
                 println(usedParameter)
             }
-            """
+            """.trimIndent()
 
             assertThat(subject.lint(code)).hasSize(1)
         }
@@ -79,7 +79,7 @@ class UnusedPrivateParameterSpec(val env: KotlinCoreEnvironment) {
                     return 5
                 }
             }
-            """
+            """.trimIndent()
 
             assertThat(subject.lint(code)).hasSize(1)
         }
@@ -99,7 +99,7 @@ class UnusedPrivateParameterSpec(val env: KotlinCoreEnvironment) {
                     return 5
                 }
             }
-            """
+            """.trimIndent()
 
             assertThat(subject.lint(code)).hasSize(2)
         }
@@ -114,7 +114,7 @@ class UnusedPrivateParameterSpec(val env: KotlinCoreEnvironment) {
                     return used
                 }
             }
-            """
+            """.trimIndent()
 
             assertThat(subject.lint(code)).isEmpty()
         }
@@ -129,7 +129,7 @@ class UnusedPrivateParameterSpec(val env: KotlinCoreEnvironment) {
                     println(used)
                 }
             }
-            """
+            """.trimIndent()
 
             assertThat(subject.lint(code)).isEmpty()
         }
@@ -144,7 +144,7 @@ class UnusedPrivateParameterSpec(val env: KotlinCoreEnvironment) {
                     return usedParameter
                 }
             }
-            """
+            """.trimIndent()
 
             assertThat(subject.lint(code)).hasSize(1)
         }
@@ -159,7 +159,7 @@ class UnusedPrivateParameterSpec(val env: KotlinCoreEnvironment) {
                     println(usedParameter)
                 }
             }
-            """
+            """.trimIndent()
 
             assertThat(subject.lint(code)).hasSize(1)
         }
@@ -171,7 +171,7 @@ class UnusedPrivateParameterSpec(val env: KotlinCoreEnvironment) {
         fun `reports unused parameter`() {
             val code = """
                 class Test(unused: Any)
-            """
+            """.trimIndent()
             assertThat(subject.lint(code)).hasSize(1)
         }
 
@@ -180,7 +180,7 @@ class UnusedPrivateParameterSpec(val env: KotlinCoreEnvironment) {
             val code = """
                 class Parent(val ignored: Any)
                 class Test(used: Any) : Parent(used)
-            """
+            """.trimIndent()
             assertThat(subject.lint(code)).isEmpty()
         }
 
@@ -192,7 +192,7 @@ class UnusedPrivateParameterSpec(val env: KotlinCoreEnvironment) {
                         used.toString()
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.lint(code)).isEmpty()
         }
 
@@ -202,7 +202,7 @@ class UnusedPrivateParameterSpec(val env: KotlinCoreEnvironment) {
                 class Test(used: Any) {
                     val usedString = used.toString()
                 }
-            """
+            """.trimIndent()
             assertThat(subject.lint(code)).isEmpty()
         }
     }
@@ -220,7 +220,7 @@ class UnusedPrivateParameterSpec(val env: KotlinCoreEnvironment) {
                     // this is actually unused, but clashes with the other constructor
                     constructor(used: Any)
                 }
-            """
+            """.trimIndent()
             assertThat(subject.lint(code)).hasSize(1)
         }
     }
@@ -231,7 +231,7 @@ class UnusedPrivateParameterSpec(val env: KotlinCoreEnvironment) {
         fun `does not report annotated parameters`() {
             val code = """
                 fun foo(@Suppress("UNUSED_PARAMETER") unused: String){}
-            """
+            """.trimIndent()
 
             assertThat(subject.lint(code)).isEmpty()
         }
@@ -240,7 +240,7 @@ class UnusedPrivateParameterSpec(val env: KotlinCoreEnvironment) {
         fun `reports parameters without annotation`() {
             val code = """
                 fun foo(@Suppress("UNUSED_PARAMETER") unused: String, unusedWithoutAnnotation: String){}
-            """
+            """.trimIndent()
 
             val lint = subject.lint(code)
 
@@ -253,7 +253,7 @@ class UnusedPrivateParameterSpec(val env: KotlinCoreEnvironment) {
             val code = """
                 @Suppress("UNUSED_PARAMETER")
                 fun foo(unused: String, otherUnused: String){}
-            """
+            """.trimIndent()
 
             assertThat(subject.lint(code)).isEmpty()
         }
@@ -266,7 +266,7 @@ class UnusedPrivateParameterSpec(val env: KotlinCoreEnvironment) {
                     fun foo(unused: String, otherUnused: String){}
                     fun bar(unused: String){}
                 }
-            """
+            """.trimIndent()
 
             assertThat(subject.lint(code)).isEmpty()
         }
@@ -278,7 +278,7 @@ class UnusedPrivateParameterSpec(val env: KotlinCoreEnvironment) {
                 object Test {
                     fun foo(unused: String){}
                 }
-            """
+            """.trimIndent()
 
             assertThat(subject.lint(code)).isEmpty()
         }
@@ -294,7 +294,7 @@ class UnusedPrivateParameterSpec(val env: KotlinCoreEnvironment) {
                         fun bar(unused: String){}
                     }
                 }
-            """
+            """.trimIndent()
 
             assertThat(subject.lint(code)).isEmpty()
         }
@@ -311,7 +311,7 @@ class UnusedPrivateParameterSpec(val env: KotlinCoreEnvironment) {
                         fun bar(unused: String){}
                     }
                 }
-            """
+            """.trimIndent()
 
             assertThat(subject.lint(code)).isEmpty()
         }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseArrayLiteralsInAnnotationsSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseArrayLiteralsInAnnotationsSpec.kt
@@ -16,7 +16,7 @@ class UseArrayLiteralsInAnnotationsSpec {
         annotation class Test(val values: Array<String>)
         @Test(arrayOf("value"))
         fun test() = Unit
-            """
+            """.trimIndent()
         )
 
         assertThat(findings).hasSize(1)
@@ -30,7 +30,7 @@ class UseArrayLiteralsInAnnotationsSpec {
         annotation class Test(val values: Array<String>)
         @Test(["value"])
         fun test() = Unit
-            """
+            """.trimIndent()
         )
 
         assertThat(findings).isEmpty()

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseCheckNotNullSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseCheckNotNullSpec.kt
@@ -16,7 +16,7 @@ class UseCheckNotNullSpec(val env: KotlinCoreEnvironment) {
             fun test(i: Int?) {
                 check(i != null)
             }
-        """
+        """.trimIndent()
         val actual = subject.compileAndLintWithContext(env, code)
         assertThat(actual).hasSize(1)
     }
@@ -27,7 +27,7 @@ class UseCheckNotNullSpec(val env: KotlinCoreEnvironment) {
             fun test(i: Int?) {
                 check(null != i)
             }
-        """
+        """.trimIndent()
         val actual = subject.compileAndLintWithContext(env, code)
         assertThat(actual).hasSize(1)
     }
@@ -38,7 +38,7 @@ class UseCheckNotNullSpec(val env: KotlinCoreEnvironment) {
             fun test(i: Int) {
                 check(i > 0)
             }
-        """
+        """.trimIndent()
         val actual = subject.compileAndLintWithContext(env, code)
         assertThat(actual).isEmpty()
     }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseCheckOrErrorSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseCheckOrErrorSpec.kt
@@ -21,7 +21,7 @@ class UseCheckOrErrorSpec(val env: KotlinCoreEnvironment) {
                 doSomething()
                 if (a < 0) throw IllegalStateException()
             }
-        """
+        """.trimIndent()
         assertThat(subject.lint(code)).hasStartSourceLocation(3, 16)
     }
 
@@ -34,7 +34,7 @@ class UseCheckOrErrorSpec(val env: KotlinCoreEnvironment) {
                     throw IllegalStateException()
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.lint(code)).hasStartSourceLocation(4, 9)
     }
 
@@ -45,7 +45,7 @@ class UseCheckOrErrorSpec(val env: KotlinCoreEnvironment) {
                 doSomething()
                 if (a < 0) throw IllegalStateException("More details")
             }
-        """
+        """.trimIndent()
         assertThat(subject.lint(code)).hasStartSourceLocation(3, 16)
     }
 
@@ -57,7 +57,7 @@ class UseCheckOrErrorSpec(val env: KotlinCoreEnvironment) {
                     1 -> doSomething()
                     else -> throw IllegalStateException()
                 }
-        """
+        """.trimIndent()
         assertThat(subject.lint(code)).hasStartSourceLocation(4, 17)
     }
 
@@ -68,7 +68,7 @@ class UseCheckOrErrorSpec(val env: KotlinCoreEnvironment) {
                 doSomething()
                 if (a < 0) throw java.lang.IllegalStateException()
             }
-        """
+        """.trimIndent()
         assertThat(subject.lint(code)).hasStartSourceLocation(3, 16)
     }
 
@@ -79,7 +79,7 @@ class UseCheckOrErrorSpec(val env: KotlinCoreEnvironment) {
                 doSomething()
                 if (a < 0) throw kotlin.IllegalStateException()
             }
-        """
+        """.trimIndent()
         assertThat(subject.lint(code)).hasStartSourceLocation(3, 16)
     }
 
@@ -90,7 +90,7 @@ class UseCheckOrErrorSpec(val env: KotlinCoreEnvironment) {
                 doSomething()
                 if (a < 0) throw SomeBusinessException()
             }
-        """
+        """.trimIndent()
         assertThat(subject.lint(code)).isEmpty()
     }
 
@@ -102,7 +102,7 @@ class UseCheckOrErrorSpec(val env: KotlinCoreEnvironment) {
                     throw IllegalStateException("message", cause)
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.lint(code)).isEmpty()
     }
 
@@ -112,7 +112,7 @@ class UseCheckOrErrorSpec(val env: KotlinCoreEnvironment) {
             fun unsafeRunSync(): A =
                 unsafeRunTimed(Duration.INFINITE)
                     .fold({ throw IllegalStateException("message") }, ::identity)
-        """
+        """.trimIndent()
         assertThat(subject.lint(code)).isEmpty()
     }
 
@@ -137,7 +137,7 @@ class UseCheckOrErrorSpec(val env: KotlinCoreEnvironment) {
                     else -> throw IllegalStateException(throwable)
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -150,7 +150,7 @@ class UseCheckOrErrorSpec(val env: KotlinCoreEnvironment) {
                     else -> throw IllegalStateException("b", throwable)
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -163,7 +163,7 @@ class UseCheckOrErrorSpec(val env: KotlinCoreEnvironment) {
                     else -> throw IllegalStateException(throwable.toString())
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -179,7 +179,7 @@ class UseCheckOrErrorSpec(val env: KotlinCoreEnvironment) {
                         else -> throw IllegalStateException(throwable)
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -192,7 +192,7 @@ class UseCheckOrErrorSpec(val env: KotlinCoreEnvironment) {
                         else -> throw IllegalStateException("b", throwable)
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -205,7 +205,7 @@ class UseCheckOrErrorSpec(val env: KotlinCoreEnvironment) {
                         else -> throw IllegalStateException(throwable.toString())
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
@@ -218,7 +218,7 @@ class UseCheckOrErrorSpec(val env: KotlinCoreEnvironment) {
                         else -> throw IllegalStateException("b")
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
     }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseDataClassSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseDataClassSpec.kt
@@ -31,7 +31,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                     }
                     object Obj
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
@@ -43,7 +43,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                         println()
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
@@ -51,7 +51,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
         fun `does not report a candidate class with a private constructor`() {
             val code = """
                 class NoDataClassCandidateWithOnlyPrivateCtor1 private constructor(val i: Int)
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
@@ -61,7 +61,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                 class NoDataClassCandidateWithOnlyPrivateCtor2 {
                     private constructor(i: Int)
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
@@ -72,7 +72,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                     data class Success(val any: Any) : NoDataClassBecauseItsSealed()
                     data class Error(val error: Throwable) : NoDataClassBecauseItsSealed()
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
@@ -82,7 +82,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                 enum class EnumNoDataClass(val i: Int) {
                     FIRST(1), SECOND(2);
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
@@ -90,7 +90,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
         fun `does not report a candidate annotation class`() {
             val code = """
                 annotation class AnnotationNoDataClass(val i: Int)
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
@@ -104,7 +104,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                 class NotDataClassBecauseItsImplementingInterfaceWithMethods(val i : Int): SomeInterface {
                     override fun foo() = i
                 }
-            """
+            """.trimIndent()
 
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
@@ -117,7 +117,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                 }
                 
                 data class DataClass(override val i: Int): SimpleInterface
-            """
+            """.trimIndent()
 
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
@@ -132,7 +132,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                 open class BaseClass(open val j: Int)
                 
                 class DataClass(override val i: Int, override val j: Int): SimpleInterface, BaseClass(j)
-            """
+            """.trimIndent()
 
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
@@ -143,7 +143,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                 interface I
                 class B() : I
                 class A(val b: B) : I by b
-            """
+            """.trimIndent()
 
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
@@ -156,7 +156,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
         fun `does report a data class candidate`() {
             val code = """
                 class DataClassCandidate1(val i: Int)
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
@@ -166,7 +166,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                 class DataClassCandidateWithProperties(val i: Int) {
                     val i2: Int = 0
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
@@ -176,7 +176,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                 class DataClassCandidate2(val s: String) {
                     private constructor(i: Int) : this(i.toString())
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
@@ -186,7 +186,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                 class DataClassCandidate3 private constructor(val s: String) {
                     constructor(i: Int) : this(i.toString())
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
@@ -204,7 +204,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                         return super.toString()
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
@@ -213,7 +213,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
             val code = """
                 interface SimpleInterface
                 class DataClass(val i: Int): SimpleInterface
-            """
+            """.trimIndent()
 
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
@@ -226,7 +226,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                 }
                 
                 class DataClass(override val i: Int): SimpleInterface
-            """
+            """.trimIndent()
 
             assertThat(subject.compileAndLint(code)).hasSize(1)
         }
@@ -241,7 +241,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                 class D(val a: Int, val b: String) {
                     fun copy(a: Int, b: String): D = D(a, b)
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
@@ -251,7 +251,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                 class D(val a: Int, val b: String) {
                     fun copy(a: Int, b: String) = D(a, b)
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
@@ -261,7 +261,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                 class D(val a: Int, val b: String) {
                     fun copy(): D = D(0, "")
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -271,7 +271,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                 class D(val a: Int, val b: String) {
                     fun copy(a: Int, b: String, c: String): D = D(a, b + c)
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -281,7 +281,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                 class D(val a: Int, val b: String) {
                     fun copy(a: Int, b: Int): D = D(a, b.toString())
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -291,7 +291,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                 class D(val a: Int, val b: String) {
                     fun copy(a: Int, b: String?): D = D(a, b.toString())
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -302,7 +302,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                     fun copy(a: Int, b: String) {
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
     }
@@ -323,7 +323,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                 class DataClassCandidateWithProperties(var i: Int) {
                     var i2: Int = 0
                 }
-            """
+            """.trimIndent()
             val config = TestConfig(mapOf(ALLOW_VARS to "true"))
             assertThat(UseDataClass(config).compileAndLint(code)).isEmpty()
         }
@@ -334,7 +334,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                 class DataClassCandidateWithMixedProperties(val i: Int) {
                     var i2: Int = 0
                 }
-            """
+            """.trimIndent()
             val config = TestConfig(mapOf(ALLOW_VARS to "true"))
             assertThat(UseDataClass(config).compileAndLint(code)).isEmpty()
         }
@@ -345,7 +345,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                 class DataClassCandidateWithMixedProperties(var i: Int) {
                     val i2: Int = 0
                 }
-            """
+            """.trimIndent()
             val config = TestConfig(mapOf(ALLOW_VARS to "true"))
             assertThat(UseDataClass(config).compileAndLint(code)).isEmpty()
         }
@@ -372,7 +372,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
 
             @SinceKotlin("1.0.0")
             class AnnotatedClass(val i: Int) {}
-        """
+        """.trimIndent()
         val config = TestConfig(mapOf(EXCLUDE_ANNOTATED_CLASSES to "kotlin.*"))
         assertThat(UseDataClass(config).compileAndLint(code)).isEmpty()
     }
@@ -386,7 +386,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                         prop, old, new -> println("")
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -401,7 +401,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseEmptyCounterpartSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseEmptyCounterpartSpec.kt
@@ -20,7 +20,7 @@ class UseEmptyCounterpartSpec(val env: KotlinCoreEnvironment) {
             val map = mapOf<Any, Any>()
             val sequence = sequenceOf<Any>()
             val set = setOf<Any>()
-        """
+        """.trimIndent()
         assertThat(rule.compileAndLintWithContext(env, code)).hasSize(6)
     }
 
@@ -33,7 +33,7 @@ class UseEmptyCounterpartSpec(val env: KotlinCoreEnvironment) {
             val map: Map<Any, Any> = mapOf()
             val sequence: Sequence<Any> = sequenceOf()
             val set: Set<Any> = setOf()
-        """
+        """.trimIndent()
         assertThat(rule.compileAndLintWithContext(env, code)).hasSize(6)
     }
 
@@ -45,7 +45,7 @@ class UseEmptyCounterpartSpec(val env: KotlinCoreEnvironment) {
             val map = emptyMap<Any, Any>()
             val sequence = emptySequence<Any>()
             val set = emptySet<Any>()
-        """
+        """.trimIndent()
         assertThat(rule.compileAndLintWithContext(env, code)).isEmpty()
     }
 
@@ -58,7 +58,7 @@ class UseEmptyCounterpartSpec(val env: KotlinCoreEnvironment) {
             val map = mapOf(0 to 0)
             val sequence = sequenceOf(0)
             val set = setOf(0)
-        """
+        """.trimIndent()
         assertThat(rule.compileAndLintWithContext(env, code)).isEmpty()
     }
 
@@ -78,7 +78,7 @@ class UseEmptyCounterpartSpec(val env: KotlinCoreEnvironment) {
             val map = mapOf<Any, Any>()
             val sequence = sequenceOf<Any>()
             val set = setOf<Any>()
-        """
+        """.trimIndent()
         assertThat(rule.compileAndLintWithContext(env, code)).isEmpty()
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIfEmptyOrIfBlankSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIfEmptyOrIfBlankSpec.kt
@@ -23,7 +23,7 @@ class UseIfEmptyOrIfBlankSpec(val env: KotlinCoreEnvironment) {
                 fun test(api: Api) {
                     val name = if (api.name.isBlank()) "John" else api.name
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasStartSourceLocation(4, 29)
@@ -42,7 +42,7 @@ class UseIfEmptyOrIfBlankSpec(val env: KotlinCoreEnvironment) {
                     else
                         "John"
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasStartSourceLocation(4, 29)
@@ -58,7 +58,7 @@ class UseIfEmptyOrIfBlankSpec(val env: KotlinCoreEnvironment) {
                 fun test(api: Api) {
                     val name = if (api.name.isEmpty()) "John" else api.name
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasStartSourceLocation(4, 29)
@@ -77,7 +77,7 @@ class UseIfEmptyOrIfBlankSpec(val env: KotlinCoreEnvironment) {
                     else
                         "John"
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasStartSourceLocation(4, 29)
@@ -95,7 +95,7 @@ class UseIfEmptyOrIfBlankSpec(val env: KotlinCoreEnvironment) {
                         list
                     }
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
@@ -111,7 +111,7 @@ class UseIfEmptyOrIfBlankSpec(val env: KotlinCoreEnvironment) {
                         listOf(1)
                     }
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
@@ -127,7 +127,7 @@ class UseIfEmptyOrIfBlankSpec(val env: KotlinCoreEnvironment) {
                         set
                     }
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
@@ -143,7 +143,7 @@ class UseIfEmptyOrIfBlankSpec(val env: KotlinCoreEnvironment) {
                         setOf(1)
                     }
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
@@ -159,7 +159,7 @@ class UseIfEmptyOrIfBlankSpec(val env: KotlinCoreEnvironment) {
                         map
                     }
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
@@ -175,7 +175,7 @@ class UseIfEmptyOrIfBlankSpec(val env: KotlinCoreEnvironment) {
                         mapOf(1 to 2)
                     }
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
@@ -191,7 +191,7 @@ class UseIfEmptyOrIfBlankSpec(val env: KotlinCoreEnvironment) {
                         collection
                     }
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
@@ -207,7 +207,7 @@ class UseIfEmptyOrIfBlankSpec(val env: KotlinCoreEnvironment) {
                         listOf(1)
                     }
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
@@ -222,7 +222,7 @@ class UseIfEmptyOrIfBlankSpec(val env: KotlinCoreEnvironment) {
                         this
                     }
                 }                
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
@@ -238,7 +238,7 @@ class UseIfEmptyOrIfBlankSpec(val env: KotlinCoreEnvironment) {
                         list
                     }
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
@@ -253,7 +253,7 @@ class UseIfEmptyOrIfBlankSpec(val env: KotlinCoreEnvironment) {
                         listOf(1)
                     }
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
             assertThat(findings[0]).hasMessage("This 'isEmpty' call can be replaced with 'ifEmpty'")
@@ -269,7 +269,7 @@ class UseIfEmptyOrIfBlankSpec(val env: KotlinCoreEnvironment) {
                         list
                     }
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
             assertThat(findings[0]).hasMessage("This 'isNotEmpty' call can be replaced with 'ifEmpty'")
@@ -287,7 +287,7 @@ class UseIfEmptyOrIfBlankSpec(val env: KotlinCoreEnvironment) {
                 fun test(api: Api) {
                     val name = if (api.name.isNullOrBlank()) "John" else api.name
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
@@ -303,7 +303,7 @@ class UseIfEmptyOrIfBlankSpec(val env: KotlinCoreEnvironment) {
                         list
                     }
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
@@ -319,7 +319,7 @@ class UseIfEmptyOrIfBlankSpec(val env: KotlinCoreEnvironment) {
                         arr
                     }
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
@@ -335,7 +335,7 @@ class UseIfEmptyOrIfBlankSpec(val env: KotlinCoreEnvironment) {
                         arrayOf("a")
                     }
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
@@ -351,7 +351,7 @@ class UseIfEmptyOrIfBlankSpec(val env: KotlinCoreEnvironment) {
                         arr
                     }
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
@@ -367,7 +367,7 @@ class UseIfEmptyOrIfBlankSpec(val env: KotlinCoreEnvironment) {
                         intArrayOf(1)
                     }
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
@@ -384,7 +384,7 @@ class UseIfEmptyOrIfBlankSpec(val env: KotlinCoreEnvironment) {
                         list
                     }
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
@@ -397,7 +397,7 @@ class UseIfEmptyOrIfBlankSpec(val env: KotlinCoreEnvironment) {
                         listOf(1)
                     }
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
@@ -412,7 +412,7 @@ class UseIfEmptyOrIfBlankSpec(val env: KotlinCoreEnvironment) {
                         list + list
                     }
                 }                
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
@@ -428,7 +428,7 @@ class UseIfEmptyOrIfBlankSpec(val env: KotlinCoreEnvironment) {
                         list
                     }
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
@@ -443,7 +443,7 @@ class UseIfEmptyOrIfBlankSpec(val env: KotlinCoreEnvironment) {
                         list
                     }
                 }                
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIfInsteadOfWhenSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIfInsteadOfWhenSpec.kt
@@ -18,7 +18,7 @@ class UseIfInsteadOfWhenSpec {
                     else -> return false
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 
@@ -31,7 +31,7 @@ class UseIfInsteadOfWhenSpec {
                     else -> return false
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -46,7 +46,7 @@ class UseIfInsteadOfWhenSpec {
                     else -> return false
                 }
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -61,7 +61,7 @@ class UseIfInsteadOfWhenSpec {
                 }
                 return false
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIsNullOrEmptySpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIsNullOrEmptySpec.kt
@@ -21,7 +21,7 @@ class UseIsNullOrEmptySpec(val env: KotlinCoreEnvironment) {
                     fun test(x: List<Int>?) {
                         if (x == null || x.isEmpty()) return
                     }
-                """
+                """.trimIndent()
                 val findings = subject.compileAndLintWithContext(env, code)
                 assertThat(findings).hasSize(1)
                 assertThat(findings).hasStartSourceLocation(2, 9)
@@ -36,7 +36,7 @@ class UseIsNullOrEmptySpec(val env: KotlinCoreEnvironment) {
                     fun test(x: List<Int>?) {
                         if (x == null || x.count() == 0) return
                     }
-                """
+                """.trimIndent()
                 val findings = subject.compileAndLintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }
@@ -47,7 +47,7 @@ class UseIsNullOrEmptySpec(val env: KotlinCoreEnvironment) {
                     fun test(x: List<Int>?) {
                         if (x == null || x.size == 0) return
                     }
-                """
+                """.trimIndent()
                 val findings = subject.compileAndLintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }
@@ -58,7 +58,7 @@ class UseIsNullOrEmptySpec(val env: KotlinCoreEnvironment) {
                     fun test(x: List<Int>?) {
                         if (null == x || x.isEmpty()) return
                     }
-                """
+                """.trimIndent()
                 val findings = subject.compileAndLintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }
@@ -69,7 +69,7 @@ class UseIsNullOrEmptySpec(val env: KotlinCoreEnvironment) {
                     fun test(x: List<Int>?) {
                         if (x == null || 0 == x.count()) return
                     }
-                """
+                """.trimIndent()
                 val findings = subject.compileAndLintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }
@@ -80,7 +80,7 @@ class UseIsNullOrEmptySpec(val env: KotlinCoreEnvironment) {
                     fun test(x: List<Int>?) {
                         if (x == null || 0 == x.size) return
                     }
-                """
+                """.trimIndent()
                 val findings = subject.compileAndLintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }
@@ -94,7 +94,7 @@ class UseIsNullOrEmptySpec(val env: KotlinCoreEnvironment) {
                     fun test(x: Set<Int>?) {
                         if (x == null || x.isEmpty()) return
                     }
-                """
+                """.trimIndent()
                 val findings = subject.compileAndLintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }
@@ -105,7 +105,7 @@ class UseIsNullOrEmptySpec(val env: KotlinCoreEnvironment) {
                     fun test(x: Set<Int>?) {
                         if (x == null || x.count() == 0) return
                     }
-                """
+                """.trimIndent()
                 val findings = subject.compileAndLintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }
@@ -116,7 +116,7 @@ class UseIsNullOrEmptySpec(val env: KotlinCoreEnvironment) {
                     fun test(x: Set<Int>?) {
                         if (x == null || x.size == 0) return
                     }
-                """
+                """.trimIndent()
                 val findings = subject.compileAndLintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }
@@ -130,7 +130,7 @@ class UseIsNullOrEmptySpec(val env: KotlinCoreEnvironment) {
                     fun test(x: Collection<Int>?) {
                         if (x == null || x.isEmpty()) return
                     }
-                """
+                """.trimIndent()
                 val findings = subject.compileAndLintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }
@@ -141,7 +141,7 @@ class UseIsNullOrEmptySpec(val env: KotlinCoreEnvironment) {
                     fun test(x: Collection<Int>?) {
                         if (x == null || x.count() == 0) return
                     }
-                """
+                """.trimIndent()
                 val findings = subject.compileAndLintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }
@@ -152,7 +152,7 @@ class UseIsNullOrEmptySpec(val env: KotlinCoreEnvironment) {
                     fun test(x: Collection<Int>?) {
                         if (x == null || x.size == 0) return
                     }
-                """
+                """.trimIndent()
                 val findings = subject.compileAndLintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }
@@ -166,7 +166,7 @@ class UseIsNullOrEmptySpec(val env: KotlinCoreEnvironment) {
                     fun test(x: Map<Int, String>?) {
                         if (x == null || x.isEmpty()) return
                     }
-                """
+                """.trimIndent()
                 val findings = subject.compileAndLintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }
@@ -177,7 +177,7 @@ class UseIsNullOrEmptySpec(val env: KotlinCoreEnvironment) {
                     fun test(x: Map<Int, String>?) {
                         if (x == null || x.count() == 0) return
                     }
-                """
+                """.trimIndent()
                 val findings = subject.compileAndLintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }
@@ -188,7 +188,7 @@ class UseIsNullOrEmptySpec(val env: KotlinCoreEnvironment) {
                     fun test(x: Map<Int, String>?) {
                         if (x == null || x.size == 0) return
                     }
-                """
+                """.trimIndent()
                 val findings = subject.compileAndLintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }
@@ -202,7 +202,7 @@ class UseIsNullOrEmptySpec(val env: KotlinCoreEnvironment) {
                     fun test(x: Array<Int>?) {
                         if (x == null || x.isEmpty()) return
                     }
-                """
+                """.trimIndent()
                 val findings = subject.compileAndLintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }
@@ -213,7 +213,7 @@ class UseIsNullOrEmptySpec(val env: KotlinCoreEnvironment) {
                     fun test(x: Array<Int>?) {
                         if (x == null || x.count() == 0) return
                     }
-                """
+                """.trimIndent()
                 val findings = subject.compileAndLintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }
@@ -224,7 +224,7 @@ class UseIsNullOrEmptySpec(val env: KotlinCoreEnvironment) {
                     fun test(x: Array<Int>?) {
                         if (x == null || x.size == 0) return
                     }
-                """
+                """.trimIndent()
                 val findings = subject.compileAndLintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }
@@ -238,7 +238,7 @@ class UseIsNullOrEmptySpec(val env: KotlinCoreEnvironment) {
                     fun test(x: String?) {
                         if (x == null || x.isEmpty()) return
                     }
-                """
+                """.trimIndent()
                 val findings = subject.compileAndLintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }
@@ -249,7 +249,7 @@ class UseIsNullOrEmptySpec(val env: KotlinCoreEnvironment) {
                     fun test(x: String?) {
                         if (x == null || x.count() == 0) return
                     }
-                """
+                """.trimIndent()
                 val findings = subject.compileAndLintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }
@@ -260,7 +260,7 @@ class UseIsNullOrEmptySpec(val env: KotlinCoreEnvironment) {
                     fun test(x: String?) {
                         if (x == null || x.length == 0) return
                     }
-                """
+                """.trimIndent()
                 val findings = subject.compileAndLintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }
@@ -271,7 +271,7 @@ class UseIsNullOrEmptySpec(val env: KotlinCoreEnvironment) {
                     fun test(x: String?) {
                         if (x == null || x == "") return
                     }
-                """
+                """.trimIndent()
                 val findings = subject.compileAndLintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }
@@ -285,7 +285,7 @@ class UseIsNullOrEmptySpec(val env: KotlinCoreEnvironment) {
                     fun test(x: MutableList<Int>?) {
                         if (x == null || x.isEmpty()) return
                     }
-                """
+                """.trimIndent()
                 val findings = subject.compileAndLintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }
@@ -299,7 +299,7 @@ class UseIsNullOrEmptySpec(val env: KotlinCoreEnvironment) {
                     fun test(x: MutableSet<Int>?) {
                         if (x == null || x.isEmpty()) return
                     }
-                """
+                """.trimIndent()
                 val findings = subject.compileAndLintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }
@@ -313,7 +313,7 @@ class UseIsNullOrEmptySpec(val env: KotlinCoreEnvironment) {
                     fun test(x: MutableCollection<Int>?) {
                         if (x == null || x.isEmpty()) return
                     }
-                """
+                """.trimIndent()
                 val findings = subject.compileAndLintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }
@@ -327,7 +327,7 @@ class UseIsNullOrEmptySpec(val env: KotlinCoreEnvironment) {
                     fun test(x: MutableMap<Int, String>?) {
                         if (x == null || x.isEmpty()) return
                     }
-                """
+                """.trimIndent()
                 val findings = subject.compileAndLintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }
@@ -344,7 +344,7 @@ class UseIsNullOrEmptySpec(val env: KotlinCoreEnvironment) {
                     fun test(x: IntArray?) {
                         if (x == null || x.isEmpty()) return
                     }
-                """
+                """.trimIndent()
                 val findings = subject.compileAndLintWithContext(env, code)
                 assertThat(findings).isEmpty()
             }
@@ -355,7 +355,7 @@ class UseIsNullOrEmptySpec(val env: KotlinCoreEnvironment) {
                     fun test(x: IntArray?) {
                         if (x == null || x.count() == 0) return
                     }
-                """
+                """.trimIndent()
                 val findings = subject.compileAndLintWithContext(env, code)
                 assertThat(findings).isEmpty()
             }
@@ -366,7 +366,7 @@ class UseIsNullOrEmptySpec(val env: KotlinCoreEnvironment) {
                     fun test(x: IntArray?) {
                         if (x == null || x.size == 0) return
                     }
-                """
+                """.trimIndent()
                 val findings = subject.compileAndLintWithContext(env, code)
                 assertThat(findings).isEmpty()
             }
@@ -380,7 +380,7 @@ class UseIsNullOrEmptySpec(val env: KotlinCoreEnvironment) {
                 fun test(x: Sequence<Int>?) {
                     if (x == null || x.count() == 0) return
                 }
-                """
+                """.trimIndent()
                 val findings = subject.compileAndLintWithContext(env, code)
                 assertThat(findings).isEmpty()
             }
@@ -392,7 +392,7 @@ class UseIsNullOrEmptySpec(val env: KotlinCoreEnvironment) {
                 fun test(x: List<Int>?, y: List<Int>) {
                     if (x == null || y.isEmpty()) return
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
@@ -403,7 +403,7 @@ class UseIsNullOrEmptySpec(val env: KotlinCoreEnvironment) {
                 fun test(x: List<Int>?) {
                     if (x != null && x.isEmpty()) return
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
@@ -414,7 +414,7 @@ class UseIsNullOrEmptySpec(val env: KotlinCoreEnvironment) {
                 fun test(x: List<Int>?) {
                     if (x == null || x.count() == 1) return
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
@@ -425,7 +425,7 @@ class UseIsNullOrEmptySpec(val env: KotlinCoreEnvironment) {
                 fun test(x: List<Int>) {
                     if (x == null || x.isEmpty()) return
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
@@ -440,7 +440,7 @@ class UseIsNullOrEmptySpec(val env: KotlinCoreEnvironment) {
                         if (x == null || x?.count() == 0) return
                     }
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseOrEmptySpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseOrEmptySpec.kt
@@ -19,7 +19,7 @@ class UseOrEmptySpec(val env: KotlinCoreEnvironment) {
                 fun test(x: List<Int>?) {
                     val a = x ?: emptyList()
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasStartSourceLocation(2, 13)
@@ -32,7 +32,7 @@ class UseOrEmptySpec(val env: KotlinCoreEnvironment) {
                 fun test(x: Set<Int>?) {
                     val a = x ?: emptySet()
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
@@ -43,7 +43,7 @@ class UseOrEmptySpec(val env: KotlinCoreEnvironment) {
                 fun test(x: Map<Int, String>?) {
                     val a = x ?: emptyMap()
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
@@ -54,7 +54,7 @@ class UseOrEmptySpec(val env: KotlinCoreEnvironment) {
                 fun test(x: Sequence<Int>?) {
                     val a = x ?: emptySequence()
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
@@ -65,7 +65,7 @@ class UseOrEmptySpec(val env: KotlinCoreEnvironment) {
                 fun test(x: Array<Int>?) {
                     val a = x ?: emptyArray()
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
@@ -76,7 +76,7 @@ class UseOrEmptySpec(val env: KotlinCoreEnvironment) {
                 fun test(x: List<Int>?) {
                     val a = x ?: listOf()
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
@@ -87,7 +87,7 @@ class UseOrEmptySpec(val env: KotlinCoreEnvironment) {
                 fun test(x: Set<Int>?) {
                     val a = x ?: setOf()
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
@@ -98,7 +98,7 @@ class UseOrEmptySpec(val env: KotlinCoreEnvironment) {
                 fun test(x: Map<Int, String>?) {
                     val a = x ?: mapOf()
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
@@ -109,7 +109,7 @@ class UseOrEmptySpec(val env: KotlinCoreEnvironment) {
                 fun test(x: Sequence<Int>?) {
                     val a = x ?: sequenceOf()
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
@@ -120,7 +120,7 @@ class UseOrEmptySpec(val env: KotlinCoreEnvironment) {
                 fun test(x: Array<Int>?) {
                     val a = x ?: arrayOf()
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
@@ -131,7 +131,7 @@ class UseOrEmptySpec(val env: KotlinCoreEnvironment) {
                 fun test(x: String?) {
                     val a = x ?: ""
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
@@ -142,7 +142,7 @@ class UseOrEmptySpec(val env: KotlinCoreEnvironment) {
                 fun test(x: MutableList<Int>?) {
                     val a = x ?: emptyList()
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
@@ -156,7 +156,7 @@ class UseOrEmptySpec(val env: KotlinCoreEnvironment) {
                 fun test(c: C) {
                     c["key"] ?: emptyList()
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
@@ -170,7 +170,7 @@ class UseOrEmptySpec(val env: KotlinCoreEnvironment) {
                 fun test(x: List<Int>) {
                     val a = x ?: emptyList()
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
@@ -181,7 +181,7 @@ class UseOrEmptySpec(val env: KotlinCoreEnvironment) {
                 fun test(x: List<Int>?) {
                     val a = x ?: listOf(1)
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
@@ -195,7 +195,7 @@ class UseOrEmptySpec(val env: KotlinCoreEnvironment) {
                 fun test(c: Any?) {
                     val x = c ?: emptyList<Int>()
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
@@ -206,7 +206,7 @@ class UseOrEmptySpec(val env: KotlinCoreEnvironment) {
                 fun test(x: MutableList<Int>?) {
                     val a = x ?: mutableListOf()
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
@@ -217,7 +217,7 @@ class UseOrEmptySpec(val env: KotlinCoreEnvironment) {
                 fun test(x: IntArray?) {
                     val a = x ?: intArrayOf()
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
@@ -233,7 +233,7 @@ class UseOrEmptySpec(val env: KotlinCoreEnvironment) {
                     val y: List<Int> = c["key"] ?: emptyList()
                     val z = (c["key"]) ?: emptyList<Int>()
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseRequireNotNullSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseRequireNotNullSpec.kt
@@ -16,7 +16,7 @@ class UseRequireNotNullSpec(val env: KotlinCoreEnvironment) {
             fun test(i: Int?) {
                 require(i != null)
             }
-        """
+        """.trimIndent()
         val actual = subject.compileAndLintWithContext(env, code)
         assertThat(actual).hasSize(1)
     }
@@ -27,7 +27,7 @@ class UseRequireNotNullSpec(val env: KotlinCoreEnvironment) {
             fun test(i: Int?) {
                 require(null != i)
             }
-        """
+        """.trimIndent()
         val actual = subject.compileAndLintWithContext(env, code)
         assertThat(actual).hasSize(1)
     }
@@ -38,7 +38,7 @@ class UseRequireNotNullSpec(val env: KotlinCoreEnvironment) {
             fun test(i: Int) {
                 require(i > 0)
             }
-        """
+        """.trimIndent()
         val actual = subject.compileAndLintWithContext(env, code)
         assertThat(actual).isEmpty()
     }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseRequireSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseRequireSpec.kt
@@ -21,7 +21,7 @@ class UseRequireSpec(val env: KotlinCoreEnvironment) {
                 if (a < 0) throw IllegalArgumentException()
                 doSomething()
             }
-        """
+        """.trimIndent()
         assertThat(subject.lint(code)).hasStartSourceLocation(2, 16)
     }
 
@@ -34,7 +34,7 @@ class UseRequireSpec(val env: KotlinCoreEnvironment) {
                 }
                 doSomething()
             }
-        """
+        """.trimIndent()
 
         assertThat(subject.lint(code)).hasStartSourceLocation(3, 9)
     }
@@ -46,7 +46,7 @@ class UseRequireSpec(val env: KotlinCoreEnvironment) {
                 if (a < 0) throw IllegalArgumentException("More details")
                 doSomething()
             }
-        """
+        """.trimIndent()
         assertThat(subject.lint(code)).hasStartSourceLocation(2, 16)
     }
 
@@ -57,7 +57,7 @@ class UseRequireSpec(val env: KotlinCoreEnvironment) {
                 if (a < 0) throw java.lang.IllegalArgumentException()
                 doSomething()
             }
-        """
+        """.trimIndent()
         assertThat(subject.lint(code)).hasStartSourceLocation(2, 16)
     }
 
@@ -68,7 +68,7 @@ class UseRequireSpec(val env: KotlinCoreEnvironment) {
                 if (a < 0) throw kotlin.IllegalArgumentException()
                 doSomething()
             }
-        """
+        """.trimIndent()
         assertThat(subject.lint(code)).hasStartSourceLocation(2, 16)
     }
 
@@ -79,7 +79,7 @@ class UseRequireSpec(val env: KotlinCoreEnvironment) {
                 if (a < 0) throw SomeBusinessException()
                 doSomething()
             }
-        """
+        """.trimIndent()
         assertThat(subject.lint(code)).isEmpty()
     }
 
@@ -90,7 +90,7 @@ class UseRequireSpec(val env: KotlinCoreEnvironment) {
                 doSomething()
                 throw IllegalArgumentException("message", cause)
             }
-        """
+        """.trimIndent()
         assertThat(subject.lint(code)).isEmpty()
     }
 
@@ -104,7 +104,7 @@ class UseRequireSpec(val env: KotlinCoreEnvironment) {
                 }
                 doSomething()
             }
-        """
+        """.trimIndent()
 
         assertThat(subject.lint(code)).isEmpty()
     }
@@ -114,7 +114,7 @@ class UseRequireSpec(val env: KotlinCoreEnvironment) {
         val code = """
             fun unsafeRunSync(): A =
                 foo.fold({ throw IllegalArgumentException("message") }, ::identity)
-        """
+        """.trimIndent()
         assertThat(subject.lint(code)).isEmpty()
     }
 
@@ -136,7 +136,7 @@ class UseRequireSpec(val env: KotlinCoreEnvironment) {
             fun test(throwable: Throwable) {
                 if (throwable !is NumberFormatException) throw IllegalArgumentException(throwable)
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -146,7 +146,7 @@ class UseRequireSpec(val env: KotlinCoreEnvironment) {
             fun test(throwable: Throwable) {
                 if (throwable !is NumberFormatException) throw IllegalArgumentException("a", throwable)
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -157,7 +157,7 @@ class UseRequireSpec(val env: KotlinCoreEnvironment) {
                 val s = ""
                 if (throwable !is NumberFormatException) throw IllegalArgumentException(s)
             }
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -170,7 +170,7 @@ class UseRequireSpec(val env: KotlinCoreEnvironment) {
                 fun test(throwable: Throwable) {
                     if (throwable !is NumberFormatException) throw IllegalArgumentException(throwable)
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -180,7 +180,7 @@ class UseRequireSpec(val env: KotlinCoreEnvironment) {
                 fun test(throwable: Throwable) {
                     if (throwable !is NumberFormatException) throw IllegalArgumentException("a", throwable)
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -191,7 +191,7 @@ class UseRequireSpec(val env: KotlinCoreEnvironment) {
                     val s = ""
                     if (throwable !is NumberFormatException) throw IllegalArgumentException(s)
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
@@ -201,7 +201,7 @@ class UseRequireSpec(val env: KotlinCoreEnvironment) {
                 fun test(throwable: Throwable) {
                     if (throwable !is NumberFormatException) throw IllegalArgumentException("a")
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
     }
@@ -217,7 +217,7 @@ class UseRequireSpec(val env: KotlinCoreEnvironment) {
                     is LinkedList<*> -> 2
                     else -> throw IllegalArgumentException("Not supported List type")
                 }
-            """
+            """.trimIndent()
             assertThat(subject.lint(code)).isEmpty()
         }
 
@@ -233,7 +233,7 @@ class UseRequireSpec(val env: KotlinCoreEnvironment) {
                     }
                     throw IllegalArgumentException("Test was too big")
                 }
-            """
+            """.trimIndent()
             assertThat(subject.lint(code)).isEmpty()
         }
 
@@ -245,7 +245,7 @@ class UseRequireSpec(val env: KotlinCoreEnvironment) {
                         ?: throw IllegalArgumentException("List is not a LinkedList")
                     return subclass
                 }
-            """
+            """.trimIndent()
             assertThat(subject.lint(code)).isEmpty()
         }
     }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UselessCallOnNotNullSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UselessCallOnNotNullSpec.kt
@@ -49,7 +49,7 @@ class UselessCallOnNotNullSpec(val env: KotlinCoreEnvironment) {
         val code = """
             val testList: List<String>? = listOf("string")
             val nonNullableTestList = testList.orEmpty()
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 
@@ -66,7 +66,7 @@ class UselessCallOnNotNullSpec(val env: KotlinCoreEnvironment) {
         val code = """
             val testString: String? = ""
             val nonNullableTestString = testString.isNullOrBlank()
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 
@@ -89,7 +89,7 @@ class UselessCallOnNotNullSpec(val env: KotlinCoreEnvironment) {
         val code = """
             val testString: String? = ""
             val nonNullableTestString = testString.isNullOrEmpty()
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 
@@ -106,7 +106,7 @@ class UselessCallOnNotNullSpec(val env: KotlinCoreEnvironment) {
         val code = """
             val testString: String? = ""
             val nonNullableTestString = testString.orEmpty()
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 
@@ -123,7 +123,7 @@ class UselessCallOnNotNullSpec(val env: KotlinCoreEnvironment) {
         val code = """
             val testSequence: Sequence<Int>? = listOf(1).asSequence()
             val nonNullableTestSequence = testSequence.orEmpty()
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 
@@ -134,7 +134,7 @@ class UselessCallOnNotNullSpec(val env: KotlinCoreEnvironment) {
 
             val noList = "str".orEmpty()
             val list = listOf(1, 2, 3).orEmpty()
-        """
+        """.trimIndent()
         val findings = subject.compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(1)
         assertThat(findings[0].message).isEqualTo("Remove redundant call to orEmpty")
@@ -144,7 +144,7 @@ class UselessCallOnNotNullSpec(val env: KotlinCoreEnvironment) {
     fun `reports when calling listOfNotNull on all non-nullable arguments`() {
         val code = """
             val strings = listOfNotNull("string")
-        """
+        """.trimIndent()
         val findings = subject.compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(1)
         assertThat(findings[0].message).isEqualTo("Replace listOfNotNull with listOf")
@@ -154,7 +154,7 @@ class UselessCallOnNotNullSpec(val env: KotlinCoreEnvironment) {
     fun `reports when calling listOfNotNull with no arguments`() {
         val code = """
             val strings = listOfNotNull<String>()
-        """
+        """.trimIndent()
         val findings = subject.compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(1)
         assertThat(findings[0].message).isEqualTo("Replace listOfNotNull with listOf")
@@ -164,7 +164,7 @@ class UselessCallOnNotNullSpec(val env: KotlinCoreEnvironment) {
     fun `does not report when calling listOfNotNull on at least one nullable argument`() {
         val code = """
             val strings = listOfNotNull("string", null)
-        """
+        """.trimIndent()
         val findings = subject.compileAndLintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
@@ -174,7 +174,7 @@ class UselessCallOnNotNullSpec(val env: KotlinCoreEnvironment) {
         val code = """
             val nullableArray = arrayOf("string", null)
             val strings = listOfNotNull(*nullableArray)
-        """
+        """.trimIndent()
         val findings = subject.compileAndLintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
@@ -184,7 +184,7 @@ class UselessCallOnNotNullSpec(val env: KotlinCoreEnvironment) {
         val code = """
             val nonNullableArray = arrayOf("string", "bar")
             val strings = listOfNotNull(*nonNullableArray)
-        """
+        """.trimIndent()
         val findings = subject.compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(1)
         assertThat(findings[0].message).isEqualTo("Replace listOfNotNull with listOf")
@@ -196,7 +196,7 @@ class UselessCallOnNotNullSpec(val env: KotlinCoreEnvironment) {
             val nullableArray = arrayOf("string", null)
             val nonNullableArray = arrayOf("string", "bar")
             val strings = listOfNotNull("string", *nonNullableArray, "foo", *nullableArray)
-        """
+        """.trimIndent()
         val findings = subject.compileAndLintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
@@ -206,7 +206,7 @@ class UselessCallOnNotNullSpec(val env: KotlinCoreEnvironment) {
         val code = """
             val nonNullableArray = arrayOf("string", "bar")
             val strings = listOfNotNull("string", *nonNullableArray, null)
-        """
+        """.trimIndent()
         val findings = subject.compileAndLintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
@@ -217,7 +217,7 @@ class UselessCallOnNotNullSpec(val env: KotlinCoreEnvironment) {
             val nonNullableArray = arrayOf("string", "bar")
             val otherNonNullableArray = arrayOf("foobar")
             val strings = listOfNotNull("string", *nonNullableArray, "foo", *otherNonNullableArray)
-        """
+        """.trimIndent()
         val findings = subject.compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(1)
         assertThat(findings[0].message).isEqualTo("Replace listOfNotNull with listOf")
@@ -229,7 +229,7 @@ class UselessCallOnNotNullSpec(val env: KotlinCoreEnvironment) {
             fun <T : Any> listOfNotNull(vararg elements: T?): List<T> = TODO()
 
             val strings = listOfNotNull("string", null)                
-        """
+        """.trimIndent()
         val findings = subject.compileAndLintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
@@ -266,7 +266,7 @@ class UselessCallOnNotNullSpec(val env: KotlinCoreEnvironment) {
             fun test(list: List<Int>) {
                 list.isNullOrEmpty()
             }                
-        """
+        """.trimIndent()
         val findings = subject.compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(1)
         assertThat(findings[0].message).isEqualTo("Replace isNullOrEmpty with isEmpty")

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UtilityClassWithPublicConstructorSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UtilityClassWithPublicConstructorSpec.kt
@@ -63,7 +63,7 @@ class UtilityClassWithPublicConstructorSpec {
                     const val FEMALE = "female"
                 }
             }
-            """
+            """.trimIndent()
             assertThat(subject.lint(code)).isEmpty()
         }
     }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/VarCouldBeValSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/VarCouldBeValSpec.kt
@@ -47,7 +47,7 @@ class VarCouldBeValSpec(val env: KotlinCoreEnvironment) {
                 fun foo() {
                     a = 2
                 }
-            """
+            """.trimIndent()
 
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
@@ -62,7 +62,7 @@ class VarCouldBeValSpec(val env: KotlinCoreEnvironment) {
                     a = 2
                 }
             }
-            """
+            """.trimIndent()
 
             assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
@@ -80,7 +80,7 @@ class VarCouldBeValSpec(val env: KotlinCoreEnvironment) {
                     a = 2
                 }
             }
-            """
+            """.trimIndent()
 
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
@@ -167,7 +167,7 @@ class VarCouldBeValSpec(val env: KotlinCoreEnvironment) {
                 var a = 1
                 a = 2
             }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -178,7 +178,7 @@ class VarCouldBeValSpec(val env: KotlinCoreEnvironment) {
                 var a = 1
                 a += 2
             }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -189,7 +189,7 @@ class VarCouldBeValSpec(val env: KotlinCoreEnvironment) {
                 var a = 1
                 a++
             }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -200,7 +200,7 @@ class VarCouldBeValSpec(val env: KotlinCoreEnvironment) {
                 var a = 1
                 --a
             }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -213,7 +213,7 @@ class VarCouldBeValSpec(val env: KotlinCoreEnvironment) {
                     a = 2
                 }
             }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -224,7 +224,7 @@ class VarCouldBeValSpec(val env: KotlinCoreEnvironment) {
                 var a = 1
                 val b = a + 2
             }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
 
             assertThat(findings).hasSize(1)
@@ -238,7 +238,7 @@ class VarCouldBeValSpec(val env: KotlinCoreEnvironment) {
                 var a = 1
                 println(a)
             }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
 
             assertThat(findings).hasSize(1)
@@ -255,7 +255,7 @@ class VarCouldBeValSpec(val env: KotlinCoreEnvironment) {
                     shadowed = 3
                 }
             }
-            """
+            """.trimIndent()
             val lint = subject.compileAndLintWithContext(env, code)
 
             assertThat(lint).hasSize(1)
@@ -277,7 +277,7 @@ class VarCouldBeValSpec(val env: KotlinCoreEnvironment) {
                         var myVar = value
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(2)
         }
 
@@ -290,7 +290,7 @@ class VarCouldBeValSpec(val env: KotlinCoreEnvironment) {
                         this.myVar = value
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -304,7 +304,7 @@ class VarCouldBeValSpec(val env: KotlinCoreEnvironment) {
                         this.myVar = value
                     }
                 }
-            """
+            """.trimIndent()
             with(subject.compileAndLintWithContext(env, code)[0]) {
                 assertThat(entity.ktElement?.text).isEqualTo("var myVar = value")
             }
@@ -321,7 +321,7 @@ class VarCouldBeValSpec(val env: KotlinCoreEnvironment) {
                         var test: Boolean = true
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
@@ -334,7 +334,7 @@ class VarCouldBeValSpec(val env: KotlinCoreEnvironment) {
                     }
                     wrapper.test = false
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -349,7 +349,7 @@ class VarCouldBeValSpec(val env: KotlinCoreEnvironment) {
                             override var optionEnabled: Boolean = false
                         }
                     }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -367,7 +367,7 @@ class VarCouldBeValSpec(val env: KotlinCoreEnvironment) {
                     }
                     o.optionEnabled = false
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
@@ -385,7 +385,7 @@ class VarCouldBeValSpec(val env: KotlinCoreEnvironment) {
                         }
                         return o
                     }
-                """
+                """.trimIndent()
                 assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
             }
 
@@ -405,7 +405,7 @@ class VarCouldBeValSpec(val env: KotlinCoreEnvironment) {
                         }
                         return o
                     }
-                """
+                """.trimIndent()
                 assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
             }
 
@@ -422,7 +422,7 @@ class VarCouldBeValSpec(val env: KotlinCoreEnvironment) {
                         }
                         return o
                     }
-                """
+                """.trimIndent()
                 assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
             }
 
@@ -443,7 +443,7 @@ class VarCouldBeValSpec(val env: KotlinCoreEnvironment) {
                         }
                         return o
                     }
-                """
+                """.trimIndent()
                 assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
             }
 
@@ -458,7 +458,7 @@ class VarCouldBeValSpec(val env: KotlinCoreEnvironment) {
                             override var optionEnabled: Boolean = false
                         }
                     }
-                """
+                """.trimIndent()
                 assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
             }
 
@@ -477,7 +477,7 @@ class VarCouldBeValSpec(val env: KotlinCoreEnvironment) {
                             null
                         }
                     }
-                """
+                """.trimIndent()
                 assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
             }
 
@@ -490,7 +490,7 @@ class VarCouldBeValSpec(val env: KotlinCoreEnvironment) {
                     fun test() = object: I {
                         override var optionEnabled: Boolean = false
                     }
-                """
+                """.trimIndent()
                 assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
             }
 
@@ -505,7 +505,7 @@ class VarCouldBeValSpec(val env: KotlinCoreEnvironment) {
                             override var optionEnabled: Boolean = false
                         }
                     } else null
-                """
+                """.trimIndent()
                 assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
             }
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/VarCouldBeValSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/VarCouldBeValSpec.kt
@@ -349,7 +349,7 @@ class VarCouldBeValSpec(val env: KotlinCoreEnvironment) {
                             override var optionEnabled: Boolean = false
                         }
                     }
-                """
+            """
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/WildcardImportSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/WildcardImportSpec.kt
@@ -20,7 +20,7 @@ class WildcardImportSpec {
 
             class Test {
             }
-        """
+        """.trimIndent()
 
         @Test
         fun `should not report anything when the rule is turned off`() {
@@ -84,7 +84,7 @@ class WildcardImportSpec {
         fun `ignores the default values`() {
             val code2 = """
                 import java.util.*
-            """
+            """.trimIndent()
 
             val findings = WildcardImport().lint(code2)
             assertThat(findings).isEmpty()
@@ -100,7 +100,7 @@ class WildcardImportSpec {
 
         class Test {
         }
-        """
+        """.trimIndent()
 
         @Test
         fun `should not report any issues`() {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/MandatoryBracesIfStatementsSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/MandatoryBracesIfStatementsSpec.kt
@@ -20,7 +20,7 @@ class MandatoryBracesIfStatementsSpec {
                 if (true)
                     println()
             }
-                """
+                """.trimIndent()
             )
 
             assertThat(findings).hasSize(1)
@@ -35,7 +35,7 @@ class MandatoryBracesIfStatementsSpec {
                 	if (true) 50
                         .toString()
                 }
-                """
+                """.trimIndent()
             )
 
             assertThat(findings).hasSize(1)
@@ -50,7 +50,7 @@ class MandatoryBracesIfStatementsSpec {
                         .toString() else 50
                         .toString()
                 }
-                """
+                """.trimIndent()
             )
 
             assertThat(findings).hasSize(2)
@@ -66,7 +66,7 @@ class MandatoryBracesIfStatementsSpec {
                 else
                     println()
             }
-                """
+                """.trimIndent()
             )
 
             assertThat(findings).hasSize(2)
@@ -85,7 +85,7 @@ class MandatoryBracesIfStatementsSpec {
                 else
                     println()
             }
-                """
+                """.trimIndent()
             )
 
             assertThat(findings).hasSize(3)
@@ -102,7 +102,7 @@ class MandatoryBracesIfStatementsSpec {
                 } else
                     println()
             }
-                """
+                """.trimIndent()
             )
 
             assertThat(findings).hasSize(1)
@@ -120,7 +120,7 @@ class MandatoryBracesIfStatementsSpec {
                     println()
                 }
             }
-                """
+                """.trimIndent()
             )
 
             assertThat(findings).hasSize(1)
@@ -135,7 +135,7 @@ class MandatoryBracesIfStatementsSpec {
                 if (true) println()
                 else println()
             }
-                """
+                """.trimIndent()
             )
 
             assertThat(findings).hasSize(1)
@@ -150,7 +150,7 @@ class MandatoryBracesIfStatementsSpec {
                 if (true) println() else
                     println()
             }
-                """
+                """.trimIndent()
             )
 
             assertThat(findings).hasSize(1)
@@ -174,7 +174,7 @@ class MandatoryBracesIfStatementsSpec {
                 	}
                 	if (true) { println() }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
     }
@@ -190,7 +190,7 @@ class MandatoryBracesIfStatementsSpec {
                 	if (true) println() else println()
                 	if (true) println() else if (false) println() else println()
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
     }
@@ -209,7 +209,7 @@ class MandatoryBracesIfStatementsSpec {
                         else -> println()
                     }
                 }
-            """
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
     }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/MandatoryBracesLoopsSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/MandatoryBracesLoopsSpec.kt
@@ -20,7 +20,7 @@ class MandatoryBracesLoopsSpec {
                     println(i)
                 }
             }
-            """
+            """.trimIndent()
 
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
@@ -31,7 +31,7 @@ class MandatoryBracesLoopsSpec {
             fun test() {
                 for (i in 0..10) println(i)
             }
-            """
+            """.trimIndent()
 
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
@@ -42,7 +42,7 @@ class MandatoryBracesLoopsSpec {
             fun test() {
                 for (i in 0..10) println(i); print(' ')
             }
-            """
+            """.trimIndent()
 
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
@@ -54,7 +54,7 @@ class MandatoryBracesLoopsSpec {
                 for (i in 0..10)
                     println(i)
             }
-            """
+            """.trimIndent()
 
             val findings = subject.compileAndLint(code)
 
@@ -71,7 +71,7 @@ class MandatoryBracesLoopsSpec {
                 for (i in 0..10)
                     println(i)
             }
-            """
+            """.trimIndent()
 
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
@@ -86,7 +86,7 @@ class MandatoryBracesLoopsSpec {
                     }
                 }
             }
-            """
+            """.trimIndent()
 
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
@@ -97,7 +97,7 @@ class MandatoryBracesLoopsSpec {
             fun test() {
                 for (i in 0..10) for (j in 0..10) println()
             }
-            """
+            """.trimIndent()
 
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
@@ -111,7 +111,7 @@ class MandatoryBracesLoopsSpec {
                         println()
                     }
             }
-            """
+            """.trimIndent()
 
             val findings = subject.compileAndLint(code)
 
@@ -129,7 +129,7 @@ class MandatoryBracesLoopsSpec {
                         println()
                 }
             }
-            """
+            """.trimIndent()
 
             val findings = subject.compileAndLint(code)
 
@@ -145,7 +145,7 @@ class MandatoryBracesLoopsSpec {
                     for (j in 0..10)
                         println()
             }
-            """
+            """.trimIndent()
 
             val findings = subject.compileAndLint(code)
 
@@ -169,7 +169,7 @@ class MandatoryBracesLoopsSpec {
                         println("Odd")
                     }
             }
-            """
+            """.trimIndent()
 
             val findings = subject.compileAndLint(code)
 
@@ -191,7 +191,7 @@ class MandatoryBracesLoopsSpec {
                     println("Odd")
                 }
             }
-            """
+            """.trimIndent()
 
             val findings = subject.compileAndLint(code)
 
@@ -212,7 +212,7 @@ class MandatoryBracesLoopsSpec {
                     println()
                 }
             }
-            """
+            """.trimIndent()
 
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
@@ -223,7 +223,7 @@ class MandatoryBracesLoopsSpec {
             fun test() {
                 while(true) println()
             }
-            """
+            """.trimIndent()
 
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
@@ -235,7 +235,7 @@ class MandatoryBracesLoopsSpec {
                 while (true)
                     println()
             }
-            """
+            """.trimIndent()
 
             val findings = subject.compileAndLint(code)
 
@@ -252,7 +252,7 @@ class MandatoryBracesLoopsSpec {
                 while(true)
                     println()
             }
-            """
+            """.trimIndent()
 
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
@@ -266,7 +266,7 @@ class MandatoryBracesLoopsSpec {
                         println()
                 }
             }
-            """
+            """.trimIndent()
 
             val findings = subject.compileAndLint(code)
 
@@ -286,7 +286,7 @@ class MandatoryBracesLoopsSpec {
                     println()
                 } while(true)
             }
-            """
+            """.trimIndent()
 
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
@@ -297,7 +297,7 @@ class MandatoryBracesLoopsSpec {
             fun test() {
                 do println() while(true)
             }
-            """
+            """.trimIndent()
 
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
@@ -310,7 +310,7 @@ class MandatoryBracesLoopsSpec {
                     println()
                 while (true)
             }
-            """
+            """.trimIndent()
 
             val findings = subject.compileAndLint(code)
 
@@ -328,7 +328,7 @@ class MandatoryBracesLoopsSpec {
                     println()
                 while(true)
             }
-            """
+            """.trimIndent()
 
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
@@ -343,7 +343,7 @@ class MandatoryBracesLoopsSpec {
                     }		
                 } while (true)	
             }		
-            """
+            """.trimIndent()
 
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
@@ -355,7 +355,7 @@ class MandatoryBracesLoopsSpec {
                 var i = 0
                 do do i += 1 while(i < 5) while (i < 5)	
             }		
-            """
+            """.trimIndent()
 
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
@@ -370,7 +370,7 @@ class MandatoryBracesLoopsSpec {
                     } while (true)
                 while (true)
             }
-            """
+            """.trimIndent()
 
             val findings = subject.compileAndLint(code)
 
@@ -389,7 +389,7 @@ class MandatoryBracesLoopsSpec {
                     while(true)
                 } while (true)
             }
-            """
+            """.trimIndent()
 
             val findings = subject.compileAndLint(code)
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/OptionalUnitSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/OptionalUnitSpec.kt
@@ -46,7 +46,7 @@ class OptionalUnitSpec(val env: KotlinCoreEnvironment) {
             }
 
             fun returnsUnit2() = Unit
-        """
+        """.trimIndent()
         lateinit var findings: List<Finding>
 
         @BeforeEach
@@ -81,7 +81,7 @@ class OptionalUnitSpec(val env: KotlinCoreEnvironment) {
                 class C : I {
                     override fun returnsUnit() = Unit
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLint(code)
             assertThat(findings).isEmpty()
         }
@@ -104,7 +104,7 @@ class OptionalUnitSpec(val env: KotlinCoreEnvironment) {
                     Unit
                 }
             }
-        """
+        """.trimIndent()
         lateinit var findings: List<Finding>
 
         @BeforeEach
@@ -139,7 +139,7 @@ class OptionalUnitSpec(val env: KotlinCoreEnvironment) {
                     Unit.equals(null)
                     val i: (Int) -> Unit = { _ -> }
                 }
-                """
+                """.trimIndent()
             )
             assertThat(findings).isEmpty()
         }
@@ -153,7 +153,7 @@ class OptionalUnitSpec(val env: KotlinCoreEnvironment) {
                 interface Foo {
                     fun method(i: Int) = Unit
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLint(code)
             assertThat(findings).hasSize(1)
         }
@@ -175,7 +175,7 @@ class OptionalUnitSpec(val env: KotlinCoreEnvironment) {
                         }
                     }
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
@@ -196,7 +196,7 @@ class OptionalUnitSpec(val env: KotlinCoreEnvironment) {
                         }
                     }.foo()
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
@@ -223,7 +223,7 @@ class OptionalUnitSpec(val env: KotlinCoreEnvironment) {
                         }
                     }.foo()
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
@@ -248,7 +248,7 @@ class OptionalUnitSpec(val env: KotlinCoreEnvironment) {
                         }
                     }.foo()
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
@@ -277,7 +277,7 @@ class OptionalUnitSpec(val env: KotlinCoreEnvironment) {
                         }
                     }.foo()
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
@@ -303,7 +303,7 @@ class OptionalUnitSpec(val env: KotlinCoreEnvironment) {
                         }
                     }.foo()
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
@@ -329,7 +329,7 @@ class OptionalUnitSpec(val env: KotlinCoreEnvironment) {
                         }
                     }.foo()
                 }
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
@@ -352,7 +352,7 @@ class OptionalUnitSpec(val env: KotlinCoreEnvironment) {
         fun `should not report when function initializer is Nothing`() {
             val code = """
                 fun test(): Unit = throw UnsupportedOperationException()
-            """
+            """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
@@ -376,7 +376,7 @@ class OptionalUnitSpec(val env: KotlinCoreEnvironment) {
         fun `should report on function initializers when there is no context`() {
             val code = """
                 fun test(): Unit = throw UnsupportedOperationException()
-            """
+            """.trimIndent()
             val findings = subject.compileAndLint(code)
             assertThat(findings).hasSize(1)
         }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/PreferToOverPairSyntaxSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/PreferToOverPairSyntaxSpec.kt
@@ -17,7 +17,7 @@ class PreferToOverPairSyntaxSpec(val env: KotlinCoreEnvironment) {
             val pair1 = Pair(1, 2)
             val pair2: Pair<Int, Int> = Pair(1, 2)
             val pair3 = Pair(Pair(1, 2), Pair(3, 4))
-        """
+        """.trimIndent()
 
         val findings = subject.compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(5)
@@ -29,7 +29,7 @@ class PreferToOverPairSyntaxSpec(val env: KotlinCoreEnvironment) {
         val code = """
             val pair = createPair()
             fun createPair() = Pair(1, 2)
-        """
+        """.trimIndent()
         val findings = subject.compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(1)
         assertThat(findings[0].message).endsWith("`1 to 2`.")
@@ -49,7 +49,7 @@ class PreferToOverPairSyntaxSpec(val env: KotlinCoreEnvironment) {
             val pair3 = Pair(Pair(1, 2), Pair(3, 4))
 
             data class Pair<T, Z>(val int1: T, val int2: Z)
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 
@@ -58,7 +58,7 @@ class PreferToOverPairSyntaxSpec(val env: KotlinCoreEnvironment) {
         val code = """
             val pair = createPair()
             fun createPair() = 1 to 2
-        """
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 }

--- a/detekt-sample-extensions/src/test/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/TooManyFunctionsSpec.kt
+++ b/detekt-sample-extensions/src/test/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/TooManyFunctionsSpec.kt
@@ -17,7 +17,7 @@ class TooManyFunctionsSpec {
     }
 }
 
-private const val code: String = """
+private val code: String = """
     class TooManyFunctions : Rule("TooManyFunctions") {
 
         override fun visitUserType(type: KtUserType) {
@@ -85,4 +85,4 @@ private const val code: String = """
         }
 
     }
-"""
+""".trimIndent()

--- a/detekt-sample-extensions/src/test/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/processors/NumberOfLoopsProcessorSpec.kt
+++ b/detekt-sample-extensions/src/test/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/processors/NumberOfLoopsProcessorSpec.kt
@@ -18,7 +18,7 @@ class NumberOfLoopsProcessorSpec {
                 }
             }
         }
-        """
+        """.trimIndent()
 
         val ktFile = compileContentForTest(code)
         ktFile.accept(DetektVisitor())

--- a/detekt-sample-extensions/src/test/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/processors/QualifiedNameProcessorSpec.kt
+++ b/detekt-sample-extensions/src/test/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/processors/QualifiedNameProcessorSpec.kt
@@ -51,10 +51,10 @@ private val result = object : Detektion {
     }
 }
 
-private const val code = """
+private val code = """
     package io.gitlab.arturbosch.detekt.sample
 
     class Foo {}
     object Bar {}
     interface Bla {}
-"""
+""".trimIndent()

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/RuleExtensions.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/RuleExtensions.kt
@@ -25,7 +25,7 @@ fun BaseRule.compileAndLint(@Language("kotlin") content: String): List<Finding> 
 }
 
 fun BaseRule.lint(@Language("kotlin") content: String): List<Finding> {
-    val ktFile = compileContentForTest(content.trimIndent())
+    val ktFile = compileContentForTest(content)
     return findingsAfterVisit(ktFile)
 }
 
@@ -39,9 +39,9 @@ fun BaseRule.lintWithContext(
     @Language("kotlin") content: String,
     @Language("kotlin") vararg additionalContents: String,
 ): List<Finding> {
-    val ktFile = compileContentForTest(content.trimIndent())
+    val ktFile = compileContentForTest(content)
     val additionalKtFiles = additionalContents.mapIndexed { index, additionalContent ->
-        compileContentForTest(additionalContent.trimIndent(), "AdditionalTest$index.kt")
+        compileContentForTest(additionalContent, "AdditionalTest$index.kt")
     }
     val bindingContext = environment.getContextForPaths(listOf(ktFile) + additionalKtFiles)
     val languageVersionSettings = environment.configuration.languageVersionSettings


### PR DESCRIPTION
This is a big change.

The idea behind this is to enable `MultilineRawStringIndentation` and fix all the format issues that we have.

This is needed because `MultilineRawStringIndentation` can't work over raw strings that don't use `.trimIndent()` because, otherwise, it would be changing the behaviour.