### PR TITLE
Fix false-positive on `NestedScopeFunctions`

### DIFF
--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedScopeFunctions.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedScopeFunctions.kt
@@ -121,7 +121,7 @@ class NestedScopeFunctions(config: Config = Config.empty) : Rule(config) {
 
         private fun KtCallExpression.isScopeFunction(): Boolean {
             val descriptors = resolveDescriptors() ?: return false
-            return !descriptors.any { !it.matchesScopeFunction() }
+            return descriptors.any { it.matchesScopeFunction() }
         }
 
         private fun KtCallExpression.resolveDescriptors(): List<CallableDescriptor>? =

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedScopeFunctions.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedScopeFunctions.kt
@@ -120,14 +120,13 @@ class NestedScopeFunctions(config: Config = Config.empty) : Rule(config) {
         }
 
         private fun KtCallExpression.isScopeFunction(): Boolean {
-            val descriptors = resolveDescriptors()
+            val descriptors = resolveDescriptors() ?: return false
             return !descriptors.any { it.matchesScopeFunction() }
         }
 
-        private fun KtCallExpression.resolveDescriptors(): List<CallableDescriptor> =
+        private fun KtCallExpression.resolveDescriptors(): List<CallableDescriptor>? =
             getResolvedCall(bindingContext)?.resultingDescriptor
                 ?.let { listOf(it) + it.overriddenDescriptors }
-                .orEmpty()
 
         private fun CallableDescriptor.matchesScopeFunction(): Boolean =
             !functions.any { it.match(this) }

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedScopeFunctions.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedScopeFunctions.kt
@@ -121,7 +121,7 @@ class NestedScopeFunctions(config: Config = Config.empty) : Rule(config) {
 
         private fun KtCallExpression.isScopeFunction(): Boolean {
             val descriptors = resolveDescriptors() ?: return false
-            return !descriptors.any { it.matchesScopeFunction() }
+            return !descriptors.any { !it.matchesScopeFunction() }
         }
 
         private fun KtCallExpression.resolveDescriptors(): List<CallableDescriptor>? =
@@ -129,6 +129,6 @@ class NestedScopeFunctions(config: Config = Config.empty) : Rule(config) {
                 ?.let { listOf(it) + it.overriddenDescriptors }
 
         private fun CallableDescriptor.matchesScopeFunction(): Boolean =
-            !functions.any { it.match(this) }
+            functions.any { it.match(this) }
     }
 }


### PR DESCRIPTION
I can't find a way to unit test this. The issue was related with `KtCallExpression.getResolvedCall(bindingContext)` returning `null`. The logic there was returning an `emptyList()` and then a `!list.any{}` make the code *really* difficult to understand.

Now, if the `KtCallExpression.getResolvedCall(bindingContext)` returns `null` we assume that it's not a scoped function so all works as desired.

Fix #5264