### PR TITLE
Backport NixOS instructions to next version of the website

### DIFF
--- a/website/docs/gettingstarted/cli.mdx
+++ b/website/docs/gettingstarted/cli.mdx
@@ -37,6 +37,14 @@ unzip detekt-cli-[detekt_version].zip
 ./detekt-cli-[detekt_version]/bin/detekt-cli --help
 ```
 
+### NixOS
+
+As a prerequisite, you have to add the unstable channel via `nix-channel` and then execute the following command.
+
+```sh
+nix-shell -I nixpkgs=channel:nixpkgs-unstable -p detekt
+```
+
 ## Use the cli
 
 detekt will exit with one of the following exit codes:


### PR DESCRIPTION
Follow up to https://github.com/detekt/detekt/pull/5757 to make sure the changes are applied also in the `next` version.
