### PR TITLE
Update rule description for errorprone rules

### DIFF
--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/CastToNullableType.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/CastToNullableType.kt
@@ -12,9 +12,8 @@ import org.jetbrains.kotlin.psi.KtBinaryExpressionWithTypeRHS
 import org.jetbrains.kotlin.psi.KtNullableType
 
 /**
- * Disallow to cast to nullable types.
- * There are cases where `as String?` is misused as safe cast (`as? String`).
- * So if you want to prevent those cases, turn on this rule.
+ * Reports unsafe cast to nullable types.
+ * `as String?` is unsafed and may be misused as safe cast (`as? String`).
  *
  * <noncompliant>
  * fun foo(a: Any?) {
@@ -32,7 +31,7 @@ class CastToNullableType(config: Config = Config.empty) : Rule(config) {
     override val issue: Issue = Issue(
         javaClass.simpleName,
         Severity.Defect,
-        "Disallow to cast to nullable types.",
+        "Use safe cast instead of unsafe cast to nullable types.",
         Debt.FIVE_MINS
     )
 

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ExitOutsideMain.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ExitOutsideMain.kt
@@ -16,9 +16,9 @@ import org.jetbrains.kotlin.resolve.calls.util.getResolvedCall
 import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameOrNull
 
 /**
- * Flags use of System.exit() and Kotlin's exitProcess() when used outside the `main` function. This makes code more
- * difficult to test, causes unexpected behaviour on Android, and is a poor way to signal a failure in the program. In
- * almost all cases it is more appropriate to throw an exception.
+ * Reports use of `System.exit()` and Kotlin's `exitProcess()` when used outside the `main` function.
+ * This makes code more difficult to test, causes unexpected behaviour on Android, and is a poor way to signal a
+ * failure in the program. In almost all cases it is more appropriate to throw an exception.
  *
  * <noncompliant>
  * fun randomFunction() {

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/LateinitUsage.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/LateinitUsage.kt
@@ -16,7 +16,7 @@ import org.jetbrains.kotlin.psi.KtProperty
 import org.jetbrains.kotlin.psi.psiUtil.containingClass
 
 /**
- * Turn on this rule to flag usages of the lateinit modifier.
+ * Reports usages of the lateinit modifier.
  *
  * Using lateinit for property initialization can be error-prone and the actual initialization is not
  * guaranteed. Try using constructor injection or delegation to initialize properties.

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/NullableToStringCall.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/NullableToStringCall.kt
@@ -27,7 +27,7 @@ import org.jetbrains.kotlin.types.isFlexible
 import org.jetbrains.kotlin.types.isNullable
 
 /**
- * Turn on this rule to flag 'toString' calls with a nullable receiver that may return the string "null".
+ * Reports `toString()` calls with a nullable receiver that may return the string "null".
  *
  * <noncompliant>
  * fun foo(a: Any?): String {
@@ -55,7 +55,7 @@ class NullableToStringCall(config: Config = Config.empty) : Rule(config) {
     override val issue = Issue(
         javaClass.simpleName,
         Severity.Defect,
-        "This call may return the string \"null\"",
+        "`toString()` on nullable receiver may return the string \"null\"",
         Debt.FIVE_MINS
     )
 

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/RedundantElseInWhen.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/RedundantElseInWhen.kt
@@ -13,7 +13,7 @@ import org.jetbrains.kotlin.diagnostics.Errors
 import org.jetbrains.kotlin.psi.KtWhenExpression
 
 /**
- * Turn on this rule to flag `when` expressions that contain a redundant `else` case. This occurs when it can be
+ * Reports `when` expressions that contain a redundant `else` case. This occurs when it can be
  * verified that all cases are already covered when checking cases on an enum or sealed class.
  *
  * <noncompliant>

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnusedUnaryOperator.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnusedUnaryOperator.kt
@@ -23,7 +23,7 @@ import org.jetbrains.kotlin.resolve.bindingContextUtil.isUsedAsExpression
 import org.jetbrains.kotlin.resolve.calls.util.getResolvedCall
 
 /**
- * This rule detects unused unary operators.
+ * Detects unused unary operators.
  *
  * <noncompliant>
  * val x = 1 + 2

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UselessPostfixExpression.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UselessPostfixExpression.kt
@@ -23,7 +23,7 @@ import org.jetbrains.kotlin.psi.psiUtil.getNonStrictParentOfType
 import org.jetbrains.kotlin.psi.psiUtil.isPropertyParameter
 
 /**
- * This rule reports postfix expressions (++, --) which are unused and thus unnecessary.
+ * Reports postfix expressions (++, --) which are unused and thus unnecessary.
  * This leads to confusion as a reader of the code might think the value will be incremented/decremented.
  * However, the value is replaced with the original value which might lead to bugs.
  *

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseOrEmpty.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseOrEmpty.kt
@@ -49,7 +49,7 @@ class UseOrEmpty(config: Config = Config.empty) : Rule(config) {
     override val issue: Issue = Issue(
         "UseOrEmpty",
         Severity.Style,
-        "Use `orEmpty()` call instead of `?: emptyList()`",
+        "Use `orEmpty()` call instead of `?:` with empty collection factory methods",
         Debt.FIVE_MINS
     )
 


### PR DESCRIPTION
When reading the latest documentation (detekt.dev), certain rule descriptions are outdated and not using imperative mood. This PR addresses a smaller part of error-prone rules.