### PR TITLE
Remove dependency between check and jacocoMergedReport

### DIFF
--- a/code-coverage-report/build.gradle.kts
+++ b/code-coverage-report/build.gradle.kts
@@ -44,10 +44,6 @@ dependencies {
     jacocoAggregation(projects.detektUtils)
 }
 
-tasks.check {
-    dependsOn(tasks.named("jacocoMergedReport"))
-}
-
 tasks.withType<JacocoReport>().configureEach {
     dependsOn(":detekt-generator:generateDocumentation")
 }


### PR DESCRIPTION
`jacocoMergedReport` is in the critical path of my builds: 
https://ge.detekt.dev/s/24zl4n3tj746e/timeline?details=j2hxxhlnrx3wg&show-only-critical-path
https://ge.detekt.dev/s/ok5dejkm7eo34/timeline?details=j2hxxhlnrx3wg&show-only-critical-path

But its output is not relevant. The only place where it is relevant is in the workflow `codecoverage.yaml`. But there we don't execute it using `check` we execute it using its name.