### PR TITLE
Revert "Use Java Toolchain support to set JVM targets"

### DIFF
--- a/build-logic/src/main/kotlin/Versions.kt
+++ b/build-logic/src/main/kotlin/Versions.kt
@@ -1,8 +1,10 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 object Versions {
 
     const val DETEKT: String = "1.22.0"
     const val SNAPSHOT_NAME: String = "main"
-    const val JDK_VERSION = 8
+    val JVM_TARGET: JvmTarget = JvmTarget.JVM_1_8
 
     fun currentOrSnapshot(): String {
         if (System.getProperty("snapshot")?.toBoolean() == true) {

--- a/build-logic/src/main/kotlin/module.gradle.kts
+++ b/build-logic/src/main/kotlin/module.gradle.kts
@@ -42,6 +42,7 @@ tasks.withType<Test>().configureEach {
 
 tasks.withType<KotlinCompile>().configureEach {
     compilerOptions {
+        jvmTarget.set(Versions.JVM_TARGET)
         freeCompilerArgs.add("-progressive")
         allWarningsAsErrors.set(providers.gradleProperty("warningsAsErrors").orNull.toBoolean())
     }
@@ -59,11 +60,9 @@ dependencies {
     compileOnly(kotlin("stdlib-jdk8"))
 }
 
-kotlin {
-    jvmToolchain(Versions.JDK_VERSION)
-}
-
 java {
     withSourcesJar()
     withJavadocJar()
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
 import io.gitlab.arturbosch.detekt.Detekt
+import io.gitlab.arturbosch.detekt.DetektCreateBaselineTask
 import io.gitlab.arturbosch.detekt.report.ReportMergeTask
 
 plugins {
@@ -36,6 +37,7 @@ allprojects {
     }
 
     tasks.withType<Detekt> detekt@{
+        jvmTarget = "1.8"
         reports {
             xml.required.set(true)
             html.required.set(true)
@@ -48,6 +50,9 @@ allprojects {
         detektReportMergeSarif.configure {
             input.from(this@detekt.sarifReportFile)
         }
+    }
+    tasks.withType<DetektCreateBaselineTask>().configureEach {
+        jvmTarget = "1.8"
     }
 }
 


### PR DESCRIPTION
Reverts detekt/detekt#5676

The original PR only was only half a solution - it meant that all builds effectively ran on Java 1.8 regardless of which Java version the Gradle build was running. This is fine for the main source build but not for tests, which we want to run on multiple Java versions.