### PR TITLE
Use convention method to set task property defaults

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektAndroid.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektAndroid.kt
@@ -126,7 +126,7 @@ internal fun Project.registerAndroidDetektTask(
         // If a baseline file is configured as input file, it must exist to be configured, otherwise the task fails.
         // We try to find the configured baseline or alternatively a specific variant matching this task.
         extension.baseline?.existingVariantOrBaseFile(variant.name)?.let { baselineFile ->
-            baseline.set(layout.file(project.provider { baselineFile }))
+            baseline.convention(layout.file(project.provider { baselineFile }))
         }
         setReportOutputConventions(reports, extension, variant.name)
         description = "EXPERIMENTAL: Run detekt analysis for ${variant.name} classes with type resolution"
@@ -148,7 +148,7 @@ internal fun Project.registerAndroidCreateBaselineTask(
             javaCompileDestination(variant),
         )
         val variantBaselineFile = extension.baseline?.addVariantName(variant.name)
-        baseline.set(project.layout.file(project.provider { variantBaselineFile }))
+        baseline.convention(project.layout.file(project.provider { variantBaselineFile }))
         description = "EXPERIMENTAL: Creates detekt baseline for ${variant.name} classes with type resolution"
     }
 

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektJvm.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektJvm.kt
@@ -29,7 +29,7 @@ internal class DetektJvm(private val project: Project) {
             // If a baseline file is configured as input file, it must exist to be configured, otherwise the task fails.
             // We try to find the configured baseline or alternatively a specific variant matching this task.
             extension.baseline?.existingVariantOrBaseFile(sourceSet.name)?.let { baselineFile ->
-                baseline.set(layout.file(project.provider { baselineFile }))
+                baseline.convention(layout.file(project.provider { baselineFile }))
             }
             setReportOutputConventions(reports, extension, sourceSet.name)
             description = "EXPERIMENTAL: Run detekt analysis for ${sourceSet.name} classes with type resolution"
@@ -43,7 +43,7 @@ internal class DetektJvm(private val project: Project) {
             source = kotlinSourceSet.kotlin
             classpath.setFrom(sourceSet.compileClasspath.existingFiles(), sourceSet.output.classesDirs.existingFiles())
             val variantBaselineFile = extension.baseline?.addVariantName(sourceSet.name)
-            baseline.set(project.layout.file(project.provider { variantBaselineFile }))
+            baseline.convention(project.layout.file(project.provider { variantBaselineFile }))
             description = "EXPERIMENTAL: Creates detekt baseline for ${sourceSet.name} classes with type resolution"
         }
     }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektMultiplatform.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektMultiplatform.kt
@@ -105,7 +105,7 @@ internal class DetektMultiplatform(private val project: Project) {
             } else {
                 extension.baseline?.takeIf { it.exists() }
             }?.let { baselineFile ->
-                baseline.set(layout.file(provider { baselineFile }))
+                baseline.convention(layout.file(provider { baselineFile }))
             }
             setReportOutputConventions(reports, extension, compilation.name)
             description =
@@ -128,7 +128,7 @@ internal class DetektMultiplatform(private val project: Project) {
             } else {
                 extension.baseline
             }
-            baseline.set(
+            baseline.convention(
                 layout.file(provider { variantBaselineFile })
             )
 

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektPlain.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektPlain.kt
@@ -17,12 +17,12 @@ internal class DetektPlain(private val project: Project) {
     private fun Project.registerDetektTask(extension: DetektExtension) {
         val detektTaskProvider = registerDetektTask(DetektPlugin.DETEKT_TASK_NAME, extension) {
             extension.baseline?.takeIf { it.exists() }?.let { baselineFile ->
-                baseline.set(project.layout.file(project.provider { baselineFile }))
+                baseline.convention(project.layout.file(project.provider { baselineFile }))
             }
             setSource(existingInputDirectoriesProvider(project, extension))
             setIncludes(DetektPlugin.defaultIncludes)
             setExcludes(DetektPlugin.defaultExcludes)
-            reportsDir.set(project.provider { extension.reportsDir })
+            reportsDir.convention(project.provider { extension.reportsDir })
         }
 
         tasks.matching { it.name == LifecycleBasePlugin.CHECK_TASK_NAME }.configureEach {
@@ -32,7 +32,7 @@ internal class DetektPlain(private val project: Project) {
 
     private fun Project.registerCreateBaselineTask(extension: DetektExtension) {
         registerCreateBaselineTask(DetektPlugin.BASELINE_TASK_NAME, extension) {
-            baseline.set(project.layout.file(project.provider { extension.baseline }))
+            baseline.convention(project.layout.file(project.provider { extension.baseline }))
             setSource(existingInputDirectoriesProvider(project, extension))
         }
     }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/SharedTasks.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/SharedTasks.kt
@@ -40,16 +40,16 @@ internal fun Project.registerDetektTask(
             }
         }
 
-        it.debugProp.set(provider { extension.debug })
-        it.parallelProp.set(provider { extension.parallel })
-        it.disableDefaultRuleSetsProp.set(provider { extension.disableDefaultRuleSets })
-        it.buildUponDefaultConfigProp.set(provider { extension.buildUponDefaultConfig })
-        it.failFastProp.set(provider { @Suppress("DEPRECATION") extension.failFast })
-        it.autoCorrectProp.set(provider { extension.autoCorrect })
+        it.debugProp.convention(provider { extension.debug })
+        it.parallelProp.convention(provider { extension.parallel })
+        it.disableDefaultRuleSetsProp.convention(provider { extension.disableDefaultRuleSets })
+        it.buildUponDefaultConfigProp.convention(provider { extension.buildUponDefaultConfig })
+        it.failFastProp.convention(provider { @Suppress("DEPRECATION") extension.failFast })
+        it.autoCorrectProp.convention(provider { extension.autoCorrect })
         it.config.setFrom(provider { extension.config })
-        it.ignoreFailuresProp.set(project.provider { extension.ignoreFailures })
-        it.basePathProp.set(extension.basePath)
-        it.allRulesProp.set(provider { extension.allRules })
+        it.ignoreFailuresProp.convention(project.provider { extension.ignoreFailures })
+        it.basePathProp.convention(extension.basePath)
+        it.allRulesProp.convention(provider { extension.allRules })
         configuration(it)
     }
 
@@ -60,13 +60,13 @@ internal fun Project.registerCreateBaselineTask(
 ): TaskProvider<DetektCreateBaselineTask> =
     tasks.register(name, DetektCreateBaselineTask::class.java) {
         it.config.setFrom(project.provider { extension.config })
-        it.debug.set(project.provider { extension.debug })
-        it.parallel.set(project.provider { extension.parallel })
-        it.disableDefaultRuleSets.set(project.provider { extension.disableDefaultRuleSets })
-        it.buildUponDefaultConfig.set(project.provider { extension.buildUponDefaultConfig })
-        @Suppress("DEPRECATION") it.failFast.set(project.provider { extension.failFast })
-        it.autoCorrect.set(project.provider { extension.autoCorrect })
-        it.basePathProp.set(extension.basePath)
-        it.allRules.set(provider { extension.allRules })
+        it.debug.convention(project.provider { extension.debug })
+        it.parallel.convention(project.provider { extension.parallel })
+        it.disableDefaultRuleSets.convention(project.provider { extension.disableDefaultRuleSets })
+        it.buildUponDefaultConfig.convention(project.provider { extension.buildUponDefaultConfig })
+        @Suppress("DEPRECATION") it.failFast.convention(project.provider { extension.failFast })
+        it.autoCorrect.convention(project.provider { extension.autoCorrect })
+        it.basePathProp.convention(extension.basePath)
+        it.allRules.convention(provider { extension.allRules })
         configuration(it)
     }


### PR DESCRIPTION
https://docs.gradle.org/7.5.1/userguide/lazy_configuration.html#applying_conventions

> Often you want to apply some convention, or default value, to a property to be used if no value has been configured for the property. You can use the `convention()` method for this. This method accepts either a value or a `Provider` and this will be used as the value until some other value is configured.

This means that whenever the plugin is applied, it will apply only default values, and if the value was `set` anywhere else in the build script, the convention will not overwrite it.