### PR TITLE
Disable Codecov's expired reports check

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,5 +1,6 @@
 codecov:
   branch: main
+  max_report_age: off
 
 coverage:
   status:


### PR DESCRIPTION
Codecov rejects reports that are over 12 hours old according to the timestamp in the report. We use Gradle's remote cache, so the CI build often pulls reports that are older than 12 hours from the cache, which leads to an "Upload expired" message in Codecov, and no report.

Disabling the check will make Codecov ignore the report timestamp so we should start seeing reports consistently generated from here on.
