### PR TITLE
Migrate to Gradle Nexus Publish Plugin

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -11,7 +11,7 @@ dependencies {
     implementation(libs.kotlin.gradle)
     implementation(libs.githubRelease.gradle)
     implementation(libs.semver4j.gradle)
-    implementation(libs.nexusStaging.gradle)
+    implementation(libs.nexusPublish.gradle)
 }
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {

--- a/build-logic/src/main/kotlin/releasing.gradle.kts
+++ b/build-logic/src/main/kotlin/releasing.gradle.kts
@@ -10,8 +10,6 @@ nexusPublishing {
 
     repositories {
         create("sonatype") {
-            stagingProfileId.set("1d8efc8232c5c")
-
             username.set(
                 findProperty("sonatypeUsername")
                     ?.toString()

--- a/build-logic/src/main/kotlin/releasing.gradle.kts
+++ b/build-logic/src/main/kotlin/releasing.gradle.kts
@@ -10,16 +10,8 @@ nexusPublishing {
 
     repositories {
         create("sonatype") {
-            username.set(
-                findProperty("sonatypeUsername")
-                    ?.toString()
-                    ?: System.getenv("MAVEN_CENTRAL_USER")
-            )
-            password.set(
-                findProperty("sonatypePassword")
-                    ?.toString()
-                    ?: System.getenv("MAVEN_CENTRAL_PW")
-            )
+            System.getenv("ORG_GRADLE_PROJECT_SONATYPE_USERNAME")?.let { username.set(it) }
+            System.getenv("ORG_GRADLE_PROJECT_SONATYPE_PASSWORD")?.let { password.set(it) }
         }
     }
 }

--- a/build-logic/src/main/kotlin/releasing.gradle.kts
+++ b/build-logic/src/main/kotlin/releasing.gradle.kts
@@ -2,18 +2,28 @@ import com.vdurmont.semver4j.Semver
 
 plugins {
     id("com.github.breadmoirai.github-release")
-    id("io.codearte.nexus-staging")
+    id("io.github.gradle-nexus.publish-plugin")
 }
 
-nexusStaging {
-    packageGroup = "io.gitlab.arturbosch"
-    stagingProfileId = "1d8efc8232c5c"
-    username = findProperty("sonatypeUsername")
-        ?.toString()
-        ?: System.getenv("MAVEN_CENTRAL_USER")
-    password = findProperty("sonatypePassword")
-        ?.toString()
-        ?: System.getenv("MAVEN_CENTRAL_PW")
+nexusPublishing {
+    packageGroup.set("io.gitlab.arturbosch")
+
+    repositories {
+        create("sonatype") {
+            stagingProfileId.set("1d8efc8232c5c")
+
+            username.set(
+                findProperty("sonatypeUsername")
+                    ?.toString()
+                    ?: System.getenv("MAVEN_CENTRAL_USER")
+            )
+            password.set(
+                findProperty("sonatypePassword")
+                    ?.toString()
+                    ?: System.getenv("MAVEN_CENTRAL_PW")
+            )
+        }
+    }
 }
 
 project.afterEvaluate {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ contester = "0.2.0"
 
 [libraries]
 githubRelease-gradle = "com.github.breadmoirai:github-release:2.4.1"
-nexusStaging-gradle = "io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.30.0"
+nexusPublish-gradle = "io.github.gradle-nexus:publish-plugin:1.1.0"
 semver4j-gradle = "com.vdurmont:semver4j:3.1.0"
 
 kotlin-compilerEmbeddable = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable", version.ref = "kotlin" }

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -6,4 +6,4 @@ gradle publishAllToMavenCentral --max-workers 1
 gradle :detekt-gradle-plugin:publishPlugins
 gradle githubRelease
 gradle applyDocVersion
-gradle closeAndReleaseRepository
+gradle closeAndReleaseSonatypeStagingRepository


### PR DESCRIPTION
The old Gradle Nexus Staging plugin is no longer updated and has been replaced by Gradle Nexus Publish Plugin.

https://blog.solidsoft.pl/2021/02/26/unified-gradle-projects-releasing-to-maven-central-in-2021-migration-guide/