### PR TITLE
CanBeNonNullable: explain why the rule does what it does.

### DIFF
--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/CanBeNonNullable.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/CanBeNonNullable.kt
@@ -62,6 +62,14 @@ import org.jetbrains.kotlin.types.isNullable
  * This rule inspects variables marked as nullable and reports which could be
  * declared as non-nullable instead.
  *
+ * It's preferred to not have functions that do "nothing".
+ * A function that does nothing when the value is null hides the logic,
+ * so it should not allow null values in the first place.
+ * It is better to move the null checks up around the calls,
+ * instead of having it inside the function.
+ *
+ * This could lead to less nullability overall in the codebase.
+ *
  * <noncompliant>
  * class A {
  *     var a: Int? = 5


### PR DESCRIPTION
Based on conversation in https://github.com/detekt/detekt/issues/5331 (closes #5331), @BraisGabin, I borrowed your thoughts.

The original explanation described what the rule does, but gave no clarity on why.