### PR TITLE
allow for float config values

### DIFF
--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/ConfigProperty.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/ConfigProperty.kt
@@ -115,7 +115,8 @@ private fun <T : Any> getValueOrDefault(configAware: ConfigAware, propertyName: 
         is List<*> -> configAware.getListOrDefault(propertyName, defaultValue) as T
         is String,
         is Boolean,
-        is Int -> configAware.valueOrDefault(propertyName, defaultValue)
+        is Int,
+        is Float -> configAware.valueOrDefault(propertyName, defaultValue)
         else -> error(
             "${defaultValue.javaClass} is not supported for delegated config property '$propertyName'. " +
                 "Use one of String, Boolean, Int or List<String> instead."

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/DefaultValue.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/DefaultValue.kt
@@ -16,6 +16,7 @@ sealed interface DefaultValue {
         fun of(defaultValue: String): DefaultValue = StringDefault(defaultValue)
         fun of(defaultValue: Boolean): DefaultValue = BooleanDefault(defaultValue)
         fun of(defaultValue: Int): DefaultValue = IntegerDefault(defaultValue)
+        fun of(defaultValue: Float): DefaultValue = FloatDefault(defaultValue)
         fun of(defaultValue: List<String>): DefaultValue = StringListDefault(defaultValue)
         fun of(defaultValue: ValuesWithReason): DefaultValue = ValuesWithReasonDefault(defaultValue)
     }
@@ -42,6 +43,16 @@ private data class BooleanDefault(private val defaultValue: Boolean) : DefaultVa
 }
 
 private data class IntegerDefault(private val defaultValue: Int) : DefaultValue {
+    override fun getPlainValue(): String = defaultValue.toString()
+    override fun printAsYaml(name: String, yaml: YamlNode) {
+        yaml.keyValue { name to defaultValue.toString() }
+    }
+
+    override fun printAsMarkdownCode(): String = defaultValue.toString()
+}
+
+// DoubleDefault and IntegerDefault could probably be combined to NumericalDefault(?)
+private data class FloatDefault(private val defaultValue: Float) : DefaultValue {
     override fun getPlainValue(): String = defaultValue.toString()
     override fun printAsYaml(name: String, yaml: YamlNode) {
         yaml.keyValue { name to defaultValue.toString() }

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/DefaultValues.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/DefaultValues.kt
@@ -10,6 +10,7 @@ private fun String.toDefaultValueIfLiteral(): DefaultValue? {
         isStringLiteral() -> DefaultValue.of(withoutQuotes())
         isBooleanLiteral() -> DefaultValue.of(toBoolean())
         isIntegerLiteral() -> DefaultValue.of(withoutUnderscores().toInt())
+        isFloatLiteral() -> DefaultValue.of(withoutUnderscores().toFloat())
         else -> null
     }
 }
@@ -18,5 +19,7 @@ private fun String.withoutUnderscores() = replace("_", "")
 private fun String.isStringLiteral() = length > 1 && startsWith(QUOTES) && endsWith(QUOTES)
 private fun String.isBooleanLiteral() = this == TRUE_KEYWORD.value || this == FALSE_KEYWORD.value
 private fun String.isIntegerLiteral() = withoutUnderscores().toIntOrNull() != null
+
+private fun String.isFloatLiteral() = withoutUnderscores().toFloatOrNull() != null
 
 private const val QUOTES = "\""


### PR DESCRIPTION
This PR allows config values using the `@Configuration` annotation and the `by config` delegates to have `float` values.

Float config values can be helpful when using fractions as threshold values, like in #5581 where a fraction (1/3) is used as a config value.