### PR TITLE
FunctionMaxLength false positive for overridden methods #5590

### DIFF
--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionMaxLength.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionMaxLength.kt
@@ -10,6 +10,7 @@ import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.config
 import io.gitlab.arturbosch.detekt.api.internal.Configuration
 import io.gitlab.arturbosch.detekt.rules.identifierName
+import io.gitlab.arturbosch.detekt.rules.isOverride
 import org.jetbrains.kotlin.psi.KtNamedFunction
 
 /**
@@ -31,6 +32,10 @@ class FunctionMaxLength(config: Config = Config.empty) : Rule(config) {
     private val maximumFunctionNameLength: Int by config(30)
 
     override fun visitNamedFunction(function: KtNamedFunction) {
+        if (function.isOverride()) {
+            return
+        }
+
         if (function.identifierName().length > maximumFunctionNameLength) {
             report(
                 CodeSmell(

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionMinLength.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionMinLength.kt
@@ -10,6 +10,7 @@ import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.config
 import io.gitlab.arturbosch.detekt.api.internal.Configuration
 import io.gitlab.arturbosch.detekt.rules.identifierName
+import io.gitlab.arturbosch.detekt.rules.isOverride
 import org.jetbrains.kotlin.psi.KtNamedFunction
 
 /**
@@ -31,6 +32,10 @@ class FunctionMinLength(config: Config = Config.empty) : Rule(config) {
     private val minimumFunctionNameLength: Int by config(3)
 
     override fun visitNamedFunction(function: KtNamedFunction) {
+        if (function.isOverride()) {
+            return
+        }
+
         if (function.identifierName().length < minimumFunctionNameLength) {
             report(
                 CodeSmell(

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableMaxLength.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableMaxLength.kt
@@ -10,6 +10,7 @@ import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.config
 import io.gitlab.arturbosch.detekt.api.internal.Configuration
 import io.gitlab.arturbosch.detekt.rules.identifierName
+import io.gitlab.arturbosch.detekt.rules.isOverride
 import org.jetbrains.kotlin.psi.KtProperty
 
 /**
@@ -28,6 +29,10 @@ class VariableMaxLength(config: Config = Config.empty) : Rule(config) {
     private val maximumVariableNameLength: Int by config(DEFAULT_MAXIMUM_VARIABLE_NAME_LENGTH)
 
     override fun visitProperty(property: KtProperty) {
+        if (property.isOverride()) {
+            return
+        }
+
         if (property.identifierName().length > maximumVariableNameLength) {
             report(
                 CodeSmell(

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableMinLength.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableMinLength.kt
@@ -10,6 +10,7 @@ import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.config
 import io.gitlab.arturbosch.detekt.api.internal.Configuration
 import io.gitlab.arturbosch.detekt.rules.identifierName
+import io.gitlab.arturbosch.detekt.rules.isOverride
 import org.jetbrains.kotlin.psi.KtProperty
 import org.jetbrains.kotlin.resolve.calls.util.isSingleUnderscore
 
@@ -29,6 +30,10 @@ class VariableMinLength(config: Config = Config.empty) : Rule(config) {
     private val minimumVariableNameLength: Int by config(DEFAULT_MINIMUM_VARIABLE_NAME_LENGTH)
 
     override fun visitProperty(property: KtProperty) {
+        if (property.isOverride()) {
+            return
+        }
+
         if (property.isSingleUnderscore) {
             return
         }

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionMaxLengthSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionMaxLengthSpec.kt
@@ -18,6 +18,21 @@ class FunctionMaxLengthSpec {
     }
 
     @Test
+    fun `should not report an overridden function name that is too long`() {
+        val code = """
+        class C : I {
+            override fun thisFunctionIsWayTooLongButStillShouldNotBeReportedByDefault() {}
+        }
+        interface I { @Suppress("FunctionMaxLength") fun thisFunctionIsWayTooLongButStillShouldNotBeReportedByDefault() }
+        """.trimIndent()
+        assertThat(
+            FunctionMaxLength(
+                TestConfig(mapOf("maximumFunctionNameLength" to 10))
+            ).compileAndLint(code)
+        ).isEmpty()
+    }
+
+    @Test
     fun `should report a function name that is too long`() {
         val code = "fun thisFunctionIsDefinitelyWayTooLongAndShouldBeMuchShorter() = 3"
         assertThat(FunctionMaxLength().compileAndLint(code)).hasSize(1)

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionMinLengthSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionMinLengthSpec.kt
@@ -27,4 +27,19 @@ class FunctionMinLengthSpec {
         val code = "fun three() = 3"
         assertThat(FunctionMinLength().compileAndLint(code)).isEmpty()
     }
+
+    @Test
+    fun `should not report an overridden function name that is too short`() {
+        val code = """
+        class C : I {
+            override fun tooShortButShouldNotBeReportedByDefault() {}
+        }
+        interface I { @Suppress("FunctionMinLength") fun tooShortButShouldNotBeReportedByDefault() }
+        """.trimIndent()
+        assertThat(
+            FunctionMinLength(
+                TestConfig(mapOf("minimumFunctionNameLength" to 50))
+            ).compileAndLint(code)
+        ).isEmpty()
+    }
 }

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableMaxLengthSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableMaxLengthSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.naming
 
+import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.junit.jupiter.api.Test
@@ -21,6 +22,26 @@ class VariableMaxLengthSpec {
     fun `should not report a variable with 64 letters`() {
         val code = "private val varThatIsExactly64LettersLongWhichYouMightNotWantToBelieveInLolz = 3"
         assertThat(VariableMaxLength().compileAndLint(code)).isEmpty()
+    }
+
+    @Test
+    fun `should not report an overridden variable name that is too long`() {
+        val code = """
+            class C : I {
+                override val tooLongButShouldNotBeReported = "banana"
+            }
+            interface I : I2 {
+                override val tooLongButShouldNotBeReported: String
+            }
+            interface I2 {
+                @Suppress("VariableMaxLength") val tooLongButShouldNotBeReported: String
+            }
+        """.trimIndent()
+        assertThat(
+            VariableMaxLength(
+                TestConfig(mapOf("maximumVariableNameLength" to 10))
+            ).compileAndLint(code)
+        ).isEmpty()
     }
 
     @Test

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableMinLengthSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableMinLengthSpec.kt
@@ -53,4 +53,24 @@ class VariableMinLengthSpec {
         """.trimIndent()
         assertThat(VariableMinLength().compileAndLint(code)).isEmpty()
     }
+
+    @Test
+    fun `should not report an overridden variable name that is too short`() {
+        val code = """
+            class C : I {
+                override val shortButOk = "banana"
+            }
+            interface I : I2 {
+                override val shortButOk: String
+            }
+            interface I2 {
+                @Suppress("VariableMinLength") val shortButOk: String
+            }
+        """.trimIndent()
+        assertThat(
+            VariableMinLength(
+                TestConfig(mapOf("minimumVariableNameLength" to 15))
+            ).compileAndLint(code)
+        ).isEmpty()
+    }
 }


### PR DESCRIPTION
By analogy with other naming rules a new `ignoreOverridden` property with default value `true` was introduced for following rules:
 - `FunctionMaxLength`
 - `FunctionMinLength`
 - `VariableMaxLength`
 - `VariableMinLength`