### PR TITLE
Fix build scan warning about build cache configuration

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,10 +2,8 @@ import com.gradle.enterprise.gradleplugin.internal.extension.BuildScanExtensionW
 
 rootProject.name = "detekt"
 
-pluginManagement {
-    includeBuild("build-logic")
-    includeBuild("detekt-gradle-plugin")
-}
+includeBuild("build-logic")
+includeBuild("detekt-gradle-plugin")
 
 include("code-coverage-report")
 include("detekt-api")


### PR DESCRIPTION
Message: "The build cache configuration of the root build differs from the build cache configuration of the early evaluated ':build-logic', ':detekt-gradle-plugin' included builds. It is recommended to keep them consistent."

See example here: https://ge.detekt.dev/s/pvz4ogayjxfzc/performance/build-cache

In theory this can be fixed by copying the `buildCache {}` config from the root settings file to the build-logic and detekt-gradle-plugin settings files, but this doesn't seem to be working (see https://github.com/gradle/gradle/issues/21630).

In the meantime, have used [this](https://docs.gradle.org/7.6/userguide/build_cache.html#sec:build_cache_composite) reference as a way to correct it:
> Gradle’s [composite build feature](https://docs.gradle.org/7.6/userguide/composite_builds.html#composite_builds) allows including other complete Gradle builds into another. Such included builds will inherit the build cache configuration from the top level build, regardless of whether the included builds define build cache configuration themselves or not.

Using `pluginManagement` reverses the order of evaluation which leads to the warning due to the bug mentioned above, so switching to the other, stable way to add `includeBuild` until the Gradle bug is fixed.