### PR TITLE
Remove unnecessary usage of BeforeAll

### DIFF
--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/printer/GeneratorSpec.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/printer/GeneratorSpec.kt
@@ -10,6 +10,24 @@ import java.nio.file.Paths
 import kotlin.io.path.readText
 
 class GeneratorSpec {
+    private val configPath = "/src/main/resources/config/config.yml"
+
+    private val tempDir1: File = Files.createTempDirectory(null).toFile()
+    private val tempDir2: File = Files.createTempDirectory(null).toFile()
+
+    @BeforeAll
+    fun init() {
+        Paths.get("../detekt-rules-complexity").toFile().copyRecursively(tempDir1)
+        Paths.get("../detekt-rules-coroutines").toFile().copyRecursively(tempDir2)
+
+        val args = arrayOf(
+            "--generate-custom-rule-config",
+            "--input",
+            "$tempDir1, $tempDir2",
+        )
+        io.gitlab.arturbosch.detekt.generator.main(args)
+    }
+
     @Test
     fun `config files generated successfully`() {
         assertThat(Paths.get(tempDir1.toString(), configPath)).exists()
@@ -27,33 +45,9 @@ class GeneratorSpec {
             .doesNotContain("complexity:")
     }
 
-    companion object {
-        private const val sourceDir1 = "../detekt-rules-complexity"
-        private const val sourceDir2 = "../detekt-rules-coroutines"
-        private const val configPath = "/src/main/resources/config/config.yml"
-
-        private val tempDir1: File = Files.createTempDirectory(null).toFile()
-        private val tempDir2: File = Files.createTempDirectory(null).toFile()
-
-        @JvmStatic
-        @BeforeAll
-        fun init() {
-            File(Paths.get(sourceDir1).toString()).copyRecursively(tempDir1)
-            File(Paths.get(sourceDir2).toString()).copyRecursively(tempDir2)
-
-            val args = arrayOf(
-                "--generate-custom-rule-config",
-                "--input",
-                "$tempDir1, $tempDir2",
-            )
-            io.gitlab.arturbosch.detekt.generator.main(args)
-        }
-
-        @JvmStatic
-        @AfterAll
-        fun tearDown() {
-            tempDir1.deleteRecursively()
-            tempDir2.deleteRecursively()
-        }
+    @AfterAll
+    fun tearDown() {
+        tempDir1.deleteRecursively()
+        tempDir2.deleteRecursively()
     }
 }

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektTaskDslSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektTaskDslSpec.kt
@@ -2,13 +2,10 @@ package io.gitlab.arturbosch.detekt
 
 import io.gitlab.arturbosch.detekt.extensions.DetektReportType
 import io.gitlab.arturbosch.detekt.extensions.loadDetektVersion
-import io.gitlab.arturbosch.detekt.testkit.DslGradleRunner
 import io.gitlab.arturbosch.detekt.testkit.DslTestBuilder.Companion.kotlin
 import io.gitlab.arturbosch.detekt.testkit.ProjectLayout
 import org.assertj.core.api.Assertions.assertThat
-import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.TaskOutcome
-import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -17,19 +14,13 @@ import org.junit.jupiter.params.provider.EnumSource
 
 class DetektTaskDslSpec {
 
-    lateinit var gradleRunner: DslGradleRunner
-    lateinit var result: BuildResult
     val defaultDetektVersion = loadDetektVersion(DetektTaskDslSpec::class.java.classLoader)
-    val builder = kotlin().dryRun()
 
     @Nested
     inner class `without detekt config` {
-
-        @BeforeAll
-        fun beforeGroup() {
-            gradleRunner = builder.build()
-            result = gradleRunner.runDetektTask()
-        }
+        private val builder = kotlin().dryRun()
+        private val gradleRunner = builder.build()
+        private val result = gradleRunner.runDetektTask()
 
         @Test
         fun `completes successfully`() {
@@ -73,20 +64,15 @@ class DetektTaskDslSpec {
 
     @Nested
     inner class `without multiple detekt configs` {
-
-        @BeforeAll
-        fun beforeGroup() {
-            @Suppress("TrimMultilineRawString")
-            val config = """
+        @Suppress("TrimMultilineRawString")
+        private val config = """
                 |detekt {
                 |    config.setFrom(files("firstConfig.yml", "secondConfig.yml"))
                 |}
             """
-
-            gradleRunner = builder.withDetektConfig(config).build()
-
-            result = gradleRunner.runDetektTask()
-        }
+        private val builder = kotlin().dryRun()
+        private val gradleRunner = builder.withDetektConfig(config).build()
+        private val result = gradleRunner.runDetektTask()
 
         @Test
         fun `passes absolute filename of both config files to detekt cli`() {
@@ -102,21 +88,18 @@ class DetektTaskDslSpec {
     inner class `with custom baseline file` {
         val baselineFilename = "custom-baseline.xml"
 
-        @BeforeAll
-        fun beforeGroup() {
-            @Suppress("TrimMultilineRawString")
-            val config = """
+        @Suppress("TrimMultilineRawString")
+        private val config = """
                 |detekt {
                 |   baseline = file("$baselineFilename")
                 |}
             """
-
-            gradleRunner = builder
-                .withDetektConfig(config)
-                .withBaseline(baselineFilename)
-                .build()
-            result = gradleRunner.runDetektTask()
-        }
+        private val builder = kotlin().dryRun()
+        private val gradleRunner = builder
+            .withDetektConfig(config)
+            .withBaseline(baselineFilename)
+            .build()
+        private val result = gradleRunner.runDetektTask()
 
         @Test
         fun `sets baseline parameter with absolute filename`() {
@@ -130,20 +113,17 @@ class DetektTaskDslSpec {
     inner class `with custom baseline file that doesn't exist` {
         val baselineFilename = "detekt-baseline-no-exist.xml"
 
-        @BeforeAll
-        fun beforeGroup() {
-            @Suppress("TrimMultilineRawString")
-            val config = """
+        @Suppress("TrimMultilineRawString")
+        private val config = """
                 |detekt {
                 |   baseline = file("$baselineFilename")
                 |}
             """
-
-            gradleRunner = builder
-                .withDetektConfig(config)
-                .build()
-            result = gradleRunner.runDetektTask()
-        }
+        private val builder = kotlin().dryRun()
+        private val gradleRunner = builder
+            .withDetektConfig(config)
+            .build()
+        private val result = gradleRunner.runDetektTask()
 
         @Test
         fun `doesn't set the baseline parameter`() {
@@ -156,23 +136,21 @@ class DetektTaskDslSpec {
     inner class CustomInputDirectoriesUsingInput {
         val customSrc1 = "gensrc/kotlin"
         val customSrc2 = "src/main/kotlin"
+        private val builder = kotlin().dryRun()
 
-        @BeforeAll
-        fun beforeGroup() {
-            @Suppress("TrimMultilineRawString")
-            val config = """
+        @Suppress("TrimMultilineRawString")
+        private val config = """
                 |detekt {
                 |    input = files("$customSrc1", "$customSrc2", "folder_that_does_not_exist")
                 |}
             """
 
-            val projectLayout = ProjectLayout(1, srcDirs = listOf(customSrc1, customSrc2))
-            gradleRunner = builder
-                .withProjectLayout(projectLayout)
-                .withDetektConfig(config)
-                .build()
-            result = gradleRunner.runDetektTask()
-        }
+        val projectLayout = ProjectLayout(1, srcDirs = listOf(customSrc1, customSrc2))
+        private val gradleRunner = builder
+            .withProjectLayout(projectLayout)
+            .withDetektConfig(config)
+            .build()
+        private val result = gradleRunner.runDetektTask()
 
         @Test
         fun `sets input parameter to absolute filenames of all source files`() {
@@ -192,23 +170,21 @@ class DetektTaskDslSpec {
     inner class `with custom input directories` {
         val customSrc1 = "gensrc/kotlin"
         val customSrc2 = "src/main/kotlin"
+        private val builder = kotlin().dryRun()
 
-        @BeforeAll
-        fun beforeGroup() {
-            @Suppress("TrimMultilineRawString")
-            val config = """
+        @Suppress("TrimMultilineRawString")
+        private val config = """
                 |detekt {
                 |    source = files("$customSrc1", "$customSrc2", "folder_that_does_not_exist")
                 |}
             """
 
-            val projectLayout = ProjectLayout(1, srcDirs = listOf(customSrc1, customSrc2))
-            gradleRunner = builder
-                .withProjectLayout(projectLayout)
-                .withDetektConfig(config)
-                .build()
-            result = gradleRunner.runDetektTask()
-        }
+        private val projectLayout = ProjectLayout(1, srcDirs = listOf(customSrc1, customSrc2))
+        private val gradleRunner = builder
+            .withProjectLayout(projectLayout)
+            .withDetektConfig(config)
+            .build()
+        private val result = gradleRunner.runDetektTask()
 
         @Test
         fun `sets input parameter to absolute filenames of all source files`() {
@@ -226,21 +202,15 @@ class DetektTaskDslSpec {
 
     @Nested
     inner class `with custom reports dir` {
-
-        @BeforeAll
-        fun beforeGroup() {
-            @Suppress("TrimMultilineRawString")
-            val config = """
+        @Suppress("TrimMultilineRawString")
+        private val config = """
                 |detekt {
                 |    reportsDir = file("build/detekt-reports")
                 |}
             """
-
-            gradleRunner = builder
-                .withDetektConfig(config)
-                .build()
-            result = gradleRunner.runDetektTask()
-        }
+        private val builder = kotlin().dryRun()
+        private val gradleRunner = builder.withDetektConfig(config).build()
+        private val result = gradleRunner.runDetektTask()
 
         @Test
         fun `configures xml report to custom directory`() {
@@ -269,11 +239,8 @@ class DetektTaskDslSpec {
 
     @Nested
     inner class `with custom reports dir and custom report filename` {
-
-        @BeforeAll
-        fun beforeGroup() {
-            @Suppress("TrimMultilineRawString")
-            val config = """
+        @Suppress("TrimMultilineRawString")
+        private val config = """
                 |detekt {
                 |    reportsDir = file("build/detekt-reports")
                 |}
@@ -284,12 +251,9 @@ class DetektTaskDslSpec {
                 |    }
                 |}
             """
-
-            gradleRunner = builder
-                .withDetektConfig(config)
-                .build()
-            result = gradleRunner.runDetektTask()
-        }
+        private val builder = kotlin().dryRun()
+        private val gradleRunner = builder.withDetektConfig(config).build()
+        private val result = gradleRunner.runDetektTask()
 
         @Test
         fun `configures xml report to specific absolute filename`() {
@@ -312,11 +276,8 @@ class DetektTaskDslSpec {
 
     @Nested
     inner class `with disabled reports` {
-
-        @BeforeAll
-        fun beforeGroup() {
-            @Suppress("TrimMultilineRawString")
-            val config = """
+        @Suppress("TrimMultilineRawString")
+        private val config = """
                 |tasks.detekt {
                 |    reports {
                 |        xml.enabled = false
@@ -335,12 +296,9 @@ class DetektTaskDslSpec {
                 |    }
                 |}
             """
-
-            gradleRunner = builder
-                .withDetektConfig(config)
-                .build()
-            result = gradleRunner.runDetektTask()
-        }
+        private val builder = kotlin().dryRun()
+        private val gradleRunner = builder.withDetektConfig(config).build()
+        private val result = gradleRunner.runDetektTask()
 
         @Test
         fun `no report param is set`() {
@@ -352,10 +310,8 @@ class DetektTaskDslSpec {
     inner class `with custom report types` {
         @Nested
         inner class `configured correctly` {
-            @BeforeAll
-            fun beforeGroup() {
-                @Suppress("TrimMultilineRawString")
-                val config = """
+            @Suppress("TrimMultilineRawString")
+            private val config = """
                     |tasks.detekt {
                     |    reports {
                     |        custom {
@@ -369,10 +325,9 @@ class DetektTaskDslSpec {
                     |    }
                     |}
                 """
-
-                gradleRunner = builder.withDetektConfig(config).build()
-                result = gradleRunner.runDetektTask()
-            }
+            private val builder = kotlin().dryRun()
+            private val gradleRunner = builder.withDetektConfig(config).build()
+            private val result = gradleRunner.runDetektTask()
 
             @Test
             fun `configures custom xml report to absolute filename`() {
@@ -389,10 +344,8 @@ class DetektTaskDslSpec {
 
         @Nested
         inner class `report id is missing` {
-            @BeforeAll
-            fun beforeGroup() {
-                @Suppress("TrimMultilineRawString")
-                val config = """
+            @Suppress("TrimMultilineRawString")
+            private val config = """
                     |tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
                     |    reports {
                     |        custom {
@@ -401,9 +354,8 @@ class DetektTaskDslSpec {
                     |    }
                     |}
                 """
-
-                gradleRunner = builder.withDetektConfig(config).build()
-            }
+            private val builder = kotlin().dryRun()
+            private val gradleRunner = builder.withDetektConfig(config).build()
 
             @Test
             fun `fails the build`() {
@@ -416,10 +368,8 @@ class DetektTaskDslSpec {
 
         @Nested
         inner class `report filename is missing` {
-            @BeforeAll
-            fun beforeGroup() {
-                @Suppress("TrimMultilineRawString")
-                val config = """
+            @Suppress("TrimMultilineRawString")
+            private val config = """
                     |tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
                     |    reports {
                     |        custom {
@@ -428,9 +378,8 @@ class DetektTaskDslSpec {
                     |    }
                     |}
                 """
-
-                gradleRunner = builder.withDetektConfig(config).build()
-            }
+            private val builder = kotlin().dryRun()
+            private val gradleRunner = builder.withDetektConfig(config).build()
 
             @Test
             fun `fails the build`() {
@@ -443,12 +392,10 @@ class DetektTaskDslSpec {
 
         @Nested
         inner class `report filename is a directory` {
-            @BeforeAll
-            fun beforeGroup() {
-                val aDirectory = "\${rootDir}/src"
+            private val aDirectory = "\${rootDir}/src"
 
-                @Suppress("TrimMultilineRawString")
-                val config = """
+            @Suppress("TrimMultilineRawString")
+            private val config = """
                     |tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
                     |    reports {
                     |        custom {
@@ -458,9 +405,8 @@ class DetektTaskDslSpec {
                     |    }
                     |}
                 """
-
-                gradleRunner = builder.withDetektConfig(config).build()
-            }
+            private val builder = kotlin().dryRun()
+            private val gradleRunner = builder.withDetektConfig(config).build()
 
             @Test
             fun `fails the build`() {
@@ -472,6 +418,8 @@ class DetektTaskDslSpec {
 
         @Nested
         inner class `using the report id of a well known type` {
+            private val builder = kotlin().dryRun()
+
             @ParameterizedTest
             @EnumSource(DetektReportType::class)
             fun `fails the build`(wellKnownType: DetektReportType) {
@@ -487,7 +435,7 @@ class DetektTaskDslSpec {
                     |}
                 """
 
-                gradleRunner = builder.withDetektConfig(config).build()
+                val gradleRunner = builder.withDetektConfig(config).build()
                 gradleRunner.runDetektTaskAndExpectFailure { result ->
                     assertThat(result.output)
                         .contains("The custom report reportId may not be same as one of the default reports")
@@ -498,27 +446,23 @@ class DetektTaskDslSpec {
 
     @Nested
     inner class `with flags` {
+        private val builder = kotlin().dryRun()
 
-        @BeforeAll
-        fun beforeGroup() {
-            @Suppress("TrimMultilineRawString")
-            val config = """
-                |detekt {
-                |    debug = true
-                |    parallel = true
-                |    disableDefaultRuleSets = true
-                |    allRules = true
-                |    autoCorrect = true
-                |    buildUponDefaultConfig = true
-                |    ignoreFailures = true
-                |}
-            """
+        @Suppress("TrimMultilineRawString")
+        private val config = """
+            |detekt {
+            |    debug = true
+            |    parallel = true
+            |    disableDefaultRuleSets = true
+            |    allRules = true
+            |    autoCorrect = true
+            |    buildUponDefaultConfig = true
+            |    ignoreFailures = true
+            |}
+        """
 
-            gradleRunner = builder
-                .withDetektConfig(config)
-                .build()
-            result = gradleRunner.runDetektTask()
-        }
+        private val gradleRunner = builder.withDetektConfig(config).build()
+        private val result = gradleRunner.runDetektTask()
 
         @Test
         fun `enables debug mode`() {
@@ -558,12 +502,9 @@ class DetektTaskDslSpec {
 
     @Nested
     inner class `with cmdline args` {
-
-        @BeforeAll
-        fun beforeGroup() {
-            gradleRunner = builder.build()
-            result = gradleRunner.runDetektTask("--auto-correct")
-        }
+        private val builder = kotlin().dryRun()
+        private val gradleRunner = builder.build()
+        private val result = gradleRunner.runDetektTask("--auto-correct")
 
         @Test
         fun `enables auto correcting`() {
@@ -573,20 +514,15 @@ class DetektTaskDslSpec {
 
     @Nested
     inner class `with an additional plugin` {
-        @BeforeAll
-        fun beforeGroup() {
-            @Suppress("TrimMultilineRawString")
-            val config = """
+        @Suppress("TrimMultilineRawString")
+        private val config = """
                 |dependencies {
                 |   detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:$defaultDetektVersion")
                 |}
             """
-
-            gradleRunner = builder
-                .withDetektConfig(config)
-                .build()
-            result = gradleRunner.runTasks("dependencies", "--configuration", "detektPlugins")
-        }
+        private val builder = kotlin().dryRun()
+        private val gradleRunner = builder.withDetektConfig(config).build()
+        private val result = gradleRunner.runTasks("dependencies", "--configuration", "detektPlugins")
 
         @Test
         fun `successfully checks dependencies`() {
@@ -603,20 +539,15 @@ class DetektTaskDslSpec {
     inner class `with a custom tool version` {
         val customVersion = "1.0.0.RC8"
 
-        @BeforeAll
-        fun beforeGroup() {
-            @Suppress("TrimMultilineRawString")
-            val config = """
+        @Suppress("TrimMultilineRawString")
+        private val config = """
                 |detekt {
                 |    toolVersion = "$customVersion"
                 |}
             """
-
-            gradleRunner = builder
-                .withDetektConfig(config)
-                .build()
-            result = gradleRunner.runTasks("dependencies", "--offline", "--configuration", "detekt")
-        }
+        private val builder = kotlin().dryRun()
+        private val gradleRunner = builder.withDetektConfig(config).build()
+        private val result = gradleRunner.runTasks("dependencies", "--offline", "--configuration", "detekt")
 
         @Test
         fun `successfully checks dependencies`() {
@@ -631,10 +562,10 @@ class DetektTaskDslSpec {
 
     @Nested
     inner class `and creating a custom task` {
-        @BeforeAll
-        fun beforeGroup() {
-            @Suppress("TrimMultilineRawString")
-            val config = """
+        private val builder = kotlin().dryRun()
+
+        @Suppress("TrimMultilineRawString")
+        private val config = """
                 |task<io.gitlab.arturbosch.detekt.Detekt>("myDetekt") {
                 |    description = "Runs a custom detekt build."
                 |
@@ -665,13 +596,12 @@ class DetektTaskDslSpec {
                 |}
             """
 
-            gradleRunner = builder
-                .withDetektConfig(config)
-                .build()
-                .apply { writeProjectFile("config.yml", "") }
+        private val gradleRunner = builder
+            .withDetektConfig(config)
+            .build()
+            .apply { writeProjectFile("config.yml", "") }
 
-            result = gradleRunner.runTasks("myDetekt")
-        }
+        private val result = gradleRunner.runTasks("myDetekt")
 
         @Test
         fun `completes successfully`() {


### PR DESCRIPTION
Tests would sometimes fail due to reuse of the builder. Tests were reconfiguring the builder and that configuration persisted when other tests ran causing failures in some scenarios. Isolating the builder config to individual test classes avoids this issue.

This also seemed a good opportunity to review use of BeforeAll in the tests and remove it as it was unnecessary in this case.