### PR TITLE
Compile detekt-compiler-plugin against standard Kotlin compiler artifact

### DIFF
--- a/detekt-compiler-plugin/build.gradle.kts
+++ b/detekt-compiler-plugin/build.gradle.kts
@@ -19,11 +19,6 @@ plugins {
     alias(libs.plugins.download)
 }
 
-repositories {
-    mavenCentral()
-    mavenLocal()
-}
-
 dependencies {
     compileOnly(kotlin("stdlib"))
     compileOnly(libs.kotlin.compiler)

--- a/detekt-compiler-plugin/build.gradle.kts
+++ b/detekt-compiler-plugin/build.gradle.kts
@@ -26,7 +26,7 @@ repositories {
 
 dependencies {
     compileOnly(kotlin("stdlib"))
-    compileOnly(kotlin("compiler-embeddable"))
+    compileOnly(libs.kotlin.compiler)
 
     implementation(projects.detektApi)
     implementation(projects.detektTooling)
@@ -35,6 +35,7 @@ dependencies {
 
     testImplementation(libs.assertj)
     testImplementation(libs.kotlinCompileTesting)
+    testImplementation(libs.kotlin.compilerEmbeddable)
 }
 
 val javaComponent = components["java"] as AdhocComponentWithVariants

--- a/detekt-compiler-plugin/build.gradle.kts
+++ b/detekt-compiler-plugin/build.gradle.kts
@@ -20,7 +20,6 @@ plugins {
 }
 
 dependencies {
-    compileOnly(kotlin("stdlib"))
     compileOnly(libs.kotlin.compiler)
 
     implementation(projects.detektApi)

--- a/detekt-compiler-plugin/src/main/kotlin/io/github/detekt/compiler/plugin/DetektAnalysisExtension.kt
+++ b/detekt-compiler-plugin/src/main/kotlin/io/github/detekt/compiler/plugin/DetektAnalysisExtension.kt
@@ -1,11 +1,11 @@
 package io.github.detekt.compiler.plugin
 
+import com.intellij.openapi.project.Project
 import io.github.detekt.compiler.plugin.internal.DetektService
 import io.github.detekt.compiler.plugin.internal.info
 import io.github.detekt.tooling.api.spec.ProcessingSpec
 import org.jetbrains.kotlin.analyzer.AnalysisResult
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
-import org.jetbrains.kotlin.com.intellij.openapi.project.Project
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.resolve.BindingTrace

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ githubRelease-gradle = "com.github.breadmoirai:github-release:2.4.1"
 nexusPublish-gradle = "io.github.gradle-nexus:publish-plugin:1.1.0"
 semver4j-gradle = "com.vdurmont:semver4j:3.1.0"
 
+kotlin-compiler = { module = "org.jetbrains.kotlin:kotlin-compiler", version.ref = "kotlin" }
 kotlin-compilerEmbeddable = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable", version.ref = "kotlin" }
 kotlin-gradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 kotlin-gradlePluginApi = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin-api", version.ref = "kotlin" }


### PR DESCRIPTION
There's little point compiling against compiler-embeddable and then relocating compiled classes when the `shadowJar` task runs.