### PR TITLE
Run specific rule with 'detekt' task against external codebase

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -22,6 +22,7 @@ import io.gitlab.arturbosch.detekt.invoke.JdkHomeArgument
 import io.gitlab.arturbosch.detekt.invoke.JvmTargetArgument
 import io.gitlab.arturbosch.detekt.invoke.LanguageVersionArgument
 import io.gitlab.arturbosch.detekt.invoke.ParallelArgument
+import io.gitlab.arturbosch.detekt.invoke.RunRuleArgument
 import io.gitlab.arturbosch.detekt.invoke.isDryRunEnabled
 import org.gradle.api.Action
 import org.gradle.api.file.ConfigurableFileCollection
@@ -61,6 +62,14 @@ import javax.inject.Inject
 abstract class Detekt @Inject constructor(
     private val objects: ObjectFactory
 ) : SourceTask(), VerificationTask {
+
+    @get:Optional
+    @get:Input
+    @set:Option(
+        option = "run-rule",
+        description = "Rule to run"
+    )
+    var ruleToRun: String = ""
 
     @get:Classpath
     abstract val detektClasspath: ConfigurableFileCollection
@@ -228,7 +237,8 @@ abstract class Detekt @Inject constructor(
             AllRulesArgument(allRulesProp.getOrElse(false)),
             AutoCorrectArgument(autoCorrectProp.getOrElse(false)),
             BasePathArgument(basePathProp.orNull),
-            DisableDefaultRuleSetArgument(disableDefaultRuleSetsProp.getOrElse(false))
+            DisableDefaultRuleSetArgument(disableDefaultRuleSetsProp.getOrElse(false)),
+            RunRuleArgument(ruleToRun + ""),
         ).plus(convertCustomReportsToArguments()).flatMap(CliArgument::toArgument)
 
     @InputFiles

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -238,7 +238,7 @@ abstract class Detekt @Inject constructor(
             AutoCorrectArgument(autoCorrectProp.getOrElse(false)),
             BasePathArgument(basePathProp.orNull),
             DisableDefaultRuleSetArgument(disableDefaultRuleSetsProp.getOrElse(false)),
-            RunRuleArgument(ruleToRun + ""),
+            RunRuleArgument(ruleToRun),
         ).plus(convertCustomReportsToArguments()).flatMap(CliArgument::toArgument)
 
     @InputFiles

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/CliArgument.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/CliArgument.kt
@@ -43,7 +43,6 @@ internal data class InputArgument(val fileCollection: FileCollection) : CliArgum
 
 internal data class RunRuleArgument(val rule: String) : CliArgument() {
     override fun toArgument() = if (rule.isNotEmpty()) {
-        println(">>> Run the only rule <<<")
         listOf(RUN_RULE_PARAMETER, rule)
     } else {
         emptyList()

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/CliArgument.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/CliArgument.kt
@@ -23,6 +23,7 @@ private const val LANGUAGE_VERSION_PARAMETER = "--language-version"
 private const val JVM_TARGET_PARAMETER = "--jvm-target"
 private const val JDK_HOME_PARAMETER = "--jdk-home"
 private const val BASE_PATH_PARAMETER = "--base-path"
+private const val RUN_RULE_PARAMETER = "--run-rule"
 
 internal sealed class CliArgument {
     abstract fun toArgument(): List<String>
@@ -38,6 +39,15 @@ internal object GenerateConfigArgument : CliArgument() {
 
 internal data class InputArgument(val fileCollection: FileCollection) : CliArgument() {
     override fun toArgument() = listOf(INPUT_PARAMETER, fileCollection.joinToString(",") { it.absolutePath })
+}
+
+internal data class RunRuleArgument(val rule: String) : CliArgument() {
+    override fun toArgument() = if (rule.isNotEmpty()) {
+        println(">>> Run the only rule <<<")
+        listOf(RUN_RULE_PARAMETER, rule)
+    } else {
+        emptyList()
+    }
 }
 
 internal data class ClasspathArgument(val fileCollection: FileCollection) : CliArgument() {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,6 +6,7 @@ pluginManagement {
     includeBuild("build-logic")
     includeBuild("detekt-gradle-plugin")
 }
+includeBuild("detekt-gradle-plugin")
 
 include("code-coverage-report")
 include("detekt-api")


### PR DESCRIPTION
[WIP]
Test new rules against an external codebase (that already uses Detekt) with Gradle's --include-build cli option to substitute online Detekt dependency with local one.

Closes #4408

Usage:
From Open Source project under test run
`./gradlew --include-build /path/to/detekt detekt --run-rule ruleset:Rule`
Ex. from mozilla fenix folder run 
`./gradlew --include-build ../../detekt detekt --run-rule comments:UndocumentedPublicFunction`