### PR TITLE
Fix isIgnored logic so excludes override includes

### DIFF
--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/PathFilters.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/PathFilters.kt
@@ -17,7 +17,7 @@ class PathFilters internal constructor(
 
     /**
      * - If [includes] and [excludes] are not specified,
-     *   always return true.
+     *   return false.
      * - If [includes] is specified but [excludes] is not,
      *   return false iff [path] matches any [includes].
      * - If [includes] is not specified but [excludes] is,
@@ -26,10 +26,10 @@ class PathFilters internal constructor(
      *   return false iff [path] matches any [includes] and [path] does not match any [excludes].
      */
     fun isIgnored(path: Path): Boolean {
-        fun isIncluded() = includes?.any { it.matches(path) }
-        fun isExcluded() = excludes?.any { it.matches(path) }
+        fun isIncluded() = includes?.any { it.matches(path) } ?: true
+        fun isExcluded() = excludes?.any { it.matches(path) } ?: false
 
-        return isIncluded()?.not() ?: isExcluded() ?: true
+        return !(isIncluded() && !isExcluded())
     }
 
     /**

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/internal/InclusionExclusionPatternsSpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/internal/InclusionExclusionPatternsSpec.kt
@@ -83,8 +83,8 @@ class InclusionExclusionPatternsSpec {
         fun `should only run on dummies`() {
             val config = TestConfig(
                 mapOf(
-                    Config.INCLUDES_KEY to "**Dummy*.kt",
-                    Config.EXCLUDES_KEY to "**/library/**"
+                    Config.INCLUDES_KEY to "**/library/**",
+                    Config.EXCLUDES_KEY to "**Library.kt"
                 )
             )
 
@@ -101,8 +101,8 @@ class InclusionExclusionPatternsSpec {
         fun `should only run on library file`() {
             val config = TestConfig(
                 mapOf(
-                    Config.INCLUDES_KEY to "**Library.kt",
-                    Config.EXCLUDES_KEY to "**/library/**"
+                    Config.INCLUDES_KEY to "**/library/**",
+                    Config.EXCLUDES_KEY to "**Dummy*.kt"
                 )
             )
 

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/PathFiltersSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/PathFiltersSpec.kt
@@ -49,6 +49,7 @@ class PathFiltersSpec {
             assertThat(pathFilter?.isIgnored(Paths.get("/one/path"))).isFalse
             assertThat(pathFilter?.isIgnored(Paths.get("/two/path"))).isTrue
             assertThat(pathFilter?.isIgnored(Paths.get("/three/path"))).isTrue
+            assertThat(pathFilter?.isIgnored(Paths.get("/one/two/three/path"))).isTrue
         }
     }
 

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/rules/RuleSetSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/rules/RuleSetSpec.kt
@@ -46,12 +46,12 @@ class RuleSetSpec {
         }
 
         @Test
-        fun `should analyze file as it's path is first excluded but then included`() {
+        fun `should not analyze file as its path is both included and excluded`() {
             val config = TestConfig(
                 Config.EXCLUDES_KEY to "**/*.kt",
                 Config.INCLUDES_KEY to "**/*.kt"
             )
-            assertThat(config.subConfig("comments").shouldAnalyzeFile(file)).isTrue()
+            assertThat(config.subConfig("comments").shouldAnalyzeFile(file)).isFalse()
         }
     }
 }


### PR DESCRIPTION
Previously the includes overrode the excludes which prevented scenarios like including a directory while excluding certain files or subdirectories within it.

Fixes #5728 