### PR TITLE
Print file path report as link file

### DIFF
--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/OutputFacade.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/OutputFacade.kt
@@ -40,7 +40,7 @@ class OutputFacade(
             val filePath = reports[defaultReportMapping(report.id)]?.path
             if (filePath != null) {
                 report.write(filePath, result)
-                result.add(SimpleNotification("Successfully generated ${report.name} at $filePath"))
+                result.add(SimpleNotification("Successfully generated ${report.name} at ${filePath.toUri()}"))
             }
         }
     }

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/OutputFacadeSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/OutputFacadeSpec.kt
@@ -45,10 +45,10 @@ class OutputFacadeSpec {
         spec.withSettings { OutputFacade(this).run(defaultResult) }
 
         assertThat(printStream.toString()).contains(
-            "Successfully generated ${TxtOutputReport().name} at $plainOutputPath",
-            "Successfully generated ${XmlOutputReport().name} at $xmlOutputPath",
-            "Successfully generated ${HtmlOutputReport().name} at $htmlOutputPath",
-            "Successfully generated ${MdOutputReport().name} at $mdOutputPath"
+            "Successfully generated ${TxtOutputReport().name} at ${plainOutputPath.toUri()}",
+            "Successfully generated ${XmlOutputReport().name} at ${xmlOutputPath.toUri()}",
+            "Successfully generated ${HtmlOutputReport().name} at ${htmlOutputPath.toUri()}",
+            "Successfully generated ${MdOutputReport().name} at ${mdOutputPath.toUri()}"
         )
     }
 }


### PR DESCRIPTION
Base on [this](https://github.com/detekt/detekt/discussions/5912) discussion. This commit will print report path as a link file. So we can click on the report path on our terminal, and will open directly browser / text editor / etc.

Before:
![WhatsApp Image 2023-03-17 at 9 36 39 PM](https://user-images.githubusercontent.com/9027262/226185464-eae96649-65c1-429b-8869-e258a4360b11.jpeg)

After
![WhatsApp Image 2023-03-17 at 9 38 25 PM](https://user-images.githubusercontent.com/9027262/226185503-8ded8741-922c-4c7e-afe7-155f4b4e343b.jpeg)
