### PR TITLE
Add suppressors to labeler for PRs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -43,3 +43,6 @@ rules:
   - "detekt-rules-naming/src/**/*"
   - "detekt-rules-performance/src/**/*"
   - "detekt-rules-style/src/**/*"
+
+suppressors:
+  - "detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/**/*"


### PR DESCRIPTION
As a companion to the new label [suppressors](https://github.com/detekt/detekt/issues?q=is%3Aissue+is%3Aopen+label%3Asuppressors) to use it automatically.