### PR TITLE
Minor fixes for the UnnecessaryAbstractClass rule

### DIFF
--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAbstractClass.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAbstractClass.kt
@@ -44,6 +44,18 @@ import org.jetbrains.kotlin.types.typeUtil.isInterface
  *     fun f() { }
  * }
  * </noncompliant>
+ *
+ * <compliant>
+ * interface OnlyAbstractMembersInInterface {
+ *     val i: Int
+ *     fun f()
+ * }
+ *
+ * class OnlyConcreteMembersInClass {
+ *     val i: Int = 0
+ *     fun f() { }
+ * }
+ * </compliant>
  */
 @ActiveByDefault(since = "1.2.0")
 @RequiresTypeResolution
@@ -78,8 +90,8 @@ class UnnecessaryAbstractClass(config: Config = Config.empty) : Rule(config) {
     }
 
     override fun visitClass(klass: KtClass) {
-        klass.check()
         super.visitClass(klass)
+        klass.check()
     }
 
     private fun KtClass.check() {


### PR DESCRIPTION
A couple of small fixes for `UnnecessaryAbstractClass`:
- `<compliant>` block was missing
- `visit*` methods were not calling `super.` (do we need a rule about this in the `ruleauthor` ruleset?)