### PR TITLE
Fix circular dependencies

### DIFF
--- a/detekt-formatting/build.gradle.kts
+++ b/detekt-formatting/build.gradle.kts
@@ -23,7 +23,11 @@ dependencies {
     extraDepsToPackage(libs.slf4j.nop)
 }
 
-tasks.build { finalizedBy(":detekt-generator:generateDocumentation") }
+consumeGeneratedConfig(
+    fromProject = projects.detektGenerator,
+    fromConfiguration = "generatedFormattingConfig",
+    forTask = "sourcesJar"
+)
 
 val depsToPackage = setOf(
     "org.ec4j.core",

--- a/detekt-generator/build.gradle.kts
+++ b/detekt-generator/build.gradle.kts
@@ -83,6 +83,11 @@ val generateDocumentation by tasks.registering(JavaExec::class) {
     )
 }
 
+val generatedFormattingConfig: Configuration by configurations.creating {
+    isCanBeConsumed = true
+    isCanBeResolved = false
+}
+
 val generatedLibrariesConfig: Configuration by configurations.creating {
     isCanBeConsumed = true
     isCanBeResolved = false
@@ -99,6 +104,9 @@ val generatedCoreConfig: Configuration by configurations.creating {
 }
 
 artifacts {
+    add(generatedFormattingConfig.name, file(formattingConfigFile)) {
+        builtBy(generateDocumentation)
+    }
     add(generatedLibrariesConfig.name, file(librariesConfigFile)) {
         builtBy(generateDocumentation)
     }

--- a/detekt-rules/build.gradle.kts
+++ b/detekt-rules/build.gradle.kts
@@ -27,5 +27,3 @@ dependencies {
     testImplementation(libs.assertj)
     testImplementation(libs.reflections)
 }
-
-tasks.build { finalizedBy(":detekt-generator:generateDocumentation") }


### PR DESCRIPTION
This PR aims to fix circular dependencies detected [here](https://github.com/detekt/detekt/pull/5773#issuecomment-1431265051)

I removed `tasks.build finalizedBy(":detekt-generator:generateDocumentation")` from `detekt-rules` and `detekt-formatting` to fix the circular dependency.

When looking at the task graph (when triggering `build` task), `generateDocumentation` already depends on `detekt-formatting:jar` and `detekt-rules:jar`, please confirm that this is sufficient.
<img width="514" alt="Screenshot 2023-02-15 at 4 45 41 PM" src="https://user-images.githubusercontent.com/10243934/219078926-9dfec40e-0209-4c25-881b-636e5bd0e0b5.png">

After that I had to use `consumeGeneratedConfig` logic not to have Gradle optimizations disabled on `:detekt-formatting:sourcesJar`