### PR TITLE
Allow apiDump to run with configuration cache enabled

### DIFF
--- a/detekt-api/build.gradle.kts
+++ b/detekt-api/build.gradle.kts
@@ -35,10 +35,6 @@ tasks.dokkaHtml {
     notCompatibleWithConfigurationCache("https://github.com/Kotlin/dokka/issues/1217")
 }
 
-tasks.apiDump {
-    notCompatibleWithConfigurationCache("https://github.com/Kotlin/binary-compatibility-validator/issues/95")
-}
-
 apiValidation {
     ignoredPackages.add("io.gitlab.arturbosch.detekt.api.internal")
 }

--- a/detekt-psi-utils/build.gradle.kts
+++ b/detekt-psi-utils/build.gradle.kts
@@ -10,10 +10,6 @@ dependencies {
     testImplementation(projects.detektTest)
 }
 
-tasks.apiDump {
-    notCompatibleWithConfigurationCache("https://github.com/Kotlin/binary-compatibility-validator/issues/95")
-}
-
 apiValidation {
     ignoredPackages.add("io.github.detekt.psi.internal")
 }

--- a/detekt-test-utils/build.gradle.kts
+++ b/detekt-test-utils/build.gradle.kts
@@ -13,7 +13,3 @@ dependencies {
     testImplementation(libs.assertj)
     runtimeOnly(libs.kotlin.scriptingCompilerEmbeddable)
 }
-
-tasks.apiDump {
-    notCompatibleWithConfigurationCache("https://github.com/Kotlin/binary-compatibility-validator/issues/95")
-}

--- a/detekt-test/build.gradle.kts
+++ b/detekt-test/build.gradle.kts
@@ -10,7 +10,3 @@ dependencies {
     compileOnly(libs.assertj)
     implementation(projects.detektCore)
 }
-
-tasks.apiDump {
-    notCompatibleWithConfigurationCache("https://github.com/Kotlin/binary-compatibility-validator/issues/95")
-}

--- a/detekt-tooling/build.gradle.kts
+++ b/detekt-tooling/build.gradle.kts
@@ -10,10 +10,6 @@ dependencies {
     testImplementation(libs.assertj)
 }
 
-tasks.apiDump {
-    notCompatibleWithConfigurationCache("https://github.com/Kotlin/binary-compatibility-validator/issues/95")
-}
-
 apiValidation {
     ignoredPackages.add("io.github.detekt.tooling.internal")
 }


### PR DESCRIPTION
Fixed in org.jetbrains.kotlinx.binary-compatibility-validator 0.11.1
