### PR TITLE
Migrate detekt compiler extension to CompilerPluginRegistrar

### DIFF
--- a/detekt-compiler-plugin/build.gradle.kts
+++ b/detekt-compiler-plugin/build.gradle.kts
@@ -83,7 +83,7 @@ val testPluginKotlinc by tasks.registering(RunTestExecutable::class) {
 
     args(
         listOf(
-            "$rootDir/src/test/resources/hello.kt",
+            "$projectDir/src/test/resources/hello.kt",
             "-Xplugin=${tasks.shadowJar.get().archiveFile.get().asFile.absolutePath}",
             "-P",
         )

--- a/detekt-compiler-plugin/build.gradle.kts
+++ b/detekt-compiler-plugin/build.gradle.kts
@@ -79,6 +79,7 @@ val unzipKotlinCompiler by tasks.registering(Copy::class) {
 }
 
 val testPluginKotlinc by tasks.registering(RunTestExecutable::class) {
+    notCompatibleWithConfigurationCache("cannot serialize objects currently used in this task")
     dependsOn(unzipKotlinCompiler, tasks.shadowJar)
 
     args(

--- a/detekt-compiler-plugin/src/main/kotlin/io/github/detekt/compiler/plugin/DetektCompilerPluginRegistrar.kt
+++ b/detekt-compiler-plugin/src/main/kotlin/io/github/detekt/compiler/plugin/DetektCompilerPluginRegistrar.kt
@@ -3,20 +3,18 @@ package io.github.detekt.compiler.plugin
 import io.github.detekt.compiler.plugin.internal.toSpec
 import org.jetbrains.kotlin.cli.common.CLIConfigurationKeys
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
-import org.jetbrains.kotlin.com.intellij.mock.MockProject
+import org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.resolve.jvm.extensions.AnalysisHandlerExtension
 import java.nio.file.Paths
 
-@Suppress("DEPRECATION")
 @OptIn(ExperimentalCompilerApi::class)
-class DetektComponentRegistrar : org.jetbrains.kotlin.compiler.plugin.ComponentRegistrar {
+class DetektCompilerPluginRegistrar : CompilerPluginRegistrar() {
 
-    override fun registerProjectComponents(
-        project: MockProject,
-        configuration: CompilerConfiguration
-    ) {
+    override val supportsK2 = false
+
+    override fun ExtensionStorage.registerExtensions(configuration: CompilerConfiguration) {
         if (configuration.get(Keys.IS_ENABLED) == false) {
             return
         }
@@ -24,7 +22,6 @@ class DetektComponentRegistrar : org.jetbrains.kotlin.compiler.plugin.ComponentR
         val messageCollector = configuration.get(CLIConfigurationKeys.MESSAGE_COLLECTOR_KEY, MessageCollector.NONE)
 
         AnalysisHandlerExtension.registerExtension(
-            project,
             DetektAnalysisExtension(
                 messageCollector,
                 configuration.toSpec(messageCollector),

--- a/detekt-compiler-plugin/src/main/resources/META-INF/services/org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
+++ b/detekt-compiler-plugin/src/main/resources/META-INF/services/org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
@@ -1,0 +1,1 @@
+io.github.detekt.compiler.plugin.DetektCompilerPluginRegistrar

--- a/detekt-compiler-plugin/src/main/resources/META-INF/services/org.jetbrains.kotlin.compiler.plugin.ComponentRegistrar
+++ b/detekt-compiler-plugin/src/main/resources/META-INF/services/org.jetbrains.kotlin.compiler.plugin.ComponentRegistrar
@@ -1,1 +1,0 @@
-io.github.detekt.compiler.plugin.DetektComponentRegistrar

--- a/detekt-compiler-plugin/src/test/kotlin/io/github/detekt/compiler/plugin/util/CompilerTestUtils.kt
+++ b/detekt-compiler-plugin/src/test/kotlin/io/github/detekt/compiler/plugin/util/CompilerTestUtils.kt
@@ -3,7 +3,6 @@ package io.github.detekt.compiler.plugin.util
 import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.SourceFile
 import io.github.detekt.compiler.plugin.DetektCommandLineProcessor
-import io.github.detekt.compiler.plugin.DetektComponentRegistrar
 import org.intellij.lang.annotations.Language
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 
@@ -16,7 +15,8 @@ object CompilerTestUtils {
         }
         return KotlinCompilation().apply {
             sources = sourceFiles
-            compilerPlugins = listOf(DetektComponentRegistrar())
+            // Uncomment when kotlin-compile-testing supports subclasses of CompilerPluginRegistrar
+            // compilerPlugins = listOf(DetektCompilerPluginRegistrar())
             commandLineProcessors = listOf(DetektCommandLineProcessor())
         }.compile()
     }


### PR DESCRIPTION
The ComponentRegistrar interface is deprecated: https://youtrack.jetbrains.com/issue/KT-52665

Stacks on #5731 