### PR TITLE
Bump minimum Gradle version to 6.8.3

### DIFF
--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/GradleVersionSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/GradleVersionSpec.kt
@@ -22,6 +22,6 @@ class GradleVersionSpec {
     }
 
     companion object {
-        const val gradleVersion = "6.7.1"
+        const val gradleVersion = "6.8.3"
     }
 }

--- a/website/docs/gettingstarted/gradle.mdx
+++ b/website/docs/gettingstarted/gradle.mdx
@@ -8,7 +8,7 @@ summary:
 sidebar_position: 2
 ---
 
-Detekt requires **Gradle 6.7.1** or higher. We, however, recommend using the version of Gradle that is [listed in this table](/docs/introduction/compatibility).
+Detekt requires **Gradle 6.8.3** or higher. We, however, recommend using the version of Gradle that is [listed in this table](/docs/introduction/compatibility).
 
 ## <a name="tasks">Available plugin tasks</a>
 


### PR DESCRIPTION
Aligns with Kotlin 1.8.

Suggest holding merging until time to release 1.23 as it updates current README.