### PR TITLE
UnusedPrivateMember: fix false positive with backtick parameters

### DIFF
--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
@@ -258,7 +258,7 @@ private class UnusedParameterVisitor(allowedNames: Regex) : UnusedMemberVisitor(
             }
 
             override fun visitReferenceExpression(expression: KtReferenceExpression) {
-                parameters.remove(expression.text)
+                parameters.remove(expression.text.removeSurrounding("`"))
                 super.visitReferenceExpression(expression)
             }
         })

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMemberSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMemberSpec.kt
@@ -1469,6 +1469,17 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
     }
 
     @Nested
+    inner class `backtick identifiers - #5251` {
+        @Test
+        fun `does not report used backtick parameters`() {
+            val code = """
+                fun test(`foo bar`: Int) = `foo bar`
+            """
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        }
+    }
+
+    @Nested
     inner class `list get overloaded operator function - #3640` {
         @Test
         fun `report used private list get operator function - declared in a class - called by operator`() {


### PR DESCRIPTION
Fixes #5251 