### PR TITLE
Replace java.util.Stack with Kotlin's ArrayDeque implementation

### DIFF
--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/IndentingXMLStreamWriter.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/IndentingXMLStreamWriter.kt
@@ -1,6 +1,5 @@
 package io.gitlab.arturbosch.detekt.core.baseline
 
-import java.util.Stack
 import javax.xml.stream.XMLStreamWriter
 
 @Suppress("TooManyFunctions")
@@ -10,12 +9,12 @@ internal class IndentingXMLStreamWriter(
 ) : XMLStreamWriter by writer {
 
     private var currentState = NOTHING
-    private val stateStack = Stack<Any>()
+    private val stateStack = ArrayDeque<Any>()
 
     private var indentationDepth = 0
 
     private fun onStartTag() {
-        stateStack.push(TAG)
+        stateStack.addFirst(TAG)
         currentState = NOTHING
         writeNL()
         writeIndent()
@@ -28,7 +27,7 @@ internal class IndentingXMLStreamWriter(
             writer.writeCharacters("\n")
             writeIndent()
         }
-        currentState = stateStack.pop()
+        currentState = stateStack.removeFirst()
     }
 
     private fun onEmptyTag() {


### PR DESCRIPTION
From `java.util.Stack` Javadoc:

> A more complete and consistent set of LIFO stack operations is provided by the [Deque](https://docs.oracle.com/javase/8/docs/api/java/util/Deque.html) interface and its implementations, which should be used in preference to this class.

I've used Kotlin's implementation instead of a Java implementation.