### PR TITLE
NonBooleanPropertyPrefixedWithIs: Allow boolean functions

### DIFF
--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NonBooleanPropertyPrefixedWithIs.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NonBooleanPropertyPrefixedWithIs.kt
@@ -72,7 +72,7 @@ class NonBooleanPropertyPrefixedWithIs(config: Config = Config.empty) : Rule(con
 
             if (!typeName.isNullOrEmpty() &&
                 isNotBooleanType &&
-                !type.isBooleanFunctionReference()
+                !type.isBooleanFunction()
             ) {
                 report(
                     reportCodeSmell(declaration, name, typeName)
@@ -101,9 +101,9 @@ class NonBooleanPropertyPrefixedWithIs(config: Config = Config.empty) : Rule(con
         fqNameOrNull()
             ?.asString()
 
-    private fun KotlinType.isBooleanFunctionReference(): Boolean {
+    private fun KotlinType.isBooleanFunction(): Boolean {
         if (!isFunctionOrKFunctionTypeWithAnySuspendability) return false
 
-        return arguments.count() == 1 && arguments[0].type.isBoolean()
+        return arguments.isNotEmpty() && arguments.last().type.isBoolean()
     }
 }

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NonBooleanPropertyWithPrefixIsSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NonBooleanPropertyWithPrefixIsSpec.kt
@@ -250,6 +250,30 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinCoreEnvironment) {
 
             assertThat(findings).hasSize(1)
         }
+
+        @Test
+        fun `should not detect boolean function`() {
+            val code = """
+                class O {
+                    val isEnabled: () -> Boolean = { true }
+                }
+            """.trimIndent()
+            val findings = subject.compileAndLintWithContext(env, code)
+
+            assertThat(findings).isEmpty()
+        }
+
+        @Test
+        fun `should not detect boolean function with parameter`() {
+            val code = """
+                class O {
+                    val isEnabled: (String) -> Boolean = { true }
+                }
+            """.trimIndent()
+            val findings = subject.compileAndLintWithContext(env, code)
+
+            assertThat(findings).isEmpty()
+        }
     }
 
     @Nested


### PR DESCRIPTION
This change builds on top of #4684 which allowed functions with a boolean return type to comply with the `NonBooleanPropertyPrefixedWithIs` rule. That change only allowed functions with zero parameters. With this change, I’m proposing that we open up the exception to any function with a boolean return type.

For example, something like the following would be considered compliant.
```
interface Business {
    val isOpenAt: (DateTime) -> Boolean
}
```

Let me know if there are any reservations around this change. My team found that it was odd that there was this limitation and I thought I’d check out if you all agree as well.
