### PR TITLE
Stale any issue with support tag in one month

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -33,6 +33,6 @@ jobs:
           close-pr-message: 'This PR was closed because its author has not followed up after 7 days.'
           stale-issue-label: stale
           stale-pr-label: stale
-          any-of-labels: waiting for feedback
+          any-of-labels: waiting for feedback, support
           exempt-issue-labels: never gets stale
           exempt-pr-labels: never gets stale


### PR DESCRIPTION
We usually mark the support issues and keep them open after answer to see if there is any other doubt. For that reason, some times, those issues keep open.

This makes the stale bot more eager to close them.