### PR TITLE
Use integrated "test retry" from Gradle Enterprise Gradle Plugin

### DIFF
--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -2,6 +2,7 @@
 // https://github.com/gradle/gradle/issues/21285
 @file:Suppress("StringLiteralDuplication")
 
+import com.gradle.enterprise.gradleplugin.testretry.retry
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 
 plugins {
@@ -12,7 +13,6 @@ plugins {
     alias(libs.plugins.pluginPublishing)
     // We use this published version of the Detekt plugin to self analyse this project.
     id("io.gitlab.arturbosch.detekt") version "1.22.0"
-    id("org.gradle.test-retry") version "1.5.0"
 }
 
 repositories {

--- a/detekt-gradle-plugin/settings.gradle.kts
+++ b/detekt-gradle-plugin/settings.gradle.kts
@@ -11,3 +11,7 @@ dependencyResolutionManagement {
         }
     }
 }
+
+plugins {
+    id("com.gradle.enterprise") version "3.12.2"
+}


### PR DESCRIPTION
Functionality from `org.gradle.test-retry` plugin was integrated directly into Gradle Enterprise Gradle Plugin in v3.12