### PR TITLE
Simplify generate documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,8 +161,3 @@ target/
 
 # Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
 !gradle-wrapper.jar
-
-# Avoid committing generated documentation to the repo
-/website/docs/rules/*.md
-/website/static/kdoc
-/website/docs/gettingstarted/_cli-options.md

--- a/detekt-generator/build.gradle.kts
+++ b/detekt-generator/build.gradle.kts
@@ -38,9 +38,8 @@ val generateDocumentation by tasks.registering(JavaExec::class) {
 
     val ruleModules = rootProject.subprojects
         .filter { "rules" in it.name || it.name == "detekt-formatting" }
-        .map { it.name }
-        .filterNot { it == "detekt-rules" }
-        .map { "$rootDir/$it/src/main/kotlin" }
+        .filterNot { it.name == "detekt-rules" }
+        .map { "${it.projectDir}/src/main/kotlin" }
 
     inputs.files(ruleModules.map { fileTree(it) })
 

--- a/detekt-generator/build.gradle.kts
+++ b/detekt-generator/build.gradle.kts
@@ -27,12 +27,6 @@ val formattingConfigFile = "$rootDir/detekt-formatting/src/main/resources/config
 val librariesConfigFile = "$rootDir/detekt-rules-libraries/src/main/resources/config/config.yml"
 val ruleauthorsConfigFile = "$rootDir/detekt-rules-ruleauthors/src/main/resources/config/config.yml"
 
-val ruleModules = rootProject.subprojects
-    .filter { "rules" in it.name || it.name == "detekt-formatting" }
-    .map { it.name }
-    .filterNot { it == "detekt-rules" }
-    .map { "$rootDir/$it/src/main/kotlin" }
-
 val generateDocumentation by tasks.registering(JavaExec::class) {
     dependsOn(
         ":detekt-api:dokkaHtml",
@@ -41,6 +35,12 @@ val generateDocumentation by tasks.registering(JavaExec::class) {
     )
     description = "Generates detekt documentation and the default config.yml based on Rule KDoc"
     group = "documentation"
+
+    val ruleModules = rootProject.subprojects
+        .filter { "rules" in it.name || it.name == "detekt-formatting" }
+        .map { it.name }
+        .filterNot { it == "detekt-rules" }
+        .map { "$rootDir/$it/src/main/kotlin" }
 
     inputs.files(ruleModules.map { fileTree(it) })
 

--- a/detekt-generator/build.gradle.kts
+++ b/detekt-generator/build.gradle.kts
@@ -36,12 +36,14 @@ val generateDocumentation by tasks.registering(JavaExec::class) {
     description = "Generates detekt documentation and the default config.yml based on Rule KDoc"
     group = "documentation"
 
-    val ruleModules = rootProject.subprojects
+    val ruleModules = rootProject.subprojects.asSequence()
         .filter { "rules" in it.name || it.name == "detekt-formatting" }
         .filterNot { it.name == "detekt-rules" }
-        .map { "${it.projectDir}/src/main/kotlin" }
+        .flatMap { it.sourceSets.main.get().kotlin.srcDirs }
+        .filter { it.exists() }
+        .toList()
 
-    inputs.files(ruleModules.map { fileTree(it) })
+    inputs.files(ruleModules)
 
     outputs.files(
         fileTree(documentationDir),

--- a/detekt-generator/build.gradle.kts
+++ b/detekt-generator/build.gradle.kts
@@ -35,7 +35,6 @@ val ruleModules = rootProject.subprojects
 
 val generateDocumentation by tasks.registering(JavaExec::class) {
     dependsOn(
-        tasks.shadowJar,
         ":detekt-api:dokkaHtml",
         ":detekt-rules-libraries:sourcesJar",
         ":detekt-rules-ruleauthors:sourcesJar",
@@ -48,7 +47,6 @@ val generateDocumentation by tasks.registering(JavaExec::class) {
         fileTree("$rootDir/detekt-rules-libraries/src/main/kotlin"),
         fileTree("$rootDir/detekt-rules-ruleauthors/src/main/kotlin"),
         fileTree("$rootDir/detekt-formatting/src/main/kotlin"),
-        file("$rootDir/detekt-generator/build/libs/detekt-generator-${Versions.DETEKT}-all.jar"),
     )
 
     outputs.files(

--- a/detekt-generator/build.gradle.kts
+++ b/detekt-generator/build.gradle.kts
@@ -28,7 +28,7 @@ val librariesConfigFile = "$rootDir/detekt-rules-libraries/src/main/resources/co
 val ruleauthorsConfigFile = "$rootDir/detekt-rules-ruleauthors/src/main/resources/config/config.yml"
 
 val ruleModules = rootProject.subprojects
-    .filter { "rules" in it.name }
+    .filter { "rules" in it.name || it.name == "detekt-formatting" }
     .map { it.name }
     .filterNot { it == "detekt-rules" }
     .map { "$rootDir/$it/src/main/kotlin" }
@@ -42,12 +42,7 @@ val generateDocumentation by tasks.registering(JavaExec::class) {
     description = "Generates detekt documentation and the default config.yml based on Rule KDoc"
     group = "documentation"
 
-    inputs.files(
-        ruleModules.map { fileTree(it) },
-        fileTree("$rootDir/detekt-rules-libraries/src/main/kotlin"),
-        fileTree("$rootDir/detekt-rules-ruleauthors/src/main/kotlin"),
-        fileTree("$rootDir/detekt-formatting/src/main/kotlin"),
-    )
+    inputs.files(ruleModules.map { fileTree(it) })
 
     outputs.files(
         fileTree(documentationDir),
@@ -67,11 +62,7 @@ val generateDocumentation by tasks.registering(JavaExec::class) {
     mainClass.set("io.gitlab.arturbosch.detekt.generator.Main")
     args = listOf(
         "--input",
-        ruleModules
-            .plus("$rootDir/detekt-rules-libraries/src/main/kotlin")
-            .plus("$rootDir/detekt-rules-ruleauthors/src/main/kotlin")
-            .plus("$rootDir/detekt-formatting/src/main/kotlin")
-            .joinToString(","),
+        ruleModules.joinToString(","),
         "--documentation",
         documentationDir,
         "--config",

--- a/website/.gitignore
+++ b/website/.gitignore
@@ -18,3 +18,8 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# Avoid committing generated documentation to the repo
+/docs/rules/*.md
+/docs/gettingstarted/_cli-options.md
+/static/kdoc


### PR DESCRIPTION
A bit of love for `generateDocumentation`. I think that this PR reviewed commit by commit should be easier.

Basically what I did:
- Remove dependencies with other tasks
- Don't hardcode paths, use gradle
- Reduce verbosity
- Some other minor Boy Scouts