### PR TITLE
Ensure verifyGeneratorOutput task checks necessary files

### DIFF
--- a/detekt-generator/build.gradle.kts
+++ b/detekt-generator/build.gradle.kts
@@ -88,16 +88,25 @@ val generateDocumentation by tasks.registering(JavaExec::class) {
 
 val verifyGeneratorOutput by tasks.registering(Exec::class) {
     dependsOn(generateDocumentation)
-    description = "Verifies that the default-detekt-config.yml is up-to-date"
-    commandLine = listOf("git", "diff", "--quiet", defaultConfigFile, deprecationFile)
+    description = "Verifies that generated config files are up-to-date"
+    commandLine = listOf(
+        "git",
+        "diff",
+        "--quiet",
+        defaultConfigFile,
+        formattingConfigFile,
+        librariesConfigFile,
+        ruleauthorsConfigFile,
+        deprecationFile,
+    )
     isIgnoreExitValue = true
 
     doLast {
         if (executionResult.get().exitValue == 1) {
             throw GradleException(
-                "The default-detekt-config.yml is not up-to-date. " +
+                "At least one generated configuration file is not up-to-date. " +
                     "You can execute the generateDocumentation Gradle task " +
-                    "to update it and commit the changed files."
+                    "to update generated files then commit the changes."
             )
         }
     }

--- a/detekt-rules-ruleauthors/src/main/resources/config/config.yml
+++ b/detekt-rules-ruleauthors/src/main/resources/config/config.yml
@@ -1,6 +1,6 @@
 ruleauthors:
   active: true
-  ViolatesTypeResolutionRequirements:
-    active: true
   UseEntityAtName:
+    active: true
+  ViolatesTypeResolutionRequirements:
     active: true


### PR DESCRIPTION
Currently only `default-detekt-config.yml` and `deprecation.properties` are validated. This adds validations for the generated `config.yml` for `formatting`, `libraries` and `ruleauthors` plugins.