### PR TITLE
Enable configuration cache by default

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,5 +4,5 @@ systemProp.dependency.analysis.test.analysis=false
 org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8
-org.gradle.unsafe.configuration-cache=false
+org.gradle.unsafe.configuration-cache=true
 systemProp.org.gradle.kotlin.dsl.precompiled.accessors.strict=true


### PR DESCRIPTION
Third time's the charm (previous attempts: #5095, #4576)

I've tested these commands successfully.
```
./gradlew build -x dokkaHtml
./gradlew build -x dokkaHtml
./gradlew clean
./gradlew clean
```