### PR TITLE
Disable configuration cache by default

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,5 +4,5 @@ systemProp.dependency.analysis.test.analysis=false
 org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8
-org.gradle.unsafe.configuration-cache=true
+org.gradle.unsafe.configuration-cache=false
 systemProp.org.gradle.kotlin.dsl.precompiled.accessors.strict=true


### PR DESCRIPTION
Closes #5289 

We'll try enabling again in Gradle 7.6.