### PR TITLE
Provide the current classpath inside `KotlinEnvironmentResolver`

### DIFF
--- a/detekt-test-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/KotlinEnvironmentTestSetup.kt
+++ b/detekt-test-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/KotlinEnvironmentTestSetup.kt
@@ -12,6 +12,7 @@ import org.spekframework.spek2.dsl.Root
 import org.spekframework.spek2.lifecycle.CachingMode
 import java.io.File
 import java.nio.file.Path
+import kotlin.script.experimental.jvm.util.classpathFromClassloader
 
 @Deprecated(
     "This is specific to Spek and will be removed in a future release. Documentation has been updated to " +
@@ -48,7 +49,12 @@ internal class KotlinEnvironmentResolver : ParameterResolver {
     override fun resolveParameter(parameterContext: ParameterContext, extensionContext: ExtensionContext): Any {
         val closeableWrapper = extensionContext.wrapper
             ?: CloseableWrapper(
-                createEnvironment(additionalJavaSourceRootPaths = extensionContext.additionalJavaSourcePaths())
+                createEnvironment(
+                    additionalRootPaths = checkNotNull(
+                        classpathFromClassloader(Thread.currentThread().contextClassLoader)
+                    ) { "We should always have a classpath" },
+                    additionalJavaSourceRootPaths = extensionContext.additionalJavaSourcePaths(),
+                )
             ).also { extensionContext.wrapper = it }
         return closeableWrapper.wrapper.env
     }


### PR DESCRIPTION
Clases like `BaseRule` are not resolved by our test engine `KotlinEnvironmentResolver`. That creates issues in #5182. I have snippet code there that compile but they don't have all the information in the `BindingContext`. @marschwar implemented #5188. But as we commented there it was odd to configure something for `KotlinEnvironmentResolver` that was not needed for the snipet compilation check.

This PR fixes exactly that. We add all the `classpath` that the curren thread has to `KotlinEnvironmentResolver`. That's what the "snippet check compiler" does.

Closes #5188