### PR TITLE
Update tests to be compatible with Gradle 7.6 output

### DIFF
--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektAndroidSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektAndroidSpec.kt
@@ -138,7 +138,7 @@ class DetektAndroidSpec {
         @DisplayName("task :app:detektMain")
         fun appDetektMain() {
             gradleRunner.runTasksAndExpectFailure(":app:detektMain") { result ->
-                assertThat(result.output).contains("Task 'detektMain' not found in project")
+                assertThat(result.output).containsIgnoringCase("Task 'detektMain' not found in project")
             }
         }
 
@@ -146,7 +146,7 @@ class DetektAndroidSpec {
         @DisplayName("task :app:detektTest")
         fun appDetektTest() {
             gradleRunner.runTasksAndExpectFailure(":app:detektTest") { result ->
-                assertThat(result.output).contains("Task 'detektTest' not found in project")
+                assertThat(result.output).containsIgnoringCase("Task 'detektTest' not found in project")
             }
         }
     }

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektMultiplatformSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektMultiplatformSpec.kt
@@ -73,14 +73,14 @@ class DetektMultiplatformSpec {
         @Test
         fun `does not configure baseline task`() {
             gradleRunner.runTasksAndExpectFailure(":shared:detektBaselineMetadataMain") { result ->
-                assertThat(result.output).contains("Task 'detektBaselineMetadataMain' not found in project")
+                assertThat(result.output).containsIgnoringCase("Task 'detektBaselineMetadataMain' not found in project")
             }
         }
 
         @Test
         fun `does not configure detekt task`() {
             gradleRunner.runTasksAndExpectFailure(":shared:detektMetadataMain") { result ->
-                assertThat(result.output).contains("Task 'detektMetadataMain' not found in project")
+                assertThat(result.output).containsIgnoringCase("Task 'detektMetadataMain' not found in project")
             }
         }
     }


### PR DESCRIPTION
Gradle 7.6 changes what's logged when tasks are missing. This updates tests to be compatible in advance of that update.