### PR TITLE
Fix Gradle dependency warnings

### DIFF
--- a/detekt-generator/build.gradle.kts
+++ b/detekt-generator/build.gradle.kts
@@ -35,7 +35,7 @@ val ruleModules = rootProject.subprojects
     .map { "${rootProject.rootDir}/$it/src/main/kotlin" }
 
 val generateDocumentation by tasks.registering(JavaExec::class) {
-    dependsOn(tasks.assemble, ":detekt-api:dokkaHtml")
+    dependsOn(tasks.assemble, ":detekt-api:dokkaHtml", tasks.shadowJar, ":detekt-rules-ruleauthors:sourcesJar")
     description = "Generates detekt documentation and the default config.yml based on Rule KDoc"
     group = "documentation"
 


### PR DESCRIPTION
Fix warnings similar to
```
> Task :detekt-generator:shadowJar
Execution optimizations have been disabled for task ':detekt-generator:shadowJar' to ensure correctness due to the following reasons:
  - Gradle detected a problem with the following location: '/Users/vvp/IdeaProjects/detekt/detekt-generator/build/libs/detekt-generator-1.22.0-RC1-all.jar'. Reason: Task ':detekt-generator:generateDocumentation' uses this output of task ':detekt-generator:shadowJar' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.5.1/userguide/validation_problems.html#implicit_dependency for more details about this problem.
```
