### PR TITLE
List currently active rules in CLI

### DIFF
--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt
@@ -149,6 +149,12 @@ class CliArgs {
     )
     var runRule: String? = null
 
+    @Parameter(
+        names = ["--list-active-rules"],
+        description = "List rule sets and their rules and that are used for the analysis.",
+    )
+    var listActiveRules: Boolean = false
+
     /*
         The following @Parameters are used for type resolution. When additional parameters are required the
         names should mirror the names found in this file (e.g. "classpath", "language-version", "jvm-target"):

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Spec.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Spec.kt
@@ -31,6 +31,7 @@ internal fun CliArgs.createSpec(output: Appendable, error: Appendable): Processi
             }
             excludeCorrectable = false // not yet supported; loaded from config
             runPolicy = args.toRunPolicy()
+            listActiveRules = args.listActiveRules
         }
 
         baseline {

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Analyzer.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Analyzer.kt
@@ -32,10 +32,9 @@ private typealias FindingsResult = List<Map<RuleSetId, List<Finding>>>
 internal class Analyzer(
     private val settings: ProcessingSettings,
     private val providers: List<RuleSetProvider>,
-    private val processors: List<FileProcessListener>
+    private val processors: List<FileProcessListener>,
+    private val config: Config,
 ) {
-
-    private val config: Config = settings.spec.workaroundConfiguration(settings.config)
 
     fun run(
         ktFiles: Collection<KtFile>,

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/rules/CollectedRules.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/rules/CollectedRules.kt
@@ -1,0 +1,19 @@
+package io.gitlab.arturbosch.detekt.core.rules
+
+import io.gitlab.arturbosch.detekt.api.RuleId
+import io.gitlab.arturbosch.detekt.api.RuleSetId
+
+data class CollectedRules(
+    val ruleSets: List<RuleSet>,
+) {
+    data class RuleSet(
+        val id: RuleSetId,
+        val active: Boolean,
+        val rules: List<Rule>,
+    )
+
+    data class Rule(
+        val id: RuleId,
+        val active: Boolean,
+    )
+}

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/rules/RuleCollector.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/rules/RuleCollector.kt
@@ -1,0 +1,61 @@
+package io.gitlab.arturbosch.detekt.core.rules
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.MultiRule
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.RuleSetProvider
+import io.gitlab.arturbosch.detekt.core.ProcessingSettings
+
+internal class RuleCollector(
+    private val settings: ProcessingSettings,
+    private val providers: List<RuleSetProvider>,
+    private val config: Config,
+) {
+    fun run(): CollectedRules? = if (settings.spec.rulesSpec.listActiveRules) {
+        collectActiveRules()
+    } else {
+        null
+    }
+
+    @Suppress("DEPRECATION")
+    private fun collectActiveRules(): CollectedRules = CollectedRules(
+        ruleSets = providers.map { provider ->
+            val ruleSetConfig = config.subConfig(provider.ruleSetId)
+            val ruleSet = provider.instance(ruleSetConfig)
+            val rules = ruleSet.rules
+                .flatMap { rule ->
+                    when (rule) {
+                        is Rule -> listOf(rule)
+                        is MultiRule -> rule.rules
+                        else -> error("Unknown rule type $rule")
+                    }
+                }
+                .map { rule ->
+                    CollectedRules.Rule(
+                        id = rule.ruleId,
+                        active = rule.active,
+                    )
+                }
+            CollectedRules.RuleSet(
+                id = provider.ruleSetId,
+                active = ruleSetConfig.isActive(),
+                rules = rules,
+            )
+        }
+    )
+}
+
+internal fun logCollectedRules(settings: ProcessingSettings, collectedRules: CollectedRules) {
+    settings.info("Currently active rules:")
+    val rulesSets = collectedRules.ruleSets.filter { it.active }
+    if (rulesSets.isEmpty()) settings.info("\t<no active rule sets>")
+    rulesSets.forEach { ruleSet ->
+        val rules = ruleSet.rules.filter { it.active }
+        settings.info("\tRule set '${ruleSet.id}':")
+        if (rules.isEmpty()) settings.info("\t\t<no active rules in the set>")
+        rules.forEach { rule ->
+            settings.info("\t\t${rule.id}")
+        }
+    }
+    settings.info("") // empty line
+}

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/util/PerformanceMonitor.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/util/PerformanceMonitor.kt
@@ -17,6 +17,7 @@ class PerformanceMonitor {
         Parsing,
         Binding,
         LoadingExtensions,
+        CollectRules,
         Analyzer,
         Reporting,
     }

--- a/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/api/spec/RulesSpec.kt
+++ b/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/api/spec/RulesSpec.kt
@@ -59,6 +59,8 @@ interface RulesSpec {
      */
     val runPolicy: RunPolicy
 
+    val listActiveRules: Boolean
+
     /**
      * Restrict rules to use for current analysis.
      */

--- a/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/dsl/RulesSpecBuilder.kt
+++ b/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/dsl/RulesSpecBuilder.kt
@@ -9,13 +9,15 @@ class RulesSpecBuilder : Builder<RulesSpec> {
     var excludeCorrectable: Boolean = false
     var autoCorrect: Boolean = false
     var runPolicy: RulesSpec.RunPolicy = RulesSpec.RunPolicy.NoRestrictions
+    var listActiveRules: Boolean = false
 
     override fun build(): RulesSpec = RulesModel(
         activateAllRules,
         maxIssuePolicy,
         excludeCorrectable,
         autoCorrect,
-        runPolicy
+        runPolicy,
+        listActiveRules,
     )
 }
 
@@ -24,5 +26,6 @@ private data class RulesModel(
     override val maxIssuePolicy: RulesSpec.MaxIssuePolicy,
     override val excludeCorrectable: Boolean,
     override val autoCorrect: Boolean,
-    override val runPolicy: RulesSpec.RunPolicy
+    override val runPolicy: RulesSpec.RunPolicy,
+    override val listActiveRules: Boolean,
 ) : RulesSpec


### PR DESCRIPTION
Implementation of the part 1 of https://github.com/detekt/detekt/issues/5524#issuecomment-1336302472. I tried to make it so it's extendable also for #5607.

I'm curious what you guys think. I'll add some docs and fix/add tests when I get some opinion. 🙂

Here are some sample outputs of using `--list-active-rules` flag.

```
Currently active rules:
        <no active rule sets>
```

```
Currently active rules:
        Rule set 'coroutines':
                GlobalCoroutineUsage
                InjectDispatcher
                RedundantSuspendModifier
                SleepInsteadOfDelay
                SuspendFunWithFlowReturnType
                SuspendFunWithCoroutineScopeReceiver
        Rule set 'comments':
                <no active rules in the set>
        Rule set 'empty-blocks':
                EmptyCatchBlock
                EmptyClassBlock
                EmptyDefaultConstructor
```