### PR TITLE
Remove Spek sample from gettingstarted guide

### DIFF
--- a/website/versioned_docs/version-1.22.0/gettingstarted/type-resolution.md
+++ b/website/versioned_docs/version-1.22.0/gettingstarted/type-resolution.md
@@ -114,41 +114,13 @@ referencing the parameter specified in the constructor:
 
 ```kotlin
 @KotlinCoreEnvironmentTest
-class MyRuleSpec(private val env: KotlinCoreEnvironment) {
+class MyRuleTest(private val env: KotlinCoreEnvironment) {
     @Test
     fun `reports cast that cannot succeed`() {
         val code = """/* The code you want to test */"""
-        assertThat(MyRuleSpec().compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(MyRuleTest().compileAndLintWithContext(env, code)).hasSize(1)
     }
 }
-```
-
-If you're using Spek for testing, you can create a `setupKotlinEnvironment()` util function, and get access to the
-`KotlinCoreEnvironment` by simply calling `val env: KotlinCoreEnvironment by memoized()`:
-
-```kotlin
-fun org.spekframework.spek2.dsl.Root.setupKotlinEnvironment(additionalJavaSourceRootPath: Path? = null) {
-    val wrapper by memoized(
-        CachingMode.SCOPE,
-        { createEnvironment(additionalJavaSourceRootPaths = listOfNotNull(additionalJavaSourceRootPath?.toFile())) },
-        { it.dispose() }
-    )
-
-    // `env` name is used for delegation
-    @Suppress("UNUSED_VARIABLE")
-    val env: KotlinCoreEnvironment by memoized(CachingMode.EACH_GROUP) { wrapper.env }
-}
-
-class MyRuleTest : Spek({
-    setupKotlinEnvironment()
-
-    val env: KotlinCoreEnvironment by memoized()
-
-    it("reports cast that cannot succeed") {
-        val code = """/* The code you want to test */"""
-        assertThat(MyRuleSpec().compileAndLintWithContext(env, code)).hasSize(1)
-    }
-})
 ```
 
 If you're using another testing framework (e.g. JUnit 4), you can use the [`createEnvironment()`](https://github.com/detekt/detekt/blob/cd659ce8737fb177caf140f46f73a1a86b22be56/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/KotlinCoreEnvironmentWrapper.kt#L26-L31) method from `detekt-test-utils`.


### PR DESCRIPTION
We do not use Spek in the code base nor support Spek anymore. Thus, this commit removes the sample from the type-resolution guide.
