### PR TITLE
Improve build after Gradle 7.6 update

### DIFF
--- a/code-coverage-report/build.gradle.kts
+++ b/code-coverage-report/build.gradle.kts
@@ -43,27 +43,3 @@ dependencies {
 tasks.check {
     dependsOn(tasks.named("jacocoMergedReport"))
 }
-
-// The `allCodeCoverageReportClassDirectories` configuration provided by the jacoco-report-aggregation plugin actually
-// resolves JARs and not class directories as the name suggests. Because the detekt-formatting JAR bundles ktlint and
-// other dependencies in its JAR, they are incorrectly displayed on the coverage report even though they're external
-// dependencies.
-configurations.allCodeCoverageReportClassDirectories.get().attributes {
-    attributes.attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category::class, Category.LIBRARY))
-    attributes.attribute(
-        LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE,
-        objects.named(LibraryElements::class, LibraryElements.CLASSES)
-    )
-}
-
-val customClassDirectories = configurations.allCodeCoverageReportClassDirectories.get().incoming.artifactView {
-    componentFilter {
-        it is ProjectComponentIdentifier
-    }
-    lenient(true)
-}
-
-tasks.named("jacocoMergedReport", JacocoReport::class).configure {
-    this.classDirectories.setFrom(customClassDirectories.files)
-    mustRunAfter(rootProject.project("detekt-generator").tasks.named("generateDocumentation"))
-}

--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -38,6 +38,7 @@ testing {
 
             dependencies {
                 implementation(libs.assertj)
+                implementation(testFixtures(project(":")))
             }
 
             targets {
@@ -66,10 +67,6 @@ pluginCompileOnly.attributes {
 dependencies {
     compileOnly(libs.kotlin.gradlePluginApi)
     implementation(libs.sarif4k)
-
-    // Migrate to `implementation(testFixtures(project))` in test suite configuration when this issue is fixed:
-    // https://github.com/gradle/gradle/pull/19472
-    functionalTestImplementation(testFixtures(project))
 
     pluginCompileOnly(libs.android.gradle)
     pluginCompileOnly(libs.kotlin.gradle)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -40,6 +40,7 @@ include("detekt-tooling")
 include("detekt-utils")
 
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
+enableFeaturePreview("STABLE_CONFIGURATION_CACHE")
 
 // build scan plugin can only be applied in settings file
 plugins {


### PR DESCRIPTION
Some config can be cleaned up now, and the stable configuration cache feature flag can also be enabled (which closes #4963).