### PR TITLE
Stop disabling config cache for publishing tasks

### DIFF
--- a/build-logic/src/main/kotlin/module.gradle.kts
+++ b/build-logic/src/main/kotlin/module.gradle.kts
@@ -20,10 +20,6 @@ val versionCatalog = project.extensions.getByType<VersionCatalogsExtension>().na
 
 jacoco.toolVersion = versionCatalog.findVersion("jacoco").get().requiredVersion
 
-tasks.withType<PublishToMavenRepository>().configureEach {
-    notCompatibleWithConfigurationCache("https://github.com/gradle/gradle/issues/13468")
-}
-
 tasks.withType<Test>().configureEach {
     useJUnitPlatform()
     systemProperty("junit.jupiter.testinstance.lifecycle.default", "per_class")


### PR DESCRIPTION
Support was added in Gradle 7.6: https://github.com/gradle/gradle/issues/13468

CC isn't supported for conditional publishing tasks e.g. using `onlyIf` but we don't use that in our build, so this should work correctly from here on.