### PR TITLE
FunctionMatcher support for fully qualified function names

### DIFF
--- a/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/api/FunctionMatcher.kt
+++ b/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/api/FunctionMatcher.kt
@@ -4,7 +4,6 @@ import io.gitlab.arturbosch.detekt.rules.fqNameOrNull
 import org.jetbrains.kotlin.descriptors.CallableDescriptor
 import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.resolve.BindingContext
-import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameOrNull
 import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
 import org.jetbrains.kotlin.types.KotlinType
 import org.jetbrains.kotlin.types.typeUtil.isTypeParameter
@@ -23,7 +22,8 @@ sealed class FunctionMatcher {
         }
 
         override fun match(function: KtNamedFunction, bindingContext: BindingContext): Boolean {
-            return function.name == fullyQualifiedName
+            return function.name == fullyQualifiedName ||
+                function.fqName?.asString() == fullyQualifiedName
         }
 
         override fun toString(): String {
@@ -48,7 +48,7 @@ sealed class FunctionMatcher {
 
         override fun match(function: KtNamedFunction, bindingContext: BindingContext): Boolean {
             if (bindingContext == BindingContext.EMPTY) return false
-            if (function.name != fullyQualifiedName) return false
+            if (function.name != fullyQualifiedName && function.fqName?.asString() != fullyQualifiedName) return false
 
             val encounteredParameters =
                 (listOfNotNull(function.receiverTypeReference) + function.valueParameters.map { it.typeReference })

--- a/detekt-tooling/src/test/kotlin/io/github/detekt/tooling/api/FunctionMatcherSpec.kt
+++ b/detekt-tooling/src/test/kotlin/io/github/detekt/tooling/api/FunctionMatcherSpec.kt
@@ -353,8 +353,8 @@ private fun buildKtFunction(
 ): Pair<KtNamedFunction, BindingContext> {
     val ktFile = compileContentForTest(
         """
-        ${if (includePackage) "package io.github.detekt" else ""}
-        $code
+            ${if (includePackage) "package io.github.detekt" else ""}
+            $code
         """.trimIndent()
     )
     val bindingContext = environment.getContextForPaths(listOf(ktFile))

--- a/detekt-tooling/src/test/kotlin/io/github/detekt/tooling/api/FunctionMatcherSpec.kt
+++ b/detekt-tooling/src/test/kotlin/io/github/detekt/tooling/api/FunctionMatcherSpec.kt
@@ -323,11 +323,11 @@ class FunctionMatcherSpec(private val env: KotlinCoreEnvironment) {
         ) {
             val ktFile = compileContentForTest(
                 """
-                package io.github.detekt
+                    package io.github.detekt
 
-                $classSignature {
-                    $functionSignature {}
-                }
+                    $classSignature {
+                        $functionSignature {}
+                    }
                 """.trimIndent()
             )
             val bindingContext = env.getContextForPaths(listOf(ktFile))


### PR DESCRIPTION
Now matcher will check both simple name e.g. `foo` and fully qualified one e.g. `com.github.detekt.FooBar.foo`.

Fixes https://github.com/detekt/detekt/issues/5767