### PR TITLE
Add toolchains support to Gradle plugin

### DIFF
--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt
@@ -194,6 +194,13 @@ class CliArgs {
     var jvmTarget: String = JvmTarget.DEFAULT.description
 
     @Parameter(
+        names = ["--jdk-home"],
+        description = "EXPERIMENTAL: Use a custom JDK home directory to include into the classpath",
+        converter = PathConverter::class
+    )
+    var jdkHome: Path? = null
+
+    @Parameter(
         names = ["--version"],
         description = "Prints the detekt CLI version."
     )

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Spec.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Spec.kt
@@ -68,6 +68,7 @@ internal fun CliArgs.createSpec(output: Appendable, error: Appendable): Processi
             jvmTarget = args.jvmTarget
             languageVersion = args.languageVersion?.versionString
             classpath = args.classpath?.trim()
+            jdkHome = args.jdkHome
         }
     }
 }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/settings/EnvironmentAware.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/settings/EnvironmentAware.kt
@@ -33,7 +33,8 @@ internal class EnvironmentFacade(
             projectSpec.inputPaths.toList(),
             classpath,
             compilerSpec.parseLanguageVersion(),
-            compilerSpec.parseJvmTarget()
+            compilerSpec.parseJvmTarget(),
+            compilerSpec.jdkHome,
         )
         createKotlinCoreEnvironment(compilerConfiguration, disposable)
     }

--- a/detekt-gradle-plugin/settings.gradle.kts
+++ b/detekt-gradle-plugin/settings.gradle.kts
@@ -2,6 +2,8 @@ pluginManagement {
     includeBuild("../build-logic")
 }
 
+includeBuild("..")
+
 dependencyResolutionManagement {
     versionCatalogs {
         create("libs") {

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -19,6 +19,7 @@ import io.gitlab.arturbosch.detekt.invoke.DetektInvoker
 import io.gitlab.arturbosch.detekt.invoke.DisableDefaultRuleSetArgument
 import io.gitlab.arturbosch.detekt.invoke.FailFastArgument
 import io.gitlab.arturbosch.detekt.invoke.InputArgument
+import io.gitlab.arturbosch.detekt.invoke.JdkHomeArgument
 import io.gitlab.arturbosch.detekt.invoke.JvmTargetArgument
 import io.gitlab.arturbosch.detekt.invoke.LanguageVersionArgument
 import io.gitlab.arturbosch.detekt.invoke.ParallelArgument
@@ -26,6 +27,7 @@ import io.gitlab.arturbosch.detekt.invoke.isDryRunEnabled
 import org.gradle.api.Action
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.Directory
+import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.FileTree
 import org.gradle.api.file.RegularFile
 import org.gradle.api.file.RegularFileProperty
@@ -38,6 +40,7 @@ import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.Console
 import org.gradle.api.tasks.IgnoreEmptyDirectories
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
@@ -95,6 +98,11 @@ abstract class Detekt @Inject constructor(
         @Internal
         get() = jvmTargetProp.get()
         set(value) = jvmTargetProp.set(value)
+
+    @get:InputDirectory
+    @get:PathSensitive(PathSensitivity.ABSOLUTE)
+    @get:Optional
+    abstract val jdkHome: DirectoryProperty
 
     @get:Internal
     internal abstract val debugProp: Property<Boolean>
@@ -216,6 +224,7 @@ abstract class Detekt @Inject constructor(
             ClasspathArgument(classpath),
             LanguageVersionArgument(languageVersionProp.orNull),
             JvmTargetArgument(jvmTargetProp.orNull),
+            JdkHomeArgument(jdkHome),
             ConfigArgument(config),
             BaselineArgument(baseline.orNull),
             DefaultReportArgument(DetektReportType.XML, xmlReportFile.orNull),

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
@@ -17,6 +17,7 @@ import io.gitlab.arturbosch.detekt.invoke.InputArgument
 import io.gitlab.arturbosch.detekt.invoke.JvmTargetArgument
 import io.gitlab.arturbosch.detekt.invoke.ParallelArgument
 import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.FileTree
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
@@ -26,6 +27,7 @@ import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.Console
 import org.gradle.api.tasks.IgnoreEmptyDirectories
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
@@ -112,6 +114,11 @@ abstract class DetektCreateBaselineTask : SourceTask() {
         @Internal
         get() = jvmTargetProp.get()
         set(value) = jvmTargetProp.set(value)
+
+    @get:InputDirectory
+    @get:PathSensitive(PathSensitivity.ABSOLUTE)
+    @get:Optional
+    abstract val jdkHome: DirectoryProperty
 
     @get:Internal
     internal val arguments: Provider<List<String>> = project.provider {

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/CliArgument.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/CliArgument.kt
@@ -1,6 +1,7 @@
 package io.gitlab.arturbosch.detekt.invoke
 
 import io.gitlab.arturbosch.detekt.extensions.DetektReportType
+import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.RegularFile
 import java.io.File
@@ -21,6 +22,7 @@ private const val CREATE_BASELINE_PARAMETER = "--create-baseline"
 private const val CLASSPATH_PARAMETER = "--classpath"
 private const val LANGUAGE_VERSION_PARAMETER = "--language-version"
 private const val JVM_TARGET_PARAMETER = "--jvm-target"
+private const val JDK_HOME_PARAMETER = "--jdk-home"
 private const val BASE_PATH_PARAMETER = "--base-path"
 
 internal sealed class CliArgument {
@@ -56,6 +58,10 @@ internal data class LanguageVersionArgument(val languageVersion: String?) : CliA
 
 internal data class JvmTargetArgument(val jvmTarget: String?) : CliArgument() {
     override fun toArgument() = jvmTarget?.let { listOf(JVM_TARGET_PARAMETER, it) }.orEmpty()
+}
+
+internal data class JdkHomeArgument(val jdkHome: DirectoryProperty) : CliArgument() {
+    override fun toArgument() = jdkHome.orNull?.let { listOf(JDK_HOME_PARAMETER, it.toString()) }.orEmpty()
 }
 
 internal data class BaselineArgument(val baseline: RegularFile?) : CliArgument() {

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/Main.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/Main.kt
@@ -1,5 +1,5 @@
 @file:JvmName("Main")
-@file:Suppress("unused", "UNUSED_PARAMETER")
+@file:Suppress("unused", "UNUSED_PARAMETER", "Filename")
 
 package io.gitlab.arturbosch.detekt.cli
 

--- a/detekt-parser/src/main/kotlin/io/github/detekt/parser/KotlinEnvironmentUtils.kt
+++ b/detekt-parser/src/main/kotlin/io/github/detekt/parser/KotlinEnvironmentUtils.kt
@@ -67,7 +67,8 @@ fun createCompilerConfiguration(
     pathsToAnalyze: List<Path>,
     classpath: List<String>,
     languageVersion: LanguageVersion?,
-    jvmTarget: JvmTarget
+    jvmTarget: JvmTarget,
+    jdkHome: Path?,
 ): CompilerConfiguration {
     val javaFiles = pathsToAnalyze.flatMap { path ->
         path.toFile().walk()
@@ -99,6 +100,8 @@ fun createCompilerConfiguration(
         addJavaSourceRoots(javaFiles)
         addKotlinSourceRoots(kotlinFiles)
         addJvmClasspathRoots(classpathFiles)
+
+        jdkHome?.let { put(JVMConfigurationKeys.JDK_HOME, it.toFile()) }
         configureJdkClasspathRoots()
     }
 }

--- a/detekt-tooling/api/detekt-tooling.api
+++ b/detekt-tooling/api/detekt-tooling.api
@@ -116,6 +116,7 @@ public abstract interface class io/github/detekt/tooling/api/spec/BaselineSpec {
 
 public abstract interface class io/github/detekt/tooling/api/spec/CompilerSpec {
 	public abstract fun getClasspath ()Ljava/lang/String;
+	public abstract fun getJdkHome ()Ljava/nio/file/Path;
 	public abstract fun getJvmTarget ()Ljava/lang/String;
 	public abstract fun getLanguageVersion ()Ljava/lang/String;
 }
@@ -243,9 +244,11 @@ public final class io/github/detekt/tooling/dsl/CompilerSpecBuilder : io/github/
 	public fun build ()Lio/github/detekt/tooling/api/spec/CompilerSpec;
 	public synthetic fun build ()Ljava/lang/Object;
 	public final fun getClasspath ()Ljava/lang/String;
+	public final fun getJdkHome ()Ljava/nio/file/Path;
 	public final fun getJvmTarget ()Ljava/lang/String;
 	public final fun getLanguageVersion ()Ljava/lang/String;
 	public final fun setClasspath (Ljava/lang/String;)V
+	public final fun setJdkHome (Ljava/nio/file/Path;)V
 	public final fun setJvmTarget (Ljava/lang/String;)V
 	public final fun setLanguageVersion (Ljava/lang/String;)V
 }

--- a/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/api/spec/CompilerSpec.kt
+++ b/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/api/spec/CompilerSpec.kt
@@ -1,5 +1,7 @@
 package io.github.detekt.tooling.api.spec
 
+import java.nio.file.Path
+
 /**
  * All these properties are based down to the Kotlin compiler for type- and symbol resolution.
  */
@@ -19,4 +21,10 @@ interface CompilerSpec {
      * Paths to class files and jars separated by a path separator.
      */
     val classpath: String?
+
+    /**
+     * Path to custom JDK home. Includes the custom JDK from the specified location into the classpath instead of using
+     * the JRE from the runtime environment.
+     */
+    val jdkHome: Path?
 }

--- a/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/dsl/CompilerSpecBuilder.kt
+++ b/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/dsl/CompilerSpecBuilder.kt
@@ -1,6 +1,7 @@
 package io.github.detekt.tooling.dsl
 
 import io.github.detekt.tooling.api.spec.CompilerSpec
+import java.nio.file.Path
 
 @ProcessingModelDsl
 class CompilerSpecBuilder : Builder<CompilerSpec> {
@@ -8,12 +9,14 @@ class CompilerSpecBuilder : Builder<CompilerSpec> {
     var jvmTarget: String = "1.8"
     var languageVersion: String? = null
     var classpath: String? = null
+    var jdkHome: Path? = null
 
-    override fun build(): CompilerSpec = CompilerModel(jvmTarget, languageVersion, classpath)
+    override fun build(): CompilerSpec = CompilerModel(jvmTarget, languageVersion, classpath, jdkHome)
 }
 
 private data class CompilerModel(
     override val jvmTarget: String,
     override val languageVersion: String?,
-    override val classpath: String?
+    override val classpath: String?,
+    override val jdkHome: Path?,
 ) : CompilerSpec


### PR DESCRIPTION
This will need some tweaking to make sure it works properly with incremental builds and build cache.

This toolchain support does what the Kotlin Gradle Plugin does, but for detekt. If a toolchain is configured for the project (either using [`java`](https://docs.gradle.org/current/userguide/toolchains.html#sec:consuming) or [`kotlin`](https://kotlinlang.org/docs/gradle.html#setting-jdk-version-with-the-task-dsl)) that will then set both `jdkTarget` and `jdkHome` defaults on any `Detekt` or `DetektCreateBaseline` tasks.

See [here](https://blog.jetbrains.com/kotlin/2021/11/gradle-jvm-toolchain-support-in-the-kotlin-plugin/#Toolchain_support_in_the_Kotlin_plugin) for more on the KGP design goals.

> In Kotlin, toolchain support affects only the Kotlin/JVM -jdk-home option’s value and additionally sets the -jvm-target value if it was not set explicitly by the user.

Notably this means that detekt itself will still run on the JDK that Gradle runs on - if Gradle is running on Java 8, then so will detekt. This means that despite [what I said](https://github.com/detekt/detekt/issues/3396#issuecomment-927073465), I expect this PR will have no effect on #3396.

Closes #4120