### PR TITLE
Fix invalid syntaxes in test code

### DIFF
--- a/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/CognitiveComplexitySpec.kt
+++ b/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/CognitiveComplexitySpec.kt
@@ -171,7 +171,7 @@ class CognitiveComplexitySpec {
         fun `does not increment on just a condition`() {
             val code = compileContentForTest(
                 """
-                fun test(cond_ Boolean) = !cond
+                fun test(cond: Boolean) = !cond
                 """.trimIndent()
             )
 
@@ -185,7 +185,7 @@ class CognitiveComplexitySpec {
             fun `adds one for just a &&`() {
                 val code = compileContentForTest(
                     """
-                    fun test(cond_ Boolean) = !cond && !cond
+                    fun test(cond: Boolean) = !cond && !cond
                     """.trimIndent()
                 )
 
@@ -196,7 +196,7 @@ class CognitiveComplexitySpec {
             fun `adds only one for repeated &&`() {
                 val code = compileContentForTest(
                     """
-                    fun test(cond_ Boolean) = !cond && !cond && !cond
+                    fun test(cond: Boolean) = !cond && !cond && !cond
                     """.trimIndent()
                 )
 
@@ -207,7 +207,7 @@ class CognitiveComplexitySpec {
             fun `adds one per logical alternate operator`() {
                 val code = compileContentForTest(
                     """
-                    fun test(cond_ Boolean) = !cond && !cond || cond
+                    fun test(cond: Boolean) = !cond && !cond || cond
                     """.trimIndent()
                 )
 
@@ -218,7 +218,7 @@ class CognitiveComplexitySpec {
             fun `adds one per logical alternate operator with like operators in between`() {
                 val code = compileContentForTest(
                     """
-                    fun test(cond_ Boolean) {
+                    fun test(cond: Boolean) {
                         if (                    // +1
                             !cond 
                             && !cond && !cond   // +1
@@ -236,7 +236,7 @@ class CognitiveComplexitySpec {
             fun `adds one for negated but similar operators`() {
                 val code = compileContentForTest(
                     """
-                    fun test(cond_ Boolean) {
+                    fun test(cond: Boolean) {
                         if (                    // +1
                             !cond 
                             && !(cond && cond)  // +2
@@ -252,7 +252,7 @@ class CognitiveComplexitySpec {
             fun `adds only one for a negated chain of similar operators`() {
                 val code = compileContentForTest(
                     """
-                    fun test(cond_ Boolean) {
+                    fun test(cond: Boolean) {
                         if (                    // +1
                             !cond 
                             && !(cond && cond && cond)  // +2
@@ -268,7 +268,7 @@ class CognitiveComplexitySpec {
             fun `adds one for every negated similar operator chain`() {
                 val code = compileContentForTest(
                     """
-                    fun test(cond_ Boolean) {
+                    fun test(cond: Boolean) {
                         if (                            // +1
                             !cond 
                             && !(cond && cond && cond)  // +2

--- a/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/CyclomaticComplexitySpec.kt
+++ b/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/CyclomaticComplexitySpec.kt
@@ -47,7 +47,7 @@ class CyclomaticComplexitySpec {
         fun `counts while, continue and break`() {
             val code = compileContentForTest(
                 """
-                    fun test(i_ Int) {
+                    fun test(i: Int) {
                         var j = i
                         while(true) { // 1
                             if (j == 5) { // 1


### PR DESCRIPTION
Revert unintended (probably due to automation...?) test code changes in #4511.

<img width="758" alt="Screen Shot 2022-10-19 at 11 27 35 PM" src="https://user-images.githubusercontent.com/37951125/196719623-011b5efe-ae54-4727-bc38-d0b4fcf5a1ae.png">
