### PR TITLE
EndOfSentenceFormat: fix HTML tag heuristic

### DIFF
--- a/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/EndOfSentenceFormat.kt
+++ b/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/EndOfSentenceFormat.kt
@@ -29,7 +29,7 @@ class EndOfSentenceFormat(config: Config = Config.empty) : Rule(config) {
     @Configuration("regular expression which should match the end of the first sentence in the KDoc")
     private val endOfSentenceFormat: Regex by config("""([.?!][ \t\n\r\f<])|([.?!:]$)""") { it.toRegex() }
 
-    private val htmlTag = Regex("<.+>")
+    private val htmlTag = Regex("^<.+>")
 
     override fun visitDeclaration(dcl: KtDeclaration) {
         super.visitDeclaration(dcl)

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/EndOfSentenceFormatSpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/EndOfSentenceFormatSpec.kt
@@ -141,6 +141,21 @@ class EndOfSentenceFormatSpec {
     }
 
     @Test
+    fun `reports invalid KDoc even when it looks like it contains html tags`() {
+        val code = """
+        /**
+         * < is the less-than sign --
+         * ```
+         * <code>this contains HTML, but doesn't start with a tag</code>
+         * ```
+         */
+        class Test {
+        }
+        """.trimIndent()
+        assertThat(subject.compileAndLint(code)).hasSize(1)
+    }
+
+    @Test
     fun `does not report KDoc ending with periods`() {
         val code = """
         /**


### PR DESCRIPTION
While doing #5311 I noticed that the code doesn't check for "starts with"