### PR TITLE
Fix dependencies to generateDocumentation task

### DIFF
--- a/detekt-generator/build.gradle.kts
+++ b/detekt-generator/build.gradle.kts
@@ -86,6 +86,14 @@ val generateDocumentation by tasks.registering(JavaExec::class) {
     )
 }
 
+rootProject.project("detekt-rules-libraries").tasks.withType<ProcessResources>().configureEach {
+    dependsOn(generateDocumentation)
+}
+
+rootProject.project("detekt-rules-ruleauthors").tasks.withType<ProcessResources>().configureEach {
+    dependsOn(generateDocumentation)
+}
+
 val verifyGeneratorOutput by tasks.registering(Exec::class) {
     dependsOn(generateDocumentation)
     description = "Verifies that generated config files are up-to-date"


### PR DESCRIPTION
The :detekt-rules-libraries:processResources and :detekt-rules-authors:processResources tasks are having implicit dependency to the :detekt-generator:generateDocumentation task

This PR adds the missing declarations