### PR TITLE
Fixed ProtectedMemberInFinalClass rule reporting valid JVM finalize

### DIFF
--- a/detekt-psi-utils/api/detekt-psi-utils.api
+++ b/detekt-psi-utils/api/detekt-psi-utils.api
@@ -124,6 +124,7 @@ public final class io/gitlab/arturbosch/detekt/rules/MethodSignatureKt {
 	public static final fun hasCorrectEqualsParameter (Lorg/jetbrains/kotlin/psi/KtFunction;)Z
 	public static final fun isEqualsFunction (Lorg/jetbrains/kotlin/psi/KtFunction;)Z
 	public static final fun isHashCodeFunction (Lorg/jetbrains/kotlin/psi/KtFunction;)Z
+	public static final fun isJvmFinalizeFunction (Lorg/jetbrains/kotlin/psi/KtNamedFunction;)Z
 	public static final fun isMainFunction (Lorg/jetbrains/kotlin/psi/KtNamedFunction;)Z
 }
 

--- a/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/MethodSignature.kt
+++ b/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/MethodSignature.kt
@@ -11,8 +11,8 @@ fun KtFunction.isEqualsFunction() =
 fun KtFunction.isHashCodeFunction() =
     this.name == "hashCode" && this.isOverride() && this.valueParameters.isEmpty()
 
-fun KtDeclaration.isJvmFinalizeFunction() =
-    this.name == "finalize" && this is KtNamedFunction && this.valueParameters.isEmpty()
+fun KtNamedFunction.isJvmFinalizeFunction() =
+    this.name == "finalize" && this.valueParameters.isEmpty()
 
 private val knownAnys = setOf("Any?", "kotlin.Any?")
 fun KtFunction.hasCorrectEqualsParameter() =

--- a/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/MethodSignature.kt
+++ b/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/MethodSignature.kt
@@ -1,9 +1,9 @@
 package io.gitlab.arturbosch.detekt.rules
 
-import org.jetbrains.kotlin.psi.KtDeclaration
 import org.jetbrains.kotlin.psi.KtFunction
 import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.KtObjectDeclaration
+import org.jetbrains.kotlin.psi.psiUtil.isPrivate
 
 fun KtFunction.isEqualsFunction() =
     this.name == "equals" && this.isOverride() && hasCorrectEqualsParameter()
@@ -11,8 +11,14 @@ fun KtFunction.isEqualsFunction() =
 fun KtFunction.isHashCodeFunction() =
     this.name == "hashCode" && this.isOverride() && this.valueParameters.isEmpty()
 
+/**
+ * [Kotlin Documentation](https://kotlinlang.org/docs/java-interop.html#finalize)
+ */
 fun KtNamedFunction.isJvmFinalizeFunction() =
-    this.name == "finalize" && this.valueParameters.isEmpty()
+    this.name == "finalize" &&
+        this.valueParameters.isEmpty() &&
+        !this.isOverride() &&
+        !this.isPrivate()
 
 private val knownAnys = setOf("Any?", "kotlin.Any?")
 fun KtFunction.hasCorrectEqualsParameter() =

--- a/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/MethodSignature.kt
+++ b/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/MethodSignature.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules
 
+import org.jetbrains.kotlin.psi.KtDeclaration
 import org.jetbrains.kotlin.psi.KtFunction
 import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.KtObjectDeclaration
@@ -9,6 +10,9 @@ fun KtFunction.isEqualsFunction() =
 
 fun KtFunction.isHashCodeFunction() =
     this.name == "hashCode" && this.isOverride() && this.valueParameters.isEmpty()
+
+fun KtDeclaration.isJvmFinalizeFunction() =
+    this.name == "finalize" && this is KtNamedFunction && this.valueParameters.isEmpty()
 
 private val knownAnys = setOf("Any?", "kotlin.Any?")
 fun KtFunction.hasCorrectEqualsParameter() =

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ProtectedMemberInFinalClass.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ProtectedMemberInFinalClass.kt
@@ -14,6 +14,7 @@ import io.gitlab.arturbosch.detekt.rules.isOpen
 import io.gitlab.arturbosch.detekt.rules.isOverride
 import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtDeclaration
+import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.psiUtil.isAbstract
 import org.jetbrains.kotlin.psi.psiUtil.isProtected
 
@@ -69,7 +70,9 @@ class ProtectedMemberInFinalClass(config: Config = Config.empty) : Rule(config) 
     internal inner class DeclarationVisitor : DetektVisitor() {
 
         override fun visitDeclaration(dcl: KtDeclaration) {
-            if (dcl.isProtected() && !dcl.isOverride() && !dcl.isJvmFinalizeFunction()) {
+            val isJvmFinalizeFunction = dcl is KtNamedFunction && dcl.isJvmFinalizeFunction()
+
+            if (dcl.isProtected() && !dcl.isOverride() && !isJvmFinalizeFunction) {
                 report(CodeSmell(issue, Entity.from(dcl), issue.description))
             }
         }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ProtectedMemberInFinalClass.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ProtectedMemberInFinalClass.kt
@@ -9,6 +9,7 @@ import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
+import io.gitlab.arturbosch.detekt.rules.isJvmFinalizeFunction
 import io.gitlab.arturbosch.detekt.rules.isOpen
 import io.gitlab.arturbosch.detekt.rules.isOverride
 import org.jetbrains.kotlin.psi.KtClass
@@ -68,7 +69,7 @@ class ProtectedMemberInFinalClass(config: Config = Config.empty) : Rule(config) 
     internal inner class DeclarationVisitor : DetektVisitor() {
 
         override fun visitDeclaration(dcl: KtDeclaration) {
-            if (dcl.isProtected() && !dcl.isOverride()) {
+            if (dcl.isProtected() && !dcl.isOverride() && !dcl.isJvmFinalizeFunction()) {
                 report(CodeSmell(issue, Entity.from(dcl), issue.description))
             }
         }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ProtectedMemberInFinalClassSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ProtectedMemberInFinalClassSpec.kt
@@ -147,7 +147,6 @@ class ProtectedMemberInFinalClassSpec {
         fun `reports a protected method named finalize if id does not match JVM signuatre in a final class`() {
             val code = """
                 class MyFinalizable {
-                     @Throws(Throwable::class)
                      protected fun finalize(parameter: String) { // note parameters are not empty
                      
                      }               
@@ -252,7 +251,6 @@ class ProtectedMemberInFinalClassSpec {
         fun `does not report protected definitions of finalize method`() {
             val code = """
                 class MyFinalizable {
-                     @Throws(Throwable::class)
                      protected fun finalize() {
                      
                      }               

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ProtectedMemberInFinalClassSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ProtectedMemberInFinalClassSpec.kt
@@ -142,6 +142,33 @@ class ProtectedMemberInFinalClassSpec {
             assertThat(findings).hasSize(1)
             assertThat(findings).hasStartSourceLocation(1, 42)
         }
+
+        @Test
+        fun `reports a protected method named finalize if id does not match JVM signuatre in a final class`() {
+            val code = """
+                class MyFinalizable {
+                     @Throws(Throwable::class)
+                     protected fun finalize(parameter: String) { // note parameters are not empty
+                     
+                     }               
+                }
+            """.trimIndent()
+            val findings = subject.compileAndLint(code)
+            assertThat(findings).hasSize(1)
+            assertThat(findings).hasStartSourceLocation(2, 6)
+        }
+
+        @Test
+        fun `reports a protected property named finalize in a final class`() {
+            val code = """
+                class MyFinalizable {
+                     protected val finalize get() = "hello world"         
+                }
+            """.trimIndent()
+            val findings = subject.compileAndLint(code)
+            assertThat(findings).hasSize(1)
+            assertThat(findings).hasStartSourceLocation(2, 6)
+        }
     }
 
     @Nested
@@ -216,6 +243,19 @@ class ProtectedMemberInFinalClassSpec {
                 enum class EnumClass {
                     ;   
                     protected fun foo() {}
+                }
+            """.trimIndent()
+            assertThat(subject.compileAndLint(code)).isEmpty()
+        }
+
+        @Test
+        fun `does not report protected definitions of finalize method`() {
+            val code = """
+                class MyFinalizable {
+                     @Throws(Throwable::class)
+                     protected fun finalize() {
+                     
+                     }               
                 }
             """.trimIndent()
             assertThat(subject.compileAndLint(code)).isEmpty()


### PR DESCRIPTION
Fixes https://github.com/detekt/detekt/issues/5660

Added check that declaration does not match JVM finalize signature:

name == "finalize"
parameters are empty