### PR TITLE
Enable NestedScopeFunctions with custom functions

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -31,6 +31,10 @@ complexity:
     excludes: ['**/test/**', '**/*.Test.kt', '**/*.Spec.kt']
   MethodOverloading:
     active: true
+  NestedScopeFunctions:
+    active: true
+    threshold: 1
+    functions: ['kotlin.apply', 'kotlin.run', 'kotlin.with']
   TooManyFunctions:
     excludes: ['**/test/**', '**/functionalTest/**']
 


### PR DESCRIPTION
This PR demonstrates that when a custom value is specified for the functions
configuration property, there are many false positives from totally unrelated
function calls. This doesn't seem to happen when `functions` is unset in the
configuration, and also seems to be somewhat unreliable in the false positives
it generates.