### PR TITLE
Deprecate `TrailingComma` as it's now split in two rules

### DIFF
--- a/detekt-core/src/main/resources/deprecation.properties
+++ b/detekt-core/src/main/resources/deprecation.properties
@@ -13,6 +13,7 @@ style>UnnecessaryAbstractClass>excludeAnnotatedClasses=Use `ignoreAnnotated` ins
 style>UseDataClass>excludeAnnotatedClasses=Use `ignoreAnnotated` instead
 formatting>Indentation>continuationIndentSize=`continuationIndentSize` is ignored by KtLint and will have no effect
 formatting>ParameterListWrapping>indentSize=`indentSize` is ignored by KtLint and will have no effect
+formatting>TrailingComma=Rule is split between `TrailingCommaOnCallSite` and `TrailingCommaOnDeclarationSite` now.
 style>ForbiddenPublicDataClass=Rule migrated to `libraries` ruleset plugin
 style>LibraryCodeMustSpecifyReturnType=Rule migrated to `libraries` ruleset plugin
 style>LibraryEntitiesShouldNotBePublic=Rule migrated to `libraries` ruleset plugin

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/DeprecatedPrinter.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/DeprecatedPrinter.kt
@@ -37,6 +37,7 @@ private fun writeProperty(ruleSet: RuleSetPage, rule: Rule, configuration: Confi
 
 internal fun writeMigratedRules(): String {
     return """
+        formatting>TrailingComma=Rule is split between `TrailingCommaOnCallSite` and `TrailingCommaOnDeclarationSite` now.
         style>ForbiddenPublicDataClass=Rule migrated to `libraries` ruleset plugin
         style>LibraryCodeMustSpecifyReturnType=Rule migrated to `libraries` ruleset plugin
         style>LibraryEntitiesShouldNotBePublic=Rule migrated to `libraries` ruleset plugin


### PR DESCRIPTION
When we bumped KtLint we effectively deprecated a rule `TrailingComma`, but we never updated the `deprecation.properties` file for it. Here I'm doing it.