### PR TITLE
Enable verbose mode for Codecov GH Action

### DIFF
--- a/.github/workflows/codecoverage.yaml
+++ b/.github/workflows/codecoverage.yaml
@@ -37,3 +37,4 @@ jobs:
         uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # tag=v3
         with:
           files: ./code-coverage-report/build/reports/jacoco/jacocoMergedReport/jacocoMergedReport.xml
+          verbose: true


### PR DESCRIPTION
Hopefully this will help uncover issues with inconsistent upload of results on main branch...