### PR TITLE
Fix IgnoredReturnValue rule crash in parallel mode

### DIFF
--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValue.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValue.kt
@@ -116,7 +116,10 @@ class IgnoredReturnValue(config: Config = Config.empty) : Rule(config) {
         if (ignoreFunctionCall.any { it.match(resultingDescriptor) }) return
 
         val annotations = resultingDescriptor.annotations + resultingDescriptor.findPackage().annotations
-        if (annotations.any { it in ignoreReturnValueAnnotations }) return
+        if (resultingDescriptor.annotations.any { it in ignoreReturnValueAnnotations } ||
+            resultingDescriptor.findPackage().annotations.any { it in ignoreReturnValueAnnotations }) {
+            return
+        }
         if (restrictToConfig &&
             resultingDescriptor.returnType !in returnValueTypes &&
             annotations.none { it in returnValueAnnotations } &&

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValue.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValue.kt
@@ -117,7 +117,8 @@ class IgnoredReturnValue(config: Config = Config.empty) : Rule(config) {
 
         val annotations = resultingDescriptor.annotations + resultingDescriptor.findPackage().annotations
         if (resultingDescriptor.annotations.any { it in ignoreReturnValueAnnotations } ||
-            resultingDescriptor.findPackage().annotations.any { it in ignoreReturnValueAnnotations }) {
+            resultingDescriptor.findPackage().annotations.any { it in ignoreReturnValueAnnotations }
+        ) {
             return
         }
         if (restrictToConfig &&


### PR DESCRIPTION
part 2 of #5403:

IgnoredReturnValue crashes due to the usage of a non-thread-safe collection operation. The usage of `Iterable<T>.plus()` causes this problem. The crash in parallel mode is fixed by iterating over each collection by itself.

See here for more details in detekt v1.21:
https://github.com/detekt/detekt/blob/32f6e22d9524804ebbb51d31e53cd28a84864ed6/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValue.kt#L90

Closes #5403
