### PR TITLE
Check FormattingRule is auto-correctable by information provided by ktlint 

### DIFF
--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/EnumEntryNameCase.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/EnumEntryNameCase.kt
@@ -15,6 +15,4 @@ class EnumEntryNameCase(config: Config) : FormattingRule(config) {
 
     override val wrapping = EnumEntryNameCaseRule()
     override val issue = issueFor("Reports enum entries with names that don't meet standard conventions.")
-
-    override fun canBeCorrectedByKtLint(message: String): Boolean = false
 }

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/Filename.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/Filename.kt
@@ -16,6 +16,4 @@ class Filename(config: Config) : FormattingRule(config) {
 
     override val wrapping = FilenameRule()
     override val issue = issueFor("Checks if top level class matches the filename")
-
-    override fun canBeCorrectedByKtLint(message: String): Boolean = false
 }

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/ImportOrdering.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/ImportOrdering.kt
@@ -24,8 +24,6 @@ class ImportOrdering(config: Config) : FormattingRule(config) {
     @Configuration("the import ordering layout")
     private val layout: String by configWithAndroidVariants(IDEA_PATTERN, ASCII_PATTERN)
 
-    override fun canBeCorrectedByKtLint(message: String): Boolean = "no autocorrection" !in message
-
     override fun overrideEditorConfigProperties(): Map<UsesEditorConfigProperties.EditorConfigProperty<*>, String> =
         mapOf(ImportOrderingRule.ideaImportsLayoutProperty to layout)
 

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/Indentation.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/Indentation.kt
@@ -28,8 +28,6 @@ class Indentation(config: Config) : FormattingRule(config) {
     @Suppress("UnusedPrivateMember")
     private val continuationIndentSize by config(4)
 
-    override fun canBeCorrectedByKtLint(message: String): Boolean = "not contain both tab(s) and space(s)" !in message
-
     override fun overrideEditorConfigProperties(): Map<UsesEditorConfigProperties.EditorConfigProperty<*>, String> =
         mapOf(
             DefaultEditorConfigProperties.indentSizeProperty to indentSize.toString(),

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/MaximumLineLength.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/MaximumLineLength.kt
@@ -32,8 +32,6 @@ class MaximumLineLength(config: Config) : FormattingRule(config) {
     @Configuration("ignore back ticked identifier")
     private val ignoreBackTickedIdentifier by config(false)
 
-    override fun canBeCorrectedByKtLint(message: String): Boolean = false
-
     override fun overrideEditorConfigProperties(): Map<UsesEditorConfigProperties.EditorConfigProperty<*>, String> =
         mapOf(
             MaxLineLengthRule.ignoreBackTickedIdentifierProperty to ignoreBackTickedIdentifier.toString(),

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/NoWildcardImports.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/NoWildcardImports.kt
@@ -20,8 +20,6 @@ class NoWildcardImports(config: Config) : FormattingRule(config) {
     @Configuration("Defines allowed wildcard imports")
     private val packagesToUseImportOnDemandProperty by config(ALLOWED_WILDCARD_IMPORTS)
 
-    override fun canBeCorrectedByKtLint(message: String): Boolean = false
-
     override fun overrideEditorConfigProperties(): Map<UsesEditorConfigProperties.EditorConfigProperty<*>, String> =
         mapOf(
             NoWildcardImportsRule.packagesToUseImportOnDemandProperty to packagesToUseImportOnDemandProperty

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/PackageName.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/PackageName.kt
@@ -16,6 +16,4 @@ class PackageName(config: Config) : FormattingRule(config) {
 
     override val wrapping = PackageNameRule()
     override val issue = issueFor("Checks package name is formatted correctly")
-
-    override fun canBeCorrectedByKtLint(message: String): Boolean = false
 }

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/RulesWhichCantBeCorrectedSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/RulesWhichCantBeCorrectedSpec.kt
@@ -2,6 +2,7 @@ package io.gitlab.arturbosch.detekt.formatting
 
 import io.gitlab.arturbosch.detekt.api.CodeSmell
 import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.formatting.wrappers.AnnotationOnSeparateLine
 import io.gitlab.arturbosch.detekt.formatting.wrappers.EnumEntryNameCase
 import io.gitlab.arturbosch.detekt.formatting.wrappers.Filename
 import io.gitlab.arturbosch.detekt.formatting.wrappers.ImportOrdering
@@ -79,6 +80,13 @@ class RulesWhichCantBeCorrectedSpec {
         """.trimIndent()
 
         assertThat(Indentation(Config.empty).lint(code))
+            .isNotEmpty
+            .hasExactlyElementsOfTypes(CodeSmell::class.java)
+    }
+
+    @Test
+    fun `Annotation contains a parameter on single line can't be corrected`() {
+        assertThat(AnnotationOnSeparateLine(Config.empty).lint("fun foo1() = @Suppress(\"DEPRECATION\") bar()"))
             .isNotEmpty
             .hasExactlyElementsOfTypes(CodeSmell::class.java)
     }


### PR DESCRIPTION
Fixes #5343 

Replace `FormattingRule::canBeCorrectedByKtlint` by ktlint's callback parameter `canBeAutoCorrected`.
This PR will prevent manual synchronizing of auto-correctable with ktlint.