### PR TITLE
Fix testPluginKotlinc task

### DIFF
--- a/detekt-compiler-plugin/build.gradle.kts
+++ b/detekt-compiler-plugin/build.gradle.kts
@@ -83,7 +83,7 @@ val testPluginKotlinc by tasks.registering(RunTestExecutable::class) {
 
     args(
         listOf(
-            "$rootDir/src/test/resources/hello.kt",
+            "$projectDir/src/test/resources/hello.kt",
             "-Xplugin=${tasks.shadowJar.get().archiveFile.get().asFile.absolutePath}",
             "-P",
         )

--- a/detekt-compiler-plugin/build.gradle.kts
+++ b/detekt-compiler-plugin/build.gradle.kts
@@ -79,6 +79,7 @@ val unzipKotlinCompiler by tasks.registering(Copy::class) {
 }
 
 val testPluginKotlinc by tasks.registering(RunTestExecutable::class) {
+    notCompatibleWithConfigurationCache("cannot serialize objects currently used in this task")
     dependsOn(unzipKotlinCompiler, tasks.shadowJar)
 
     args(


### PR DESCRIPTION
The task does not currently run successfully and is also currently incompatible with the configuration cache. With this PR the task will run successfully without error, tested locally on Windows 11.

The task is not currently run in CI, but probably should be...