### PR TITLE
Fixed ProtectedMemberInFinalClass rule reporting valid JVM finalize

### DIFF
--- a/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/MethodSignature.kt
+++ b/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/MethodSignature.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules
 
+import org.jetbrains.kotlin.psi.KtDeclaration
 import org.jetbrains.kotlin.psi.KtFunction
 import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.KtObjectDeclaration
@@ -9,6 +10,9 @@ fun KtFunction.isEqualsFunction() =
 
 fun KtFunction.isHashCodeFunction() =
     this.name == "hashCode" && this.isOverride() && this.valueParameters.isEmpty()
+
+fun KtDeclaration.isJvmFinalizeFunction() =
+    this.name == "finalize" && this is KtNamedFunction && this.valueParameters.isEmpty()
 
 private val knownAnys = setOf("Any?", "kotlin.Any?")
 fun KtFunction.hasCorrectEqualsParameter() =

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ProtectedMemberInFinalClass.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ProtectedMemberInFinalClass.kt
@@ -9,6 +9,7 @@ import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
+import io.gitlab.arturbosch.detekt.rules.isJvmFinalizeFunction
 import io.gitlab.arturbosch.detekt.rules.isOpen
 import io.gitlab.arturbosch.detekt.rules.isOverride
 import org.jetbrains.kotlin.psi.KtClass
@@ -68,7 +69,7 @@ class ProtectedMemberInFinalClass(config: Config = Config.empty) : Rule(config) 
     internal inner class DeclarationVisitor : DetektVisitor() {
 
         override fun visitDeclaration(dcl: KtDeclaration) {
-            if (dcl.isProtected() && !dcl.isOverride()) {
+            if (dcl.isProtected() && !dcl.isOverride() && !dcl.isJvmFinalizeFunction()) {
                 report(CodeSmell(issue, Entity.from(dcl), issue.description))
             }
         }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ProtectedMemberInFinalClassSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ProtectedMemberInFinalClassSpec.kt
@@ -147,7 +147,6 @@ class ProtectedMemberInFinalClassSpec {
         fun `reports a protected method named finalize if id does not match JVM signuatre in a final class`() {
             val code = """
                 class MyFinalizable {
-                     @Throws(Throwable::class)
                      protected fun finalize(parameter: String) { // note parameters are not empty
                      
                      }               
@@ -252,7 +251,6 @@ class ProtectedMemberInFinalClassSpec {
         fun `does not report protected definitions of finalize method`() {
             val code = """
                 class MyFinalizable {
-                     @Throws(Throwable::class)
                      protected fun finalize() {
                      
                      }               

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ProtectedMemberInFinalClassSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ProtectedMemberInFinalClassSpec.kt
@@ -142,6 +142,33 @@ class ProtectedMemberInFinalClassSpec {
             assertThat(findings).hasSize(1)
             assertThat(findings).hasStartSourceLocation(1, 42)
         }
+
+        @Test
+        fun `reports a protected method named finalize if id does not match JVM signuatre in a final class`() {
+            val code = """
+                class MyFinalizable {
+                     @Throws(Throwable::class)
+                     protected fun finalize(parameter: String) { // note parameters are not empty
+                     
+                     }               
+                }
+            """.trimIndent()
+            val findings = subject.compileAndLint(code)
+            assertThat(findings).hasSize(1)
+            assertThat(findings).hasStartSourceLocation(2, 6)
+        }
+
+        @Test
+        fun `reports a protected property named finalize in a final class`() {
+            val code = """
+                class MyFinalizable {
+                     protected val finalize get() = "hello world"         
+                }
+            """.trimIndent()
+            val findings = subject.compileAndLint(code)
+            assertThat(findings).hasSize(1)
+            assertThat(findings).hasStartSourceLocation(2, 6)
+        }
     }
 
     @Nested
@@ -216,6 +243,19 @@ class ProtectedMemberInFinalClassSpec {
                 enum class EnumClass {
                     ;   
                     protected fun foo() {}
+                }
+            """.trimIndent()
+            assertThat(subject.compileAndLint(code)).isEmpty()
+        }
+
+        @Test
+        fun `does not report protected definitions of finalize method`() {
+            val code = """
+                class MyFinalizable {
+                     @Throws(Throwable::class)
+                     protected fun finalize() {
+                     
+                     }               
                 }
             """.trimIndent()
             assertThat(subject.compileAndLint(code)).isEmpty()


### PR DESCRIPTION
Fixes https://github.com/detekt/detekt/issues/5660

Added check that declaration does not match JVM finalize signature:
1. name == "finalize"
2. parameters are empty
