### PR TITLE
Pass compilation output classes to detekt analysis classpath

### DIFF
--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/JvmSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/JvmSpec.kt
@@ -14,11 +14,15 @@ class JvmSpec {
             .withArguments("detektMain")
             .buildAndFail()
 
-        assertThat(result.output).contains("failed with 2 weighted issues.")
+        assertThat(result.output).contains("failed with 3 weighted issues.")
         assertThat(result.output).contains(
             "Do not directly exit the process outside the `main` function. Throw an exception(...)"
         )
+        assertThat(result.output).contains(
+            "The method `jvm.src.main.kotlin.Callee.forbiddenMethod` has been forbidden in th(...)"
+        )
         assertThat(result.output).contains("Errors.kt:7:9")
         assertThat(result.output).contains("Errors.kt:12:16")
+        assertThat(result.output).contains("Caller.kt:5:18")
     }
 }

--- a/detekt-gradle-plugin/src/functionalTest/resources/jvm/build.gradle
+++ b/detekt-gradle-plugin/src/functionalTest/resources/jvm/build.gradle
@@ -7,3 +7,7 @@ repositories {
     mavenCentral()
     mavenLocal()
 }
+
+tasks.detektMain {
+    exclude("**/Callee.kt")
+}

--- a/detekt-gradle-plugin/src/functionalTest/resources/jvm/config/detekt/detekt.yml
+++ b/detekt-gradle-plugin/src/functionalTest/resources/jvm/config/detekt/detekt.yml
@@ -1,3 +1,9 @@
 potential-bugs:
   ExitOutsideMain:
     active: true
+
+style:
+  ForbiddenMethodCall:
+    active: true
+    methods:
+      - 'jvm.src.main.kotlin.Callee.forbiddenMethod'

--- a/detekt-gradle-plugin/src/functionalTest/resources/jvm/src/main/kotlin/Callee.kt
+++ b/detekt-gradle-plugin/src/functionalTest/resources/jvm/src/main/kotlin/Callee.kt
@@ -1,0 +1,7 @@
+package jvm.src.main.kotlin
+
+class Callee {
+    fun forbiddenMethod() {
+        error("don't ever call this method")
+    }
+}

--- a/detekt-gradle-plugin/src/functionalTest/resources/jvm/src/main/kotlin/Caller.kt
+++ b/detekt-gradle-plugin/src/functionalTest/resources/jvm/src/main/kotlin/Caller.kt
@@ -1,0 +1,7 @@
+package jvm.src.main.kotlin
+
+class Caller {
+    fun method() {
+        Callee().forbiddenMethod()
+    }
+}

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektJvm.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektJvm.kt
@@ -26,7 +26,7 @@ internal class DetektJvm(private val project: Project) {
     ) {
         registerDetektTask(DetektPlugin.DETEKT_TASK_NAME + compilation.name.capitalize(), extension) {
             setSource(inputSource)
-            classpath.setFrom(inputSource, compilation.compileDependencyFiles)
+            classpath.setFrom(compilation.output.classesDirs, compilation.compileDependencyFiles)
             // If a baseline file is configured as input file, it must exist to be configured, otherwise the task fails.
             // We try to find the configured baseline or alternatively a specific variant matching this task.
             extension.baseline?.existingVariantOrBaseFile(compilation.name)?.let { baselineFile ->
@@ -44,7 +44,7 @@ internal class DetektJvm(private val project: Project) {
     ) {
         registerCreateBaselineTask(DetektPlugin.BASELINE_TASK_NAME + compilation.name.capitalize(), extension) {
             setSource(inputSource)
-            classpath.setFrom(inputSource, compilation.compileDependencyFiles)
+            classpath.setFrom(compilation.output.classesDirs, compilation.compileDependencyFiles)
             val variantBaselineFile = extension.baseline?.addVariantName(compilation.name)
             baseline.convention(layout.file(provider { variantBaselineFile }))
             description = "EXPERIMENTAL: Creates detekt baseline for ${compilation.name} classes with type resolution"

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektMultiplatform.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektMultiplatform.kt
@@ -96,7 +96,7 @@ internal class DetektMultiplatform(private val project: Project) {
         ) {
             setSource(inputSource)
             if (runWithTypeResolution) {
-                classpath.setFrom(inputSource, compilation.compileDependencyFiles)
+                classpath.setFrom(compilation.output.classesDirs, compilation.compileDependencyFiles)
             }
             // If a baseline file is configured as input file, it must exist to be configured, otherwise the task fails.
             // We try to find the configured baseline or alternatively a specific variant matching this task.
@@ -121,7 +121,7 @@ internal class DetektMultiplatform(private val project: Project) {
         ) {
             setSource(inputSource)
             if (runWithTypeResolution) {
-                classpath.setFrom(inputSource, compilation.compileDependencyFiles)
+                classpath.setFrom(compilation.output.classesDirs, compilation.compileDependencyFiles)
             }
             val variantBaselineFile = if (runWithTypeResolution) {
                 extension.baseline?.addVariantName(compilation.name)


### PR DESCRIPTION
This is needed to avoid excluding files from analysis classpath if they're excluded from the analysis input source.

Fixes #5555