### PR TITLE
Make `UnnecessaryAbstractClass` only run with type resolution

### DIFF
--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAbstractClass.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAbstractClass.kt
@@ -11,6 +11,7 @@ import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.config
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
 import io.gitlab.arturbosch.detekt.api.internal.Configuration
+import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.rules.isAbstract
 import io.gitlab.arturbosch.detekt.rules.isInternal
 import io.gitlab.arturbosch.detekt.rules.isProtected
@@ -44,8 +45,8 @@ import org.jetbrains.kotlin.types.typeUtil.isInterface
  * }
  * </noncompliant>
  */
-@Suppress("ViolatesTypeResolutionRequirements")
 @ActiveByDefault(since = "1.2.0")
+@RequiresTypeResolution
 class UnnecessaryAbstractClass(config: Config = Config.empty) : Rule(config) {
 
     private val noConcreteMember = "An abstract class without a concrete member can be refactored to an interface."


### PR DESCRIPTION
Fix #4753

This rule has false positives without type resolution. More about this here: #4753