### PR TITLE
Apply #5615 also on `next`

### DIFF
--- a/website/docs/gettingstarted/gradletask.md
+++ b/website/docs/gettingstarted/gradletask.md
@@ -62,7 +62,7 @@ val detektTask = tasks.register<JavaExec>("detekt") {
 }
 
 dependencies {
-    detekt("io.gitlab.arturbosch.detekt:detekt-cli:[detekt_version])
+    detekt("io.gitlab.arturbosch.detekt:detekt-cli:[detekt_version]")
 }
 
 // Remove this block if you don't want to run detekt on every build


### PR DESCRIPTION
Just noticed that #5615 updated the docs of 1.22.0 only while `next` (i.e. main) also has the same bug.