### PR TITLE
Remove Spek support from detekt-test-utils

### DIFF
--- a/detekt-test-utils/api/detekt-test-utils.api
+++ b/detekt-test-utils/api/detekt-test-utils.api
@@ -50,8 +50,3 @@ public abstract interface annotation class io/gitlab/arturbosch/detekt/rules/Kot
 	public abstract fun additionalJavaSourcePaths ()[Ljava/lang/String;
 }
 
-public final class io/gitlab/arturbosch/detekt/rules/KotlinEnvironmentTestSetupKt {
-	public static final fun setupKotlinEnvironment (Lorg/spekframework/spek2/dsl/Root;Ljava/nio/file/Path;)V
-	public static synthetic fun setupKotlinEnvironment$default (Lorg/spekframework/spek2/dsl/Root;Ljava/nio/file/Path;ILjava/lang/Object;)V
-}
-

--- a/detekt-test-utils/build.gradle.kts
+++ b/detekt-test-utils/build.gradle.kts
@@ -6,7 +6,6 @@ plugins {
 dependencies {
     api(libs.kotlin.stdlibJdk8)
     api(libs.junit.api)
-    compileOnly(libs.spek.dsl)
     implementation(projects.detektParser)
     implementation(libs.kotlin.scriptUtil)
 

--- a/detekt-test-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/KotlinEnvironmentTestSetup.kt
+++ b/detekt-test-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/KotlinEnvironmentTestSetup.kt
@@ -8,27 +8,8 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.ExtensionContext
 import org.junit.jupiter.api.extension.ParameterContext
 import org.junit.jupiter.api.extension.ParameterResolver
-import org.spekframework.spek2.dsl.Root
-import org.spekframework.spek2.lifecycle.CachingMode
 import java.io.File
-import java.nio.file.Path
 import kotlin.script.experimental.jvm.util.classpathFromClassloader
-
-@Deprecated(
-    "This is specific to Spek and will be removed in a future release. Documentation has been updated to " +
-        "show alternative approaches: https://detekt.dev/type-resolution.html#testing-a-rule-that-uses-type-resolution"
-)
-fun Root.setupKotlinEnvironment(additionalJavaSourceRootPath: Path? = null) {
-    val wrapper by memoized(
-        CachingMode.SCOPE,
-        { createEnvironment(additionalJavaSourceRootPaths = listOfNotNull(additionalJavaSourceRootPath?.toFile())) },
-        { it.dispose() }
-    )
-
-    // name is used for delegation
-    @Suppress("UNUSED_VARIABLE")
-    val env: KotlinCoreEnvironment by memoized(CachingMode.EACH_GROUP) { wrapper.env }
-}
 
 @Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.CLASS)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,8 +37,6 @@ ktlint-rulesetExperimental = { module = "com.pinterest.ktlint:ktlint-ruleset-exp
 slf4j-nop = { module = "org.slf4j:slf4j-nop", version = "1.7.36" }
 slf4j-simple = { module = "org.slf4j:slf4j-simple", version = "1.7.36" }
 
-spek-dsl = { module = "org.spekframework.spek2:spek-dsl-jvm", version = "2.0.19" }
-
 junit-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit" }
 
 sarif4k = "io.github.detekt.sarif4k:sarif4k:0.2.0"

--- a/website/docs/gettingstarted/type-resolution.md
+++ b/website/docs/gettingstarted/type-resolution.md
@@ -123,32 +123,4 @@ class MyRuleSpec(private val env: KotlinCoreEnvironment) {
 }
 ```
 
-If you're using Spek for testing, you can create a `setupKotlinEnvironment()` util function, and get access to the
-`KotlinCoreEnvironment` by simply calling `val env: KotlinCoreEnvironment by memoized()`:
-
-```kotlin
-fun org.spekframework.spek2.dsl.Root.setupKotlinEnvironment(additionalJavaSourceRootPath: Path? = null) {
-    val wrapper by memoized(
-        CachingMode.SCOPE,
-        { createEnvironment(additionalJavaSourceRootPaths = listOfNotNull(additionalJavaSourceRootPath?.toFile())) },
-        { it.dispose() }
-    )
-
-    // `env` name is used for delegation
-    @Suppress("UNUSED_VARIABLE")
-    val env: KotlinCoreEnvironment by memoized(CachingMode.EACH_GROUP) { wrapper.env }
-}
-
-class MyRuleTest : Spek({
-    setupKotlinEnvironment()
-
-    val env: KotlinCoreEnvironment by memoized()
-
-    it("reports cast that cannot succeed") {
-        val code = """/* The code you want to test */"""
-        assertThat(MyRuleSpec().compileAndLintWithContext(env, code)).hasSize(1)
-    }
-})
-```
-
 If you're using another testing framework (e.g. JUnit 4), you can use the [`createEnvironment()`](https://github.com/detekt/detekt/blob/cd659ce8737fb177caf140f46f73a1a86b22be56/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/KotlinCoreEnvironmentWrapper.kt#L26-L31) method from `detekt-test-utils`.


### PR DESCRIPTION
It's been about 10 months since v1.20.0 was released and we deprecated Spek support. I think it's time to drop it completely.

For future readers, if you want to continue using the support that was provided by detekt, just use:

```kotlin
fun Root.setupKotlinEnvironment(additionalJavaSourceRootPath: Path? = null) {
    val wrapper by memoized(
        CachingMode.SCOPE,
        { createEnvironment(additionalJavaSourceRootPaths = listOfNotNull(additionalJavaSourceRootPath?.toFile())) },
        { it.dispose() }
    )

    // name is used for delegation
    @Suppress("UNUSED_VARIABLE")
    val env: KotlinCoreEnvironment by memoized(CachingMode.EACH_GROUP) { wrapper.env }
}
```

You'll need to tweak your imports but otherwise this should continue working for the foreseeable future.