### PR TITLE
Fix typo

### DIFF
--- a/website/src/components/HomepageFeatures.js
+++ b/website/src/components/HomepageFeatures.js
@@ -40,7 +40,7 @@ const FeatureList = [
     description: (
       <>
         Detekt is entirely open-source and developed by the community. Join us
-        on Github and help us shape the future of this tool.
+        on GitHub and help us shape the future of this tool.
       </>
     ),
   },


### PR DESCRIPTION
It is written as 'GitHub' elsewhere. But only here, it is written as 'Github'.
So modified it to 'GitHub' for consistency.