### PR TITLE
Fail when unexpected version of kotlin-compiler-embeddable is on runtime classpath

### DIFF
--- a/build-logic/src/main/kotlin/module.gradle.kts
+++ b/build-logic/src/main/kotlin/module.gradle.kts
@@ -9,10 +9,11 @@ plugins {
     jacoco
 }
 
-// bundle detekt's version for all jars to use it at runtime
+// Add attributes to JAR manifest, to be used at runtime
 tasks.withType<Jar>().configureEach {
     manifest {
         attributes(mapOf("DetektVersion" to Versions.DETEKT))
+        attributes(mapOf("KotlinImplementationVersion" to versionCatalog.findVersion("kotlin").get().requiredVersion))
     }
 }
 

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/Versions.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/Versions.kt
@@ -18,25 +18,25 @@ fun whichJava(): String = System.getProperty("java.runtime.version")
 /**
  * Returns the version of Kotlin that detekt was compiled with
  */
-fun whichKotlin(): String? {
+fun whichKotlin(): String {
     fun readVersion(resource: URL): String? = resource.openSafeStream()
         .use { Manifest(it).mainAttributes.getValue("KotlinImplementationVersion") }
 
     return Extension::class.java.classLoader.getResources("META-INF/MANIFEST.MF")
         .asSequence()
         .mapNotNull { runCatching { readVersion(it) }.getOrNull() }
-        .firstOrNull()
+        .first()
 }
 
 /**
  * Returns the bundled detekt version.
  */
-fun whichDetekt(): String? {
+fun whichDetekt(): String {
     fun readVersion(resource: URL): String? = resource.openSafeStream()
         .use { Manifest(it).mainAttributes.getValue("DetektVersion") }
 
     return Extension::class.java.classLoader.getResources("META-INF/MANIFEST.MF")
         .asSequence()
         .mapNotNull { runCatching { readVersion(it) }.getOrNull() }
-        .firstOrNull()
+        .first()
 }

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/Versions.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/Versions.kt
@@ -18,22 +18,16 @@ fun whichJava(): String = System.getProperty("java.runtime.version")
 /**
  * Returns the version of Kotlin that detekt was compiled with
  */
-fun whichKotlin(): String {
-    fun readVersion(resource: URL): String? = resource.openSafeStream()
-        .use { Manifest(it).mainAttributes.getValue("KotlinImplementationVersion") }
-
-    return Extension::class.java.classLoader.getResources("META-INF/MANIFEST.MF")
-        .asSequence()
-        .mapNotNull { runCatching { readVersion(it) }.getOrNull() }
-        .first()
-}
+fun whichKotlin(): String = getManifestValue("KotlinImplementationVersion")
 
 /**
  * Returns the bundled detekt version.
  */
-fun whichDetekt(): String {
+fun whichDetekt(): String = getManifestValue("DetektVersion")
+
+private fun getManifestValue(key: String): String {
     fun readVersion(resource: URL): String? = resource.openSafeStream()
-        .use { Manifest(it).mainAttributes.getValue("DetektVersion") }
+        .use { Manifest(it).mainAttributes.getValue(key) }
 
     return Extension::class.java.classLoader.getResources("META-INF/MANIFEST.MF")
         .asSequence()

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/Versions.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/Versions.kt
@@ -16,6 +16,19 @@ fun whichOS(): String = System.getProperty("os.name")
 fun whichJava(): String = System.getProperty("java.runtime.version")
 
 /**
+ * Returns the version of Kotlin that detekt was compiled with
+ */
+fun whichKotlin(): String? {
+    fun readVersion(resource: URL): String? = resource.openSafeStream()
+        .use { Manifest(it).mainAttributes.getValue("KotlinImplementationVersion") }
+
+    return Extension::class.java.classLoader.getResources("META-INF/MANIFEST.MF")
+        .asSequence()
+        .mapNotNull { runCatching { readVersion(it) }.getOrNull() }
+        .firstOrNull()
+}
+
+/**
  * Returns the bundled detekt version.
  */
 fun whichDetekt(): String? {

--- a/detekt-cli/build.gradle.kts
+++ b/detekt-cli/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.apache.tools.ant.filters.ReplaceTokens
+
 plugins {
     alias(libs.plugins.shadow)
     id("module")
@@ -46,6 +48,11 @@ publishing {
 tasks {
     shadowJar {
         mergeServiceFiles()
+    }
+
+    processTestResources {
+        filter(ReplaceTokens::class, "tokens" to mapOf("kotlinVersion" to libs.versions.kotlin.get()))
+        filteringCharset = "UTF-8"
     }
 
     val runWithHelpFlag by registering(JavaExec::class) {

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Main.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Main.kt
@@ -7,10 +7,12 @@ import io.github.detekt.tooling.api.MaxIssuesReached
 import io.github.detekt.tooling.api.UnexpectedError
 import io.github.detekt.tooling.api.exitCode
 import io.github.detekt.tooling.internal.NotApiButProbablyUsedByUsers
+import io.gitlab.arturbosch.detekt.api.internal.whichKotlin
 import io.gitlab.arturbosch.detekt.cli.runners.ConfigExporter
 import io.gitlab.arturbosch.detekt.cli.runners.Executable
 import io.gitlab.arturbosch.detekt.cli.runners.Runner
 import io.gitlab.arturbosch.detekt.cli.runners.VersionPrinter
+import org.jetbrains.kotlin.config.KotlinCompilerVersion
 import java.io.PrintStream
 import kotlin.system.exitProcess
 
@@ -50,6 +52,12 @@ fun buildRunner(
     outputPrinter: PrintStream,
     errorPrinter: PrintStream
 ): Executable {
+    check(KotlinCompilerVersion.VERSION == whichKotlin()) {
+        """
+            detekt was compiled with Kotlin ${whichKotlin()} but is currently running with ${KotlinCompilerVersion.VERSION}.
+            This is not supported. See https://detekt.dev/docs/gettingstarted/gradle#dependencies for more information.
+        """.trimIndent()
+    }
     val arguments = parseArguments(args)
     return when {
         arguments.showVersion -> VersionPrinter(outputPrinter)

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/MainSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/MainSpec.kt
@@ -34,7 +34,7 @@ class MainSpec {
 
         @ParameterizedTest
         @MethodSource("runnerConfigs")
-        fun `builds correct runnner`(args: Array<String>, expectedRunnerClass: KClass<*>) {
+        fun `builds correct runner`(args: Array<String>, expectedRunnerClass: KClass<*>) {
             val runner = buildRunner(args, NullPrintStream(), NullPrintStream())
 
             assertThat(runner).isExactlyInstanceOf(expectedRunnerClass.java)

--- a/detekt-cli/src/test/resources/META-INF/MANIFEST.MF
+++ b/detekt-cli/src/test/resources/META-INF/MANIFEST.MF
@@ -1,3 +1,3 @@
 Manifest-Version: 1.0
 DetektVersion: 1.6.0
-
+KotlinImplementationVersion: @kotlinVersion@

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Analyzer.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Analyzer.kt
@@ -178,7 +178,7 @@ private fun throwIllegalStateException(file: KtFile, error: Throwable): Nothing 
         Analyzing ${file.absolutePath()} led to an exception.
         Location: ${error.stackTrace.firstOrNull()?.toString()}
         The original exception message was: ${error.localizedMessage}
-        Running detekt '${whichDetekt() ?: "unknown"}' on Java '${whichJava()}' on OS '${whichOS()}'
+        Running detekt '${whichDetekt()}' on Java '${whichJava()}' on OS '${whichOS()}'
         If the exception message does not help, please feel free to create an issue on our GitHub page.
     """.trimIndent()
     throw IllegalStateException(message, error)

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/tooling/DefaultVersionProvider.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/tooling/DefaultVersionProvider.kt
@@ -5,5 +5,5 @@ import io.gitlab.arturbosch.detekt.api.internal.whichDetekt
 
 class DefaultVersionProvider : VersionProvider {
 
-    override fun current(): String = checkNotNull(whichDetekt()) { "No version packaged. Invalid jar." }
+    override fun current(): String = whichDetekt()
 }

--- a/detekt-report-html/src/main/kotlin/io/github/detekt/report/html/HtmlOutputReport.kt
+++ b/detekt-report-html/src/main/kotlin/io/github/detekt/report/html/HtmlOutputReport.kt
@@ -61,7 +61,7 @@ class HtmlOutputReport : OutputReport() {
             .replace(PLACEHOLDER_COMPLEXITY_REPORT, renderComplexity(getComplexityMetrics(detektion)))
             .replace(PLACEHOLDER_FINDINGS, renderFindings(detektion.findings))
 
-    private fun renderVersion(): String = whichDetekt() ?: "unknown"
+    private fun renderVersion(): String = whichDetekt()
 
     private fun renderDate(): String {
         val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")

--- a/detekt-report-html/src/main/kotlin/io/github/detekt/report/html/HtmlUtils.kt
+++ b/detekt-report-html/src/main/kotlin/io/github/detekt/report/html/HtmlUtils.kt
@@ -85,7 +85,7 @@ private fun createReportUrl(ruleName: String, throwable: Throwable): String {
     val bodyMessage = """
         |I found an error in the html report:
         |- Rule: $ruleName
-        |- Detekt version: ${whichDetekt() ?: "<WRITE HERE THE VERSION OF DETEKT THAT YOU ARE USING>"}
+        |- Detekt version: ${whichDetekt()}"}
         |- Stacktrace:
         |```
         |$stackTrace

--- a/detekt-report-md/src/main/kotlin/io/github/detekt/report/md/MdOutputReport.kt
+++ b/detekt-report-md/src/main/kotlin/io/github/detekt/report/md/MdOutputReport.kt
@@ -56,7 +56,7 @@ class MdOutputReport : OutputReport() {
         }
     }
 
-    private fun renderVersion(): String = whichDetekt() ?: "unknown"
+    private fun renderVersion(): String = whichDetekt()
 
     private fun renderDate(): String {
         val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")

--- a/website/docs/gettingstarted/gradle.mdx
+++ b/website/docs/gettingstarted/gradle.mdx
@@ -496,15 +496,16 @@ The source code of the plugin is available here: [detekt/detekt-intellij-plugin]
 detekt is tightly coupled to the Kotlin compiler and requires a specific version to be available at runtime to perform
 its analysis.
 
-If detekt is run with an unexpected version of the Kotlin compiler on its runtime classpath, you will see an error like
-this when you try to run detekt via Gradle:
+If detekt is run with an unexpected version of the Kotlin compiler on its classpath, you will see an error like this
+when you try to run detekt via Gradle:
 
 ```
 detekt was compiled with Kotlin 1.8.0 but is currently running with 1.7.0
 ```
 
-This happens when the version of `kotlin-compiler-embeddable` is overridden on detekt's classpath. This can happen when
-build scripts use things like this which override all dependency configurations:
+This happens when the version of `kotlin-compiler-embeddable` is overridden on detekt's classpath (in the `detekt`
+dependency configuration). This can happen when build scripts use things like this which override all dependency
+configurations:
 
 ```kotlin
 configurations.all {
@@ -516,5 +517,5 @@ configurations.all {
 }
 ```
 
-If Kotlin dependencies are being aligned like this then exclude the `detekt` dependency configuration with something like
-`configurations.matching { it.name != "detekt" }.all`.
+If Kotlin dependencies are being aligned like this then exclude the `detekt` dependency configuration with something
+like `configurations.matching { it.name != "detekt" }.all`.

--- a/website/docs/gettingstarted/gradle.mdx
+++ b/website/docs/gettingstarted/gradle.mdx
@@ -490,3 +490,31 @@ Instead of disabling detekt for the check task, you may want to increase the bui
 detekt comes with an [IntelliJ Plugin](https://plugins.jetbrains.com/plugin/10761-detekt) that you can install directly from the IDE. The plugin offers warning highlight directly inside the IDE as well as support for code formatting.
 
 The source code of the plugin is available here: [detekt/detekt-intellij-plugin](https://github.com/detekt/detekt-intellij-plugin)
+
+## <a name="dependencies">Gradle runtime dependencies</a>
+
+detekt is tightly coupled to the Kotlin compiler and requires a specific version to be available at runtime to perform
+its analysis.
+
+If detekt is run with an unexpected version of the Kotlin compiler on its runtime classpath, you will see an error like
+this when you try to run detekt via Gradle:
+
+```
+detekt was compiled with Kotlin 1.8.0 but is currently running with 1.7.0
+```
+
+This happens when the version of `kotlin-compiler-embeddable` is overridden on detekt's classpath. This can happen when
+build scripts use things like this which override all dependency configurations:
+
+```kotlin
+configurations.all {
+    resolutionStrategy.eachDependency {
+        if (requested.group == "org.jetbrains.kotlin") {
+            useVersion("1.7.0")
+        }
+    }
+}
+```
+
+If Kotlin dependencies are being aligned like this then exclude the `detekt` dependency configuration with something like
+`configurations.matching { it.name != "detekt" }.all`.


### PR DESCRIPTION
Fixes #5645 
Closes #5551