### PR TITLE
Enable test retry for all our modules

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,4 @@
+import com.gradle.enterprise.gradleplugin.testretry.retry
 import io.gitlab.arturbosch.detekt.Detekt
 import io.gitlab.arturbosch.detekt.DetektCreateBaselineTask
 import io.gitlab.arturbosch.detekt.report.ReportMergeTask
@@ -58,6 +59,13 @@ allprojects {
 
 subprojects {
     tasks.withType<Test>().configureEach {
+        retry {
+            @Suppress("MagicNumber")
+            if (System.getenv().containsKey("CI")) {
+                maxRetries.set(3)
+                maxFailures.set(20)
+            }
+        }
         predictiveSelection {
             enabled.set(System.getenv("CI") == null)
         }


### PR DESCRIPTION
This was a point we talked with the Gradle folks. It improves the predictive tests.

Documentation: https://docs.gradle.com/enterprise/predictive-test-selection/#flaky_test_retry