### PR TITLE
Remove usage of MPP targets function for JVM-only projects

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektJvm.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektJvm.kt
@@ -1,5 +1,3 @@
-@file:Suppress("DEPRECATION")
-
 package io.gitlab.arturbosch.detekt.internal
 
 import io.gitlab.arturbosch.detekt.DetektPlugin

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektJvm.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektJvm.kt
@@ -9,18 +9,15 @@ import org.gradle.api.file.FileCollection
 import org.jetbrains.kotlin.gradle.dsl.KotlinCommonOptions
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
-import org.jetbrains.kotlin.gradle.plugin.mpp.pm20.util.targets
 
 internal class DetektJvm(private val project: Project) {
     fun registerTasks(extension: DetektExtension) {
-        project.extensions.getByType(KotlinJvmProjectExtension::class.java).targets.forEach { target ->
-            target.compilations.all { compilation ->
-                val inputSource = compilation.kotlinSourceSets
-                    .map { it.kotlin.sourceDirectories }
-                    .fold(project.files() as FileCollection) { collection, next -> collection.plus(next) }
-                project.registerJvmDetektTask(compilation, extension, inputSource)
-                project.registerJvmCreateBaselineTask(compilation, extension, inputSource)
-            }
+        project.extensions.getByType(KotlinJvmProjectExtension::class.java).target.compilations.all { compilation ->
+            val inputSource = compilation.kotlinSourceSets
+                .map { it.kotlin.sourceDirectories }
+                .fold(project.files() as FileCollection) { collection, next -> collection.plus(next) }
+            project.registerJvmDetektTask(compilation, extension, inputSource)
+            project.registerJvmCreateBaselineTask(compilation, extension, inputSource)
         }
     }
 


### PR DESCRIPTION
`KotlinJvmProjectExtension` is a `KotlinSingleJavaTargetExtension` and only has a single target, so using the MPP `targets` function is unnecessary.

See https://github.com/detekt/detekt/pull/5381#issuecomment-1269979238 for background.