### PR TITLE
Grant permission for type resolution Gradle job

### DIFF
--- a/.github/workflows/detekt-with-type-resolution.yaml
+++ b/.github/workflows/detekt-with-type-resolution.yaml
@@ -46,6 +46,9 @@ jobs:
 
 
   gradle:
+    permissions:
+      contents: read  # for actions/checkout to fetch code
+      security-events: write  # for github/codeql-action/upload-sarif to upload SARIF results
     runs-on: ubuntu-latest
     if: ${{ !contains(github.event.head_commit.message, 'ci skip') }}
     steps:


### PR DESCRIPTION
Broken `main` CI since yesterday because https://github.com/detekt/detekt/pull/5452 got merged.
