### PR TITLE
Never skip ci

### DIFF
--- a/.github/workflows/codecoverage.yaml
+++ b/.github/workflows/codecoverage.yaml
@@ -13,7 +13,6 @@ permissions:
 
 jobs:
   publish-code-coverage:
-    if: ${{ !contains(github.event.head_commit.message, 'coverage skip') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo

--- a/.github/workflows/deploy-snapshot.yaml
+++ b/.github/workflows/deploy-snapshot.yaml
@@ -14,7 +14,6 @@ permissions:
 jobs:
   gradle:
     runs-on: ubuntu-latest
-    if: github.repository == 'detekt/detekt' && !contains(github.event.head_commit.message, 'ci skip')
     steps:
       - name: Checkout Repo
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3

--- a/.github/workflows/detekt-with-type-resolution.yaml
+++ b/.github/workflows/detekt-with-type-resolution.yaml
@@ -22,7 +22,6 @@ jobs:
       contents: read  # for actions/checkout to fetch code
       security-events: write  # for github/codeql-action/upload-sarif to upload SARIF results
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.head_commit.message, 'ci skip') }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3
@@ -50,7 +49,6 @@ jobs:
       contents: read  # for actions/checkout to fetch code
       security-events: write  # for github/codeql-action/upload-sarif to upload SARIF results
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.head_commit.message, 'ci skip') }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -18,7 +18,6 @@ permissions:
 
 jobs:
   gradle:
-    if: ${{ !contains(github.event.head_commit.message, 'ci skip') }}
     strategy:
       fail-fast: false
       matrix:
@@ -65,7 +64,6 @@ jobs:
           arguments: publishToMavenLocal
 
   verify-generated-config-file:
-    if: ${{ !contains(github.event.head_commit.message, 'ci skip') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
@@ -83,7 +81,6 @@ jobs:
           arguments: verifyGeneratorOutput
 
   compile-test-snippets:
-    if: ${{ !contains(github.event.head_commit.message, 'ci skip') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
@@ -101,7 +98,6 @@ jobs:
           arguments: test -Pcompile-test-snippets=true
 
   warnings-as-errors:
-    if: ${{ !contains(github.event.head_commit.message, 'ci skip') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo


### PR DESCRIPTION
I can't find any reason to don't want to run ci on every PR. And this could even be sploited by someone sending a PR. For that reason I'm removing this `if`