### PR TITLE
BooleanPropertyNaming highlight only the name of the variable

### DIFF
--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/BooleanPropertyNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/BooleanPropertyNaming.kt
@@ -79,7 +79,7 @@ class BooleanPropertyNaming(config: Config = Config.empty) : Rule(config) {
         val description = "Boolean property name should match a $allowedPattern pattern."
         return CodeSmell(
             issue,
-            Entity.from(declaration.nameIdentifier ?: declaration),
+            Entity.atName(declaration),
             message = "$description Actual name is $name"
         )
     }

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/BooleanPropertyNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/BooleanPropertyNaming.kt
@@ -79,7 +79,7 @@ class BooleanPropertyNaming(config: Config = Config.empty) : Rule(config) {
         val description = "Boolean property name should match a $allowedPattern pattern."
         return CodeSmell(
             issue,
-            Entity.from(declaration),
+            Entity.from(declaration.nameIdentifier ?: declaration),
             message = "$description Actual name is $name"
         )
     }

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/BooleanPropertyNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/BooleanPropertyNamingSpec.kt
@@ -254,6 +254,24 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
 
             assertThat(findings).isEmpty()
         }
+
+        @Test
+        fun `should highlight only the name`() {
+            val code = """
+                data class Test(
+                    /**
+                     * True if the user's e-mail address has been verified; otherwise false.
+                     */
+                    @Deprecated("Don't use this", replaceWith = ReplaceWith("email_verified"))
+                    val emailVerified: Boolean?,
+                )
+            """.trimIndent()
+            val findings = subject.compileAndLintWithContext(env, code)
+
+            assertThat(findings)
+                .hasSize(1)
+                .hasTextLocations("emailVerified")
+        }
     }
 
     @Nested
@@ -616,6 +634,24 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
             val config = TestConfig(mapOf(ALLOWED_PATTERN to "^(is|has|are|need)"))
             assertThat(BooleanPropertyNaming(config).compileAndLint(code))
                 .isEmpty()
+        }
+
+        @Test
+        fun `should highlight only the name`() {
+            val code = """
+                class Test {
+                    /**
+                     * True if the user's e-mail address has been verified; otherwise false.
+                     */
+                    @Deprecated("Don't use this", replaceWith = ReplaceWith("email_verified"))
+                    var emailVerified: Boolean? = false
+                }
+            """.trimIndent()
+            val findings = subject.compileAndLintWithContext(env, code)
+
+            assertThat(findings)
+                .hasSize(1)
+                .hasTextLocations("emailVerified")
         }
     }
 }


### PR DESCRIPTION
... the usual, the warning hides too much, but also deeplinking is broken, e.g. clicking on the this code location:
```
BooleanPropertyNaming - [Boolean property name should match a ^(is|has|are) pattern. Actual name is email(...)] at P:\projects\workspace\net.twisterrob.cinema\Heroku\backend\endpoint\src\main\kotlin\net\twisterrob\cinema\cineworld\backend\endpoint\auth\data\UserInfoOpenID.kt:31:2
```
brings me to (before)
![image](https://user-images.githubusercontent.com/2906988/196196762-631b11ba-8d0a-4360-a058-73ef0d276698.png)

(expected)
![image](https://user-images.githubusercontent.com/2906988/196196881-95af0d23-4e95-4ade-9585-68e6cb29631e.png)