### PR TITLE
Stop using Gradle toolchains in tests

### DIFF
--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektMultiplatformSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektMultiplatformSpec.kt
@@ -102,7 +102,6 @@ class DetektMultiplatformSpec {
                                 attributes.attribute(targetType, "jvmBackend")
                             }
                             jvm("jvmEmbedded")
-                            jvmToolchain(8)
                         }
                         $DETEKT_BLOCK
                     """.trimIndent(),
@@ -169,8 +168,11 @@ class DetektMultiplatformSpec {
                             }
                         }
                         kotlin {
-                            android()
-                            jvmToolchain(8)
+                            android {
+                                compilations.all {
+                                    kotlinOptions.jvmTarget = "1.8"
+                                }
+                            }
                         }
                         $DETEKT_BLOCK
                     """.trimIndent(),

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/report/ReportMergeSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/report/ReportMergeSpec.kt
@@ -111,8 +111,10 @@ class ReportMergeSpec {
                            targetCompatibility = JavaVersion.VERSION_11
                        }
                     }
-                    kotlin {
-                        jvmToolchain(11)
+                    tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+                        compilerOptions {
+                            jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11)
+                        }
                     }
                     dependencies {
                         implementation(project(":lib"))
@@ -136,8 +138,10 @@ class ReportMergeSpec {
                            targetCompatibility = JavaVersion.VERSION_11
                        }
                     }
-                    kotlin {
-                        jvmToolchain(11)
+                    tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+                        compilerOptions {
+                            jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11)
+                        }
                     }
                 """.trimIndent(),
                 srcDirs = listOf("src/main/java", "src/debug/java", "src/test/java", "src/androidTest/java")


### PR DESCRIPTION
Kotlin and Java compilation JVM targets must align when using Kotlin 1.8+ and Gradle 8+ together. Toolchains also require a plugin to enable auto-provisioning as of Gradle 8. It's simpler to explicitly configure the JVM versions for Kotlin & Java tasks as needed in the individual tests.

See https://docs.gradle.org/8.0.1/userguide/toolchains.html#sec:provisioning and https://kotlinlang.org/docs/whatsnew18.html#obligatory-check-for-jvm-targets-of-related-kotlin-and-java-compile-tasks