### PR TITLE
detektVersionReplace.js plugin is not replacing all [detekt_version] tags on website

### DIFF
--- a/website/src/remark/detektVersionReplace.js
+++ b/website/src/remark/detektVersionReplace.js
@@ -9,7 +9,7 @@ const plugin = (options) => {
   const transformer = async (ast) => {
     visit(ast, "code", (node) => {
       if (node.value.includes("[detekt_version]")) {
-        node.value = node.value.replace("[detekt_version]", detektVersion);
+        node.value = node.value.replaceAll("[detekt_version]", detektVersion);
       }
     });
   };


### PR DESCRIPTION
There is error on [cli guide installation](https://detekt.dev/docs/gettingstarted/cli/) page.

Instead of 
>curl -sSLO https://github.com/detekt/detekt/releases/download/v1.21.0/detekt-cli-1.21.0.zip
unzip detekt-cli-1.21.0.zip
./detekt-cli-1.21.0/bin/detekt-cli --help

the block **Any OS** is showing next command:

>curl -sSLO https://github.com/detekt/detekt/releases/download/v1.21.0/detekt-cli-[detekt_version].zip
unzip detekt-cli-[detekt_version].zip
./detekt-cli-[detekt_version]/bin/detekt-cli --help

I suppose this issue is happening because detektVersionReplace.js plugin uses 'replace' in node instead of 'replaceAll'.
Or I can also suggest to use `do while` instead of `if` block.