### PR TITLE
Use correct resolvable/consumable flags on detekt's configurations

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
@@ -84,12 +84,16 @@ class DetektPlugin : Plugin<Project> {
             configuration.isVisible = false
             configuration.isTransitive = true
             configuration.description = "The $CONFIGURATION_DETEKT_PLUGINS libraries to be used for this project."
+            configuration.isCanBeResolved = true
+            configuration.isCanBeConsumed = false
         }
 
         project.configurations.create(CONFIGURATION_DETEKT) { configuration ->
             configuration.isVisible = false
             configuration.isTransitive = true
             configuration.description = "The $CONFIGURATION_DETEKT dependencies to be used for this project."
+            configuration.isCanBeResolved = true
+            configuration.isCanBeConsumed = false
 
             configuration.defaultDependencies { dependencySet ->
                 val version = extension.toolVersion


### PR DESCRIPTION
> Both flags have a default value of true, but as a plugin author, you should always determine the right values for those flags, or you might accidentally introduce resolution errors.

Source: https://docs.gradle.org/7.6/userguide/declaring_dependencies.html#sec:resolvable-consumable-configs

This was uncovered when messages like these were seen in the logs when detekt was run with Gradle's `--info` logging level:
```
The configuration :detekt-tooling:detekt is both resolvable and consumable. This is considered a legacy configuration and it will eventually only be possible to be one of these.
The configuration :detekt-tooling:detekt is both consumable and declarable. This combination is incorrect, only one of these flags should be set.
The configuration :detekt-tooling:detektPlugins is both resolvable and consumable. This is considered a legacy configuration and it will eventually only be possible to be one of these.
The configuration :detekt-tooling:detektPlugins is both consumable and declarable. This combination is incorrect, only one of these flags should be set.
```

The messages disappear as expected when setting `isCanBeConsumed = false`. These configurations only need to be resolved so they can be used on the classpath when detekt tasks run, they do not need to be consumable.