### PR TITLE
Fix generateDocumentation implicit dependencies

### DIFF
--- a/build-logic/src/main/kotlin/ConsumeGeneratedConfig.kt
+++ b/build-logic/src/main/kotlin/ConsumeGeneratedConfig.kt
@@ -1,0 +1,25 @@
+import org.gradle.api.Project
+import org.gradle.api.artifacts.ProjectDependency
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.kotlin.dsl.creating
+import org.gradle.kotlin.dsl.dependencies
+import org.gradle.kotlin.dsl.getValue
+
+fun Project.consumeGeneratedConfig(fromProject: ProjectDependency, fromConfiguration: String, forTask: String) {
+    val generatedConfig by configurations.creating {
+        isCanBeConsumed = false
+        isCanBeResolved = true
+    }
+
+    dependencies {
+        generatedConfig(fromProject) {
+            targetConfiguration = fromConfiguration
+        }
+    }
+
+    tasks.named(forTask).configure {
+        inputs.files(generatedConfig)
+            .withPropertyName(generatedConfig.name)
+            .withPathSensitivity(PathSensitivity.RELATIVE)
+    }
+}

--- a/build-logic/src/main/kotlin/Extensions.kt
+++ b/build-logic/src/main/kotlin/Extensions.kt
@@ -1,3 +1,0 @@
-import org.gradle.api.artifacts.ProjectDependency
-
-val ProjectDependency.path: String get() = this.dependencyProject.path

--- a/build-logic/src/main/kotlin/Extensions.kt
+++ b/build-logic/src/main/kotlin/Extensions.kt
@@ -1,0 +1,3 @@
+import org.gradle.api.artifacts.ProjectDependency
+
+val ProjectDependency.path: String get() = this.dependencyProject.path

--- a/detekt-core/build.gradle.kts
+++ b/detekt-core/build.gradle.kts
@@ -31,7 +31,7 @@ dependencies {
     testRuntimeOnly(libs.slf4j.simple)
 
     generatedCoreConfig(
-        project(":detekt-generator", "generatedCoreConfig")
+        project(projects.detektGenerator.path, "generatedCoreConfig")
     )
 }
 

--- a/detekt-core/build.gradle.kts
+++ b/detekt-core/build.gradle.kts
@@ -2,11 +2,6 @@ plugins {
     id("module")
 }
 
-val generatedConfig: Configuration by configurations.creating {
-    isCanBeConsumed = false
-    isCanBeResolved = true
-}
-
 dependencies {
     api(projects.detektApi)
     api(projects.detektParser)
@@ -29,14 +24,10 @@ dependencies {
     testImplementation(libs.reflections)
     testImplementation(libs.assertj)
     testRuntimeOnly(libs.slf4j.simple)
-
-    generatedConfig(projects.detektGenerator) {
-        targetConfiguration = "generatedCoreConfig"
-    }
 }
 
-tasks.named("sourcesJar").configure {
-    inputs.files(generatedConfig)
-        .withPropertyName(generatedConfig.name)
-        .withPathSensitivity(PathSensitivity.RELATIVE)
-}
+consumeGeneratedConfig(
+    fromProject = projects.detektGenerator,
+    fromConfiguration = "generatedCoreConfig",
+    forTask = "sourcesJar"
+)

--- a/detekt-core/build.gradle.kts
+++ b/detekt-core/build.gradle.kts
@@ -2,6 +2,11 @@ plugins {
     id("module")
 }
 
+val generatedCoreConfig: Configuration by configurations.creating {
+    isCanBeConsumed = false
+    isCanBeResolved = true
+}
+
 dependencies {
     api(projects.detektApi)
     api(projects.detektParser)
@@ -24,4 +29,15 @@ dependencies {
     testImplementation(libs.reflections)
     testImplementation(libs.assertj)
     testRuntimeOnly(libs.slf4j.simple)
+
+    generatedCoreConfig(
+        project(":detekt-generator", "generatedCoreConfig")
+    )
 }
+
+tasks.named("sourcesJar").configure {
+    inputs.files(generatedCoreConfig)
+        .withPropertyName(generatedCoreConfig.name)
+        .withPathSensitivity(PathSensitivity.RELATIVE)
+}
+

--- a/detekt-core/build.gradle.kts
+++ b/detekt-core/build.gradle.kts
@@ -40,4 +40,3 @@ tasks.named("sourcesJar").configure {
         .withPropertyName(generatedCoreConfig.name)
         .withPathSensitivity(PathSensitivity.RELATIVE)
 }
-

--- a/detekt-core/build.gradle.kts
+++ b/detekt-core/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     id("module")
 }
 
-val generatedCoreConfig: Configuration by configurations.creating {
+val generatedConfig: Configuration by configurations.creating {
     isCanBeConsumed = false
     isCanBeResolved = true
 }
@@ -30,13 +30,11 @@ dependencies {
     testImplementation(libs.assertj)
     testRuntimeOnly(libs.slf4j.simple)
 
-    generatedCoreConfig(
-        project(projects.detektGenerator.path, "generatedCoreConfig")
-    )
+    generatedConfig(project(projects.detektGenerator.path, "generatedCoreConfig"))
 }
 
 tasks.named("sourcesJar").configure {
-    inputs.files(generatedCoreConfig)
-        .withPropertyName(generatedCoreConfig.name)
+    inputs.files(generatedConfig)
+        .withPropertyName(generatedConfig.name)
         .withPathSensitivity(PathSensitivity.RELATIVE)
 }

--- a/detekt-core/build.gradle.kts
+++ b/detekt-core/build.gradle.kts
@@ -30,7 +30,9 @@ dependencies {
     testImplementation(libs.assertj)
     testRuntimeOnly(libs.slf4j.simple)
 
-    generatedConfig(project(projects.detektGenerator.path, "generatedCoreConfig"))
+    generatedConfig(projects.detektGenerator) {
+        targetConfiguration = "generatedCoreConfig"
+    }
 }
 
 tasks.named("sourcesJar").configure {

--- a/detekt-generator/build.gradle.kts
+++ b/detekt-generator/build.gradle.kts
@@ -93,11 +93,22 @@ val generatedRulesConfig: Configuration by configurations.creating {
     isCanBeResolved = false
 }
 
+val generatedCoreConfig: Configuration by configurations.creating {
+    isCanBeConsumed = true
+    isCanBeResolved = false
+}
+
 artifacts {
     add(generatedLibrariesConfig.name, file(librariesConfigFile)) {
         builtBy(generateDocumentation)
     }
     add(generatedRulesConfig.name, file(ruleauthorsConfigFile)) {
+        builtBy(generateDocumentation)
+    }
+    add(generatedCoreConfig.name, file(defaultConfigFile)) {
+        builtBy(generateDocumentation)
+    }
+    add(generatedCoreConfig.name, file(deprecationFile)) {
         builtBy(generateDocumentation)
     }
 }

--- a/detekt-generator/build.gradle.kts
+++ b/detekt-generator/build.gradle.kts
@@ -3,8 +3,6 @@ plugins {
     id("module")
 }
 
-tasks.build { finalizedBy(tasks.shadowJar) }
-
 dependencies {
     implementation(projects.detektParser)
     implementation(projects.detektApi)
@@ -37,7 +35,6 @@ val ruleModules = rootProject.subprojects
 
 val generateDocumentation by tasks.registering(JavaExec::class) {
     dependsOn(
-        tasks.assemble,
         tasks.shadowJar,
         ":detekt-api:dokkaHtml",
         ":detekt-rules-libraries:sourcesJar",
@@ -84,6 +81,25 @@ val generateDocumentation by tasks.registering(JavaExec::class) {
         "--cli-options",
         cliOptionsFile,
     )
+}
+
+val generateDocumentationConfigurationLibraries: Configuration by configurations.creating {
+    isCanBeConsumed = true
+    isCanBeResolved = false
+}
+
+val generateDocumentationConfigurationRules: Configuration by configurations.creating {
+    isCanBeConsumed = true
+    isCanBeResolved = false
+}
+
+artifacts {
+    add(generateDocumentationConfigurationLibraries.name, file(librariesConfigFile)) {
+        builtBy(generateDocumentation)
+    }
+    add(generateDocumentationConfigurationRules.name, file(ruleauthorsConfigFile)) {
+        builtBy(generateDocumentation)
+    }
 }
 
 val verifyGeneratorOutput by tasks.registering(Exec::class) {

--- a/detekt-generator/build.gradle.kts
+++ b/detekt-generator/build.gradle.kts
@@ -83,21 +83,21 @@ val generateDocumentation by tasks.registering(JavaExec::class) {
     )
 }
 
-val generateDocumentationConfigurationLibraries: Configuration by configurations.creating {
+val generatedLibrariesConfig: Configuration by configurations.creating {
     isCanBeConsumed = true
     isCanBeResolved = false
 }
 
-val generateDocumentationConfigurationRules: Configuration by configurations.creating {
+val generatedRulesConfig: Configuration by configurations.creating {
     isCanBeConsumed = true
     isCanBeResolved = false
 }
 
 artifacts {
-    add(generateDocumentationConfigurationLibraries.name, file(librariesConfigFile)) {
+    add(generatedLibrariesConfig.name, file(librariesConfigFile)) {
         builtBy(generateDocumentation)
     }
-    add(generateDocumentationConfigurationRules.name, file(ruleauthorsConfigFile)) {
+    add(generatedRulesConfig.name, file(ruleauthorsConfigFile)) {
         builtBy(generateDocumentation)
     }
 }

--- a/detekt-generator/build.gradle.kts
+++ b/detekt-generator/build.gradle.kts
@@ -88,7 +88,7 @@ val generatedLibrariesConfig: Configuration by configurations.creating {
     isCanBeResolved = false
 }
 
-val generatedRulesConfig: Configuration by configurations.creating {
+val generatedRuleauthorsConfig: Configuration by configurations.creating {
     isCanBeConsumed = true
     isCanBeResolved = false
 }
@@ -102,7 +102,7 @@ artifacts {
     add(generatedLibrariesConfig.name, file(librariesConfigFile)) {
         builtBy(generateDocumentation)
     }
-    add(generatedRulesConfig.name, file(ruleauthorsConfigFile)) {
+    add(generatedRuleauthorsConfig.name, file(ruleauthorsConfigFile)) {
         builtBy(generateDocumentation)
     }
     add(generatedCoreConfig.name, file(defaultConfigFile)) {

--- a/detekt-rules-libraries/build.gradle.kts
+++ b/detekt-rules-libraries/build.gradle.kts
@@ -17,7 +17,7 @@ dependencies {
     )
 }
 
-tasks.withType<ProcessResources>().configureEach {
+tasks.named<ProcessResources>("processResources").configure {
     inputs.files(generatedLibrariesConfig)
         .withPropertyName(generatedLibrariesConfig.name)
         .withPathSensitivity(PathSensitivity.RELATIVE)

--- a/detekt-rules-libraries/build.gradle.kts
+++ b/detekt-rules-libraries/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     id("module")
 }
 
-val generateDocumentationConfiguration: Configuration by configurations.creating {
+val generatedLibrariesConfig: Configuration by configurations.creating {
     isCanBeConsumed = false
     isCanBeResolved = true
 }
@@ -12,19 +12,13 @@ dependencies {
     testImplementation(projects.detektTest)
     testImplementation(libs.assertj)
 
-    generateDocumentationConfiguration(
-        project(
-            mapOf(
-                "path" to ":detekt-generator",
-                "configuration" to "generateDocumentationConfigurationLibraries"
-            )
-        )
+    generatedLibrariesConfig(
+        project(":detekt-generator", "generatedLibrariesConfig")
     )
 }
 
 tasks.withType<ProcessResources>().configureEach {
-    val generateDocumentationFiles: FileCollection = generateDocumentationConfiguration
-    inputs.files(generateDocumentationFiles)
-        .withPropertyName("generateDocumentationConfiguration")
+    inputs.files(generatedLibrariesConfig)
+        .withPropertyName(generatedLibrariesConfig.name)
         .withPathSensitivity(PathSensitivity.RELATIVE)
 }

--- a/detekt-rules-libraries/build.gradle.kts
+++ b/detekt-rules-libraries/build.gradle.kts
@@ -2,23 +2,14 @@ plugins {
     id("module")
 }
 
-val generatedConfig: Configuration by configurations.creating {
-    isCanBeConsumed = false
-    isCanBeResolved = true
-}
-
 dependencies {
     compileOnly(projects.detektApi)
     testImplementation(projects.detektTest)
     testImplementation(libs.assertj)
-
-    generatedConfig(projects.detektGenerator) {
-        targetConfiguration = "generatedLibrariesConfig"
-    }
 }
 
-tasks.named("processResources").configure {
-    inputs.files(generatedConfig)
-        .withPropertyName(generatedConfig.name)
-        .withPathSensitivity(PathSensitivity.RELATIVE)
-}
+consumeGeneratedConfig(
+    fromProject = projects.detektGenerator,
+    fromConfiguration = "generatedLibrariesConfig",
+    forTask = "processResources"
+)

--- a/detekt-rules-libraries/build.gradle.kts
+++ b/detekt-rules-libraries/build.gradle.kts
@@ -13,7 +13,7 @@ dependencies {
     testImplementation(libs.assertj)
 
     generatedLibrariesConfig(
-        project(":detekt-generator", "generatedLibrariesConfig")
+        project(projects.detektGenerator.path, "generatedLibrariesConfig")
     )
 }
 

--- a/detekt-rules-libraries/build.gradle.kts
+++ b/detekt-rules-libraries/build.gradle.kts
@@ -12,7 +12,9 @@ dependencies {
     testImplementation(projects.detektTest)
     testImplementation(libs.assertj)
 
-    generatedConfig(project(projects.detektGenerator.path, "generatedLibrariesConfig"))
+    generatedConfig(projects.detektGenerator) {
+        targetConfiguration = "generatedLibrariesConfig"
+    }
 }
 
 tasks.named("processResources").configure {

--- a/detekt-rules-libraries/build.gradle.kts
+++ b/detekt-rules-libraries/build.gradle.kts
@@ -2,8 +2,29 @@ plugins {
     id("module")
 }
 
+val generateDocumentationConfiguration: Configuration by configurations.creating {
+    isCanBeConsumed = false
+    isCanBeResolved = true
+}
+
 dependencies {
     compileOnly(projects.detektApi)
     testImplementation(projects.detektTest)
     testImplementation(libs.assertj)
+
+    generateDocumentationConfiguration(
+        project(
+            mapOf(
+                "path" to ":detekt-generator",
+                "configuration" to "generateDocumentationConfigurationLibraries"
+            )
+        )
+    )
+}
+
+tasks.withType<ProcessResources>().configureEach {
+    val generateDocumentationFiles: FileCollection = generateDocumentationConfiguration
+    inputs.files(generateDocumentationFiles)
+        .withPropertyName("generateDocumentationConfiguration")
+        .withPathSensitivity(PathSensitivity.RELATIVE)
 }

--- a/detekt-rules-libraries/build.gradle.kts
+++ b/detekt-rules-libraries/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     id("module")
 }
 
-val generatedLibrariesConfig: Configuration by configurations.creating {
+val generatedConfig: Configuration by configurations.creating {
     isCanBeConsumed = false
     isCanBeResolved = true
 }
@@ -12,13 +12,11 @@ dependencies {
     testImplementation(projects.detektTest)
     testImplementation(libs.assertj)
 
-    generatedLibrariesConfig(
-        project(projects.detektGenerator.path, "generatedLibrariesConfig")
-    )
+    generatedConfig(project(projects.detektGenerator.path, "generatedLibrariesConfig"))
 }
 
-tasks.named<ProcessResources>("processResources").configure {
-    inputs.files(generatedLibrariesConfig)
-        .withPropertyName(generatedLibrariesConfig.name)
+tasks.named("processResources").configure {
+    inputs.files(generatedConfig)
+        .withPropertyName(generatedConfig.name)
         .withPathSensitivity(PathSensitivity.RELATIVE)
 }

--- a/detekt-rules-ruleauthors/build.gradle.kts
+++ b/detekt-rules-ruleauthors/build.gradle.kts
@@ -12,7 +12,9 @@ dependencies {
     testImplementation(projects.detektTest)
     testImplementation(libs.assertj)
 
-    generatedConfig(project(projects.detektGenerator.path, "generatedRuleauthorsConfig"))
+    generatedConfig(projects.detektGenerator) {
+        targetConfiguration = "generatedRuleauthorsConfig"
+    }
 }
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {

--- a/detekt-rules-ruleauthors/build.gradle.kts
+++ b/detekt-rules-ruleauthors/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     id("module")
 }
 
-val generatedRuleauthorsConfig: Configuration by configurations.creating {
+val generatedConfig: Configuration by configurations.creating {
     isCanBeConsumed = false
     isCanBeResolved = true
 }
@@ -12,17 +12,15 @@ dependencies {
     testImplementation(projects.detektTest)
     testImplementation(libs.assertj)
 
-    generatedRuleauthorsConfig(
-        project(projects.detektGenerator.path, "generatedRuleauthorsConfig")
-    )
+    generatedConfig(project(projects.detektGenerator.path, "generatedRuleauthorsConfig"))
 }
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
     compilerOptions.freeCompilerArgs.add("-Xcontext-receivers")
 }
 
-tasks.named<ProcessResources>("processResources").configure {
-    inputs.files(generatedRuleauthorsConfig)
-        .withPropertyName(generatedRuleauthorsConfig.name)
+tasks.named("processResources").configure {
+    inputs.files(generatedConfig)
+        .withPropertyName(generatedConfig.name)
         .withPathSensitivity(PathSensitivity.RELATIVE)
 }

--- a/detekt-rules-ruleauthors/build.gradle.kts
+++ b/detekt-rules-ruleauthors/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     id("module")
 }
 
-val generatedRulesConfig: Configuration by configurations.creating {
+val generatedRuleauthorsConfig: Configuration by configurations.creating {
     isCanBeConsumed = false
     isCanBeResolved = true
 }
@@ -12,8 +12,8 @@ dependencies {
     testImplementation(projects.detektTest)
     testImplementation(libs.assertj)
 
-    generatedRulesConfig(
-        project(projects.detektGenerator.path, "generatedRulesConfig")
+    generatedRuleauthorsConfig(
+        project(projects.detektGenerator.path, "generatedRuleauthorsConfig")
     )
 }
 
@@ -22,7 +22,7 @@ tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach 
 }
 
 tasks.withType<ProcessResources>().configureEach {
-    inputs.files(generatedRulesConfig)
-        .withPropertyName(generatedRulesConfig.name)
+    inputs.files(generatedRuleauthorsConfig)
+        .withPropertyName(generatedRuleauthorsConfig.name)
         .withPathSensitivity(PathSensitivity.RELATIVE)
 }

--- a/detekt-rules-ruleauthors/build.gradle.kts
+++ b/detekt-rules-ruleauthors/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     id("module")
 }
 
-val generateDocumentationConfiguration: Configuration by configurations.creating {
+val generatedRulesConfig: Configuration by configurations.creating {
     isCanBeConsumed = false
     isCanBeResolved = true
 }
@@ -12,13 +12,8 @@ dependencies {
     testImplementation(projects.detektTest)
     testImplementation(libs.assertj)
 
-    generateDocumentationConfiguration(
-        project(
-            mapOf(
-                "path" to ":detekt-generator",
-                "configuration" to "generateDocumentationConfigurationRules"
-            )
-        )
+    generatedRulesConfig(
+        project(":detekt-generator", "generatedRulesConfig")
     )
 }
 
@@ -27,8 +22,7 @@ tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach 
 }
 
 tasks.withType<ProcessResources>().configureEach {
-    val generateDocumentationFiles: FileCollection = generateDocumentationConfiguration
-    inputs.files(generateDocumentationFiles)
-        .withPropertyName("generateDocumentationConfiguration")
+    inputs.files(generatedRulesConfig)
+        .withPropertyName(generatedRulesConfig.name)
         .withPathSensitivity(PathSensitivity.RELATIVE)
 }

--- a/detekt-rules-ruleauthors/build.gradle.kts
+++ b/detekt-rules-ruleauthors/build.gradle.kts
@@ -21,7 +21,7 @@ tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach 
     compilerOptions.freeCompilerArgs.add("-Xcontext-receivers")
 }
 
-tasks.withType<ProcessResources>().configureEach {
+tasks.named<ProcessResources>("processResources").configure {
     inputs.files(generatedRuleauthorsConfig)
         .withPropertyName(generatedRuleauthorsConfig.name)
         .withPathSensitivity(PathSensitivity.RELATIVE)

--- a/detekt-rules-ruleauthors/build.gradle.kts
+++ b/detekt-rules-ruleauthors/build.gradle.kts
@@ -13,7 +13,7 @@ dependencies {
     testImplementation(libs.assertj)
 
     generatedRulesConfig(
-        project(":detekt-generator", "generatedRulesConfig")
+        project(projects.detektGenerator.path, "generatedRulesConfig")
     )
 }
 

--- a/detekt-rules-ruleauthors/build.gradle.kts
+++ b/detekt-rules-ruleauthors/build.gradle.kts
@@ -2,27 +2,18 @@ plugins {
     id("module")
 }
 
-val generatedConfig: Configuration by configurations.creating {
-    isCanBeConsumed = false
-    isCanBeResolved = true
-}
-
 dependencies {
     compileOnly(projects.detektApi)
     testImplementation(projects.detektTest)
     testImplementation(libs.assertj)
-
-    generatedConfig(projects.detektGenerator) {
-        targetConfiguration = "generatedRuleauthorsConfig"
-    }
 }
+
+consumeGeneratedConfig(
+    fromProject = projects.detektGenerator,
+    fromConfiguration = "generatedRuleauthorsConfig",
+    forTask = "processResources"
+)
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
     compilerOptions.freeCompilerArgs.add("-Xcontext-receivers")
-}
-
-tasks.named("processResources").configure {
-    inputs.files(generatedConfig)
-        .withPropertyName(generatedConfig.name)
-        .withPathSensitivity(PathSensitivity.RELATIVE)
 }

--- a/detekt-rules-ruleauthors/build.gradle.kts
+++ b/detekt-rules-ruleauthors/build.gradle.kts
@@ -2,12 +2,33 @@ plugins {
     id("module")
 }
 
+val generateDocumentationConfiguration: Configuration by configurations.creating {
+    isCanBeConsumed = false
+    isCanBeResolved = true
+}
+
 dependencies {
     compileOnly(projects.detektApi)
     testImplementation(projects.detektTest)
     testImplementation(libs.assertj)
+
+    generateDocumentationConfiguration(
+        project(
+            mapOf(
+                "path" to ":detekt-generator",
+                "configuration" to "generateDocumentationConfigurationRules"
+            )
+        )
+    )
 }
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
     compilerOptions.freeCompilerArgs.add("-Xcontext-receivers")
+}
+
+tasks.withType<ProcessResources>().configureEach {
+    val generateDocumentationFiles: FileCollection = generateDocumentationConfiguration
+    inputs.files(generateDocumentationFiles)
+        .withPropertyName("generateDocumentationConfiguration")
+        .withPathSensitivity(PathSensitivity.RELATIVE)
 }


### PR DESCRIPTION
The `:detekt-rules-libraries:processResources` and `:detekt-rules-authors:processResources` tasks have an implicit dependency on `:detekt-generator:generateDocumentation` task, the files `detekt-rules-libraries/src/main/resources/config/config.yml` and `detekt-rules-ruleauthors/src/main/resources/config/config.yml` being outputs of `:detekt-generator:generateDocumentation`.

This has a small impact on performances (see [here](https://ge.detekt.dev/s/ltywkmui6n6ka/timeline?cacheability=validation-failure#6q6tf2ndv5xfi) an example on `detekt-rules-authors:processResources`)

This PR fixes this by [sharing the artifacts through a Gradle configuration](https://docs.gradle.org/current/userguide/cross_project_publications.html#sec:simple-sharing-artifacts-between-projects).

Please note that I had to cut some task dependencies in `detekt-generator` build script to avoid a cycle in the task graph (`assemble` => `build` => `shadowJar` => `generateDocumentation` => `assemble`). Please review those carefully as I am not familiar enough with the codebase to measure the impacts.
