### PR TITLE
Add support for local suppression inside formatting

### DIFF
--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingRule.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingRule.kt
@@ -4,20 +4,15 @@ import com.pinterest.ktlint.core.Rule.VisitorModifier.RunAsLateAsPossible
 import com.pinterest.ktlint.core.api.EditorConfigProperties
 import com.pinterest.ktlint.core.api.editorconfig.CODE_STYLE_PROPERTY
 import com.pinterest.ktlint.core.api.editorconfig.EditorConfigProperty
-import io.github.detekt.psi.fileName
-import io.github.detekt.psi.toFilePath
 import io.gitlab.arturbosch.detekt.api.CodeSmell
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.CorrectableCodeSmell
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.Location
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.SingleAssign
-import io.gitlab.arturbosch.detekt.api.SourceLocation
-import io.gitlab.arturbosch.detekt.api.TextLocation
 import org.ec4j.core.model.Property
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.JavaDummyElement
@@ -40,32 +35,6 @@ abstract class FormattingRule(config: Config) : Rule(config) {
 
     val runAsLateAsPossible
         get() = RunAsLateAsPossible in wrapping.visitorModifiers
-
-    private val emit = { offset: Int, message: String, canBeAutoCorrected: Boolean ->
-        val (line, column) = positionByOffset(offset)
-        val location = Location(
-            SourceLocation(line, column),
-            // Use offset + 1 since ktlint always reports a single location.
-            TextLocation(offset, offset + 1),
-            root.toFilePath()
-        )
-
-        // Nodes reported by 'NoConsecutiveBlankLines' are dangling whitespace nodes which means they have
-        // no direct parent which we can use to get the containing file needed to baseline or suppress findings.
-        // For these reasons we do not report a KtElement which may lead to crashes when postprocessing it
-        // e.g. reports (html), baseline etc.
-        val packageName = root.packageFqName.asString()
-            .takeIf { it.isNotEmpty() }
-            ?.plus(".")
-            .orEmpty()
-        val entity = Entity("", "$packageName${root.fileName}:$line", location, root)
-
-        if (canBeAutoCorrected) {
-            report(CorrectableCodeSmell(issue, entity, message, autoCorrectEnabled = autoCorrect))
-        } else {
-            report(CodeSmell(issue, entity, message))
-        }
-    }
 
     private var positionByOffset: (offset: Int) -> Pair<Int, Int> by SingleAssign()
     private var root: KtFile by SingleAssign()
@@ -107,15 +76,25 @@ abstract class FormattingRule(config: Config) : Rule(config) {
         }
     }
 
+    private fun emitFinding(message: String, canBeAutoCorrected: Boolean, node: ASTNode) {
+        val entity = Entity.from(node.psi)
+
+        if (canBeAutoCorrected) {
+            report(CorrectableCodeSmell(issue, entity, message, autoCorrectEnabled = autoCorrect))
+        } else {
+            report(CodeSmell(issue, entity, message))
+        }
+    }
+
     private fun beforeVisitChildNodes(node: ASTNode) {
-        wrapping.beforeVisitChildNodes(node, autoCorrect) { offset, errorMessage, canBeAutoCorrected ->
-            emit.invoke(offset, errorMessage, canBeAutoCorrected)
+        wrapping.beforeVisitChildNodes(node, autoCorrect) { _, errorMessage, canBeAutoCorrected ->
+            emitFinding(errorMessage, canBeAutoCorrected, node)
         }
     }
 
     private fun afterVisitChildNodes(node: ASTNode) {
-        wrapping.afterVisitChildNodes(node, autoCorrect) { offset, errorMessage, canBeAutoCorrected ->
-            emit.invoke(offset, errorMessage, canBeAutoCorrected)
+        wrapping.afterVisitChildNodes(node, autoCorrect) { _, errorMessage, canBeAutoCorrected ->
+            emitFinding(errorMessage, canBeAutoCorrected, node)
         }
     }
 

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingRuleSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingRuleSpec.kt
@@ -3,6 +3,7 @@ package io.gitlab.arturbosch.detekt.formatting
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.formatting.wrappers.NoLineBreakBeforeAssignment
 import io.gitlab.arturbosch.detekt.test.assertThat
+import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -22,8 +23,8 @@ class FormattingRuleSpec {
     inner class `formatting rules can be suppressed` {
 
         @Test
-        fun `does support suppression only on file level`() {
-            val findings = subject.lint(
+        fun `does support suppression on file level`() {
+            val findings = subject.compileAndLint(
                 """
                     @file:Suppress("NoLineBreakBeforeAssignment")
                     fun main()
@@ -35,8 +36,8 @@ class FormattingRuleSpec {
         }
 
         @Test
-        fun `does not support suppression on node level`() {
-            val findings = subject.lint(
+        fun `support suppression on node level`() {
+            val findings = subject.compileAndLint(
                 """
                     @Suppress("NoLineBreakBeforeAssignment")
                     fun main()
@@ -44,7 +45,7 @@ class FormattingRuleSpec {
                 """.trimIndent()
             )
 
-            assertThat(findings).hasSize(1)
+            assertThat(findings).isEmpty()
         }
     }
 
@@ -52,20 +53,20 @@ class FormattingRuleSpec {
     inner class `formatting rules have a signature` {
 
         @Test
-        fun `has no package name`() {
-            val findings = subject.lint(
+        fun `in a file without package name`() {
+            val findings = subject.compileAndLint(
                 """
                     fun main()
                     = Unit
                 """.trimIndent()
             )
 
-            assertThat(findings.first().signature).isEqualTo("Test.kt:1")
+            assertThat(findings.first().signature).isEqualTo("Test.kt\$=")
         }
 
         @Test
-        fun `has a package name`() {
-            val findings = subject.lint(
+        fun `with a file with package name`() {
+            val findings = subject.compileAndLint(
                 """
                     package test.test.test
                     fun main()
@@ -73,7 +74,7 @@ class FormattingRuleSpec {
                 """.trimIndent()
             )
 
-            assertThat(findings.first().signature).isEqualTo("test.test.test.Test.kt:2")
+            assertThat(findings.first().signature).isEqualTo("Test.kt\$=")
         }
     }
 

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/IndentationSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/IndentationSpec.kt
@@ -4,6 +4,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.formatting.wrappers.Indentation
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assert
+import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -33,9 +34,9 @@ class IndentationSpec {
 
             @Test
             fun `places finding location to the indentation`() {
-                subject.lint(code).assert()
-                    .hasStartSourceLocation(2, 1)
-                    .hasTextLocations(13 to 14)
+                subject.compileAndLint(code).assert()
+                    .hasStartSourceLocation(1, 13)
+                    .hasTextLocations(12 to 14)
             }
         }
 

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/MaximumLineLengthSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/MaximumLineLengthSpec.kt
@@ -2,6 +2,7 @@ package io.gitlab.arturbosch.detekt.formatting
 
 import io.gitlab.arturbosch.detekt.formatting.wrappers.MaximumLineLength
 import io.gitlab.arturbosch.detekt.test.TestConfig
+import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -31,13 +32,13 @@ class MaximumLineLengthSpec {
         }
 
         @Test
-        fun `reports issues with the filename and package as signature`() {
+        fun `reports issues with the filename in signature`() {
             val finding = subject.lint(
                 code,
                 Path("home", "test", "Test.kt").toString()
             ).first()
 
-            assertThat(finding.entity.signature).isEqualTo("home.test.Test.kt:2")
+            assertThat(finding.entity.signature).isEqualTo("Test.kt\$fun")
         }
 
         @Test
@@ -55,14 +56,13 @@ class MaximumLineLengthSpec {
 
     @Test
     fun `reports correct line numbers`() {
-        val findings = subject.lint(longLines)
+        val findings = subject.compileAndLint(longLines)
 
         // Note that KtLint's MaximumLineLength rule, in contrast to detekt's MaxLineLength rule, does not report
         // exceeded lines in block comments.
-        assertThat(findings).hasSize(2)
-
-        assertThat(findings[0].entity.location.source.line).isEqualTo(8)
-        assertThat(findings[1].entity.location.source.line).isEqualTo(14)
+        io.gitlab.arturbosch.detekt.test.assertThat(findings).hasSize(2)
+        io.gitlab.arturbosch.detekt.test.assertThat(findings[0]).hasSourceLocation(7, 8)
+        io.gitlab.arturbosch.detekt.test.assertThat(findings[1]).hasSourceLocation(13, 12)
     }
 
     @Test

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/WrappingSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/WrappingSpec.kt
@@ -3,6 +3,7 @@ package io.gitlab.arturbosch.detekt.formatting
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.formatting.wrappers.Wrapping
 import io.gitlab.arturbosch.detekt.test.assert
+import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
@@ -28,9 +29,9 @@ class WrappingSpec {
             
         """.trimIndent()
 
-        subject.lint(code).assert()
+        subject.compileAndLint(code).assert()
             .hasSize(1)
-            .hasStartSourceLocation(1, 12)
-            .hasTextLocations(11 to 12)
+            .hasStartSourceLocation(1, 13)
+            .hasTextLocations(12 to 20)
     }
 }


### PR DESCRIPTION
Fixes #5547
Fixes #5566
Related to #1999 also

This introduced the possibility to do more fine grained suppression on `detekt-formatting` rules. Specifically I'm dropping the custom logic we apply to the `Entity` we receive and just pass over the `PsiElement` that KtLint passes us.

Some of the location in the tests changed due to this, so this is a disruptive change at least for baselines (as the signature also changes). If we decide to merge it we should flag it in the release notes.

At the same time with KtLint you could only suppress at the `@file:` level so, aside from baseline, this won't disrupt other workflows.