### PR TITLE
Cleaner merging of Gradle blocks for functionalTests

### DIFF
--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/ConfigurationCacheSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/ConfigurationCacheSpec.kt
@@ -23,12 +23,11 @@ class ConfigurationCacheSpec {
     inner class `Create baseline task` {
         @Test
         fun `can be loaded from the configuration cache`() {
-            @Suppress("TrimMultilineRawString")
             val detektConfig = """
-                |detekt {
-                |   baseline = file("build/baseline.xml")
-                |}
-            """
+                detekt {
+                    baseline = file("build/baseline.xml")
+                }
+            """.trimIndent()
             val gradleRunner = DslTestBuilder.kotlin()
                 .withDetektConfig(detektConfig)
                 .build()

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/CreateBaselineTaskDslSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/CreateBaselineTaskDslSpec.kt
@@ -11,12 +11,11 @@ class CreateBaselineTaskDslSpec {
     fun `detektBaseline task can be executed when baseline file is specified`() {
         val baselineFilename = "baseline.xml"
 
-        @Suppress("TrimMultilineRawString")
         val detektConfig = """
-            |detekt {
-            |   baseline = file("$baselineFilename")
-            |}
-        """
+            detekt {
+                baseline = file("$baselineFilename")
+            }
+        """.trimIndent()
         val gradleRunner = DslTestBuilder.kotlin()
             .withProjectLayout(
                 ProjectLayout(
@@ -36,11 +35,10 @@ class CreateBaselineTaskDslSpec {
 
     @Test
     fun `detektBaseline task can be executed when baseline file is not specified`() {
-        @Suppress("TrimMultilineRawString")
         val detektConfig = """
-            |detekt {
-            |}
-        """
+            detekt {
+            }
+        """.trimIndent()
         val gradleRunner = DslTestBuilder.kotlin()
             .withProjectLayout(
                 ProjectLayout(
@@ -59,12 +57,11 @@ class CreateBaselineTaskDslSpec {
 
     @Test
     fun `detektBaseline task can not be executed when baseline file is specified null`() {
-        @Suppress("TrimMultilineRawString")
         val detektConfig = """
-            |detekt {
-            |   baseline = null
-            |}
-        """
+            detekt {
+                baseline = null
+            }
+        """.trimIndent()
         val gradleRunner = DslTestBuilder.kotlin()
             .withProjectLayout(
                 ProjectLayout(

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektAndroidSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektAndroidSpec.kt
@@ -2,7 +2,9 @@ package io.gitlab.arturbosch.detekt
 
 import io.gitlab.arturbosch.detekt.testkit.DslGradleRunner
 import io.gitlab.arturbosch.detekt.testkit.ProjectLayout
+import io.gitlab.arturbosch.detekt.testkit.joinGradleBlocks
 import org.assertj.core.api.Assertions.assertThat
+import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -23,11 +25,11 @@ class DetektAndroidSpec {
                 name = "app",
                 numberOfSourceFilesPerSourceDir = 1,
                 numberOfCodeSmells = 1,
-                buildFileContent = """
-                    $APP_PLUGIN_BLOCK
-                    $ANDROID_BLOCK
-                    $DETEKT_REPORTS_BLOCK
-                """.trimIndent(),
+                buildFileContent = joinGradleBlocks(
+                    APP_PLUGIN_BLOCK,
+                    ANDROID_BLOCK,
+                    DETEKT_REPORTS_BLOCK,
+                ),
                 srcDirs = listOf(
                     "src/main/java",
                     "src/debug/java",
@@ -115,11 +117,11 @@ class DetektAndroidSpec {
                 name = "app",
                 numberOfSourceFilesPerSourceDir = 1,
                 numberOfCodeSmells = 1,
-                buildFileContent = """
-                    $APP_PLUGIN_BLOCK
-                    $ANDROID_BLOCK
-                    $DETEKT_REPORTS_BLOCK
-                """.trimIndent(),
+                buildFileContent = joinGradleBlocks(
+                    APP_PLUGIN_BLOCK,
+                    ANDROID_BLOCK,
+                    DETEKT_REPORTS_BLOCK,
+                ),
                 srcDirs = listOf("src/main/java", "src/debug/java", "src/test/java", "src/androidTest/java")
             )
         }
@@ -158,11 +160,11 @@ class DetektAndroidSpec {
                 name = "lib",
                 numberOfSourceFilesPerSourceDir = 1,
                 numberOfCodeSmells = 1,
-                buildFileContent = """
-                    $LIB_PLUGIN_BLOCK
-                    $ANDROID_BLOCK
-                    $DETEKT_REPORTS_BLOCK
-                """.trimIndent(),
+                buildFileContent = joinGradleBlocks(
+                    LIB_PLUGIN_BLOCK,
+                    ANDROID_BLOCK,
+                    DETEKT_REPORTS_BLOCK,
+                ),
                 srcDirs = listOf("src/main/java", "src/debug/java", "src/test/java", "src/androidTest/java"),
                 baselineFiles = listOf(
                     "detekt-baseline.xml",
@@ -229,10 +231,10 @@ class DetektAndroidSpec {
                 name = "kotlin_only_lib",
                 numberOfSourceFilesPerSourceDir = 1,
                 numberOfCodeSmells = 1,
-                buildFileContent = """
-                    $KOTLIN_ONLY_LIB_PLUGIN_BLOCK
-                    $DETEKT_REPORTS_BLOCK
-                """.trimIndent(),
+                buildFileContent = joinGradleBlocks(
+                    KOTLIN_ONLY_LIB_PLUGIN_BLOCK,
+                    DETEKT_REPORTS_BLOCK,
+                ),
                 srcDirs = listOf("src/main/java", "src/debug/java", "src/test/java", "src/androidTest/java"),
                 baselineFiles = listOf(
                     "detekt-baseline.xml",
@@ -247,15 +249,16 @@ class DetektAndroidSpec {
                 name = "android_lib",
                 numberOfSourceFilesPerSourceDir = 1,
                 numberOfCodeSmells = 1,
-                buildFileContent = """
-                    $LIB_PLUGIN_BLOCK
-                    $ANDROID_BLOCK
-                    $DETEKT_REPORTS_BLOCK
-                    
-                    dependencies {
-                        implementation(project(":kotlin_only_lib"))
-                    }
-                """.trimIndent(),
+                buildFileContent = joinGradleBlocks(
+                    LIB_PLUGIN_BLOCK,
+                    ANDROID_BLOCK,
+                    DETEKT_REPORTS_BLOCK,
+                    """
+                        dependencies {
+                            implementation(project(":kotlin_only_lib"))
+                        }
+                    """.trimIndent()
+                ),
                 srcDirs = listOf("src/main/java", "src/debug/java", "src/test/java", "src/androidTest/java"),
                 baselineFiles = listOf(
                     "detekt-baseline.xml",
@@ -326,11 +329,11 @@ class DetektAndroidSpec {
                 name = "lib",
                 numberOfSourceFilesPerSourceDir = 1,
                 numberOfCodeSmells = 1,
-                buildFileContent = """
-                    $LIB_PLUGIN_BLOCK
-                    $ANDROID_BLOCK_WITH_FLAVOR
-                    $DETEKT_REPORTS_BLOCK
-                """.trimIndent(),
+                buildFileContent = joinGradleBlocks(
+                    LIB_PLUGIN_BLOCK,
+                    ANDROID_BLOCK_WITH_FLAVOR,
+                    DETEKT_REPORTS_BLOCK,
+                ),
                 srcDirs = listOf("src/main/java", "src/debug/java", "src/test/java", "src/androidTest/java")
             )
         }
@@ -377,13 +380,15 @@ class DetektAndroidSpec {
                 name = "lib",
                 numberOfSourceFilesPerSourceDir = 1,
                 numberOfCodeSmells = 1,
-                buildFileContent = """
-                    $LIB_PLUGIN_BLOCK
-                    $ANDROID_BLOCK_WITH_FLAVOR
-                    detekt {
-                        ignoredBuildTypes = listOf("release")
-                    }
-                """.trimIndent(),
+                buildFileContent = joinGradleBlocks(
+                    LIB_PLUGIN_BLOCK,
+                    ANDROID_BLOCK_WITH_FLAVOR,
+                    """
+                        detekt {
+                            ignoredBuildTypes = listOf("release")
+                        }
+                    """.trimIndent(),
+                ),
                 srcDirs = listOf("src/main/java", "src/debug/java", "src/test/java", "src/androidTest/java")
             )
         }
@@ -432,13 +437,15 @@ class DetektAndroidSpec {
                 name = "lib",
                 numberOfSourceFilesPerSourceDir = 1,
                 numberOfCodeSmells = 1,
-                buildFileContent = """
-                    $LIB_PLUGIN_BLOCK
-                    $ANDROID_BLOCK_WITH_FLAVOR
-                    detekt {
-                        ignoredVariants = listOf("youngHarryDebug", "oldHarryRelease")
-                    }
-                """.trimIndent(),
+                buildFileContent = joinGradleBlocks(
+                    LIB_PLUGIN_BLOCK,
+                    ANDROID_BLOCK_WITH_FLAVOR,
+                    """
+                        detekt {
+                            ignoredVariants = listOf("youngHarryDebug", "oldHarryRelease")
+                        }
+                    """.trimIndent(),
+                ),
                 srcDirs = listOf("src/main/java", "src/debug/java", "src/test/java", "src/androidTest/java")
             )
         }
@@ -487,13 +494,15 @@ class DetektAndroidSpec {
                 name = "lib",
                 numberOfSourceFilesPerSourceDir = 1,
                 numberOfCodeSmells = 1,
-                buildFileContent = """
-                    $LIB_PLUGIN_BLOCK
-                    $ANDROID_BLOCK_WITH_FLAVOR
-                    detekt {
-                        ignoredFlavors = listOf("youngHarry")
-                    }
-                """.trimIndent(),
+                buildFileContent = joinGradleBlocks(
+                    LIB_PLUGIN_BLOCK,
+                    ANDROID_BLOCK_WITH_FLAVOR,
+                    """
+                        detekt {
+                            ignoredFlavors = listOf("youngHarry")
+                        }
+                    """.trimIndent(),
+                ),
                 srcDirs = listOf("src/main/java", "src/debug/java", "src/test/java", "src/androidTest/java")
             )
         }
@@ -542,10 +551,10 @@ class DetektAndroidSpec {
                     name = "app",
                     numberOfSourceFilesPerSourceDir = 0,
                     numberOfCodeSmells = 0,
-                    buildFileContent = """
-                        $APP_PLUGIN_BLOCK
-                        $ANDROID_BLOCK_WITH_VIEW_BINDING
-                    """.trimIndent(),
+                    buildFileContent = joinGradleBlocks(
+                        APP_PLUGIN_BLOCK,
+                        ANDROID_BLOCK_WITH_VIEW_BINDING,
+                    ),
                     srcDirs = listOf("src/main/java"),
                 )
             }
@@ -553,14 +562,8 @@ class DetektAndroidSpec {
                 it.projectFile("app/src/main/java").mkdirs()
                 it.projectFile("app/src/main/res/layout").mkdirs()
                 it.writeProjectFile("app/src/main/AndroidManifest.xml", manifestContent())
-                it.writeProjectFile(
-                    "app/src/main/res/layout/activity_sample.xml",
-                    SAMPLE_ACTIVITY_LAYOUT
-                )
-                it.writeProjectFile(
-                    "app/src/main/java/SampleActivity.kt",
-                    SAMPLE_ACTIVITY_USING_VIEW_BINDING
-                )
+                it.writeProjectFile("app/src/main/res/layout/activity_sample.xml", SAMPLE_ACTIVITY_LAYOUT)
+                it.writeProjectFile("app/src/main/java/SampleActivity.kt", SAMPLE_ACTIVITY_USING_VIEW_BINDING)
             }
 
             @Test
@@ -589,10 +592,13 @@ class DetektAndroidSpec {
 internal fun isAndroidSdkInstalled() =
     System.getenv("ANDROID_SDK_ROOT") != null || System.getenv("ANDROID_HOME") != null
 
+@Language("xml")
 internal fun manifestContent() = """
+    <!--suppress XmlUnusedNamespaceDeclaration -->
     <manifest xmlns:android="http://schemas.android.com/apk/res/android"/>
 """.trimIndent()
 
+@Language("gradle.kts")
 private val APP_PLUGIN_BLOCK = """
     plugins {
         id("com.android.application")
@@ -601,6 +607,7 @@ private val APP_PLUGIN_BLOCK = """
     }
 """.trimIndent()
 
+@Language("gradle.kts")
 private val LIB_PLUGIN_BLOCK = """
     plugins {
         id("com.android.library")
@@ -609,6 +616,7 @@ private val LIB_PLUGIN_BLOCK = """
     }
 """.trimIndent()
 
+@Language("gradle.kts")
 private val KOTLIN_ONLY_LIB_PLUGIN_BLOCK = """
     plugins {
         kotlin("jvm")
@@ -616,35 +624,37 @@ private val KOTLIN_ONLY_LIB_PLUGIN_BLOCK = """
     }
 """.trimIndent()
 
+@Language("gradle.kts")
 private val ANDROID_BLOCK = """
     android {
-       compileSdk = 30
-       namespace = "io.gitlab.arturbosch.detekt.app"
-       compileOptions {
-           sourceCompatibility = JavaVersion.VERSION_1_8
-           targetCompatibility = JavaVersion.VERSION_1_8
-       }
-       kotlinOptions {
-           jvmTarget = "1.8"
-       }
+        compileSdk = 30
+        namespace = "io.gitlab.arturbosch.detekt.app"
+        compileOptions {
+            sourceCompatibility = JavaVersion.VERSION_1_8
+            targetCompatibility = JavaVersion.VERSION_1_8
+        }
+        kotlinOptions {
+            jvmTarget = "1.8"
+        }
     }
 """.trimIndent()
 
+@Language("gradle.kts")
 private val ANDROID_BLOCK_WITH_FLAVOR = """
     android {
         compileSdk = 30
         namespace = "io.gitlab.arturbosch.detekt.app"
         flavorDimensions("age", "name")
         productFlavors {
-           create("harry") {
-             dimension = "name"
-           }
-           create("young") {
-             dimension = "age"
-           }
-           create("old") {
-             dimension = "age"
-           }
+            create("harry") {
+                dimension = "name"
+            }
+            create("young") {
+                dimension = "age"
+            }
+            create("old") {
+                dimension = "age"
+            }
         }
         compileOptions {
             sourceCompatibility = JavaVersion.VERSION_1_8
@@ -656,6 +666,7 @@ private val ANDROID_BLOCK_WITH_FLAVOR = """
     }
 """.trimIndent()
 
+@Language("gradle.kts")
 private val ANDROID_BLOCK_WITH_VIEW_BINDING = """
     android {
         compileSdk = 30
@@ -677,6 +688,7 @@ private val ANDROID_BLOCK_WITH_VIEW_BINDING = """
     }
 """.trimIndent()
 
+@Language("gradle.kts")
 private val DETEKT_REPORTS_BLOCK = """
     tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
         reports {
@@ -685,6 +697,7 @@ private val DETEKT_REPORTS_BLOCK = """
     }
 """.trimIndent()
 
+@Language("xml")
 private val SAMPLE_ACTIVITY_LAYOUT = """
     <?xml version="1.0" encoding="utf-8"?>
     <View
@@ -695,6 +708,7 @@ private val SAMPLE_ACTIVITY_LAYOUT = """
         />
 """.trimIndent()
 
+@Language("kotlin")
 private val SAMPLE_ACTIVITY_USING_VIEW_BINDING = """
     import android.app.Activity
     import android.os.Bundle
@@ -711,7 +725,8 @@ private val SAMPLE_ACTIVITY_USING_VIEW_BINDING = """
             setContentView(binding.root)
         }
     }
-""".trimIndent() + "\n" // new line at end of file rule
+    
+""".trimIndent() // Last line to prevent NewLineAtEndOfFile.
 
 private fun createGradleRunnerAndSetupProject(
     projectLayout: ProjectLayout,

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektMultiplatformSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektMultiplatformSpec.kt
@@ -2,8 +2,10 @@ package io.gitlab.arturbosch.detekt
 
 import io.gitlab.arturbosch.detekt.testkit.DslGradleRunner
 import io.gitlab.arturbosch.detekt.testkit.ProjectLayout
+import io.gitlab.arturbosch.detekt.testkit.joinGradleBlocks
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.BuildResult
+import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.condition.EnabledForJreRange
@@ -24,13 +26,15 @@ class DetektMultiplatformSpec {
                     "shared",
                     1,
                     1,
-                    buildFileContent = """
-                        $KMM_PLUGIN_BLOCK
-                        kotlin {
-                            jvm()
-                        }
-                        $DETEKT_BLOCK
-                    """.trimIndent(),
+                    buildFileContent = joinGradleBlocks(
+                        KMM_PLUGIN_BLOCK,
+                        """
+                            kotlin {
+                                jvm()
+                            }
+                        """.trimIndent(),
+                        DETEKT_BLOCK,
+                    ),
                     srcDirs = listOf("src/commonMain/kotlin", "src/commonTest/kotlin"),
                     baselineFiles = listOf("detekt-baseline.xml", "detekt-baseline-metadataMain.xml")
                 )
@@ -59,13 +63,15 @@ class DetektMultiplatformSpec {
                     "shared",
                     1,
                     1,
-                    buildFileContent = """
-                        $KMM_PLUGIN_BLOCK
-                        kotlin {
-                            jvm()
-                        }
-                        $DETEKT_BLOCK
-                    """.trimIndent(),
+                    buildFileContent = joinGradleBlocks(
+                        KMM_PLUGIN_BLOCK,
+                        """
+                            kotlin {
+                                jvm()
+                            }
+                        """.trimIndent(),
+                        DETEKT_BLOCK,
+                    ),
                     srcDirs = listOf("src/commonMain/kotlin", "src/commonTest/kotlin")
                 )
             }
@@ -93,18 +99,20 @@ class DetektMultiplatformSpec {
                     "shared",
                     1,
                     1,
-                    buildFileContent = """
-                        $KMM_PLUGIN_BLOCK
-                        val targetType = Attribute.of("com.example.target.type", String::class.java)
-                        
-                        kotlin {
-                            jvm("jvmBackend") {
-                                attributes.attribute(targetType, "jvmBackend")
+                    buildFileContent = joinGradleBlocks(
+                        KMM_PLUGIN_BLOCK,
+                        """
+                            val targetType = Attribute.of("com.example.target.type", String::class.java)
+                            
+                            kotlin {
+                                jvm("jvmBackend") {
+                                    attributes.attribute(targetType, "jvmBackend")
+                                }
+                                jvm("jvmEmbedded")
                             }
-                            jvm("jvmEmbedded")
-                        }
-                        $DETEKT_BLOCK
-                    """.trimIndent(),
+                        """.trimIndent(),
+                        DETEKT_BLOCK,
+                    ),
                     srcDirs = listOf(
                         "src/commonMain/kotlin",
                         "src/commonTest/kotlin",
@@ -150,32 +158,34 @@ class DetektMultiplatformSpec {
                     "shared",
                     1,
                     1,
-                    buildFileContent = """
-                        plugins {
-                            kotlin("multiplatform")
-                            id("com.android.library")
-                            id("io.gitlab.arturbosch.detekt")
-                        }
-                        android {
-                            compileSdk = 30
-                            namespace = "io.gitlab.arturbosch.detekt.app"
-                            sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
-                            buildTypes {
-                                release {
-                                }
-                                debug {
-                                }
+                    buildFileContent = joinGradleBlocks(
+                        """
+                            plugins {
+                                kotlin("multiplatform")
+                                id("com.android.library")
+                                id("io.gitlab.arturbosch.detekt")
                             }
-                        }
-                        kotlin {
                             android {
-                                compilations.all {
-                                    kotlinOptions.jvmTarget = "1.8"
+                                compileSdk = 30
+                                namespace = "io.gitlab.arturbosch.detekt.app"
+                                sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
+                                buildTypes {
+                                    release {
+                                    }
+                                    debug {
+                                    }
                                 }
                             }
-                        }
-                        $DETEKT_BLOCK
-                    """.trimIndent(),
+                            kotlin {
+                                android {
+                                    compilations.all {
+                                        kotlinOptions.jvmTarget = "1.8"
+                                    }
+                                }
+                            }
+                        """.trimIndent(),
+                        DETEKT_BLOCK,
+                    ),
                     srcDirs = listOf(
                         "src/debug/kotlin",
                         "src/release/kotlin",
@@ -226,15 +236,17 @@ class DetektMultiplatformSpec {
                     "shared",
                     1,
                     1,
-                    buildFileContent = """
-                        $KMM_PLUGIN_BLOCK
-                        kotlin {
-                            js(IR) {
-                                browser()
+                    buildFileContent = joinGradleBlocks(
+                        KMM_PLUGIN_BLOCK,
+                        """
+                            kotlin {
+                                js(IR) {
+                                    browser()
+                                }
                             }
-                        }
-                        $DETEKT_BLOCK
-                    """.trimIndent(),
+                        """.trimIndent(),
+                        DETEKT_BLOCK,
+                    ),
                     srcDirs = listOf(
                         "src/commonMain/kotlin",
                         "src/commonTest/kotlin",
@@ -277,13 +289,15 @@ class DetektMultiplatformSpec {
                     "shared",
                     1,
                     1,
-                    buildFileContent = """
-                        $KMM_PLUGIN_BLOCK
-                        kotlin {
-                            ios()
-                        }
-                        $DETEKT_BLOCK
-                    """.trimIndent(),
+                    buildFileContent = joinGradleBlocks(
+                        KMM_PLUGIN_BLOCK,
+                        """
+                            kotlin {
+                                ios()
+                            }
+                        """.trimIndent(),
+                        DETEKT_BLOCK,
+                    ),
                     srcDirs = listOf(
                         "src/commonMain/kotlin",
                         "src/commonTest/kotlin",
@@ -372,6 +386,7 @@ private fun assertDetektWithClasspath(buildResult: BuildResult) {
     assertThat(buildResult.output).contains("--classpath")
 }
 
+@Language("gradle.kts")
 private val KMM_PLUGIN_BLOCK = """
     plugins {
         kotlin("multiplatform")
@@ -379,6 +394,7 @@ private val KMM_PLUGIN_BLOCK = """
     }
 """.trimIndent()
 
+@Language("gradle.kts")
 private val DETEKT_BLOCK = """
     tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
         reports.txt.enabled = false

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektReportMergeSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektReportMergeSpec.kt
@@ -3,6 +3,7 @@ package io.gitlab.arturbosch.detekt
 import io.gitlab.arturbosch.detekt.testkit.DslGradleRunner
 import io.gitlab.arturbosch.detekt.testkit.DslTestBuilder
 import io.gitlab.arturbosch.detekt.testkit.ProjectLayout
+import io.gitlab.arturbosch.detekt.testkit.reIndent
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -11,34 +12,32 @@ class DetektReportMergeSpec {
     @Suppress("LongMethod")
     fun `Sarif merge is configured correctly for multi module project`() {
         val builder = DslTestBuilder.kotlin()
-        val buildFileContent =
-            """
-                |${builder.gradlePlugins}
-                |
-                |allprojects {
-                |  ${builder.gradleRepositories}
-                |}
-                |
-                |val sarifReportMerge by tasks.registering(io.gitlab.arturbosch.detekt.report.ReportMergeTask::class) {
-                |  output.set(project.layout.buildDirectory.file("reports/detekt/merge.sarif"))
-                |}
-                |
-                |subprojects {
-                |  ${builder.gradleSubprojectsApplyPlugins}
-                |
-                |  detekt {
-                |    reports.sarif.enabled = true
-                |  }
-                |
-                |  tasks.withType(io.gitlab.arturbosch.detekt.Detekt::class).configureEach {
-                |     finalizedBy(sarifReportMerge)
-                |  }
-                |  sarifReportMerge {
-                |    input.from(tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().map { it.sarifReportFile })
-                |  }
-                |}
-                |
-            """.trimMargin()
+        val buildFileContent = """
+            ${builder.gradlePlugins.reIndent()}
+            
+            allprojects {
+                ${builder.gradleRepositories.reIndent(1)}
+            }
+            
+            val sarifReportMerge by tasks.registering(io.gitlab.arturbosch.detekt.report.ReportMergeTask::class) {
+                output.set(project.layout.buildDirectory.file("reports/detekt/merge.sarif"))
+            }
+            
+            subprojects {
+                ${builder.gradleSubprojectsApplyPlugins.reIndent(1)}
+            
+                detekt {
+                    reports.sarif.enabled = true
+                }
+            
+                tasks.withType(io.gitlab.arturbosch.detekt.Detekt::class).configureEach {
+                    finalizedBy(sarifReportMerge)
+                }
+                sarifReportMerge {
+                  input.from(tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().map { it.sarifReportFile })
+                }
+            }
+        """.trimIndent()
 
         val projectLayout = ProjectLayout(numberOfSourceFilesInRootPerSourceDir = 0).apply {
             addSubmodule(
@@ -84,32 +83,31 @@ class DetektReportMergeSpec {
     fun `XML merge is configured correctly for multi module project`() {
         val builder = DslTestBuilder.kotlin()
         val buildFileContent = """
-            |${builder.gradlePlugins}
-            |
-            |allprojects {
-            |  ${builder.gradleRepositories}
-            |}
-            |
-            |val xmlReportMerge by tasks.registering(io.gitlab.arturbosch.detekt.report.ReportMergeTask::class) {
-            |  output.set(project.layout.buildDirectory.file("reports/detekt/merge.xml"))
-            |}
-            |
-            |subprojects {
-            |  ${builder.gradleSubprojectsApplyPlugins}
-            |
-            |  detekt {
-            |    reports.xml.enabled = true
-            |  }
-            |
-            |  tasks.withType(io.gitlab.arturbosch.detekt.Detekt::class).configureEach {
-            |     finalizedBy(xmlReportMerge)
-            |  }
-            |  xmlReportMerge {
-            |    input.from(tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().map { it.xmlReportFile })
-            |  }
-            |}
-            |
-        """.trimMargin()
+            ${builder.gradlePlugins.reIndent()}
+            
+            allprojects {
+                ${builder.gradleRepositories.reIndent(1)}
+            }
+            
+            val xmlReportMerge by tasks.registering(io.gitlab.arturbosch.detekt.report.ReportMergeTask::class) {
+                output.set(project.layout.buildDirectory.file("reports/detekt/merge.xml"))
+            }
+            
+            subprojects {
+                ${builder.gradleSubprojectsApplyPlugins.reIndent(1)}
+            
+                detekt {
+                    reports.xml.enabled = true
+                }
+            
+                tasks.withType(io.gitlab.arturbosch.detekt.Detekt::class).configureEach {
+                    finalizedBy(xmlReportMerge)
+                }
+                xmlReportMerge {
+                    input.from(tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().map { it.xmlReportFile })
+                }
+            }
+        """.trimIndent()
 
         val projectLayout = ProjectLayout(numberOfSourceFilesInRootPerSourceDir = 0).apply {
             addSubmodule(
@@ -143,7 +141,7 @@ class DetektReportMergeSpec {
             assertThat(projectFile("build/reports/detekt/detekt.xml")).doesNotExist()
             assertThat(projectFile("build/reports/detekt/merge.xml")).exists()
             assertThat(projectFile("build/reports/detekt/merge.xml").readText())
-                .contains("<error column=\"30\" line=\"4\"")
+                .contains("<error column=\"31\" line=\"4\"")
             projectLayout.submodules.forEach {
                 assertThat(projectFile("${it.name}/build/reports/detekt/detekt.xml")).exists()
             }

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektTaskDslSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektTaskDslSpec.kt
@@ -64,12 +64,11 @@ class DetektTaskDslSpec {
 
     @Nested
     inner class `without multiple detekt configs` {
-        @Suppress("TrimMultilineRawString")
         private val config = """
-                |detekt {
-                |    config.setFrom(files("firstConfig.yml", "secondConfig.yml"))
-                |}
-            """
+            detekt {
+                config.setFrom(files("firstConfig.yml", "secondConfig.yml"))
+            }
+        """.trimIndent()
         private val builder = kotlin().dryRun()
         private val gradleRunner = builder.withDetektConfig(config).build()
         private val result = gradleRunner.runDetektTask()
@@ -88,12 +87,11 @@ class DetektTaskDslSpec {
     inner class `with custom baseline file` {
         val baselineFilename = "custom-baseline.xml"
 
-        @Suppress("TrimMultilineRawString")
         private val config = """
-                |detekt {
-                |   baseline = file("$baselineFilename")
-                |}
-            """
+            detekt {
+                baseline = file("$baselineFilename")
+            }
+        """.trimIndent()
         private val builder = kotlin().dryRun()
         private val gradleRunner = builder
             .withDetektConfig(config)
@@ -113,12 +111,11 @@ class DetektTaskDslSpec {
     inner class `with custom baseline file that doesn't exist` {
         val baselineFilename = "detekt-baseline-no-exist.xml"
 
-        @Suppress("TrimMultilineRawString")
         private val config = """
-                |detekt {
-                |   baseline = file("$baselineFilename")
-                |}
-            """
+            detekt {
+                baseline = file("$baselineFilename")
+            }
+        """.trimIndent()
         private val builder = kotlin().dryRun()
         private val gradleRunner = builder
             .withDetektConfig(config)
@@ -138,12 +135,11 @@ class DetektTaskDslSpec {
         val customSrc2 = "src/main/kotlin"
         private val builder = kotlin().dryRun()
 
-        @Suppress("TrimMultilineRawString")
         private val config = """
-                |detekt {
-                |    input = files("$customSrc1", "$customSrc2", "folder_that_does_not_exist")
-                |}
-            """
+            detekt {
+                input = files("$customSrc1", "$customSrc2", "folder_that_does_not_exist")
+            }
+        """.trimIndent()
 
         val projectLayout = ProjectLayout(1, srcDirs = listOf(customSrc1, customSrc2))
         private val gradleRunner = builder
@@ -172,12 +168,11 @@ class DetektTaskDslSpec {
         val customSrc2 = "src/main/kotlin"
         private val builder = kotlin().dryRun()
 
-        @Suppress("TrimMultilineRawString")
         private val config = """
-                |detekt {
-                |    source = files("$customSrc1", "$customSrc2", "folder_that_does_not_exist")
-                |}
-            """
+            detekt {
+                source = files("$customSrc1", "$customSrc2", "folder_that_does_not_exist")
+            }
+        """.trimIndent()
 
         private val projectLayout = ProjectLayout(1, srcDirs = listOf(customSrc1, customSrc2))
         private val gradleRunner = builder
@@ -202,12 +197,11 @@ class DetektTaskDslSpec {
 
     @Nested
     inner class `with custom reports dir` {
-        @Suppress("TrimMultilineRawString")
         private val config = """
-                |detekt {
-                |    reportsDir = file("build/detekt-reports")
-                |}
-            """
+            detekt {
+                reportsDir = file("build/detekt-reports")
+            }
+        """.trimIndent()
         private val builder = kotlin().dryRun()
         private val gradleRunner = builder.withDetektConfig(config).build()
         private val result = gradleRunner.runDetektTask()
@@ -239,18 +233,17 @@ class DetektTaskDslSpec {
 
     @Nested
     inner class `with custom reports dir and custom report filename` {
-        @Suppress("TrimMultilineRawString")
         private val config = """
-                |detekt {
-                |    reportsDir = file("build/detekt-reports")
-                |}
-                |
-                |tasks.detekt {
-                |    reports {
-                |        xml.destination = file("build/xml-reports/custom-detekt.xml")
-                |    }
-                |}
-            """
+            detekt {
+                reportsDir = file("build/detekt-reports")
+            }
+            
+            tasks.detekt {
+                reports {
+                    xml.destination = file("build/xml-reports/custom-detekt.xml")
+                }
+            }
+        """.trimIndent()
         private val builder = kotlin().dryRun()
         private val gradleRunner = builder.withDetektConfig(config).build()
         private val result = gradleRunner.runDetektTask()
@@ -276,26 +269,25 @@ class DetektTaskDslSpec {
 
     @Nested
     inner class `with disabled reports` {
-        @Suppress("TrimMultilineRawString")
         private val config = """
-                |tasks.detekt {
-                |    reports {
-                |        xml.enabled = false
-                |        html {
-                |            enabled = false
-                |        }
-                |        txt {
-                |            enabled = false
-                |        }
-                |        sarif {
-                |            enabled = false
-                |        }
-                |        md {
-                |            enabled = false
-                |        }
-                |    }
-                |}
-            """
+            tasks.detekt {
+                reports {
+                    xml.enabled = false
+                    html {
+                        enabled = false
+                    }
+                    txt {
+                        enabled = false
+                    }
+                    sarif {
+                        enabled = false
+                    }
+                    md {
+                        enabled = false
+                    }
+                }
+            }
+        """.trimIndent()
         private val builder = kotlin().dryRun()
         private val gradleRunner = builder.withDetektConfig(config).build()
         private val result = gradleRunner.runDetektTask()
@@ -310,21 +302,20 @@ class DetektTaskDslSpec {
     inner class `with custom report types` {
         @Nested
         inner class `configured correctly` {
-            @Suppress("TrimMultilineRawString")
             private val config = """
-                    |tasks.detekt {
-                    |    reports {
-                    |        custom {
-                    |           reportId = "customXml"
-                    |           destination = file("build/reports/custom.xml")
-                    |       }
-                    |        custom {
-                    |           reportId = "customJson"
-                    |           destination = file("build/reports/custom.json")
-                    |       }
-                    |    }
-                    |}
-                """
+                tasks.detekt {
+                    reports {
+                        custom {
+                           reportId = "customXml"
+                           destination = file("build/reports/custom.xml")
+                       }
+                        custom {
+                           reportId = "customJson"
+                           destination = file("build/reports/custom.json")
+                       }
+                    }
+                }
+            """.trimIndent()
             private val builder = kotlin().dryRun()
             private val gradleRunner = builder.withDetektConfig(config).build()
             private val result = gradleRunner.runDetektTask()
@@ -344,16 +335,15 @@ class DetektTaskDslSpec {
 
         @Nested
         inner class `report id is missing` {
-            @Suppress("TrimMultilineRawString")
             private val config = """
-                    |tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
-                    |    reports {
-                    |        custom {
-                    |           destination = file("build/reports/custom.xml")
-                    |       }
-                    |    }
-                    |}
-                """
+                tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
+                    reports {
+                        custom {
+                           destination = file("build/reports/custom.xml")
+                       }
+                    }
+                }
+            """.trimIndent()
             private val builder = kotlin().dryRun()
             private val gradleRunner = builder.withDetektConfig(config).build()
 
@@ -368,16 +358,15 @@ class DetektTaskDslSpec {
 
         @Nested
         inner class `report filename is missing` {
-            @Suppress("TrimMultilineRawString")
             private val config = """
-                    |tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
-                    |    reports {
-                    |        custom {
-                    |           reportId = "customJson"
-                    |       }
-                    |    }
-                    |}
-                """
+                tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
+                    reports {
+                        custom {
+                           reportId = "customJson"
+                       }
+                    }
+                }
+            """.trimIndent()
             private val builder = kotlin().dryRun()
             private val gradleRunner = builder.withDetektConfig(config).build()
 
@@ -394,17 +383,16 @@ class DetektTaskDslSpec {
         inner class `report filename is a directory` {
             private val aDirectory = "\${rootDir}/src"
 
-            @Suppress("TrimMultilineRawString")
             private val config = """
-                    |tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
-                    |    reports {
-                    |        custom {
-                    |           reportId = "foo"
-                    |           destination = file("$aDirectory")
-                    |       }
-                    |    }
-                    |}
-                """
+                tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
+                    reports {
+                        custom {
+                           reportId = "foo"
+                           destination = file("$aDirectory")
+                       }
+                    }
+                }
+            """.trimIndent()
             private val builder = kotlin().dryRun()
             private val gradleRunner = builder.withDetektConfig(config).build()
 
@@ -423,17 +411,16 @@ class DetektTaskDslSpec {
             @ParameterizedTest
             @EnumSource(DetektReportType::class)
             fun `fails the build`(wellKnownType: DetektReportType) {
-                @Suppress("TrimMultilineRawString")
                 val config = """
-                    |tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
-                    |    reports {
-                    |        custom {
-                    |            reportId = "${wellKnownType.reportId}"
-                    |            destination = file("build/reports/custom.xml")
-                    |        }
-                    |    }
-                    |}
-                """
+                    tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
+                        reports {
+                            custom {
+                                reportId = "${wellKnownType.reportId}"
+                                destination = file("build/reports/custom.xml")
+                            }
+                        }
+                    }
+                """.trimIndent()
 
                 val gradleRunner = builder.withDetektConfig(config).build()
                 gradleRunner.runDetektTaskAndExpectFailure { result ->
@@ -448,18 +435,17 @@ class DetektTaskDslSpec {
     inner class `with flags` {
         private val builder = kotlin().dryRun()
 
-        @Suppress("TrimMultilineRawString")
         private val config = """
-            |detekt {
-            |    debug = true
-            |    parallel = true
-            |    disableDefaultRuleSets = true
-            |    allRules = true
-            |    autoCorrect = true
-            |    buildUponDefaultConfig = true
-            |    ignoreFailures = true
-            |}
-        """
+            detekt {
+                debug = true
+                parallel = true
+                disableDefaultRuleSets = true
+                allRules = true
+                autoCorrect = true
+                buildUponDefaultConfig = true
+                ignoreFailures = true
+            }
+        """.trimIndent()
 
         private val gradleRunner = builder.withDetektConfig(config).build()
         private val result = gradleRunner.runDetektTask()
@@ -514,12 +500,11 @@ class DetektTaskDslSpec {
 
     @Nested
     inner class `with an additional plugin` {
-        @Suppress("TrimMultilineRawString")
         private val config = """
-                |dependencies {
-                |   detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:$defaultDetektVersion")
-                |}
-            """
+            dependencies {
+               detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:$defaultDetektVersion")
+            }
+        """.trimIndent()
         private val builder = kotlin().dryRun()
         private val gradleRunner = builder.withDetektConfig(config).build()
         private val result = gradleRunner.runTasks("dependencies", "--configuration", "detektPlugins")
@@ -539,12 +524,11 @@ class DetektTaskDslSpec {
     inner class `with a custom tool version` {
         val customVersion = "1.0.0.RC8"
 
-        @Suppress("TrimMultilineRawString")
         private val config = """
-                |detekt {
-                |    toolVersion = "$customVersion"
-                |}
-            """
+            detekt {
+                toolVersion = "$customVersion"
+            }
+        """.trimIndent()
         private val builder = kotlin().dryRun()
         private val gradleRunner = builder.withDetektConfig(config).build()
         private val result = gradleRunner.runTasks("dependencies", "--offline", "--configuration", "detekt")
@@ -564,37 +548,36 @@ class DetektTaskDslSpec {
     inner class `and creating a custom task` {
         private val builder = kotlin().dryRun()
 
-        @Suppress("TrimMultilineRawString")
         private val config = """
-                |task<io.gitlab.arturbosch.detekt.Detekt>("myDetekt") {
-                |    description = "Runs a custom detekt build."
-                |
-                |    setSource(files("${"$"}projectDir"))
-                |    setIncludes(listOf("**/*.kt", "**/*.kts"))
-                |    setExcludes(listOf("build/"))
-                |    config.setFrom(files("config.yml"))
-                |    debug = true
-                |    parallel = true
-                |    disableDefaultRuleSets = true
-                |    buildUponDefaultConfig = true
-                |    allRules = false
-                |    ignoreFailures = false
-                |    autoCorrect = false
-                |    reports {
-                |        xml {
-                |            enabled = true
-                |            destination = file("build/reports/mydetekt.xml")
-                |        }
-                |        html.destination = file("build/reports/mydetekt.html")
-                |        txt.destination = file("build/reports/mydetekt.txt")
-                |        sarif {
-                |            enabled = true
-                |            destination = file("build/reports/mydetekt.sarif")
-                |        }
-                |    }
-                |    basePath = projectDir.toString()
-                |}
-            """
+            task<io.gitlab.arturbosch.detekt.Detekt>("myDetekt") {
+                description = "Runs a custom detekt build."
+            
+                setSource(files("${"$"}projectDir"))
+                setIncludes(listOf("**/*.kt", "**/*.kts"))
+                setExcludes(listOf("build/"))
+                config.setFrom(files("config.yml"))
+                debug = true
+                parallel = true
+                disableDefaultRuleSets = true
+                buildUponDefaultConfig = true
+                allRules = false
+                ignoreFailures = false
+                autoCorrect = false
+                reports {
+                    xml {
+                        enabled = true
+                        destination = file("build/reports/mydetekt.xml")
+                    }
+                    html.destination = file("build/reports/mydetekt.html")
+                    txt.destination = file("build/reports/mydetekt.txt")
+                    sarif {
+                        enabled = true
+                        destination = file("build/reports/mydetekt.sarif")
+                    }
+                }
+                basePath = projectDir.toString()
+            }
+        """.trimIndent()
 
         private val gradleRunner = builder
             .withDetektConfig(config)

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektTaskGroovyDslSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektTaskGroovyDslSpec.kt
@@ -9,26 +9,25 @@ class DetektTaskGroovyDslSpec {
 
     @Test
     fun `detekt extension can be configured without errors`() {
-        @Suppress("TrimMultilineRawString")
         val config = """
-            |detekt {
-            |    toolVersion = "1.0.0.RC8"
-            |    ignoreFailures = true
-            |    source = files("src/main/kotlin")
-            |    baseline = file("path/to/baseline.xml")
-            |    basePath = projectDir
-            |    config = files("config/detekt/detekt.yml")
-            |    debug = true
-            |    parallel = true
-            |    allRules = true
-            |    buildUponDefaultConfig = true
-            |    disableDefaultRuleSets = true
-            |    autoCorrect = true
-            |    ignoredVariants = ["variantA", "variantB"]
-            |    ignoredBuildTypes = ["buildTypeA", "buildTypeB"]
-            |    ignoredFlavors = ["flavorA", "flavorB"]
-            |}
-        """
+            detekt {
+                toolVersion = "1.0.0.RC8"
+                ignoreFailures = true
+                source = files("src/main/kotlin")
+                baseline = file("path/to/baseline.xml")
+                basePath = projectDir
+                config = files("config/detekt/detekt.yml")
+                debug = true
+                parallel = true
+                allRules = true
+                buildUponDefaultConfig = true
+                disableDefaultRuleSets = true
+                autoCorrect = true
+                ignoredVariants = ["variantA", "variantB"]
+                ignoredBuildTypes = ["buildTypeA", "buildTypeB"]
+                ignoredFlavors = ["flavorA", "flavorB"]
+            }
+        """.trimIndent()
         val groovyBuilder = DslTestBuilder.groovy()
         val gradleRunner = groovyBuilder.withDetektConfig(config).build()
         val result = gradleRunner.runTasks(":help")
@@ -37,45 +36,44 @@ class DetektTaskGroovyDslSpec {
 
     @Test
     fun `detekt task can be fully configured without errors`() {
-        @Suppress("TrimMultilineRawString")
         val config = """
-            |tasks.create("customDetektTask", io.gitlab.arturbosch.detekt.Detekt) {
-            |    source = files("${"$"}projectDir")
-            |    includes = ["**/*.kt", "**/*.kts"]
-            |    excludes = ["build/"]
-            |    ignoreFailures = false
-            |    detektClasspath.setFrom(files("config.yml"))
-            |    pluginClasspath.setFrom(files("config.yml"))
-            |    baseline = file("config.yml")
-            |    config.setFrom(files("config.yml"))
-            |    classpath.setFrom(files("config.yml"))
-            |    languageVersion = "1.6"
-            |    jvmTarget = "1.8"
-            |    jdkHome = file("path/to/jdk")
-            |    debug = true
-            |    parallel = true
-            |    disableDefaultRuleSets = true
-            |    buildUponDefaultConfig = true
-            |    allRules = false
-            |    autoCorrect = false
-            |    basePath = projectDir
-            |    reports {
-            |        xml {
-            |            enabled = true
-            |            destination = file("build/reports/mydetekt.xml")
-            |        }
-            |        html.enabled = true
-            |        html.destination = file("build/reports/mydetekt.html")
-            |        txt.enabled = true
-            |        txt.destination = file("build/reports/mydetekt.txt")
-            |        sarif {
-            |            enabled = true
-            |            destination = file("build/reports/mydetekt.sarif")
-            |        }
-            |    }
-            |    reportsDir = file("config.yml")
-            |}
-        """
+            tasks.create("customDetektTask", io.gitlab.arturbosch.detekt.Detekt) {
+                source = files("${"$"}projectDir")
+                includes = ["**/*.kt", "**/*.kts"]
+                excludes = ["build/"]
+                ignoreFailures = false
+                detektClasspath.setFrom(files("config.yml"))
+                pluginClasspath.setFrom(files("config.yml"))
+                baseline = file("config.yml")
+                config.setFrom(files("config.yml"))
+                classpath.setFrom(files("config.yml"))
+                languageVersion = "1.6"
+                jvmTarget = "1.8"
+                jdkHome = file("path/to/jdk")
+                debug = true
+                parallel = true
+                disableDefaultRuleSets = true
+                buildUponDefaultConfig = true
+                allRules = false
+                autoCorrect = false
+                basePath = projectDir
+                reports {
+                    xml {
+                        enabled = true
+                        destination = file("build/reports/mydetekt.xml")
+                    }
+                    html.enabled = true
+                    html.destination = file("build/reports/mydetekt.html")
+                    txt.enabled = true
+                    txt.destination = file("build/reports/mydetekt.txt")
+                    sarif {
+                        enabled = true
+                        destination = file("build/reports/mydetekt.sarif")
+                    }
+                }
+                reportsDir = file("config.yml")
+            }
+        """.trimIndent()
         val groovyBuilder = DslTestBuilder.groovy()
         val gradleRunner = groovyBuilder.withDetektConfig(config).build()
         val result = gradleRunner.runTasks(":help")
@@ -84,29 +82,28 @@ class DetektTaskGroovyDslSpec {
 
     @Test
     fun `detekt create baseline task can be configured without errors`() {
-        @Suppress("TrimMultilineRawString")
         val config = """
-            |tasks.create("customDetektCreateBaselineTask", io.gitlab.arturbosch.detekt.DetektCreateBaselineTask) {
-            |    source = files("${"$"}projectDir")
-            |    includes = ["**/*.kt", "**/*.kts"]
-            |    excludes = ["build/"]
-            |    ignoreFailures = false
-            |    detektClasspath.setFrom(files("config.yml"))
-            |    pluginClasspath.setFrom(files("config.yml"))
-            |    baseline = file("config.yml")
-            |    config.setFrom(files("config.yml"))
-            |    classpath.setFrom(files("config.yml"))
-            |    jvmTarget = "1.8"
-            |    jdkHome = file("path/to/jdk")
-            |    debug = true
-            |    parallel = true
-            |    disableDefaultRuleSets = true
-            |    buildUponDefaultConfig = true
-            |    allRules = false
-            |    autoCorrect = false
-            |    basePath = projectDir
-            |}
-        """
+            tasks.create("customDetektCreateBaselineTask", io.gitlab.arturbosch.detekt.DetektCreateBaselineTask) {
+                source = files("${"$"}projectDir")
+                includes = ["**/*.kt", "**/*.kts"]
+                excludes = ["build/"]
+                ignoreFailures = false
+                detektClasspath.setFrom(files("config.yml"))
+                pluginClasspath.setFrom(files("config.yml"))
+                baseline = file("config.yml")
+                config.setFrom(files("config.yml"))
+                classpath.setFrom(files("config.yml"))
+                jvmTarget = "1.8"
+                jdkHome = file("path/to/jdk")
+                debug = true
+                parallel = true
+                disableDefaultRuleSets = true
+                buildUponDefaultConfig = true
+                allRules = false
+                autoCorrect = false
+                basePath = projectDir
+            }
+        """.trimIndent()
         val groovyBuilder = DslTestBuilder.groovy()
         val gradleRunner = groovyBuilder.withDetektConfig(config).build()
         val result = gradleRunner.runTasks(":help")
@@ -115,13 +112,12 @@ class DetektTaskGroovyDslSpec {
 
     @Test
     fun `detekt generate config task can be configured without errors`() {
-        @Suppress("TrimMultilineRawString")
         val config = """
-            |tasks.create("customDetektGenerateConfigTask", io.gitlab.arturbosch.detekt.DetektGenerateConfigTask) {
-            |    detektClasspath.setFrom(files("config.yml"))
-            |    config.setFrom(files("config.yml"))
-            |}
-        """
+            tasks.create("customDetektGenerateConfigTask", io.gitlab.arturbosch.detekt.DetektGenerateConfigTask) {
+                detektClasspath.setFrom(files("config.yml"))
+                config.setFrom(files("config.yml"))
+            }
+        """.trimIndent()
         val groovyBuilder = DslTestBuilder.groovy()
         val gradleRunner = groovyBuilder.withDetektConfig(config).build()
         val result = gradleRunner.runTasks(":help")

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektTaskMultiModuleSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektTaskMultiModuleSpec.kt
@@ -3,6 +3,7 @@ package io.gitlab.arturbosch.detekt
 import io.gitlab.arturbosch.detekt.testkit.DslGradleRunner
 import io.gitlab.arturbosch.detekt.testkit.DslTestBuilder
 import io.gitlab.arturbosch.detekt.testkit.ProjectLayout
+import io.gitlab.arturbosch.detekt.testkit.reIndent
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.TaskOutcome
 import org.junit.jupiter.api.DisplayName
@@ -24,16 +25,14 @@ class DetektTaskMultiModuleSpec {
         val builder = DslTestBuilder.kotlin()
 
         val mainBuildFileContent: String = """
-            |${builder.gradlePlugins}
-            |
-            |allprojects {
-            |   ${builder.gradleRepositories}
-            |}
-            |subprojects {
-            |   ${builder.gradleSubprojectsApplyPlugins}
-            |}
-            |
-        """.trimMargin()
+            ${builder.gradlePlugins.reIndent()}
+            allprojects {
+                ${builder.gradleRepositories.reIndent(1)}
+            }
+            subprojects {
+                ${builder.gradleSubprojectsApplyPlugins.reIndent(1)}
+            }
+        """.trimIndent()
 
         val gradleRunner = DslGradleRunner(projectLayout, builder.gradleBuildName, mainBuildFileContent)
 
@@ -69,14 +68,13 @@ class DetektTaskMultiModuleSpec {
         val builder = DslTestBuilder.kotlin()
 
         val mainBuildFileContent: String = """
-            |${builder.gradlePlugins}
-            |
-            |allprojects {
-            |   ${builder.gradleRepositories}
-            |   ${builder.gradleSubprojectsApplyPlugins}
-            |}
-            |
-        """.trimMargin()
+            ${builder.gradlePlugins.reIndent()}
+            
+            allprojects {
+                ${builder.gradleRepositories.reIndent(1)}
+                ${builder.gradleSubprojectsApplyPlugins.reIndent(1)}
+            }
+        """.trimIndent()
 
         val gradleRunner = DslGradleRunner(projectLayout, builder.gradleBuildName, mainBuildFileContent)
 
@@ -108,18 +106,17 @@ class DetektTaskMultiModuleSpec {
         val builder = DslTestBuilder.kotlin()
 
         val mainBuildFileContent: String = """
-            |${builder.gradlePlugins}
-            |
-            |allprojects {
-            |   ${builder.gradleRepositories}
-            |   ${builder.gradleSubprojectsApplyPlugins}
-            |
-            |   detekt {
-            |       reportsDir = file("build/detekt-reports")
-            |   }
-            |}
-            |
-        """.trimMargin()
+            ${builder.gradlePlugins.reIndent()}
+            
+            allprojects {
+                ${builder.gradleRepositories.reIndent(1)}
+                ${builder.gradleSubprojectsApplyPlugins.reIndent(1)}
+            
+                detekt {
+                    reportsDir = file("build/detekt-reports")
+                }
+            }
+        """.trimIndent()
 
         val gradleRunner = DslGradleRunner(projectLayout, builder.gradleBuildName, mainBuildFileContent)
         gradleRunner.setupProject()
@@ -144,11 +141,10 @@ class DetektTaskMultiModuleSpec {
     @DisplayName("it allows changing defaults in allprojects block that can be overwritten in subprojects")
     fun allowsChangingDefaultsInAllProjectsThatAreOverwrittenInSubprojects() {
         val child2DetektConfig = """
-            |detekt {
-            |   reportsDir = file("build/custom")
-            |}
-            |
-        """.trimMargin()
+            detekt {
+               reportsDir = file("build/custom")
+            }
+        """.trimIndent()
 
         val projectLayout = ProjectLayout(1).apply {
             addSubmodule("child1", 2)
@@ -158,18 +154,17 @@ class DetektTaskMultiModuleSpec {
         val builder = DslTestBuilder.kotlin()
 
         val mainBuildFileContent: String = """
-            |${builder.gradlePlugins}
-            |
-            |allprojects {
-            |   ${builder.gradleRepositories}
-            |   ${builder.gradleSubprojectsApplyPlugins}
-            |
-            |   detekt {
-            |       reportsDir = file("build/detekt-reports")
-            |   }
-            |}
-            |
-        """.trimMargin()
+            ${builder.gradlePlugins.reIndent()}
+            
+            allprojects {
+                ${builder.gradleRepositories.reIndent(1)}
+                ${builder.gradleSubprojectsApplyPlugins.reIndent(1)}
+            
+                detekt {
+                    reportsDir = file("build/detekt-reports")
+                }
+            }
+        """.trimIndent()
 
         val gradleRunner = DslGradleRunner(projectLayout, builder.gradleBuildName, mainBuildFileContent)
 
@@ -200,14 +195,14 @@ class DetektTaskMultiModuleSpec {
         }
 
         val detektConfig: String = """
-            |detekt {
-            |    source = files(
-            |       "${"$"}projectDir/src",
-            |       "${"$"}projectDir/child1/src",
-            |       "${"$"}projectDir/child2/src"
-            |    )
-            |}
-        """.trimMargin()
+            detekt {
+                source = files(
+                   "${"$"}projectDir/src",
+                   "${"$"}projectDir/child1/src",
+                   "${"$"}projectDir/child2/src"
+                )
+            }
+        """.trimIndent()
         val gradleRunner = DslTestBuilder.kotlin()
             .withProjectLayout(projectLayout)
             .withDetektConfig(detektConfig)

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektTaskSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektTaskSpec.kt
@@ -15,12 +15,11 @@ class DetektTaskSpec {
 
     @Test
     fun `build succeeds with more issues than threshold if ignoreFailures = true`() {
-        @Suppress("TrimMultilineRawString")
         val config = """
-            |detekt {
-            |   ignoreFailures = true
-            |}
-        """
+            detekt {
+                ignoreFailures = true
+            }
+        """.trimIndent()
 
         val gradleRunner = DslTestBuilder.kotlin()
             .withProjectLayout(projectLayoutWithTooManyIssues)
@@ -34,12 +33,11 @@ class DetektTaskSpec {
 
     @Test
     fun `build fails with more issues than threshold successfully if ignoreFailures = false`() {
-        @Suppress("TrimMultilineRawString")
         val config = """
-            |detekt {
-            |   ignoreFailures = false
-            |}
-        """
+            detekt {
+                ignoreFailures = false
+            }
+        """.trimIndent()
 
         val gradleRunner = DslTestBuilder.kotlin()
             .withProjectLayout(projectLayoutWithTooManyIssues)

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/GenerateConfigTaskSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/GenerateConfigTaskSpec.kt
@@ -22,12 +22,11 @@ class GenerateConfigTaskSpec {
     fun `chooses the last config file when configured`() {
         val builder = DslTestBuilder.kotlin()
         val gradleRunner = builder.withDetektConfig(
-            @Suppress("TrimMultilineRawString")
             """
-                |detekt {
-                |   config = files("config/detekt/detekt.yml", "config/other/detekt.yml")
-                |}
-            """
+                detekt {
+                   config = files("config/detekt/detekt.yml", "config/other/detekt.yml")
+                }
+            """.trimIndent()
         ).withConfigFile("config/detekt/detekt.yml").build()
         gradleRunner.writeProjectFile("config/other/detekt.yml", content = "")
 
@@ -41,17 +40,16 @@ class GenerateConfigTaskSpec {
     fun `setting configFile property overrides extension & task configs`() {
         val builder = DslTestBuilder.kotlin()
         val gradleRunner = builder.withDetektConfig(
-            @Suppress("TrimMultilineRawString")
             """
-                |detekt {
-                |   config = files("config/wrongpath1/detekt.yml", "config/wrongpath2/detekt.yml")
-                |}
-                |
-                |tasks.detektGenerateConfig {
-                |   config.setFrom("config/wrongpath3/detekt.yml")
-                |   configFile.set(file("config/correctpath/detekt.yml"))
-                |}
-            """
+                detekt {
+                   config = files("config/wrongpath1/detekt.yml", "config/wrongpath2/detekt.yml")
+                }
+                
+                tasks.detektGenerateConfig {
+                   config.setFrom("config/wrongpath3/detekt.yml")
+                   configFile.set(file("config/correctpath/detekt.yml"))
+                }
+            """.trimIndent()
         ).withConfigFile("config/detekt/detekt.yml").build()
         gradleRunner.writeProjectFile("config/other/detekt.yml", content = "")
 

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/PluginTaskBehaviorSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/PluginTaskBehaviorSpec.kt
@@ -4,6 +4,7 @@ import io.gitlab.arturbosch.detekt.testkit.DslGradleRunner
 import io.gitlab.arturbosch.detekt.testkit.DslTestBuilder.Companion.kotlin
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.TaskOutcome
+import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
@@ -13,16 +14,15 @@ import org.junit.jupiter.api.Test
  */
 class PluginTaskBehaviorSpec {
 
-    val configFileName = "config.yml"
-    val baselineFileName = "baseline.xml"
+    private val configFileName = "config.yml"
+    private val baselineFileName = "baseline.xml"
 
-    @Suppress("TrimMultilineRawString")
-    val detektConfig = """
-        |detekt {
-        |    config = files("$configFileName")
-        |    baseline = file("$baselineFileName")
-        |}
-    """
+    private val detektConfig = """
+        detekt {
+            config = files("$configFileName")
+            baseline = file("$baselineFileName")
+        }
+    """.trimIndent()
 
     lateinit var gradleRunner: DslGradleRunner
 
@@ -72,10 +72,11 @@ class PluginTaskBehaviorSpec {
 
     @Test
     fun `should run again after changing config`() {
+        @Language("yaml")
         val configFileWithCommentsDisabled = """
-            |comments:
-            |  active: false
-        """.trimMargin()
+            comments:
+              active: false
+        """.trimIndent()
 
         gradleRunner.runDetektTaskAndCheckResult { result ->
             assertThat(result.task(":detekt")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
@@ -91,12 +92,13 @@ class PluginTaskBehaviorSpec {
 
     @Test
     fun `should run again after changing baseline`() {
+        @Language("xml")
         val changedBaselineContent = """
-            |<some>
-            |    <more/>
-            |    <xml/>
-            |</some>
-        """.trimMargin()
+            <some>
+                <more/>
+                <xml/>
+            </some>
+        """.trimIndent()
 
         gradleRunner.runDetektTaskAndCheckResult { result ->
             assertThat(result.task(":detekt")?.outcome).isEqualTo(TaskOutcome.SUCCESS)

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/report/ReportMergeSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/report/ReportMergeSpec.kt
@@ -4,6 +4,7 @@ import io.gitlab.arturbosch.detekt.manifestContent
 import io.gitlab.arturbosch.detekt.testkit.DslGradleRunner
 import io.gitlab.arturbosch.detekt.testkit.DslTestBuilder
 import io.gitlab.arturbosch.detekt.testkit.ProjectLayout
+import io.gitlab.arturbosch.detekt.testkit.reIndent
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.TaskOutcome
 import org.junit.jupiter.api.Test
@@ -22,50 +23,50 @@ class ReportMergeSpec {
                 "child1",
                 numberOfSourceFilesPerSourceDir = 2,
                 buildFileContent = """
-                    ${builder.gradleSubprojectsApplyPlugins}
-                    |plugins.apply("java-library")
-                """.trimMargin()
+                    ${builder.gradleSubprojectsApplyPlugins.reIndent(baseIndent = 5)}
+                    plugins.apply("java-library")
+                """.trimIndent()
             )
             addSubmodule(
                 "child2",
                 numberOfSourceFilesPerSourceDir = 2,
                 buildFileContent = """
-                    ${builder.gradleSubprojectsApplyPlugins}
-                    |plugins.apply("java-library")
-                """.trimMargin()
+                    ${builder.gradleSubprojectsApplyPlugins.reIndent(baseIndent = 5)}
+                    plugins.apply("java-library")
+                """.trimIndent()
             )
         }
         val mainBuildFileContent: String = """
-            |plugins {
-            |    id("io.gitlab.arturbosch.detekt")
-            |}
-            |
-            |allprojects {
-            |    ${builder.gradleRepositories}
-            |}
-            |
-            |val reportMerge by tasks.registering(io.gitlab.arturbosch.detekt.report.ReportMergeTask::class) {
-            |    output.set(project.layout.buildDirectory.file("reports/detekt/merge.xml"))
-            |    outputs.cacheIf { false }
-            |    outputs.upToDateWhen { false }
-            |}
-            |
-            |subprojects {
-            |    apply(plugin = "org.jetbrains.kotlin.jvm")
-            |    apply(plugin = "io.gitlab.arturbosch.detekt")
-            |
-            |    detekt {
-            |        reports.xml.enabled = true
-            |    }
-            |
-            |    plugins.withType<io.gitlab.arturbosch.detekt.DetektPlugin> {
-            |        tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
-            |            finalizedBy(reportMerge)
-            |            reportMerge.configure { input.from(xmlReportFile) }
-            |        }
-            |    }
-            |}
-        """.trimMargin()
+            plugins {
+                id("io.gitlab.arturbosch.detekt")
+            }
+            
+            allprojects {
+                ${builder.gradleRepositories.reIndent(1)}
+            }
+            
+            val reportMerge by tasks.registering(io.gitlab.arturbosch.detekt.report.ReportMergeTask::class) {
+                output.set(project.layout.buildDirectory.file("reports/detekt/merge.xml"))
+                outputs.cacheIf { false }
+                outputs.upToDateWhen { false }
+            }
+            
+            subprojects {
+                apply(plugin = "org.jetbrains.kotlin.jvm")
+                apply(plugin = "io.gitlab.arturbosch.detekt")
+            
+                detekt {
+                    reports.xml.enabled = true
+                }
+            
+                plugins.withType<io.gitlab.arturbosch.detekt.DetektPlugin> {
+                    tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
+                        finalizedBy(reportMerge)
+                        reportMerge.configure { input.from(xmlReportFile) }
+                    }
+                }
+            }
+        """.trimIndent()
 
         val gradleRunner = DslGradleRunner(
             projectLayout = projectLayout,
@@ -131,12 +132,12 @@ class ReportMergeSpec {
                         kotlin("android")
                     }
                     android {
-                       compileSdk = 30
-                       namespace = "io.github.detekt.lib"
-                       compileOptions {
-                           sourceCompatibility = JavaVersion.VERSION_11
-                           targetCompatibility = JavaVersion.VERSION_11
-                       }
+                        compileSdk = 30
+                        namespace = "io.github.detekt.lib"
+                        compileOptions {
+                            sourceCompatibility = JavaVersion.VERSION_11
+                            targetCompatibility = JavaVersion.VERSION_11
+                        }
                     }
                     tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
                         compilerOptions {
@@ -148,39 +149,39 @@ class ReportMergeSpec {
             )
         }
         val mainBuildFileContent: String = """
-            |plugins {
-            |    id("io.gitlab.arturbosch.detekt")
-            |}
-            |
-            |allprojects {
-            |    repositories {
-            |        mavenCentral()
-            |        google()
-            |        mavenLocal()
-            |    }
-            |}
-            |
-            |val reportMerge by tasks.registering(io.gitlab.arturbosch.detekt.report.ReportMergeTask::class) {
-            |    output.set(project.layout.buildDirectory.file("reports/detekt/merge.xml"))
-            |    outputs.cacheIf { false }
-            |    outputs.upToDateWhen { false }
-            |}
-            |
-            |subprojects {
-            |    apply(plugin = "io.gitlab.arturbosch.detekt")
-            |
-            |    detekt {
-            |        reports.xml.enabled = true
-            |    }
-            |
-            |    plugins.withType<io.gitlab.arturbosch.detekt.DetektPlugin> {
-            |        tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
-            |            finalizedBy(reportMerge)
-            |            reportMerge.configure { input.from(xmlReportFile) }
-            |        }
-            |    }
-            |}
-        """.trimMargin()
+            plugins {
+                id("io.gitlab.arturbosch.detekt")
+            }
+            
+            allprojects {
+                repositories {
+                    mavenCentral()
+                    google()
+                    mavenLocal()
+                }
+            }
+            
+            val reportMerge by tasks.registering(io.gitlab.arturbosch.detekt.report.ReportMergeTask::class) {
+                output.set(project.layout.buildDirectory.file("reports/detekt/merge.xml"))
+                outputs.cacheIf { false }
+                outputs.upToDateWhen { false }
+            }
+            
+            subprojects {
+                apply(plugin = "io.gitlab.arturbosch.detekt")
+            
+                detekt {
+                    reports.xml.enabled = true
+                }
+            
+                plugins.withType<io.gitlab.arturbosch.detekt.DetektPlugin> {
+                    tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
+                        finalizedBy(reportMerge)
+                        reportMerge.configure { input.from(xmlReportFile) }
+                    }
+                }
+            }
+        """.trimIndent()
 
         val jvmArgs = "-Xmx2g -XX:MaxMetaspaceSize=1g"
 
@@ -192,14 +193,8 @@ class ReportMergeSpec {
         )
 
         gradleRunner.setupProject()
-        gradleRunner.writeProjectFile(
-            "app/src/main/AndroidManifest.xml",
-            manifestContent()
-        )
-        gradleRunner.writeProjectFile(
-            "lib/src/main/AndroidManifest.xml",
-            manifestContent()
-        )
+        gradleRunner.writeProjectFile("app/src/main/AndroidManifest.xml", manifestContent())
+        gradleRunner.writeProjectFile("lib/src/main/AndroidManifest.xml", manifestContent())
         gradleRunner.runTasksAndCheckResult("detektMain", "reportMerge", "--continue") { result ->
             projectLayout.submodules.forEach { submodule ->
                 assertThat(result.task(":${submodule.name}:detektMain")?.outcome).isEqualTo(TaskOutcome.SUCCESS)

--- a/detekt-gradle-plugin/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/testkit/DslGradleRunner.kt
+++ b/detekt-gradle-plugin/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/testkit/DslGradleRunner.kt
@@ -100,7 +100,6 @@ constructor(
     fun projectFile(path: String): File = File(rootDir, path).canonicalFile
 
     fun writeProjectFile(filename: String, content: String) {
-        println("Writing file $filename with content:\n${content.replace(" ", ".")}")
         File(rootDir, filename)
             .also { it.parentFile.mkdirs() }
             .writeText(content)
@@ -116,7 +115,6 @@ constructor(
     }
 
     private fun Submodule.writeModuleFile(filename: String, content: String) {
-        println("Writing file $filename with content:\n${content.replace(" ", ".")}")
         File(moduleRoot, filename).writeText(content)
     }
 

--- a/detekt-gradle-plugin/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/testkit/DslTestBuilder.kt
+++ b/detekt-gradle-plugin/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/testkit/DslTestBuilder.kt
@@ -8,7 +8,7 @@ abstract class DslTestBuilder {
     abstract val gradleBuildName: String
     abstract val gradlePlugins: String
     abstract val gradleSubprojectsApplyPlugins: String
-    
+
     @Language("gradle.kts")
     val gradleRepositories = """
         repositories {

--- a/detekt-gradle-plugin/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/testkit/Helpers.kt
+++ b/detekt-gradle-plugin/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/testkit/Helpers.kt
@@ -1,6 +1,32 @@
 package io.gitlab.arturbosch.detekt.testkit
 
 import org.gradle.api.Task
+import org.intellij.lang.annotations.Language
 
 fun Task.dependenciesAsNames() = this.taskDependencies.getDependencies(this).map { it.name }
 fun Task.dependenciesAsPaths() = this.taskDependencies.getDependencies(this).map { it.path }
+
+/**
+ * This assumes the usual structure of a Kotlin test file:
+ * ```
+ * class Test {
+ *     fun `test name`() {
+ *         val code = """
+ *             // code
+ *             ${otherCode.reIndent()}
+ *             // more code
+ *             some.block {
+ *                 ${innerCode.reIndent(1)}
+ *             }
+ *         """.trimIndent()
+ *     }
+ * }
+ * ```
+ * In case the call site doesn't look like the above,
+ * set the [baseIndent] parameter to the number of indentation levels until the inside of the `"""`.
+ */
+fun String.reIndent(level: Int = 0, baseIndent: Int = 3): String =
+    this.replaceIndent("    ".repeat(baseIndent + level)).trim()
+
+fun joinGradleBlocks(@Language("gradle.kts") vararg blocks: String): String =
+    blocks.joinToString(separator = "\n\n")

--- a/detekt-gradle-plugin/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/testkit/ProjectLayout.kt
+++ b/detekt-gradle-plugin/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/testkit/ProjectLayout.kt
@@ -1,5 +1,7 @@
 package io.gitlab.arturbosch.detekt.testkit
 
+import org.intellij.lang.annotations.Language
+
 class ProjectLayout(
     val numberOfSourceFilesInRootPerSourceDir: Int,
     val numberOfCodeSmellsInRootPerSourceDir: Int = 0,
@@ -15,6 +17,7 @@ class ProjectLayout(
         name: String,
         numberOfSourceFilesPerSourceDir: Int,
         numberOfCodeSmells: Int = 0,
+        @Language("gradle.kts")
         buildFileContent: String? = null,
         srcDirs: List<String> = this.srcDirs,
         baselineFiles: List<String> = emptyList(),
@@ -35,6 +38,7 @@ data class Submodule(
     val name: String,
     val numberOfSourceFilesPerSourceDir: Int,
     val numberOfCodeSmells: Int,
+    @Language("gradle.kts")
     val buildFileContent: String?,
     val srcDirs: List<String>,
     val baselineFiles: List<String>,


### PR DESCRIPTION
Follow-up on https://github.com/detekt/detekt/pull/5819#discussion_r1116745695
Related #5827
Closes #5828 

Changes:
 * Fix indentation of fixture code (somewhere 4, somewhere 3, somewhere 2 spaces), yaml kept at 2 everything else is 4.
 * Replace all remaining trimMargin with trimIndent
 * Add some `@Language` annotations, the build code in functionalTests will be highlighted properly (requires trimMargin removal).
 * Re-think how multiple pieces of Gradle script blocks are merged.
   * Previously
     * they were relying on the `|` being present in the input string,
     * some of them didn't have the leading margin marker.
     * simple string concatenation was done with triple-quotes
     * the generated output was still messy, mis-indented, and hard to follow.
   * In this PR
     * Removed all `@Suppress("TrimMultilineRawString")`
     * Each code block is self-contained
     * This is achieved by 2 simple rules:
       1. Apply trimIndent() at the definition of the fragment
       2. Deal with indentation where the merging happens
     * This needed two small functions to be introduced: `reIndent` and `mergeGradleBlocks`.  
       Their usages are pretty localized and make the fragment re-use be at a higher level of abstraction (like `"""$a $b"""` -> `merge(a, b)`).

You can look at the resulting changes by diffing these two files (note: console output trims empty lines so the effect of `\n\n` is not clearly visible here, but it is in the JUnit test report):
[main.txt](https://github.com/detekt/detekt/files/10824885/main.txt)
[pr.txt](https://github.com/detekt/detekt/files/10824887/pr.txt)
