### PR TITLE
Add TodoWithoutLink rule

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -89,6 +89,8 @@ comments:
     active: false
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']
     searchProtectedProperty: false
+  TodoWithoutLink:
+    active: false
 
 complexity:
   active: true

--- a/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentSmellProvider.kt
+++ b/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentSmellProvider.kt
@@ -26,7 +26,8 @@ class CommentSmellProvider : DefaultRuleSetProvider {
             UndocumentedPublicFunction(config),
             UndocumentedPublicProperty(config),
             AbsentOrWrongFileLicense(config),
-            KDocReferencesNonPublicProperty(config)
+            KDocReferencesNonPublicProperty(config),
+            TodoWithoutLink(config)
         )
     )
 }

--- a/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/TodoWithoutLink.kt
+++ b/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/TodoWithoutLink.kt
@@ -1,0 +1,105 @@
+package io.gitlab.arturbosch.detekt.rules.documentation
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.config
+import io.gitlab.arturbosch.detekt.api.internal.Configuration
+import org.jetbrains.kotlin.com.intellij.psi.PsiComment
+import org.jetbrains.kotlin.com.intellij.psi.PsiElement
+import org.jetbrains.kotlin.psi.KtDeclaration
+import org.jetbrains.kotlin.psi.psiUtil.nextSiblingOfSameType
+
+/**
+ * Checks if the To-Do contains linked ticket
+ */
+class TodoWithoutLink(config: Config = Config.empty) : Rule(config) {
+
+    override val issue: Issue = Issue(
+        id = "TodoWithoutLink",
+        description = "Checks if the link was added for ToDo",
+        severity = Severity.Maintainability,
+        debt = Debt.FIVE_MINS
+    )
+
+    @Configuration("custom link regex pattern")
+    private val linkRegexPattern: String by config(DEFAULT_LINK_PATTERN)
+
+    private var pendingCommentWithOffset: Pair<PsiComment, Int>? = null
+
+    /** Visit only docs like this one */
+    override fun visitDeclaration(dcl: KtDeclaration) {
+        super.visitDeclaration(dcl)
+        val kDoc = dcl.docComment ?: return
+        validateBlockComment(kDoc)
+    }
+
+    // Visit only comments like this one
+    override fun visitComment(comment: PsiComment) {
+        super.visitComment(comment)
+        if (comment.tokenType.toString() == "EOL_COMMENT") {
+            validateEOLComment(comment)
+        } else {
+            validateBlockComment(comment)
+        }
+    }
+
+    private fun validateBlockComment(comment: PsiComment) {
+        val lines = comment.text.lines()
+        var offset = 0
+        lines.forEachIndexed { index, line ->
+            offset += line.length
+            validate(comment, line, hasContinuationOnNewLine = { index < lines.lastIndex }, offset)
+            offset += 1
+        }
+    }
+
+    private fun validateEOLComment(comment: PsiComment) {
+        val line = comment.text
+        validate(comment, line, { comment.hasContinuationOnNewLine() }, offset = line.length)
+    }
+
+    private fun validate(comment: PsiComment, line: String, hasContinuationOnNewLine: () -> Boolean, offset: Int) {
+        when {
+            line.containsTodoWithoutTicket() -> {
+                if (hasContinuationOnNewLine()) {
+                    pendingCommentWithOffset = comment to offset
+                } else {
+                    report(comment, offset)
+                }
+            }
+            pendingCommentWithOffset != null && line.containsTicket() -> {
+                pendingCommentWithOffset = null
+            }
+            pendingCommentWithOffset != null && !hasContinuationOnNewLine() -> {
+                pendingCommentWithOffset?.let { report(it.first, it.second) }
+            }
+        }
+    }
+
+    private fun String.containsTodoWithoutTicket(): Boolean =
+        contains("todo", ignoreCase = true) && !containsTicket()
+
+    private fun String.containsTicket(): Boolean = linkRegexPattern.toRegex() in this
+
+    private fun report(element: PsiComment, offset: Int) {
+        report(CodeSmell(issue, Entity.from(element, offset), message = "$element has TODO without linked ticket."))
+    }
+
+    companion object {
+
+        private const val DEFAULT_LINK_PATTERN = """\bhttps?://(?:www\d?)?[\w/#&?=\-.]+\b"""
+    }
+}
+
+private val PsiElement.lineNumber: Int
+    get() = containingFile.viewProvider.document?.getLineNumber(textRange.startOffset)?.plus(1) ?: -1
+
+private fun PsiComment.hasContinuationOnNewLine(): Boolean {
+    val nextComment = nextSiblingOfSameType() ?: return false
+    return containingFile == nextComment.containingFile && lineNumber + 1 == nextComment.lineNumber
+}

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/TodoWithoutLinkSpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/TodoWithoutLinkSpec.kt
@@ -1,0 +1,122 @@
+package io.gitlab.arturbosch.detekt.rules.documentation
+
+import io.github.detekt.test.utils.compileContentForTest
+import io.gitlab.arturbosch.detekt.api.Finding
+import io.gitlab.arturbosch.detekt.test.lint
+import org.junit.jupiter.api.Test
+
+/**
+ * Unit tests for [TodoWithoutLink] rule.
+ */
+class TodoWithoutLinkSpec {
+
+    private val sut = TodoWithoutLink()
+
+    private fun List<Finding>.assert(vararg failingTodos: FailingTodo) {
+        assert(size == failingTodos.size) { "issues size: $size" }
+        assert(all { it.id == "TodoWithoutLink" })
+        assert(map { it.location.source.line }.sorted() == failingTodos.map { it.atLine }.sorted())
+    }
+
+    private fun String.lint(): List<Finding> {
+        val file = compileContentForTest(this.trimIndent())
+        return sut.lint(file)
+    }
+
+    @Test
+    fun contains_todo_in_comments_and_docs() {
+        """
+        package io.gitlab.arturbosch
+        import io.gitlab.arturbosch.detekt.api.RuleSetProvider
+        /**
+         * todo 1 
+         * https://github.com/detekt/detekt
+         TODO 2
+         */
+        class DetektRuleSetProvider : RuleSetProvider {
+            override val ruleSetId: String = "detekt-rules"
+            // ToDo 3 
+            // https://github.com/detekt/detekt 
+            override fun instance(config: Config) = RuleSet(
+                // TODO() 4
+                rules = listOf(
+                    TodoWithoutLink(config), Todo
+                )
+            )
+        }
+        
+        // TODO: 5  https://github.com/detekt/detekt        
+        implementation(project(":detekt"))
+        /* TODO: 6 */   
+        
+        /* TODO: 7 */
+        implementation(project(":detekt"))
+        /** TODO: 8 https://github.com/detekt/detekt */
+        fun foo(s:String) = TODO()
+        """
+            .lint().assert(
+                FailingTodo(id = 2, atLine = 6),
+                FailingTodo(id = 4, atLine = 13),
+                FailingTodo(id = 6, atLine = 22),
+                FailingTodo(id = 7, atLine = 24),
+            )
+    }
+
+    @Test
+    fun contains_links_in_comment() {
+        """
+        // lorem
+        // TODO 1 https://github.com/detekt/detekt 
+        // lorem
+        // TODO 2
+        // lorem 
+        // https://github.com/detekt/detekt 
+        // lorem
+        // TODO 3
+        
+        // https://github.com/detekt/detekt 
+        // lorem
+        // TODO 4
+        // lorem
+        """
+            .lint().assert(FailingTodo(id = 3, atLine = 8), FailingTodo(id = 4, atLine = 12))
+    }
+
+    @Test
+    fun contains_links_in_doc() {
+        """
+        /** 
+         * lorem
+         * TODO 1 https://github.com/detekt/detekt 
+         * lorem
+         * TODO 2
+         * lorem 
+         * https://github.com/detekt/detekt 
+         * lorem
+         * TODO 3
+         
+         * https://github.com/detekt/detekt 
+         * lorem
+         * TODO 4
+         * lorem
+         
+        */
+        @Module()
+        interface A
+        """
+            .lint().assert(FailingTodo(id = 4, atLine = 13))
+    }
+
+    @Test
+    fun contains_todo_in_doc_without_element() {
+        """
+        /**
+         * TODO
+         */
+        """
+            .lint().assert()
+    }
+
+    private data class FailingTodo(val id: Int, val atLine: Int)
+}
+


### PR DESCRIPTION
Checks whether comment or documentation has TODO without a web-link.

This rule is supposed to be disabled by default, but it can be useful for some teams as mine to reuse it if there is a need. 