### PR TITLE
Improve error reporting for CascadingCallWrapping

### DIFF
--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/CascadingCallWrappingSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/CascadingCallWrappingSpec.kt
@@ -19,7 +19,7 @@ class CascadingCallWrappingSpec {
 
         assertThat(subject.compileAndLint(code))
             .hasSize(1)
-            .hasTextLocations(8 to 30)
+            .hasTextLocations(23 to 30)
             .first()
             .hasMessage("Chained call `plus(0)` should be wrapped to a new line since preceding calls were.")
     }
@@ -119,7 +119,9 @@ class CascadingCallWrappingSpec {
                     )
             """.trimIndent()
 
-            assertThat(subject.compileAndLint(code)).hasSize(1)
+            assertThat(subject.compileAndLint(code))
+                .hasTextLocations(65 to 86)
+                .hasSize(1)
         }
 
         @Test
@@ -168,10 +170,27 @@ class CascadingCallWrappingSpec {
         fun `reports missing wrapping`() {
             val code = """
                 val a = 0
-                    .plus(0) ?: 0
+                    .plus(0) ?: 42
             """.trimIndent()
 
-            assertThat(subjectIncludingElvis.compileAndLint(code)).hasSize(1)
+            assertThat(subjectIncludingElvis.compileAndLint(code))
+                .hasTextLocations(23 to 28)
+                .hasSize(1)
+            assertThat(subjectExcludingElvis.compileAndLint(code)).isEmpty()
+        }
+
+        @Test
+        fun `reports missing wrapping multiline call`() {
+            val code = """
+                val a = 0
+                    .plus(0) ?: let {
+                  42
+                }
+            """.trimIndent()
+
+            assertThat(subjectIncludingElvis.compileAndLint(code))
+                .hasTextLocations(23 to 38)
+                .hasSize(1)
             assertThat(subjectExcludingElvis.compileAndLint(code)).isEmpty()
         }
     }


### PR DESCRIPTION
Make the error report point of failure more precisely by highlighting the exact part of expression which should be wrapped to a new line

Closes #5043