### PR TITLE
Use `name` that return name after backticks

### DIFF
--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ConstructorParameterNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ConstructorParameterNaming.kt
@@ -10,7 +10,6 @@ import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.config
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
 import io.gitlab.arturbosch.detekt.api.internal.Configuration
-import io.gitlab.arturbosch.detekt.rules.identifierName
 import io.gitlab.arturbosch.detekt.rules.isOverride
 import io.gitlab.arturbosch.detekt.rules.naming.util.isContainingExcludedClassOrObject
 import org.jetbrains.kotlin.psi.KtConstructor
@@ -50,11 +49,11 @@ class ConstructorParameterNaming(config: Config = Config.empty) : Rule(config) {
             return
         }
 
-        val identifier = parameter.identifierName()
+        val identifier = parameter.name
         if (parameter.isPrivate()) {
             visitPrivateParameter(parameter)
         } else {
-            if (!identifier.matches(parameterPattern)) {
+            if (identifier?.matches(parameterPattern) == false) {
                 report(
                     CodeSmell(
                         issue,
@@ -67,8 +66,8 @@ class ConstructorParameterNaming(config: Config = Config.empty) : Rule(config) {
     }
 
     private fun visitPrivateParameter(parameter: KtParameter) {
-        val identifier = parameter.identifierName()
-        if (!identifier.matches(privateParameterPattern)) {
+        val identifier = parameter.name
+        if (identifier?.matches(privateParameterPattern) == false) {
             report(
                 CodeSmell(
                     issue,

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ConstructorParameterNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ConstructorParameterNamingSpec.kt
@@ -3,6 +3,7 @@ package io.gitlab.arturbosch.detekt.rules.naming
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLint
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 class ConstructorParameterNamingSpec {
@@ -60,6 +61,50 @@ class ConstructorParameterNamingSpec {
         """.trimIndent()
         val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to "false"))
         assertThat(ConstructorParameterNaming(config).compileAndLint(code)).hasTextLocations(8 to 34)
+    }
+
+    @Nested
+    inner class `with backticks` {
+        @Test
+        fun `should not complain about public param name - #5531`() {
+            val code = """
+                class Foo(val `is`: Boolean)
+            """.trimIndent()
+            val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to "false"))
+            assertThat(ConstructorParameterNaming(config).compileAndLint(code)).isEmpty()
+        }
+
+        @Test
+        fun `should not complain about private param name`() {
+            val code = """
+                class Foo(private val `is`: Boolean)
+            """.trimIndent()
+            val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to "false"))
+            assertThat(ConstructorParameterNaming(config).compileAndLint(code)).isEmpty()
+        }
+
+        @Test
+        fun `should complain about param name with violation`() {
+            val code = """
+                class Foo(private val `PARAM_NAME`: Boolean)
+            """.trimIndent()
+            val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to "false"))
+            assertThat(ConstructorParameterNaming(config).compileAndLint(code))
+                .hasSize(1)
+                .hasStartSourceLocation(1, 11)
+        }
+
+        @Test
+        fun `should not complain about param in secondary constructor`() {
+            val code = """
+                @JvmInline
+                value class A1 constructor(val `is`: Boolean) {
+                    constructor(`is`: Boolean, `when`: Boolean): this(`is`)
+                }
+            """.trimIndent()
+            val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to "false"))
+            assertThat(ConstructorParameterNaming(config).compileAndLint(code)).isEmpty()
+        }
     }
 }
 

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ConstructorParameterNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ConstructorParameterNamingSpec.kt
@@ -70,8 +70,7 @@ class ConstructorParameterNamingSpec {
             val code = """
                 class Foo(val `is`: Boolean)
             """.trimIndent()
-            val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to "false"))
-            assertThat(ConstructorParameterNaming(config).compileAndLint(code)).isEmpty()
+            assertThat(ConstructorParameterNaming().compileAndLint(code)).isEmpty()
         }
 
         @Test
@@ -79,8 +78,7 @@ class ConstructorParameterNamingSpec {
             val code = """
                 class Foo(private val `is`: Boolean)
             """.trimIndent()
-            val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to "false"))
-            assertThat(ConstructorParameterNaming(config).compileAndLint(code)).isEmpty()
+            assertThat(ConstructorParameterNaming().compileAndLint(code)).isEmpty()
         }
 
         @Test
@@ -88,8 +86,7 @@ class ConstructorParameterNamingSpec {
             val code = """
                 class Foo(private val `PARAM_NAME`: Boolean)
             """.trimIndent()
-            val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to "false"))
-            assertThat(ConstructorParameterNaming(config).compileAndLint(code))
+            assertThat(ConstructorParameterNaming().compileAndLint(code))
                 .hasSize(1)
                 .hasStartSourceLocation(1, 11)
         }
@@ -102,8 +99,7 @@ class ConstructorParameterNamingSpec {
                     constructor(`is`: Boolean, `when`: Boolean): this(`is`)
                 }
             """.trimIndent()
-            val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to "false"))
-            assertThat(ConstructorParameterNaming(config).compileAndLint(code)).isEmpty()
+            assertThat(ConstructorParameterNaming().compileAndLint(code)).isEmpty()
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/detekt/detekt/issues/5531