### PR TITLE
Introduce configFile property on DetektGenerateTask

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/CliArgument.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/CliArgument.kt
@@ -82,7 +82,7 @@ internal data class BasePathArgument(val basePath: String?) : CliArgument() {
 
 internal data class ConfigArgument(val files: Collection<File>) : CliArgument() {
 
-    constructor(configFile: File) : this(listOf(configFile))
+    constructor(configFile: RegularFile) : this(listOf(configFile.asFile))
     constructor(config: FileCollection) : this(config.files)
 
     override fun toArgument() = if (files.isEmpty()) {


### PR DESCRIPTION
This corrects a few issues:

1. The config file parameter should refer to a single file, but it's currently a `ConfigurableFileCollection`. Replacing with `RegularFileProperty` is more correct as the task only generates a single file, not a collection of files.
2. The `config` parameter is incorrectly annotated with `@InputFiles`, but task generates a file and doesn't use the values as an input at all.
3. The `config` parameter is annotated `@Optional`. This doesn't make sense - if the task is run, it should generate a file, and the config file parameter must have a value to achieve this.

This deprecation is backwards compatible. When the `config` parameter is removed from the task there will be a small code clean up required.