### PR TITLE
Check for InaccessibleObjectExceptions in CI

### DIFF
--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -59,6 +59,11 @@ jobs:
         with:
           arguments: :detekt-cli:runWithArgsFile
 
+      - name: Run detekt-cli with autocorrect
+        uses: gradle/gradle-build-action@3fbe033aaae657f011f88f29be9e65ed26bd29ef # tag=v2
+        with:
+          arguments: :detekt-cli:runWithAutocorrectAndFormatting
+
       - name: Try to publish to Maven Local
         uses: gradle/gradle-build-action@3fbe033aaae657f011f88f29be9e65ed26bd29ef # tag=v2
         with:

--- a/detekt-cli/build.gradle.kts
+++ b/detekt-cli/build.gradle.kts
@@ -63,6 +63,20 @@ tasks {
         args = listOf("@./config/detekt/argsfile", "-p", pluginsJar.files.joinToString(",") { it.path })
     }
 
+    // use in CI only to  https://github.com/detekt/detekt/issues/5247
+    register<JavaExec>("runWithAutocorrectAndFormatting") {
+        inputs.files(pluginsJar)
+        doNotTrackState("The entire root directory is read as the input source.")
+        classpath = files(shadowJar)
+        workingDir = projectDir
+        args = listOf(
+            "--auto-correct",
+            "--build-upon-default-config",
+            "-p",
+            pluginsJar.files.joinToString(",") { it.path }
+        )
+    }
+
     check {
         dependsOn(runWithHelpFlag, runWithArgsFile)
     }


### PR DESCRIPTION
Investigating ways to test for #5247 in CI. That issue relates to the brew config, but we have this problem in our build too depending on how it's invoked.

This is caused by upstream Kotlin/ktlint issues.