### PR TITLE
Use modern API to get Gradle property values

### DIFF
--- a/build-logic/src/main/kotlin/module.gradle.kts
+++ b/build-logic/src/main/kotlin/module.gradle.kts
@@ -23,11 +23,7 @@ jacoco.toolVersion = versionCatalog.findVersion("jacoco").get().requiredVersion
 tasks.withType<Test>().configureEach {
     useJUnitPlatform()
     systemProperty("junit.jupiter.testinstance.lifecycle.default", "per_class")
-    val compileTestSnippets: Boolean = if (project.hasProperty("compile-test-snippets")) {
-        (project.property("compile-test-snippets") as String).toBoolean()
-    } else {
-        false
-    }
+    val compileTestSnippets = providers.gradleProperty("compile-test-snippets").orNull.toBoolean()
     systemProperty("compile-test-snippets", compileTestSnippets)
     testLogging {
         // set options for log level LIFECYCLE
@@ -48,7 +44,7 @@ tasks.withType<KotlinCompile>().configureEach {
     compilerOptions {
         jvmTarget.set(Versions.JVM_TARGET)
         freeCompilerArgs.add("-progressive")
-        allWarningsAsErrors.set(project.findProperty("warningsAsErrors") == "true")
+        allWarningsAsErrors.set(providers.gradleProperty("warningsAsErrors").orNull.toBoolean())
     }
 }
 

--- a/build-logic/src/main/kotlin/packaging.gradle.kts
+++ b/build-logic/src/main/kotlin/packaging.gradle.kts
@@ -74,4 +74,4 @@ signing {
     isRequired = !(signingKey.isNullOrBlank() || signingPwd.isNullOrBlank())
 }
 
-val String.byProperty: String? get() = findProperty(this) as? String
+val String.byProperty: String? get() = providers.gradleProperty(this).orNull

--- a/build-logic/src/main/kotlin/releasing.gradle.kts
+++ b/build-logic/src/main/kotlin/releasing.gradle.kts
@@ -18,7 +18,7 @@ nexusPublishing {
 
 project.afterEvaluate {
     githubRelease {
-        token(project.findProperty("github.token") as? String ?: "")
+        token(providers.gradleProperty("github.token"))
         owner.set("detekt")
         repo.set("detekt")
         overwrite.set(true)

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -22,7 +22,6 @@ import io.gitlab.arturbosch.detekt.invoke.JdkHomeArgument
 import io.gitlab.arturbosch.detekt.invoke.JvmTargetArgument
 import io.gitlab.arturbosch.detekt.invoke.LanguageVersionArgument
 import io.gitlab.arturbosch.detekt.invoke.ParallelArgument
-import io.gitlab.arturbosch.detekt.invoke.isDryRunEnabled
 import org.gradle.api.Action
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.Directory
@@ -201,7 +200,7 @@ abstract class Detekt @Inject constructor(
         .dir(ReportingExtension.DEFAULT_REPORTS_DIR_NAME)
         .dir("detekt")
 
-    private val isDryRun: Boolean = project.isDryRunEnabled()
+    private val isDryRun = project.providers.gradleProperty(DRY_RUN_PROPERTY)
 
     init {
         group = LifecycleBasePlugin.VERIFICATION_GROUP
@@ -250,7 +249,7 @@ abstract class Detekt @Inject constructor(
 
     @TaskAction
     fun check() {
-        DetektInvoker.create(task = this, isDryRun = isDryRun).invokeCli(
+        DetektInvoker.create(task = this, isDryRun = isDryRun.orNull.toBoolean()).invokeCli(
             arguments = arguments,
             ignoreFailures = ignoreFailures,
             classpath = detektClasspath.plus(pluginClasspath),
@@ -285,3 +284,5 @@ abstract class Detekt @Inject constructor(
         return provider
     }
 }
+
+private const val DRY_RUN_PROPERTY = "detekt-dry-run"

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/DetektInvoker.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/DetektInvoker.kt
@@ -3,7 +3,6 @@ package io.gitlab.arturbosch.detekt.invoke
 import io.gitlab.arturbosch.detekt.internal.ClassLoaderCache
 import io.gitlab.arturbosch.detekt.internal.GlobalClassLoaderCache
 import org.gradle.api.GradleException
-import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.file.FileCollection
 import org.gradle.api.logging.Logger
@@ -28,12 +27,6 @@ internal interface DetektInvoker {
                 DefaultCliInvoker()
             }
     }
-}
-
-private const val DRY_RUN_PROPERTY = "detekt-dry-run"
-
-internal fun Project.isDryRunEnabled(): Boolean {
-    return hasProperty(DRY_RUN_PROPERTY) && property(DRY_RUN_PROPERTY) == "true"
 }
 
 internal class DefaultCliInvoker(


### PR DESCRIPTION
The `gradleProperty` method was introduced in Gradle 6.2 and improves compatibility with Gradle's configuration cache.