### PR TITLE
Reduce configuration of UnusedPrivateMember's split rules

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -710,7 +710,7 @@ style:
     active: true
   UnusedPrivateMember:
     active: true
-    allowedNames: 'ignored|expected'
+    allowedNames: ''
   UnusedPrivateProperty:
     active: true
     allowedNames: '_|ignored|expected|serialVersionUID'

--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -705,12 +705,12 @@ style:
     active: false
   UnusedParameter:
     active: true
-    allowedNames: '(ignored|expected|serialVersionUID)'
+    allowedNames: '(ignored|expected)'
   UnusedPrivateClass:
     active: true
   UnusedPrivateMember:
     active: true
-    allowedNames: '(ignored|expected|serialVersionUID)'
+    allowedNames: '(ignored|expected)'
   UnusedPrivateProperty:
     active: true
     allowedNames: '(_|ignored|expected|serialVersionUID)'

--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -705,15 +705,15 @@ style:
     active: false
   UnusedParameter:
     active: true
-    allowedNames: '(ignored|expected)'
+    allowedNames: 'ignored|expected'
   UnusedPrivateClass:
     active: true
   UnusedPrivateMember:
     active: true
-    allowedNames: '(ignored|expected)'
+    allowedNames: 'ignored|expected'
   UnusedPrivateProperty:
     active: true
-    allowedNames: '(_|ignored|expected|serialVersionUID)'
+    allowedNames: '_|ignored|expected|serialVersionUID'
   UseAnyOrNoneInsteadOfFind:
     active: true
   UseArrayLiteralsInAnnotations:

--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -705,12 +705,12 @@ style:
     active: false
   UnusedParameter:
     active: true
-    allowedNames: '(_|ignored|expected|serialVersionUID)'
+    allowedNames: '(ignored|expected|serialVersionUID)'
   UnusedPrivateClass:
     active: true
   UnusedPrivateMember:
     active: true
-    allowedNames: '(_|ignored|expected|serialVersionUID)'
+    allowedNames: '(ignored|expected|serialVersionUID)'
   UnusedPrivateProperty:
     active: true
     allowedNames: '(_|ignored|expected|serialVersionUID)'

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedParameter.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedParameter.kt
@@ -57,7 +57,7 @@ class UnusedParameter(config: Config = Config.empty) : Rule(config) {
     )
 
     @Configuration("unused parameter names matching this regex are ignored")
-    private val allowedNames: Regex by config("(ignored|expected)", String::toRegex)
+    private val allowedNames: Regex by config("ignored|expected", String::toRegex)
 
     override fun visit(root: KtFile) {
         super.visit(root)

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedParameter.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedParameter.kt
@@ -57,7 +57,7 @@ class UnusedParameter(config: Config = Config.empty) : Rule(config) {
     )
 
     @Configuration("unused parameter names matching this regex are ignored")
-    private val allowedNames: Regex by config("(_|ignored|expected|serialVersionUID)", String::toRegex)
+    private val allowedNames: Regex by config("(ignored|expected|serialVersionUID)", String::toRegex)
 
     override fun visit(root: KtFile) {
         super.visit(root)

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedParameter.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedParameter.kt
@@ -57,7 +57,7 @@ class UnusedParameter(config: Config = Config.empty) : Rule(config) {
     )
 
     @Configuration("unused parameter names matching this regex are ignored")
-    private val allowedNames: Regex by config("(ignored|expected|serialVersionUID)", String::toRegex)
+    private val allowedNames: Regex by config("(ignored|expected)", String::toRegex)
 
     override fun visit(root: KtFile) {
         super.visit(root)

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
@@ -56,7 +56,7 @@ class UnusedPrivateMember(config: Config = Config.empty) : Rule(config) {
     )
 
     @Configuration("unused private function names matching this regex are ignored")
-    private val allowedNames: Regex by config("ignored|expected", String::toRegex)
+    private val allowedNames: Regex by config("", String::toRegex)
 
     override fun visit(root: KtFile) {
         super.visit(root)

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
@@ -56,7 +56,7 @@ class UnusedPrivateMember(config: Config = Config.empty) : Rule(config) {
     )
 
     @Configuration("unused private function names matching this regex are ignored")
-    private val allowedNames: Regex by config("(ignored|expected|serialVersionUID)", String::toRegex)
+    private val allowedNames: Regex by config("(ignored|expected)", String::toRegex)
 
     override fun visit(root: KtFile) {
         super.visit(root)

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
@@ -56,7 +56,7 @@ class UnusedPrivateMember(config: Config = Config.empty) : Rule(config) {
     )
 
     @Configuration("unused private function names matching this regex are ignored")
-    private val allowedNames: Regex by config("(ignored|expected)", String::toRegex)
+    private val allowedNames: Regex by config("ignored|expected", String::toRegex)
 
     override fun visit(root: KtFile) {
         super.visit(root)

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
@@ -38,6 +38,7 @@ private const val ARRAY_GET_METHOD_NAME = "get"
 
 /**
  * Reports unused private functions.
+ *
  * If these private functions are unused they should be removed. Otherwise, this dead code
  * can lead to confusion and potential bugs.
  */
@@ -55,7 +56,7 @@ class UnusedPrivateMember(config: Config = Config.empty) : Rule(config) {
     )
 
     @Configuration("unused private function names matching this regex are ignored")
-    private val allowedNames: Regex by config("(_|ignored|expected|serialVersionUID)", String::toRegex)
+    private val allowedNames: Regex by config("(ignored|expected|serialVersionUID)", String::toRegex)
 
     override fun visit(root: KtFile) {
         super.visit(root)

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateProperty.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateProperty.kt
@@ -58,7 +58,7 @@ class UnusedPrivateProperty(config: Config = Config.empty) : Rule(config) {
     )
 
     @Configuration("unused property names matching this regex are ignored")
-    private val allowedNames: Regex by config("(_|ignored|expected|serialVersionUID)", String::toRegex)
+    private val allowedNames: Regex by config("_|ignored|expected|serialVersionUID", String::toRegex)
 
     override fun visit(root: KtFile) {
         super.visit(root)

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMemberSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMemberSpec.kt
@@ -279,20 +279,6 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
     }
 
     @Nested
-    inner class `unused class declarations which are allowed` {
-
-        @Test
-        fun `does not report the unused private function and parameter`() {
-            val code = """
-                class Test {
-                    private fun ignored(ignored: Int) {}
-                }
-            """.trimIndent()
-            assertThat(subject.lint(code)).isEmpty()
-        }
-    }
-
-    @Nested
     inner class `error messages` {
 
         @Test


### PR DESCRIPTION
Those `allowedNames` were copy&pasted when `UnusedPrivateMember` was splitted. But some of them have no sense in some usages.

This is a follow up of #5722