### PR TITLE
Dont reexecute tasks and make them more parallel

### DIFF
--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -49,16 +49,6 @@ jobs:
           path: '**.hprof'
           if-no-files-found: ignore
 
-      - name: Run detekt-cli --help
-        uses: gradle/gradle-build-action@3fbe033aaae657f011f88f29be9e65ed26bd29ef # tag=v2
-        with:
-          arguments: :detekt-cli:runWithHelpFlag
-
-      - name: Run detekt-cli with argsfile
-        uses: gradle/gradle-build-action@3fbe033aaae657f011f88f29be9e65ed26bd29ef # tag=v2
-        with:
-          arguments: :detekt-cli:runWithArgsFile
-
       - name: Try to publish to Maven Local
         uses: gradle/gradle-build-action@3fbe033aaae657f011f88f29be9e65ed26bd29ef # tag=v2
         with:

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -41,18 +41,13 @@ jobs:
       - name: Build detekt
         uses: gradle/gradle-build-action@3fbe033aaae657f011f88f29be9e65ed26bd29ef # tag=v2
         with:
-          arguments: build -x detekt
+          arguments: build -x detekt publishToMavenLocal
 
       - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3
         with:
           name: heap-dump
           path: '**.hprof'
           if-no-files-found: ignore
-
-      - name: Try to publish to Maven Local
-        uses: gradle/gradle-build-action@3fbe033aaae657f011f88f29be9e65ed26bd29ef # tag=v2
-        with:
-          arguments: publishToMavenLocal
 
   verify-generated-config-file:
     if: ${{ !contains(github.event.head_commit.message, 'ci skip') }}


### PR DESCRIPTION
We were executing the tasks `detekt-cli:runWithHelpFlag` and `:detekt-cli:runWithArgsFile` twice:

https://github.com/detekt/detekt/blob/ad0e7930340e73a64318165ac08f00b4f5e4f757/detekt-cli/build.gradle.kts#L73-L75

And we don't need to execute `publishToMavenLocal` in a different ci task. We can executes them together and use the parallelism of gradle.