### PR TITLE
Docs: Add missing `File.absolutePath` call in Kotlin DSL sample

### DIFF
--- a/website/docs/gettingstarted/gradle.mdx
+++ b/website/docs/gettingstarted/gradle.mdx
@@ -291,7 +291,7 @@ detekt {
     
     // Specify the base path for file paths in the formatted reports. 
     // If not set, all file paths reported will be absolute file path.
-    basePath = projectDir
+    basePath = projectDir.absolutePath
 }
 ```
 


### PR DESCRIPTION
Not sure if this is also necessary in Groovy as I've never used it.