### PR TITLE
ForbiddenAnnotation rule #2719

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -528,6 +528,11 @@ style:
   ExpressionBodySyntax:
     active: false
     includeLineWrapping: false
+  ForbiddenAnnotation:
+    active: false
+    annotations:
+      - reason: 'it is a java annotation. Use `Suppress` instead.'
+        value: 'java.lang.SuppressWarnings'
   ForbiddenComment:
     active: true
     values:

--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -533,6 +533,18 @@ style:
     annotations:
       - reason: 'it is a java annotation. Use `Suppress` instead.'
         value: 'java.lang.SuppressWarnings'
+      - reason: 'it is a java annotation. Use `kotlin.Deprecated` instead.'
+        value: 'java.lang.Deprecated'
+      - reason: 'it is a java annotation. Use `kotlin.annotation.MustBeDocumented` instead.'
+        value: 'java.lang.annotation.Documented'
+      - reason: 'it is a java annotation. Use `kotlin.annotation.Target` instead.'
+        value: 'java.lang.annotation.Target'
+      - reason: 'it is a java annotation. Use `kotlin.annotation.Retention` instead.'
+        value: 'java.lang.annotation.Retention'
+      - reason: 'it is a java annotation. Use `kotlin.annotation.Repeatable` instead.'
+        value: 'java.lang.annotation.Repeatable'
+      - reason: 'Kotlin does not support @Inherited annotation, see https://youtrack.jetbrains.com/issue/KT-22265'
+        value: 'java.lang.annotation.Inherited'
   ForbiddenComment:
     active: true
     values:

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenAnnotation.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenAnnotation.kt
@@ -50,11 +50,13 @@ class ForbiddenAnnotation(config: Config = Config.empty) : Rule(config) {
         valuesWithReason(
             "java.lang.SuppressWarnings" to "it is a java annotation. Use `Suppress` instead.",
             "java.lang.Deprecated" to "it is a java annotation. Use `kotlin.Deprecated` instead.",
-            "java.lang.annotation.Documented" to "it is a java annotation. Use `kotlin.annotation.MustBeDocumented` instead.",
+            "java.lang.annotation.Documented" to "it is a java annotation. " +
+                "Use `kotlin.annotation.MustBeDocumented` instead.",
             "java.lang.annotation.Target" to "it is a java annotation. Use `kotlin.annotation.Target` instead.",
             "java.lang.annotation.Retention" to "it is a java annotation. Use `kotlin.annotation.Retention` instead.",
             "java.lang.annotation.Repeatable" to "it is a java annotation. Use `kotlin.annotation.Repeatable` instead.",
-            "java.lang.annotation.Inherited" to "Kotlin doesn't support @Inherited annotation, see https://youtrack.jetbrains.com/issue/KT-22265",
+            "java.lang.annotation.Inherited" to "Kotlin does not support @Inherited annotation, " +
+                "see https://youtrack.jetbrains.com/issue/KT-22265",
         )
     ) { list ->
         list.associate { it.value to Forbidden(it.value, it.reason) }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenAnnotation.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenAnnotation.kt
@@ -35,9 +35,7 @@ class ForbiddenAnnotation(config: Config = Config.empty) : Rule(config) {
     override val issue = Issue(
         javaClass.simpleName,
         Severity.Style,
-        "Mark forbidden annotations. A forbidden annotation could be an invocation of an unwanted " +
-            "language annotation which does not require explicit import and hence you might want to mark it " +
-            "as forbidden in order to get warned about the usage.",
+        "Avoid using this annotation.",
         Debt.FIVE_MINS
     )
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenAnnotation.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenAnnotation.kt
@@ -110,19 +110,9 @@ class ForbiddenAnnotation(config: Config = Config.empty) : Rule(config) {
 
     private data class Forbidden(val name: String, val reason: String?)
 
-    private fun KtTypeReference.fqNameOrNull(): FqName? {
-        return if (bindingContext != BindingContext.EMPTY) {
-            bindingContext[BindingContext.TYPE, this]?.fqNameOrNull()
-        } else {
-            null
-        }
-    }
+    private fun KtTypeReference.fqNameOrNull(): FqName? =
+        bindingContext[BindingContext.TYPE, this]?.fqNameOrNull()
 
-    private fun KtExpression.expressionTypeOrNull(): KotlinType? {
-        return if (bindingContext != BindingContext.EMPTY) {
-            bindingContext[BindingContext.EXPRESSION_TYPE_INFO, this]?.type
-        } else {
-            null
-        }
-    }
+    private fun KtExpression.expressionTypeOrNull(): KotlinType? =
+        bindingContext[BindingContext.EXPRESSION_TYPE_INFO, this]?.type
 }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenAnnotation.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenAnnotation.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Location
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.config
@@ -15,6 +16,7 @@ import io.gitlab.arturbosch.detekt.rules.fqNameOrNull
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.psi.KtAnnotationEntry
 import org.jetbrains.kotlin.psi.KtTypeReference
+import org.jetbrains.kotlin.psi.psiUtil.endOffset
 import org.jetbrains.kotlin.resolve.BindingContext
 
 /**
@@ -67,7 +69,14 @@ class ForbiddenAnnotation(config: Config = Config.empty) : Rule(config) {
             } else {
                 "The annotation `${forbidden.name}` has been forbidden in the detekt config."
             }
-            report(CodeSmell(issue, Entity.from(annotation), message))
+            val location = Location.from(annotation).let { location ->
+                location.copy(
+                    text = location.text.copy(
+                        end = annotation.children.firstOrNull()?.endOffset ?: location.text.end
+                    )
+                )
+            }
+            report(CodeSmell(issue, Entity.from(annotation, location), message))
         }
     }
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenAnnotation.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenAnnotation.kt
@@ -1,0 +1,83 @@
+package io.gitlab.arturbosch.detekt.rules.style
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.config
+import io.gitlab.arturbosch.detekt.api.internal.Configuration
+import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
+import io.gitlab.arturbosch.detekt.api.valuesWithReason
+import io.gitlab.arturbosch.detekt.rules.fqNameOrNull
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.psi.KtAnnotationEntry
+import org.jetbrains.kotlin.psi.KtTypeReference
+import org.jetbrains.kotlin.resolve.BindingContext
+
+/**
+ * This rule allows to set a list of forbidden annotations. This can be used to discourage the use
+ * of language annotations which do not require explicit import.
+ *
+ * <noncompliant>
+ * @@SuppressWarnings("unused")
+ * class SomeClass()
+ * </noncompliant>
+ *
+ */
+@RequiresTypeResolution
+class ForbiddenAnnotation(config: Config = Config.empty) : Rule(config) {
+
+    override val issue = Issue(
+        javaClass.simpleName,
+        Severity.Style,
+        "Mark forbidden annotations. A forbidden annotation could be an invocation of an unwanted " +
+            "language annotation which does not require explicit import and hence you might want to mark it " +
+            "as forbidden in order to get warned about the usage.",
+        Debt.FIVE_MINS
+    )
+
+    @Configuration(
+        "List of fully qualified annotation classes which are forbidden. " +
+            "For example, `kotlin.jvm.Transient`."
+    )
+    private val annotations: Map<String, Forbidden> by config(
+        valuesWithReason(
+            "java.lang.SuppressWarnings" to "it is a java annotation. Use `Suppress` instead.",
+        )
+    ) { list ->
+        list.associate { it.value to Forbidden(it.value, it.reason) }
+    }
+
+    override fun visitAnnotationEntry(annotation: KtAnnotationEntry) {
+        super.visitAnnotationEntry(annotation)
+        if (annotations.isEmpty()) {
+            return
+        }
+
+        val forbidden = annotation.typeReference?.fqNameOrNull()?.let {
+            annotations[it.asString()]
+        }
+
+        if (forbidden != null) {
+            val message = if (forbidden.reason != null) {
+                "The annotation `${forbidden.name}` has been forbidden: ${forbidden.reason}"
+            } else {
+                "The annotation `${forbidden.name}` has been forbidden in the detekt config."
+            }
+            report(CodeSmell(issue, Entity.from(annotation), message))
+        }
+    }
+
+    private data class Forbidden(val name: String, val reason: String?)
+
+    private fun KtTypeReference.fqNameOrNull(): FqName? {
+        return if (bindingContext != BindingContext.EMPTY) {
+            bindingContext[BindingContext.TYPE, this]?.fqNameOrNull()
+        } else {
+            null
+        }
+    }
+}

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenAnnotation.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenAnnotation.kt
@@ -47,8 +47,7 @@ class ForbiddenAnnotation(config: Config = Config.empty) : Rule(config) {
     )
 
     @Configuration(
-        "List of fully qualified annotation classes which are forbidden. " +
-            "For example, `kotlin.jvm.Transient`."
+        "List of fully qualified annotation classes which are forbidden."
     )
     private val annotations: Map<String, Forbidden> by config(
         valuesWithReason(

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenAnnotation.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenAnnotation.kt
@@ -31,6 +31,10 @@ import org.jetbrains.kotlin.types.KotlinType
  * class SomeClass()
  * </noncompliant>
  *
+ * <compliant>
+ * @@Suppress("unused")
+ * class SomeClass()
+ * </compliant>
  */
 @RequiresTypeResolution
 class ForbiddenAnnotation(config: Config = Config.empty) : Rule(config) {

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenAnnotation.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenAnnotation.kt
@@ -48,7 +48,13 @@ class ForbiddenAnnotation(config: Config = Config.empty) : Rule(config) {
     private val annotations: Map<String, Forbidden> by config(
         valuesWithReason(
             "java.lang.SuppressWarnings" to "it is a java annotation. Use `Suppress` instead.",
-        )
+            "java.lang.Deprecated" to "it is a java annotation. Use `kotlin.Deprecated` instead.",
+            "java.lang.annotation.Documented" to "it is a java annotation. Use `kotlin.annotation.MustBeDocumented` instead.",
+            "java.lang.annotation.Target" to "it is a java annotation. Use `kotlin.annotation.Target` instead.",
+            "java.lang.annotation.Retention" to "it is a java annotation. Use `kotlin.annotation.Retention` instead.",
+            "java.lang.annotation.Repeatable" to "it is a java annotation. Use `kotlin.annotation.Repeatable` instead.",
+            "java.lang.annotation.Inherited" to "Kotlin doesn't support @Inherited annotation, see https://youtrack.jetbrains.com/issue/KT-22265",
+            )
     ) { list ->
         list.associate { it.value to Forbidden(it.value, it.reason) }
     }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenAnnotation.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenAnnotation.kt
@@ -68,9 +68,6 @@ class ForbiddenAnnotation(config: Config = Config.empty) : Rule(config) {
 
     override fun visitAnnotationEntry(annotation: KtAnnotationEntry) {
         super.visitAnnotationEntry(annotation)
-        if (annotations.isEmpty()) {
-            return
-        }
 
         annotation.typeReference?.fqNameOrNull()?.let {
             check(annotation, it)
@@ -80,9 +77,6 @@ class ForbiddenAnnotation(config: Config = Config.empty) : Rule(config) {
     override fun visitExpression(expression: KtExpression) {
         super.visitExpression(expression)
 
-        if (annotations.isEmpty()) {
-            return
-        }
         expression.expressionTypeOrNull()?.fqNameOrNull()?.let {
             check(expression, it)
         }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/StyleGuideProvider.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/StyleGuideProvider.kt
@@ -38,6 +38,7 @@ class StyleGuideProvider : DefaultRuleSetProvider {
             NoTabs(config),
             EqualsOnSignatureLine(config),
             EqualsNullCall(config),
+            ForbiddenAnnotation(config),
             ForbiddenComment(config),
             ForbiddenImport(config),
             ForbiddenMethodCall(config),

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenAnnotationSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenAnnotationSpec.kt
@@ -26,7 +26,7 @@ class ForbiddenAnnotationSpec(val env: KotlinCoreEnvironment) {
             .hasStartSourceLocations(
                 SourceLocation(1, 1)
             )
-            .hasTextLocations(0 to 17)
+            .hasTextLocations("@SuppressWarnings")
             .extracting("message")
             .containsExactly(
                 "The annotation `java.lang.SuppressWarnings` has been forbidden: it is a java annotation. Use `Suppress` instead.",
@@ -54,14 +54,14 @@ class ForbiddenAnnotationSpec(val env: KotlinCoreEnvironment) {
         """.trimIndent()
         val findings = ForbiddenAnnotation(TestConfig()).compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(6)
-        assertThat(findings).hasTextLocations(
-            301 to 312,
-            313 to 324,
-            325 to 335,
-            361 to 368,
-            387 to 398,
-            425 to 435
-        )
+            .hasTextLocations(
+                "@Deprecated",
+                "@Documented",
+                "@Retention",
+                "@Target",
+                "@Repeatable",
+                "@Inherited"
+            )
     }
 
     @Test
@@ -86,7 +86,7 @@ class ForbiddenAnnotationSpec(val env: KotlinCoreEnvironment) {
             TestConfig(mapOf(ANNOTATIONS to listOf("java.lang.SuppressWarnings")))
         ).compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(1)
-        assertThat(findings).hasTextLocations(0 to 27)
+            .hasTextLocations("@java.lang.SuppressWarnings")
     }
 
     @Test
@@ -111,7 +111,7 @@ class ForbiddenAnnotationSpec(val env: KotlinCoreEnvironment) {
             )
         ).compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(3)
-        assertThat(findings).hasTextLocations(0 to 17, 54 to 64, 69 to 78)
+            .hasTextLocations("@SuppressWarnings", "@Transient", "@Volatile")
     }
 
     @Test
@@ -123,7 +123,8 @@ class ForbiddenAnnotationSpec(val env: KotlinCoreEnvironment) {
         val findings = ForbiddenAnnotation(
             TestConfig(mapOf(ANNOTATIONS to listOf("java.lang.SuppressWarnings")))
         ).compileAndLintWithContext(env, code)
-        assertThat(findings).hasSize(1).hasStartSourceLocation(1, 1)
+        assertThat(findings).hasSize(1)
+            .hasTextLocations("@SuppressWarnings")
     }
 
     @Test
@@ -137,7 +138,8 @@ class ForbiddenAnnotationSpec(val env: KotlinCoreEnvironment) {
         val findings = ForbiddenAnnotation(
             TestConfig(mapOf(ANNOTATIONS to listOf("java.lang.SuppressWarnings")))
         ).compileAndLintWithContext(env, code)
-        assertThat(findings).hasSize(1).hasStartSourceLocation(2, 5)
+        assertThat(findings).hasSize(1)
+            .hasTextLocations("@SuppressWarnings")
     }
 
     @Test
@@ -151,7 +153,8 @@ class ForbiddenAnnotationSpec(val env: KotlinCoreEnvironment) {
         val findings = ForbiddenAnnotation(
             TestConfig(mapOf(ANNOTATIONS to listOf("java.lang.SuppressWarnings")))
         ).compileAndLintWithContext(env, code)
-        assertThat(findings).hasSize(1).hasStartSourceLocation(2, 5)
+        assertThat(findings).hasSize(1)
+            .hasTextLocations("@SuppressWarnings")
     }
 
     @Test
@@ -162,7 +165,8 @@ class ForbiddenAnnotationSpec(val env: KotlinCoreEnvironment) {
         val findings = ForbiddenAnnotation(
             TestConfig(mapOf(ANNOTATIONS to listOf("java.lang.SuppressWarnings")))
         ).compileAndLintWithContext(env, code)
-        assertThat(findings).hasSize(1).hasStartSourceLocation(1, 10)
+        assertThat(findings).hasSize(1)
+            .hasTextLocations("@SuppressWarnings")
     }
 
     @Test
@@ -177,7 +181,8 @@ class ForbiddenAnnotationSpec(val env: KotlinCoreEnvironment) {
         val findings = ForbiddenAnnotation(
             TestConfig(mapOf(ANNOTATIONS to listOf("java.lang.SuppressWarnings")))
         ).compileAndLintWithContext(env, code)
-        assertThat(findings).hasSize(1).hasStartSourceLocation(2, 5)
+        assertThat(findings).hasSize(1)
+            .hasTextLocations("@SuppressWarnings")
     }
 
     @Test
@@ -192,13 +197,14 @@ class ForbiddenAnnotationSpec(val env: KotlinCoreEnvironment) {
         val findings = ForbiddenAnnotation(
             TestConfig(mapOf(ANNOTATIONS to listOf("java.lang.SuppressWarnings")))
         ).compileAndLintWithContext(env, code)
-        assertThat(findings).hasSize(1).hasStartSourceLocation(2, 5)
+        assertThat(findings).hasSize(1)
+            .hasTextLocations("@SuppressWarnings")
     }
 
     @Test
     fun `should report nested annotations`() {
         val code = """
-        @Deprecated("unused", ReplaceWith("bar"))
+        @Deprecated(message = "unused", replaceWith = ReplaceWith("bar"))
         fun foo() = "1234"
         """.trimIndent()
         val findings = ForbiddenAnnotation(
@@ -217,21 +223,19 @@ class ForbiddenAnnotationSpec(val env: KotlinCoreEnvironment) {
         """.trimIndent()
         val findings = ForbiddenAnnotation(TestConfig()).compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(1)
-            .hasStartSourceLocation(2, 1)
-            .hasTextLocations(37 to 41)
+            .hasTextLocations("@Dep")
     }
 
     @Test
     fun `should report annotations for expressions`() {
         val code = """
-        val num = @Suppress("MagicNumber") 42
         val x = 0 + @Suppress("UnnecessaryParentheses") (((1)+(2))) + 3
         """.trimIndent()
         val findings = ForbiddenAnnotation(
             TestConfig(mapOf(ANNOTATIONS to listOf("kotlin.Suppress")))
         ).compileAndLintWithContext(env, code)
-        assertThat(findings).hasSize(2)
-            .hasTextLocations(10 to 19, 50 to 59)
+        assertThat(findings).hasSize(1)
+            .hasTextLocations("@Suppress")
     }
 
     @Test
@@ -245,6 +249,6 @@ class ForbiddenAnnotationSpec(val env: KotlinCoreEnvironment) {
             TestConfig(mapOf(ANNOTATIONS to listOf("kotlin.Suppress")))
         ).compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(1)
-            .hasTextLocations(41 to 50)
+            .hasTextLocations("@Suppress")
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenAnnotationSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenAnnotationSpec.kt
@@ -61,21 +61,25 @@ class ForbiddenAnnotationSpec(val env: KotlinCoreEnvironment) {
     fun `should report multiple different annotations`() {
         val code = """
         @SuppressWarnings("unused")
-        @Transient
-        fun main() {}
+        data class SomeClass(
+            @Transient
+            @Volatile
+            var transient: String? = null
+        )
         """.trimIndent()
         val findings = ForbiddenAnnotation(
             TestConfig(
                 mapOf(
                     ANNOTATIONS to listOf(
                         "java.lang.SuppressWarnings",
-                        "kotlin.jvm.Transient"
+                        "kotlin.jvm.Transient",
+                        "kotlin.jvm.Volatile"
                     )
                 )
             )
         ).compileAndLintWithContext(env, code)
-        assertThat(findings).hasSize(2)
-        assertThat(findings).hasTextLocations(0 to 27, 28 to 38)
+        assertThat(findings).hasSize(3)
+        assertThat(findings).hasTextLocations(0 to 27, 54 to 64, 69 to 78)
     }
 
     @Test
@@ -109,7 +113,7 @@ class ForbiddenAnnotationSpec(val env: KotlinCoreEnvironment) {
         val code = """
         class SomeClass {
             @SuppressWarnings("unused")
-            val someField: String
+            val someField: String = "lalala"
         }
         """.trimIndent()
         val findings = ForbiddenAnnotation(

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenAnnotationSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenAnnotationSpec.kt
@@ -230,4 +230,16 @@ class ForbiddenAnnotationSpec(val env: KotlinCoreEnvironment) {
         assertThat(findings).hasSize(2)
             .hasTextLocations(10 to 27, 58 to 75)
     }
+
+    @Test
+    fun `should report annotations for blocks`() {
+        val code = """
+        fun f(list: List<String>) {
+            list.map @SuppressWarnings("x") { it.length }
+        }
+        """.trimIndent()
+        val findings = ForbiddenAnnotation(TestConfig()).compileAndLintWithContext(env, code)
+        assertThat(findings).hasSize(1)
+            .hasTextLocations(41 to 58)
+    }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenAnnotationSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenAnnotationSpec.kt
@@ -41,24 +41,26 @@ class ForbiddenAnnotationSpec(val env: KotlinCoreEnvironment) {
         import java.lang.annotation.Target
         import java.lang.annotation.Repeatable
         import java.lang.annotation.Inherited
+        import java.lang.annotation.RetentionPolicy
+        import java.lang.annotation.ElementType
         import java.lang.Deprecated
         @Deprecated
         @Documented    
         @Retention(RetentionPolicy.RUNTIME)
         @Target(ElementType.TYPE)
-        @Repeatable
+        @Repeatable(value = SomeClass::class)
         @Inherited
-        annotation class SomeClass
+        annotation class SomeClass(val value: Array<SomeClass>)
         """.trimIndent()
         val findings = ForbiddenAnnotation(TestConfig()).compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(6)
         assertThat(findings).hasTextLocations(
-            219 to 230,
-            231 to 242,
-            247 to 257,
-            283 to 290,
-            309 to 320,
-            321 to 331
+            303 to 314,
+            315 to 326,
+            331 to 341,
+            367 to 374,
+            393 to 404,
+            431 to 441
         )
     }
 
@@ -223,23 +225,27 @@ class ForbiddenAnnotationSpec(val env: KotlinCoreEnvironment) {
     @Test
     fun `should report annotations for expressions`() {
         val code = """
-        val num = @SuppressWarnings("MagicNumber") 42
-        val x = 0 + @SuppressWarnings("UnnecessaryParentheses") (((1)+(2))) + 3
+        val num = @Suppress("MagicNumber") 42
+        val x = 0 + @Suppress("UnnecessaryParentheses") (((1)+(2))) + 3
         """.trimIndent()
-        val findings = ForbiddenAnnotation(TestConfig()).compileAndLintWithContext(env, code)
+        val findings = ForbiddenAnnotation(
+            TestConfig(mapOf(ANNOTATIONS to listOf("kotlin.Suppress")))
+        ).compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(2)
-            .hasTextLocations(10 to 27, 58 to 75)
+            .hasTextLocations(10 to 19, 50 to 59)
     }
 
     @Test
     fun `should report annotations for blocks`() {
         val code = """
         fun f(list: List<String>) {
-            list.map @SuppressWarnings("x") { it.length }
+            list.map @Suppress("x") { it.length }
         }
         """.trimIndent()
-        val findings = ForbiddenAnnotation(TestConfig()).compileAndLintWithContext(env, code)
+        val findings = ForbiddenAnnotation(
+            TestConfig(mapOf(ANNOTATIONS to listOf("kotlin.Suppress")))
+        ).compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(1)
-            .hasTextLocations(41 to 58)
+            .hasTextLocations(41 to 50)
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenAnnotationSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenAnnotationSpec.kt
@@ -192,4 +192,18 @@ class ForbiddenAnnotationSpec(val env: KotlinCoreEnvironment) {
         ).compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(1).hasStartSourceLocation(2, 5)
     }
+
+    @Test
+    fun `should report nested annotations`() {
+        val code = """
+        @Deprecated("unused", ReplaceWith("bar"))
+        fun foo() = "1234"
+        """.trimIndent()
+        val findings = ForbiddenAnnotation(
+            TestConfig(mapOf(ANNOTATIONS to listOf("kotlin.ReplaceWith")))
+        ).compileAndLintWithContext(env, code)
+        assertThat(findings).hasSize(1)
+            .hasStartSourceLocation(1, 23)
+            .hasTextLocations("ReplaceWith")
+    }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenAnnotationSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenAnnotationSpec.kt
@@ -16,7 +16,7 @@ class ForbiddenAnnotationSpec(val env: KotlinCoreEnvironment) {
     @Test
     fun `should report SuppressWarnings usages by default`() {
         val code = """
-        @SuppressWarnings("unused")    
+        @SuppressWarnings("unused")
         fun main() {}
         """.trimIndent()
         val findings = ForbiddenAnnotation(TestConfig()).compileAndLintWithContext(env, code)
@@ -36,8 +36,8 @@ class ForbiddenAnnotationSpec(val env: KotlinCoreEnvironment) {
     @Test
     fun `should report annotations from java lang annotation package by default`() {
         val code = """
-        import java.lang.annotation.Retention 
-        import java.lang.annotation.Documented 
+        import java.lang.annotation.Retention
+        import java.lang.annotation.Documented
         import java.lang.annotation.Target
         import java.lang.annotation.Repeatable
         import java.lang.annotation.Inherited
@@ -45,7 +45,7 @@ class ForbiddenAnnotationSpec(val env: KotlinCoreEnvironment) {
         import java.lang.annotation.ElementType
         import java.lang.Deprecated
         @Deprecated
-        @Documented    
+        @Documented
         @Retention(RetentionPolicy.RUNTIME)
         @Target(ElementType.TYPE)
         @Repeatable(value = SomeClass::class)
@@ -55,19 +55,19 @@ class ForbiddenAnnotationSpec(val env: KotlinCoreEnvironment) {
         val findings = ForbiddenAnnotation(TestConfig()).compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(6)
         assertThat(findings).hasTextLocations(
-            303 to 314,
-            315 to 326,
-            331 to 341,
-            367 to 374,
-            393 to 404,
-            431 to 441
+            301 to 312,
+            313 to 324,
+            325 to 335,
+            361 to 368,
+            387 to 398,
+            425 to 435
         )
     }
 
     @Test
     fun `should report nothing when annotations do not match`() {
         val code = """
-        @SuppressWarnings("unused") 
+        @SuppressWarnings("unused")
         fun main() {}
         """.trimIndent()
         val findings = ForbiddenAnnotation(
@@ -79,7 +79,7 @@ class ForbiddenAnnotationSpec(val env: KotlinCoreEnvironment) {
     @Test
     fun `should report annotation call when the fully qualified name is used`() {
         val code = """
-        @java.lang.SuppressWarnings("unused") 
+        @java.lang.SuppressWarnings("unused")
         fun main() {}
         """.trimIndent()
         val findings = ForbiddenAnnotation(

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenAnnotationSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenAnnotationSpec.kt
@@ -206,4 +206,17 @@ class ForbiddenAnnotationSpec(val env: KotlinCoreEnvironment) {
             .hasStartSourceLocation(1, 23)
             .hasTextLocations("ReplaceWith")
     }
+
+    @Test
+    fun `should report aliased annotations`() {
+        val code = """
+        typealias Dep = java.lang.Deprecated
+        @Dep
+        fun f() = Unit
+        """.trimIndent()
+        val findings = ForbiddenAnnotation(TestConfig()).compileAndLintWithContext(env, code)
+        assertThat(findings).hasSize(1)
+            .hasStartSourceLocation(2, 1)
+            .hasTextLocations(37 to 41)
+    }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenAnnotationSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenAnnotationSpec.kt
@@ -33,18 +33,6 @@ class ForbiddenAnnotationSpec(val env: KotlinCoreEnvironment) {
     }
 
     @Test
-    fun `should report nothing when annotations are blank`() {
-        val code = """
-        @SuppressWarnings("unused") 
-        fun main() {}
-        """.trimIndent()
-        val findings = ForbiddenAnnotation(
-            TestConfig(mapOf(ANNOTATIONS to listOf("  ")))
-        ).compileAndLintWithContext(env, code)
-        assertThat(findings).isEmpty()
-    }
-
-    @Test
     fun `should report nothing when annotations do not match`() {
         val code = """
         @SuppressWarnings("unused") 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenAnnotationSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenAnnotationSpec.kt
@@ -34,6 +34,35 @@ class ForbiddenAnnotationSpec(val env: KotlinCoreEnvironment) {
     }
 
     @Test
+    fun `should report annotations from java lang annotation package by default`() {
+        val code = """
+        import java.lang.annotation.Retention 
+        import java.lang.annotation.Documented 
+        import java.lang.annotation.Target
+        import java.lang.annotation.Repeatable
+        import java.lang.annotation.Inherited
+        import java.lang.Deprecated
+        @Deprecated
+        @Documented    
+        @Retention(RetentionPolicy.RUNTIME)
+        @Target(ElementType.TYPE)
+        @Repeatable
+        @Inherited
+        annotation class SomeClass
+        """.trimIndent()
+        val findings = ForbiddenAnnotation(TestConfig()).compileAndLintWithContext(env, code)
+        assertThat(findings).hasSize(6)
+        assertThat(findings).hasTextLocations(
+            219 to 230,
+            231 to 242,
+            247 to 257,
+            283 to 290,
+            309 to 320,
+            321 to 331
+        )
+    }
+
+    @Test
     fun `should report nothing when annotations do not match`() {
         val code = """
         @SuppressWarnings("unused") 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenAnnotationSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenAnnotationSpec.kt
@@ -1,0 +1,173 @@
+package io.gitlab.arturbosch.detekt.rules.style
+
+import io.gitlab.arturbosch.detekt.api.SourceLocation
+import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
+import io.gitlab.arturbosch.detekt.test.TestConfig
+import io.gitlab.arturbosch.detekt.test.assertThat
+import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
+import org.junit.jupiter.api.Test
+
+private const val ANNOTATIONS = "annotations"
+
+@KotlinCoreEnvironmentTest
+class ForbiddenAnnotationSpec(val env: KotlinCoreEnvironment) {
+
+    @Test
+    fun `should report SuppressWarnings usages by default`() {
+        val code = """
+        @SuppressWarnings("unused")    
+        fun main() {}
+        """.trimIndent()
+        val findings = ForbiddenAnnotation(TestConfig()).compileAndLintWithContext(env, code)
+
+        assertThat(findings)
+            .hasSize(1)
+            .hasStartSourceLocations(
+                SourceLocation(1, 1)
+            )
+            .extracting("message")
+            .containsExactly(
+                "The annotation `java.lang.SuppressWarnings` has been forbidden: it is a java annotation. Use `Suppress` instead.",
+            )
+    }
+
+    @Test
+    fun `should report nothing when annotations are blank`() {
+        val code = """
+        @SuppressWarnings("unused") 
+        fun main() {}
+        """.trimIndent()
+        val findings = ForbiddenAnnotation(
+            TestConfig(mapOf(ANNOTATIONS to listOf("  ")))
+        ).compileAndLintWithContext(env, code)
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `should report nothing when annotations do not match`() {
+        val code = """
+        @SuppressWarnings("unused") 
+        fun main() {}
+        """.trimIndent()
+        val findings = ForbiddenAnnotation(
+            TestConfig(mapOf(ANNOTATIONS to listOf("kotlin.jvm.Transient")))
+        ).compileAndLintWithContext(env, code)
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `should report annotation call when the fully qualified name is used`() {
+        val code = """
+        @java.lang.SuppressWarnings("unused") 
+        fun main() {}
+        """.trimIndent()
+        val findings = ForbiddenAnnotation(
+            TestConfig(mapOf(ANNOTATIONS to listOf("java.lang.SuppressWarnings")))
+        ).compileAndLintWithContext(env, code)
+        assertThat(findings).hasSize(1)
+        assertThat(findings).hasTextLocations(0 to 37)
+    }
+
+    @Test
+    fun `should report multiple different annotations`() {
+        val code = """
+        @SuppressWarnings("unused")
+        @Transient
+        fun main() {}
+        """.trimIndent()
+        val findings = ForbiddenAnnotation(
+            TestConfig(
+                mapOf(
+                    ANNOTATIONS to listOf(
+                        "java.lang.SuppressWarnings",
+                        "kotlin.jvm.Transient"
+                    )
+                )
+            )
+        ).compileAndLintWithContext(env, code)
+        assertThat(findings).hasSize(2)
+        assertThat(findings).hasTextLocations(0 to 27, 28 to 38)
+    }
+
+    @Test
+    fun `should report annotation on class`() {
+        val code = """
+        @SuppressWarnings("unused")
+        class SomeClass
+        """.trimIndent()
+        val findings = ForbiddenAnnotation(
+            TestConfig(mapOf(ANNOTATIONS to listOf("java.lang.SuppressWarnings")))
+        ).compileAndLintWithContext(env, code)
+        assertThat(findings).hasSize(1).hasStartSourceLocation(1, 1)
+    }
+
+    @Test
+    fun `should report annotation on method`() {
+        val code = """
+        class SomeClass {
+            @SuppressWarnings("unused")
+            fun someMethod(){}
+        }
+        """.trimIndent()
+        val findings = ForbiddenAnnotation(
+            TestConfig(mapOf(ANNOTATIONS to listOf("java.lang.SuppressWarnings")))
+        ).compileAndLintWithContext(env, code)
+        assertThat(findings).hasSize(1).hasStartSourceLocation(2, 5)
+    }
+
+    @Test
+    fun `should report annotation on field`() {
+        val code = """
+        class SomeClass {
+            @SuppressWarnings("unused")
+            val someField: String
+        }
+        """.trimIndent()
+        val findings = ForbiddenAnnotation(
+            TestConfig(mapOf(ANNOTATIONS to listOf("java.lang.SuppressWarnings")))
+        ).compileAndLintWithContext(env, code)
+        assertThat(findings).hasSize(1).hasStartSourceLocation(2, 5)
+    }
+
+    @Test
+    fun `should report annotation on function parameter`() {
+        val code = """
+        fun main(@SuppressWarnings("unused") args: Array<String>){}
+        """.trimIndent()
+        val findings = ForbiddenAnnotation(
+            TestConfig(mapOf(ANNOTATIONS to listOf("java.lang.SuppressWarnings")))
+        ).compileAndLintWithContext(env, code)
+        assertThat(findings).hasSize(1).hasStartSourceLocation(1, 10)
+    }
+
+    @Test
+    fun `should report annotation on constructor`() {
+        val code = """
+        class SomeClass {
+            @SuppressWarnings("unused")
+            constructor(s: String)
+            constructor(t: Int)
+        }
+        """.trimIndent()
+        val findings = ForbiddenAnnotation(
+            TestConfig(mapOf(ANNOTATIONS to listOf("java.lang.SuppressWarnings")))
+        ).compileAndLintWithContext(env, code)
+        assertThat(findings).hasSize(1).hasStartSourceLocation(2, 5)
+    }
+
+    @Test
+    fun `should report annotation on local variable`() {
+        val code = """
+        fun some(): Int {
+            @SuppressWarnings("unused")
+            val q = "1234"
+            return 10
+        }
+        """.trimIndent()
+        val findings = ForbiddenAnnotation(
+            TestConfig(mapOf(ANNOTATIONS to listOf("java.lang.SuppressWarnings")))
+        ).compileAndLintWithContext(env, code)
+        assertThat(findings).hasSize(1).hasStartSourceLocation(2, 5)
+    }
+}

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenAnnotationSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenAnnotationSpec.kt
@@ -205,7 +205,6 @@ class ForbiddenAnnotationSpec(val env: KotlinCoreEnvironment) {
             TestConfig(mapOf(ANNOTATIONS to listOf("kotlin.ReplaceWith")))
         ).compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(1)
-            .hasStartSourceLocation(1, 23)
             .hasTextLocations("ReplaceWith")
     }
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenAnnotationSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenAnnotationSpec.kt
@@ -26,6 +26,7 @@ class ForbiddenAnnotationSpec(val env: KotlinCoreEnvironment) {
             .hasStartSourceLocations(
                 SourceLocation(1, 1)
             )
+            .hasTextLocations(0 to 17)
             .extracting("message")
             .containsExactly(
                 "The annotation `java.lang.SuppressWarnings` has been forbidden: it is a java annotation. Use `Suppress` instead.",
@@ -54,7 +55,7 @@ class ForbiddenAnnotationSpec(val env: KotlinCoreEnvironment) {
             TestConfig(mapOf(ANNOTATIONS to listOf("java.lang.SuppressWarnings")))
         ).compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(1)
-        assertThat(findings).hasTextLocations(0 to 37)
+        assertThat(findings).hasTextLocations(0 to 27)
     }
 
     @Test
@@ -79,7 +80,7 @@ class ForbiddenAnnotationSpec(val env: KotlinCoreEnvironment) {
             )
         ).compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(3)
-        assertThat(findings).hasTextLocations(0 to 27, 54 to 64, 69 to 78)
+        assertThat(findings).hasTextLocations(0 to 17, 54 to 64, 69 to 78)
     }
 
     @Test

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenAnnotationSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenAnnotationSpec.kt
@@ -204,6 +204,7 @@ class ForbiddenAnnotationSpec(val env: KotlinCoreEnvironment) {
     @Test
     fun `should report nested annotations`() {
         val code = """
+        import kotlin.Deprecated
         @Deprecated(message = "unused", replaceWith = ReplaceWith("bar"))
         fun foo() = "1234"
         """.trimIndent()

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenAnnotationSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenAnnotationSpec.kt
@@ -219,4 +219,15 @@ class ForbiddenAnnotationSpec(val env: KotlinCoreEnvironment) {
             .hasStartSourceLocation(2, 1)
             .hasTextLocations(37 to 41)
     }
+
+    @Test
+    fun `should report annotations for expressions`() {
+        val code = """
+        val num = @SuppressWarnings("MagicNumber") 42
+        val x = 0 + @SuppressWarnings("UnnecessaryParentheses") (((1)+(2))) + 3
+        """.trimIndent()
+        val findings = ForbiddenAnnotation(TestConfig()).compileAndLintWithContext(env, code)
+        assertThat(findings).hasSize(2)
+            .hasTextLocations(10 to 27, 58 to 75)
+    }
 }


### PR DESCRIPTION
As discussed in #2719, this rule could be sometimes useful for cases when an annotation does not require import: `java.lang.SuppressWarnings`, `kotlin.jvm.Transient`, etc. These cases can't be caught with the `ForbiddenImport` rule.
Also, this rule can be useful for pushing people towards the Kotlin implementations (see [this issue](https://github.com/jhipster/jhipster-kotlin/issues/143) for an example).

More specifically, forbidding `kotlin.jvm.Transient` can be useful in applications with `kotlinx.serialization`: `kotlin.jvm.Transient` does not affect `@Serializable` classes. `ForbiddenAnnotation` can be a quick-fix for that.