### PR TITLE
Disable PTS from local and enable it for PRs

### DIFF
--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -37,10 +37,17 @@ jobs:
           java-version: ${{ matrix.jdk }}
           distribution: 'temurin'
 
-      - name: Build detekt
+      - if: ${{ !(github.event_name == 'push' && github.ref == 'refs/heads/main') }}
+        name: Build detekt with PTS
         uses: gradle/gradle-build-action@3fbe033aaae657f011f88f29be9e65ed26bd29ef # tag=v2
         with:
-          arguments: build -x detekt publishToMavenLocal
+          arguments: build -x detekt publishToMavenLocal -PenablePTS=true
+
+      - if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        name: Build detekt without PTS
+        uses: gradle/gradle-build-action@3fbe033aaae657f011f88f29be9e65ed26bd29ef # tag=v2
+        with:
+          arguments: build -x detekt publishToMavenLocal -PenablePTS=false
 
       - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3
         with:

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: Build detekt
         uses: gradle/gradle-build-action@3fbe033aaae657f011f88f29be9e65ed26bd29ef # tag=v2
         with:
-          arguments: build -x detekt publishToMavenLocal -PenablePTS=${{ github.event_name != 'push' }}
+          arguments: build -x detekt publishToMavenLocal -PenablePTS=${{ github.event_name == 'pull_request' }}
 
       - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3
         with:

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -37,17 +37,10 @@ jobs:
           java-version: ${{ matrix.jdk }}
           distribution: 'temurin'
 
-      - if: ${{ !(github.event_name == 'push' && github.ref == 'refs/heads/main') }}
-        name: Build detekt with PTS
+      - name: Build detekt
         uses: gradle/gradle-build-action@3fbe033aaae657f011f88f29be9e65ed26bd29ef # tag=v2
         with:
-          arguments: build -x detekt publishToMavenLocal -PenablePTS=true
-
-      - if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-        name: Build detekt without PTS
-        uses: gradle/gradle-build-action@3fbe033aaae657f011f88f29be9e65ed26bd29ef # tag=v2
-        with:
-          arguments: build -x detekt publishToMavenLocal -PenablePTS=false
+          arguments: build -x detekt publishToMavenLocal -PenablePTS=${{ github.event_name != 'push' }}
 
       - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3
         with:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -59,7 +59,7 @@ allprojects {
 subprojects {
     tasks.withType<Test>().configureEach {
         predictiveSelection {
-            enabled.set(providers.gradleProperty("enablePTS").map(String::toBooleanStrict).orElse(false))
+            enabled.set(providers.gradleProperty("enablePTS").map(String::toBooleanStrict))
         }
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -59,7 +59,7 @@ allprojects {
 subprojects {
     tasks.withType<Test>().configureEach {
         predictiveSelection {
-            enabled.set(System.getenv("CI") == null)
+            enabled.set(providers.gradleProperty("enablePTS").map(String::toBooleanStrict).orElse(false))
         }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,3 +5,7 @@ org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8
 org.gradle.unsafe.configuration-cache=true
+
+# Allows to enable/disable Predictive Test Selection: https://docs.gradle.com/enterprise/predictive-test-selection/
+# disable by default
+enablePTS=false


### PR DESCRIPTION
The github yaml configuration make this a bit ugly.

This was discussed with the gradle folks on how to improve the usage of PTS.

PTS on local doesn't provide us too much benefits because it breaks the incremental compilariont (`UP-TO-DATE` check).

The idea is that we make our PR checks faster now that we have a trained PTS but we run all our tests once it's merged to `main` to ensure that nothing was broken.