### PR TITLE
Run Kotlin compiler plugin CLI test as part of standard build

### DIFF
--- a/detekt-compiler-plugin/build.gradle.kts
+++ b/detekt-compiler-plugin/build.gradle.kts
@@ -114,3 +114,7 @@ val testPluginKotlinc by tasks.registering(RunTestExecutable::class) {
         (this as RunTestExecutable).executionResult.get().assertNormalExitValue()
     }
 }
+
+tasks.check {
+    dependsOn(testPluginKotlinc)
+}


### PR DESCRIPTION
This will add a little time to the CI build times, but will reduce the risk of the task failing in future.

Follow up to #5731/#5732
