### PR TITLE
Use code syntax for `Unit` for ImplicitUnitReturnType rule

### DIFF
--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ImplicitUnitReturnType.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ImplicitUnitReturnType.kt
@@ -51,7 +51,7 @@ class ImplicitUnitReturnType(config: Config) : Rule(config) {
         Debt.FIVE_MINS
     )
 
-    @Configuration("if functions with explicit 'Unit' return type should be allowed")
+    @Configuration("if functions with explicit `Unit` return type should be allowed")
     private val allowExplicitReturnType: Boolean by config(true)
 
     override fun visitNamedFunction(function: KtNamedFunction) {
@@ -68,7 +68,7 @@ class ImplicitUnitReturnType(config: Config) : Rule(config) {
 
         if (function.hasImplicitUnitReturnType()) {
             val message = buildString {
-                append("'${function.name}'  has the implicit return type 'Unit'.")
+                append("'${function.name}'  has the implicit return type `Unit`.")
                 append(" Prefer using a block statement")
                 if (allowExplicitReturnType) {
                     append(" or specify the return type explicitly")


### PR DESCRIPTION
Minor documentation change
