### PR TITLE
Improve raw strings format

### DIFF
--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/ElementPrinterSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/ElementPrinterSpec.kt
@@ -18,7 +18,8 @@ class ElementPrinterSpec {
     }
 }
 
-private val expected = """0: KtFile
+private val expected = """
+0: KtFile
   1: KtPackageDirective
     1: KtNameReferenceExpression
     1: KtImportList

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/printer/defaultconfig/RuleSetConfigPrinterTest.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/printer/defaultconfig/RuleSetConfigPrinterTest.kt
@@ -194,7 +194,8 @@ internal class RuleSetConfigPrinterTest {
             fun `string list default value`() {
                 val given = configurationTemplate.copy(defaultValue = DefaultValue.of(listOf("a", "b", "c")))
                 val actual = yaml { printConfiguration(given) }
-                val expected = """name:
+                val expected = """
+                    |name:
                     |  - 'a'
                     |  - 'b'
                     |  - 'c'
@@ -221,7 +222,8 @@ internal class RuleSetConfigPrinterTest {
                     )
                 )
                 val actual = yaml { printConfiguration(given) }
-                val expected = """name:
+                val expected = """
+                    |name:
                     |  - reason: 'reason a'
                     |    value: 'a'
                     |  - value: 'b'

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterListSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterListSpec.kt
@@ -150,8 +150,10 @@ class LongParameterListSpec {
 
         @Test
         fun `does not report long parameter list for functions if enough function parameters are annotated with ignored annotation`() {
-            val code = """class Data {
-                fun foo(@kotlin.Suppress("") a: Int) {} }
+            val code = """
+                class Data {
+                    fun foo(@kotlin.Suppress("") a: Int) {}
+                }
             """
             assertThat(rule.compileAndLint(code)).isEmpty()
         }

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/KDocReferencesNonPublicPropertySpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/KDocReferencesNonPublicPropertySpec.kt
@@ -9,7 +9,7 @@ class KDocReferencesNonPublicPropertySpec {
 
     @Test
     fun `reports referenced non-public properties`() {
-        val code = """ 
+        val code = """
             /**
              * Comment
              * [prop1] - non-public property
@@ -26,7 +26,7 @@ class KDocReferencesNonPublicPropertySpec {
 
     @Test
     fun `reports referenced non-public properties in private class`() {
-        val code = """ 
+        val code = """
             /**
              * Comment
              * [prop1] - non-public property
@@ -43,7 +43,7 @@ class KDocReferencesNonPublicPropertySpec {
 
     @Test
     fun `reports referenced non-public properties in nested objects`() {
-        val code = """ 
+        val code = """
         /**
              * Comment
              * [prop1] - non-public property
@@ -72,7 +72,7 @@ class KDocReferencesNonPublicPropertySpec {
 
     @Test
     fun `does not report properties with no KDoc`() {
-        val code = """ 
+        val code = """
             class Test {
                 private val prop1 = 0
                 val prop2 = 0
@@ -109,7 +109,7 @@ class KDocReferencesNonPublicPropertySpec {
 
     @Test
     fun `does not report referenced public properties in nested objects`() {
-        val code = """ 
+        val code = """
             /**
              * Comment
              * [prop1] - public property

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/CanBeNonNullableSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/CanBeNonNullableSpec.kt
@@ -579,7 +579,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
             inner class `in a non-return statement` {
                 @Test
                 fun `does report when the safe-qualified expression is the only expression of the function`() {
-                    val code = """   
+                    val code = """
                         class A(val foo: String)
 
                         fun foo(a: A?) {
@@ -899,7 +899,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
 
             @Test
             fun `does report null-check returning unit type`() {
-                val code = """   
+                val code = """
                     fun foo(a: Int?) {
                         if (a == null) return
                         println(a)
@@ -910,7 +910,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
 
             @Test
             fun `does report null-check returning unit type in block`() {
-                val code = """   
+                val code = """
                     fun foo(a: Int?) {
                         if (a == null) { return }
                         println(a)
@@ -921,7 +921,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
 
             @Test
             fun `does not report guard statement with side effect ahead`() {
-                val code = """   
+                val code = """
                     fun foo(a: Int?) {
                         println("side effect")
                         if (a == null) return
@@ -933,7 +933,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
 
             @Test
             fun `does not report null-check returning non-unit type`() {
-                val code = """   
+                val code = """
                     fun foo(a: Int?): Int {
                         if (a == null) return 0
                         println(a)

--- a/detekt-utils/src/test/kotlin/io/github/detekt/utils/YamlSpec.kt
+++ b/detekt-utils/src/test/kotlin/io/github/detekt/utils/YamlSpec.kt
@@ -10,7 +10,7 @@ class YamlSpec {
     inner class KeyValue {
         @Test
         fun `renders key and value as provided`() {
-            val result = yaml { keyValue() { "key" to "value" } }
+            val result = yaml { keyValue { "key" to "value" } }
             assertThat(result).isEqualTo("key: value")
         }
     }
@@ -30,7 +30,8 @@ class YamlSpec {
         fun `renders single element`() {
             val given = listOf("value")
             val result = yaml { list("key", given) }
-            val expected = """key:
+            val expected = """
+                |key:
                 |  - 'value'
             """.trimMargin()
             assertThat(result).isEqualTo(expected)
@@ -40,7 +41,8 @@ class YamlSpec {
         fun `renders multiple elements`() {
             val given = listOf("value 1", "value 2")
             val result = yaml { list("key", given) }
-            val expected = """key:
+            val expected = """
+                |key:
                 |  - 'value 1'
                 |  - 'value 2'
             """.trimMargin()
@@ -51,7 +53,8 @@ class YamlSpec {
         fun `quotes a value containing special characters`() {
             val given = listOf("val*ue1", "val|ue2", "val\$ue3")
             val result = yaml { list("key", given) }
-            val expected = """key:
+            val expected = """
+                |key:
                 |  - 'val*ue1'
                 |  - 'val|ue2'
                 |  - 'val${"$"}ue3'
@@ -63,7 +66,8 @@ class YamlSpec {
         fun `quotes a blank value`() {
             val given = listOf("   ")
             val result = yaml { list("key", given) }
-            val expected = """key:
+            val expected = """
+                |key:
                 |  - '   '
             """.trimMargin()
             assertThat(result).isEqualTo(expected)
@@ -73,7 +77,8 @@ class YamlSpec {
         fun `does not add quotes when value is already enclosed in quotes`() {
             val given = listOf("'val*ue1'", "\"val|ue2\"", "\"\"", "''")
             val result = yaml { list("key", given) }
-            val expected = """key:
+            val expected = """
+                |key:
                 |  - 'val*ue1'
                 |  - "val|ue2"
                 |  - ""
@@ -106,7 +111,8 @@ class YamlSpec {
         fun `renders single map with single element`() {
             val given = listOf(mapOf("name" to "value"))
             val result = yaml { listOfMaps("key", given) }
-            val expected = """key:
+            val expected = """
+                |key:
                 |  - name: 'value'
             """.trimMargin()
             assertThat(result).isEqualTo(expected)
@@ -122,7 +128,8 @@ class YamlSpec {
                 )
             )
             val result = yaml { listOfMaps("key", given) }
-            val expected = """key:
+            val expected = """
+                |key:
                 |  - name1: 'value 1'
                 |    name2: 'value 2'
                 |    name3: 'value 3'
@@ -147,7 +154,8 @@ class YamlSpec {
                 )
             )
             val result = yaml { listOfMaps("key", given) }
-            val expected = """key:
+            val expected = """
+                |key:
                 |  - name1: 'value 1'
                 |    name2: 'value 2'
                 |  - name3: 'value 3'
@@ -168,7 +176,8 @@ class YamlSpec {
                 ),
             )
             val result = yaml { listOfMaps("key", given) }
-            val expected = """key:
+            val expected = """
+                |key:
                 |  - a: 'value'
                 |    b: 'value'
                 |    x: 'value'
@@ -187,7 +196,8 @@ class YamlSpec {
                 ),
             )
             val result = yaml { listOfMaps("key", given) }
-            val expected = """key:
+            val expected = """
+                |key:
                 |  - a: 'value'
                 |    c: 'value'
             """.trimMargin()
@@ -204,7 +214,8 @@ class YamlSpec {
                 )
             )
             val result = yaml { listOfMaps("key", given) }
-            val expected = """key:
+            val expected = """
+                |key:
                 |  - name1: 'already quoted'
                 |    name2: "also quoted"
                 |    name3: 'should be quoted'


### PR DESCRIPTION
A Multiline raw string should start with a break line and end with another break line.