### PR TITLE
ElseCaseInsteadOfExhaustiveWhen - Add ignoredSubjectTypes config key (#5623)

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -425,6 +425,7 @@ potential-bugs:
       - 'java.util.HashMap'
   ElseCaseInsteadOfExhaustiveWhen:
     active: false
+    ignoredSubjectTypes: []
   EqualsAlwaysReturnsTrueOrFalse:
     active: true
   EqualsWithHashCodeExist:


### PR DESCRIPTION
A new `ignoredSubjectTypes` property with an empty default value was introduced. It can be configured with a list of subject types fully qualified names which should be ignored by the `ElseCaseInsteadOfExhaustiveWhen` rule.

Fixes #5623 
