### PR TITLE
Fat-Jar version of detekt-generator module

### DIFF
--- a/build-logic/src/main/kotlin/releasing.gradle.kts
+++ b/build-logic/src/main/kotlin/releasing.gradle.kts
@@ -39,6 +39,7 @@ project.afterEvaluate {
                 cliBuildDir.resolve("libs/detekt-cli-${project.version}-all.jar"),
                 cliBuildDir.resolve("distributions/detekt-cli-${project.version}.zip"),
                 project(":detekt-formatting").buildDir.resolve("libs/detekt-formatting-${project.version}.jar"),
+                project(":detekt-generator").buildDir.resolve("libs/detekt-generator-${project.version}-all.jar"),
                 project(":detekt-rules-ruleauthors").buildDir
                     .resolve("libs/detekt-rules-ruleauthors-${project.version}.jar")
             )

--- a/detekt-generator/build.gradle.kts
+++ b/detekt-generator/build.gradle.kts
@@ -1,6 +1,9 @@
 plugins {
+    alias(libs.plugins.shadow)
     id("module")
 }
+
+tasks.build { finalizedBy(tasks.shadowJar) }
 
 dependencies {
     implementation(projects.detektParser)

--- a/website/docs/gettingstarted/_cli-generator-options.md
+++ b/website/docs/gettingstarted/_cli-generator-options.md
@@ -1,0 +1,10 @@
+```
+Usage: java -jar detekt-generator-[detekt_version]-all.jar [options]
+  Options:
+    --generate-custom-rule-config, -gcrc
+      Generate custom rules configuration files. The files will be
+      placed under 'resources' folder of each rule respectively
+      (e.g. 'custom-rule/src/main/resources/config/config.yml').
+    --input, -i
+      Input paths to rules to analyze. Multiple paths are separated by comma.
+```

--- a/website/docs/gettingstarted/cli.mdx
+++ b/website/docs/gettingstarted/cli.mdx
@@ -9,6 +9,7 @@ sidebar_position: 1
 ---
 
 import CliOptions from "./_cli-options.md";
+import CliGeneratorOptions from "./_cli-generator-options.md";
 
 ## Install the cli
 
@@ -50,3 +51,11 @@ detekt will exit with one of the following exit codes:
 The following parameters are shown when `--help` is entered.
 
 <CliOptions />
+
+## Use the cli to generate configuration for custom rules
+
+<CliGeneratorOptions />
+
+```sh
+java -jar detekt-generator-[detekt_version]-all.jar -gcrc -i /path/to/rule1, /path/to/rule2
+```


### PR DESCRIPTION
To finalize https://github.com/detekt/detekt/pull/5080 

To be able to call `detekt-generator` through `java -jar detek-generator.jar --other-options` shadowJar plugin was used in build.gradle.kts.

Docs on usage were also added.