### PR TITLE
Stop including root build unnecessarily in detekt-gradle-plugin

### DIFF
--- a/detekt-gradle-plugin/settings.gradle.kts
+++ b/detekt-gradle-plugin/settings.gradle.kts
@@ -4,8 +4,6 @@ pluginManagement {
     includeBuild("../build-logic")
 }
 
-includeBuild("..")
-
 dependencyResolutionManagement {
     versionCatalogs {
         create("libs") {


### PR DESCRIPTION
This isn't currently used for anything.