### PR TITLE
Simplify `TestConfig` usages

### DIFF
--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/ConfigPropertySpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/ConfigPropertySpec.kt
@@ -526,5 +526,5 @@ private open class TestConfigAware(private vararg val data: Pair<String, Any>) :
     override val ruleId: RuleId
         get() = "test"
     override val ruleSetConfig: Config
-        get() = TestConfig(data.toMap())
+        get() = TestConfig(*data)
 }

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/internal/InclusionExclusionPatternsSpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/internal/InclusionExclusionPatternsSpec.kt
@@ -22,7 +22,7 @@ class InclusionExclusionPatternsSpec {
     @Nested
     inner class `rule should only run on library file specified by 'includes' pattern` {
 
-        private val config = TestConfig(mapOf(Config.INCLUDES_KEY to "**/library/*.kt"))
+        private val config = TestConfig(Config.INCLUDES_KEY to "**/library/*.kt")
 
         @Test
         fun `should run`() {
@@ -42,7 +42,7 @@ class InclusionExclusionPatternsSpec {
     @Nested
     inner class `rule should only run on library file not matching the specified 'excludes' pattern` {
 
-        private val config = TestConfig(mapOf(Config.EXCLUDES_KEY to "glob:**/Default.kt"))
+        private val config = TestConfig(Config.EXCLUDES_KEY to "glob:**/Default.kt")
 
         @Test
         fun `should run`() {
@@ -83,10 +83,8 @@ class InclusionExclusionPatternsSpec {
         @Test
         fun `should only run on dummies`() {
             val config = TestConfig(
-                mapOf(
-                    Config.INCLUDES_KEY to "**/library/**",
-                    Config.EXCLUDES_KEY to "**Library.kt"
-                )
+                Config.INCLUDES_KEY to "**/library/**",
+                Config.EXCLUDES_KEY to "**Library.kt",
             )
 
             OnlyLibraryTrackingRule(config).apply {
@@ -101,10 +99,8 @@ class InclusionExclusionPatternsSpec {
         @Test
         fun `should only run on library file`() {
             val config = TestConfig(
-                mapOf(
-                    Config.INCLUDES_KEY to "**/library/**",
-                    Config.EXCLUDES_KEY to "**Dummy*.kt"
-                )
+                Config.INCLUDES_KEY to "**/library/**",
+                Config.EXCLUDES_KEY to "**Dummy*.kt",
             )
 
             OnlyLibraryTrackingRule(config).apply {

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/SuppressionSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/SuppressionSpec.kt
@@ -229,7 +229,7 @@ class SuppressionSpec {
             }
                 """.trimIndent()
             )
-            val rule = TestRule(TestConfig(mutableMapOf("aliases" to "[MyTest]")))
+            val rule = TestRule(TestConfig("aliases" to "[MyTest]"))
             rule.visitFile(ktFile)
             assertThat(rule.expected).isNotNull()
         }

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/IssueExtensionSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/IssueExtensionSpec.kt
@@ -40,7 +40,7 @@ class IssueExtensionSpec {
 
         @Test
         fun `excludeCorrectable = true`() {
-            val config = TestConfig(mapOf("maxIssues" to "0", "excludeCorrectable" to "true"))
+            val config = TestConfig("maxIssues" to "0", "excludeCorrectable" to "true")
             val detektion = object : TestDetektion() {
                 override val findings: Map<String, List<Finding>> = issues
             }

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/ValueOrDefaultCommaSeparatedSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/ValueOrDefaultCommaSeparatedSpec.kt
@@ -42,8 +42,8 @@ class ValueOrDefaultCommaSeparatedSpec {
         @Test
         fun `and empty String`() {
             val config = CompositeConfig(
-                TestConfig(mapOf("imports" to "")),
-                TestConfig(mapOf("imports" to emptyList<String>()))
+                TestConfig("imports" to ""),
+                TestConfig("imports" to emptyList<String>())
             )
 
             assertThat(config.valueOrDefaultCommaSeparated("imports", emptyList())).isEmpty()
@@ -52,8 +52,8 @@ class ValueOrDefaultCommaSeparatedSpec {
         @Test
         fun `and empty List`() {
             val config = CompositeConfig(
-                TestConfig(mapOf("imports" to emptyList<String>())),
-                TestConfig(mapOf("imports" to emptyList<String>()))
+                TestConfig("imports" to emptyList<String>()),
+                TestConfig("imports" to emptyList<String>())
             )
 
             assertThat(config.valueOrDefaultCommaSeparated("imports", emptyList())).isEmpty()
@@ -62,8 +62,8 @@ class ValueOrDefaultCommaSeparatedSpec {
         @Test
         fun `and String with values`() {
             val config = CompositeConfig(
-                TestConfig(mapOf("imports" to "java.utils.*,butterknife.*")),
-                TestConfig(mapOf("imports" to emptyList<String>()))
+                TestConfig("imports" to "java.utils.*,butterknife.*"),
+                TestConfig("imports" to emptyList<String>())
             )
 
             assertThat(config.valueOrDefaultCommaSeparated("imports", emptyList()))
@@ -73,8 +73,8 @@ class ValueOrDefaultCommaSeparatedSpec {
         @Test
         fun `and List with values`() {
             val config = CompositeConfig(
-                TestConfig(mapOf("imports" to listOf("java.utils.*", "butterknife.*"))),
-                TestConfig(mapOf("imports" to emptyList<String>()))
+                TestConfig("imports" to listOf("java.utils.*", "butterknife.*")),
+                TestConfig("imports" to emptyList<String>())
             )
 
             assertThat(config.valueOrDefaultCommaSeparated("imports", emptyList()))

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/AutoCorrectableIssueAssert.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/AutoCorrectableIssueAssert.kt
@@ -9,7 +9,7 @@ import org.assertj.core.api.Assertions.assertThat
 internal object AutoCorrectableIssueAssert {
 
     fun isReportNull(report: ConsoleReport) {
-        val config = TestConfig(mapOf("maxIssues" to "0", "excludeCorrectable" to "true"))
+        val config = TestConfig("maxIssues" to "0", "excludeCorrectable" to "true")
         report.init(config)
         val correctableCodeSmell = createCorrectableFinding()
         val detektionWithCorrectableSmell = TestDetektion(correctableCodeSmell)

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/TrailingCommaOnCallSiteSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/TrailingCommaOnCallSiteSpec.kt
@@ -21,7 +21,7 @@ class TrailingCommaOnCallSiteSpec {
             val code = """
                 val foo1 = listOf("a", "b",)
             """.trimIndent()
-            val findings = TrailingCommaOnCallSite(TestConfig(mapOf(USE_TRAILING_COMMA to false))).lint(code)
+            val findings = TrailingCommaOnCallSite(TestConfig(USE_TRAILING_COMMA to false)).lint(code)
             assertThat(findings).hasSize(1)
         }
 
@@ -30,7 +30,7 @@ class TrailingCommaOnCallSiteSpec {
             val code = """
                 val foo2 = Pair(1, 2,)
             """.trimIndent()
-            val findings = TrailingCommaOnCallSite(TestConfig(mapOf(USE_TRAILING_COMMA to false))).lint(code)
+            val findings = TrailingCommaOnCallSite(TestConfig(USE_TRAILING_COMMA to false)).lint(code)
             assertThat(findings).hasSize(1)
         }
 
@@ -39,7 +39,7 @@ class TrailingCommaOnCallSiteSpec {
             val code = """
                 val foo3: List<String,> = emptyList()
             """.trimIndent()
-            val findings = TrailingCommaOnCallSite(TestConfig(mapOf(USE_TRAILING_COMMA to false))).lint(code)
+            val findings = TrailingCommaOnCallSite(TestConfig(USE_TRAILING_COMMA to false)).lint(code)
             assertThat(findings).hasSize(1)
         }
 
@@ -49,7 +49,7 @@ class TrailingCommaOnCallSiteSpec {
                 val foo4 = Array(2) { 42 }
                 val bar4 = foo4[1,]
             """.trimIndent()
-            val findings = TrailingCommaOnCallSite(TestConfig(mapOf(USE_TRAILING_COMMA to false))).lint(code)
+            val findings = TrailingCommaOnCallSite(TestConfig(USE_TRAILING_COMMA to false)).lint(code)
             assertThat(findings).hasSize(1)
         }
 
@@ -59,7 +59,7 @@ class TrailingCommaOnCallSiteSpec {
                 @Foo5([1, 2,])
                 val foo5: Int = 0
             """.trimIndent()
-            val findings = TrailingCommaOnCallSite(TestConfig(mapOf(USE_TRAILING_COMMA to false))).lint(code)
+            val findings = TrailingCommaOnCallSite(TestConfig(USE_TRAILING_COMMA to false)).lint(code)
             assertThat(findings).hasSize(1)
         }
     }
@@ -76,7 +76,7 @@ class TrailingCommaOnCallSiteSpec {
                     "b"
                 )
             """.trimIndent()
-            val findings = TrailingCommaOnCallSite(TestConfig(mapOf(USE_TRAILING_COMMA to true))).lint(code)
+            val findings = TrailingCommaOnCallSite(TestConfig(USE_TRAILING_COMMA to true)).lint(code)
             assertThat(findings).hasSize(1)
         }
 
@@ -89,7 +89,7 @@ class TrailingCommaOnCallSiteSpec {
                     2
                 )
             """.trimIndent()
-            val findings = TrailingCommaOnCallSite(TestConfig(mapOf(USE_TRAILING_COMMA to true))).lint(code)
+            val findings = TrailingCommaOnCallSite(TestConfig(USE_TRAILING_COMMA to true)).lint(code)
             assertThat(findings).hasSize(1)
         }
     }

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/TrailingCommaOnDeclarationSiteSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/TrailingCommaOnDeclarationSiteSpec.kt
@@ -21,7 +21,7 @@ class TrailingCommaOnDeclarationSiteSpec {
             val code = """
                 class Foo1<A, B,> {}
             """.trimIndent()
-            val findings = TrailingCommaOnDeclarationSite(TestConfig(mapOf(USE_TRAILING_COMMA to false))).lint(code)
+            val findings = TrailingCommaOnDeclarationSite(TestConfig(USE_TRAILING_COMMA to false)).lint(code)
             assertThat(findings).hasSize(1)
         }
 
@@ -33,7 +33,7 @@ class TrailingCommaOnDeclarationSiteSpec {
                    val bar: Int,
                 )
             """.trimIndent()
-            val findings = TrailingCommaOnDeclarationSite(TestConfig(mapOf(USE_TRAILING_COMMA to false))).lint(code)
+            val findings = TrailingCommaOnDeclarationSite(TestConfig(USE_TRAILING_COMMA to false)).lint(code)
             assertThat(findings).hasSize(2)
         }
     }
@@ -49,7 +49,7 @@ class TrailingCommaOnDeclarationSiteSpec {
                     B
                 > {}
             """.trimIndent()
-            val findings = TrailingCommaOnDeclarationSite(TestConfig(mapOf(USE_TRAILING_COMMA to true))).lint(code)
+            val findings = TrailingCommaOnDeclarationSite(TestConfig(USE_TRAILING_COMMA to true)).lint(code)
             assertThat(findings).hasSize(1)
         }
 
@@ -61,7 +61,7 @@ class TrailingCommaOnDeclarationSiteSpec {
                    val bar: Int
                 )
             """.trimIndent()
-            val findings = TrailingCommaOnDeclarationSite(TestConfig(mapOf(USE_TRAILING_COMMA to true))).lint(code)
+            val findings = TrailingCommaOnDeclarationSite(TestConfig(USE_TRAILING_COMMA to true)).lint(code)
             assertThat(findings).hasSize(1)
         }
     }

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexInterfaceSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexInterfaceSpec.kt
@@ -6,15 +6,14 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
-private const val THRESHOLD = 4
-private val defaultConfig = "threshold" to THRESHOLD
-private val staticDeclarationsConfig = TestConfig(defaultConfig, "includeStaticDeclarations" to true)
-private val privateDeclarationsConfig = TestConfig(defaultConfig, "includePrivateDeclarations" to true)
-private val ignoreOverloadedConfig = TestConfig(defaultConfig, "ignoreOverloaded" to true)
+private val defaultThreshold = "threshold" to 4
+private val staticDeclarationsConfig = TestConfig(defaultThreshold, "includeStaticDeclarations" to true)
+private val privateDeclarationsConfig = TestConfig(defaultThreshold, "includePrivateDeclarations" to true)
+private val ignoreOverloadedConfig = TestConfig(defaultThreshold, "ignoreOverloaded" to true)
 
 class ComplexInterfaceSpec {
 
-    private val subject = ComplexInterface(TestConfig(defaultConfig))
+    private val subject = ComplexInterface(TestConfig(defaultThreshold))
 
     @Nested
     inner class `ComplexInterface rule positives` {

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexInterfaceSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexInterfaceSpec.kt
@@ -7,20 +7,14 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 private const val THRESHOLD = 4
-private val defaultConfigMap = mapOf("threshold" to THRESHOLD)
-private val staticDeclarationsConfig = TestConfig(
-    defaultConfigMap + ("includeStaticDeclarations" to true)
-)
-private val privateDeclarationsConfig = TestConfig(
-    defaultConfigMap + ("includePrivateDeclarations" to true)
-)
-private val ignoreOverloadedConfig = TestConfig(
-    defaultConfigMap + ("ignoreOverloaded" to true)
-)
+private val defaultConfig = "threshold" to THRESHOLD
+private val staticDeclarationsConfig = TestConfig(defaultConfig, "includeStaticDeclarations" to true)
+private val privateDeclarationsConfig = TestConfig(defaultConfig, "includePrivateDeclarations" to true)
+private val ignoreOverloadedConfig = TestConfig(defaultConfig, "ignoreOverloaded" to true)
 
 class ComplexInterfaceSpec {
 
-    private val subject = ComplexInterface(TestConfig(defaultConfigMap))
+    private val subject = ComplexInterface(TestConfig(defaultConfig))
 
     @Nested
     inner class `ComplexInterface rule positives` {

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/CyclomaticComplexMethodSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/CyclomaticComplexMethodSpec.kt
@@ -10,7 +10,7 @@ import io.gitlab.arturbosch.detekt.test.lint
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
-private val defaultConfigMap: Map<String, Any> = mapOf("threshold" to "1")
+private val defaultConfig = "threshold" to "1"
 
 class CyclomaticComplexMethodSpec {
 
@@ -21,7 +21,7 @@ class CyclomaticComplexMethodSpec {
 
         @Test
         fun `counts different loops`() {
-            val findings = CyclomaticComplexMethod(TestConfig(defaultConfigMap)).compileAndLint(
+            val findings = CyclomaticComplexMethod(TestConfig(defaultConfig)).compileAndLint(
                 """
                 fun test() {
                     for (i in 1..10) {}
@@ -37,7 +37,7 @@ class CyclomaticComplexMethodSpec {
 
         @Test
         fun `counts catch blocks`() {
-            val findings = CyclomaticComplexMethod(TestConfig(defaultConfigMap)).compileAndLint(
+            val findings = CyclomaticComplexMethod(TestConfig(defaultConfig)).compileAndLint(
                 """
                 fun test() {
                     try {} catch(e: IllegalArgumentException) {} catch(e: Exception) {} finally {}
@@ -50,7 +50,7 @@ class CyclomaticComplexMethodSpec {
 
         @Test
         fun `counts nested conditional statements`() {
-            val findings = CyclomaticComplexMethod(TestConfig(defaultConfigMap)).compileAndLint(
+            val findings = CyclomaticComplexMethod(TestConfig(defaultConfig)).compileAndLint(
                 """
                 fun test() {
                     try {
@@ -85,31 +85,31 @@ class CyclomaticComplexMethodSpec {
 
         @Test
         fun `counts three with nesting function 'forEach'`() {
-            val config = TestConfig(defaultConfigMap.plus("ignoreNestingFunctions" to "false"))
+            val config = TestConfig(defaultConfig, "ignoreNestingFunctions" to "false")
             assertExpectedComplexityValue(code, config, expectedValue = 3)
         }
 
         @Test
         fun `can ignore nesting functions like 'forEach'`() {
-            val config = TestConfig(defaultConfigMap.plus("ignoreNestingFunctions" to "true"))
+            val config = TestConfig(defaultConfig, "ignoreNestingFunctions" to "true")
             assertExpectedComplexityValue(code, config, expectedValue = 2)
         }
 
         @Test
         fun `skips all if if the nested functions is empty`() {
-            val config = TestConfig(defaultConfigMap.plus("nestingFunctions" to ""))
+            val config = TestConfig(defaultConfig, "nestingFunctions" to "")
             assertExpectedComplexityValue(code, config, expectedValue = 2)
         }
 
         @Test
         fun `skips 'forEach' as it is not specified`() {
-            val config = TestConfig(defaultConfigMap.plus("nestingFunctions" to "let,apply,also"))
+            val config = TestConfig(defaultConfig, "nestingFunctions" to "let,apply,also")
             assertExpectedComplexityValue(code, config, expectedValue = 2)
         }
 
         @Test
         fun `skips 'forEach' as it is not specified list`() {
-            val config = TestConfig(defaultConfigMap.plus("nestingFunctions" to listOf("let", "apply", "also")))
+            val config = TestConfig(defaultConfig, "nestingFunctions" to listOf("let", "apply", "also"))
             assertExpectedComplexityValue(code, config, expectedValue = 2)
         }
     }
@@ -122,10 +122,8 @@ class CyclomaticComplexMethodSpec {
         @Test
         fun `does not report complex methods with a single when expression`() {
             val config = TestConfig(
-                mapOf(
-                    "threshold" to "4",
-                    "ignoreSingleWhenExpression" to "true"
-                )
+                "threshold" to "4",
+                "ignoreSingleWhenExpression" to "true",
             )
             val subject = CyclomaticComplexMethod(config)
 
@@ -134,7 +132,7 @@ class CyclomaticComplexMethodSpec {
 
         @Test
         fun `reports all complex methods`() {
-            val config = TestConfig(mapOf("threshold" to "4"))
+            val config = TestConfig("threshold" to "4")
             val subject = CyclomaticComplexMethod(config)
 
             assertThat(subject.lint(path)).hasStartSourceLocations(
@@ -148,7 +146,7 @@ class CyclomaticComplexMethodSpec {
 
         @Test
         fun `does not trip for a reasonable amount of simple when entries when ignoreSimpleWhenEntries is true`() {
-            val config = TestConfig(mapOf("ignoreSimpleWhenEntries" to "true"))
+            val config = TestConfig("ignoreSimpleWhenEntries" to "true")
             val subject = CyclomaticComplexMethod(config)
             val code = """
                  fun f() {

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/CyclomaticComplexMethodSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/CyclomaticComplexMethodSpec.kt
@@ -10,7 +10,7 @@ import io.gitlab.arturbosch.detekt.test.lint
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
-private val defaultConfig = "threshold" to "1"
+private val defaultThreshold = "threshold" to "1"
 
 class CyclomaticComplexMethodSpec {
 
@@ -21,7 +21,7 @@ class CyclomaticComplexMethodSpec {
 
         @Test
         fun `counts different loops`() {
-            val findings = CyclomaticComplexMethod(TestConfig(defaultConfig)).compileAndLint(
+            val findings = CyclomaticComplexMethod(TestConfig(defaultThreshold)).compileAndLint(
                 """
                 fun test() {
                     for (i in 1..10) {}
@@ -37,7 +37,7 @@ class CyclomaticComplexMethodSpec {
 
         @Test
         fun `counts catch blocks`() {
-            val findings = CyclomaticComplexMethod(TestConfig(defaultConfig)).compileAndLint(
+            val findings = CyclomaticComplexMethod(TestConfig(defaultThreshold)).compileAndLint(
                 """
                 fun test() {
                     try {} catch(e: IllegalArgumentException) {} catch(e: Exception) {} finally {}
@@ -50,7 +50,7 @@ class CyclomaticComplexMethodSpec {
 
         @Test
         fun `counts nested conditional statements`() {
-            val findings = CyclomaticComplexMethod(TestConfig(defaultConfig)).compileAndLint(
+            val findings = CyclomaticComplexMethod(TestConfig(defaultThreshold)).compileAndLint(
                 """
                 fun test() {
                     try {
@@ -85,31 +85,31 @@ class CyclomaticComplexMethodSpec {
 
         @Test
         fun `counts three with nesting function 'forEach'`() {
-            val config = TestConfig(defaultConfig, "ignoreNestingFunctions" to "false")
+            val config = TestConfig(defaultThreshold, "ignoreNestingFunctions" to "false")
             assertExpectedComplexityValue(code, config, expectedValue = 3)
         }
 
         @Test
         fun `can ignore nesting functions like 'forEach'`() {
-            val config = TestConfig(defaultConfig, "ignoreNestingFunctions" to "true")
+            val config = TestConfig(defaultThreshold, "ignoreNestingFunctions" to "true")
             assertExpectedComplexityValue(code, config, expectedValue = 2)
         }
 
         @Test
         fun `skips all if if the nested functions is empty`() {
-            val config = TestConfig(defaultConfig, "nestingFunctions" to "")
+            val config = TestConfig(defaultThreshold, "nestingFunctions" to "")
             assertExpectedComplexityValue(code, config, expectedValue = 2)
         }
 
         @Test
         fun `skips 'forEach' as it is not specified`() {
-            val config = TestConfig(defaultConfig, "nestingFunctions" to "let,apply,also")
+            val config = TestConfig(defaultThreshold, "nestingFunctions" to "let,apply,also")
             assertExpectedComplexityValue(code, config, expectedValue = 2)
         }
 
         @Test
         fun `skips 'forEach' as it is not specified list`() {
-            val config = TestConfig(defaultConfig, "nestingFunctions" to listOf("let", "apply", "also"))
+            val config = TestConfig(defaultThreshold, "nestingFunctions" to listOf("let", "apply", "also"))
             assertExpectedComplexityValue(code, config, expectedValue = 2)
         }
     }

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LabeledExpressionSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LabeledExpressionSpec.kt
@@ -144,7 +144,7 @@ class LabeledExpressionSpec {
                 loop@ for (i in 1..5) {}
             }
         """.trimIndent()
-        val config = TestConfig(mapOf("ignoredLabels" to listOf("loop")))
+        val config = TestConfig("ignoredLabels" to listOf("loop"))
         val findings = LabeledExpression(config).compileAndLint(code)
         assertThat(findings).isEmpty()
     }
@@ -156,7 +156,7 @@ class LabeledExpressionSpec {
                 loop@ for (i in 1..5) {}
             }
         """.trimIndent()
-        val config = TestConfig(mapOf("ignoredLabels" to "loop"))
+        val config = TestConfig("ignoredLabels" to "loop")
         val findings = LabeledExpression(config).compileAndLint(code)
         assertThat(findings).isEmpty()
     }
@@ -168,7 +168,7 @@ class LabeledExpressionSpec {
                 loop@ for (i in 1..5) {}
             }
         """.trimIndent()
-        val config = TestConfig(mapOf("ignoredLabels" to "*loop*,other"))
+        val config = TestConfig("ignoredLabels" to "*loop*,other")
         val findings = LabeledExpression(config).compileAndLint(code)
         assertThat(findings).isEmpty()
     }

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LargeClassSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LargeClassSpec.kt
@@ -8,7 +8,7 @@ import io.gitlab.arturbosch.detekt.test.compileAndLint
 import io.gitlab.arturbosch.detekt.test.lint
 import org.junit.jupiter.api.Test
 
-private fun subject(threshold: Int) = LargeClass(TestConfig(mapOf("threshold" to threshold)))
+private fun subject(threshold: Int) = LargeClass(TestConfig("threshold" to threshold))
 
 class LargeClassSpec {
 

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongMethodSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongMethodSpec.kt
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test
 
 class LongMethodSpec {
 
-    val subject = LongMethod(TestConfig(mapOf("threshold" to 5)))
+    val subject = LongMethod(TestConfig("threshold" to 5))
 
     @Test
     fun `should find two long methods`() {

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterListSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterListSpec.kt
@@ -8,13 +8,11 @@ import org.junit.jupiter.api.Test
 
 class LongParameterListSpec {
 
-    val defaultThreshold = 2
-    val defaultConfig =
+    private val defaultThreshold = 2
+    private val defaultConfig =
         TestConfig(
-            mapOf(
-                "functionThreshold" to defaultThreshold,
-                "constructorThreshold" to defaultThreshold
-            )
+            "functionThreshold" to defaultThreshold,
+            "constructorThreshold" to defaultThreshold,
         )
 
     val subject = LongParameterList(defaultConfig)
@@ -46,7 +44,7 @@ class LongParameterListSpec {
 
     @Test
     fun `does not report long parameter list if parameters with defaults should be ignored`() {
-        val config = TestConfig(mapOf("ignoreDefaultParameters" to "true"))
+        val config = TestConfig("ignoreDefaultParameters" to "true")
         val rule = LongParameterList(config)
         val code = "fun long(a: Int, b: Int, c: Int = 2) {}"
         assertThat(rule.compileAndLint(code)).isEmpty()
@@ -82,7 +80,7 @@ class LongParameterListSpec {
 
     @Test
     fun `reports long parameter list if custom threshold is set`() {
-        val config = TestConfig(mapOf("constructorThreshold" to "1"))
+        val config = TestConfig("constructorThreshold" to "1")
         val rule = LongParameterList(config)
         val code = "class LongCtor(a: Int)"
         assertThat(rule.compileAndLint(code)).hasSize(1)
@@ -91,10 +89,8 @@ class LongParameterListSpec {
     @Test
     fun `does not report long parameter list for constructors of data classes if asked`() {
         val config = TestConfig(
-            mapOf(
-                "ignoreDataClasses" to "true",
-                "constructorThreshold" to "1"
-            )
+            "ignoreDataClasses" to "true",
+            "constructorThreshold" to "1",
         )
         val rule = LongParameterList(config)
         val code = "data class Data(val a: Int)"
@@ -104,21 +100,18 @@ class LongParameterListSpec {
     @Nested
     inner class `constructors and functions with ignored annotations` {
 
-        val config =
-            TestConfig(
-                mapOf(
-                    "ignoreAnnotatedParameter" to listOf(
-                        "Generated",
-                        "kotlin.Deprecated",
-                        "kotlin.jvm.JvmName",
-                        "kotlin.Suppress"
-                    ),
-                    "functionThreshold" to 1,
-                    "constructorThreshold" to 1
-                )
-            )
+        private val config = TestConfig(
+            "ignoreAnnotatedParameter" to listOf(
+                "Generated",
+                "kotlin.Deprecated",
+                "kotlin.jvm.JvmName",
+                "kotlin.Suppress",
+            ),
+            "functionThreshold" to 1,
+            "constructorThreshold" to 1,
+        )
 
-        val rule = LongParameterList(config)
+        private val rule = LongParameterList(config)
 
         @Test
         fun `reports long parameter list for constructors if constructor parameters are annotated with annotation that is not ignored`() {

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterListSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterListSpec.kt
@@ -9,17 +9,16 @@ import org.junit.jupiter.api.Test
 class LongParameterListSpec {
 
     private val defaultThreshold = 2
-    private val defaultConfig =
-        TestConfig(
-            "functionThreshold" to defaultThreshold,
-            "constructorThreshold" to defaultThreshold,
-        )
+    private val defaultConfig = TestConfig(
+        "functionThreshold" to defaultThreshold,
+        "constructorThreshold" to defaultThreshold,
+    )
 
-    val subject = LongParameterList(defaultConfig)
+    private val subject = LongParameterList(defaultConfig)
 
-    val reportMessageForFunction = "The function long(a: Int, b: Int) has too many parameters. " +
+    private val reportMessageForFunction = "The function long(a: Int, b: Int) has too many parameters. " +
         "The current threshold is set to $defaultThreshold."
-    val reportMessageForConstructor = "The constructor(a: Int, b: Int) has too many parameters. " +
+    private val reportMessageForConstructor = "The constructor(a: Int, b: Int) has too many parameters. " +
         "The current threshold is set to $defaultThreshold."
 
     @Test

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/MethodOverloadingSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/MethodOverloadingSpec.kt
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test
 
 class MethodOverloadingSpec {
     val defaultThreshold = 3
-    val defaultConfig = TestConfig(mapOf("threshold" to defaultThreshold))
+    val defaultConfig = TestConfig("threshold" to defaultThreshold)
 
     val subject = MethodOverloading(defaultConfig)
 

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NamedArgumentsSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NamedArgumentsSpec.kt
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test
 @KotlinCoreEnvironmentTest
 class NamedArgumentsSpec(val env: KotlinCoreEnvironment) {
     val defaultThreshold = 2
-    val defaultConfig = TestConfig(mapOf("threshold" to defaultThreshold))
+    val defaultConfig = TestConfig("threshold" to defaultThreshold)
     val subject = NamedArguments(defaultConfig)
 
     @Test
@@ -204,7 +204,7 @@ class NamedArgumentsSpec(val env: KotlinCoreEnvironment) {
                 require(n == 2) { "N is not 2" }
             }
             """.trimIndent()
-            val subject = NamedArguments(TestConfig(mapOf("threshold" to 1)))
+            val subject = NamedArguments(TestConfig("threshold" to 1))
             val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(0)
         }
@@ -215,7 +215,7 @@ class NamedArgumentsSpec(val env: KotlinCoreEnvironment) {
         @Nested
         inner class `ignoreArgumentsMatchingNames is true` {
             val subject =
-                NamedArguments(TestConfig(mapOf("threshold" to 2, "ignoreArgumentsMatchingNames" to true)))
+                NamedArguments(TestConfig("threshold" to 2, "ignoreArgumentsMatchingNames" to true))
 
             @Test
             fun `all arguments are the same as the parameter names`() {

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedBlockDepthSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedBlockDepthSpec.kt
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.Test
 class NestedBlockDepthSpec {
 
     val defaultThreshold = 4
-    val defaultConfig = TestConfig(mapOf("threshold" to defaultThreshold))
+    val defaultConfig = TestConfig("threshold" to defaultThreshold)
     val subject = NestedBlockDepth(defaultConfig)
 
     @Test

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedScopeFunctionsSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedScopeFunctionsSpec.kt
@@ -12,10 +12,8 @@ import org.junit.jupiter.api.Test
 class NestedScopeFunctionsSpec(private val env: KotlinCoreEnvironment) {
 
     private val defaultConfig = TestConfig(
-        mapOf(
-            "threshold" to 1,
-            "functions" to listOf("kotlin.run", "kotlin.with")
-        )
+        "threshold" to 1,
+        "functions" to listOf("kotlin.run", "kotlin.with")
     )
     private val subject = NestedScopeFunctions(defaultConfig)
 

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/StringLiteralDuplicationSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/StringLiteralDuplicationSpec.kt
@@ -58,7 +58,7 @@ class StringLiteralDuplicationSpec {
 
         @Test
         fun `reports strings in annotations according to config`() {
-            val config = TestConfig(mapOf(IGNORE_ANNOTATION to "false"))
+            val config = TestConfig(IGNORE_ANNOTATION to "false")
             assertFindingWithConfig(code, config, 1)
         }
     }
@@ -75,7 +75,7 @@ class StringLiteralDuplicationSpec {
 
         @Test
         fun `reports string with 4 characters`() {
-            val config = TestConfig(mapOf(EXCLUDE_SHORT_STRING to "false"))
+            val config = TestConfig(EXCLUDE_SHORT_STRING to "false")
             assertFindingWithConfig(code, config, 1)
         }
     }
@@ -94,23 +94,22 @@ class StringLiteralDuplicationSpec {
                 val str1 = "lorem" + "lorem" + "lorem"
                 val str2 = "ipsum" + "ipsum" + "ipsum"
             """.trimIndent()
-            val config = TestConfig(mapOf(IGNORE_STRINGS_REGEX to "(lorem|ipsum)"))
+            val config = TestConfig(IGNORE_STRINGS_REGEX to "(lorem|ipsum)")
             assertFindingWithConfig(code, config, 0)
         }
 
         @Test
         fun `should not fail with invalid regex when disabled`() {
-            val configValues = mapOf(
+            val config = TestConfig(
                 "active" to "false",
-                IGNORE_STRINGS_REGEX to "*lorem"
+                IGNORE_STRINGS_REGEX to "*lorem",
             )
-            val config = TestConfig(configValues)
             assertFindingWithConfig(regexTestingCode, config, 0)
         }
 
         @Test
         fun `should fail with invalid regex`() {
-            val config = TestConfig(mapOf(IGNORE_STRINGS_REGEX to "*lorem"))
+            val config = TestConfig(IGNORE_STRINGS_REGEX to "*lorem")
             assertThatExceptionOfType(PatternSyntaxException::class.java).isThrownBy {
                 StringLiteralDuplication(config).compileAndLint(regexTestingCode)
             }

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/TooManyFunctionsSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/TooManyFunctionsSpec.kt
@@ -16,18 +16,15 @@ private const val IGNORE_PRIVATE = "ignorePrivate"
 private const val IGNORE_OVERRIDDEN = "ignoreOverridden"
 
 class TooManyFunctionsSpec {
-    val rule =
-        TooManyFunctions(
-            TestConfig(
-                mapOf(
-                    THRESHOLD_IN_CLASSES to "1",
-                    THRESHOLD_IN_ENUMS to "1",
-                    THRESHOLD_IN_FILES to "1",
-                    THRESHOLD_IN_INTERFACES to "1",
-                    THRESHOLD_IN_OBJECTS to "1"
-                )
-            )
+    val rule = TooManyFunctions(
+        TestConfig(
+            THRESHOLD_IN_CLASSES to "1",
+            THRESHOLD_IN_ENUMS to "1",
+            THRESHOLD_IN_FILES to "1",
+            THRESHOLD_IN_INTERFACES to "1",
+            THRESHOLD_IN_OBJECTS to "1",
         )
+    )
 
     @Test
     fun `finds one function in class`() {
@@ -142,11 +139,9 @@ class TooManyFunctionsSpec {
         fun `finds no deprecated functions`() {
             val configuredRule = TooManyFunctions(
                 TestConfig(
-                    mapOf(
-                        THRESHOLD_IN_CLASSES to "1",
-                        THRESHOLD_IN_FILES to "1",
-                        IGNORE_DEPRECATED to "true"
-                    )
+                    THRESHOLD_IN_CLASSES to "1",
+                    THRESHOLD_IN_FILES to "1",
+                    IGNORE_DEPRECATED to "true",
                 )
             )
             assertThat(configuredRule.compileAndLint(code)).isEmpty()
@@ -171,11 +166,9 @@ class TooManyFunctionsSpec {
         fun `finds no private functions`() {
             val configuredRule = TooManyFunctions(
                 TestConfig(
-                    mapOf(
-                        THRESHOLD_IN_CLASSES to "1",
-                        THRESHOLD_IN_FILES to "1",
-                        IGNORE_PRIVATE to "true"
-                    )
+                    THRESHOLD_IN_CLASSES to "1",
+                    THRESHOLD_IN_FILES to "1",
+                    IGNORE_PRIVATE to "true",
                 )
             )
             assertThat(configuredRule.compileAndLint(code)).isEmpty()
@@ -207,13 +200,11 @@ class TooManyFunctionsSpec {
             """.trimIndent()
             val configuredRule = TooManyFunctions(
                 TestConfig(
-                    mapOf(
-                        THRESHOLD_IN_CLASSES to "1",
-                        THRESHOLD_IN_FILES to "1",
-                        IGNORE_PRIVATE to "true",
-                        IGNORE_DEPRECATED to "true",
-                        IGNORE_OVERRIDDEN to "true"
-                    )
+                    THRESHOLD_IN_CLASSES to "1",
+                    THRESHOLD_IN_FILES to "1",
+                    IGNORE_PRIVATE to "true",
+                    IGNORE_DEPRECATED to "true",
+                    IGNORE_OVERRIDDEN to "true",
                 )
             )
             assertThat(configuredRule.compileAndLint(code)).isEmpty()
@@ -239,11 +230,9 @@ class TooManyFunctionsSpec {
         fun `should not report class with overridden functions, if ignoreOverridden is enabled`() {
             val configuredRule = TooManyFunctions(
                 TestConfig(
-                    mapOf(
-                        THRESHOLD_IN_CLASSES to "1",
-                        THRESHOLD_IN_FILES to "1",
-                        IGNORE_OVERRIDDEN to "true"
-                    )
+                    THRESHOLD_IN_CLASSES to "1",
+                    THRESHOLD_IN_FILES to "1",
+                    IGNORE_OVERRIDDEN to "true",
                 )
             )
             assertThat(configuredRule.compileAndLint(code)).isEmpty()
@@ -253,11 +242,9 @@ class TooManyFunctionsSpec {
         fun `should count overridden functions, if ignoreOverridden is disabled`() {
             val configuredRule = TooManyFunctions(
                 TestConfig(
-                    mapOf(
-                        THRESHOLD_IN_CLASSES to "1",
-                        THRESHOLD_IN_FILES to "1",
-                        IGNORE_OVERRIDDEN to "false"
-                    )
+                    THRESHOLD_IN_CLASSES to "1",
+                    THRESHOLD_IN_FILES to "1",
+                    IGNORE_OVERRIDDEN to "false",
                 )
             )
             assertThat(configuredRule.compileAndLint(code)).hasSize(1)

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/OutdatedDocumentationSpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/OutdatedDocumentationSpec.kt
@@ -352,8 +352,7 @@ class OutdatedDocumentationSpec {
 
     @Nested
     inner class `configuration matchTypeParameters` {
-        val configuredSubject =
-            OutdatedDocumentation(TestConfig(mapOf("matchTypeParameters" to "false")))
+        private val configuredSubject = OutdatedDocumentation(TestConfig("matchTypeParameters" to "false"))
 
         @Test
         fun `should not report when class type parameters mismatch and configuration is off`() {
@@ -380,8 +379,7 @@ class OutdatedDocumentationSpec {
 
     @Nested
     inner class `configuration matchDeclarationsOrder` {
-        val configuredSubject =
-            OutdatedDocumentation(TestConfig(mapOf("matchDeclarationsOrder" to "false")))
+        private val configuredSubject = OutdatedDocumentation(TestConfig("matchDeclarationsOrder" to "false"))
 
         @Test
         fun `should not report when declarations order mismatch and configuration is off`() {
@@ -412,8 +410,9 @@ class OutdatedDocumentationSpec {
 
     @Nested
     inner class `configuration allowParamOnConstructorProperties` {
-        val configuredSubject =
-            OutdatedDocumentation(TestConfig(mapOf("allowParamOnConstructorProperties" to "true")))
+        private val configuredSubject = OutdatedDocumentation(
+            TestConfig("allowParamOnConstructorProperties" to "true")
+        )
 
         @Test
         fun `should not report when property is documented as param`() {
@@ -442,15 +441,12 @@ class OutdatedDocumentationSpec {
 
     @Nested
     inner class `configuration matchDeclarationsOrder and allowParamOnConstructorProperties` {
-        val configuredSubject =
-            OutdatedDocumentation(
-                TestConfig(
-                    mapOf(
-                        "matchDeclarationsOrder" to "false",
-                        "allowParamOnConstructorProperties" to "true"
-                    )
-                )
+        private val configuredSubject = OutdatedDocumentation(
+            TestConfig(
+                "matchDeclarationsOrder" to "false",
+                "allowParamOnConstructorProperties" to "true",
             )
+        )
 
         @Test
         fun `should not report when property is documented as param`() {

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicClassSpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicClassSpec.kt
@@ -102,21 +102,21 @@ class UndocumentedPublicClassSpec {
     @Test
     fun `should not report inner classes when turned off`() {
         val findings =
-            UndocumentedPublicClass(TestConfig(mapOf(SEARCH_IN_INNER_CLASS to "false"))).compileAndLint(inner)
+            UndocumentedPublicClass(TestConfig(SEARCH_IN_INNER_CLASS to "false")).compileAndLint(inner)
         assertThat(findings).isEmpty()
     }
 
     @Test
     fun `should not report inner objects when turned off`() {
         val findings =
-            UndocumentedPublicClass(TestConfig(mapOf(SEARCH_IN_INNER_OBJECT to "false"))).compileAndLint(innerObject)
+            UndocumentedPublicClass(TestConfig(SEARCH_IN_INNER_OBJECT to "false")).compileAndLint(innerObject)
         assertThat(findings).isEmpty()
     }
 
     @Test
     fun `should not report inner interfaces when turned off`() {
         val findings =
-            UndocumentedPublicClass(TestConfig(mapOf(SEARCH_IN_INNER_INTERFACE to "false"))).compileAndLint(
+            UndocumentedPublicClass(TestConfig(SEARCH_IN_INNER_INTERFACE to "false")).compileAndLint(
                 innerInterface
             )
         assertThat(findings).isEmpty()
@@ -125,7 +125,7 @@ class UndocumentedPublicClassSpec {
     @Test
     fun `should not report nested classes when turned off`() {
         val findings =
-            UndocumentedPublicClass(TestConfig(mapOf(SEARCH_IN_NESTED_CLASS to "false"))).compileAndLint(nested)
+            UndocumentedPublicClass(TestConfig(SEARCH_IN_NESTED_CLASS to "false")).compileAndLint(nested)
         assertThat(findings).isEmpty()
     }
 
@@ -250,7 +250,7 @@ class UndocumentedPublicClassSpec {
         protected class Test {
         }
         """.trimIndent()
-        val subject = UndocumentedPublicClass(TestConfig(mapOf(SEARCH_IN_PROTECTED_CLASS to "true")))
+        val subject = UndocumentedPublicClass(TestConfig(SEARCH_IN_PROTECTED_CLASS to "true"))
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 }

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicFunctionSpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicFunctionSpec.kt
@@ -161,7 +161,7 @@ class UndocumentedPublicFunctionSpec {
                 protected fun noComment1() {}
             }
         """.trimIndent()
-        val subject = UndocumentedPublicFunction(TestConfig(mapOf(SEARCH_PROTECTED_FUN to "true")))
+        val subject = UndocumentedPublicFunction(TestConfig(SEARCH_PROTECTED_FUN to "true"))
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicPropertySpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicPropertySpec.kt
@@ -233,7 +233,7 @@ class UndocumentedPublicPropertySpec {
                 protected val a = 1
             }
         """.trimIndent()
-        val subject = UndocumentedPublicProperty(TestConfig(mapOf(SEARCH_PROTECTED_PROPERTY to "true")))
+        val subject = UndocumentedPublicProperty(TestConfig(SEARCH_PROTECTED_PROPERTY to "true"))
         assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 

--- a/detekt-rules-empty/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyCodeSpec.kt
+++ b/detekt-rules-empty/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyCodeSpec.kt
@@ -66,7 +66,7 @@ class EmptyCodeSpec {
             }
         }
         """.trimIndent()
-        val config = TestConfig(mapOf(ALLOWED_EXCEPTION_NAME_REGEX to "foo"))
+        val config = TestConfig(ALLOWED_EXCEPTION_NAME_REGEX to "foo")
         assertThat(EmptyCatchBlock(config).compileAndLint(code)).isEmpty()
     }
 
@@ -138,18 +138,16 @@ class EmptyCodeSpec {
 
     @Test
     fun doesNotFailWithInvalidRegexWhenDisabled() {
-        val configValues = mapOf(
+        val config = TestConfig(
             "active" to "false",
-            ALLOWED_EXCEPTION_NAME_REGEX to "*foo"
+            ALLOWED_EXCEPTION_NAME_REGEX to "*foo",
         )
-        val config = TestConfig(configValues)
         assertThat(EmptyCatchBlock(config).compileAndLint(regexTestingCode)).isEmpty()
     }
 
     @Test
     fun doesFailWithInvalidRegex() {
-        val configValues = mapOf(ALLOWED_EXCEPTION_NAME_REGEX to "*foo")
-        val config = TestConfig(configValues)
+        val config = TestConfig(ALLOWED_EXCEPTION_NAME_REGEX to "*foo")
         assertThatExceptionOfType(PatternSyntaxException::class.java).isThrownBy {
             EmptyCatchBlock(config).compileAndLint(regexTestingCode)
         }

--- a/detekt-rules-empty/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyFunctionBlockSpec.kt
+++ b/detekt-rules-empty/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyFunctionBlockSpec.kt
@@ -88,7 +88,7 @@ class EmptyFunctionBlockSpec {
 
         @Test
         fun `should not flag overridden functions`() {
-            val config = TestConfig(mapOf(IGNORE_OVERRIDDEN_FUNCTIONS to "true"))
+            val config = TestConfig(IGNORE_OVERRIDDEN_FUNCTIONS to "true")
             assertThat(EmptyFunctionBlock(config).compileAndLint(code)).hasStartSourceLocation(1, 13)
         }
     }
@@ -120,7 +120,7 @@ class EmptyFunctionBlockSpec {
 
         @Test
         fun `should not flag overridden functions with ignoreOverridden`() {
-            val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to "true"))
+            val config = TestConfig(IGNORE_OVERRIDDEN to "true")
             assertThat(EmptyFunctionBlock(config).compileAndLint(code)).isEmpty()
         }
     }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DoubleMutabilityForCollectionSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DoubleMutabilityForCollectionSpec.kt
@@ -120,11 +120,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
             @Test
             fun `detects var declaration with MutableState, when configured`() {
                 val rule = DoubleMutabilityForCollection(
-                    TestConfig(
-                        mapOf(
-                            MUTABLE_TYPES to listOf("MutableState")
-                        )
-                    )
+                    TestConfig(MUTABLE_TYPES to listOf("MutableState"))
                 )
 
                 val code = """
@@ -141,11 +137,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
             @Test
             fun `detects var declaration with MutableState via factory function, when configured`() {
                 val rule = DoubleMutabilityForCollection(
-                    TestConfig(
-                        mapOf(
-                            MUTABLE_TYPES to listOf("MutableState")
-                        )
-                    )
+                    TestConfig(MUTABLE_TYPES to listOf("MutableState"))
                 )
 
                 val code = """
@@ -163,11 +155,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
             @Test
             fun `detects var declaration with MutableState via calculation lambda, when configured`() {
                 val rule = DoubleMutabilityForCollection(
-                    TestConfig(
-                        mapOf(
-                            MUTABLE_TYPES to listOf("MutableState")
-                        )
-                    )
+                    TestConfig(MUTABLE_TYPES to listOf("MutableState"))
                 )
 
                 val code = """
@@ -319,11 +307,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
             @Test
             fun `does not detect var declaration with property delegate`() {
                 val rule = DoubleMutabilityForCollection(
-                    TestConfig(
-                        mapOf(
-                            MUTABLE_TYPES to listOf("MutableState")
-                        )
-                    )
+                    TestConfig(MUTABLE_TYPES to listOf("MutableState"))
                 )
 
                 val code = """
@@ -433,11 +417,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
             @Test
             fun `detects var declaration with MutableState, when configured`() {
                 val rule = DoubleMutabilityForCollection(
-                    TestConfig(
-                        mapOf(
-                            MUTABLE_TYPES to listOf("MutableState")
-                        )
-                    )
+                    TestConfig(MUTABLE_TYPES to listOf("MutableState"))
                 )
 
                 val code = """
@@ -452,11 +432,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
             @Test
             fun `detects var declaration with MutableState via factory function, when configured`() {
                 val rule = DoubleMutabilityForCollection(
-                    TestConfig(
-                        mapOf(
-                            MUTABLE_TYPES to listOf("MutableState")
-                        )
-                    )
+                    TestConfig(MUTABLE_TYPES to listOf("MutableState"))
                 )
 
                 val code = """
@@ -472,11 +448,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
             @Test
             fun `detects var declaration with MutableState via calculation lambda, when configured`() {
                 val rule = DoubleMutabilityForCollection(
-                    TestConfig(
-                        mapOf(
-                            MUTABLE_TYPES to listOf("MutableState")
-                        )
-                    )
+                    TestConfig(MUTABLE_TYPES to listOf("MutableState"))
                 )
 
                 val code = """
@@ -604,11 +576,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
             @Test
             fun `does not detect var declaration with property delegate`() {
                 val rule = DoubleMutabilityForCollection(
-                    TestConfig(
-                        mapOf(
-                            MUTABLE_TYPES to listOf("MutableState")
-                        )
-                    )
+                    TestConfig(MUTABLE_TYPES to listOf("MutableState"))
                 )
 
                 val code = """
@@ -732,11 +700,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
             @Test
             fun `detects var declaration with MutableState, when configured`() {
                 val rule = DoubleMutabilityForCollection(
-                    TestConfig(
-                        mapOf(
-                            MUTABLE_TYPES to listOf("MutableState")
-                        )
-                    )
+                    TestConfig(MUTABLE_TYPES to listOf("MutableState"))
                 )
 
                 val code = """
@@ -753,11 +717,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
             @Test
             fun `detects var declaration with MutableState via factory function, when configured`() {
                 val rule = DoubleMutabilityForCollection(
-                    TestConfig(
-                        mapOf(
-                            MUTABLE_TYPES to listOf("MutableState")
-                        )
-                    )
+                    TestConfig(MUTABLE_TYPES to listOf("MutableState"))
                 )
 
                 val code = """
@@ -775,11 +735,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
             @Test
             fun `detects var declaration with MutableState via calculation lambda, when configured`() {
                 val rule = DoubleMutabilityForCollection(
-                    TestConfig(
-                        mapOf(
-                            MUTABLE_TYPES to listOf("MutableState")
-                        )
-                    )
+                    TestConfig(MUTABLE_TYPES to listOf("MutableState"))
                 )
 
                 val code = """
@@ -931,11 +887,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
             @Test
             fun `does not detect var declaration with property delegate`() {
                 val rule = DoubleMutabilityForCollection(
-                    TestConfig(
-                        mapOf(
-                            MUTABLE_TYPES to listOf("MutableState")
-                        )
-                    )
+                    TestConfig(MUTABLE_TYPES to listOf("MutableState"))
                 )
 
                 val code = """

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DoubleMutabilityForCollectionSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DoubleMutabilityForCollectionSpec.kt
@@ -154,9 +154,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
 
             @Test
             fun `detects var declaration with MutableState via calculation lambda, when configured`() {
-                val rule = DoubleMutabilityForCollection(
-                    TestConfig(MUTABLE_TYPES to listOf("MutableState"))
-                )
+                val rule = DoubleMutabilityForCollection(TestConfig(MUTABLE_TYPES to listOf("MutableState")))
 
                 val code = """
                 data class MutableState<T>(var state: T)

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ElseCaseInsteadOfExhaustiveWhenSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ElseCaseInsteadOfExhaustiveWhenSpec.kt
@@ -177,7 +177,7 @@ class ElseCaseInsteadOfExhaustiveWhenSpec(private val env: KotlinCoreEnvironment
             """.trimIndent()
             assertThat(
                 ElseCaseInsteadOfExhaustiveWhen(
-                    TestConfig(mapOf("ignoredSubjectTypes" to listOf("com.example.Color")))
+                    TestConfig("ignoredSubjectTypes" to listOf("com.example.Color"))
                 ).compileAndLintWithContext(env, code)
             ).isEmpty()
         }
@@ -203,7 +203,7 @@ class ElseCaseInsteadOfExhaustiveWhenSpec(private val env: KotlinCoreEnvironment
             """.trimIndent()
             assertThat(
                 ElseCaseInsteadOfExhaustiveWhen(
-                    TestConfig(mapOf("ignoredSubjectTypes" to listOf("com.example.Variant")))
+                    TestConfig("ignoredSubjectTypes" to listOf("com.example.Variant"))
                 ).compileAndLintWithContext(env, code)
             ).isEmpty()
         }
@@ -229,7 +229,7 @@ class ElseCaseInsteadOfExhaustiveWhenSpec(private val env: KotlinCoreEnvironment
             """.trimIndent()
             assertThat(
                 ElseCaseInsteadOfExhaustiveWhen(
-                    TestConfig(mapOf("ignoredSubjectTypes" to listOf("com.example.Class")))
+                    TestConfig("ignoredSubjectTypes" to listOf("com.example.Class"))
                 ).compileAndLintWithContext(env, code)
             ).hasSize(1)
         }
@@ -255,7 +255,7 @@ class ElseCaseInsteadOfExhaustiveWhenSpec(private val env: KotlinCoreEnvironment
             """.trimIndent()
             assertThat(
                 ElseCaseInsteadOfExhaustiveWhen(
-                    TestConfig(mapOf("ignoredSubjectTypes" to listOf("com.example.Class")))
+                    TestConfig("ignoredSubjectTypes" to listOf("com.example.Class"))
                 ).compileAndLintWithContext(env, code)
             ).hasSize(1)
         }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValueSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValueSpec.kt
@@ -713,7 +713,7 @@ class IgnoredReturnValueSpec {
     @KotlinCoreEnvironmentTest
     inner class `custom annotation config`(private val env: KotlinCoreEnvironment) {
         val subject = IgnoredReturnValue(
-            TestConfig(mapOf("returnValueAnnotations" to listOf("*.CustomReturn")))
+            TestConfig("returnValueAnnotations" to listOf("*.CustomReturn"))
         )
 
         @Test
@@ -775,7 +775,7 @@ class IgnoredReturnValueSpec {
     @Nested
     @KotlinCoreEnvironmentTest
     inner class `restrict to config`(private val env: KotlinCoreEnvironment) {
-        val subject = IgnoredReturnValue(TestConfig(mapOf("restrictToConfig" to false)))
+        val subject = IgnoredReturnValue(TestConfig("restrictToConfig" to false))
 
         @Test
         fun `reports when a function is annotated with a custom annotation`() {
@@ -869,10 +869,8 @@ class IgnoredReturnValueSpec {
             """.trimIndent()
             val rule = IgnoredReturnValue(
                 TestConfig(
-                    mapOf(
-                        "ignoreReturnValueAnnotations" to listOf("*.CustomIgnoreReturn"),
-                        "restrictToConfig" to false
-                    )
+                    "ignoreReturnValueAnnotations" to listOf("*.CustomIgnoreReturn"),
+                    "restrictToConfig" to false,
                 )
             )
             val findings = rule.compileAndLintWithContext(env, code)
@@ -893,10 +891,8 @@ class IgnoredReturnValueSpec {
             """.trimIndent()
             val rule = IgnoredReturnValue(
                 TestConfig(
-                    mapOf(
-                        "ignoreFunctionCall" to listOf("foo.listOfChecked"),
-                        "restrictToConfig" to false
-                    )
+                    "ignoreFunctionCall" to listOf("foo.listOfChecked"),
+                    "restrictToConfig" to false,
                 )
             )
             val findings = rule.compileAndLintWithContext(env, code)

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/LateinitUsageSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/LateinitUsageSpec.kt
@@ -29,7 +29,7 @@ class LateinitUsageSpec {
     @DisplayName("should only report lateinit property with no @SinceKotlin annotation")
     fun `should only report lateinit property with no SinceKotlin annotation`() {
         val findings =
-            LateinitUsage(TestConfig(mapOf(EXCLUDE_ANNOTATED_PROPERTIES to listOf("SinceKotlin")))).compileAndLint(
+            LateinitUsage(TestConfig(EXCLUDE_ANNOTATED_PROPERTIES to listOf("SinceKotlin"))).compileAndLint(
                 code
             )
         assertThat(findings).hasSize(1)
@@ -39,13 +39,13 @@ class LateinitUsageSpec {
     @DisplayName("should only report lateinit properties not matching kotlin.*")
     fun `should only report lateinit properties not matching any kotlin annotation`() {
         val findings =
-            LateinitUsage(TestConfig(mapOf(EXCLUDE_ANNOTATED_PROPERTIES to listOf("kotlin.*")))).compileAndLint(code)
+            LateinitUsage(TestConfig(EXCLUDE_ANNOTATED_PROPERTIES to listOf("kotlin.*"))).compileAndLint(code)
         assertThat(findings).hasSize(1)
     }
 
     @Test
     fun `should only report lateinit properties matching kotlin_SinceKotlin`() {
-        val config = TestConfig(mapOf(EXCLUDE_ANNOTATED_PROPERTIES to listOf("kotlin.SinceKotlin")))
+        val config = TestConfig(EXCLUDE_ANNOTATED_PROPERTIES to listOf("kotlin.SinceKotlin"))
         val findings = LateinitUsage(config).compileAndLint(code)
         assertThat(findings).hasSize(1)
     }
@@ -53,49 +53,50 @@ class LateinitUsageSpec {
     @Test
     fun `should only report lateinit property with no @SinceKotlin annotation with config string`() {
         val findings =
-            LateinitUsage(TestConfig(mapOf(EXCLUDE_ANNOTATED_PROPERTIES to "SinceKotlin"))).compileAndLint(code)
+            LateinitUsage(TestConfig(EXCLUDE_ANNOTATED_PROPERTIES to "SinceKotlin")).compileAndLint(code)
         assertThat(findings).hasSize(1)
     }
 
     @Test
     fun `should only report lateinit property with no @SinceKotlin annotation containing whitespaces with config string`() {
         val findings =
-            LateinitUsage(TestConfig(mapOf(EXCLUDE_ANNOTATED_PROPERTIES to " SinceKotlin "))).compileAndLint(code)
+            LateinitUsage(TestConfig(EXCLUDE_ANNOTATED_PROPERTIES to " SinceKotlin ")).compileAndLint(code)
         assertThat(findings).hasSize(1)
     }
 
     @Test
     fun `should report lateinit properties not matching the exclude pattern`() {
         val findings =
-            LateinitUsage(TestConfig(mapOf(EXCLUDE_ANNOTATED_PROPERTIES to "IgnoreThis"))).compileAndLint(code)
+            LateinitUsage(TestConfig(EXCLUDE_ANNOTATED_PROPERTIES to "IgnoreThis")).compileAndLint(code)
         assertThat(findings).hasSize(2)
     }
 
     @Test
     fun `should report lateinit properties when ignoreOnClassesPattern does not match`() {
         val findings =
-            LateinitUsage(TestConfig(mapOf(IGNORE_ON_CLASSES_PATTERN to "[\\w]+Test1234"))).compileAndLint(code)
+            LateinitUsage(TestConfig(IGNORE_ON_CLASSES_PATTERN to "[\\w]+Test1234")).compileAndLint(code)
         assertThat(findings).hasSize(2)
     }
 
     @Test
     fun `should not report lateinit properties when ignoreOnClassesPattern does match`() {
         val findings =
-            LateinitUsage(TestConfig(mapOf(IGNORE_ON_CLASSES_PATTERN to "[\\w]+Test"))).compileAndLint(code)
+            LateinitUsage(TestConfig(IGNORE_ON_CLASSES_PATTERN to "[\\w]+Test")).compileAndLint(code)
         assertThat(findings).isEmpty()
     }
 
     @Test
     fun `should fail when enabled with faulty regex pattern`() {
         assertThatExceptionOfType(PatternSyntaxException::class.java).isThrownBy {
-            LateinitUsage(TestConfig(mapOf(IGNORE_ON_CLASSES_PATTERN to "*Test"))).compileAndLint(code)
+            LateinitUsage(TestConfig(IGNORE_ON_CLASSES_PATTERN to "*Test")).compileAndLint(code)
         }
     }
 
     @Test
     fun `should not fail when disabled with faulty regex pattern`() {
-        val configValues = mapOf("active" to "false", IGNORE_ON_CLASSES_PATTERN to "*Test")
-        val findings = LateinitUsage(TestConfig(configValues)).compileAndLint(code)
+        val findings = LateinitUsage(
+            TestConfig("active" to "false", IGNORE_ON_CLASSES_PATTERN to "*Test")
+        ).compileAndLint(code)
         assertThat(findings).isEmpty()
     }
 }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/LateinitUsageSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/LateinitUsageSpec.kt
@@ -29,9 +29,7 @@ class LateinitUsageSpec {
     @DisplayName("should only report lateinit property with no @SinceKotlin annotation")
     fun `should only report lateinit property with no SinceKotlin annotation`() {
         val findings =
-            LateinitUsage(TestConfig(EXCLUDE_ANNOTATED_PROPERTIES to listOf("SinceKotlin"))).compileAndLint(
-                code
-            )
+            LateinitUsage(TestConfig(EXCLUDE_ANNOTATED_PROPERTIES to listOf("SinceKotlin"))).compileAndLint(code)
         assertThat(findings).hasSize(1)
     }
 
@@ -94,9 +92,11 @@ class LateinitUsageSpec {
 
     @Test
     fun `should not fail when disabled with faulty regex pattern`() {
-        val findings = LateinitUsage(
-            TestConfig("active" to "false", IGNORE_ON_CLASSES_PATTERN to "*Test")
-        ).compileAndLint(code)
+        val config = TestConfig(
+            "active" to "false",
+            IGNORE_ON_CLASSES_PATTERN to "*Test"
+        )
+        val findings = LateinitUsage(config).compileAndLint(code)
         assertThat(findings).isEmpty()
     }
 }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingWhenCaseSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingWhenCaseSpec.kt
@@ -313,9 +313,7 @@ class MissingWhenCaseSpec(private val env: KotlinCoreEnvironment) {
     inner class `MissingWhenCase rule when else expression is not considered` {
 
         @Suppress("DEPRECATION")
-        private val subject = MissingWhenCase(
-            TestConfig("allowElseExpression" to false)
-        )
+        private val subject = MissingWhenCase(TestConfig("allowElseExpression" to false))
 
         @Nested
         inner class Enum {

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingWhenCaseSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingWhenCaseSpec.kt
@@ -314,7 +314,7 @@ class MissingWhenCaseSpec(private val env: KotlinCoreEnvironment) {
 
         @Suppress("DEPRECATION")
         private val subject = MissingWhenCase(
-            TestConfig(mapOf("allowElseExpression" to false))
+            TestConfig("allowElseExpression" to false)
         )
 
         @Nested

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ExceptionRaisedInUnexpectedLocationSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ExceptionRaisedInUnexpectedLocationSpec.kt
@@ -24,7 +24,7 @@ class ExceptionRaisedInUnexpectedLocationSpec {
 
     @Test
     fun `reports the configured method`() {
-        val config = TestConfig(mapOf("methodNames" to listOf("toDo", "todo2")))
+        val config = TestConfig("methodNames" to listOf("toDo", "todo2"))
         val findings = ExceptionRaisedInUnexpectedLocation(config).compileAndLint(
             """
         fun toDo() {
@@ -37,7 +37,7 @@ class ExceptionRaisedInUnexpectedLocationSpec {
 
     @Test
     fun `reports the configured method with String`() {
-        val config = TestConfig(mapOf("methodNames" to "toDo,todo2"))
+        val config = TestConfig("methodNames" to "toDo,todo2")
         val findings = ExceptionRaisedInUnexpectedLocation(config).compileAndLint(
             """
         fun toDo() {

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ReturnFromFinallySpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ReturnFromFinallySpec.kt
@@ -109,7 +109,7 @@ class ReturnFromFinallySpec(val env: KotlinCoreEnvironment) {
 
         @Test
         fun `should not report when ignoreLabeled is true`() {
-            val config = TestConfig(mapOf("ignoreLabeled" to "true"))
+            val config = TestConfig("ignoreLabeled" to "true")
             val findings = ReturnFromFinally(config).compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedExceptionSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedExceptionSpec.kt
@@ -213,8 +213,7 @@ class SwallowedExceptionSpec {
     @Nested
     inner class `ignores given exception name config` {
 
-        val config = TestConfig("allowedExceptionNameRegex" to "myIgnore")
-        val rule = SwallowedException(config)
+        val rule = SwallowedException(TestConfig("allowedExceptionNameRegex" to "myIgnore"))
 
         @Test
         fun `ignores given exception name`() {

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedExceptionSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedExceptionSpec.kt
@@ -213,7 +213,7 @@ class SwallowedExceptionSpec {
     @Nested
     inner class `ignores given exception name config` {
 
-        val config = TestConfig(mapOf("allowedExceptionNameRegex" to "myIgnore"))
+        val config = TestConfig("allowedExceptionNameRegex" to "myIgnore")
         val rule = SwallowedException(config)
 
         @Test

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionCaughtSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionCaughtSpec.kt
@@ -44,7 +44,7 @@ class TooGenericExceptionCaughtSpec {
 
         @Test
         fun `should not report an ignored catch blocks because of its exception name`() {
-            val config = TestConfig(mapOf(ALLOWED_EXCEPTION_NAME_REGEX to "myIgnore"))
+            val config = TestConfig(ALLOWED_EXCEPTION_NAME_REGEX to "myIgnore")
             val rule = TooGenericExceptionCaught(config)
 
             val findings = rule.compileAndLint(code)
@@ -54,7 +54,7 @@ class TooGenericExceptionCaughtSpec {
 
         @Test
         fun `should not report an ignored catch blocks because of its exception type`() {
-            val config = TestConfig(mapOf(CAUGHT_EXCEPTIONS_PROPERTY to "[MyException]"))
+            val config = TestConfig(CAUGHT_EXCEPTIONS_PROPERTY to "[MyException]")
             val rule = TooGenericExceptionCaught(config)
 
             val findings = rule.compileAndLint(code)
@@ -64,11 +64,10 @@ class TooGenericExceptionCaughtSpec {
 
         @Test
         fun `should not fail when disabled with invalid regex on allowed exception names`() {
-            val configRules = mapOf(
+            val config = TestConfig(
                 "active" to "false",
-                ALLOWED_EXCEPTION_NAME_REGEX to "*MyException"
+                ALLOWED_EXCEPTION_NAME_REGEX to "*MyException",
             )
-            val config = TestConfig(configRules)
             val rule = TooGenericExceptionCaught(config)
             val findings = rule.compileAndLint(tooGenericExceptionCode)
 
@@ -77,7 +76,7 @@ class TooGenericExceptionCaughtSpec {
 
         @Test
         fun `should fail with invalid regex on allowed exception names`() {
-            val config = TestConfig(mapOf(ALLOWED_EXCEPTION_NAME_REGEX to "*Foo"))
+            val config = TestConfig(ALLOWED_EXCEPTION_NAME_REGEX to "*Foo")
             val rule = TooGenericExceptionCaught(config)
             assertThatExceptionOfType(PatternSyntaxException::class.java).isThrownBy {
                 rule.compileAndLint(tooGenericExceptionCode)

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionThrownSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionThrownSpec.kt
@@ -14,7 +14,7 @@ class TooGenericExceptionThrownSpec {
     @ParameterizedTest
     @ValueSource(strings = ["Error", "Exception", "Throwable", "RuntimeException"])
     fun `should report $exceptionName`(exceptionName: String) {
-        val config = TestConfig(mapOf(EXCEPTION_NAMES to "[$exceptionName]"))
+        val config = TestConfig(EXCEPTION_NAMES to "[$exceptionName]")
         val rule = TooGenericExceptionThrown(config)
 
         val findings = rule.compileAndLint(tooGenericExceptionCode)
@@ -24,7 +24,7 @@ class TooGenericExceptionThrownSpec {
 
     @Test
     fun `should not report thrown exceptions`() {
-        val config = TestConfig(mapOf(EXCEPTION_NAMES to "['MyException', Bar]"))
+        val config = TestConfig(EXCEPTION_NAMES to "['MyException', Bar]")
         val rule = TooGenericExceptionThrown(config)
 
         val findings = rule.compileAndLint(tooGenericExceptionCode)
@@ -34,7 +34,7 @@ class TooGenericExceptionThrownSpec {
 
     @Test
     fun `should not report caught exceptions`() {
-        val config = TestConfig(mapOf(EXCEPTION_NAMES to "['Exception']"))
+        val config = TestConfig(EXCEPTION_NAMES to "['Exception']")
         val rule = TooGenericExceptionThrown(config)
 
         val code = """
@@ -53,7 +53,7 @@ class TooGenericExceptionThrownSpec {
 
     @Test
     fun `should not report initialize exceptions`() {
-        val config = TestConfig(mapOf(EXCEPTION_NAMES to "['Exception']"))
+        val config = TestConfig(EXCEPTION_NAMES to "['Exception']")
         val rule = TooGenericExceptionThrown(config)
 
         val code = """fun f() { val ex = Exception() }"""

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/BooleanPropertyNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/BooleanPropertyNamingSpec.kt
@@ -46,7 +46,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                 
                 data class TestImpl (override var default: Boolean) : Test
             """.trimIndent()
-            val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to false))
+            val config = TestConfig(IGNORE_OVERRIDDEN to false)
             val findings = BooleanPropertyNaming(config).compileAndLintWithContext(env, code)
 
             assertThat(findings).hasSize(2)
@@ -61,7 +61,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                 
                 data class TestImpl (override var default: Boolean) : Test
             """.trimIndent()
-            val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to true))
+            val config = TestConfig(IGNORE_OVERRIDDEN to true)
             val findings = BooleanPropertyNaming(config).compileAndLintWithContext(env, code)
 
             assertThat(findings).hasSize(1)
@@ -98,7 +98,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                 
                 data class TestImpl (override var default: Boolean?) : Test
             """.trimIndent()
-            val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to false))
+            val config = TestConfig(IGNORE_OVERRIDDEN to false)
             val findings = BooleanPropertyNaming(config).compileAndLintWithContext(env, code)
 
             assertThat(findings).hasSize(2)
@@ -113,7 +113,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                 
                 data class TestImpl (override var default: Boolean?) : Test
             """.trimIndent()
-            val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to true))
+            val config = TestConfig(IGNORE_OVERRIDDEN to true)
             val findings = BooleanPropertyNaming(config).compileAndLintWithContext(env, code)
 
             assertThat(findings).hasSize(1)
@@ -150,7 +150,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                 
                 data class TestImpl (override var default: Boolean = false) : Test
             """.trimIndent()
-            val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to false))
+            val config = TestConfig(IGNORE_OVERRIDDEN to false)
             val findings = BooleanPropertyNaming(config).compileAndLintWithContext(env, code)
 
             assertThat(findings).hasSize(2)
@@ -165,7 +165,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                 
                 data class TestImpl (override var default: Boolean = false) : Test
             """.trimIndent()
-            val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to true))
+            val config = TestConfig(IGNORE_OVERRIDDEN to true)
             val findings = BooleanPropertyNaming(config).compileAndLintWithContext(env, code)
 
             assertThat(findings).hasSize(1)
@@ -218,7 +218,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                 
                 data class TestImpl (override var default: java.lang.Boolean) : Test
             """.trimIndent()
-            val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to false))
+            val config = TestConfig(IGNORE_OVERRIDDEN to false)
             val findings = BooleanPropertyNaming(config).compileAndLintWithContext(env, code)
 
             assertThat(findings).hasSize(2)
@@ -233,7 +233,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                 
                 data class TestImpl (override var default: java.lang.Boolean) : Test
             """.trimIndent()
-            val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to true))
+            val config = TestConfig(IGNORE_OVERRIDDEN to true)
             val findings = BooleanPropertyNaming(config).compileAndLintWithContext(env, code)
 
             assertThat(findings).hasSize(1)
@@ -327,7 +327,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                     override var default: Boolean = true
                 }
             """.trimIndent()
-            val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to false))
+            val config = TestConfig(IGNORE_OVERRIDDEN to false)
             val findings = BooleanPropertyNaming(config).compileAndLintWithContext(env, code)
 
             assertThat(findings).hasSize(2)
@@ -344,7 +344,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                     override var default: Boolean = true
                 }
             """.trimIndent()
-            val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to true))
+            val config = TestConfig(IGNORE_OVERRIDDEN to true)
             val findings = BooleanPropertyNaming(config).compileAndLintWithContext(env, code)
 
             assertThat(findings).hasSize(1)
@@ -389,7 +389,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                     override var default: Boolean? = null
                 }
             """.trimIndent()
-            val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to false))
+            val config = TestConfig(IGNORE_OVERRIDDEN to false)
             val findings = BooleanPropertyNaming(config).compileAndLintWithContext(env, code)
 
             assertThat(findings).hasSize(2)
@@ -406,7 +406,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                     override var default: Boolean? = null
                 }
             """.trimIndent()
-            val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to true))
+            val config = TestConfig(IGNORE_OVERRIDDEN to true)
             val findings = BooleanPropertyNaming(config).compileAndLintWithContext(env, code)
 
             assertThat(findings).hasSize(1)
@@ -451,7 +451,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                     override var default: Boolean = false
                 }
             """.trimIndent()
-            val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to false))
+            val config = TestConfig(IGNORE_OVERRIDDEN to false)
             val findings = BooleanPropertyNaming(config).compileAndLintWithContext(env, code)
 
             assertThat(findings).hasSize(2)
@@ -468,7 +468,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                     override var default: Boolean = false
                 }
             """.trimIndent()
-            val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to true))
+            val config = TestConfig(IGNORE_OVERRIDDEN to true)
             val findings = BooleanPropertyNaming(config).compileAndLintWithContext(env, code)
 
             assertThat(findings).hasSize(1)
@@ -513,7 +513,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                     override var default = true
                 }
             """.trimIndent()
-            val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to false))
+            val config = TestConfig(IGNORE_OVERRIDDEN to false)
             val findings = BooleanPropertyNaming(config).compileAndLintWithContext(env, code)
 
             assertThat(findings).hasSize(2)
@@ -530,7 +530,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                     override var default = true
                 }
             """.trimIndent()
-            val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to true))
+            val config = TestConfig(IGNORE_OVERRIDDEN to true)
             val findings = BooleanPropertyNaming(config).compileAndLintWithContext(env, code)
 
             assertThat(findings).hasSize(1)
@@ -575,7 +575,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                     override var default: java.lang.Boolean = java.lang.Boolean(true)
                 }
             """.trimIndent()
-            val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to false))
+            val config = TestConfig(IGNORE_OVERRIDDEN to false)
             val findings = BooleanPropertyNaming(config).compileAndLintWithContext(env, code)
 
             assertThat(findings).hasSize(2)
@@ -592,7 +592,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                     override var default: java.lang.Boolean = java.lang.Boolean(true)
                 }
             """.trimIndent()
-            val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to true))
+            val config = TestConfig(IGNORE_OVERRIDDEN to true)
             val findings = BooleanPropertyNaming(config).compileAndLintWithContext(env, code)
 
             assertThat(findings).hasSize(1)
@@ -631,7 +631,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            val config = TestConfig(mapOf(ALLOWED_PATTERN to "^(is|has|are|need)"))
+            val config = TestConfig(ALLOWED_PATTERN to "^(is|has|are|need)")
             assertThat(BooleanPropertyNaming(config).compileAndLint(code))
                 .isEmpty()
         }

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ClassNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ClassNamingSpec.kt
@@ -23,7 +23,7 @@ class ClassNamingSpec {
 
     @Test
     fun `should use custom name for method and class`() {
-        val config = TestConfig(mapOf(ClassNaming.CLASS_PATTERN to "^aBbD$"))
+        val config = TestConfig(ClassNaming.CLASS_PATTERN to "^aBbD$")
         assertThat(
             ClassNaming(config).compileAndLint(
                 """

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ConstructorParameterNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ConstructorParameterNamingSpec.kt
@@ -59,7 +59,7 @@ class ConstructorParameterNamingSpec {
             
             interface I { val PARAM: String }
         """.trimIndent()
-        val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to "false"))
+        val config = TestConfig(IGNORE_OVERRIDDEN to "false")
         assertThat(ConstructorParameterNaming(config).compileAndLint(code)).hasTextLocations(8 to 34)
     }
 

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/EnumNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/EnumNamingSpec.kt
@@ -9,7 +9,7 @@ class EnumNamingSpec {
 
     @Test
     fun `should use custom name for enum`() {
-        val rule = EnumNaming(TestConfig(mapOf(EnumNaming.ENUM_PATTERN to "^(enum1)|(enum2)$")))
+        val rule = EnumNaming(TestConfig(EnumNaming.ENUM_PATTERN to "^(enum1)|(enum2)$"))
         assertThat(
             rule.compileAndLint(
                 """

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ForbiddenClassNameSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ForbiddenClassNameSpec.kt
@@ -19,8 +19,7 @@ class ForbiddenClassNameSpec {
         assertThat(
             ForbiddenClassName(TestConfig(FORBIDDEN_NAME to listOf("Manager", "Provider")))
                 .compileAndLint(code)
-        )
-            .hasSize(2)
+        ).hasSize(2)
     }
 
     @Test
@@ -29,8 +28,7 @@ class ForbiddenClassNameSpec {
         assertThat(
             ForbiddenClassName(TestConfig(FORBIDDEN_NAME to listOf("test")))
                 .compileAndLint(code)
-        )
-            .hasSize(1)
+        ).hasSize(1)
     }
 
     @Test
@@ -43,8 +41,7 @@ class ForbiddenClassNameSpec {
         assertThat(
             ForbiddenClassName(TestConfig(FORBIDDEN_NAME to "Manager, Provider"))
                 .compileAndLint(code)
-        )
-            .hasSize(2)
+        ).hasSize(2)
     }
 
     @Test
@@ -57,8 +54,7 @@ class ForbiddenClassNameSpec {
         assertThat(
             ForbiddenClassName(TestConfig(FORBIDDEN_NAME to "*Manager*, *Provider*"))
                 .compileAndLint(code)
-        )
-            .hasSize(2)
+        ).hasSize(2)
     }
 
     @Test

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ForbiddenClassNameSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ForbiddenClassNameSpec.kt
@@ -17,7 +17,7 @@ class ForbiddenClassNameSpec {
             class TestHolder
         """.trimIndent()
         assertThat(
-            ForbiddenClassName(TestConfig(mapOf(FORBIDDEN_NAME to listOf("Manager", "Provider"))))
+            ForbiddenClassName(TestConfig(FORBIDDEN_NAME to listOf("Manager", "Provider")))
                 .compileAndLint(code)
         )
             .hasSize(2)
@@ -27,7 +27,7 @@ class ForbiddenClassNameSpec {
     fun `should report a class that starts with a forbidden name`() {
         val code = "class TestProvider {}"
         assertThat(
-            ForbiddenClassName(TestConfig(mapOf(FORBIDDEN_NAME to listOf("test"))))
+            ForbiddenClassName(TestConfig(FORBIDDEN_NAME to listOf("test")))
                 .compileAndLint(code)
         )
             .hasSize(1)
@@ -41,7 +41,7 @@ class ForbiddenClassNameSpec {
             class TestHolder
         """.trimIndent()
         assertThat(
-            ForbiddenClassName(TestConfig(mapOf(FORBIDDEN_NAME to "Manager, Provider")))
+            ForbiddenClassName(TestConfig(FORBIDDEN_NAME to "Manager, Provider"))
                 .compileAndLint(code)
         )
             .hasSize(2)
@@ -55,7 +55,7 @@ class ForbiddenClassNameSpec {
             class TestHolder
         """.trimIndent()
         assertThat(
-            ForbiddenClassName(TestConfig(mapOf(FORBIDDEN_NAME to "*Manager*, *Provider*")))
+            ForbiddenClassName(TestConfig(FORBIDDEN_NAME to "*Manager*, *Provider*"))
                 .compileAndLint(code)
         )
             .hasSize(2)
@@ -66,7 +66,7 @@ class ForbiddenClassNameSpec {
         val code = """
             class TestManager {}
         """.trimIndent()
-        val actual = ForbiddenClassName(TestConfig(mapOf(FORBIDDEN_NAME to "Test, Manager, Provider")))
+        val actual = ForbiddenClassName(TestConfig(FORBIDDEN_NAME to "Test, Manager, Provider"))
             .compileAndLint(code)
         assertThat(actual.first().message)
             .isEqualTo("Class name TestManager is forbidden as it contains: Test, Manager")

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionMaxLengthSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionMaxLengthSpec.kt
@@ -11,10 +11,8 @@ class FunctionMaxLengthSpec {
     fun `should report a function name that is too long base on config`() {
         val code = "fun thisFunctionLongName() = 3"
         assertThat(
-            FunctionMaxLength(TestConfig("maximumFunctionNameLength" to 10))
-                .compileAndLint(code)
-        )
-            .hasSize(1)
+            FunctionMaxLength(TestConfig("maximumFunctionNameLength" to 10)).compileAndLint(code)
+        ).hasSize(1)
     }
 
     @Test
@@ -26,9 +24,7 @@ class FunctionMaxLengthSpec {
         interface I { @Suppress("FunctionMaxLength") fun thisFunctionIsWayTooLongButStillShouldNotBeReportedByDefault() }
         """.trimIndent()
         assertThat(
-            FunctionMaxLength(
-                TestConfig("maximumFunctionNameLength" to 10)
-            ).compileAndLint(code)
+            FunctionMaxLength(TestConfig("maximumFunctionNameLength" to 10)).compileAndLint(code)
         ).isEmpty()
     }
 
@@ -55,9 +51,7 @@ class FunctionMaxLengthSpec {
             }
         """.trimIndent()
         assertThat(
-            FunctionMaxLength(
-                TestConfig("maximumFunctionNameLength" to 5)
-            ).compileAndLint(code)
+            FunctionMaxLength(TestConfig("maximumFunctionNameLength" to 5)).compileAndLint(code)
         ).isEmpty()
     }
 }

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionMaxLengthSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionMaxLengthSpec.kt
@@ -11,7 +11,7 @@ class FunctionMaxLengthSpec {
     fun `should report a function name that is too long base on config`() {
         val code = "fun thisFunctionLongName() = 3"
         assertThat(
-            FunctionMaxLength(TestConfig(mapOf("maximumFunctionNameLength" to 10)))
+            FunctionMaxLength(TestConfig("maximumFunctionNameLength" to 10))
                 .compileAndLint(code)
         )
             .hasSize(1)
@@ -27,7 +27,7 @@ class FunctionMaxLengthSpec {
         """.trimIndent()
         assertThat(
             FunctionMaxLength(
-                TestConfig(mapOf("maximumFunctionNameLength" to 10))
+                TestConfig("maximumFunctionNameLength" to 10)
             ).compileAndLint(code)
         ).isEmpty()
     }
@@ -56,9 +56,7 @@ class FunctionMaxLengthSpec {
         """.trimIndent()
         assertThat(
             FunctionMaxLength(
-                TestConfig(
-                    mapOf("maximumFunctionNameLength" to 5)
-                )
+                TestConfig("maximumFunctionNameLength" to 5)
             ).compileAndLint(code)
         ).isEmpty()
     }

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionMinLengthSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionMinLengthSpec.kt
@@ -17,7 +17,7 @@ class FunctionMinLengthSpec {
     fun `should report a function name that is too short base on config`() {
         val code = "fun four() = 3"
         assertThat(
-            FunctionMinLength(TestConfig(mapOf("minimumFunctionNameLength" to 5)))
+            FunctionMinLength(TestConfig("minimumFunctionNameLength" to 5))
                 .compileAndLint(code)
         ).hasSize(1)
     }
@@ -38,7 +38,7 @@ class FunctionMinLengthSpec {
         """.trimIndent()
         assertThat(
             FunctionMinLength(
-                TestConfig(mapOf("minimumFunctionNameLength" to 50))
+                TestConfig("minimumFunctionNameLength" to 50)
             ).compileAndLint(code)
         ).isEmpty()
     }
@@ -53,9 +53,7 @@ class FunctionMinLengthSpec {
         """.trimIndent()
         assertThat(
             FunctionMinLength(
-                TestConfig(
-                    mapOf("minimumFunctionNameLength" to 5)
-                )
+                TestConfig("minimumFunctionNameLength" to 5)
             ).compileAndLint(code)
         ).isEmpty()
     }

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNamingSpec.kt
@@ -37,7 +37,7 @@ class FunctionNamingSpec {
             fun SHOULD_NOT_BE_FLAGGED() {}
         }
         """.trimIndent()
-        val config = TestConfig(mapOf(FunctionNaming.EXCLUDE_CLASS_PATTERN to ".*Test$"))
+        val config = TestConfig(FunctionNaming.EXCLUDE_CLASS_PATTERN to ".*Test$")
         assertThat(FunctionNaming(config).compileAndLint(code)).isEmpty()
     }
 
@@ -73,7 +73,7 @@ class FunctionNamingSpec {
         
         fun Foo(): Foo = FooImpl()
         """.trimIndent()
-        val config = TestConfig(mapOf(FunctionNaming.IGNORE_OVERRIDDEN to "false"))
+        val config = TestConfig(FunctionNaming.IGNORE_OVERRIDDEN to "false")
         assertThat(FunctionNaming(config).compileAndLint(code)).isEmpty()
     }
 
@@ -98,7 +98,7 @@ class FunctionNamingSpec {
         }
         interface I { fun SHOULD_BE_FLAGGED() }
         """.trimIndent()
-        val config = TestConfig(mapOf(FunctionNaming.IGNORE_OVERRIDDEN to "false"))
+        val config = TestConfig(FunctionNaming.IGNORE_OVERRIDDEN to "false")
         assertThat(FunctionNaming(config).compileAndLint(code)).hasStartSourceLocations(
             SourceLocation(2, 18),
             SourceLocation(4, 19)
@@ -115,7 +115,7 @@ class FunctionNamingSpec {
 
     @Test
     fun `should use custom name for method`() {
-        val config = TestConfig(mapOf(FunctionNaming.FUNCTION_PATTERN to "^`.+`$"))
+        val config = TestConfig(FunctionNaming.FUNCTION_PATTERN to "^`.+`$")
         assertThat(
             FunctionNaming(config).compileAndLint(
                 """
@@ -139,7 +139,7 @@ class FunctionNamingSpec {
             fun MYFun() {}
         }
         """.trimIndent()
-        val config = TestConfig(mapOf(FunctionNaming.EXCLUDE_CLASS_PATTERN to "Foo|Bar"))
+        val config = TestConfig(FunctionNaming.EXCLUDE_CLASS_PATTERN to "Foo|Bar")
         assertThat(FunctionNaming(config).compileAndLint(code)).isEmpty()
     }
 
@@ -165,7 +165,7 @@ class FunctionNamingSpec {
 
         @Test
         fun shouldFailWithInvalidRegexFunctionNaming() {
-            val config = TestConfig(mapOf(FunctionNaming.EXCLUDE_CLASS_PATTERN to "*Foo"))
+            val config = TestConfig(FunctionNaming.EXCLUDE_CLASS_PATTERN to "*Foo")
             assertThatExceptionOfType(PatternSyntaxException::class.java).isThrownBy {
                 FunctionNaming(config).compileAndLint(excludeClassPatternFunctionRegexCode)
             }
@@ -173,11 +173,10 @@ class FunctionNamingSpec {
 
         @Test
         fun shouldNotFailWithInvalidRegexWhenDisabledFunctionNaming() {
-            val configRules = mapOf(
+            val config = TestConfig(
                 "active" to "false",
-                FunctionNaming.EXCLUDE_CLASS_PATTERN to "*Foo"
+                FunctionNaming.EXCLUDE_CLASS_PATTERN to "*Foo",
             )
-            val config = TestConfig(configRules)
             assertThat(FunctionNaming(config).compileAndLint(excludeClassPatternFunctionRegexCode)).isEmpty()
         }
     }

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionParameterNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionParameterNamingSpec.kt
@@ -43,7 +43,7 @@ class FunctionParameterNamingSpec {
                 }
                 interface I { fun someStuff(`object`: String) }
             """.trimIndent()
-            val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to "false"))
+            val config = TestConfig(IGNORE_OVERRIDDEN to "false")
             assertThat(FunctionParameterNaming(config).compileAndLint(code)).hasSize(2)
         }
 
@@ -61,7 +61,7 @@ class FunctionParameterNamingSpec {
     @Nested
     inner class `parameters in a function of an excluded class` {
 
-        val config = TestConfig(mapOf(EXCLUDE_CLASS_PATTERN to "Excluded"))
+        val config = TestConfig(EXCLUDE_CLASS_PATTERN to "Excluded")
 
         @Test
         fun `should not detect function parameter`() {

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/InvalidPackageDeclarationSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/InvalidPackageDeclarationSpec.kt
@@ -57,7 +57,7 @@ class InvalidPackageDeclarationSpec {
     @Nested
     inner class `with root package specified` {
 
-        val config = TestConfig(mapOf(ROOT_PACKAGE to "com.example"))
+        val config = TestConfig(ROOT_PACKAGE to "com.example")
 
         @Test
         fun `should pass if file is located within the root package`() {
@@ -133,7 +133,7 @@ class InvalidPackageDeclarationSpec {
     @Nested
     inner class `with root package required` {
 
-        val config = TestConfig(mapOf(ROOT_PACKAGE to "com.example", REQUIRE_ROOT_PACKAGE to true))
+        val config = TestConfig(ROOT_PACKAGE to "com.example", REQUIRE_ROOT_PACKAGE to true)
 
         @Test
         fun `should pass if declaration starts with root package`() {

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MemberNameEqualsClassNameSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MemberNameEqualsClassNameSpec.kt
@@ -15,17 +15,10 @@ private const val IGNORE_OVERRIDDEN = "ignoreOverridden"
 
 @KotlinCoreEnvironmentTest
 class MemberNameEqualsClassNameSpec(val env: KotlinCoreEnvironment) {
-    val subject = MemberNameEqualsClassName(Config.empty)
-
-    val noIgnoreOverridden =
-        TestConfig(
-            mapOf(
-                IGNORE_OVERRIDDEN to "false"
-            )
-        )
 
     @Nested
     inner class `some classes with methods which don't have the same name` {
+        private val subject = MemberNameEqualsClassName(Config.empty)
 
         @Test
         fun `does not report a nested function with the same name as the class`() {
@@ -66,6 +59,7 @@ class MemberNameEqualsClassNameSpec(val env: KotlinCoreEnvironment) {
 
     @Nested
     inner class `some classes with members which have the same name` {
+        private val noIgnoreOverridden = TestConfig(IGNORE_OVERRIDDEN to "false")
 
         @Test
         fun `reports a method which is named after the class`() {

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNamingSpec.kt
@@ -183,14 +183,11 @@ class ObjectPropertyNamingSpec {
     @Nested
     inner class `variables and constants in objects with custom config` {
 
-        val config =
-            TestConfig(
-                mapOf(
-                    CONSTANT_PATTERN to "_[A-Za-z]*",
-                    PRIVATE_PROPERTY_PATTERN to ".*"
-                )
-            )
-        val subject = ObjectPropertyNaming(config)
+        private val config = TestConfig(
+            CONSTANT_PATTERN to "_[A-Za-z]*",
+            PRIVATE_PROPERTY_PATTERN to ".*",
+        )
+        private val subject = ObjectPropertyNaming(config)
 
         @Test
         fun `should not detect constants in object with underscores`() {
@@ -219,11 +216,7 @@ class ObjectPropertyNamingSpec {
     inner class `local properties` {
         @Test
         fun `should not detect local properties`() {
-            val config = TestConfig(
-                mapOf(
-                    PROPERTY_PATTERN to "valid"
-                )
-            )
+            val config = TestConfig(PROPERTY_PATTERN to "valid")
             val subject = ObjectPropertyNaming(config)
 
             val code = """

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableMaxLengthSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableMaxLengthSpec.kt
@@ -38,9 +38,7 @@ class VariableMaxLengthSpec {
             }
         """.trimIndent()
         assertThat(
-            VariableMaxLength(
-                TestConfig("maximumVariableNameLength" to 10)
-            ).compileAndLint(code)
+            VariableMaxLength(TestConfig("maximumVariableNameLength" to 10)).compileAndLint(code)
         ).isEmpty()
     }
 

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableMaxLengthSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableMaxLengthSpec.kt
@@ -39,7 +39,7 @@ class VariableMaxLengthSpec {
         """.trimIndent()
         assertThat(
             VariableMaxLength(
-                TestConfig(mapOf("maximumVariableNameLength" to 10))
+                TestConfig("maximumVariableNameLength" to 10)
             ).compileAndLint(code)
         ).isEmpty()
     }

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableMinLengthSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableMinLengthSpec.kt
@@ -12,7 +12,7 @@ class VariableMinLengthSpec {
     inner class `VariableMinLength rule with a custom minimum length` {
 
         val variableMinLength =
-            VariableMinLength(TestConfig(mapOf(VariableMinLength.MINIMUM_VARIABLE_NAME_LENGTH to "2")))
+            VariableMinLength(TestConfig(VariableMinLength.MINIMUM_VARIABLE_NAME_LENGTH to "2"))
 
         @Test
         fun `reports a very short variable name`() {
@@ -69,7 +69,7 @@ class VariableMinLengthSpec {
         """.trimIndent()
         assertThat(
             VariableMinLength(
-                TestConfig(mapOf("minimumVariableNameLength" to 15))
+                TestConfig("minimumVariableNameLength" to 15)
             ).compileAndLint(code)
         ).isEmpty()
     }

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableMinLengthSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableMinLengthSpec.kt
@@ -68,9 +68,7 @@ class VariableMinLengthSpec {
             }
         """.trimIndent()
         assertThat(
-            VariableMinLength(
-                TestConfig("minimumVariableNameLength" to 15)
-            ).compileAndLint(code)
+            VariableMinLength(TestConfig("minimumVariableNameLength" to 15)).compileAndLint(code)
         ).isEmpty()
     }
 }

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableNamingSpec.kt
@@ -26,17 +26,16 @@ class VariableNamingSpec {
 
         @Test
         fun shouldNotFailWithInvalidRegexWhenDisabledVariableNaming() {
-            val configValues = mapOf(
+            val config = TestConfig(
                 "active" to "false",
-                VariableNaming.EXCLUDE_CLASS_PATTERN to "*Foo"
+                VariableNaming.EXCLUDE_CLASS_PATTERN to "*Foo",
             )
-            val config = TestConfig(configValues)
             assertThat(VariableNaming(config).compileAndLint(excludeClassPatternVariableRegexCode)).isEmpty()
         }
 
         @Test
         fun shouldFailWithInvalidRegexVariableNaming() {
-            val config = TestConfig(mapOf(VariableNaming.EXCLUDE_CLASS_PATTERN to "*Foo"))
+            val config = TestConfig(VariableNaming.EXCLUDE_CLASS_PATTERN to "*Foo")
             assertThatExceptionOfType(PatternSyntaxException::class.java).isThrownBy {
                 VariableNaming(config).compileAndLint(excludeClassPatternVariableRegexCode)
             }
@@ -54,7 +53,7 @@ class VariableNamingSpec {
             val MYVar = 3
         }
         """.trimIndent()
-        val config = TestConfig(mapOf(VariableNaming.EXCLUDE_CLASS_PATTERN to "Foo|Bar"))
+        val config = TestConfig(VariableNaming.EXCLUDE_CLASS_PATTERN to "Foo|Bar")
         assertThat(VariableNaming(config).compileAndLint(code)).isEmpty()
     }
 
@@ -129,7 +128,7 @@ class VariableNamingSpec {
                 @Suppress("VariableNaming") val SHOULD_BE_FLAGGED: String
             }
         """.trimIndent()
-        val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to "false"))
+        val config = TestConfig(IGNORE_OVERRIDDEN to "false")
         assertThat(VariableNaming(config).compileAndLint(code))
             .hasStartSourceLocations(
                 SourceLocation(2, 18),

--- a/detekt-rules-performance/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/CouldBeSequenceSpec.kt
+++ b/detekt-rules-performance/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/CouldBeSequenceSpec.kt
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
 class CouldBeSequenceSpec(val env: KotlinCoreEnvironment) {
-    val subject = CouldBeSequence(TestConfig(mapOf("threshold" to 3)))
+    val subject = CouldBeSequence(TestConfig("threshold" to 3))
 
     @Test
     fun `long collection chain should be sequence`() {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/BracesOnIfStatementsSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/BracesOnIfStatementsSpec.kt
@@ -2107,10 +2107,8 @@ class BracesOnIfStatementsSpec {
 
         private fun createSubject(singleLine: String, multiLine: String): BracesOnIfStatements {
             val config = TestConfig(
-                mapOf(
-                    "singleLine" to singleLine,
-                    "multiLine" to multiLine
-                )
+                "singleLine" to singleLine,
+                "multiLine" to multiLine,
             )
             return BracesOnIfStatements(config)
         }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/CascadingCallWrappingSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/CascadingCallWrappingSpec.kt
@@ -151,8 +151,8 @@ class CascadingCallWrappingSpec {
 
     @Nested
     inner class `with elvis operators` {
-        private val subjectIncludingElvis = CascadingCallWrapping(TestConfig(mapOf("includeElvis" to true)))
-        private val subjectExcludingElvis = CascadingCallWrapping(TestConfig(mapOf("includeElvis" to false)))
+        private val subjectIncludingElvis = CascadingCallWrapping(TestConfig("includeElvis" to true))
+        private val subjectExcludingElvis = CascadingCallWrapping(TestConfig("includeElvis" to false))
 
         @Test
         fun `does not report with wrapping`() {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/DataClassContainsFunctionsSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/DataClassContainsFunctionsSpec.kt
@@ -31,14 +31,14 @@ class DataClassContainsFunctionsSpec {
 
         @Test
         fun `reports valid data class without conversion function string`() {
-            val config = TestConfig(mapOf(CONVERSION_FUNCTION_PREFIX to ""))
+            val config = TestConfig(CONVERSION_FUNCTION_PREFIX to "")
             val rule = DataClassContainsFunctions(config)
             assertThat(rule.compileAndLint(code)).hasSize(2)
         }
 
         @Test
         fun `reports valid data class without conversion function list`() {
-            val config = TestConfig(mapOf(CONVERSION_FUNCTION_PREFIX to emptyList<String>()))
+            val config = TestConfig(CONVERSION_FUNCTION_PREFIX to emptyList<String>())
             val rule = DataClassContainsFunctions(config)
             assertThat(rule.compileAndLint(code)).hasSize(2)
         }
@@ -60,14 +60,14 @@ class DataClassContainsFunctionsSpec {
 
         @Test
         fun `reports operators if not allowed`() {
-            val config = TestConfig(mapOf(ALLOW_OPERATORS to false))
+            val config = TestConfig(ALLOW_OPERATORS to false)
             val rule = DataClassContainsFunctions(config)
             assertThat(rule.compileAndLint(code)).hasSize(1)
         }
 
         @Test
         fun `does not report operators if allowed`() {
-            val config = TestConfig(mapOf(ALLOW_OPERATORS to true))
+            val config = TestConfig(ALLOW_OPERATORS to true)
             val rule = DataClassContainsFunctions(config)
             assertThat(rule.compileAndLint(code)).isEmpty()
         }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/DestructuringDeclarationWithTooManyEntriesSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/DestructuringDeclarationWithTooManyEntriesSpec.kt
@@ -86,7 +86,7 @@ class DestructuringDeclarationWithTooManyEntriesSpec {
 
         val configuredRule =
             DestructuringDeclarationWithTooManyEntries(
-                TestConfig(mapOf(MAX_DESTRUCTURING_ENTRIES to "2"))
+                TestConfig(MAX_DESTRUCTURING_ENTRIES to "2")
             )
 
         @Test

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExpressionBodySyntaxSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExpressionBodySyntaxSpec.kt
@@ -105,7 +105,7 @@ class ExpressionBodySyntaxSpec {
 
         @Test
         fun `reports with includeLineWrapping = true configuration`() {
-            val config = TestConfig(mapOf(INCLUDE_LINE_WRAPPING to "true"))
+            val config = TestConfig(INCLUDE_LINE_WRAPPING to "true")
             assertThat(ExpressionBodySyntax(config).compileAndLint(code)).hasSize(1)
         }
     }
@@ -129,7 +129,7 @@ class ExpressionBodySyntaxSpec {
 
         @Test
         fun `reports with includeLineWrapping = true configuration`() {
-            val config = TestConfig(mapOf(INCLUDE_LINE_WRAPPING to "true"))
+            val config = TestConfig(INCLUDE_LINE_WRAPPING to "true")
             assertThat(ExpressionBodySyntax(config).compileAndLint(code)).hasSize(1)
         }
     }
@@ -151,7 +151,7 @@ class ExpressionBodySyntaxSpec {
 
         @Test
         fun `reports with includeLineWrapping = true configuration`() {
-            val config = TestConfig(mapOf(INCLUDE_LINE_WRAPPING to "true"))
+            val config = TestConfig(INCLUDE_LINE_WRAPPING to "true")
             assertThat(ExpressionBodySyntax(config).compileAndLint(code)).hasSize(1)
         }
     }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenAnnotationSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenAnnotationSpec.kt
@@ -19,7 +19,7 @@ class ForbiddenAnnotationSpec(val env: KotlinCoreEnvironment) {
         @SuppressWarnings("unused")
         fun main() {}
         """.trimIndent()
-        val findings = ForbiddenAnnotation(TestConfig()).compileAndLintWithContext(env, code)
+        val findings = ForbiddenAnnotation().compileAndLintWithContext(env, code)
 
         assertThat(findings)
             .hasSize(1)
@@ -52,7 +52,7 @@ class ForbiddenAnnotationSpec(val env: KotlinCoreEnvironment) {
         @Inherited
         annotation class SomeClass(val value: Array<SomeClass>)
         """.trimIndent()
-        val findings = ForbiddenAnnotation(TestConfig()).compileAndLintWithContext(env, code)
+        val findings = ForbiddenAnnotation().compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(6)
             .hasTextLocations(
                 "@Deprecated",
@@ -71,7 +71,7 @@ class ForbiddenAnnotationSpec(val env: KotlinCoreEnvironment) {
         fun main() {}
         """.trimIndent()
         val findings = ForbiddenAnnotation(
-            TestConfig(mapOf(ANNOTATIONS to listOf("kotlin.jvm.Transient")))
+            TestConfig(ANNOTATIONS to listOf("kotlin.jvm.Transient"))
         ).compileAndLintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
@@ -83,7 +83,7 @@ class ForbiddenAnnotationSpec(val env: KotlinCoreEnvironment) {
         fun main() {}
         """.trimIndent()
         val findings = ForbiddenAnnotation(
-            TestConfig(mapOf(ANNOTATIONS to listOf("java.lang.SuppressWarnings")))
+            TestConfig(ANNOTATIONS to listOf("java.lang.SuppressWarnings"))
         ).compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(1)
             .hasTextLocations("@java.lang.SuppressWarnings")
@@ -101,12 +101,10 @@ class ForbiddenAnnotationSpec(val env: KotlinCoreEnvironment) {
         """.trimIndent()
         val findings = ForbiddenAnnotation(
             TestConfig(
-                mapOf(
-                    ANNOTATIONS to listOf(
-                        "java.lang.SuppressWarnings",
-                        "kotlin.jvm.Transient",
-                        "kotlin.jvm.Volatile"
-                    )
+                ANNOTATIONS to listOf(
+                    "java.lang.SuppressWarnings",
+                    "kotlin.jvm.Transient",
+                    "kotlin.jvm.Volatile",
                 )
             )
         ).compileAndLintWithContext(env, code)
@@ -121,7 +119,7 @@ class ForbiddenAnnotationSpec(val env: KotlinCoreEnvironment) {
         class SomeClass
         """.trimIndent()
         val findings = ForbiddenAnnotation(
-            TestConfig(mapOf(ANNOTATIONS to listOf("java.lang.SuppressWarnings")))
+            TestConfig(ANNOTATIONS to listOf("java.lang.SuppressWarnings"))
         ).compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(1)
             .hasTextLocations("@SuppressWarnings")
@@ -136,7 +134,7 @@ class ForbiddenAnnotationSpec(val env: KotlinCoreEnvironment) {
         }
         """.trimIndent()
         val findings = ForbiddenAnnotation(
-            TestConfig(mapOf(ANNOTATIONS to listOf("java.lang.SuppressWarnings")))
+            TestConfig(ANNOTATIONS to listOf("java.lang.SuppressWarnings"))
         ).compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(1)
             .hasTextLocations("@SuppressWarnings")
@@ -151,7 +149,7 @@ class ForbiddenAnnotationSpec(val env: KotlinCoreEnvironment) {
         }
         """.trimIndent()
         val findings = ForbiddenAnnotation(
-            TestConfig(mapOf(ANNOTATIONS to listOf("java.lang.SuppressWarnings")))
+            TestConfig(ANNOTATIONS to listOf("java.lang.SuppressWarnings"))
         ).compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(1)
             .hasTextLocations("@SuppressWarnings")
@@ -163,7 +161,7 @@ class ForbiddenAnnotationSpec(val env: KotlinCoreEnvironment) {
         fun main(@SuppressWarnings("unused") args: Array<String>){}
         """.trimIndent()
         val findings = ForbiddenAnnotation(
-            TestConfig(mapOf(ANNOTATIONS to listOf("java.lang.SuppressWarnings")))
+            TestConfig(ANNOTATIONS to listOf("java.lang.SuppressWarnings"))
         ).compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(1)
             .hasTextLocations("@SuppressWarnings")
@@ -179,7 +177,7 @@ class ForbiddenAnnotationSpec(val env: KotlinCoreEnvironment) {
         }
         """.trimIndent()
         val findings = ForbiddenAnnotation(
-            TestConfig(mapOf(ANNOTATIONS to listOf("java.lang.SuppressWarnings")))
+            TestConfig(ANNOTATIONS to listOf("java.lang.SuppressWarnings"))
         ).compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(1)
             .hasTextLocations("@SuppressWarnings")
@@ -195,7 +193,7 @@ class ForbiddenAnnotationSpec(val env: KotlinCoreEnvironment) {
         }
         """.trimIndent()
         val findings = ForbiddenAnnotation(
-            TestConfig(mapOf(ANNOTATIONS to listOf("java.lang.SuppressWarnings")))
+            TestConfig(ANNOTATIONS to listOf("java.lang.SuppressWarnings"))
         ).compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(1)
             .hasTextLocations("@SuppressWarnings")
@@ -209,7 +207,7 @@ class ForbiddenAnnotationSpec(val env: KotlinCoreEnvironment) {
         fun foo() = "1234"
         """.trimIndent()
         val findings = ForbiddenAnnotation(
-            TestConfig(mapOf(ANNOTATIONS to listOf("kotlin.ReplaceWith")))
+            TestConfig(ANNOTATIONS to listOf("kotlin.ReplaceWith"))
         ).compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(1)
             .hasTextLocations("ReplaceWith")
@@ -222,7 +220,7 @@ class ForbiddenAnnotationSpec(val env: KotlinCoreEnvironment) {
         @Dep
         fun f() = Unit
         """.trimIndent()
-        val findings = ForbiddenAnnotation(TestConfig()).compileAndLintWithContext(env, code)
+        val findings = ForbiddenAnnotation().compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(1)
             .hasTextLocations("@Dep")
     }
@@ -233,7 +231,7 @@ class ForbiddenAnnotationSpec(val env: KotlinCoreEnvironment) {
         val x = 0 + @Suppress("UnnecessaryParentheses") (((1)+(2))) + 3
         """.trimIndent()
         val findings = ForbiddenAnnotation(
-            TestConfig(mapOf(ANNOTATIONS to listOf("kotlin.Suppress")))
+            TestConfig(ANNOTATIONS to listOf("kotlin.Suppress"))
         ).compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(1)
             .hasTextLocations("@Suppress")
@@ -247,7 +245,7 @@ class ForbiddenAnnotationSpec(val env: KotlinCoreEnvironment) {
         }
         """.trimIndent()
         val findings = ForbiddenAnnotation(
-            TestConfig(mapOf(ANNOTATIONS to listOf("kotlin.Suppress")))
+            TestConfig(ANNOTATIONS to listOf("kotlin.Suppress"))
         ).compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(1)
             .hasTextLocations("@Suppress")

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenCommentSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenCommentSpec.kt
@@ -98,7 +98,7 @@ class ForbiddenCommentSpec {
 
         @Nested
         inner class `when given Banana` {
-            val config = TestConfig(mapOf(VALUES to "Banana"))
+            val config = TestConfig(VALUES to "Banana")
 
             @Test
             @DisplayName("should not report TODO: usages")
@@ -129,7 +129,7 @@ class ForbiddenCommentSpec {
 
             @Test
             fun `should report Banana usages regardless of case sensitive`() {
-                val forbiddenComment = ForbiddenComment(TestConfig(mapOf(VALUES to "bAnAnA")))
+                val forbiddenComment = ForbiddenComment(TestConfig(VALUES to "bAnAnA"))
                 val findings = forbiddenComment.compileAndLint(banana)
                 assertThat(findings).hasSize(1)
             }
@@ -138,7 +138,7 @@ class ForbiddenCommentSpec {
         @Nested
         @DisplayName("when given listOf(\"banana\")")
         inner class ListOfBanana {
-            val config = TestConfig(mapOf(VALUES to listOf("Banana")))
+            val config = TestConfig(VALUES to listOf("Banana"))
 
             @Test
             @DisplayName("should not report TODO: usages")
@@ -169,7 +169,7 @@ class ForbiddenCommentSpec {
 
             @Test
             fun `should report Banana usages regardless of case sensitive`() {
-                val forbiddenComment = ForbiddenComment(TestConfig(mapOf(VALUES to "bAnAnA")))
+                val forbiddenComment = ForbiddenComment(TestConfig(VALUES to "bAnAnA"))
                 val findings = forbiddenComment.compileAndLint(banana)
                 assertThat(findings).hasSize(1)
             }
@@ -179,13 +179,10 @@ class ForbiddenCommentSpec {
     @Nested
     inner class `custom default values with allowed patterns are configured` {
 
-        val patternsConfig =
-            TestConfig(
-                mapOf(
-                    VALUES to "Comment",
-                    ALLOWED_PATTERNS to "Ticket|Task"
-                )
-            )
+        private val patternsConfig = TestConfig(
+            VALUES to "Comment",
+            ALLOWED_PATTERNS to "Ticket|Task",
+        )
 
         @Test
         fun `should report Comment usages when regex does not match`() {
@@ -211,13 +208,10 @@ class ForbiddenCommentSpec {
 
     @Nested
     inner class `custom message is configured` {
-        val messageConfig =
-            TestConfig(
-                mapOf(
-                    VALUES to "Comment",
-                    MESSAGE to "Custom Message"
-                )
-            )
+        private val messageConfig = TestConfig(
+            VALUES to "Comment",
+            MESSAGE to "Custom Message",
+        )
 
         @Test
         fun `should report a Finding with message 'Custom Message'`() {
@@ -230,12 +224,7 @@ class ForbiddenCommentSpec {
 
     @Nested
     inner class `custom message is not configured` {
-        val messageConfig =
-            TestConfig(
-                mapOf(
-                    VALUES to "Comment"
-                )
-            )
+        private val messageConfig = TestConfig(VALUES to "Comment")
 
         @Test
         fun `should report a Finding with default Message`() {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenImportSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenImportSpec.kt
@@ -77,8 +77,7 @@ class ForbiddenImportSpec {
     @DisplayName("should report kotlin.SinceKotlin and kotlin.jvm.JvmField when specified via fully qualified names")
     fun reportMultipleConfiguredImportsCommaSeparated() {
         val findings =
-            ForbiddenImport(TestConfig(IMPORTS to listOf("kotlin.SinceKotlin", "kotlin.jvm.JvmField")))
-                .lint(code)
+            ForbiddenImport(TestConfig(IMPORTS to listOf("kotlin.SinceKotlin", "kotlin.jvm.JvmField"))).lint(code)
         assertThat(findings).hasSize(2)
     }
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenImportSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenImportSpec.kt
@@ -31,20 +31,20 @@ class ForbiddenImportSpec {
 
     @Test
     fun `should report nothing when imports are blank`() {
-        val findings = ForbiddenImport(TestConfig(mapOf(IMPORTS to listOf("  ")))).lint(code)
+        val findings = ForbiddenImport(TestConfig(IMPORTS to listOf("  "))).lint(code)
         assertThat(findings).isEmpty()
     }
 
     @Test
     fun `should report nothing when imports do not match`() {
-        val findings = ForbiddenImport(TestConfig(mapOf(IMPORTS to listOf("org.*")))).lint(code)
+        val findings = ForbiddenImport(TestConfig(IMPORTS to listOf("org.*"))).lint(code)
         assertThat(findings).isEmpty()
     }
 
     @Test
     @DisplayName("should report kotlin.* when imports are kotlin.*")
     fun reportKotlinWildcardImports() {
-        val findings = ForbiddenImport(TestConfig(mapOf(IMPORTS to listOf("kotlin.*")))).lint(code)
+        val findings = ForbiddenImport(TestConfig(IMPORTS to listOf("kotlin.*"))).lint(code)
         assertThat(findings)
             .extracting("message")
             .containsExactlyInAnyOrder(
@@ -56,7 +56,7 @@ class ForbiddenImportSpec {
     @Test
     @DisplayName("should report kotlin.* when imports are kotlin.* with reasons")
     fun reportKotlinWildcardImports2() {
-        val config = TestConfig(mapOf(IMPORTS to listOf(ValueWithReason("kotlin.*", "I'm just joking!").toConfig())))
+        val config = TestConfig(IMPORTS to listOf(ValueWithReason("kotlin.*", "I'm just joking!").toConfig()))
         val findings = ForbiddenImport(config).lint(code)
         assertThat(findings).hasSize(2)
         assertThat(findings[0].message)
@@ -68,7 +68,7 @@ class ForbiddenImportSpec {
     @Test
     @DisplayName("should report kotlin.SinceKotlin when specified via fully qualified name")
     fun reportKotlinSinceKotlinWhenFqdnSpecified() {
-        val findings = ForbiddenImport(TestConfig(mapOf(IMPORTS to listOf("kotlin.SinceKotlin")))).lint(code)
+        val findings = ForbiddenImport(TestConfig(IMPORTS to listOf("kotlin.SinceKotlin"))).lint(code)
         assertThat(findings)
             .hasSize(1)
     }
@@ -77,7 +77,7 @@ class ForbiddenImportSpec {
     @DisplayName("should report kotlin.SinceKotlin and kotlin.jvm.JvmField when specified via fully qualified names")
     fun reportMultipleConfiguredImportsCommaSeparated() {
         val findings =
-            ForbiddenImport(TestConfig(mapOf(IMPORTS to listOf("kotlin.SinceKotlin", "kotlin.jvm.JvmField"))))
+            ForbiddenImport(TestConfig(IMPORTS to listOf("kotlin.SinceKotlin", "kotlin.jvm.JvmField")))
                 .lint(code)
         assertThat(findings).hasSize(2)
     }
@@ -87,28 +87,23 @@ class ForbiddenImportSpec {
         "should report kotlin.SinceKotlin and kotlin.jvm.JvmField when specified via fully qualified names list"
     )
     fun reportMultipleConfiguredImportsInList() {
-        val findings =
-            ForbiddenImport(
-                TestConfig(
-                    mapOf(
-                        IMPORTS to listOf("kotlin.SinceKotlin", "kotlin.jvm.JvmField")
-                    )
-                )
-            ).lint(code)
+        val findings = ForbiddenImport(
+            TestConfig(IMPORTS to listOf("kotlin.SinceKotlin", "kotlin.jvm.JvmField"))
+        ).lint(code)
         assertThat(findings).hasSize(2)
     }
 
     @Test
     @DisplayName("should report kotlin.SinceKotlin when specified via kotlin.Since*")
     fun reportsKotlinSinceKotlinWhenSpecifiedWithWildcard() {
-        val findings = ForbiddenImport(TestConfig(mapOf(IMPORTS to listOf("kotlin.Since*")))).lint(code)
+        val findings = ForbiddenImport(TestConfig(IMPORTS to listOf("kotlin.Since*"))).lint(code)
         assertThat(findings).hasSize(1)
     }
 
     @Test
     @DisplayName("should report all of com.example.R.string, net.example.R.dimen, and net.example.R.dimension")
     fun preAndPostWildcard() {
-        val findings = ForbiddenImport(TestConfig(mapOf(IMPORTS to listOf("*.R.*")))).lint(code)
+        val findings = ForbiddenImport(TestConfig(IMPORTS to listOf("*.R.*"))).lint(code)
         assertThat(findings).hasSize(3)
     }
 
@@ -116,21 +111,21 @@ class ForbiddenImportSpec {
     @DisplayName("should report net.example.R.dimen but not net.example.R.dimension")
     fun doNotReportSubstringOfFqdn() {
         val findings =
-            ForbiddenImport(TestConfig(mapOf(IMPORTS to listOf("net.example.R.dimen")))).lint(code)
+            ForbiddenImport(TestConfig(IMPORTS to listOf("net.example.R.dimen"))).lint(code)
         assertThat(findings).hasSize(1)
     }
 
     @Test
     fun `should not report import when it does not match any pattern`() {
         val findings =
-            ForbiddenImport(TestConfig(mapOf(FORBIDDEN_PATTERNS to "nets.*R"))).lint(code)
+            ForbiddenImport(TestConfig(FORBIDDEN_PATTERNS to "nets.*R")).lint(code)
         assertThat(findings).isEmpty()
     }
 
     @Test
     fun `should report import when it matches the forbidden pattern`() {
         val findings =
-            ForbiddenImport(TestConfig(mapOf(FORBIDDEN_PATTERNS to "net.*R|com.*expiremental"))).lint(code)
+            ForbiddenImport(TestConfig(FORBIDDEN_PATTERNS to "net.*R|com.*expiremental")).lint(code)
         assertThat(findings).hasSize(2)
         assertThat(findings[0].message)
             .isEqualTo("The import `net.example.R.dimen` has been forbidden in the detekt config.")

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCallSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCallSpec.kt
@@ -46,7 +46,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
         }
         """.trimIndent()
         val findings = ForbiddenMethodCall(
-            TestConfig(mapOf(METHODS to listOf("  ")))
+            TestConfig(METHODS to listOf("  "))
         ).compileAndLintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
@@ -60,7 +60,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
         }
         """.trimIndent()
         val findings = ForbiddenMethodCall(
-            TestConfig(mapOf(METHODS to listOf("java.lang.System.gc")))
+            TestConfig(METHODS to listOf("java.lang.System.gc"))
         ).compileAndLintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
@@ -73,7 +73,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
         }
         """.trimIndent()
         val findings = ForbiddenMethodCall(
-            TestConfig(mapOf(METHODS to listOf("java.io.PrintStream.println")))
+            TestConfig(METHODS to listOf("java.io.PrintStream.println"))
         ).compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(1)
         assertThat(findings).hasTextLocations(38 to 54)
@@ -88,7 +88,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
         }
         """.trimIndent()
         val findings = ForbiddenMethodCall(
-            TestConfig(mapOf(METHODS to listOf("java.io.PrintStream.println")))
+            TestConfig(METHODS to listOf("java.io.PrintStream.println"))
         ).compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(1)
         assertThat(findings).hasTextLocations(49 to 65)
@@ -105,11 +105,9 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
         """.trimIndent()
         val findings = ForbiddenMethodCall(
             TestConfig(
-                mapOf(
-                    METHODS to listOf(
-                        "java.io.PrintStream.println",
-                        "java.lang.System.gc"
-                    )
+                METHODS to listOf(
+                    "java.io.PrintStream.println",
+                    "java.lang.System.gc",
                 )
             )
         ).compileAndLintWithContext(env, code)
@@ -125,7 +123,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
             }
         """.trimIndent()
         val findings = ForbiddenMethodCall(
-            TestConfig(mapOf(METHODS to listOf("java.math.BigDecimal.equals")))
+            TestConfig(METHODS to listOf("java.math.BigDecimal.equals"))
         ).compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(1)
     }
@@ -139,7 +137,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
             }
         """.trimIndent()
         val findings = ForbiddenMethodCall(
-            TestConfig(mapOf(METHODS to listOf("kotlin.Int.inc")))
+            TestConfig(METHODS to listOf("kotlin.Int.inc"))
         ).compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(1)
     }
@@ -153,7 +151,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
             }
         """.trimIndent()
         val findings = ForbiddenMethodCall(
-            TestConfig(mapOf(METHODS to listOf("kotlin.Int.dec")))
+            TestConfig(METHODS to listOf("kotlin.Int.dec"))
         ).compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(1)
     }
@@ -170,7 +168,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
             }
         """.trimIndent()
         val findings = ForbiddenMethodCall(
-            TestConfig(mapOf(METHODS to listOf("java.time.LocalDate.now")))
+            TestConfig(METHODS to listOf("java.time.LocalDate.now"))
         ).compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(2)
     }
@@ -187,7 +185,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
             }
         """.trimIndent()
         val findings = ForbiddenMethodCall(
-            TestConfig(mapOf(METHODS to listOf("java.time.LocalDate.now()")))
+            TestConfig(METHODS to listOf("java.time.LocalDate.now()"))
         ).compileAndLintWithContext(env, code)
         assertThat(findings).hasStartSourceLocation(5, 26)
         assertThat(findings[0])
@@ -206,7 +204,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
             }
         """.trimIndent()
         val findings = ForbiddenMethodCall(
-            TestConfig(mapOf(METHODS to listOf("java.time.LocalDate.now(java.time.Clock)")))
+            TestConfig(METHODS to listOf("java.time.LocalDate.now(java.time.Clock)"))
         ).compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(1)
         assertThat(findings).hasStartSourceLocation(6, 27)
@@ -221,7 +219,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
             }
         """.trimIndent()
         val findings = ForbiddenMethodCall(
-            TestConfig(mapOf(METHODS to listOf("java.time.LocalDate.of(kotlin.Int, kotlin.Int, kotlin.Int)")))
+            TestConfig(METHODS to listOf("java.time.LocalDate.of(kotlin.Int, kotlin.Int, kotlin.Int)"))
         ).compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(1)
         assertThat(findings).hasStartSourceLocation(3, 26)
@@ -236,7 +234,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
             }
         """.trimIndent()
         val findings = ForbiddenMethodCall(
-            TestConfig(mapOf(METHODS to listOf("java.time.LocalDate.of(kotlin.Int,kotlin.Int,kotlin.Int)")))
+            TestConfig(METHODS to listOf("java.time.LocalDate.of(kotlin.Int,kotlin.Int,kotlin.Int)"))
         ).compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(1)
         assertThat(findings).hasStartSourceLocation(3, 26)
@@ -254,7 +252,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
             }
         """.trimIndent()
         val findings = ForbiddenMethodCall(
-            TestConfig(mapOf(METHODS to listOf("io.gitlab.arturbosch.detekt.rules.style.`some, test`()")))
+            TestConfig(METHODS to listOf("io.gitlab.arturbosch.detekt.rules.style.`some, test`()"))
         ).compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(1)
         assertThat(findings).hasStartSourceLocation(6, 13)
@@ -273,10 +271,8 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
         """.trimIndent()
         val findings = ForbiddenMethodCall(
             TestConfig(
-                mapOf(
-                    METHODS to
-                        listOf("io.gitlab.arturbosch.detekt.rules.style.defaultParamsMethod(kotlin.String,kotlin.Int)")
-                )
+                METHODS to
+                    listOf("io.gitlab.arturbosch.detekt.rules.style.defaultParamsMethod(kotlin.String,kotlin.Int)")
             )
         ).compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(1)
@@ -295,7 +291,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
             }
         """.trimIndent()
         val methodName = "io.gitlab.arturbosch.detekt.rules.style.arrayMethod(kotlin.Array)"
-        val findings = ForbiddenMethodCall(TestConfig(mapOf(METHODS to listOf(methodName))))
+        val findings = ForbiddenMethodCall(TestConfig(METHODS to listOf(methodName)))
             .compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(1).hasStartSourceLocation(6, 13)
     }
@@ -312,7 +308,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
             }
         """.trimIndent()
         val methodName = "io.gitlab.arturbosch.detekt.rules.style.listMethod(kotlin.collections.List)"
-        val findings = ForbiddenMethodCall(TestConfig(mapOf(METHODS to listOf(methodName))))
+        val findings = ForbiddenMethodCall(TestConfig(METHODS to listOf(methodName)))
             .compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(1).hasStartSourceLocation(6, 13)
     }
@@ -329,7 +325,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
             }
         """.trimIndent()
         val methodName = "io.gitlab.arturbosch.detekt.rules.style.varargMethod(kotlin.Array)"
-        val findings = ForbiddenMethodCall(TestConfig(mapOf(METHODS to listOf(methodName))))
+        val findings = ForbiddenMethodCall(TestConfig(METHODS to listOf(methodName)))
             .compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(1).hasStartSourceLocation(6, 13)
     }
@@ -350,7 +346,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
             }
         """.trimIndent()
         val methodName = "io.gitlab.arturbosch.detekt.rules.style.TestClass.Companion.staticMethod()"
-        val findings = ForbiddenMethodCall(TestConfig(mapOf(METHODS to listOf(methodName))))
+        val findings = ForbiddenMethodCall(TestConfig(METHODS to listOf(methodName)))
             .compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(1).hasStartSourceLocation(10, 15)
     }
@@ -372,7 +368,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
             }
         """.trimIndent()
         val methodName = "io.gitlab.arturbosch.detekt.rules.style.TestClass.Companion.staticMethod()"
-        val findings = ForbiddenMethodCall(TestConfig(mapOf(METHODS to listOf(methodName))))
+        val findings = ForbiddenMethodCall(TestConfig(METHODS to listOf(methodName)))
             .compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(1).hasStartSourceLocation(11, 15)
     }
@@ -396,7 +392,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
             }
         """.trimIndent()
         val findings = ForbiddenMethodCall(
-            TestConfig(mapOf(METHODS to listOf("org.example.com.I.f")))
+            TestConfig(METHODS to listOf("org.example.com.I.f"))
         ).compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(2)
     }
@@ -413,7 +409,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
             }
         """.trimIndent()
         val findings = ForbiddenMethodCall(
-            TestConfig(mapOf(METHODS to listOf("org.example.bar((kotlin.String) -> kotlin.String)")))
+            TestConfig(METHODS to listOf("org.example.bar((kotlin.String) -> kotlin.String)"))
         ).compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(1)
     }
@@ -430,7 +426,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
             }
         """.trimIndent()
         val findings = ForbiddenMethodCall(
-            TestConfig(mapOf(METHODS to listOf("org.example.bar(kotlin.String)")))
+            TestConfig(METHODS to listOf("org.example.bar(kotlin.String)"))
         ).compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(1)
     }
@@ -450,7 +446,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
         @Test
         fun `raise the issue`() {
             val findings = ForbiddenMethodCall(
-                TestConfig(mapOf(METHODS to listOf("org.example.bar(T, U, kotlin.String)")))
+                TestConfig(METHODS to listOf("org.example.bar(T, U, kotlin.String)"))
             ).compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
@@ -458,7 +454,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
         @Test
         fun `It doesn't raise any issue because the generics don't match`() {
             val findings = ForbiddenMethodCall(
-                TestConfig(mapOf(METHODS to listOf("org.example.bar(U, T, kotlin.String)")))
+                TestConfig(METHODS to listOf("org.example.bar(U, T, kotlin.String)"))
             ).compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
@@ -479,7 +475,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
         @Test
         fun `raise the issue`() {
             val findings = ForbiddenMethodCall(
-                TestConfig(mapOf(METHODS to listOf("org.example.bar(R, kotlin.String)")))
+                TestConfig(METHODS to listOf("org.example.bar(R, kotlin.String)"))
             ).compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
@@ -487,7 +483,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
         @Test
         fun `It doesn't raise any issue because the type doesn't match`() {
             val findings = ForbiddenMethodCall(
-                TestConfig(mapOf(METHODS to listOf("org.example.bar(kotlin.Int, kotlin.String)")))
+                TestConfig(METHODS to listOf("org.example.bar(kotlin.Int, kotlin.String)"))
             ).compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
@@ -509,7 +505,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
         @Test
         fun `forbid the one without receiver`() {
             val findings = ForbiddenMethodCall(
-                TestConfig(mapOf(METHODS to listOf("kotlin.runCatching(() -> R)")))
+                TestConfig(METHODS to listOf("kotlin.runCatching(() -> R)"))
             ).compileAndLintWithContext(env, code)
             assertThat(findings)
                 .hasSize(1)
@@ -519,7 +515,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
         @Test
         fun `forbid the one with receiver`() {
             val findings = ForbiddenMethodCall(
-                TestConfig(mapOf(METHODS to listOf("kotlin.runCatching(T, (T) -> R)")))
+                TestConfig(METHODS to listOf("kotlin.runCatching(T, (T) -> R)"))
             ).compileAndLintWithContext(env, code)
             assertThat(findings)
                 .hasSize(1)
@@ -541,7 +537,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
             val findings =
-                ForbiddenMethodCall(TestConfig(mapOf(METHODS to listOf("java.util.Calendar.getFirstDayOfWeek")))).compileAndLintWithContext(
+                ForbiddenMethodCall(TestConfig(METHODS to listOf("java.util.Calendar.getFirstDayOfWeek"))).compileAndLintWithContext(
                     env,
                     code
                 )
@@ -559,7 +555,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
             val findings =
-                ForbiddenMethodCall(TestConfig(mapOf(METHODS to listOf("java.util.Calendar.getFirstDayOfWeek")))).compileAndLintWithContext(
+                ForbiddenMethodCall(TestConfig(METHODS to listOf("java.util.Calendar.getFirstDayOfWeek"))).compileAndLintWithContext(
                     env,
                     code
                 )
@@ -578,7 +574,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
                 }
         """.trimIndent()
         val findings =
-            ForbiddenMethodCall(TestConfig(mapOf(METHODS to listOf("java.util.Calendar.setFirstDayOfWeek")))).compileAndLintWithContext(
+            ForbiddenMethodCall(TestConfig(METHODS to listOf("java.util.Calendar.setFirstDayOfWeek"))).compileAndLintWithContext(
                 env,
                 code
             )
@@ -596,7 +592,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
                 }
         """.trimIndent()
         val findings =
-            ForbiddenMethodCall(TestConfig(mapOf(METHODS to listOf("java.util.Calendar.compareTo")))).compileAndLintWithContext(
+            ForbiddenMethodCall(TestConfig(METHODS to listOf("java.util.Calendar.compareTo"))).compileAndLintWithContext(
                 env,
                 code
             )

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCallSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCallSpec.kt
@@ -536,11 +536,9 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
                     val day = calendar.getFirstDayOfWeek()
                 }
             """.trimIndent()
-            val findings =
-                ForbiddenMethodCall(TestConfig(METHODS to listOf("java.util.Calendar.getFirstDayOfWeek"))).compileAndLintWithContext(
-                    env,
-                    code
-                )
+            val findings = ForbiddenMethodCall(
+                TestConfig(METHODS to listOf("java.util.Calendar.getFirstDayOfWeek"))
+            ).compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
 
@@ -554,11 +552,9 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
                     val day = calendar.firstDayOfWeek
                 }
             """.trimIndent()
-            val findings =
-                ForbiddenMethodCall(TestConfig(METHODS to listOf("java.util.Calendar.getFirstDayOfWeek"))).compileAndLintWithContext(
-                    env,
-                    code
-                )
+            val findings = ForbiddenMethodCall(
+                TestConfig(METHODS to listOf("java.util.Calendar.getFirstDayOfWeek"))
+            ).compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
     }
@@ -573,11 +569,9 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
                     calendar.firstDayOfWeek = 1
                 }
         """.trimIndent()
-        val findings =
-            ForbiddenMethodCall(TestConfig(METHODS to listOf("java.util.Calendar.setFirstDayOfWeek"))).compileAndLintWithContext(
-                env,
-                code
-            )
+        val findings = ForbiddenMethodCall(
+            TestConfig(METHODS to listOf("java.util.Calendar.setFirstDayOfWeek"))
+        ).compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(1)
     }
 
@@ -591,11 +585,9 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
                     calendar.let(calendar::compareTo)
                 }
         """.trimIndent()
-        val findings =
-            ForbiddenMethodCall(TestConfig(METHODS to listOf("java.util.Calendar.compareTo"))).compileAndLintWithContext(
-                env,
-                code
-            )
+        val findings = ForbiddenMethodCall(
+            TestConfig(METHODS to listOf("java.util.Calendar.compareTo"))
+        ).compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(1)
     }
 
@@ -610,11 +602,9 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
                     
                     val a = Date()
                 """.trimIndent()
-                val findings =
-                    ForbiddenMethodCall(TestConfig(METHODS to listOf("java.util.Date.<init>"))).compileAndLintWithContext(
-                        env,
-                        code
-                    )
+                val findings = ForbiddenMethodCall(
+                    TestConfig(METHODS to listOf("java.util.Date.<init>"))
+                ).compileAndLintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }
 
@@ -625,11 +615,9 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
                     
                     val a = Date(2022, 8 ,7)
                 """.trimIndent()
-                val findings =
-                    ForbiddenMethodCall(TestConfig(METHODS to listOf("java.util.Date.<init>"))).compileAndLintWithContext(
-                        env,
-                        code
-                    )
+                val findings = ForbiddenMethodCall(
+                    TestConfig(METHODS to listOf("java.util.Date.<init>"))
+                ).compileAndLintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }
         }
@@ -643,11 +631,9 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
                     
                     val a = Date()
                 """.trimIndent()
-                val findings =
-                    ForbiddenMethodCall(TestConfig(METHODS to listOf("java.util.Date.<init>()"))).compileAndLintWithContext(
-                        env,
-                        code
-                    )
+                val findings = ForbiddenMethodCall(
+                    TestConfig(METHODS to listOf("java.util.Date.<init>()"))
+                ).compileAndLintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }
 
@@ -658,10 +644,9 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
                     
                     val a = Date(2022, 8 ,7)
                 """.trimIndent()
-                val findings =
-                    ForbiddenMethodCall(
-                        TestConfig(METHODS to listOf("java.util.Date.<init>(kotlin.Int, kotlin.Int, kotlin.Int)"))
-                    ).compileAndLintWithContext(env, code)
+                val findings = ForbiddenMethodCall(
+                    TestConfig(METHODS to listOf("java.util.Date.<init>(kotlin.Int, kotlin.Int, kotlin.Int)"))
+                ).compileAndLintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }
         }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenVoidSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenVoidSpec.kt
@@ -63,7 +63,7 @@ class ForbiddenVoidSpec(val env: KotlinCoreEnvironment) {
     @Nested
     inner class `ignoreOverridden is enabled` {
 
-        val config = TestConfig(mapOf(IGNORE_OVERRIDDEN to "true"))
+        val config = TestConfig(IGNORE_OVERRIDDEN to "true")
 
         @Test
         fun `should not report Void in overriding function declarations`() {
@@ -139,7 +139,7 @@ class ForbiddenVoidSpec(val env: KotlinCoreEnvironment) {
     @Nested
     inner class `ignoreUsageInGenerics is enabled` {
 
-        val config = TestConfig(mapOf(IGNORE_USAGE_IN_GENERICS to "true"))
+        val config = TestConfig(IGNORE_USAGE_IN_GENERICS to "true")
 
         @Test
         fun `should not report Void in generic type declaration`() {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/FunctionOnlyReturningConstantSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/FunctionOnlyReturningConstantSpec.kt
@@ -45,7 +45,7 @@ class FunctionOnlyReturningConstantSpec {
 
         @Test
         fun `reports overridden functions which return constants`() {
-            val config = TestConfig(mapOf(IGNORE_OVERRIDABLE_FUNCTION to "false"))
+            val config = TestConfig(IGNORE_OVERRIDABLE_FUNCTION to "false")
             val rule = FunctionOnlyReturningConstant(config)
             assertThat(rule.lint(path)).hasSize(9)
         }
@@ -57,7 +57,7 @@ class FunctionOnlyReturningConstantSpec {
 
         @Test
         fun `reports actual functions which return constants`() {
-            val config = TestConfig(mapOf(IGNORE_ACTUAL_FUNCTION to "false"))
+            val config = TestConfig(IGNORE_ACTUAL_FUNCTION to "false")
             val rule = FunctionOnlyReturningConstant(config)
             assertThat(rule.lint(actualFunctionCode)).hasSize(1)
         }
@@ -65,7 +65,7 @@ class FunctionOnlyReturningConstantSpec {
         @Test
         fun `does not report excluded function which returns a constant (with string configuration)`() {
             val code = "fun f() = 1"
-            val config = TestConfig(mapOf(EXCLUDED_FUNCTIONS to "f"))
+            val config = TestConfig(EXCLUDED_FUNCTIONS to "f")
             val rule = FunctionOnlyReturningConstant(config)
             assertThat(rule.compileAndLint(code)).isEmpty()
         }
@@ -73,7 +73,7 @@ class FunctionOnlyReturningConstantSpec {
         @Test
         fun `does not report excluded function which returns a constant`() {
             val code = "fun f() = 1"
-            val config = TestConfig(mapOf(EXCLUDED_FUNCTIONS to listOf("f")))
+            val config = TestConfig(EXCLUDED_FUNCTIONS to listOf("f"))
             val rule = FunctionOnlyReturningConstant(config)
             assertThat(rule.compileAndLint(code)).isEmpty()
         }
@@ -81,7 +81,7 @@ class FunctionOnlyReturningConstantSpec {
         @Test
         fun `does not report wildcard excluded function which returns a constant`() {
             val code = "fun function() = 1"
-            val config = TestConfig(mapOf(EXCLUDED_FUNCTIONS to listOf("f*ion")))
+            val config = TestConfig(EXCLUDED_FUNCTIONS to listOf("f*ion"))
             val rule = FunctionOnlyReturningConstant(config)
             assertThat(rule.compileAndLint(code)).isEmpty()
         }
@@ -91,7 +91,7 @@ class FunctionOnlyReturningConstantSpec {
             "does not report excluded annotated function which returns a constant when given \"kotlin.SinceKotlin\""
         )
         fun ignoreAnnotatedFunctionWhichReturnsConstantWhenGivenKotlinSinceKotlin() {
-            val config = TestConfig(mapOf(EXCLUDE_ANNOTATED_FUNCTION to "kotlin.SinceKotlin"))
+            val config = TestConfig(EXCLUDE_ANNOTATED_FUNCTION to "kotlin.SinceKotlin")
             val rule = FunctionOnlyReturningConstant(config)
             assertThat(rule.compileAndLint(code)).isEmpty()
         }
@@ -101,7 +101,7 @@ class FunctionOnlyReturningConstantSpec {
             "does not report excluded annotated function which returns a constant when given listOf(\"kotlin.SinceKotlin\")"
         )
         fun ignoreAnnotatedFunctionWhichReturnsConstantWhenGivenListOfKotlinSinceKotlin() {
-            val config = TestConfig(mapOf(EXCLUDE_ANNOTATED_FUNCTION to listOf("kotlin.SinceKotlin")))
+            val config = TestConfig(EXCLUDE_ANNOTATED_FUNCTION to listOf("kotlin.SinceKotlin"))
             val rule = FunctionOnlyReturningConstant(config)
             assertThat(rule.compileAndLint(code)).isEmpty()
         }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/LoopWithTooManyJumpStatementsSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/LoopWithTooManyJumpStatementsSpec.kt
@@ -19,7 +19,7 @@ class LoopWithTooManyJumpStatementsSpec {
 
     @Test
     fun `does not report when max count configuration is set to 2`() {
-        val config = TestConfig(mapOf(MAX_JUMP_COUNT to "2"))
+        val config = TestConfig(MAX_JUMP_COUNT to "2")
         val findings = LoopWithTooManyJumpStatements(config).lint(path)
         assertThat(findings).isEmpty()
     }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumberSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumberSpec.kt
@@ -38,7 +38,7 @@ class MagicNumberSpec {
 
         @Test
         fun `should be reported when ignoredNumbers is empty`() {
-            val findings = MagicNumber(TestConfig(mapOf(IGNORE_NUMBERS to emptyList<String>()))).lint(code)
+            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to emptyList<String>())).lint(code)
             assertThat(findings).hasStartSourceLocation(1, 15)
         }
     }
@@ -55,7 +55,7 @@ class MagicNumberSpec {
 
         @Test
         fun `should not be reported when ignoredNumbers is empty`() {
-            val findings = MagicNumber(TestConfig(mapOf(IGNORE_NUMBERS to emptyList<String>()))).lint(code)
+            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to emptyList<String>())).lint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -72,7 +72,7 @@ class MagicNumberSpec {
 
         @Test
         fun `should be reported when ignoredNumbers is empty`() {
-            val findings = MagicNumber(TestConfig(mapOf(IGNORE_NUMBERS to emptyList<String>()))).lint(code)
+            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to emptyList<String>())).lint(code)
             assertThat(findings).hasStartSourceLocation(1, 13)
         }
     }
@@ -89,7 +89,7 @@ class MagicNumberSpec {
 
         @Test
         fun `should not be reported when ignoredNumbers is empty`() {
-            val findings = MagicNumber(TestConfig(mapOf(IGNORE_NUMBERS to emptyList<String>()))).lint(code)
+            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to emptyList<String>())).lint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -106,7 +106,7 @@ class MagicNumberSpec {
 
         @Test
         fun `should be reported when ignoredNumbers is empty`() {
-            val findings = MagicNumber(TestConfig(mapOf(IGNORE_NUMBERS to emptyList<String>()))).lint(code)
+            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to emptyList<String>())).lint(code)
             assertThat(findings).hasStartSourceLocation(1, 14)
         }
     }
@@ -123,7 +123,7 @@ class MagicNumberSpec {
 
         @Test
         fun `should be reported when ignoredNumbers is empty`() {
-            val findings = MagicNumber(TestConfig(mapOf(IGNORE_NUMBERS to emptyList<String>()))).lint(code)
+            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to emptyList<String>())).lint(code)
             assertThat(findings).hasStartSourceLocation(1, 15)
         }
     }
@@ -140,26 +140,26 @@ class MagicNumberSpec {
 
         @Test
         fun `should be ignored when ignoredNumbers contains it verbatim`() {
-            val findings = MagicNumber(TestConfig(mapOf(IGNORE_NUMBERS to listOf("-2L")))).lint(code)
+            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to listOf("-2L"))).lint(code)
             assertThat(findings).isEmpty()
         }
 
         @Test
         fun `should be ignored when ignoredNumbers contains it as floating point`() {
-            val findings = MagicNumber(TestConfig(mapOf(IGNORE_NUMBERS to listOf("-2f")))).lint(code)
+            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to listOf("-2f"))).lint(code)
             assertThat(findings).isEmpty()
         }
 
         @Test
         fun `should not be ignored when ignoredNumbers contains 2 but not -2`() {
-            val findings = MagicNumber(TestConfig(mapOf(IGNORE_NUMBERS to listOf("1", "2", "3", "-1", "0"))))
+            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to listOf("1", "2", "3", "-1", "0")))
                 .lint(code)
             assertThat(findings).hasStartSourceLocation(1, 15)
         }
 
         @Test
         fun `should not be ignored when ignoredNumbers contains 2 but not -2 config with string`() {
-            val findings = MagicNumber(TestConfig(mapOf(IGNORE_NUMBERS to "1,2,3,-1,0")))
+            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to "1,2,3,-1,0"))
                 .lint(code)
             assertThat(findings).hasStartSourceLocation(1, 15)
         }
@@ -177,7 +177,7 @@ class MagicNumberSpec {
 
         @Test
         fun `should not be reported when ignoredNumbers is empty`() {
-            val findings = MagicNumber(TestConfig(mapOf(IGNORE_NUMBERS to emptyList<String>()))).lint(code)
+            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to emptyList<String>())).lint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -194,7 +194,7 @@ class MagicNumberSpec {
 
         @Test
         fun `should be reported when ignoredNumbers is empty`() {
-            val findings = MagicNumber(TestConfig(mapOf(IGNORE_NUMBERS to emptyList<String>()))).lint(code)
+            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to emptyList<String>())).lint(code)
             assertThat(findings).hasStartSourceLocation(1, 16)
         }
     }
@@ -211,7 +211,7 @@ class MagicNumberSpec {
 
         @Test
         fun `should not be reported when ignoredNumbers is empty`() {
-            val findings = MagicNumber(TestConfig(mapOf(IGNORE_NUMBERS to emptyList<String>()))).lint(code)
+            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to emptyList<String>())).lint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -228,7 +228,7 @@ class MagicNumberSpec {
 
         @Test
         fun `should be reported when ignoredNumbers is empty`() {
-            val findings = MagicNumber(TestConfig(mapOf(IGNORE_NUMBERS to emptyList<String>()))).lint(code)
+            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to emptyList<String>())).lint(code)
             assertThat(findings).hasStartSourceLocation(1, 13)
         }
     }
@@ -245,7 +245,7 @@ class MagicNumberSpec {
 
         @Test
         fun `should not be reported when ignoredNumbers is empty`() {
-            val findings = MagicNumber(TestConfig(mapOf(IGNORE_NUMBERS to emptyList<String>()))).lint(code)
+            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to emptyList<String>())).lint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -256,13 +256,13 @@ class MagicNumberSpec {
 
         @Test
         fun `should not be reported when ignoredNumbers contains 300`() {
-            val findings = MagicNumber(TestConfig(mapOf(IGNORE_NUMBERS to listOf("300")))).lint(code)
+            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to listOf("300"))).lint(code)
             assertThat(findings).isEmpty()
         }
 
         @Test
         fun `should not be reported when ignoredNumbers contains a floating point 300`() {
-            val findings = MagicNumber(TestConfig(mapOf(IGNORE_NUMBERS to listOf("300.0")))).lint(code)
+            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to listOf("300.0"))).lint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -279,7 +279,7 @@ class MagicNumberSpec {
 
         @Test
         fun `should not be reported when ignoredNumbers contains a binary literal 0b01001`() {
-            val findings = MagicNumber(TestConfig(mapOf(IGNORE_NUMBERS to listOf("0b01001")))).lint(code)
+            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to listOf("0b01001"))).lint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -296,19 +296,19 @@ class MagicNumberSpec {
 
         @Test
         fun `should not be reported when ignored verbatim`() {
-            val findings = MagicNumber(TestConfig(mapOf(IGNORE_NUMBERS to listOf("100_000")))).lint(code)
+            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to listOf("100_000"))).lint(code)
             assertThat(findings).isEmpty()
         }
 
         @Test
         fun `should not be reported when ignored with different underscores`() {
-            val findings = MagicNumber(TestConfig(mapOf(IGNORE_NUMBERS to listOf("10_00_00")))).lint(code)
+            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to listOf("10_00_00"))).lint(code)
             assertThat(findings).isEmpty()
         }
 
         @Test
         fun `should not be reported when ignored without underscores`() {
-            val findings = MagicNumber(TestConfig(mapOf(IGNORE_NUMBERS to listOf("100000")))).lint(code)
+            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to listOf("100000"))).lint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -410,7 +410,7 @@ class MagicNumberSpec {
 
         @Test
         fun `should not be reported when ignoredNumbers contains it`() {
-            val findings = MagicNumber(TestConfig(mapOf(IGNORE_NUMBERS to listOf(".5")))).lint(code)
+            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to listOf(".5"))).lint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -432,7 +432,7 @@ class MagicNumberSpec {
         @Test
         fun `throws a NumberFormatException`() {
             assertThatExceptionOfType(NumberFormatException::class.java).isThrownBy {
-                MagicNumber(TestConfig(mapOf(IGNORE_NUMBERS to listOf("banana")))).compileAndLint("val i = 0")
+                MagicNumber(TestConfig(IGNORE_NUMBERS to listOf("banana"))).compileAndLint("val i = 0")
             }
         }
     }
@@ -442,7 +442,7 @@ class MagicNumberSpec {
 
         @Test
         fun `doesn't throw an exception`() {
-            MagicNumber(TestConfig(mapOf(IGNORE_NUMBERS to emptyList<String>())))
+            MagicNumber(TestConfig(IGNORE_NUMBERS to emptyList<String>()))
         }
     }
 
@@ -474,14 +474,12 @@ class MagicNumberSpec {
         @Test
         fun `should report all without ignore flags`() {
             val config = TestConfig(
-                mapOf(
-                    IGNORE_PROPERTY_DECLARATION to "false",
-                    IGNORE_ANNOTATION to "false",
-                    IGNORE_NAMED_ARGUMENT to "false",
-                    IGNORE_HASH_CODE to "false",
-                    IGNORE_CONSTANT_DECLARATION to "false",
-                    IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "false"
-                )
+                IGNORE_PROPERTY_DECLARATION to "false",
+                IGNORE_ANNOTATION to "false",
+                IGNORE_NAMED_ARGUMENT to "false",
+                IGNORE_HASH_CODE to "false",
+                IGNORE_CONSTANT_DECLARATION to "false",
+                IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "false",
             )
 
             val findings = MagicNumber(config).lint(code)
@@ -502,13 +500,11 @@ class MagicNumberSpec {
         @Test
         fun `should not report any issues with all ignore flags`() {
             val config = TestConfig(
-                mapOf(
-                    IGNORE_PROPERTY_DECLARATION to "true",
-                    IGNORE_ANNOTATION to "true",
-                    IGNORE_HASH_CODE to "true",
-                    IGNORE_CONSTANT_DECLARATION to "true",
-                    IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "true"
-                )
+                IGNORE_PROPERTY_DECLARATION to "true",
+                IGNORE_ANNOTATION to "true",
+                IGNORE_HASH_CODE to "true",
+                IGNORE_CONSTANT_DECLARATION to "true",
+                IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "true",
             )
 
             val findings = MagicNumber(config).lint(code)
@@ -537,11 +533,9 @@ class MagicNumberSpec {
         @Test
         fun `should not report any issues when ignoring properties but not constants nor companion objects`() {
             val config = TestConfig(
-                mapOf(
-                    IGNORE_PROPERTY_DECLARATION to "true",
-                    IGNORE_CONSTANT_DECLARATION to "false",
-                    IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "false"
-                )
+                IGNORE_PROPERTY_DECLARATION to "true",
+                IGNORE_CONSTANT_DECLARATION to "false",
+                IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "false",
             )
 
             val findings = MagicNumber(config).lint(code)
@@ -551,11 +545,9 @@ class MagicNumberSpec {
         @Test
         fun `should not report any issues when ignoring properties and constants but not companion objects`() {
             val config = TestConfig(
-                mapOf(
-                    IGNORE_PROPERTY_DECLARATION to "true",
-                    IGNORE_CONSTANT_DECLARATION to "true",
-                    IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "false"
-                )
+                IGNORE_PROPERTY_DECLARATION to "true",
+                IGNORE_CONSTANT_DECLARATION to "true",
+                IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "false",
             )
 
             val findings = MagicNumber(config).lint(code)
@@ -565,11 +557,9 @@ class MagicNumberSpec {
         @Test
         fun `should not report any issues when ignoring properties, constants and companion objects`() {
             val config = TestConfig(
-                mapOf(
-                    IGNORE_PROPERTY_DECLARATION to "true",
-                    IGNORE_CONSTANT_DECLARATION to "true",
-                    IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "true"
-                )
+                IGNORE_PROPERTY_DECLARATION to "true",
+                IGNORE_CONSTANT_DECLARATION to "true",
+                IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "true"
             )
 
             val findings = MagicNumber(config).lint(code)
@@ -579,11 +569,9 @@ class MagicNumberSpec {
         @Test
         fun `should not report any issues when ignoring companion objects but not properties and constants`() {
             val config = TestConfig(
-                mapOf(
-                    IGNORE_PROPERTY_DECLARATION to "false",
-                    IGNORE_CONSTANT_DECLARATION to "false",
-                    IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "true"
-                )
+                IGNORE_PROPERTY_DECLARATION to "false",
+                IGNORE_CONSTANT_DECLARATION to "false",
+                IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "true",
             )
 
             val findings = MagicNumber(config).lint(code)
@@ -593,11 +581,9 @@ class MagicNumberSpec {
         @Test
         fun `should report property when ignoring constants but not properties and companion objects`() {
             val config = TestConfig(
-                mapOf(
-                    IGNORE_PROPERTY_DECLARATION to "false",
-                    IGNORE_CONSTANT_DECLARATION to "true",
-                    IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "false"
-                )
+                IGNORE_PROPERTY_DECLARATION to "false",
+                IGNORE_CONSTANT_DECLARATION to "true",
+                IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "false",
             )
 
             val findings = MagicNumber(config).lint(code)
@@ -607,11 +593,9 @@ class MagicNumberSpec {
         @Test
         fun `should report property and constant when not ignoring properties, constants nor companion objects`() {
             val config = TestConfig(
-                mapOf(
-                    IGNORE_PROPERTY_DECLARATION to "false",
-                    IGNORE_CONSTANT_DECLARATION to "false",
-                    IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "false"
-                )
+                IGNORE_PROPERTY_DECLARATION to "false",
+                IGNORE_CONSTANT_DECLARATION to "false",
+                IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "false",
             )
 
             val findings = MagicNumber(config).lint(code)
@@ -649,25 +633,25 @@ class MagicNumberSpec {
 
             @Test
             fun `should not ignore int`() {
-                val rule = MagicNumber(TestConfig(mapOf(IGNORE_NAMED_ARGUMENT to "false")))
+                val rule = MagicNumber(TestConfig(IGNORE_NAMED_ARGUMENT to "false"))
                 assertThat(rule.lint(code("53"))).hasSize(1)
             }
 
             @Test
             fun `should not ignore float`() {
-                val rule = MagicNumber(TestConfig(mapOf(IGNORE_NAMED_ARGUMENT to "false")))
+                val rule = MagicNumber(TestConfig(IGNORE_NAMED_ARGUMENT to "false"))
                 assertThat(rule.lint(code("53f"))).hasSize(1)
             }
 
             @Test
             fun `should not ignore binary`() {
-                val rule = MagicNumber(TestConfig(mapOf(IGNORE_NAMED_ARGUMENT to "false")))
+                val rule = MagicNumber(TestConfig(IGNORE_NAMED_ARGUMENT to "false"))
                 assertThat(rule.lint(code("0b01001"))).hasSize(1)
             }
 
             @Test
             fun `should ignore integer with underscores`() {
-                val rule = MagicNumber(TestConfig(mapOf(IGNORE_NAMED_ARGUMENT to "false")))
+                val rule = MagicNumber(TestConfig(IGNORE_NAMED_ARGUMENT to "false"))
                 assertThat(rule.lint(code("101_000"))).hasSize(1)
             }
 
@@ -762,7 +746,7 @@ class MagicNumberSpec {
 
             @Test
             fun `numbers when 'ignoreEnums' is set to true`() {
-                val rule = MagicNumber(TestConfig(mapOf(IGNORE_ENUMS to "true")))
+                val rule = MagicNumber(TestConfig(IGNORE_ENUMS to "true"))
                 assertThat(rule.lint(code)).isEmpty()
             }
         }
@@ -778,7 +762,7 @@ class MagicNumberSpec {
 
             @Test
             fun `should be reported`() {
-                val rule = MagicNumber(TestConfig(mapOf(IGNORE_NAMED_ARGUMENT to "false")))
+                val rule = MagicNumber(TestConfig(IGNORE_NAMED_ARGUMENT to "false"))
                 assertThat(rule.lint(code)).hasSize(1)
             }
 
@@ -786,10 +770,8 @@ class MagicNumberSpec {
             fun `numbers when 'ignoreEnums' is set to true`() {
                 val rule = MagicNumber(
                     TestConfig(
-                        mapOf(
-                            IGNORE_NAMED_ARGUMENT to "false",
-                            IGNORE_ENUMS to "true"
-                        )
+                        IGNORE_NAMED_ARGUMENT to "false",
+                        IGNORE_ENUMS to "true",
                     )
                 )
                 assertThat(rule.lint(code)).isEmpty()
@@ -905,27 +887,27 @@ class MagicNumberSpec {
         @ParameterizedTest
         @MethodSource("cases")
         fun `reports a code smell if ranges are not ignored`(code: String) {
-            assertThat(MagicNumber(TestConfig(mapOf(IGNORE_RANGES to "false"))).lint(code))
+            assertThat(MagicNumber(TestConfig(IGNORE_RANGES to "false")).lint(code))
                 .hasSize(1)
         }
 
         @ParameterizedTest
         @MethodSource("cases")
         fun `reports no finding if ranges are ignored`(code: String) {
-            assertThat(MagicNumber(TestConfig(mapOf(IGNORE_RANGES to "true"))).lint(code))
+            assertThat(MagicNumber(TestConfig(IGNORE_RANGES to "true")).lint(code))
                 .isEmpty()
         }
 
         @Test
         fun `reports a finding for a parenthesized number if ranges are ignored`() {
             val code = "val foo : Int = (127)"
-            assertThat(MagicNumber(TestConfig(mapOf(IGNORE_RANGES to "true"))).lint(code)).hasSize(1)
+            assertThat(MagicNumber(TestConfig(IGNORE_RANGES to "true")).lint(code)).hasSize(1)
         }
 
         @Test
         fun `reports a finding for an addition if ranges are ignored`() {
             val code = "val foo : Int = 1 + 27"
-            assertThat(MagicNumber(TestConfig(mapOf(IGNORE_RANGES to "true"))).lint(code)).hasSize(1)
+            assertThat(MagicNumber(TestConfig(IGNORE_RANGES to "true")).lint(code)).hasSize(1)
         }
     }
 
@@ -936,13 +918,13 @@ class MagicNumberSpec {
 
         @Test
         fun `reports 3 due to the assignment to a local variable`() {
-            val rule = MagicNumber(TestConfig(mapOf(IGNORE_LOCAL_VARIABLES to "false")))
+            val rule = MagicNumber(TestConfig(IGNORE_LOCAL_VARIABLES to "false"))
             assertThat(rule.compileAndLint(code)).hasSize(1)
         }
 
         @Test
         fun `should not report 3 due to the ignored local variable config`() {
-            val rule = MagicNumber(TestConfig(mapOf(IGNORE_LOCAL_VARIABLES to "true")))
+            val rule = MagicNumber(TestConfig(IGNORE_LOCAL_VARIABLES to "true"))
             assertThat(rule.compileAndLint(code)).isEmpty()
         }
     }
@@ -950,15 +932,12 @@ class MagicNumberSpec {
     @Nested
     inner class `meaningful variables - #1536` {
 
-        val rule =
-            MagicNumber(
-                TestConfig(
-                    mapOf(
-                        IGNORE_LOCAL_VARIABLES to "true",
-                        IGNORE_NAMED_ARGUMENT to "true"
-                    )
-                )
+        private val rule = MagicNumber(
+            TestConfig(
+                IGNORE_LOCAL_VARIABLES to "true",
+                IGNORE_NAMED_ARGUMENT to "true",
             )
+        )
 
         @Test
         fun `should report 3`() {
@@ -979,14 +958,9 @@ class MagicNumberSpec {
     @Nested
     inner class `with extension function` {
 
-        val rule =
-            MagicNumber(
-                TestConfig(
-                    mapOf(
-                        IGNORE_EXTENSION_FUNCTIONS to "true"
-                    )
-                )
-            )
+        private val rule = MagicNumber(
+            TestConfig(IGNORE_EXTENSION_FUNCTIONS to "true")
+        )
 
         @Test
         fun `should not report when function`() {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxChainedCallsOnSameLineSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxChainedCallsOnSameLineSpec.kt
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
 class MaxChainedCallsOnSameLineSpec(private val env: KotlinCoreEnvironment) {
-    private val rule = MaxChainedCallsOnSameLine(TestConfig(mapOf("maxChainedCalls" to 3)))
+    private val rule = MaxChainedCallsOnSameLine(TestConfig("maxChainedCalls" to 3))
 
     @Test
     fun `does not report 2 calls on a single line with a max of 3`() {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ModifierOrderSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ModifierOrderSpec.kt
@@ -43,7 +43,7 @@ class ModifierOrderSpec {
 
         @Test
         fun `should not report issues if inactive`() {
-            val rule = ModifierOrder(TestConfig(mapOf(Config.ACTIVE_KEY to "false")))
+            val rule = ModifierOrder(TestConfig(Config.ACTIVE_KEY to "false"))
             assertThat(rule.compileAndLint(bad1)).isEmpty()
             assertThat(rule.lint(bad2)).isEmpty()
             assertThat(rule.lint(bad3)).isEmpty()

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MultilineRawStringIndentationSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MultilineRawStringIndentationSpec.kt
@@ -340,7 +340,7 @@ class MultilineRawStringIndentationSpec {
                 $TAB)
                 }
             """.trimIndent()
-            val subject = MultilineRawStringIndentation(TestConfig(mapOf("indentSize" to 1)))
+            val subject = MultilineRawStringIndentation(TestConfig("indentSize" to 1))
             subject.compileAndLint(code)
             assertThat(subject.findings).isEmpty()
         }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCountSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCountSpec.kt
@@ -55,7 +55,7 @@ class ReturnCountSpec {
 
         @Test
         fun `should not get flagged for if condition guard clauses`() {
-            val findings = ReturnCount(TestConfig(mapOf(EXCLUDE_GUARD_CLAUSES to "true")))
+            val findings = ReturnCount(TestConfig(EXCLUDE_GUARD_CLAUSES to "true"))
                 .compileAndLint(code)
             assertThat(findings).isEmpty()
         }
@@ -79,14 +79,14 @@ class ReturnCountSpec {
 
         @Test
         fun `should not get flagged for if condition guard clauses`() {
-            val findings = ReturnCount(TestConfig(mapOf(EXCLUDE_GUARD_CLAUSES to "true")))
+            val findings = ReturnCount(TestConfig(EXCLUDE_GUARD_CLAUSES to "true"))
                 .compileAndLint(code)
             assertThat(findings).isEmpty()
         }
 
         @Test
         fun `should get flagged without guard clauses`() {
-            val findings = ReturnCount(TestConfig(mapOf(EXCLUDE_GUARD_CLAUSES to "false")))
+            val findings = ReturnCount(TestConfig(EXCLUDE_GUARD_CLAUSES to "false"))
                 .compileAndLint(code)
             assertThat(findings).hasSize(1)
         }
@@ -114,7 +114,7 @@ class ReturnCountSpec {
 
         @Test
         fun `should report a too-complicated if statement for being a guard clause, with EXCLUDE_GUARD_CLAUSES on`() {
-            val findings = ReturnCount(TestConfig(mapOf(EXCLUDE_GUARD_CLAUSES to "true")))
+            val findings = ReturnCount(TestConfig(EXCLUDE_GUARD_CLAUSES to "true"))
                 .compileAndLint(code)
             assertThat(findings).hasSize(1)
         }
@@ -135,7 +135,7 @@ class ReturnCountSpec {
 
         @Test
         fun `should not get flagged for ELVIS operator guard clauses`() {
-            val findings = ReturnCount(TestConfig(mapOf(EXCLUDE_GUARD_CLAUSES to "true")))
+            val findings = ReturnCount(TestConfig(EXCLUDE_GUARD_CLAUSES to "true"))
                 .compileAndLint(code)
             assertThat(findings).isEmpty()
         }
@@ -156,7 +156,7 @@ class ReturnCountSpec {
 
         @Test
         fun `should get flagged for an if condition guard clause which is not the first statement`() {
-            val findings = ReturnCount(TestConfig(mapOf(EXCLUDE_GUARD_CLAUSES to "true")))
+            val findings = ReturnCount(TestConfig(EXCLUDE_GUARD_CLAUSES to "true"))
                 .compileAndLint(code)
             assertThat(findings).hasSize(1)
         }
@@ -177,7 +177,7 @@ class ReturnCountSpec {
 
         @Test
         fun `should get flagged for an ELVIS guard clause which is not the first statement`() {
-            val findings = ReturnCount(TestConfig(mapOf(EXCLUDE_GUARD_CLAUSES to "true")))
+            val findings = ReturnCount(TestConfig(EXCLUDE_GUARD_CLAUSES to "true"))
                 .compileAndLint(code)
             assertThat(findings).hasSize(1)
         }
@@ -243,13 +243,13 @@ class ReturnCountSpec {
 
         @Test
         fun `should not get flagged when max value is 3`() {
-            val findings = ReturnCount(TestConfig(mapOf(MAX to "3"))).compileAndLint(code)
+            val findings = ReturnCount(TestConfig(MAX to "3")).compileAndLint(code)
             assertThat(findings).isEmpty()
         }
 
         @Test
         fun `should get flagged when max value is 1`() {
-            val findings = ReturnCount(TestConfig(mapOf(MAX to "1"))).compileAndLint(code)
+            val findings = ReturnCount(TestConfig(MAX to "1")).compileAndLint(code)
             assertThat(findings).hasSize(1)
         }
     }
@@ -274,13 +274,13 @@ class ReturnCountSpec {
 
         @Test
         fun `should not get flagged when max value is 2`() {
-            val findings = ReturnCount(TestConfig(mapOf(MAX to "2"))).compileAndLint(code)
+            val findings = ReturnCount(TestConfig(MAX to "2")).compileAndLint(code)
             assertThat(findings).isEmpty()
         }
 
         @Test
         fun `should get flagged when max value is 1`() {
-            val findings = ReturnCount(TestConfig(mapOf(MAX to "1"))).compileAndLint(code)
+            val findings = ReturnCount(TestConfig(MAX to "1")).compileAndLint(code)
             assertThat(findings).hasSize(1)
         }
     }
@@ -302,10 +302,8 @@ class ReturnCountSpec {
         fun `should not get flagged`() {
             val findings = ReturnCount(
                 TestConfig(
-                    mapOf(
-                        MAX to "2",
-                        EXCLUDED_FUNCTIONS to "test"
-                    )
+                    MAX to "2",
+                    EXCLUDED_FUNCTIONS to "test",
                 )
             ).compileAndLint(code)
             assertThat(findings).isEmpty()
@@ -347,10 +345,8 @@ class ReturnCountSpec {
         fun `should flag none of the ignored functions`() {
             val findings = ReturnCount(
                 TestConfig(
-                    mapOf(
-                        MAX to "2",
-                        EXCLUDED_FUNCTIONS to listOf("factorial", "fac"),
-                    )
+                    MAX to "2",
+                    EXCLUDED_FUNCTIONS to listOf("factorial", "fac"),
                 )
             ).compileAndLint(code)
             assertThat(findings).hasSize(1)
@@ -360,10 +356,8 @@ class ReturnCountSpec {
         fun `should flag none of the ignored functions using globbing`() {
             val findings = ReturnCount(
                 TestConfig(
-                    mapOf(
-                        MAX to "2",
-                        EXCLUDED_FUNCTIONS to listOf("fa*ctorial"),
-                    )
+                    MAX to "2",
+                    EXCLUDED_FUNCTIONS to listOf("fa*ctorial"),
                 )
             ).compileAndLint(code)
             assertThat(findings).hasSize(1)
@@ -393,7 +387,7 @@ class ReturnCountSpec {
 
         @Test
         fun `should not get flag when returns is in inner object`() {
-            val findings = ReturnCount(TestConfig(mapOf(MAX to "2"))).compileAndLint(code)
+            val findings = ReturnCount(TestConfig(MAX to "2")).compileAndLint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -430,7 +424,7 @@ class ReturnCountSpec {
 
         @Test
         fun `should not get flag when returns is in inner object`() {
-            val findings = ReturnCount(TestConfig(mapOf(MAX to "2"))).compileAndLint(code)
+            val findings = ReturnCount(TestConfig(MAX to "2")).compileAndLint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -469,7 +463,7 @@ class ReturnCountSpec {
 
         @Test
         fun `should get flagged when returns is in inner object`() {
-            val findings = ReturnCount(TestConfig(mapOf(MAX to "2"))).compileAndLint(code)
+            val findings = ReturnCount(TestConfig(MAX to "2")).compileAndLint(code)
             assertThat(findings).hasSize(1)
         }
     }
@@ -496,7 +490,7 @@ class ReturnCountSpec {
         @Test
         fun `should count labeled returns from lambda when activated`() {
             val findings = ReturnCount(
-                TestConfig(mapOf(EXCLUDE_RETURN_FROM_LAMBDA to "false"))
+                TestConfig(EXCLUDE_RETURN_FROM_LAMBDA to "false")
             ).lint(code)
             assertThat(findings).hasSize(1)
         }
@@ -505,10 +499,8 @@ class ReturnCountSpec {
         fun `should be empty when labeled returns are de-activated`() {
             val findings = ReturnCount(
                 TestConfig(
-                    mapOf(
-                        EXCLUDE_LABELED to "true",
-                        EXCLUDE_RETURN_FROM_LAMBDA to "false"
-                    )
+                    EXCLUDE_LABELED to "true",
+                    EXCLUDE_RETURN_FROM_LAMBDA to "false",
                 )
             ).lint(code)
             assertThat(findings).isEmpty()
@@ -529,7 +521,7 @@ class ReturnCountSpec {
 
         @Test
         fun `should count labeled return of lambda with explicit label`() {
-            val findings = ReturnCount(TestConfig(mapOf(EXCLUDE_RETURN_FROM_LAMBDA to "false"))).compileAndLint(code)
+            val findings = ReturnCount(TestConfig(EXCLUDE_RETURN_FROM_LAMBDA to "false")).compileAndLint(code)
             assertThat(findings).hasSize(1)
         }
 
@@ -543,10 +535,8 @@ class ReturnCountSpec {
         fun `excludeReturnFromLambda should take precedence over excludeLabeled`() {
             val findings = ReturnCount(
                 TestConfig(
-                    mapOf(
-                        EXCLUDE_RETURN_FROM_LAMBDA to "true",
-                        EXCLUDE_LABELED to "false"
-                    )
+                    EXCLUDE_RETURN_FROM_LAMBDA to "true",
+                    EXCLUDE_LABELED to "false",
                 )
             ).compileAndLint(code)
             assertThat(findings).isEmpty()

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/StringShouldBeRawStringSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/StringShouldBeRawStringSpec.kt
@@ -20,7 +20,7 @@ class StringShouldBeRawStringSpec {
             }
         """.trimIndent()
         val subject =
-            StringShouldBeRawString(TestConfig(mapOf(MAX_ESCAPED_CHARACTER_COUNT to maxEscapedCharacterCount)))
+            StringShouldBeRawString(TestConfig(MAX_ESCAPED_CHARACTER_COUNT to maxEscapedCharacterCount))
         subject.compileAndLint(code)
         assertThat(subject.findings).hasSize(1)
     }
@@ -36,7 +36,7 @@ class StringShouldBeRawStringSpec {
             }
         """.trimIndent()
         val subject =
-            StringShouldBeRawString(TestConfig(mapOf(MAX_ESCAPED_CHARACTER_COUNT to maxEscapedCharacterCount)))
+            StringShouldBeRawString(TestConfig(MAX_ESCAPED_CHARACTER_COUNT to maxEscapedCharacterCount))
         subject.compileAndLint(code)
         assertThat(subject.findings).isEmpty()
     }
@@ -55,7 +55,7 @@ class StringShouldBeRawStringSpec {
             }
         """.trimIndent()
         val subject =
-            StringShouldBeRawString(TestConfig(mapOf(MAX_ESCAPED_CHARACTER_COUNT to maxEscapedCharacterCount)))
+            StringShouldBeRawString(TestConfig(MAX_ESCAPED_CHARACTER_COUNT to maxEscapedCharacterCount))
         subject.compileAndLint(code)
         assertThat(subject.findings).isEmpty()
     }
@@ -74,7 +74,7 @@ class StringShouldBeRawStringSpec {
             }
         """.trimIndent()
         val subject =
-            StringShouldBeRawString(TestConfig(mapOf(MAX_ESCAPED_CHARACTER_COUNT to maxEscapedCharacterCount - 1)))
+            StringShouldBeRawString(TestConfig(MAX_ESCAPED_CHARACTER_COUNT to maxEscapedCharacterCount - 1))
         subject.compileAndLint(code)
         assertThat(subject.findings).hasSize(1)
     }
@@ -96,10 +96,8 @@ class StringShouldBeRawStringSpec {
         """.trimIndent()
         val subject = StringShouldBeRawString(
             TestConfig(
-                mapOf(
-                    MAX_ESCAPED_CHARACTER_COUNT to 0,
-                    IGNORED_CHARACTERS to allowedCharacters
-                )
+                MAX_ESCAPED_CHARACTER_COUNT to 0,
+                IGNORED_CHARACTERS to allowedCharacters,
             )
         )
         subject.compileAndLint(code)
@@ -115,7 +113,7 @@ class StringShouldBeRawStringSpec {
                 val testString = "a${'$'}{`"a`}"
             }
         """.trimIndent()
-        val subject = StringShouldBeRawString(TestConfig(mapOf(MAX_ESCAPED_CHARACTER_COUNT to 0)))
+        val subject = StringShouldBeRawString(TestConfig(MAX_ESCAPED_CHARACTER_COUNT to 0))
         subject.compileAndLint(code)
         assertThat(subject.findings).isEmpty()
     }
@@ -127,7 +125,7 @@ class StringShouldBeRawStringSpec {
                 val totalSize = "\n + \n".length + "\n + \n".length
             }
         """.trimIndent()
-        val subject = StringShouldBeRawString(TestConfig(mapOf(MAX_ESCAPED_CHARACTER_COUNT to 1)))
+        val subject = StringShouldBeRawString(TestConfig(MAX_ESCAPED_CHARACTER_COUNT to 1))
         subject.compileAndLint(code)
         assertThat(subject.findings).hasSize(2)
     }
@@ -140,7 +138,7 @@ class StringShouldBeRawStringSpec {
                 val size2 = "\n + \n".length
             }
         """.trimIndent()
-        val subject = StringShouldBeRawString(TestConfig(mapOf(MAX_ESCAPED_CHARACTER_COUNT to 1)))
+        val subject = StringShouldBeRawString(TestConfig(MAX_ESCAPED_CHARACTER_COUNT to 1))
         subject.compileAndLint(code)
         assertThat(subject.findings).hasSize(2)
     }
@@ -151,7 +149,7 @@ class StringShouldBeRawStringSpec {
             operator fun String.not() = true
             val totalSize = !"\n\n"
         """.trimIndent()
-        val subject = StringShouldBeRawString(TestConfig(mapOf(MAX_ESCAPED_CHARACTER_COUNT to 1)))
+        val subject = StringShouldBeRawString(TestConfig(MAX_ESCAPED_CHARACTER_COUNT to 1))
         subject.compileAndLint(code)
         assertThat(subject.findings).hasSize(1)
     }
@@ -162,7 +160,7 @@ class StringShouldBeRawStringSpec {
             operator fun String.not() = true
             val totalSize = "\n\n".not()
         """.trimIndent()
-        val subject = StringShouldBeRawString(TestConfig(mapOf(MAX_ESCAPED_CHARACTER_COUNT to 1)))
+        val subject = StringShouldBeRawString(TestConfig(MAX_ESCAPED_CHARACTER_COUNT to 1))
         subject.compileAndLint(code)
         assertThat(subject.findings).hasSize(1)
     }
@@ -173,7 +171,7 @@ class StringShouldBeRawStringSpec {
             operator fun String.not() = true
             val totalSize = (!"\n\n").toString() + "\n"
         """.trimIndent()
-        val subject = StringShouldBeRawString(TestConfig(mapOf(MAX_ESCAPED_CHARACTER_COUNT to 2)))
+        val subject = StringShouldBeRawString(TestConfig(MAX_ESCAPED_CHARACTER_COUNT to 2))
         subject.compileAndLint(code)
         assertThat(subject.findings).isEmpty()
     }
@@ -184,7 +182,7 @@ class StringShouldBeRawStringSpec {
             operator fun String.not() = true
             val totalSize = (!"\n\n").toString() + "\n\n\n"
         """.trimIndent()
-        val subject = StringShouldBeRawString(TestConfig(mapOf(MAX_ESCAPED_CHARACTER_COUNT to 2)))
+        val subject = StringShouldBeRawString(TestConfig(MAX_ESCAPED_CHARACTER_COUNT to 2))
         subject.compileAndLint(code)
         assertThat(subject.findings).hasSize(1)
     }
@@ -195,7 +193,7 @@ class StringShouldBeRawStringSpec {
             operator fun String.not() = true
             val totalSize = (!"\n\n").toString() + "\n" + "\n"
         """.trimIndent()
-        val subject = StringShouldBeRawString(TestConfig(mapOf(MAX_ESCAPED_CHARACTER_COUNT to 1)))
+        val subject = StringShouldBeRawString(TestConfig(MAX_ESCAPED_CHARACTER_COUNT to 1))
         subject.compileAndLint(code)
         assertThat(subject.findings).hasSize(2)
     }
@@ -206,7 +204,7 @@ class StringShouldBeRawStringSpec {
             operator fun String.not() = true
             val totalSize = ((!"\n\n").toString() + "\n") + "\n"
         """.trimIndent()
-        val subject = StringShouldBeRawString(TestConfig(mapOf(MAX_ESCAPED_CHARACTER_COUNT to 1)))
+        val subject = StringShouldBeRawString(TestConfig(MAX_ESCAPED_CHARACTER_COUNT to 1))
         subject.compileAndLint(code)
         assertThat(subject.findings).hasSize(2)
     }
@@ -217,7 +215,7 @@ class StringShouldBeRawStringSpec {
             operator fun String.not() = true
             val totalSize = (!"\n\n").toString() + ("\n" + "\n")
         """.trimIndent()
-        val subject = StringShouldBeRawString(TestConfig(mapOf(MAX_ESCAPED_CHARACTER_COUNT to 1)))
+        val subject = StringShouldBeRawString(TestConfig(MAX_ESCAPED_CHARACTER_COUNT to 1))
         subject.compileAndLint(code)
         assertThat(subject.findings).hasSize(2)
     }
@@ -228,7 +226,7 @@ class StringShouldBeRawStringSpec {
             operator fun String.not() = true
             val totalSize = (!"\n\n").toString() + ("\n" + "\n") + "\n"
         """.trimIndent()
-        val subject = StringShouldBeRawString(TestConfig(mapOf(MAX_ESCAPED_CHARACTER_COUNT to 1)))
+        val subject = StringShouldBeRawString(TestConfig(MAX_ESCAPED_CHARACTER_COUNT to 1))
         subject.compileAndLint(code)
         assertThat(subject.findings).hasSize(2)
     }
@@ -239,7 +237,7 @@ class StringShouldBeRawStringSpec {
             operator fun String.not() = true
             val totalSize = (!"\n\n").toString() + ("\n" + "\n") + "\n"
         """.trimIndent()
-        val subject = StringShouldBeRawString(TestConfig(mapOf(MAX_ESCAPED_CHARACTER_COUNT to 2)))
+        val subject = StringShouldBeRawString(TestConfig(MAX_ESCAPED_CHARACTER_COUNT to 2))
         subject.compileAndLint(code)
         assertThat(subject.findings).hasSize(1)
     }
@@ -250,7 +248,7 @@ class StringShouldBeRawStringSpec {
             operator fun String.not() = true
             val totalSize = (!("\n\n" + "\n")).toString() + ("\n" + "\n") + "\n"
         """.trimIndent()
-        val subject = StringShouldBeRawString(TestConfig(mapOf(MAX_ESCAPED_CHARACTER_COUNT to 2)))
+        val subject = StringShouldBeRawString(TestConfig(MAX_ESCAPED_CHARACTER_COUNT to 2))
         subject.compileAndLint(code)
         assertThat(subject.findings).hasSize(2)
     }
@@ -261,7 +259,7 @@ class StringShouldBeRawStringSpec {
             operator fun String.not() = true
             val totalSize = ((!"\n\n").toString()) + "\n"
         """.trimIndent()
-        val subject = StringShouldBeRawString(TestConfig(mapOf(MAX_ESCAPED_CHARACTER_COUNT to 2)))
+        val subject = StringShouldBeRawString(TestConfig(MAX_ESCAPED_CHARACTER_COUNT to 2))
         subject.compileAndLint(code)
         assertThat(subject.findings).isEmpty()
     }
@@ -272,7 +270,7 @@ class StringShouldBeRawStringSpec {
             operator fun String.get(index: Int) = this
             val totalSize = "\n\n"[0] + "\n"
         """.trimIndent()
-        val subject = StringShouldBeRawString(TestConfig(mapOf(MAX_ESCAPED_CHARACTER_COUNT to 2)))
+        val subject = StringShouldBeRawString(TestConfig(MAX_ESCAPED_CHARACTER_COUNT to 2))
         subject.compileAndLint(code)
         assertThat(subject.findings).isEmpty()
     }
@@ -283,7 +281,7 @@ class StringShouldBeRawStringSpec {
             operator fun String.get(index: Int) = this
             val totalSize = ("\n\n"[0]) + "\n"
         """.trimIndent()
-        val subject = StringShouldBeRawString(TestConfig(mapOf(MAX_ESCAPED_CHARACTER_COUNT to 2)))
+        val subject = StringShouldBeRawString(TestConfig(MAX_ESCAPED_CHARACTER_COUNT to 2))
         subject.compileAndLint(code)
         assertThat(subject.findings).isEmpty()
     }
@@ -296,7 +294,7 @@ class StringShouldBeRawStringSpec {
                 val finalString = "\n" + test("\n\n") + "\n"
             }
         """.trimIndent()
-        val subject = StringShouldBeRawString(TestConfig(mapOf(MAX_ESCAPED_CHARACTER_COUNT to 2)))
+        val subject = StringShouldBeRawString(TestConfig(MAX_ESCAPED_CHARACTER_COUNT to 2))
         subject.compileAndLint(code)
         assertThat(subject.findings).isEmpty()
     }
@@ -309,7 +307,7 @@ class StringShouldBeRawStringSpec {
                 val finalString = "\n" + test("\n\n") + "\n"
             }
         """.trimIndent()
-        val subject = StringShouldBeRawString(TestConfig(mapOf(MAX_ESCAPED_CHARACTER_COUNT to 1)))
+        val subject = StringShouldBeRawString(TestConfig(MAX_ESCAPED_CHARACTER_COUNT to 1))
         subject.compileAndLint(code)
         assertThat(subject.findings).hasSize(2)
     }
@@ -322,7 +320,7 @@ class StringShouldBeRawStringSpec {
                 val size1 = "\nThis rule is awesome\n"
             }
         """.trimIndent()
-        val subject = StringShouldBeRawString(TestConfig(mapOf(MAX_ESCAPED_CHARACTER_COUNT to 2)))
+        val subject = StringShouldBeRawString(TestConfig(MAX_ESCAPED_CHARACTER_COUNT to 2))
         subject.compileAndLint(code)
         assertThat(subject.findings).hasSize(0)
     }
@@ -337,7 +335,7 @@ class StringShouldBeRawStringSpec {
                 val size1 = "\nThis rule is awesome\n"
             }
         """.trimIndent()
-        val subject = StringShouldBeRawString(TestConfig(mapOf(MAX_ESCAPED_CHARACTER_COUNT to 2)))
+        val subject = StringShouldBeRawString(TestConfig(MAX_ESCAPED_CHARACTER_COUNT to 2))
         subject.compileAndLint(code)
         assertThat(subject.findings).hasSize(0)
     }
@@ -350,7 +348,7 @@ class StringShouldBeRawStringSpec {
                 val size1 = "This rule is awesome"
             }
         """.trimIndent()
-        val subject = StringShouldBeRawString(TestConfig(mapOf(MAX_ESCAPED_CHARACTER_COUNT to 0)))
+        val subject = StringShouldBeRawString(TestConfig(MAX_ESCAPED_CHARACTER_COUNT to 0))
         subject.compileAndLint(code)
         assertThat(subject.findings).hasSize(1)
     }
@@ -363,7 +361,7 @@ class StringShouldBeRawStringSpec {
                 val size1 = "This rule is awesome"
             }
         """.trimIndent()
-        val subject = StringShouldBeRawString(TestConfig(mapOf(MAX_ESCAPED_CHARACTER_COUNT to 0)))
+        val subject = StringShouldBeRawString(TestConfig(MAX_ESCAPED_CHARACTER_COUNT to 0))
         subject.compileAndLint(code)
         assertThat(subject.findings).isEmpty()
     }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ThrowsCountSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ThrowsCountSpec.kt
@@ -130,14 +130,14 @@ class ThrowsCountSpec {
 
         @Test
         fun `does not report when max parameter is 3`() {
-            val config = TestConfig(mapOf(MAX to "3"))
+            val config = TestConfig(MAX to "3")
             val subject = ThrowsCount(config)
             assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
         fun `reports violation when max parameter is 2`() {
-            val config = TestConfig(mapOf(MAX to "2"))
+            val config = TestConfig(MAX to "2")
             val subject = ThrowsCount(config)
             assertThat(subject.lint(code)).hasSize(1)
         }
@@ -158,14 +158,14 @@ class ThrowsCountSpec {
 
         @Test
         fun `should not report violation with EXCLUDE_GUARD_CLAUSES as true`() {
-            val config = TestConfig(mapOf(EXCLUDE_GUARD_CLAUSES to "true"))
+            val config = TestConfig(EXCLUDE_GUARD_CLAUSES to "true")
             val subject = ThrowsCount(config)
             assertThat(subject.lint(codeWithGuardClause)).isEmpty()
         }
 
         @Test
         fun `should report violation with EXCLUDE_GUARD_CLAUSES as false`() {
-            val config = TestConfig(mapOf(EXCLUDE_GUARD_CLAUSES to "false"))
+            val config = TestConfig(EXCLUDE_GUARD_CLAUSES to "false")
             val subject = ThrowsCount(config)
             assertThat(subject.lint(codeWithGuardClause)).hasSize(1)
         }
@@ -186,14 +186,14 @@ class ThrowsCountSpec {
 
         @Test
         fun `should not report violation with EXCLUDE_GUARD_CLAUSES as true`() {
-            val config = TestConfig(mapOf(EXCLUDE_GUARD_CLAUSES to "true"))
+            val config = TestConfig(EXCLUDE_GUARD_CLAUSES to "true")
             val subject = ThrowsCount(config)
             assertThat(subject.lint(codeWithGuardClause)).isEmpty()
         }
 
         @Test
         fun `should report violation with EXCLUDE_GUARD_CLAUSES as false`() {
-            val config = TestConfig(mapOf(EXCLUDE_GUARD_CLAUSES to "false"))
+            val config = TestConfig(EXCLUDE_GUARD_CLAUSES to "false")
             val subject = ThrowsCount(config)
             assertThat(subject.lint(codeWithGuardClause)).hasSize(1)
         }
@@ -221,7 +221,7 @@ class ThrowsCountSpec {
 
         @Test
         fun `should report violation even with EXCLUDE_GUARD_CLAUSES as true`() {
-            val config = TestConfig(mapOf(EXCLUDE_GUARD_CLAUSES to "true"))
+            val config = TestConfig(EXCLUDE_GUARD_CLAUSES to "true")
             val subject = ThrowsCount(config)
             assertThat(subject.lint(codeWithIfCondition)).hasSize(1)
         }
@@ -242,7 +242,7 @@ class ThrowsCountSpec {
 
         @Test
         fun `should report the violation even with EXCLUDE_GUARD_CLAUSES as true`() {
-            val config = TestConfig(mapOf(EXCLUDE_GUARD_CLAUSES to "true"))
+            val config = TestConfig(EXCLUDE_GUARD_CLAUSES to "true")
             val subject = ThrowsCount(config)
             assertThat(subject.lint(codeWithIfCondition)).hasSize(1)
         }
@@ -263,7 +263,7 @@ class ThrowsCountSpec {
 
         @Test
         fun `should report the violation even with EXCLUDE_GUARD_CLAUSES as true`() {
-            val config = TestConfig(mapOf(EXCLUDE_GUARD_CLAUSES to "true"))
+            val config = TestConfig(EXCLUDE_GUARD_CLAUSES to "true")
             val subject = ThrowsCount(config)
             assertThat(subject.lint(codeWithIfCondition)).hasSize(1)
         }
@@ -287,14 +287,14 @@ class ThrowsCountSpec {
 
         @Test
         fun `should not report violation with EXCLUDE_GUARD_CLAUSES as true`() {
-            val config = TestConfig(mapOf(EXCLUDE_GUARD_CLAUSES to "true"))
+            val config = TestConfig(EXCLUDE_GUARD_CLAUSES to "true")
             val subject = ThrowsCount(config)
             assertThat(subject.lint(codeWithMultipleGuardClauses)).isEmpty()
         }
 
         @Test
         fun `should report violation with EXCLUDE_GUARD_CLAUSES as false`() {
-            val config = TestConfig(mapOf(EXCLUDE_GUARD_CLAUSES to "false"))
+            val config = TestConfig(EXCLUDE_GUARD_CLAUSES to "false")
             val subject = ThrowsCount(config)
             assertThat(subject.lint(codeWithMultipleGuardClauses)).hasSize(1)
         }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiteralsSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiteralsSpec.kt
@@ -27,7 +27,7 @@ class UnderscoresInNumericLiteralsSpec {
         @Test
         fun `should be reported if acceptableLength is 3`() {
             val findings = UnderscoresInNumericLiterals(
-                TestConfig(mapOf(ACCEPTABLE_LENGTH to "3"))
+                TestConfig(ACCEPTABLE_LENGTH to "3")
             ).compileAndLint(code)
             assertThat(findings).isNotEmpty
         }
@@ -35,7 +35,7 @@ class UnderscoresInNumericLiteralsSpec {
         @Test
         fun `should be reported if deprecated acceptableDecimalLength is 4`() {
             val findings = UnderscoresInNumericLiterals(
-                TestConfig(mapOf(ACCEPTABLE_DECIMAL_LENGTH to "4"))
+                TestConfig(ACCEPTABLE_DECIMAL_LENGTH to "4")
             ).compileAndLint(code)
             assertThat(findings).isNotEmpty
         }
@@ -65,7 +65,7 @@ class UnderscoresInNumericLiteralsSpec {
         @Test
         fun `should not be reported if acceptableLength is 7`() {
             val findings = UnderscoresInNumericLiterals(
-                TestConfig(mapOf(ACCEPTABLE_LENGTH to "7"))
+                TestConfig(ACCEPTABLE_LENGTH to "7")
             ).compileAndLint(code)
             assertThat(findings).isEmpty()
         }
@@ -84,7 +84,7 @@ class UnderscoresInNumericLiteralsSpec {
         @Test
         fun `should be reported if acceptableLength is 3`() {
             val findings = UnderscoresInNumericLiterals(
-                TestConfig(mapOf(ACCEPTABLE_LENGTH to "3"))
+                TestConfig(ACCEPTABLE_LENGTH to "3")
             ).compileAndLint(code)
             assertThat(findings).isNotEmpty
         }
@@ -103,7 +103,7 @@ class UnderscoresInNumericLiteralsSpec {
         @Test
         fun `should be reported if acceptableLength is 3`() {
             val findings = UnderscoresInNumericLiterals(
-                TestConfig(mapOf(ACCEPTABLE_LENGTH to "3"))
+                TestConfig(ACCEPTABLE_LENGTH to "3")
             ).compileAndLint(code)
             assertThat(findings).isNotEmpty
         }
@@ -133,7 +133,7 @@ class UnderscoresInNumericLiteralsSpec {
         @Test
         fun `should not be reported if ignored acceptableLength is 7`() {
             val findings = UnderscoresInNumericLiterals(
-                TestConfig(mapOf(ACCEPTABLE_LENGTH to "7"))
+                TestConfig(ACCEPTABLE_LENGTH to "7")
             ).compileAndLint(code)
             assertThat(findings).isEmpty()
         }
@@ -164,7 +164,7 @@ class UnderscoresInNumericLiteralsSpec {
         @Test
         fun `should be reported if acceptableLength is 3`() {
             val findings = UnderscoresInNumericLiterals(
-                TestConfig(mapOf(ACCEPTABLE_LENGTH to "3"))
+                TestConfig(ACCEPTABLE_LENGTH to "3")
             ).compileAndLint(code)
             assertThat(findings).isNotEmpty
         }
@@ -205,7 +205,7 @@ class UnderscoresInNumericLiteralsSpec {
         @Test
         fun `should still be reported even if acceptableLength is 99`() {
             val findings = UnderscoresInNumericLiterals(
-                TestConfig(mapOf(ACCEPTABLE_LENGTH to "99"))
+                TestConfig(ACCEPTABLE_LENGTH to "99")
             ).compileAndLint(code)
             assertThat(findings).isNotEmpty
         }
@@ -213,7 +213,7 @@ class UnderscoresInNumericLiteralsSpec {
         @Test
         fun `should not be reported if allowNonStandardGrouping is true`() {
             val findings = UnderscoresInNumericLiterals(
-                TestConfig(mapOf(ALLOW_NON_STANDARD_GROUPING to true))
+                TestConfig(ALLOW_NON_STANDARD_GROUPING to true)
             ).compileAndLint(code)
             assertThat(findings).isEmpty()
         }
@@ -376,7 +376,7 @@ class UnderscoresInNumericLiteralsSpec {
         @Test
         fun `should not be reported if acceptableLength is 5`() {
             val findings = UnderscoresInNumericLiterals(
-                TestConfig(mapOf(ACCEPTABLE_LENGTH to "5"))
+                TestConfig(ACCEPTABLE_LENGTH to "5")
             ).compileAndLint(code)
             assertThat(findings).isEmpty()
         }
@@ -414,7 +414,7 @@ class UnderscoresInNumericLiteralsSpec {
         @Test
         fun `should be reported if acceptableLength is 3`() {
             val findings = UnderscoresInNumericLiterals(
-                TestConfig(mapOf(ACCEPTABLE_LENGTH to "3"))
+                TestConfig(ACCEPTABLE_LENGTH to "3")
             ).compileAndLint(code)
             assertThat(findings).isNotEmpty
         }
@@ -434,7 +434,7 @@ class UnderscoresInNumericLiteralsSpec {
         @Test
         fun `should not be reported if acceptableLength is 7`() {
             val findings = UnderscoresInNumericLiterals(
-                TestConfig(mapOf(ACCEPTABLE_LENGTH to "7"))
+                TestConfig(ACCEPTABLE_LENGTH to "7")
             ).compileAndLint(code)
             assertThat(findings).isEmpty()
         }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAbstractClassSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAbstractClassSpec.kt
@@ -14,7 +14,7 @@ private const val EXCLUDE_ANNOTATED_CLASSES = "excludeAnnotatedClasses"
 @KotlinCoreEnvironmentTest
 class UnnecessaryAbstractClassSpec(val env: KotlinCoreEnvironment) {
     val subject =
-        UnnecessaryAbstractClass(TestConfig(mapOf(EXCLUDE_ANNOTATED_CLASSES to listOf("Deprecated"))))
+        UnnecessaryAbstractClass(TestConfig(EXCLUDE_ANNOTATED_CLASSES to listOf("Deprecated")))
 
     @Nested
     inner class `abstract classes with no concrete members` {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAbstractClassSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAbstractClassSpec.kt
@@ -13,8 +13,7 @@ private const val EXCLUDE_ANNOTATED_CLASSES = "excludeAnnotatedClasses"
 
 @KotlinCoreEnvironmentTest
 class UnnecessaryAbstractClassSpec(val env: KotlinCoreEnvironment) {
-    val subject =
-        UnnecessaryAbstractClass(TestConfig(EXCLUDE_ANNOTATED_CLASSES to listOf("Deprecated")))
+    val subject = UnnecessaryAbstractClass(TestConfig(EXCLUDE_ANNOTATED_CLASSES to listOf("Deprecated")))
 
     @Nested
     inner class `abstract classes with no concrete members` {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivatePropertySpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivatePropertySpec.kt
@@ -91,18 +91,16 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
 
         @Test
         fun `does not fail when disabled with invalid regex`() {
-            val configRules = mapOf(
+            val config = TestConfig(
                 "active" to "false",
                 ALLOWED_NAMES_PATTERN to "*foo",
             )
-            val config = TestConfig(configRules)
             assertThat(UnusedPrivateMember(config).lint(regexTestingCode)).isEmpty()
         }
 
         @Test
         fun `does fail when enabled with invalid regex`() {
-            val configRules = mapOf(ALLOWED_NAMES_PATTERN to "*foo")
-            val config = TestConfig(configRules)
+            val config = TestConfig(ALLOWED_NAMES_PATTERN to "*foo")
             assertThatExceptionOfType(PatternSyntaxException::class.java)
                 .isThrownBy { UnusedPrivateMember(config).lint(regexTestingCode) }
         }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseDataClassSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseDataClassSpec.kt
@@ -318,7 +318,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
         @Test
         fun `does not report class with mutable constructor parameter`() {
             val code = """class DataClassCandidateWithVar(var i: Int)"""
-            val config = TestConfig(mapOf(ALLOW_VARS to "true"))
+            val config = TestConfig(ALLOW_VARS to "true")
             assertThat(UseDataClass(config).compileAndLint(code)).isEmpty()
         }
 
@@ -329,7 +329,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                     var i2: Int = 0
                 }
             """.trimIndent()
-            val config = TestConfig(mapOf(ALLOW_VARS to "true"))
+            val config = TestConfig(ALLOW_VARS to "true")
             assertThat(UseDataClass(config).compileAndLint(code)).isEmpty()
         }
 
@@ -340,7 +340,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                     var i2: Int = 0
                 }
             """.trimIndent()
-            val config = TestConfig(mapOf(ALLOW_VARS to "true"))
+            val config = TestConfig(ALLOW_VARS to "true")
             assertThat(UseDataClass(config).compileAndLint(code)).isEmpty()
         }
 
@@ -351,7 +351,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                     val i2: Int = 0
                 }
             """.trimIndent()
-            val config = TestConfig(mapOf(ALLOW_VARS to "true"))
+            val config = TestConfig(ALLOW_VARS to "true")
             assertThat(UseDataClass(config).compileAndLint(code)).isEmpty()
         }
     }
@@ -378,7 +378,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
             @SinceKotlin("1.0.0")
             class AnnotatedClass(val i: Int) {}
         """.trimIndent()
-        val config = TestConfig(mapOf(EXCLUDE_ANNOTATED_CLASSES to "kotlin.*"))
+        val config = TestConfig(EXCLUDE_ANNOTATED_CLASSES to "kotlin.*")
         assertThat(UseDataClass(config).compileAndLint(code)).isEmpty()
     }
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/WildcardImportSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/WildcardImportSpec.kt
@@ -24,7 +24,7 @@ class WildcardImportSpec {
 
         @Test
         fun `should not report anything when the rule is turned off`() {
-            val rule = WildcardImport(TestConfig(mapOf(Config.ACTIVE_KEY to "false")))
+            val rule = WildcardImport(TestConfig(Config.ACTIVE_KEY to "false"))
 
             val findings = rule.compileAndLint(code)
             assertThat(findings).isEmpty()
@@ -40,7 +40,7 @@ class WildcardImportSpec {
 
         @Test
         fun `should not report excluded wildcard imports`() {
-            val rule = WildcardImport(TestConfig(mapOf(EXCLUDED_IMPORTS to listOf("io.mockk.*"))))
+            val rule = WildcardImport(TestConfig(EXCLUDED_IMPORTS to listOf("io.mockk.*")))
 
             val findings = rule.compileAndLint(code)
             assertThat(findings).hasSize(1)
@@ -50,11 +50,9 @@ class WildcardImportSpec {
         fun `should not report excluded wildcard imports when multiple are excluded`() {
             val rule = WildcardImport(
                 TestConfig(
-                    mapOf(
-                        EXCLUDED_IMPORTS to listOf(
-                            "io.mockk.*",
-                            "io.gitlab.arturbosch.detekt"
-                        )
+                    EXCLUDED_IMPORTS to listOf(
+                        "io.mockk.*",
+                        "io.gitlab.arturbosch.detekt"
                     )
                 )
             )
@@ -66,7 +64,7 @@ class WildcardImportSpec {
         @Test
         fun `should not report excluded wildcard imports when multiple are excluded using config string`() {
             val rule =
-                WildcardImport(TestConfig(mapOf(EXCLUDED_IMPORTS to "io.mockk.*, io.gitlab.arturbosch.detekt")))
+                WildcardImport(TestConfig(EXCLUDED_IMPORTS to "io.mockk.*, io.gitlab.arturbosch.detekt"))
 
             val findings = rule.compileAndLint(code)
             assertThat(findings).isEmpty()
@@ -74,7 +72,7 @@ class WildcardImportSpec {
 
         @Test
         fun `ignores excludes that are not matching`() {
-            val rule = WildcardImport(TestConfig(mapOf(EXCLUDED_IMPORTS to listOf("other.test.*"))))
+            val rule = WildcardImport(TestConfig(EXCLUDED_IMPORTS to listOf("other.test.*")))
 
             val findings = rule.compileAndLint(code)
             assertThat(findings).hasSize(2)

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/SuppressingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/SuppressingSpec.kt
@@ -48,7 +48,7 @@ class SuppressingSpec {
 
     @Test
     fun `should suppress TooManyFunctionsRule on class level`() {
-        val rule = TooManyFunctions(TestConfig(mapOf("thresholdInClass" to "0")))
+        val rule = TooManyFunctions(TestConfig("thresholdInClass" to "0"))
 
         val findings = rule.lint(resourceAsPath("SuppressedElementsByClassAnnotation.kt"))
 

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/TestConfig.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/TestConfig.kt
@@ -6,9 +6,14 @@ import io.gitlab.arturbosch.detekt.core.config.tryParseBasedOnDefault
 import io.gitlab.arturbosch.detekt.core.config.valueOrDefaultInternal
 
 @Suppress("UNCHECKED_CAST")
-open class TestConfig(
+open class TestConfig
+@Deprecated("Use Detekt instead TestConfig(vararg Pair<String, Any>) instead")
+constructor(
     private val values: Map<String, Any> = mutableMapOf()
 ) : Config {
+
+    @Suppress("DEPRECATION")
+    constructor() : this(emptyMap())
 
     override fun subConfig(key: String) = this
 
@@ -54,6 +59,7 @@ open class TestConfig(
     }
 
     companion object {
+        @Suppress("DEPRECATION")
         operator fun invoke(vararg pairs: Pair<String, Any>) = TestConfig(mapOf(*pairs))
     }
 }


### PR DESCRIPTION
In nearlly all our tests we use `TestConfig(Map<String, Any>)`. This make us write code like this:

```kotlin
val rule = TooManyFunctions(
    TestConfig(
        mapOf(
            THRESHOLD_IN_CLASSES to "1",
            THRESHOLD_IN_FILES to "1",
            IGNORE_OVERRIDDEN to "false"
        )
    )
)
```

The `mapOf` provide us really little value there and only increase the verbosity. I changed all our test to use `TestConfig(vararg Pair<String, Any>)` it does exactly the same but the code is a bit easier:

```kotlin
val rule = TooManyFunctions(
    TestConfig(
        THRESHOLD_IN_CLASSES to "1",
        THRESHOLD_IN_FILES to "1",
        IGNORE_OVERRIDDEN to "false",
    )
)
```

I also deprecated the old version to promote this new one. I can't remove it because it is part of our public API.