### PR TITLE
Fix documentation for deprecated 'reports' object (Issue #5908)

### DIFF
--- a/website/versioned_docs/version-1.22.0/introduction/reporting.md
+++ b/website/versioned_docs/version-1.22.0/introduction/reporting.md
@@ -93,8 +93,10 @@ tasks.register("reportMerge", io.gitlab.arturbosch.detekt.report.ReportMergeTask
 
 subprojects {
   detekt {
-    reports.xml.required.set(true)
-    // reports.sarif.required.set(true)
+    reports {
+      xml.required.set(true)
+      // sarif.required.set(true)
+    }
   }
 
   plugins.withType(io.gitlab.arturbosch.detekt.DetektPlugin) {
@@ -118,8 +120,10 @@ val reportMerge by tasks.registering(io.gitlab.arturbosch.detekt.report.ReportMe
 
 subprojects {
   detekt {
-    reports.xml.required.set(true)
-    // reports.sarif.required.set(true)
+    reports {
+      xml.required.set(true)
+      // sarif.required.set(true)
+    }
   }
 
   plugins.withType<io.gitlab.arturbosch.detekt.DetektPlugin> {

--- a/website/versioned_docs/version-1.22.0/introduction/reporting.md
+++ b/website/versioned_docs/version-1.22.0/introduction/reporting.md
@@ -92,7 +92,7 @@ tasks.register("reportMerge", io.gitlab.arturbosch.detekt.report.ReportMergeTask
 }
 
 subprojects {
-  detekt {
+  tasks.named("detekt").configure {
     reports {
       xml.required.set(true)
       // sarif.required.set(true)
@@ -119,7 +119,7 @@ val reportMerge by tasks.registering(io.gitlab.arturbosch.detekt.report.ReportMe
 }
 
 subprojects {
-  detekt {
+  tasks.named("detekt").configure {
     reports {
       xml.required.set(true)
       // sarif.required.set(true)


### PR DESCRIPTION
I made a completely new branch and removed whitespaced and fixed the deprecated reports object.

Fixes #5908