### PR TITLE
Simplify release script by replacing "or exit" with "always exit"

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env sh
-gradle publishToMavenLocal || exit
-gradle build || exit
-gradle publishAllToMavenCentral --max-workers 1 || exit
-gradle :detekt-gradle-plugin:publishPlugins || exit
-gradle githubRelease || exit
-gradle applyDocVersion || exit
-gradle closeAndReleaseRepository || exit
+set -e
+gradle publishToMavenLocal
+gradle build
+gradle publishAllToMavenCentral --max-workers 1
+gradle :detekt-gradle-plugin:publishPlugins
+gradle githubRelease
+gradle applyDocVersion
+gradle closeAndReleaseRepository


### PR DESCRIPTION
Note: GitHub actions actively turns this on as well for all unix shell types:

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsshell

(I have a feeling it could be even put in `#!/usr/bin/env sh -e`, but not sure what would happen if someone did `bash release.sh`.)