### PR TITLE
Explicitly set root project name for included builds

### DIFF
--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -1,3 +1,5 @@
+rootProject.name = "build-logic"
+
 dependencyResolutionManagement {
     versionCatalogs {
         create("libs") {

--- a/detekt-gradle-plugin/settings.gradle.kts
+++ b/detekt-gradle-plugin/settings.gradle.kts
@@ -1,3 +1,5 @@
+rootProject.name = "detekt-gradle-plugin"
+
 pluginManagement {
     includeBuild("../build-logic")
 }


### PR DESCRIPTION
This recommended practice also removes a warning in certain cases involving composite builds.