### PR TITLE
Reduce execution of warningsAsErrors job

### DIFF
--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -101,4 +101,4 @@ jobs:
       - name: Run with allWarningsAsErrors
         uses: gradle/gradle-build-action@3fbe033aaae657f011f88f29be9e65ed26bd29ef # tag=v2
         with:
-          arguments: build -x detekt -PwarningsAsErrors=true
+          arguments: compileKotlin compileTestKotlin compileTestFixturesKotlin -PwarningsAsErrors=true


### PR DESCRIPTION
On this task we just want to execute the kotlin compile to get errors if there is any warning.