### PR TITLE
Fix ObjectPropertyNaming Rule false positive

### DIFF
--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNaming.kt
@@ -15,7 +15,6 @@ import io.gitlab.arturbosch.detekt.rules.isConstant
 import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.KtObjectDeclaration
 import org.jetbrains.kotlin.psi.KtProperty
-import org.jetbrains.kotlin.psi.KtVariableDeclaration
 import org.jetbrains.kotlin.psi.psiUtil.getNonStrictParentOfType
 import org.jetbrains.kotlin.psi.psiUtil.isPrivate
 

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNaming.kt
@@ -12,7 +12,11 @@ import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
 import io.gitlab.arturbosch.detekt.api.internal.Configuration
 import io.gitlab.arturbosch.detekt.rules.identifierName
 import io.gitlab.arturbosch.detekt.rules.isConstant
+import org.jetbrains.kotlin.psi.KtClassOrObject
+import org.jetbrains.kotlin.psi.KtObjectDeclaration
 import org.jetbrains.kotlin.psi.KtProperty
+import org.jetbrains.kotlin.psi.KtVariableDeclaration
+import org.jetbrains.kotlin.psi.psiUtil.getNonStrictParentOfType
 import org.jetbrains.kotlin.psi.psiUtil.isPrivate
 
 /**
@@ -38,7 +42,7 @@ class ObjectPropertyNaming(config: Config = Config.empty) : Rule(config) {
     private val privatePropertyPattern: Regex by config("(_)?[A-Za-z][_A-Za-z0-9]*") { it.toRegex() }
 
     override fun visitProperty(property: KtProperty) {
-        if (property.isLocal || property.isTopLevel) {
+        if (property.isPropertyOfObjectDeclaration().not()) {
             return
         }
 
@@ -48,6 +52,9 @@ class ObjectPropertyNaming(config: Config = Config.empty) : Rule(config) {
             handleProperty(property)
         }
     }
+
+    private fun KtProperty.isPropertyOfObjectDeclaration(): Boolean =
+        this.isMember && this.getNonStrictParentOfType<KtClassOrObject>() is KtObjectDeclaration
 
     private fun handleConstant(property: KtProperty) {
         if (!property.identifierName().matches(constantPattern)) {

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNamingSpec.kt
@@ -259,7 +259,7 @@ class ObjectPropertyNamingSpec {
                 class O {
                     val _invalidNaming = 1
                 }
-            """.trimIndent()
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
@@ -272,7 +272,7 @@ class ObjectPropertyNamingSpec {
                         val _invalidNaming = 1
                     }
                 }
-            """.trimIndent()
+        """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 }

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNamingSpec.kt
@@ -251,6 +251,30 @@ class ObjectPropertyNamingSpec {
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
     }
+
+    @Test
+    fun `should not detect class properties`() {
+        val subject = ObjectPropertyNaming()
+        val code = """
+                class O {
+                    val _invalidNaming = 1
+                }
+            """.trimIndent()
+        assertThat(subject.compileAndLint(code)).isEmpty()
+    }
+
+    @Test
+    fun `should not detect properties of class in object declaration`() {
+        val subject = ObjectPropertyNaming()
+        val code = """
+                object A {
+                    class O {
+                        val _invalidNaming = 1
+                    }
+                }
+            """.trimIndent()
+        assertThat(subject.compileAndLint(code)).isEmpty()
+    }
 }
 
 @Suppress("UnnecessaryAbstractClass")


### PR DESCRIPTION
## Expected Behavior
ObjectPropertyNaming should only check the properties of the object declaration

## Current Behavior
Rule checks every property which is non-local and not-top level