### PR TITLE
Fix IgnoredReturnValue rule crash in parallel mode

### DIFF
--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValue.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValue.kt
@@ -91,7 +91,7 @@ class IgnoredReturnValue(config: Config = Config.empty) : Rule(config) {
         it.map(FunctionMatcher::fromFunctionSignature)
     }
 
-    @Suppress("ReturnCount")
+    @Suppress("ReturnCount", "ComplexCondition")
     override fun visitCallExpression(expression: KtCallExpression) {
         super.visitCallExpression(expression)
 
@@ -106,7 +106,8 @@ class IgnoredReturnValue(config: Config = Config.empty) : Rule(config) {
         if (annotations.any { it in ignoreReturnValueAnnotations }) return
         if (restrictToConfig &&
             resultingDescriptor.returnType !in returnValueTypes &&
-            (annotations + resultingDescriptor.containingDeclaration.annotations).none { it in returnValueAnnotations }
+            annotations.none { it in returnValueAnnotations } &&
+            resultingDescriptor.containingDeclaration.annotations.none { it in returnValueAnnotations }
         ) {
             return
         }


### PR DESCRIPTION
IgnoredReturnValue crashes due to the usage of a non-thread-safe collection operation. The usage of `Iterable<T>.plus()` causes this problem. The crash in parallel mode is fixed by iterating over each collection by itself.

See here for more details in detekt v1.21:
https://github.com/detekt/detekt/blob/32f6e22d9524804ebbb51d31e53cd28a84864ed6/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValue.kt#L90

Closes #5403