### PR TITLE
Use stdlib functions for file & path operations

### DIFF
--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Location.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Location.kt
@@ -9,7 +9,7 @@ import org.jetbrains.kotlin.diagnostics.PsiDiagnosticUtils
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.psiUtil.endOffset
 import org.jetbrains.kotlin.psi.psiUtil.startOffset
-import java.nio.file.Paths
+import kotlin.io.path.Path
 
 /**
  * Specifies a position within a source code fragment.
@@ -27,7 +27,7 @@ constructor(
         )
     )
     val file: String,
-    val filePath: FilePath = FilePath.fromAbsolute(Paths.get(file))
+    val filePath: FilePath = FilePath.fromAbsolute(Path(file))
 ) : Compactable {
     var endSource: SourceLocation = source
         private set

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/OutputReport.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/OutputReport.kt
@@ -1,8 +1,8 @@
 package io.gitlab.arturbosch.detekt.api
 
-import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.io.path.createDirectories
+import kotlin.io.path.writeText
 
 /**
  * Translates detekt's result container - [Detektion] - into an output report
@@ -31,7 +31,7 @@ abstract class OutputReport : Extension {
                 "The $name needs to have a file ending of type .$ending, but was ${filePath.fileName}."
             }
             filePath.parent?.createDirectories()
-            Files.write(filePath, reportData.toByteArray())
+            filePath.writeText(reportData)
         }
     }
 

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/OutputReport.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/OutputReport.kt
@@ -2,6 +2,7 @@ package io.gitlab.arturbosch.detekt.api
 
 import java.nio.file.Files
 import java.nio.file.Path
+import kotlin.io.path.createDirectories
 
 /**
  * Translates detekt's result container - [Detektion] - into an output report
@@ -29,7 +30,7 @@ abstract class OutputReport : Extension {
             assert(filePath.fileName.toString().endsWith(ending)) {
                 "The $name needs to have a file ending of type .$ending, but was ${filePath.fileName}."
             }
-            filePath.parent?.let { Files.createDirectories(it) }
+            filePath.parent?.createDirectories()
             Files.write(filePath, reportData.toByteArray())
         }
     }

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/OutputReport.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/OutputReport.kt
@@ -2,6 +2,7 @@ package io.gitlab.arturbosch.detekt.api
 
 import java.nio.file.Path
 import kotlin.io.path.createDirectories
+import kotlin.io.path.extension
 import kotlin.io.path.writeText
 
 /**
@@ -27,7 +28,7 @@ abstract class OutputReport : Extension {
     fun write(filePath: Path, detektion: Detektion) {
         val reportData = render(detektion)
         if (reportData != null) {
-            assert(filePath.fileName.toString().endsWith(ending)) {
+            assert(filePath.extension == ending) {
                 "The $name needs to have a file ending of type .$ending, but was ${filePath.fileName}."
             }
             filePath.parent?.createDirectories()

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/EntitySpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/EntitySpec.kt
@@ -8,11 +8,11 @@ import org.jetbrains.kotlin.psi.psiUtil.collectDescendantsOfType
 import org.jetbrains.kotlin.psi.psiUtil.findDescendantOfType
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import java.nio.file.Paths
+import kotlin.io.path.Path
 
 class EntitySpec {
 
-    private val path = Paths.get("/full/path/to/Test.kt")
+    private val path = Path("/full/path/to/Test.kt")
     private val code = compileContentForTest(
         """
             package test

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/internal/InclusionExclusionPatternsSpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/internal/InclusionExclusionPatternsSpec.kt
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import java.nio.file.Files
 import java.nio.file.Path
+import kotlin.io.path.isRegularFile
 
 class InclusionExclusionPatternsSpec {
 
@@ -90,7 +91,7 @@ class InclusionExclusionPatternsSpec {
 
             OnlyLibraryTrackingRule(config).apply {
                 Files.walk(resourceAsPath("library/Library.kt").parent)
-                    .filter { Files.isRegularFile(it) }
+                    .filter { it.isRegularFile() }
                     .forEach { this.lint(it) }
                 assertOnlyLibraryFileVisited(false)
                 assertCounterWasCalledTimes(2)
@@ -108,7 +109,7 @@ class InclusionExclusionPatternsSpec {
 
             OnlyLibraryTrackingRule(config).apply {
                 Files.walk(resourceAsPath("library/Library.kt").parent)
-                    .filter { Files.isRegularFile(it) }
+                    .filter { it.isRegularFile() }
                     .forEach { this.lint(it) }
                 assertOnlyLibraryFileVisited(true)
                 assertCounterWasCalledTimes(0)

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/internal/PathMatchersSpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/internal/PathMatchersSpec.kt
@@ -5,12 +5,12 @@ import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import java.nio.file.Path
-import java.nio.file.Paths
+import kotlin.io.path.Path
 
 class PathMatchersSpec {
 
-    private val expectedMatch: Path = Paths.get("/detekt/api/Issue.kt")
-    private val nonMatchingPath: Path = Paths.get("/detekt/cli/Issue.kt")
+    private val expectedMatch: Path = Path("/detekt/api/Issue.kt")
+    private val nonMatchingPath: Path = Path("/detekt/cli/Issue.kt")
 
     @Nested
     inner class `supports globbing` {
@@ -30,7 +30,7 @@ class PathMatchersSpec {
 
         @Test
         fun `should work with windows like paths`() {
-            assertThat(matcher.matches(Paths.get("C:/detekt/api/Issue.kt"))).isTrue()
+            assertThat(matcher.matches(Path("C:/detekt/api/Issue.kt"))).isTrue()
         }
     }
 

--- a/detekt-api/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/test/TestFactory.kt
+++ b/detekt-api/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/test/TestFactory.kt
@@ -11,7 +11,7 @@ import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.api.TextLocation
 import org.jetbrains.kotlin.psi.KtElement
-import java.nio.file.Paths
+import kotlin.io.path.Path
 
 fun createFinding(ruleName: String = "TestSmell", fileName: String = "TestFile.kt") =
     CodeSmell(createIssue(ruleName), createEntity(fileName), "TestMessage")
@@ -41,7 +41,7 @@ fun createFindingForRelativePath(
         location = Location(
             source = SourceLocation(1, 1),
             text = TextLocation(0, 0),
-            filePath = FilePath.fromRelative(Paths.get(basePath), Paths.get(relativePath))
+            filePath = FilePath.fromRelative(Path(basePath), Path(relativePath))
         ),
         ktElement = null
     ),
@@ -67,8 +67,8 @@ fun createEntity(
     location = Location(
         source = SourceLocation(position.first, position.second),
         text = TextLocation(text.first, text.last),
-        filePath = basePath?.let { FilePath.fromRelative(Paths.get(it), Paths.get(path)) }
-            ?: FilePath.fromAbsolute(Paths.get(path))
+        filePath = basePath?.let { FilePath.fromRelative(Path(it), Path(path)) }
+            ?: FilePath.fromAbsolute(Path(path))
     ),
     ktElement = ktElement
 )

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/ArgumentConverters.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/ArgumentConverters.kt
@@ -5,15 +5,15 @@ import com.beust.jcommander.ParameterException
 import org.jetbrains.kotlin.config.LanguageVersion
 import java.io.File
 import java.net.URL
-import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.io.path.Path
+import kotlin.io.path.notExists
 
 class ExistingPathConverter : IStringConverter<Path> {
     override fun convert(value: String): Path {
         require(value.isNotBlank()) { "Provided path '$value' is empty." }
         val config = File(value).toPath()
-        if (Files.notExists(config)) {
+        if (config.notExists()) {
             throw ParameterException("Provided path '$value' does not exist!")
         }
         return config

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/ArgumentConverters.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/ArgumentConverters.kt
@@ -3,7 +3,6 @@ package io.gitlab.arturbosch.detekt.cli
 import com.beust.jcommander.IStringConverter
 import com.beust.jcommander.ParameterException
 import org.jetbrains.kotlin.config.LanguageVersion
-import java.io.File
 import java.net.URL
 import java.nio.file.Path
 import kotlin.io.path.Path
@@ -12,7 +11,7 @@ import kotlin.io.path.notExists
 class ExistingPathConverter : IStringConverter<Path> {
     override fun convert(value: String): Path {
         require(value.isNotBlank()) { "Provided path '$value' is empty." }
-        val config = File(value).toPath()
+        val config = Path(value)
         if (config.notExists()) {
             throw ParameterException("Provided path '$value' does not exist!")
         }

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/ArgumentConverters.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/ArgumentConverters.kt
@@ -7,7 +7,7 @@ import java.io.File
 import java.net.URL
 import java.nio.file.Files
 import java.nio.file.Path
-import java.nio.file.Paths
+import kotlin.io.path.Path
 
 class ExistingPathConverter : IStringConverter<Path> {
     override fun convert(value: String): Path {
@@ -21,9 +21,7 @@ class ExistingPathConverter : IStringConverter<Path> {
 }
 
 class PathConverter : IStringConverter<Path> {
-    override fun convert(value: String): Path {
-        return Paths.get(value)
-    }
+    override fun convert(value: String) = Path(value)
 }
 
 interface DetektInputPathConverter<T> : IStringConverter<List<T>> {

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/JCommander.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/JCommander.kt
@@ -2,6 +2,7 @@ package io.gitlab.arturbosch.detekt.cli
 
 import com.beust.jcommander.JCommander
 import com.beust.jcommander.ParameterException
+import kotlin.io.path.isRegularFile
 import java.nio.file.Files
 
 fun parseArguments(args: Array<out String>): CliArgs {
@@ -42,7 +43,7 @@ private fun CliArgs.validate(jCommander: JCommander) {
     if (!createBaseline && baseline != null) {
         if (Files.notExists(baseline)) {
             violations.appendLine("The file specified by --baseline should exist '$baseline'.")
-        } else if (!Files.isRegularFile(baseline)) {
+        } else if (!baseline.isRegularFile()) {
             violations.appendLine("The path specified by --baseline should be a file '$baseline'.")
         }
     }

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/JCommander.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/JCommander.kt
@@ -3,7 +3,7 @@ package io.gitlab.arturbosch.detekt.cli
 import com.beust.jcommander.JCommander
 import com.beust.jcommander.ParameterException
 import kotlin.io.path.isRegularFile
-import java.nio.file.Files
+import kotlin.io.path.notExists
 
 fun parseArguments(args: Array<out String>): CliArgs {
     val cli = CliArgs()
@@ -41,7 +41,7 @@ private fun CliArgs.validate(jCommander: JCommander) {
     }
 
     if (!createBaseline && baseline != null) {
-        if (Files.notExists(baseline)) {
+        if (baseline.notExists()) {
             violations.appendLine("The file specified by --baseline should exist '$baseline'.")
         } else if (!baseline.isRegularFile()) {
             violations.appendLine("The path specified by --baseline should be a file '$baseline'.")

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/ReportPath.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/ReportPath.kt
@@ -1,7 +1,7 @@
 package io.gitlab.arturbosch.detekt.cli
 
 import java.nio.file.Path
-import java.nio.file.Paths
+import kotlin.io.path.Path
 
 data class ReportPath(val kind: String, val path: Path) {
 
@@ -24,7 +24,7 @@ data class ReportPath(val kind: String, val path: Path) {
             val kind = parts[0]
             require(kind.isNotEmpty()) { "The kind of report must not be empty (path - $path)" }
             require(path.isNotEmpty()) { "The path of the report must not be empty (kind - $kind)" }
-            return ReportPath(kind, Paths.get(path))
+            return ReportPath(kind, Path(path))
         }
     }
 }

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/ConfigExporter.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/ConfigExporter.kt
@@ -5,6 +5,7 @@ import io.github.detekt.tooling.api.spec.ProcessingSpec
 import io.gitlab.arturbosch.detekt.cli.CliArgs
 import io.gitlab.arturbosch.detekt.cli.MultipleExistingPathConverter
 import kotlin.io.path.Path
+import kotlin.io.path.absolute
 
 class ConfigExporter(
     private val arguments: CliArgs,
@@ -20,6 +21,6 @@ class ConfigExporter(
             }
         }
         DefaultConfigurationProvider.load(spec.extensionsSpec).copy(configPath)
-        outputPrinter.appendLine("Successfully copied default config to ${configPath.toAbsolutePath()}")
+        outputPrinter.appendLine("Successfully copied default config to ${configPath.absolute()}")
     }
 }

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/ConfigExporter.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/ConfigExporter.kt
@@ -4,7 +4,7 @@ import io.github.detekt.tooling.api.DefaultConfigurationProvider
 import io.github.detekt.tooling.api.spec.ProcessingSpec
 import io.gitlab.arturbosch.detekt.cli.CliArgs
 import io.gitlab.arturbosch.detekt.cli.MultipleExistingPathConverter
-import java.nio.file.Paths
+import kotlin.io.path.Path
 
 class ConfigExporter(
     private val arguments: CliArgs,
@@ -12,7 +12,7 @@ class ConfigExporter(
 ) : Executable {
 
     override fun execute() {
-        val configPath = Paths.get(arguments.config ?: "detekt.yml")
+        val configPath = Path(arguments.config ?: "detekt.yml")
         val spec = ProcessingSpec {
             extensions {
                 disableDefaultRuleSets = arguments.disableDefaultRuleSets

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgsSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgsSpec.kt
@@ -9,7 +9,7 @@ import org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import java.nio.file.Path
-import java.nio.file.Paths
+import kotlin.io.path.Path
 
 internal class CliArgsSpec {
 
@@ -22,7 +22,7 @@ internal class CliArgsSpec {
         fun `the current working directory is used if parameter is not set`() {
             val cli = parseArguments(emptyArray())
             assertThat(cli.inputPaths).hasSize(1)
-            assertThat(cli.inputPaths.first()).isEqualTo(Paths.get(System.getProperty("user.dir")))
+            assertThat(cli.inputPaths.first()).isEqualTo(Path(System.getProperty("user.dir")))
         }
 
         @Test

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgsSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgsSpec.kt
@@ -10,10 +10,11 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import java.nio.file.Path
 import kotlin.io.path.Path
+import kotlin.io.path.absolute
 
 internal class CliArgsSpec {
 
-    private val projectPath: Path = resourceAsPath("/").parent.parent.parent.parent.toAbsolutePath()
+    private val projectPath: Path = resourceAsPath("/").parent.parent.parent.parent.absolute()
 
     @Nested
     inner class `Parsing the input path` {
@@ -29,16 +30,16 @@ internal class CliArgsSpec {
         fun `a single value is converted to a path`() {
             val cli = parseArguments(arrayOf("--input", "$projectPath"))
             assertThat(cli.inputPaths).hasSize(1)
-            assertThat(cli.inputPaths.first().toAbsolutePath()).isEqualTo(projectPath)
+            assertThat(cli.inputPaths.first().absolute()).isEqualTo(projectPath)
         }
 
         @Test
         fun `multiple input paths can be separated by comma`() {
-            val mainPath = projectPath.resolve("src/main").toAbsolutePath()
-            val testPath = projectPath.resolve("src/test").toAbsolutePath()
+            val mainPath = projectPath.resolve("src/main").absolute()
+            val testPath = projectPath.resolve("src/test").absolute()
             val cli = parseArguments(arrayOf("--input", "$mainPath,$testPath"))
             assertThat(cli.inputPaths).hasSize(2)
-            assertThat(cli.inputPaths.map(Path::toAbsolutePath)).containsExactlyInAnyOrder(mainPath, testPath)
+            assertThat(cli.inputPaths.map(Path::absolute)).containsExactlyInAnyOrder(mainPath, testPath)
         }
 
         @Test

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/PathFiltersSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/PathFiltersSpec.kt
@@ -5,15 +5,15 @@ import io.gitlab.arturbosch.detekt.api.internal.PathFilters
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import java.nio.file.Paths
+import kotlin.io.path.Path
 
 class PathFiltersSpec {
 
     @Test
     fun `should load single filter`() {
         val filters = CliArgs { excludes = "**/one/**" }.toSpecFilters()
-        assertThat(filters?.isIgnored(Paths.get("/one/path"))).isTrue()
-        assertThat(filters?.isIgnored(Paths.get("/two/path"))).isFalse()
+        assertThat(filters?.isIgnored(Path("/one/path"))).isTrue()
+        assertThat(filters?.isIgnored(Path("/two/path"))).isFalse()
     }
 
     @Nested
@@ -28,28 +28,28 @@ class PathFiltersSpec {
         fun `parses includes correctly`() {
             val pathFilter = PathFilters.of(listOf("**/one/**", "**/two/**"), emptyList())
             assertThat(pathFilter).isNotNull
-            assertThat(pathFilter?.isIgnored(Paths.get("/one/path"))).isFalse
-            assertThat(pathFilter?.isIgnored(Paths.get("/two/path"))).isFalse
-            assertThat(pathFilter?.isIgnored(Paths.get("/three/path"))).isTrue
+            assertThat(pathFilter?.isIgnored(Path("/one/path"))).isFalse
+            assertThat(pathFilter?.isIgnored(Path("/two/path"))).isFalse
+            assertThat(pathFilter?.isIgnored(Path("/three/path"))).isTrue
         }
 
         @Test
         fun `parses excludes correctly`() {
             val pathFilter = PathFilters.of(emptyList(), listOf("**/one/**", "**/two/**"))
             assertThat(pathFilter).isNotNull
-            assertThat(pathFilter?.isIgnored(Paths.get("/one/path"))).isTrue
-            assertThat(pathFilter?.isIgnored(Paths.get("/two/path"))).isTrue
-            assertThat(pathFilter?.isIgnored(Paths.get("/three/path"))).isFalse
+            assertThat(pathFilter?.isIgnored(Path("/one/path"))).isTrue
+            assertThat(pathFilter?.isIgnored(Path("/two/path"))).isTrue
+            assertThat(pathFilter?.isIgnored(Path("/three/path"))).isFalse
         }
 
         @Test
         fun `parses both includes and excludes correctly`() {
             val pathFilter = PathFilters.of(listOf("**/one/**"), listOf("**/two/**"))
             assertThat(pathFilter).isNotNull
-            assertThat(pathFilter?.isIgnored(Paths.get("/one/path"))).isFalse
-            assertThat(pathFilter?.isIgnored(Paths.get("/two/path"))).isTrue
-            assertThat(pathFilter?.isIgnored(Paths.get("/three/path"))).isTrue
-            assertThat(pathFilter?.isIgnored(Paths.get("/one/two/three/path"))).isTrue
+            assertThat(pathFilter?.isIgnored(Path("/one/path"))).isFalse
+            assertThat(pathFilter?.isIgnored(Path("/two/path"))).isTrue
+            assertThat(pathFilter?.isIgnored(Path("/three/path"))).isTrue
+            assertThat(pathFilter?.isIgnored(Path("/one/two/three/path"))).isTrue
         }
     }
 
@@ -96,11 +96,11 @@ class PathFiltersSpec {
     @Test
     fun `should ignore empty and blank filters`() {
         val filters = CliArgs { excludes = " ,,**/three" }.toSpecFilters()
-        assertThat(filters?.isIgnored(Paths.get("/three"))).isTrue()
-        assertThat(filters?.isIgnored(Paths.get("/root/three"))).isTrue()
-        assertThat(filters?.isIgnored(Paths.get("/one/path"))).isFalse()
-        assertThat(filters?.isIgnored(Paths.get("/two/path"))).isFalse()
-        assertThat(filters?.isIgnored(Paths.get("/three/path"))).isFalse()
+        assertThat(filters?.isIgnored(Path("/three"))).isTrue()
+        assertThat(filters?.isIgnored(Path("/root/three"))).isTrue()
+        assertThat(filters?.isIgnored(Path("/one/path"))).isFalse()
+        assertThat(filters?.isIgnored(Path("/two/path"))).isFalse()
+        assertThat(filters?.isIgnored(Path("/three/path"))).isFalse()
     }
 }
 
@@ -111,9 +111,9 @@ private fun CliArgs.toSpecFilters(): PathFilters? {
 
 // can parse pattern **/one/**,**/two/**,**/three
 private fun assertSameFiltersIndependentOfSpacingAndSeparater(filters: PathFilters?) {
-    assertThat(filters?.isIgnored(Paths.get("/one/path"))).isTrue()
-    assertThat(filters?.isIgnored(Paths.get("/two/path"))).isTrue()
-    assertThat(filters?.isIgnored(Paths.get("/three"))).isTrue()
-    assertThat(filters?.isIgnored(Paths.get("/root/three"))).isTrue()
-    assertThat(filters?.isIgnored(Paths.get("/three/path"))).isFalse()
+    assertThat(filters?.isIgnored(Path("/one/path"))).isTrue()
+    assertThat(filters?.isIgnored(Path("/two/path"))).isTrue()
+    assertThat(filters?.isIgnored(Path("/three"))).isTrue()
+    assertThat(filters?.isIgnored(Path("/root/three"))).isTrue()
+    assertThat(filters?.isIgnored(Path("/three/path"))).isFalse()
 }

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/ReportPathSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/ReportPathSpec.kt
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.condition.DisabledOnOs
 import org.junit.jupiter.api.condition.EnabledOnOs
 import org.junit.jupiter.api.condition.OS
-import java.nio.file.Paths
+import kotlin.io.path.Path
 
 class ReportPathSpec {
 
@@ -19,14 +19,14 @@ class ReportPathSpec {
         fun `parses a valid absolute path correctly`() {
             val reportPath = ReportPath.from("test:C:\\tmp\\valid\\report")
 
-            assertThat(reportPath.path).isEqualTo(Paths.get("C:\\tmp\\valid\\report"))
+            assertThat(reportPath.path).isEqualTo(Path("C:\\tmp\\valid\\report"))
         }
 
         @Test
         fun `parses a valid relative path correctly`() {
             val reportPath = ReportPath.from("test:valid\\report")
 
-            assertThat(reportPath.path).isEqualTo(Paths.get("valid\\report"))
+            assertThat(reportPath.path).isEqualTo(Path("valid\\report"))
         }
 
         @Test
@@ -49,14 +49,14 @@ class ReportPathSpec {
         fun `parses a valid absolute path correctly`() {
             val reportPath = ReportPath.from("test:/tmp/valid/report")
 
-            assertThat(reportPath.path).isEqualTo(Paths.get("/tmp/valid/report"))
+            assertThat(reportPath.path).isEqualTo(Path("/tmp/valid/report"))
         }
 
         @Test
         fun `parses a valid relative path correctly`() {
             val reportPath = ReportPath.from("test:valid/report")
 
-            assertThat(reportPath.path).isEqualTo(Paths.get("valid/report"))
+            assertThat(reportPath.path).isEqualTo(Path("valid/report"))
         }
 
         @Test

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/ConfigExporterSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/ConfigExporterSpec.kt
@@ -5,14 +5,14 @@ import io.github.detekt.test.utils.createTempFileForTest
 import io.gitlab.arturbosch.detekt.cli.parseArguments
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import java.nio.file.Files
+import kotlin.io.path.deleteExisting
 import kotlin.io.path.readLines
 
 class ConfigExporterSpec {
 
     @Test
     fun `should export the given config`() {
-        val tmpConfig = createTempFileForTest("ConfigPrinterSpec", ".yml").also { Files.delete(it) }
+        val tmpConfig = createTempFileForTest("ConfigPrinterSpec", ".yml").also { it.deleteExisting() }
         val cliArgs = parseArguments(arrayOf("--config", tmpConfig.toString()))
 
         ConfigExporter(cliArgs, NullPrintStream()).execute()

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/ConfigExporterSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/ConfigExporterSpec.kt
@@ -6,6 +6,7 @@ import io.gitlab.arturbosch.detekt.cli.parseArguments
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.nio.file.Files
+import kotlin.io.path.readLines
 
 class ConfigExporterSpec {
 
@@ -16,6 +17,6 @@ class ConfigExporterSpec {
 
         ConfigExporter(cliArgs, NullPrintStream()).execute()
 
-        assertThat(Files.readAllLines(tmpConfig)).isNotEmpty
+        assertThat(tmpConfig.readLines()).isNotEmpty
     }
 }

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/RunnerSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/RunnerSpec.kt
@@ -13,8 +13,8 @@ import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import java.nio.file.Files
 import java.nio.file.Path
+import kotlin.io.path.readLines
 
 class RunnerSpec {
 
@@ -36,7 +36,7 @@ class RunnerSpec {
                 "/configs/max-issues-2.yml"
             )
 
-            assertThat(Files.readAllLines(tmpReport)).hasSize(1)
+            assertThat(tmpReport.readLines()).hasSize(1)
         }
 
         @Test
@@ -64,7 +64,7 @@ class RunnerSpec {
                 "/configs/max-issues--1.yml"
             )
 
-            assertThat(Files.readAllLines(tmpReport)).hasSize(1)
+            assertThat(tmpReport.readLines()).hasSize(1)
         }
 
         @Nested
@@ -85,7 +85,7 @@ class RunnerSpec {
                     resourceAsPath("configs/baseline-with-two-excludes.xml").toString()
                 )
 
-                assertThat(Files.readAllLines(tmpReport)).isEmpty()
+                assertThat(tmpReport).isEmptyFile()
             }
         }
     }
@@ -241,7 +241,7 @@ class RunnerSpec {
                     "test:test"
                 )
             }.isExactlyInstanceOf(MaxIssuesReached::class.java)
-            assertThat(Files.readAllLines(tmp)).hasSize(1)
+            assertThat(tmp.readLines()).hasSize(1)
         }
 
         @Test

--- a/detekt-compiler-plugin/src/main/kotlin/io/github/detekt/compiler/plugin/DetektAnalysisExtension.kt
+++ b/detekt-compiler-plugin/src/main/kotlin/io/github/detekt/compiler/plugin/DetektAnalysisExtension.kt
@@ -12,7 +12,7 @@ import org.jetbrains.kotlin.resolve.BindingTrace
 import org.jetbrains.kotlin.resolve.jvm.extensions.AnalysisHandlerExtension
 import java.nio.file.FileSystems
 import java.nio.file.Path
-import java.nio.file.Paths
+import kotlin.io.path.Path
 
 class DetektAnalysisExtension(
     private val log: MessageCollector,
@@ -32,7 +32,7 @@ class DetektAnalysisExtension(
         }
         val matchers = excludes.map { FileSystems.getDefault().getPathMatcher("glob:$it") }
         val (includedFiles, excludedFiles) = files.partition { file ->
-            matchers.none { it.matches(rootPath.relativize(Paths.get(file.virtualFilePath))) }
+            matchers.none { it.matches(rootPath.relativize(Path(file.virtualFilePath))) }
         }
         log.info("Running detekt on module '${module.name.asString()}'")
         excludedFiles.forEach { log.info("File excluded by filter: ${it.virtualFilePath}") }

--- a/detekt-compiler-plugin/src/main/kotlin/io/github/detekt/compiler/plugin/DetektCommandLineProcessor.kt
+++ b/detekt-compiler-plugin/src/main/kotlin/io/github/detekt/compiler/plugin/DetektCommandLineProcessor.kt
@@ -8,8 +8,8 @@ import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import java.io.ByteArrayInputStream
 import java.io.ObjectInputStream
-import java.nio.file.Paths
 import java.util.Base64
+import kotlin.io.path.Path
 
 @OptIn(ExperimentalCompilerApi::class)
 class DetektCommandLineProcessor : CommandLineProcessor {
@@ -97,8 +97,8 @@ class DetektCommandLineProcessor : CommandLineProcessor {
 
     override fun processOption(option: AbstractCliOption, value: String, configuration: CompilerConfiguration) {
         when (option.optionName) {
-            Options.baseline -> configuration.put(Keys.BASELINE, Paths.get(value))
-            Options.config -> configuration.put(Keys.CONFIG, value.split(",;").map { Paths.get(it) })
+            Options.baseline -> configuration.put(Keys.BASELINE, Path(value))
+            Options.config -> configuration.put(Keys.CONFIG, value.split(",;").map { Path(it) })
             Options.configDigest -> configuration.put(Keys.CONFIG_DIGEST, value)
             Options.debug -> configuration.put(Keys.DEBUG, value.toBoolean())
             Options.isEnabled -> configuration.put(Keys.IS_ENABLED, value.toBoolean())
@@ -106,12 +106,12 @@ class DetektCommandLineProcessor : CommandLineProcessor {
             Options.allRules -> configuration.put(Keys.ALL_RULES, value.toBoolean())
             Options.disableDefaultRuleSets -> configuration.put(Keys.DISABLE_DEFAULT_RULE_SETS, value.toBoolean())
             Options.parallel -> configuration.put(Keys.PARALLEL, value.toBoolean())
-            Options.rootPath -> configuration.put(Keys.ROOT_PATH, Paths.get(value))
+            Options.rootPath -> configuration.put(Keys.ROOT_PATH, Path(value))
             Options.excludes -> configuration.put(Keys.EXCLUDES, value.decodeToGlobSet())
             Options.report -> configuration.put(
                 Keys.REPORTS,
                 value.substringBefore(':'),
-                Paths.get(value.substringAfter(':')),
+                Path(value.substringAfter(':')),
             )
             else -> throw CliOptionProcessingException("Unknown option: ${option.optionName}")
         }

--- a/detekt-compiler-plugin/src/main/kotlin/io/github/detekt/compiler/plugin/DetektCompilerPluginRegistrar.kt
+++ b/detekt-compiler-plugin/src/main/kotlin/io/github/detekt/compiler/plugin/DetektCompilerPluginRegistrar.kt
@@ -7,7 +7,7 @@ import org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.resolve.jvm.extensions.AnalysisHandlerExtension
-import java.nio.file.Paths
+import kotlin.io.path.Path
 
 @OptIn(ExperimentalCompilerApi::class)
 class DetektCompilerPluginRegistrar : CompilerPluginRegistrar() {
@@ -25,7 +25,7 @@ class DetektCompilerPluginRegistrar : CompilerPluginRegistrar() {
             DetektAnalysisExtension(
                 messageCollector,
                 configuration.toSpec(messageCollector),
-                configuration.get(Keys.ROOT_PATH, Paths.get(System.getProperty("user.dir"))),
+                configuration.get(Keys.ROOT_PATH, Path(System.getProperty("user.dir"))),
                 configuration.getList(Keys.EXCLUDES)
             )
         )

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Junk.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Junk.kt
@@ -1,10 +1,3 @@
 package io.gitlab.arturbosch.detekt.core
 
-import java.nio.file.Files
-import java.nio.file.Path
-
-fun Path.exists(): Boolean = Files.exists(this)
-fun Path.isFile(): Boolean = Files.isRegularFile(this)
-fun Path.isDirectory(): Boolean = Files.isDirectory(this)
-
 val NL: String = System.lineSeparator()

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/KtFileModifier.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/KtFileModifier.kt
@@ -9,8 +9,8 @@ import org.jetbrains.kotlin.com.intellij.openapi.util.text.StringUtilRt
 import org.jetbrains.kotlin.fileClasses.javaFileFacadeFqName
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.resolve.BindingContext
-import java.nio.file.Files
 import java.nio.file.Path
+import kotlin.io.path.writeText
 
 class KtFileModifier : FileProcessListener {
 
@@ -19,7 +19,7 @@ class KtFileModifier : FileProcessListener {
             .map { it.absolutePath() to it.unnormalizeContent() }
             .forEach {
                 result.add(ModificationNotification(it.first))
-                Files.write(it.first, it.second.toByteArray())
+                it.first.writeText(it.second)
             }
     }
 

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/KtTreeCompiler.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/KtTreeCompiler.kt
@@ -6,7 +6,7 @@ import io.gitlab.arturbosch.detekt.api.internal.PathFilters
 import org.jetbrains.kotlin.psi.KtFile
 import java.nio.file.Files
 import java.nio.file.Path
-import kotlin.io.path.absolutePathString
+import kotlin.io.path.extension
 import kotlin.streams.asSequence
 
 class KtTreeCompiler(
@@ -49,11 +49,7 @@ class KtTreeCompiler(
         }
     }
 
-    private fun Path.isKotlinFile(): Boolean {
-        val fullPath = absolutePathString()
-        val kotlinEnding = fullPath.substring(fullPath.lastIndexOf('.') + 1)
-        return kotlinEnding in KT_ENDINGS
-    }
+    private fun Path.isKotlinFile() = extension in KT_ENDINGS
 
     private fun isIgnored(path: Path): Boolean {
         val ignored = pathFilters?.isIgnored(path)

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/KtTreeCompiler.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/KtTreeCompiler.kt
@@ -6,6 +6,7 @@ import io.gitlab.arturbosch.detekt.api.internal.PathFilters
 import org.jetbrains.kotlin.psi.KtFile
 import java.nio.file.Files
 import java.nio.file.Path
+import kotlin.io.path.absolutePathString
 import kotlin.streams.asSequence
 
 class KtTreeCompiler(
@@ -49,7 +50,7 @@ class KtTreeCompiler(
     }
 
     private fun Path.isKotlinFile(): Boolean {
-        val fullPath = toAbsolutePath().toString()
+        val fullPath = absolutePathString()
         val kotlinEnding = fullPath.substring(fullPath.lastIndexOf('.') + 1)
         return kotlinEnding in KT_ENDINGS
     }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/KtTreeCompiler.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/KtTreeCompiler.kt
@@ -6,6 +6,7 @@ import io.gitlab.arturbosch.detekt.api.internal.PathFilters
 import org.jetbrains.kotlin.psi.KtFile
 import java.nio.file.Files
 import java.nio.file.Path
+import kotlin.io.path.exists
 import kotlin.io.path.extension
 import kotlin.io.path.isDirectory
 import kotlin.io.path.isRegularFile
@@ -22,7 +23,7 @@ class KtTreeCompiler(
         PathFilters.of(projectSpec.includes.toList(), projectSpec.excludes.toList())
 
     fun compile(path: Path): List<KtFile> {
-        require(Files.exists(path)) { "Given path $path does not exist!" }
+        require(path.exists()) { "Given path $path does not exist!" }
         return when {
             path.isRegularFile() && path.isKotlinFile() -> listOf(compiler.compile(basePath, path))
             path.isDirectory() -> compileProject(path)

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/KtTreeCompiler.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/KtTreeCompiler.kt
@@ -7,6 +7,8 @@ import org.jetbrains.kotlin.psi.KtFile
 import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.io.path.extension
+import kotlin.io.path.isDirectory
+import kotlin.io.path.isRegularFile
 import kotlin.streams.asSequence
 
 class KtTreeCompiler(
@@ -22,7 +24,7 @@ class KtTreeCompiler(
     fun compile(path: Path): List<KtFile> {
         require(Files.exists(path)) { "Given path $path does not exist!" }
         return when {
-            path.isFile() && path.isKotlinFile() -> listOf(compiler.compile(basePath, path))
+            path.isRegularFile() && path.isKotlinFile() -> listOf(compiler.compile(basePath, path))
             path.isDirectory() -> compileProject(path)
             else -> {
                 settings.debug { "Ignoring a file detekt cannot handle: $path" }
@@ -34,7 +36,7 @@ class KtTreeCompiler(
     private fun compileProject(project: Path): List<KtFile> {
         val kotlinFiles = Files.walk(project)
             .asSequence()
-            .filter(Path::isFile)
+            .filter(Path::isRegularFile)
             .filter { it.isKotlinFile() }
             .filter { !isIgnored(it) }
         return if (settings.spec.executionSpec.parallelParsing) {

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineFacade.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineFacade.kt
@@ -4,8 +4,8 @@ import io.gitlab.arturbosch.detekt.api.Detektion
 import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.core.exists
 import io.gitlab.arturbosch.detekt.core.isFile
-import java.nio.file.Files
 import java.nio.file.Path
+import kotlin.io.path.createDirectories
 
 class BaselineFacade {
 
@@ -27,7 +27,7 @@ class BaselineFacade {
         val baselineFormat = BaselineFormat()
         val baseline = baselineFormat.of(oldBaseline.manuallySuppressedIssues, ids)
         if (oldBaseline != baseline) {
-            baselineFile.parent?.let { Files.createDirectories(it) }
+            baselineFile.parent?.createDirectories()
             baselineFormat.write(baselineFile, baseline)
         }
     }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineFacade.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineFacade.kt
@@ -2,10 +2,10 @@ package io.gitlab.arturbosch.detekt.core.baseline
 
 import io.gitlab.arturbosch.detekt.api.Detektion
 import io.gitlab.arturbosch.detekt.api.Finding
-import io.gitlab.arturbosch.detekt.core.exists
-import io.gitlab.arturbosch.detekt.core.isFile
 import java.nio.file.Path
 import kotlin.io.path.createDirectories
+import kotlin.io.path.exists
+import kotlin.io.path.isRegularFile
 
 class BaselineFacade {
 
@@ -32,5 +32,5 @@ class BaselineFacade {
         }
     }
 
-    private fun baselineExists(baseline: Path) = baseline.exists() && baseline.isFile()
+    private fun baselineExists(baseline: Path) = baseline.exists() && baseline.isRegularFile()
 }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineFormat.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineFormat.kt
@@ -6,12 +6,13 @@ import io.github.detekt.tooling.api.FindingId
 import io.github.detekt.tooling.api.FindingsIdList
 import io.gitlab.arturbosch.detekt.api.Finding
 import org.xml.sax.SAXParseException
-import java.nio.file.Files
 import java.nio.file.Path
 import javax.xml.XMLConstants
 import javax.xml.parsers.SAXParserFactory
 import javax.xml.stream.XMLStreamException
 import javax.xml.stream.XMLStreamWriter
+import kotlin.io.path.bufferedWriter
+import kotlin.io.path.inputStream
 
 internal class BaselineFormat : BaselineProvider {
 
@@ -27,7 +28,7 @@ internal class BaselineFormat : BaselineProvider {
 
     override fun read(sourcePath: Path): DefaultBaseline {
         try {
-            Files.newInputStream(sourcePath).use {
+            sourcePath.inputStream().use {
                 val reader = SAXParserFactory.newInstance()
                     .apply {
                         setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true)
@@ -45,7 +46,7 @@ internal class BaselineFormat : BaselineProvider {
 
     override fun write(targetPath: Path, baseline: Baseline) {
         try {
-            Files.newBufferedWriter(targetPath).addFinalNewLine().use {
+            targetPath.bufferedWriter().addFinalNewLine().use {
                 it.streamXml().prettyPrinter().save(baseline)
             }
         } catch (error: XMLStreamException) {

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/DefaultBaseline.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/DefaultBaseline.kt
@@ -4,9 +4,9 @@ import io.github.detekt.tooling.api.Baseline
 import io.github.detekt.tooling.api.FindingId
 import io.github.detekt.tooling.api.FindingsIdList
 import io.gitlab.arturbosch.detekt.api.Finding
-import io.gitlab.arturbosch.detekt.core.exists
-import io.gitlab.arturbosch.detekt.core.isFile
 import java.nio.file.Path
+import kotlin.io.path.exists
+import kotlin.io.path.isRegularFile
 
 internal data class DefaultBaseline(
     override val manuallySuppressedIssues: FindingsIdList,
@@ -20,7 +20,7 @@ internal data class DefaultBaseline(
 
         fun load(baselineFile: Path): Baseline {
             require(baselineFile.exists()) { "Baseline file does not exist." }
-            require(baselineFile.isFile()) { "Baseline file is not a regular file." }
+            require(baselineFile.isRegularFile()) { "Baseline file is not a regular file." }
             return BaselineFormat().read(baselineFile)
         }
     }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/YamlConfig.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/YamlConfig.kt
@@ -11,6 +11,10 @@ import org.snakeyaml.engine.v2.api.Load
 import org.snakeyaml.engine.v2.api.LoadSettings
 import java.io.Reader
 import java.nio.file.Path
+import kotlin.io.path.exists
+import kotlin.io.path.isReadable
+import kotlin.io.path.isRegularFile
+import kotlin.io.path.reader
 
 /**
  * Config implementation using the yaml format. SubConfigurations can return sub maps according to the
@@ -52,17 +56,15 @@ class YamlConfig internal constructor(
         private const val ALIASES_LIMIT = 10
 
         /**
-         * Factory method to load a yaml configuration. Given path must exist
-         * and point to a readable file.
+         * Factory method to load a yaml configuration. Given path must exist and point to a readable file.
          */
-        fun load(path: Path): Config =
-            load(
-                path.toFile().apply {
-                    require(exists()) { "Configuration does not exist: $path" }
-                    require(isFile) { "Configuration must be a file: $path" }
-                    require(canRead()) { "Configuration must be readable: $path" }
-                }.reader()
-            )
+        fun load(path: Path): Config {
+            require(path.exists()) { "Configuration does not exist: $path" }
+            require(path.isRegularFile()) { "Configuration must be a file: $path" }
+            require(path.isReadable()) { "Configuration must be readable: $path" }
+
+            return load(path.reader())
+        }
 
         /**
          * Constructs a [YamlConfig] from any [Reader].

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/settings/ClassloaderAware.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/settings/ClassloaderAware.kt
@@ -5,6 +5,7 @@ import org.jetbrains.kotlin.utils.closeQuietly
 import java.io.Closeable
 import java.net.URLClassLoader
 import java.nio.file.Files
+import kotlin.io.path.extension
 
 interface ClassloaderAware {
 
@@ -20,7 +21,7 @@ class ExtensionFacade(
     init {
         plugins?.paths?.forEach {
             require(Files.exists(it)) { "Given plugin ‘$it’ does not exist." }
-            require(it.toString().endsWith("jar")) { "Given plugin ‘$it’ is not a JAR." }
+            require(it.extension == "jar") { "Given plugin ‘$it’ is not a JAR." }
         }
     }
 

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/settings/ClassloaderAware.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/settings/ClassloaderAware.kt
@@ -4,7 +4,7 @@ import io.github.detekt.tooling.api.spec.ExtensionsSpec
 import org.jetbrains.kotlin.utils.closeQuietly
 import java.io.Closeable
 import java.net.URLClassLoader
-import java.nio.file.Files
+import kotlin.io.path.exists
 import kotlin.io.path.extension
 
 interface ClassloaderAware {
@@ -20,7 +20,7 @@ class ExtensionFacade(
 
     init {
         plugins?.paths?.forEach {
-            require(Files.exists(it)) { "Given plugin ‘$it’ does not exist." }
+            require(it.exists()) { "Given plugin ‘$it’ does not exist." }
             require(it.extension == "jar") { "Given plugin ‘$it’ is not a JAR." }
         }
     }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/tooling/AnalysisFacade.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/tooling/AnalysisFacade.kt
@@ -16,7 +16,7 @@ import io.gitlab.arturbosch.detekt.core.config.getOrComputeWeightedAmountOfIssue
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.resolve.BindingContext
 import java.nio.file.Path
-import java.nio.file.Paths
+import kotlin.io.path.Path
 
 class AnalysisFacade(
     private val spec: ProcessingSpec
@@ -31,7 +31,7 @@ class AnalysisFacade(
 
     override fun run(sourceCode: String, filename: String): AnalysisResult =
         runAnalysis {
-            DefaultLifecycle(spec.getDefaultConfiguration(), it, contentToKtFile(sourceCode, Paths.get(filename)))
+            DefaultLifecycle(spec.getDefaultConfiguration(), it, contentToKtFile(sourceCode, Path(filename)))
         }
 
     override fun run(files: Collection<KtFile>, bindingContext: BindingContext): AnalysisResult =

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/KtTreeCompilerSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/KtTreeCompilerSpec.kt
@@ -6,7 +6,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 import org.jetbrains.kotlin.psi.KtFile
 import org.junit.jupiter.api.Test
-import java.nio.file.Paths
+import kotlin.io.path.Path
 
 class KtTreeCompilerSpec {
 
@@ -48,7 +48,7 @@ class KtTreeCompilerSpec {
     fun `throws an exception if given file does not exist`() {
         val invalidPath = "NOTHERE"
         assertThatIllegalArgumentException()
-            .isThrownBy { fixture { compile(Paths.get(invalidPath)) } }
+            .isThrownBy { fixture { compile(Path(invalidPath)) } }
             .withMessage("Given path $invalidPath does not exist!")
     }
 

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineFacadeSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineFacadeSpec.kt
@@ -8,6 +8,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import java.nio.file.Files
+import kotlin.io.path.deleteIfExists
 
 class BaselineFacadeSpec {
 
@@ -16,7 +17,7 @@ class BaselineFacadeSpec {
 
     @AfterEach
     fun tearDown() {
-        Files.deleteIfExists(baselineFile)
+        baselineFile.deleteIfExists()
     }
 
     @Test

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineFacadeSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineFacadeSpec.kt
@@ -7,7 +7,7 @@ import io.gitlab.arturbosch.detekt.test.createFinding
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
-import java.nio.file.Files
+import kotlin.io.path.copyTo
 import kotlin.io.path.deleteIfExists
 
 class BaselineFacadeSpec {
@@ -44,7 +44,7 @@ class BaselineFacadeSpec {
 
     @Test
     fun `creates on top of an existing a baseline file without findings`() {
-        Files.copy(validBaseline, baselineFile)
+        validBaseline.copyTo(baselineFile)
 
         BaselineFacade().createOrUpdate(baselineFile, emptyList())
 
@@ -64,7 +64,7 @@ class BaselineFacadeSpec {
 
     @Test
     fun `creates on top of an existing a baseline file with findings`() {
-        Files.copy(validBaseline, baselineFile)
+        validBaseline.copyTo(baselineFile)
 
         BaselineFacade().createOrUpdate(baselineFile, listOf(createFinding()))
 

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineFormatSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineFormatSpec.kt
@@ -9,7 +9,7 @@ import org.assertj.core.api.Assertions.assertThatIllegalStateException
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import java.nio.file.Files
+import kotlin.io.path.readText
 
 class BaselineFormatSpec {
 
@@ -95,8 +95,7 @@ class BaselineFormatSpec {
 
             val format = BaselineFormat()
             format.write(tempFile, savedBaseline)
-            val bytes = Files.readAllBytes(tempFile)
-            val content = String(bytes, Charsets.UTF_8)
+            val content = tempFile.readText()
 
             assertThat(content).endsWith(">\n")
         }

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineResultMappingSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineResultMappingSpec.kt
@@ -17,6 +17,7 @@ import java.io.PrintStream
 import java.net.URI
 import java.nio.file.Files
 import java.nio.file.Path
+import kotlin.io.path.deleteIfExists
 
 @OptIn(UnstableApi::class)
 class BaselineResultMappingSpec {
@@ -37,7 +38,7 @@ class BaselineResultMappingSpec {
 
     @AfterEach
     fun tearDown() {
-        Files.deleteIfExists(baselineFile)
+        baselineFile.deleteIfExists()
     }
 
     @Test

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineResultMappingSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineResultMappingSpec.kt
@@ -7,7 +7,6 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.api.SetupContext
 import io.gitlab.arturbosch.detekt.api.UnstableApi
-import io.gitlab.arturbosch.detekt.core.exists
 import io.mockk.every
 import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
@@ -50,7 +49,7 @@ class BaselineResultMappingSpec {
 
         mapping.transformFindings(emptyMap())
 
-        assertThat(baselineFile.exists()).isFalse()
+        assertThat(baselineFile).doesNotExist()
     }
 
     @Test
@@ -90,7 +89,7 @@ class BaselineResultMappingSpec {
 
         mapping.transformFindings(findings)
 
-        assertThat(baselineFile.exists()).isFalse()
+        assertThat(baselineFile).doesNotExist()
     }
 
     @Test
@@ -102,7 +101,7 @@ class BaselineResultMappingSpec {
 
         mapping.transformFindings(findings)
 
-        assertThat(baselineFile.exists()).isTrue()
+        assertThat(baselineFile).exists()
     }
 
     @Test

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineResultMappingSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineResultMappingSpec.kt
@@ -15,8 +15,8 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.io.PrintStream
 import java.net.URI
-import java.nio.file.Files
 import java.nio.file.Path
+import kotlin.io.path.copyTo
 import kotlin.io.path.deleteIfExists
 
 @OptIn(UnstableApi::class)
@@ -107,7 +107,7 @@ class BaselineResultMappingSpec {
 
     @Test
     fun `should update an existing baseline file if a file is configured`() {
-        Files.copy(existingBaselineFile, baselineFile)
+        existingBaselineFile.copyTo(baselineFile)
         val existing = DefaultBaseline.load(baselineFile)
         val mapping = resultMapping(
             baselineFile = baselineFile,

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/YamlConfigSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/YamlConfigSpec.kt
@@ -14,7 +14,7 @@ import org.assertj.core.api.Assertions.assertThatIllegalStateException
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.snakeyaml.engine.v2.exceptions.ParserException
-import java.nio.file.Paths
+import kotlin.io.path.Path
 
 class YamlConfigSpec {
 
@@ -174,7 +174,7 @@ class YamlConfigSpec {
 
         @Test
         fun `throws an exception on an non-existing file`() {
-            val path = Paths.get("doesNotExist.yml")
+            val path = Path("doesNotExist.yml")
             assertThatIllegalArgumentException()
                 .isThrownBy { YamlConfig.load(path) }
                 .withMessageStartingWith("Configuration does not exist")

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/OutputReportsSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/OutputReportsSpec.kt
@@ -15,8 +15,8 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Condition
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import java.nio.file.Paths
 import java.util.function.Predicate
+import kotlin.io.path.Path
 
 class OutputReportsSpec {
 
@@ -25,11 +25,11 @@ class OutputReportsSpec {
 
         private val reportUnderTest = TestOutputReport::class.java.simpleName
         private val reports = ReportsSpecBuilder().apply {
-            report { "xml" to Paths.get("/tmp/path1") }
-            report { "txt" to Paths.get("/tmp/path2") }
-            report { reportUnderTest to Paths.get("/tmp/path3") }
-            report { "html" to Paths.get("D:_Gradle\\xxx\\xxx\\build\\reports\\detekt\\detekt.html") }
-            report { "md" to Paths.get("/tmp/path4") }
+            report { "xml" to Path("/tmp/path1") }
+            report { "txt" to Path("/tmp/path2") }
+            report { reportUnderTest to Path("/tmp/path3") }
+            report { "html" to Path("D:_Gradle\\xxx\\xxx\\build\\reports\\detekt\\detekt.html") }
+            report { "md" to Path("/tmp/path4") }
         }.build().reports.toList()
 
         @Test
@@ -41,14 +41,14 @@ class OutputReportsSpec {
         fun `it should properly parse XML report entry`() {
             val xmlReport = reports[0]
             assertThat(xmlReport.type).isEqualTo(defaultReportMapping(XmlOutputReport::class.java.simpleName))
-            assertThat(xmlReport.path).isEqualTo(Paths.get("/tmp/path1"))
+            assertThat(xmlReport.path).isEqualTo(Path("/tmp/path1"))
         }
 
         @Test
         fun `it should properly parse TXT report entry`() {
             val txtRepot = reports[1]
             assertThat(txtRepot.type).isEqualTo(defaultReportMapping(TxtOutputReport::class.java.simpleName))
-            assertThat(txtRepot.path).isEqualTo(Paths.get("/tmp/path2"))
+            assertThat(txtRepot.path).isEqualTo(Path("/tmp/path2"))
         }
 
         @Test
@@ -56,7 +56,7 @@ class OutputReportsSpec {
             val customReport = reports[2]
             assertThat(customReport.type).isEqualTo(reportUnderTest)
             assertThat(defaultReportMapping(customReport.type)).isEqualTo(reportUnderTest)
-            assertThat(customReport.path).isEqualTo(Paths.get("/tmp/path3"))
+            assertThat(customReport.path).isEqualTo(Path("/tmp/path3"))
         }
 
         @Test
@@ -64,7 +64,7 @@ class OutputReportsSpec {
             val htmlReport = reports[3]
             assertThat(htmlReport.type).isEqualTo(defaultReportMapping(HtmlOutputReport::class.java.simpleName))
             assertThat(htmlReport.path).isEqualTo(
-                Paths.get("D:_Gradle\\xxx\\xxx\\build\\reports\\detekt\\detekt.html")
+                Path("D:_Gradle\\xxx\\xxx\\build\\reports\\detekt\\detekt.html")
             )
         }
 
@@ -72,7 +72,7 @@ class OutputReportsSpec {
         fun `it should properly parse MD report entry`() {
             val mdRepot = reports[4]
             assertThat(mdRepot.type).isEqualTo(defaultReportMapping(MdOutputReport::class.java.simpleName))
-            assertThat(mdRepot.path).isEqualTo(Paths.get("/tmp/path4"))
+            assertThat(mdRepot.path).isEqualTo(Path("/tmp/path4"))
         }
 
         @Nested

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/Builders.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/Builders.kt
@@ -15,7 +15,7 @@ import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.api.TextLocation
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import org.jetbrains.kotlin.psi.KtElement
-import java.nio.file.Paths
+import kotlin.io.path.Path
 
 internal fun buildFinding(element: KtElement?): Finding = CodeSmell(
     issue = Issue("RuleName", Severity.CodeSmell, "", Debt.FIVE_MINS),
@@ -26,7 +26,7 @@ internal fun buildFinding(element: KtElement?): Finding = CodeSmell(
 private fun buildEmptyEntity(): Entity = Entity(
     name = "",
     signature = "",
-    location = Location(SourceLocation(0, 0), TextLocation(0, 0), FilePath.fromAbsolute(Paths.get("/"))),
+    location = Location(SourceLocation(0, 0), TextLocation(0, 0), FilePath.fromAbsolute(Path("/"))),
     ktElement = null,
 )
 

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/tooling/DefaultConfigProviderSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/tooling/DefaultConfigProviderSpec.kt
@@ -6,7 +6,7 @@ import io.gitlab.arturbosch.detekt.core.createNullLoggingSpec
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import java.nio.file.Files
+import kotlin.io.path.readText
 
 class DefaultConfigProviderSpec {
     @Nested
@@ -54,8 +54,8 @@ class DefaultConfigProviderSpec {
             val path = createTempFileForTest("test", "test")
             DefaultConfigProvider().apply { init(extensionsSpec) }.copy(path)
 
-            val actual = String(Files.readAllBytes(path), Charsets.UTF_8)
-            val expected = String(Files.readAllBytes(resourceAsPath("default-detekt-config.yml")), Charsets.UTF_8) +
+            val actual = path.readText()
+            val expected = resourceAsPath("default-detekt-config.yml").readText() +
                 """
                     |
                     |sample:

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingRuleSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingRuleSpec.kt
@@ -7,7 +7,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import java.nio.file.Paths
+import kotlin.io.path.Path
 
 class FormattingRuleSpec {
 
@@ -79,7 +79,7 @@ class FormattingRuleSpec {
 
     @Test
     fun `#3063_ formatting issues have an absolute path`() {
-        val expectedPath = Paths.get("/root/kotlin/test.kt").toString()
+        val expectedPath = Path("/root/kotlin/test.kt").toString()
 
         val findings = subject.lint(
             """

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/MaximumLineLengthSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/MaximumLineLengthSpec.kt
@@ -6,7 +6,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import java.nio.file.Paths
+import kotlin.io.path.Path
 
 class MaximumLineLengthSpec {
 
@@ -34,7 +34,7 @@ class MaximumLineLengthSpec {
         fun `reports issues with the filename and package as signature`() {
             val finding = subject.lint(
                 code,
-                Paths.get("home", "test", "Test.kt").toString()
+                Path("home", "test", "Test.kt").toString()
             ).first()
 
             assertThat(finding.entity.signature).isEqualTo("home.test.Test.kt:2")

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/TestFiles.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/TestFiles.kt
@@ -7,7 +7,7 @@ import io.gitlab.arturbosch.detekt.api.Finding
 import org.intellij.lang.annotations.Language
 import org.jetbrains.kotlin.com.intellij.openapi.util.text.StringUtilRt
 import java.io.File
-import java.nio.file.Paths
+import kotlin.io.path.toPath
 
 fun FormattingRule.lint(@Language("kotlin") content: String, fileName: String = "Test.kt"): List<Finding> {
     val root = compileContentForTest(content, fileName)
@@ -15,7 +15,7 @@ fun FormattingRule.lint(@Language("kotlin") content: String, fileName: String = 
     return this.findings
 }
 
-fun loadFile(resourceName: String) = compileForTest(Paths.get(resource(resourceName)))
+fun loadFile(resourceName: String) = compileForTest(resource(resourceName).toPath())
 
 fun loadFileContent(resourceName: String) =
     StringUtilRt.convertLineSeparators(File(resource(resourceName)).readText())

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/DetektPrinter.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/DetektPrinter.kt
@@ -9,7 +9,7 @@ import io.gitlab.arturbosch.detekt.generator.printer.DeprecatedPrinter
 import io.gitlab.arturbosch.detekt.generator.printer.RuleSetPagePrinter
 import io.gitlab.arturbosch.detekt.generator.printer.defaultconfig.ConfigPrinter
 import io.gitlab.arturbosch.detekt.generator.printer.defaultconfig.printRuleSetPage
-import java.nio.file.Paths
+import kotlin.io.path.Path
 
 class DetektPrinter(private val arguments: GeneratorArgs) {
 
@@ -33,17 +33,17 @@ class DetektPrinter(private val arguments: GeneratorArgs) {
             // properties from that ruleset as well.
             DeprecatedPrinter.print(pages)
         }
-        yamlWriter.write(Paths.get("../detekt-formatting/src/main/resources/config"), "config") {
+        yamlWriter.write(Path("../detekt-formatting/src/main/resources/config"), "config") {
             yaml {
                 printRuleSetPage(pages.first { it.ruleSet.name == "formatting" })
             }
         }
-        yamlWriter.write(Paths.get("../detekt-rules-libraries/src/main/resources/config"), "config") {
+        yamlWriter.write(Path("../detekt-rules-libraries/src/main/resources/config"), "config") {
             yaml {
                 printRuleSetPage(pages.first { it.ruleSet.name == "libraries" })
             }
         }
-        yamlWriter.write(Paths.get("../detekt-rules-ruleauthors/src/main/resources/config"), "config") {
+        yamlWriter.write(Path("../detekt-rules-ruleauthors/src/main/resources/config"), "config") {
             yaml {
                 printRuleSetPage(pages.first { it.ruleSet.name == "ruleauthors" })
             }
@@ -51,7 +51,7 @@ class DetektPrinter(private val arguments: GeneratorArgs) {
     }
 
     fun printCustomRuleConfig(pages: List<RuleSetPage>, folder: String) {
-        yamlWriter.write(Paths.get(folder), "config") {
+        yamlWriter.write(Path(folder), "config") {
             ConfigPrinter.printCustomRuleConfig(pages)
         }
     }

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/Generator.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/Generator.kt
@@ -7,6 +7,7 @@ import org.jetbrains.kotlin.psi.KtFile
 import java.io.PrintStream
 import java.nio.file.Files
 import java.nio.file.Path
+import kotlin.io.path.extension
 import kotlin.streams.asSequence
 import kotlin.system.measureTimeMillis
 
@@ -21,7 +22,7 @@ class Generator(
     private fun parseAll(parser: KtCompiler, root: Path): Collection<KtFile> =
         Files.walk(root)
             .asSequence()
-            .filter { it.fileName.toString().endsWith(".kt") }
+            .filter { it.extension == "kt" }
             .map { parser.compile(root, it) }
             .toList()
 

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/GeneratorArgs.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/GeneratorArgs.kt
@@ -1,9 +1,9 @@
 package io.gitlab.arturbosch.detekt.generator
 
 import com.beust.jcommander.Parameter
-import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.io.path.Path
+import kotlin.io.path.exists
 
 class GeneratorArgs {
 
@@ -56,7 +56,7 @@ class GeneratorArgs {
             .map(String::trim)
             .filter { it.isNotEmpty() }
             .map { first -> Path(first) }
-            .onEach { require(Files.exists(it)) { "Input path must exist!" } }
+            .onEach { require(it.exists()) { "Input path must exist!" } }
             .toList()
     }
     val documentationPath: Path

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/GeneratorArgs.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/GeneratorArgs.kt
@@ -3,7 +3,7 @@ package io.gitlab.arturbosch.detekt.generator
 import com.beust.jcommander.Parameter
 import java.nio.file.Files
 import java.nio.file.Path
-import java.nio.file.Paths
+import kotlin.io.path.Path
 
 class GeneratorArgs {
 
@@ -55,22 +55,22 @@ class GeneratorArgs {
             .splitToSequence(",", ";")
             .map(String::trim)
             .filter { it.isNotEmpty() }
-            .map { first -> Paths.get(first) }
+            .map { first -> Path(first) }
             .onEach { require(Files.exists(it)) { "Input path must exist!" } }
             .toList()
     }
     val documentationPath: Path
-        get() = Paths.get(
+        get() = Path(
             checkNotNull(documentation) {
                 "Documentation output path was not initialized by jcommander!"
             }
         )
 
     val configPath: Path
-        get() = Paths.get(checkNotNull(config) { "Configuration output path was not initialized by jcommander!" })
+        get() = Path(checkNotNull(config) { "Configuration output path was not initialized by jcommander!" })
 
     val cliOptionsPath: Path
-        get() = Paths.get(
+        get() = Path(
             checkNotNull(cliOptions) {
                 "Cli options output path was not initialized by jcommander!"
             }

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/Main.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/Main.kt
@@ -3,7 +3,7 @@
 package io.gitlab.arturbosch.detekt.generator
 
 import com.beust.jcommander.JCommander
-import java.nio.file.Files
+import kotlin.io.path.isDirectory
 import kotlin.system.exitProcess
 
 @Suppress("detekt.SpreadOperator")
@@ -22,8 +22,8 @@ fun main(args: Array<String>) {
         return
     }
 
-    require(Files.isDirectory(options.documentationPath)) { "Documentation path must be a directory." }
-    require(Files.isDirectory(options.configPath)) { "Config path must be a directory." }
+    require(options.documentationPath.isDirectory()) { "Documentation path must be a directory." }
+    require(options.configPath.isDirectory()) { "Config path must be a directory." }
 
     Generator(options).execute()
 }

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/out/AbstractWriter.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/out/AbstractWriter.kt
@@ -1,9 +1,9 @@
 package io.gitlab.arturbosch.detekt.generator.out
 
 import java.io.PrintStream
-import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.io.path.createDirectories
+import kotlin.io.path.exists
 import kotlin.io.path.writeText
 
 internal abstract class AbstractWriter(
@@ -15,7 +15,7 @@ internal abstract class AbstractWriter(
     fun write(path: Path, fileName: String, content: () -> String) {
         val filePath = path.resolve("$fileName.$ending")
         filePath.parent?.let { parentPath ->
-            if (!Files.exists(parentPath)) {
+            if (!parentPath.exists()) {
                 parentPath.createDirectories()
             }
         }

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/out/AbstractWriter.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/out/AbstractWriter.kt
@@ -4,6 +4,7 @@ import java.io.PrintStream
 import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.io.path.createDirectories
+import kotlin.io.path.writeText
 
 internal abstract class AbstractWriter(
     private val outputPrinter: PrintStream,
@@ -18,7 +19,7 @@ internal abstract class AbstractWriter(
                 parentPath.createDirectories()
             }
         }
-        Files.write(filePath, content().toByteArray())
+        filePath.writeText(content())
         outputPrinter.println("Wrote: $filePath")
     }
 }

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/out/AbstractWriter.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/out/AbstractWriter.kt
@@ -3,6 +3,7 @@ package io.gitlab.arturbosch.detekt.generator.out
 import java.io.PrintStream
 import java.nio.file.Files
 import java.nio.file.Path
+import kotlin.io.path.createDirectories
 
 internal abstract class AbstractWriter(
     private val outputPrinter: PrintStream,
@@ -14,7 +15,7 @@ internal abstract class AbstractWriter(
         val filePath = path.resolve("$fileName.$ending")
         filePath.parent?.let { parentPath ->
             if (!Files.exists(parentPath)) {
-                Files.createDirectories(parentPath)
+                parentPath.createDirectories()
             }
         }
         Files.write(filePath, content().toByteArray())

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/CliOptionsPrinter.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/CliOptionsPrinter.kt
@@ -2,8 +2,8 @@ package io.gitlab.arturbosch.detekt.generator.printer
 
 import com.beust.jcommander.JCommander
 import io.gitlab.arturbosch.detekt.cli.CliArgs
-import java.nio.file.Files
 import java.nio.file.Path
+import kotlin.io.path.writeText
 
 class CliOptionsPrinter {
 
@@ -12,13 +12,12 @@ class CliOptionsPrinter {
     }
 
     fun print(filePath: Path) {
-        Files.write(
-            filePath,
+        filePath.writeText(
             buildString {
                 appendLine("```")
                 jCommander.usageFormatter.usage(this)
                 appendLine("```")
-            }.toByteArray()
+            }
         )
     }
 }

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/config/DetektYmlConfigSpec.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/config/DetektYmlConfigSpec.kt
@@ -7,7 +7,7 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.Arguments.arguments
 import org.junit.jupiter.params.provider.MethodSource
-import java.nio.file.Paths
+import kotlin.io.path.Path
 
 class DetektYmlConfigSpec {
 
@@ -20,7 +20,7 @@ class DetektYmlConfigSpec {
     )
 
     private val config: YamlConfig = YamlConfig.load(
-        Paths.get("../detekt-core/src/main/resources/default-detekt-config.yml").toAbsolutePath()
+        Path("../detekt-core/src/main/resources/default-detekt-config.yml").toAbsolutePath()
     ) as YamlConfig
 
     private fun ruleSetsNamesToPackage(): List<Arguments> = listOf(

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/config/DetektYmlConfigSpec.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/config/DetektYmlConfigSpec.kt
@@ -8,6 +8,7 @@ import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.Arguments.arguments
 import org.junit.jupiter.params.provider.MethodSource
 import kotlin.io.path.Path
+import kotlin.io.path.absolute
 
 class DetektYmlConfigSpec {
 
@@ -20,7 +21,7 @@ class DetektYmlConfigSpec {
     )
 
     private val config: YamlConfig = YamlConfig.load(
-        Path("../detekt-core/src/main/resources/default-detekt-config.yml").toAbsolutePath()
+        Path("../detekt-core/src/main/resources/default-detekt-config.yml").absolute()
     ) as YamlConfig
 
     private fun ruleSetsNamesToPackage(): List<Arguments> = listOf(

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/printer/CliOptionsPrinterSpec.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/printer/CliOptionsPrinterSpec.kt
@@ -4,6 +4,7 @@ import io.github.detekt.test.utils.createTempFileForTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import kotlin.io.path.absolute
+import kotlin.io.path.readText
 
 class CliOptionsPrinterSpec {
 
@@ -11,7 +12,7 @@ class CliOptionsPrinterSpec {
     fun `prints the correct cli-options_md`() {
         val cliOptionsFile = createTempFileForTest("cli-options", ".md")
         CliOptionsPrinter().print(cliOptionsFile.absolute())
-        val markdownString = cliOptionsFile.toFile().readText()
+        val markdownString = cliOptionsFile.readText()
 
         assertThat(markdownString).contains("Usage: detekt [options]")
         assertThat(markdownString).contains("--input, -i")

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/printer/CliOptionsPrinterSpec.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/printer/CliOptionsPrinterSpec.kt
@@ -3,13 +3,14 @@ package io.gitlab.arturbosch.detekt.generator.printer
 import io.github.detekt.test.utils.createTempFileForTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import kotlin.io.path.absolute
 
 class CliOptionsPrinterSpec {
 
     @Test
     fun `prints the correct cli-options_md`() {
         val cliOptionsFile = createTempFileForTest("cli-options", ".md")
-        CliOptionsPrinter().print(cliOptionsFile.toAbsolutePath())
+        CliOptionsPrinter().print(cliOptionsFile.absolute())
         val markdownString = cliOptionsFile.toFile().readText()
 
         assertThat(markdownString).contains("Usage: detekt [options]")

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/printer/GeneratorSpec.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/printer/GeneratorSpec.kt
@@ -5,15 +5,15 @@ import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import java.io.File
-import java.nio.file.Files
 import kotlin.io.path.Path
+import kotlin.io.path.createTempDirectory
 import kotlin.io.path.readText
 
 class GeneratorSpec {
     private val configPath = "/src/main/resources/config/config.yml"
 
-    private val tempDir1: File = Files.createTempDirectory(null).toFile()
-    private val tempDir2: File = Files.createTempDirectory(null).toFile()
+    private val tempDir1: File = createTempDirectory().toFile()
+    private val tempDir2: File = createTempDirectory().toFile()
 
     @BeforeAll
     fun init() {

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/printer/GeneratorSpec.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/printer/GeneratorSpec.kt
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import java.io.File
 import java.nio.file.Files
-import java.nio.file.Paths
+import kotlin.io.path.Path
 import kotlin.io.path.readText
 
 class GeneratorSpec {
@@ -17,8 +17,8 @@ class GeneratorSpec {
 
     @BeforeAll
     fun init() {
-        Paths.get("../detekt-rules-complexity").toFile().copyRecursively(tempDir1)
-        Paths.get("../detekt-rules-coroutines").toFile().copyRecursively(tempDir2)
+        Path("../detekt-rules-complexity").toFile().copyRecursively(tempDir1)
+        Path("../detekt-rules-coroutines").toFile().copyRecursively(tempDir2)
 
         val args = arrayOf(
             "--generate-custom-rule-config",
@@ -30,17 +30,17 @@ class GeneratorSpec {
 
     @Test
     fun `config files generated successfully`() {
-        assertThat(Paths.get(tempDir1.toString(), configPath)).exists()
-        assertThat(Paths.get(tempDir2.toString(), configPath)).exists()
+        assertThat(Path(tempDir1.toString(), configPath)).exists()
+        assertThat(Path(tempDir2.toString(), configPath)).exists()
     }
 
     @Test
     fun `config files have their own content`() {
-        assertThat(Paths.get(tempDir1.toString(), configPath).readText())
+        assertThat(Path(tempDir1.toString(), configPath).readText())
             .contains("complexity:")
             .doesNotContain("coroutines:")
 
-        assertThat(Paths.get(tempDir2.toString(), configPath).readText())
+        assertThat(Path(tempDir2.toString(), configPath).readText())
             .contains("coroutines:")
             .doesNotContain("complexity:")
     }

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/printer/RuleSetPagePrinterSpec.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/printer/RuleSetPagePrinterSpec.kt
@@ -1,17 +1,17 @@
 package io.gitlab.arturbosch.detekt.generator.printer
 
-import io.github.detekt.test.utils.resource
+import io.github.detekt.test.utils.resourceAsPath
 import io.gitlab.arturbosch.detekt.generator.util.createRuleSetPage
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import java.io.File
+import kotlin.io.path.readText
 
 class RuleSetPagePrinterSpec {
 
     @Test
     fun `prints the correct markdown format`() {
         val markdownString = RuleSetPagePrinter.print(createRuleSetPage())
-        val expectedMarkdownString = File(resource("/RuleSet.md")).readText()
+        val expectedMarkdownString = resourceAsPath("/RuleSet.md").readText()
         assertThat(markdownString).isEqualTo(expectedMarkdownString)
     }
 }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/report/ReportMergeTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/report/ReportMergeTask.kt
@@ -27,13 +27,13 @@ abstract class ReportMergeTask : DefaultTask() {
         logger.info(input.files.joinToString(separator = "\n") { it.absolutePath })
         logger.info("Output = ${output.get().asFile.absolutePath}")
         val existingFiles = input.files.filter { it.exists() }
-        fun isXmlReport(file: File): Boolean = file.name.endsWith(".xml")
+        fun isXmlReport(file: File): Boolean = file.extension == "xml"
         if (existingFiles.any(::isXmlReport)) {
             XmlReportMerger.merge(existingFiles.filter(::isXmlReport), output.get().asFile)
             logger.lifecycle("Merged XML output to ${output.get().asFile.absolutePath}")
         }
 
-        fun isSarifReport(file: File): Boolean = file.name.endsWith(".sarif") ||
+        fun isSarifReport(file: File): Boolean = file.extension == "sarif" ||
             file.name.endsWith(".sarif.json")
         if (existingFiles.any(::isSarifReport)) {
             SarifReportMerger.merge(existingFiles.filter(::isSarifReport), output.get().asFile)

--- a/detekt-parser/src/main/kotlin/io/github/detekt/parser/KtCompiler.kt
+++ b/detekt-parser/src/main/kotlin/io/github/detekt/parser/KtCompiler.kt
@@ -7,9 +7,9 @@ import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.jetbrains.kotlin.com.intellij.openapi.util.text.StringUtilRt
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtPsiFactory
-import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.io.path.absolute
+import kotlin.io.path.isRegularFile
 import kotlin.io.path.readText
 
 open class KtCompiler(
@@ -19,13 +19,13 @@ open class KtCompiler(
     protected val psiFileFactory = KtPsiFactory(environment.project, markGenerated = false)
 
     fun compile(basePath: Path?, path: Path): KtFile {
-        require(Files.isRegularFile(path)) { "Given sub path ($path) should be a regular file!" }
+        require(path.isRegularFile()) { "Given sub path ($path) should be a regular file!" }
         val content = path.readText()
         return createKtFile(content, basePath, path)
     }
 
     fun createKtFile(content: String, basePath: Path?, path: Path): KtFile {
-        require(Files.isRegularFile(path)) { "Given sub path ($path) should be a regular file!" }
+        require(path.isRegularFile()) { "Given sub path ($path) should be a regular file!" }
 
         val normalizedAbsolutePath = path.absolute().normalize()
         val lineSeparator = content.determineLineSeparator()

--- a/detekt-parser/src/main/kotlin/io/github/detekt/parser/KtCompiler.kt
+++ b/detekt-parser/src/main/kotlin/io/github/detekt/parser/KtCompiler.kt
@@ -9,6 +9,7 @@ import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtPsiFactory
 import java.nio.file.Files
 import java.nio.file.Path
+import kotlin.io.path.absolute
 
 open class KtCompiler(
     protected val environment: KotlinCoreEnvironment = createKotlinCoreEnvironment(printStream = System.err)
@@ -25,7 +26,7 @@ open class KtCompiler(
     fun createKtFile(content: String, basePath: Path?, path: Path): KtFile {
         require(Files.isRegularFile(path)) { "Given sub path ($path) should be a regular file!" }
 
-        val normalizedAbsolutePath = path.toAbsolutePath().normalize()
+        val normalizedAbsolutePath = path.absolute().normalize()
         val lineSeparator = content.determineLineSeparator()
 
         val psiFile = psiFileFactory.createPhysicalFile(
@@ -35,9 +36,9 @@ open class KtCompiler(
 
         return psiFile.apply {
             putUserData(LINE_SEPARATOR, lineSeparator)
-            val normalizedBasePath = basePath?.toAbsolutePath()?.normalize()
+            val normalizedBasePath = basePath?.absolute()?.normalize()
             normalizedBasePath?.relativize(normalizedAbsolutePath)?.let { relativePath ->
-                putUserData(BASE_PATH, normalizedBasePath.toAbsolutePath().toString())
+                putUserData(BASE_PATH, normalizedBasePath.absolute().toString())
                 putUserData(RELATIVE_PATH, relativePath.toString())
             }
         }

--- a/detekt-parser/src/main/kotlin/io/github/detekt/parser/KtCompiler.kt
+++ b/detekt-parser/src/main/kotlin/io/github/detekt/parser/KtCompiler.kt
@@ -10,6 +10,7 @@ import org.jetbrains.kotlin.psi.KtPsiFactory
 import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.io.path.absolute
+import kotlin.io.path.readText
 
 open class KtCompiler(
     protected val environment: KotlinCoreEnvironment = createKotlinCoreEnvironment(printStream = System.err)
@@ -19,7 +20,7 @@ open class KtCompiler(
 
     fun compile(basePath: Path?, path: Path): KtFile {
         require(Files.isRegularFile(path)) { "Given sub path ($path) should be a regular file!" }
-        val content = path.toFile().readText()
+        val content = path.readText()
         return createKtFile(content, basePath, path)
     }
 

--- a/detekt-psi-utils/src/main/kotlin/io/github/detekt/psi/KtFiles.kt
+++ b/detekt-psi-utils/src/main/kotlin/io/github/detekt/psi/KtFiles.kt
@@ -7,6 +7,7 @@ import org.jetbrains.kotlin.diagnostics.PsiDiagnosticUtils
 import java.io.File
 import java.nio.file.Path
 import kotlin.io.path.Path
+import kotlin.io.path.invariantSeparatorsPathString
 
 const val KOTLIN_SUFFIX = ".kt"
 const val KOTLIN_SCRIPT_SUFFIX = ".kts"
@@ -82,4 +83,8 @@ fun getLineAndColumnInPsiFile(file: PsiFile, range: TextRange): PsiDiagnosticUti
 /**
  * Returns a system-independent string with UNIX system file separator.
  */
-fun Path.toUnifiedString(): String = toString().replace(File.separatorChar, '/')
+@Deprecated(
+    "Use stdlib method",
+    ReplaceWith("invariantSeparatorsPathString", "kotlin.io.path.invariantSeparatorsPathString")
+)
+fun Path.toUnifiedString(): String = invariantSeparatorsPathString

--- a/detekt-psi-utils/src/main/kotlin/io/github/detekt/psi/KtFiles.kt
+++ b/detekt-psi-utils/src/main/kotlin/io/github/detekt/psi/KtFiles.kt
@@ -6,7 +6,7 @@ import org.jetbrains.kotlin.diagnostics.DiagnosticUtils
 import org.jetbrains.kotlin.diagnostics.PsiDiagnosticUtils
 import java.io.File
 import java.nio.file.Path
-import java.nio.file.Paths
+import kotlin.io.path.Path
 
 const val KOTLIN_SUFFIX = ".kt"
 const val KOTLIN_SCRIPT_SUFFIX = ".kts"
@@ -22,11 +22,11 @@ fun PsiFile.fileNameWithoutSuffix(): String {
     return fileName.removeSuffix(KOTLIN_SUFFIX)
 }
 
-fun PsiFile.absolutePath(): Path = Paths.get(name)
+fun PsiFile.absolutePath(): Path = Path(name)
 
-fun PsiFile.relativePath(): Path? = getUserData(RELATIVE_PATH)?.let { Paths.get(it) }
+fun PsiFile.relativePath(): Path? = getUserData(RELATIVE_PATH)?.let { Path(it) }
 
-fun PsiFile.basePath(): Path? = getUserData(BASE_PATH)?.let { Paths.get(it) }
+fun PsiFile.basePath(): Path? = getUserData(BASE_PATH)?.let { Path(it) }
 
 /**
  * Represents both absolute path and relative path if available.

--- a/detekt-report-html/src/main/kotlin/io/github/detekt/report/html/HtmlOutputReport.kt
+++ b/detekt-report-html/src/main/kotlin/io/github/detekt/report/html/HtmlOutputReport.kt
@@ -1,7 +1,6 @@
 package io.github.detekt.report.html
 
 import io.github.detekt.metrics.ComplexityReportGenerator
-import io.github.detekt.psi.toUnifiedString
 import io.github.detekt.utils.openSafeStream
 import io.gitlab.arturbosch.detekt.api.Detektion
 import io.gitlab.arturbosch.detekt.api.Finding
@@ -30,6 +29,7 @@ import java.time.OffsetDateTime
 import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 import java.util.Locale
+import kotlin.io.path.invariantSeparatorsPathString
 
 private const val DEFAULT_TEMPLATE = "default-html-report-template.html"
 private const val PLACEHOLDER_METRICS = "@@@metrics@@@"
@@ -141,8 +141,11 @@ class HtmlOutputReport : OutputReport() {
 
     private fun FlowContent.renderFinding(finding: Finding) {
         val filePath = finding.location.filePath.relativePath ?: finding.location.filePath.absolutePath
+        val pathString = filePath.invariantSeparatorsPathString
         span("location") {
-            text("${filePath.toUnifiedString()}:${finding.location.source.line}:${finding.location.source.column}")
+            text(
+                "$pathString:${finding.location.source.line}:${finding.location.source.column}"
+            )
         }
 
         if (finding.message.isNotEmpty()) {

--- a/detekt-report-html/src/test/kotlin/io/github/detekt/report/html/HtmlOutputReportSpec.kt
+++ b/detekt-report-html/src/test/kotlin/io/github/detekt/report/html/HtmlOutputReportSpec.kt
@@ -22,8 +22,8 @@ import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.com.intellij.psi.PsiFile
 import org.jetbrains.kotlin.psi.KtElement
 import org.junit.jupiter.api.Test
-import java.nio.file.Files
 import java.nio.file.Path
+import kotlin.io.path.writeText
 
 class HtmlOutputReportSpec {
 
@@ -175,7 +175,7 @@ class HtmlOutputReportSpec {
         result = generatedRegex.replace(result, replacement)
 
         val actual = createTempFileForTest("actual-report", ".html")
-        Files.write(actual, result.toByteArray())
+        actual.writeText(result)
 
         assertThat(actual).hasSameTextualContentAs(expected)
     }
@@ -294,6 +294,6 @@ private fun createReportWithFindings(findings: Array<Pair<String, List<Finding>>
     var result = htmlReport.render(detektion)
     result = generatedRegex.replace(result, replacement)
     val reportPath = createTempFileForTest("report", ".html")
-    Files.write(reportPath, result.toByteArray())
+    reportPath.writeText(result)
     return reportPath
 }

--- a/detekt-report-md/src/main/kotlin/io/github/detekt/report/md/MdOutputReport.kt
+++ b/detekt-report-md/src/main/kotlin/io/github/detekt/report/md/MdOutputReport.kt
@@ -1,7 +1,6 @@
 package io.github.detekt.report.md
 
 import io.github.detekt.metrics.ComplexityReportGenerator
-import io.github.detekt.psi.toUnifiedString
 import io.github.detekt.utils.MarkdownContent
 import io.github.detekt.utils.codeBlock
 import io.github.detekt.utils.emptyLine
@@ -22,6 +21,7 @@ import java.time.OffsetDateTime
 import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 import java.util.Locale
+import kotlin.io.path.invariantSeparatorsPathString
 import kotlin.math.max
 import kotlin.math.min
 
@@ -129,7 +129,8 @@ private fun MarkdownContent.renderFindings(findings: Map<String, List<Finding>>)
 
 private fun MarkdownContent.renderFinding(finding: Finding): String {
     val filePath = finding.location.filePath.relativePath ?: finding.location.filePath.absolutePath
-    val location = "${filePath.toUnifiedString()}:${finding.location.source.line}:${finding.location.source.column}"
+    val location =
+        "${filePath.invariantSeparatorsPathString}:${finding.location.source.line}:${finding.location.source.column}"
 
     val message = if (finding.message.isNotEmpty()) {
         codeBlock("") { finding.message }

--- a/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/Results.kt
+++ b/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/Results.kt
@@ -1,6 +1,5 @@
 package io.github.detekt.report.sarif
 
-import io.github.detekt.psi.toUnifiedString
 import io.github.detekt.sarif4k.ArtifactLocation
 import io.github.detekt.sarif4k.Level
 import io.github.detekt.sarif4k.Message
@@ -11,6 +10,7 @@ import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.api.Location
 import io.gitlab.arturbosch.detekt.api.RuleSetId
 import io.gitlab.arturbosch.detekt.api.SeverityLevel
+import kotlin.io.path.invariantSeparatorsPathString
 
 internal fun toResults(detektion: Detektion): List<io.github.detekt.sarif4k.Result> =
     detektion.findings.flatMap { (ruleSetId, findings) ->
@@ -54,11 +54,11 @@ private fun Location.toLocation(code: String?): io.github.detekt.sarif4k.Locatio
             ),
             artifactLocation = if (filePath.relativePath != null) {
                 ArtifactLocation(
-                    uri = filePath.relativePath?.toUnifiedString(),
+                    uri = filePath.relativePath?.invariantSeparatorsPathString,
                     uriBaseID = SRCROOT
                 )
             } else {
-                ArtifactLocation(uri = filePath.absolutePath.toUnifiedString())
+                ArtifactLocation(uri = filePath.absolutePath.invariantSeparatorsPathString)
             }
         )
     )

--- a/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/SarifOutputReport.kt
+++ b/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/SarifOutputReport.kt
@@ -17,6 +17,7 @@ import io.gitlab.arturbosch.detekt.api.UnstableApi
 import io.gitlab.arturbosch.detekt.api.getOrNull
 import io.gitlab.arturbosch.detekt.api.internal.whichDetekt
 import java.nio.file.Path
+import kotlin.io.path.absolute
 
 const val DETEKT_OUTPUT_REPORT_BASE_PATH_KEY = "detekt.output.report.base.path"
 const val SRCROOT = "%SRCROOT%"
@@ -34,7 +35,7 @@ class SarifOutputReport : OutputReport() {
     override fun init(context: SetupContext) {
         this.config = context.config
         this.basePath = context.getOrNull<Path>(DETEKT_OUTPUT_REPORT_BASE_PATH_KEY)
-            ?.toAbsolutePath()
+            ?.absolute()
             ?.toUnifiedString()
             ?.let {
                 if (!it.endsWith("/")) "$it/" else it

--- a/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/SarifOutputReport.kt
+++ b/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/SarifOutputReport.kt
@@ -1,6 +1,5 @@
 package io.github.detekt.report.sarif
 
-import io.github.detekt.psi.toUnifiedString
 import io.github.detekt.sarif4k.ArtifactLocation
 import io.github.detekt.sarif4k.Run
 import io.github.detekt.sarif4k.SarifSchema210
@@ -18,6 +17,7 @@ import io.gitlab.arturbosch.detekt.api.getOrNull
 import io.gitlab.arturbosch.detekt.api.internal.whichDetekt
 import java.nio.file.Path
 import kotlin.io.path.absolute
+import kotlin.io.path.invariantSeparatorsPathString
 
 const val DETEKT_OUTPUT_REPORT_BASE_PATH_KEY = "detekt.output.report.base.path"
 const val SRCROOT = "%SRCROOT%"
@@ -36,7 +36,7 @@ class SarifOutputReport : OutputReport() {
         this.config = context.config
         this.basePath = context.getOrNull<Path>(DETEKT_OUTPUT_REPORT_BASE_PATH_KEY)
             ?.absolute()
-            ?.toUnifiedString()
+            ?.invariantSeparatorsPathString
             ?.let {
                 if (!it.endsWith("/")) "$it/" else it
             }

--- a/detekt-report-sarif/src/test/kotlin/io/github/detekt/report/sarif/SarifOutputReportSpec.kt
+++ b/detekt-report-sarif/src/test/kotlin/io/github/detekt/report/sarif/SarifOutputReportSpec.kt
@@ -24,7 +24,7 @@ import io.gitlab.arturbosch.detekt.test.createIssue
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.junit.jupiter.api.Test
-import java.nio.file.Paths
+import kotlin.io.path.Path
 
 @OptIn(UnstableApi::class)
 class SarifOutputReportSpec {
@@ -57,7 +57,7 @@ class SarifOutputReportSpec {
             .apply {
                 init(
                     EmptySetupContext().apply {
-                        register(DETEKT_OUTPUT_REPORT_BASE_PATH_KEY, Paths.get(basePath))
+                        register(DETEKT_OUTPUT_REPORT_BASE_PATH_KEY, Path(basePath))
                     }
                 )
             }
@@ -68,7 +68,7 @@ class SarifOutputReportSpec {
 
         // Note: Github CI uses D: drive, but it could be any drive for local development
         val systemAwareExpectedReport = if (whichOS().startsWith("windows", ignoreCase = true)) {
-            val winRoot = Paths.get("/").toAbsolutePath().toString().replace("\\", "/")
+            val winRoot = Path("/").toAbsolutePath().toString().replace("\\", "/")
             expectedReport.replace("file:///", "file://$winRoot")
         } else {
             expectedReport

--- a/detekt-report-sarif/src/test/kotlin/io/github/detekt/report/sarif/SarifOutputReportSpec.kt
+++ b/detekt-report-sarif/src/test/kotlin/io/github/detekt/report/sarif/SarifOutputReportSpec.kt
@@ -25,6 +25,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.junit.jupiter.api.Test
 import kotlin.io.path.Path
+import kotlin.io.path.absolutePathString
 
 @OptIn(UnstableApi::class)
 class SarifOutputReportSpec {
@@ -68,7 +69,7 @@ class SarifOutputReportSpec {
 
         // Note: Github CI uses D: drive, but it could be any drive for local development
         val systemAwareExpectedReport = if (whichOS().startsWith("windows", ignoreCase = true)) {
-            val winRoot = Path("/").toAbsolutePath().toString().replace("\\", "/")
+            val winRoot = Path("/").absolutePathString().replace("\\", "/")
             expectedReport.replace("file:///", "file://$winRoot")
         } else {
             expectedReport

--- a/detekt-report-xml/src/main/kotlin/io/github/detekt/report/xml/XmlOutputReport.kt
+++ b/detekt-report-xml/src/main/kotlin/io/github/detekt/report/xml/XmlOutputReport.kt
@@ -1,10 +1,10 @@
 package io.github.detekt.report.xml
 
-import io.github.detekt.psi.toUnifiedString
 import io.gitlab.arturbosch.detekt.api.Detektion
 import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.api.OutputReport
 import java.util.Locale
+import kotlin.io.path.invariantSeparatorsPathString
 
 /**
  * Contains rule violations in an XML format. The report follows the structure of a Checkstyle report.
@@ -28,7 +28,7 @@ class XmlOutputReport : OutputReport() {
 
         smells.groupBy { it.location.filePath.relativePath ?: it.location.filePath.absolutePath }
             .forEach { (filePath, findings) ->
-                lines += "<file name=\"${filePath.toUnifiedString().toXmlString()}\">"
+                lines += "<file name=\"${filePath.invariantSeparatorsPathString.toXmlString()}\">"
                 findings.forEach {
                     lines += arrayOf(
                         "\t<error line=\"${it.location.source.line.toXmlString()}\"",

--- a/detekt-report-xml/src/test/kotlin/io/github/detekt/report/xml/XmlOutputFormatSpec.kt
+++ b/detekt-report-xml/src/test/kotlin/io/github/detekt/report/xml/XmlOutputFormatSpec.kt
@@ -19,8 +19,8 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
-import java.nio.file.Paths
 import java.util.Locale
+import kotlin.io.path.Path
 
 private const val TAB = "\t"
 
@@ -32,7 +32,7 @@ class XmlOutputFormatSpec {
         Location(
             SourceLocation(11, 1),
             TextLocation(0, 10),
-            FilePath.fromAbsolute(Paths.get("src/main/com/sample/Sample1.kt"))
+            FilePath.fromAbsolute(Path("src/main/com/sample/Sample1.kt"))
         )
     )
     private val entity2 = Entity(
@@ -41,7 +41,7 @@ class XmlOutputFormatSpec {
         Location(
             SourceLocation(22, 2),
             TextLocation(0, 20),
-            FilePath.fromAbsolute(Paths.get("src/main/com/sample/Sample2.kt"))
+            FilePath.fromAbsolute(Path("src/main/com/sample/Sample2.kt"))
         )
     )
     private val outputFormat = XmlOutputReport()

--- a/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/LicenceHeaderLoaderExtension.kt
+++ b/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/LicenceHeaderLoaderExtension.kt
@@ -14,10 +14,10 @@ import org.jetbrains.kotlin.com.intellij.openapi.util.Key
 import org.jetbrains.kotlin.com.intellij.openapi.util.text.StringUtilRt
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.resolve.BindingContext
-import java.io.BufferedReader
 import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.io.path.absolute
+import kotlin.io.path.readText
 import kotlin.io.path.toPath
 
 @OptIn(UnstableApi::class)
@@ -58,9 +58,7 @@ class LicenceHeaderLoaderExtension : FileProcessListener {
                 """.trimIndent()
             }
 
-            return Files.newBufferedReader(templateFile)
-                .use(BufferedReader::readText)
-                .convertLineSeparators()
+            return templateFile.readText().convertLineSeparators()
         }
 
         fun cacheLicence(dir: Path, isRegexTemplate: Boolean) {

--- a/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/LicenceHeaderLoaderExtension.kt
+++ b/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/LicenceHeaderLoaderExtension.kt
@@ -14,9 +14,9 @@ import org.jetbrains.kotlin.com.intellij.openapi.util.Key
 import org.jetbrains.kotlin.com.intellij.openapi.util.text.StringUtilRt
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.resolve.BindingContext
-import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.io.path.absolute
+import kotlin.io.path.exists
 import kotlin.io.path.readText
 import kotlin.io.path.toPath
 
@@ -51,7 +51,7 @@ class LicenceHeaderLoaderExtension : FileProcessListener {
         fun loadLicence(dir: Path): String {
             val templateFile = dir.resolve(getPathToTemplate())
 
-            require(Files.exists(templateFile)) {
+            require(templateFile.exists()) {
                 """
                     Rule '$RULE_NAME': License template file not found at `${templateFile.absolute()}`.
                     Create file license header file or check your running path.

--- a/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/LicenceHeaderLoaderExtension.kt
+++ b/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/LicenceHeaderLoaderExtension.kt
@@ -17,6 +17,7 @@ import org.jetbrains.kotlin.resolve.BindingContext
 import java.io.BufferedReader
 import java.nio.file.Files
 import java.nio.file.Path
+import kotlin.io.path.absolute
 import kotlin.io.path.toPath
 
 @OptIn(UnstableApi::class)
@@ -52,7 +53,7 @@ class LicenceHeaderLoaderExtension : FileProcessListener {
 
             require(Files.exists(templateFile)) {
                 """
-                    Rule '$RULE_NAME': License template file not found at `${templateFile.toAbsolutePath()}`.
+                    Rule '$RULE_NAME': License template file not found at `${templateFile.absolute()}`.
                     Create file license header file or check your running path.
                 """.trimIndent()
             }

--- a/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/LicenceHeaderLoaderExtension.kt
+++ b/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/LicenceHeaderLoaderExtension.kt
@@ -17,7 +17,7 @@ import org.jetbrains.kotlin.resolve.BindingContext
 import java.io.BufferedReader
 import java.nio.file.Files
 import java.nio.file.Path
-import java.nio.file.Paths
+import kotlin.io.path.toPath
 
 @OptIn(UnstableApi::class)
 class LicenceHeaderLoaderExtension : FileProcessListener {
@@ -27,7 +27,7 @@ class LicenceHeaderLoaderExtension : FileProcessListener {
 
     override fun init(context: SetupContext) {
         this.config = context.config
-        this.configPath = context.configUris.lastOrNull()?.let(Paths::get)
+        this.configPath = context.configUris.lastOrNull()?.toPath()
     }
 
     override fun onStart(files: List<KtFile>, bindingContext: BindingContext) {

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/InvalidPackageDeclarationSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/InvalidPackageDeclarationSpec.kt
@@ -7,7 +7,7 @@ import io.gitlab.arturbosch.detekt.test.lint
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import java.nio.file.FileSystems
-import java.nio.file.Paths
+import kotlin.io.path.Path
 
 private const val ROOT_PACKAGE = "rootPackage"
 private const val REQUIRE_ROOT_PACKAGE = "requireRootInDeclaration"
@@ -173,6 +173,6 @@ class InvalidPackageDeclarationSpec {
 private fun createPath(universalPath: String): String {
     val pathSegments = universalPath.split('/')
     val aRootPath = FileSystems.getDefault().rootDirectories.first()
-    val path = Paths.get(aRootPath.toString(), *pathSegments.toTypedArray())
+    val path = Path(aRootPath.toString(), *pathSegments.toTypedArray())
     return path.toString()
 }

--- a/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/FileExtension.kt
+++ b/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/FileExtension.kt
@@ -1,7 +1,8 @@
 package io.github.detekt.test.utils
 
-import java.nio.file.Files
 import java.nio.file.Path
+import kotlin.io.path.createTempDirectory
+import kotlin.io.path.createTempFile
 
 /**
  * Creates an empty file in the default temporary-file directory, using
@@ -9,7 +10,7 @@ import java.nio.file.Path
  * The resulting file in the returned path is automatically deleted on JVM exit.
  */
 fun createTempFileForTest(prefix: String, suffix: String): Path {
-    val path = Files.createTempFile(prefix, suffix)
+    val path = createTempFile(prefix, suffix)
     path.toFile().deleteOnExit()
     return path
 }
@@ -20,7 +21,7 @@ fun createTempFileForTest(prefix: String, suffix: String): Path {
  * The resulting directory in the returned path is automatically deleted on JVM exit.
  */
 fun createTempDirectoryForTest(prefix: String): Path {
-    val dir = Files.createTempDirectory(prefix)
+    val dir = createTempDirectory(prefix)
     dir.toFile().deleteOnExit()
     return dir
 }

--- a/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/Resources.kt
+++ b/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/Resources.kt
@@ -4,7 +4,7 @@ import java.net.URI
 import java.net.URL
 import java.nio.file.Files
 import java.nio.file.Path
-import java.nio.file.Paths
+import kotlin.io.path.toPath
 
 internal object Resources
 
@@ -15,7 +15,7 @@ fun resourceUrl(name: String): URL {
 
 fun resource(name: String): URI = resourceUrl(name).toURI()
 
-fun resourceAsPath(name: String): Path = Paths.get(resource(name))
+fun resourceAsPath(name: String): Path = resource(name).toPath()
 
 fun readResourceContent(name: String): String {
     val path = resourceAsPath(name)

--- a/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/Resources.kt
+++ b/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/Resources.kt
@@ -2,8 +2,8 @@ package io.github.detekt.test.utils
 
 import java.net.URI
 import java.net.URL
-import java.nio.file.Files
 import java.nio.file.Path
+import kotlin.io.path.readLines
 import kotlin.io.path.toPath
 
 internal object Resources
@@ -19,5 +19,5 @@ fun resourceAsPath(name: String): Path = resource(name).toPath()
 
 fun readResourceContent(name: String): String {
     val path = resourceAsPath(name)
-    return Files.readAllLines(path).joinToString("\n") + "\n"
+    return path.readLines().joinToString("\n") + "\n"
 }

--- a/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/internal/PluginsHolder.kt
+++ b/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/internal/PluginsHolder.kt
@@ -1,8 +1,8 @@
 package io.github.detekt.tooling.internal
 
 import io.github.detekt.tooling.api.spec.ExtensionsSpec
-import java.nio.file.Files
 import java.nio.file.Path
+import kotlin.io.path.exists
 
 internal data class PluginsHolder(
     override val paths: Collection<Path>?,
@@ -11,6 +11,6 @@ internal data class PluginsHolder(
 
     init {
         require(paths == null || loader == null) { "Either paths or loader must be specified, not both." }
-        paths?.forEach { require(Files.exists(it)) { "Plugin jar '$it' does not exist." } }
+        paths?.forEach { require(it.exists()) { "Plugin jar '$it' does not exist." } }
     }
 }

--- a/detekt-tooling/src/test/kotlin/io/github/detekt/tooling/api/PluginsSpec.kt
+++ b/detekt-tooling/src/test/kotlin/io/github/detekt/tooling/api/PluginsSpec.kt
@@ -4,7 +4,7 @@ import io.github.detekt.tooling.dsl.ExtensionsSpecBuilder
 import io.github.detekt.tooling.internal.PluginsHolder
 import org.assertj.core.api.Assertions.assertThatCode
 import org.junit.jupiter.api.Test
-import java.nio.file.Paths
+import kotlin.io.path.Path
 
 class PluginsSpec {
 
@@ -33,7 +33,7 @@ class PluginsSpec {
 
     @Test
     fun `plugins from paths must exist`() {
-        assertThatCode { PluginsHolder(listOf(Paths.get("/does/not/exist")), null) }
+        assertThatCode { PluginsHolder(listOf(Path("/does/not/exist")), null) }
             .isInstanceOf(IllegalArgumentException::class.java)
     }
 }


### PR DESCRIPTION
I set out to remove these imports and use replacements from stdlib:
* `java.io.File`
* `java.nio.file.Files`
* `java.nio.file.Paths`

I was mostly successful, held back by the detekt-gradle-plugin being on API version 1.4, and a couple of stdlib functions which still require an opt in. I chose not to use the opt in functions until they're stable, hopefully in Kotlin 1.9 if not before.

I recommend reviewing by individual commit as I've broken up the changes into logical chunks.