### PR TITLE
Cleanup detekt-formatting to use detekt's own assertThat function

### DIFF
--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/ArgumentListWrappingSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/ArgumentListWrappingSpec.kt
@@ -3,7 +3,7 @@ package io.gitlab.arturbosch.detekt.formatting
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.formatting.wrappers.ArgumentListWrapping
 import io.gitlab.arturbosch.detekt.test.TestConfig
-import org.assertj.core.api.Assertions.assertThat
+import io.gitlab.arturbosch.detekt.test.assertThat
 import org.junit.jupiter.api.Test
 
 class ArgumentListWrappingSpec {

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/AutoCorrectLevelSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/AutoCorrectLevelSpec.kt
@@ -2,11 +2,12 @@ package io.gitlab.arturbosch.detekt.formatting
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Finding
+import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.loadRuleSet
 import io.gitlab.arturbosch.detekt.test.yamlConfig
-import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.psi.KtFile
 import org.junit.jupiter.api.Test
+import org.assertj.core.api.Assertions.assertThat as assertJThat
 
 class AutoCorrectLevelSpec {
 
@@ -16,8 +17,8 @@ class AutoCorrectLevelSpec {
 
         val (file, findings) = runRule(config)
 
-        assertThat(wasLinted(findings)).isTrue()
-        assertThat(wasFormatted(file)).isTrue()
+        assertThat(findings).isNotEmpty()
+        assertJThat(wasFormatted(file)).isTrue()
     }
 
     @Test
@@ -26,8 +27,8 @@ class AutoCorrectLevelSpec {
 
         val (file, findings) = runRule(config)
 
-        assertThat(wasLinted(findings)).isTrue()
-        assertThat(wasFormatted(file)).isFalse()
+        assertThat(findings).isNotEmpty()
+        assertJThat(wasFormatted(file)).isFalse()
     }
 
     @Test
@@ -36,8 +37,8 @@ class AutoCorrectLevelSpec {
 
         val (file, findings) = runRule(config)
 
-        assertThat(wasLinted(findings)).isTrue()
-        assertThat(wasFormatted(file)).isFalse()
+        assertThat(findings).isNotEmpty()
+        assertJThat(wasFormatted(file)).isFalse()
     }
 
     @Test
@@ -46,8 +47,8 @@ class AutoCorrectLevelSpec {
 
         val (file, findings) = runRule(config)
 
-        assertThat(wasLinted(findings)).isFalse()
-        assertThat(wasFormatted(file)).isFalse()
+        assertThat(findings).isEmpty()
+        assertJThat(wasFormatted(file)).isFalse()
     }
 }
 
@@ -58,5 +59,4 @@ private fun runRule(config: Config): Pair<KtFile, List<Finding>> {
     return testFile to ruleSet.rules.flatMap { it.findings }
 }
 
-private fun wasLinted(findings: List<Finding>) = findings.isNotEmpty()
 private fun wasFormatted(file: KtFile) = file.text == contentAfterChainWrapping

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/ChainWrappingSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/ChainWrappingSpec.kt
@@ -2,8 +2,9 @@ package io.gitlab.arturbosch.detekt.formatting
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.formatting.wrappers.ChainWrapping
-import org.assertj.core.api.Assertions.assertThat
+import io.gitlab.arturbosch.detekt.test.assertThat
 import org.junit.jupiter.api.Test
+import org.assertj.core.api.Assertions.assertThat as assertJThat
 
 class ChainWrappingSpec {
 
@@ -14,7 +15,7 @@ class ChainWrappingSpec {
 
         val findings = ChainWrapping(Config.empty).lint(subject.text)
 
-        assertThat(findings).isNotEmpty
-        assertThat(subject.text).isEqualTo(expected)
+        assertThat(findings).isNotEmpty()
+        assertJThat(subject.text).isEqualTo(expected)
     }
 }

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/FinalNewlineSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/FinalNewlineSpec.kt
@@ -3,7 +3,7 @@ package io.gitlab.arturbosch.detekt.formatting
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.formatting.wrappers.FinalNewline
 import io.gitlab.arturbosch.detekt.test.TestConfig
-import org.assertj.core.api.Assertions.assertThat
+import io.gitlab.arturbosch.detekt.test.assertThat
 import org.junit.jupiter.api.Test
 
 class FinalNewlineSpec {

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingRuleSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingRuleSpec.kt
@@ -4,11 +4,11 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.formatting.wrappers.NoLineBreakBeforeAssignment
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLint
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import kotlin.io.path.Path
+import org.assertj.core.api.Assertions.assertThat as assertJThat
 
 class FormattingRuleSpec {
 
@@ -61,7 +61,7 @@ class FormattingRuleSpec {
                 """.trimIndent()
             )
 
-            assertThat(findings.first().signature).isEqualTo("Test.kt\$=")
+            assertJThat(findings.first().signature).isEqualTo("Test.kt\$=")
         }
 
         @Test
@@ -74,7 +74,7 @@ class FormattingRuleSpec {
                 """.trimIndent()
             )
 
-            assertThat(findings.first().signature).isEqualTo("Test.kt\$=")
+            assertJThat(findings.first().signature).isEqualTo("Test.kt\$=")
         }
     }
 
@@ -90,6 +90,6 @@ class FormattingRuleSpec {
             expectedPath
         )
 
-        assertThat(findings.first().location.filePath.absolutePath.toString()).isEqualTo(expectedPath)
+        assertJThat(findings.first().location.filePath.absolutePath.toString()).isEqualTo(expectedPath)
     }
 }

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/ImportOrderingSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/ImportOrderingSpec.kt
@@ -3,7 +3,7 @@ package io.gitlab.arturbosch.detekt.formatting
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.formatting.wrappers.ImportOrdering
 import io.gitlab.arturbosch.detekt.test.TestConfig
-import org.assertj.core.api.Assertions.assertThat
+import io.gitlab.arturbosch.detekt.test.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/IndentationSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/IndentationSpec.kt
@@ -3,9 +3,8 @@ package io.gitlab.arturbosch.detekt.formatting
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.formatting.wrappers.Indentation
 import io.gitlab.arturbosch.detekt.test.TestConfig
-import io.gitlab.arturbosch.detekt.test.assert
+import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLint
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -34,7 +33,7 @@ class IndentationSpec {
 
             @Test
             fun `places finding location to the indentation`() {
-                subject.compileAndLint(code).assert()
+                assertThat(subject.compileAndLint(code))
                     .hasStartSourceLocation(1, 13)
                     .hasTextLocations(12 to 14)
             }

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/MaximumLineLengthSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/MaximumLineLengthSpec.kt
@@ -1,13 +1,15 @@
 package io.gitlab.arturbosch.detekt.formatting
 
+import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.formatting.wrappers.MaximumLineLength
 import io.gitlab.arturbosch.detekt.test.TestConfig
+import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLint
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import kotlin.io.path.Path
+import org.assertj.core.api.Assertions.assertThat as assertJThat
 
 class MaximumLineLengthSpec {
 
@@ -38,7 +40,7 @@ class MaximumLineLengthSpec {
                 Path("home", "test", "Test.kt").toString()
             ).first()
 
-            assertThat(finding.entity.signature).isEqualTo("Test.kt\$fun")
+            assertJThat(finding.entity.signature).isEqualTo("Test.kt\$fun")
         }
 
         @Test
@@ -60,9 +62,9 @@ class MaximumLineLengthSpec {
 
         // Note that KtLint's MaximumLineLength rule, in contrast to detekt's MaxLineLength rule, does not report
         // exceeded lines in block comments.
-        io.gitlab.arturbosch.detekt.test.assertThat(findings).hasSize(2)
-        io.gitlab.arturbosch.detekt.test.assertThat(findings[0]).hasSourceLocation(7, 8)
-        io.gitlab.arturbosch.detekt.test.assertThat(findings[1]).hasSourceLocation(13, 12)
+        assertThat(findings)
+            .hasSize(2)
+            .hasStartSourceLocations(SourceLocation(7, 8), SourceLocation(13, 12))
     }
 
     @Test

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/NoWildcardImportsSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/NoWildcardImportsSpec.kt
@@ -3,7 +3,7 @@ package io.gitlab.arturbosch.detekt.formatting
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.formatting.wrappers.NoWildcardImports
 import io.gitlab.arturbosch.detekt.test.TestConfig
-import org.assertj.core.api.Assertions.assertThat
+import io.gitlab.arturbosch.detekt.test.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/ParameterListWrappingSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/ParameterListWrappingSpec.kt
@@ -3,7 +3,7 @@ package io.gitlab.arturbosch.detekt.formatting
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.formatting.wrappers.ParameterListWrapping
 import io.gitlab.arturbosch.detekt.test.TestConfig
-import org.assertj.core.api.Assertions.assertThat
+import io.gitlab.arturbosch.detekt.test.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/UnnecessaryParenthesesBeforeTrailingLambdaSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/UnnecessaryParenthesesBeforeTrailingLambdaSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.formatting
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.formatting.wrappers.UnnecessaryParenthesesBeforeTrailingLambda
-import org.assertj.core.api.Assertions.assertThat
+import io.gitlab.arturbosch.detekt.test.assertThat
 import org.junit.jupiter.api.Test
 
 /**

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/WrappingSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/WrappingSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.formatting
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.formatting.wrappers.Wrapping
-import io.gitlab.arturbosch.detekt.test.assert
+import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -29,7 +29,7 @@ class WrappingSpec {
             
         """.trimIndent()
 
-        subject.compileAndLint(code).assert()
+        assertThat(subject.compileAndLint(code))
             .hasSize(1)
             .hasStartSourceLocation(1, 13)
             .hasTextLocations(12 to 20)


### PR DESCRIPTION
We do have several tests inside `detekt-formatting` which are not using `io.gitlab.arturbosch.detekt.test.assertThat`. This diverges them from the rest of the codebase, I'm cleaning this up a bit.
