### PR TITLE
Save a step when embedding version.properties in Gradle plugin lib

### DIFF
--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -123,11 +123,7 @@ tasks {
         property("detektVersion", project.version)
     }
 
-    processResources {
-        from(writeDetektVersionProperties)
-    }
-
-    processTestResources {
+    jar {
         from(writeDetektVersionProperties)
     }
 


### PR DESCRIPTION
There's no need to copy files with the `processResources` tasks here.