### PR TITLE
Forbid using Jupiter Kotlin assertions

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -181,6 +181,16 @@ style:
         reason: 'Import Assertions.assertThat instead.'
       - value: 'org.junit.jupiter.api.Assertions*'
         reason: 'Use AssertJ assertions instead.'
+      - value: 'org.junit.jupiter.api.assertAll'
+        reason: 'Use AssertJ assertSoftly instead.'
+      - value: 'org.junit.jupiter.api.assertThrows'
+        reason: 'Use AssertJ assertThatCode { }.isInstanceOf() or assertThatExceptionOfType().isThrownBy { } instead.'
+      - value: 'org.junit.jupiter.api.assertDoesNotThrow'
+        reason: 'Use AssertJ assertThatCode { }.doesNotThrowAnyException() instead.'
+      # These don't have AssertJ alternatives, so just allow them:
+      #- value: 'org.junit.jupiter.api.fail'
+      #- value: 'org.junit.jupiter.api.assertTimeout'
+      #- value: 'org.junit.jupiter.api.assertTimeoutPreemptively'
       - value: 'java.util.stream.*'
         reason: "Use Kotlin's sequences instead."
   ForbiddenMethodCall:

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/RunnerSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/RunnerSpec.kt
@@ -13,7 +13,6 @@ import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
 import java.nio.file.Files
 import java.nio.file.Path
 
@@ -303,7 +302,7 @@ class RunnerSpec {
 
     @Test
     fun `does not fail on rule property type change from comma separated string to list when YamlConfig is wrapped`() {
-        assertDoesNotThrow {
+        assertThatCode {
             executeDetekt(
                 "--all-rules", // wrapping config
                 "--input",
@@ -313,6 +312,6 @@ class RunnerSpec {
                 "--max-issues",
                 "-1"
             )
-        }
+        }.doesNotThrowAnyException()
     }
 }


### PR DESCRIPTION
Here are the imports that are relevant in this PR:
```kotlin
import org.junit.jupiter.api.fail
import org.junit.jupiter.api.assertAll
import org.junit.jupiter.api.assertThrows
import org.junit.jupiter.api.assertDoesNotThrow
import org.junit.jupiter.api.assertTimeout
import org.junit.jupiter.api.assertTimeoutPreemptively
```
and the signatures from `org.junit.jupiter.api.AssertionsKt`:
```kotlin
fun fail(message: String?, throwable: Throwable? = null): Nothing = TODO()
fun fail(message: (() -> String)?): Nothing = TODO()
fun fail(throwable: Throwable?): Nothing = TODO()
fun assertAll(vararg executables: () -> Unit): Nothing = TODO()
fun assertAll(heading: String?, vararg executables: () -> Unit): Nothing = TODO()
fun <reified T : Throwable> assertThrows(executable: () -> Unit): T = TODO()
fun <reified T : Throwable> assertThrows(message: String, executable: () -> Unit): T = TODO()
fun <reified T : Throwable> assertThrows(noinline message: () -> String, executable: () -> Unit): T =  TODO()
fun <R> assertDoesNotThrow(executable: () -> R): R = TODO()
fun <R> assertDoesNotThrow(message: String, executable: () -> R): R = TODO()
fun <R> assertDoesNotThrow(noinline message: () -> String, executable: () -> R): R = TODO()
fun <R> assertTimeout(timeout: Duration, executable: () -> R): R = TODO()
fun <R> assertTimeout(timeout: Duration, message: String, executable: () -> R): R = TODO()
fun <R> assertTimeout(timeout: Duration, message: () -> String, executable: () -> R): R = TODO()
fun <R> assertTimeoutPreemptively(timeout: Duration, executable: () -> R): R = TODO()
fun <R> assertTimeoutPreemptively(timeout: Duration, message: String, executable: () -> R): R = TODO()
fun <R> assertTimeoutPreemptively(timeout: Duration, message: () -> String, executable: () -> R): R = TODO()
```

Not all of them have AssertJ equivalent, but the ones who do are forbidden.