### PR TITLE
Add missing task dependency

### DIFF
--- a/code-coverage-report/build.gradle.kts
+++ b/code-coverage-report/build.gradle.kts
@@ -43,3 +43,7 @@ dependencies {
 tasks.check {
     dependsOn(tasks.named("jacocoMergedReport"))
 }
+
+tasks.withType<JacocoReport>().configureEach {
+    dependsOn(":detekt-generator:generateDocumentation")
+}


### PR DESCRIPTION
The `:codeCoverageReport:jacocoMergedReport` task is not getting build cache hits due to an implicit dependency to the `:detekt-generator:generateDocumentation` task which [disables cache for this task](https://ge.detekt.dev/s/7qj2dfznhsbna/timeline?cacheability=validation-failure)

This PR is the technical way to fix it.