### PR TITLE
Exclude operator functions in function min/max length

### DIFF
--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionMaxLength.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionMaxLength.kt
@@ -10,6 +10,7 @@ import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.config
 import io.gitlab.arturbosch.detekt.api.internal.Configuration
 import io.gitlab.arturbosch.detekt.rules.identifierName
+import io.gitlab.arturbosch.detekt.rules.isOperator
 import io.gitlab.arturbosch.detekt.rules.isOverride
 import org.jetbrains.kotlin.psi.KtNamedFunction
 
@@ -32,7 +33,7 @@ class FunctionMaxLength(config: Config = Config.empty) : Rule(config) {
     private val maximumFunctionNameLength: Int by config(30)
 
     override fun visitNamedFunction(function: KtNamedFunction) {
-        if (function.isOverride()) {
+        if (function.isOverride() || function.isOperator()) {
             return
         }
 

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionMinLength.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionMinLength.kt
@@ -10,6 +10,7 @@ import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.config
 import io.gitlab.arturbosch.detekt.api.internal.Configuration
 import io.gitlab.arturbosch.detekt.rules.identifierName
+import io.gitlab.arturbosch.detekt.rules.isOperator
 import io.gitlab.arturbosch.detekt.rules.isOverride
 import org.jetbrains.kotlin.psi.KtNamedFunction
 
@@ -32,7 +33,7 @@ class FunctionMinLength(config: Config = Config.empty) : Rule(config) {
     private val minimumFunctionNameLength: Int by config(3)
 
     override fun visitNamedFunction(function: KtNamedFunction) {
-        if (function.isOverride()) {
+        if (function.isOverride() || function.isOperator()) {
             return
         }
 

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionMaxLengthSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionMaxLengthSpec.kt
@@ -43,4 +43,21 @@ class FunctionMaxLengthSpec {
         val code = "fun three() = 3"
         assertThat(FunctionMaxLength().compileAndLint(code)).isEmpty()
     }
+
+    @Test
+    fun `should not report an operator function`() {
+        val code = """
+            data class Point2D(var x: Int = 0, var y: Int = 0) {
+                operator fun plusAssign(another: Point2D) {
+                    x += another.x
+                    y += another.y
+                }
+            }
+        """.trimIndent()
+        assertThat(
+            FunctionMaxLength(
+                TestConfig(mapOf("maximumFunctionNameLength" to 5))
+            ).compileAndLint(code)
+        ).isEmpty()
+    }
 }

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionMaxLengthSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionMaxLengthSpec.kt
@@ -56,7 +56,9 @@ class FunctionMaxLengthSpec {
         """.trimIndent()
         assertThat(
             FunctionMaxLength(
-                TestConfig(mapOf("maximumFunctionNameLength" to 5))
+                TestConfig(
+                    mapOf("maximumFunctionNameLength" to 5)
+                )
             ).compileAndLint(code)
         ).isEmpty()
     }

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionMinLengthSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionMinLengthSpec.kt
@@ -42,4 +42,17 @@ class FunctionMinLengthSpec {
             ).compileAndLint(code)
         ).isEmpty()
     }
+
+    @Test
+    fun `should not report an operator function`() {
+        val code = """
+            data class Point2D(var x: Int = 0, var y: Int = 0) {
+                operator fun plus(another: Point2D): Point2D =
+                    Point2D(x = x + another.x, y = y + another.y)
+            }
+        """.trimIndent()
+        assertThat(FunctionMinLength(
+            TestConfig(mapOf("minimumFunctionNameLength" to 5))
+        ).compileAndLint(code)).isEmpty()
+    }
 }

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionMinLengthSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionMinLengthSpec.kt
@@ -51,8 +51,12 @@ class FunctionMinLengthSpec {
                     Point2D(x = x + another.x, y = y + another.y)
             }
         """.trimIndent()
-        assertThat(FunctionMinLength(
-            TestConfig(mapOf("minimumFunctionNameLength" to 5))
-        ).compileAndLint(code)).isEmpty()
+        assertThat(
+            FunctionMinLength(
+                TestConfig(
+                    mapOf("minimumFunctionNameLength" to 5)
+                )
+            ).compileAndLint(code)
+        ).isEmpty()
     }
 }


### PR DESCRIPTION
Fixes #5602 

Similar to excluding override functions (https://github.com/detekt/detekt/pull/5599), operator function's name cannot be changed arbitrarily.