### PR TITLE
Stop configuring report merge tasks while configuring Detekt tasks

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,7 +36,7 @@ allprojects {
         detektPlugins(project(":detekt-rules-ruleauthors"))
     }
 
-    tasks.withType<Detekt>().configureEach detekt@{
+    tasks.withType<Detekt>().configureEach {
         jvmTarget = "1.8"
         reports {
             xml.required.set(true)
@@ -47,9 +47,9 @@ allprojects {
         }
         basePath = rootProject.projectDir.absolutePath
         finalizedBy(detektReportMergeSarif)
-        detektReportMergeSarif.configure {
-            input.from(this@detekt.sarifReportFile)
-        }
+    }
+    detektReportMergeSarif {
+        input.from(tasks.withType<Detekt>().map { it.sarifReportFile })
     }
     tasks.withType<DetektCreateBaselineTask>().configureEach {
         jvmTarget = "1.8"

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektReportMergeSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektReportMergeSpec.kt
@@ -30,13 +30,11 @@ class DetektReportMergeSpec {
                 |    reports.sarif.enabled = true
                 |  }
                 |
-                |  plugins.withType(io.gitlab.arturbosch.detekt.DetektPlugin::class) {
-                |    tasks.withType(io.gitlab.arturbosch.detekt.Detekt::class) detekt@{
-                |       sarifReportMerge.configure {
-                |         this.mustRunAfter(this@detekt)
-                |         input.from(this@detekt.sarifReportFile)
-                |       }
-                |    }
+                |  tasks.withType(io.gitlab.arturbosch.detekt.Detekt::class).configureEach {
+                |     finalizedBy(sarifReportMerge)
+                |  }
+                |  sarifReportMerge {
+                |    input.from(tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().map { it.sarifReportFile })
                 |  }
                 |}
                 |
@@ -103,13 +101,11 @@ class DetektReportMergeSpec {
             |    reports.xml.enabled = true
             |  }
             |
-            |  plugins.withType(io.gitlab.arturbosch.detekt.DetektPlugin::class) {
-            |    tasks.withType(io.gitlab.arturbosch.detekt.Detekt::class) detekt@{
-            |       xmlReportMerge.configure {
-            |         this.mustRunAfter(this@detekt)
-            |         input.from(this@detekt.xmlReportFile)
-            |       }
-            |    }
+            |  tasks.withType(io.gitlab.arturbosch.detekt.Detekt::class).configureEach {
+            |     finalizedBy(xmlReportMerge)
+            |  }
+            |  xmlReportMerge {
+            |    input.from(tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().map { it.xmlReportFile })
             |  }
             |}
             |

--- a/website/docs/introduction/reporting.md
+++ b/website/docs/introduction/reporting.md
@@ -97,14 +97,12 @@ subprojects {
     // reports.sarif.required.set(true)
   }
 
-  plugins.withType(io.gitlab.arturbosch.detekt.DetektPlugin) {
-    tasks.withType(io.gitlab.arturbosch.detekt.Detekt) { detektTask -> // Sadly it has to be eager.
-      finalizedBy(reportMerge)
+  tasks.withType(io.gitlab.arturbosch.detekt.Detekt).configureEach {
+    finalizedBy(reportMerge)
+  }
 
-      reportMerge.configure { mergeTask ->
-        mergeTask.input.from(detektTask.xmlReportFile) // or detektTask.sarifReportFile
-      }
-    }
+  reportMerge.configure {
+    input.from(tasks.withType(io.gitlab.arturbosch.detekt.Detekt).collect { it.xmlReportFile }) // or sarifReportFile
   }
 }
 ```
@@ -122,14 +120,12 @@ subprojects {
     // reports.sarif.required.set(true)
   }
 
-  plugins.withType<io.gitlab.arturbosch.detekt.DetektPlugin> {
-    tasks.withType<io.gitlab.arturbosch.detekt.Detekt> detekt@{ // Sadly it has to be eager.
-      finalizedBy(reportMerge)
+  tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
+    finalizedBy(reportMerge)
+  }
 
-      reportMerge.configure {
-        input.from(this@detekt.xmlReportFile) // or .sarifReportFile
-      }
-    }
+  reportMerge {
+    input.from(tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().map { it.xmlReportFile }) // or .sarifReportFile
   }
 }
 ```


### PR DESCRIPTION
See point 2: https://docs.gradle.org/8.0.1/userguide/task_configuration_avoidance.html#sec:task_configuration_avoidance_general

> Only mutate the current task inside a configuration action... Mutating anything other than the current task can cause indeterminate behavior in your build.

Also see: https://github.com/detekt/detekt/pull/5772#issuecomment-1431708458.

Docs should be updated to align - that can be done in a new commit once these changes are reviewed & approved.