### PR TITLE
Specify path to coverage report

### DIFF
--- a/.github/workflows/codecoverage.yaml
+++ b/.github/workflows/codecoverage.yaml
@@ -36,3 +36,5 @@ jobs:
       - name: Publish Coverage
         if: success()
         uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # tag=v3
+        with:
+          files: ./code-coverage-report/build/reports/jacoco/jacocoMergedReport/jacocoMergedReport.xml


### PR DESCRIPTION
Set this explicitly. Currently the Codecov action is looking at two files, only one of which is an actual coverage report:

```
[2022-12-[30](https://github.com/detekt/detekt/actions/runs/3804672020/jobs/6472054910#step:5:31)T03:48:04.495Z] ['info'] => Found 2 possible coverage files:
  .github/workflows/codecoverage.yaml
  code-coverage-report/build/reports/jacoco/jacocoMergedReport/jacocoMergedReport.xml
[2022-12-30T03:48:04.495Z] ['info'] Processing /home/runner/work/detekt/detekt/.github/workflows/codecoverage.yaml...
[2022-12-30T03:48:04.498Z] ['info'] Processing /home/runner/work/detekt/detekt/code-coverage-report/build/reports/jacoco/jacocoMergedReport/jacocoMergedReport.xml...
```