### PR TITLE
Broken link at EmptyFunctionBlock

### DIFF
--- a/detekt-rules-empty/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyFunctionBlock.kt
+++ b/detekt-rules-empty/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyFunctionBlock.kt
@@ -15,9 +15,9 @@ import org.jetbrains.kotlin.psi.psiUtil.getParentOfType
 /**
  * Reports empty functions. Empty blocks of code serve no purpose and should be removed.
  * This rule will not report functions with the override modifier that have a comment as their only body contents
- * (e.g., a // no-op comment in an unused listener function).
+ * (e.g., a `// no-op` comment in an unused listener function).
  *
- * Set the [ignoreOverridden] parameter to `true` to exclude all functions which are overriding other
+ * Set the `ignoreOverridden` parameter to `true` to exclude all functions which are overriding other
  * functions from the superclass or from an interface (i.e., functions declared with the override modifier).
  */
 @ActiveByDefault(since = "1.0.0")

--- a/website/versioned_docs/version-1.21.0/rules/empty-blocks.md
+++ b/website/versioned_docs/version-1.21.0/rules/empty-blocks.md
@@ -77,7 +77,7 @@ Reports empty `for` loops. Empty blocks of code serve no purpose and should be r
 
 Reports empty functions. Empty blocks of code serve no purpose and should be removed.
 This rule will not report functions with the override modifier that have a comment as their only body contents
-(e.g., a `// no-op comment` in an unused listener function).
+(e.g., a `// no-op` comment in an unused listener function).
 
 Set the `ignoreOverridden` parameter to `true` to exclude all functions which are overriding other
 functions from the superclass or from an interface (i.e., functions declared with the override modifier).

--- a/website/versioned_docs/version-1.21.0/rules/empty-blocks.md
+++ b/website/versioned_docs/version-1.21.0/rules/empty-blocks.md
@@ -77,9 +77,9 @@ Reports empty `for` loops. Empty blocks of code serve no purpose and should be r
 
 Reports empty functions. Empty blocks of code serve no purpose and should be removed.
 This rule will not report functions with the override modifier that have a comment as their only body contents
-(e.g., a // no-op comment in an unused listener function).
+(e.g., a `// no-op comment` in an unused listener function).
 
-Set the [ignoreOverridden] parameter to `true` to exclude all functions which are overriding other
+Set the `ignoreOverridden` parameter to `true` to exclude all functions which are overriding other
 functions from the superclass or from an interface (i.e., functions declared with the override modifier).
 
 **Active by default**: Yes - Since v1.0.0

--- a/website/versioned_docs/version-1.22.0/rules/empty-blocks.md
+++ b/website/versioned_docs/version-1.22.0/rules/empty-blocks.md
@@ -77,9 +77,9 @@ Reports empty `for` loops. Empty blocks of code serve no purpose and should be r
 
 Reports empty functions. Empty blocks of code serve no purpose and should be removed.
 This rule will not report functions with the override modifier that have a comment as their only body contents
-(e.g., a // no-op comment in an unused listener function).
+(e.g., a `// no-op` comment in an unused listener function).
 
-Set the [ignoreOverridden] parameter to `true` to exclude all functions which are overriding other
+Set the `ignoreOverridden` parameter to `true` to exclude all functions which are overriding other
 functions from the superclass or from an interface (i.e., functions declared with the override modifier).
 
 **Active by default**: Yes - Since v1.0.0


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX197vFnGLUGAlAmD36K295azCE0WOp2adE%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=WAE_ESL)
A similar PR may already be submitted!
Please search among the [Pull requests](https://github.com/detekt/detekt/pulls) before creating one.

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Link to relevant issues if possible.

The documentation of EmptyFunctionBlock has a "broken link":

Set the [ignoreOverridden] parameter to...

Fixes https://github.com/detekt/detekt/issues/5601
For more information, see the [CONTRIBUTING guide](https://github.com/detekt/detekt/blob/main/.github/CONTRIBUTING.md).
