### PR TITLE
Improve correctness of UnusedPrivateProperty

### DIFF
--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivatePropertySpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivatePropertySpec.kt
@@ -808,4 +808,41 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
             assertThat(subject.lint(code)).hasSize(1)
         }
     }
+
+    @Nested
+    inner class `local variables` {
+        @Test
+        fun `doesn't report used local variable`() {
+            val code = """
+                fun main() {
+                    val used = 1
+                    println(used)
+                }
+            """.trimIndent()
+            assertThat(subject.lint(code)).isEmpty()
+        }
+
+        @Test
+        fun `reports unused local variable`() {
+            val code = """
+                fun main() {
+                    val unused = 1
+                    println("foo")
+                }
+            """.trimIndent()
+            assertThat(subject.lint(code)).hasSize(1)
+        }
+
+        @Test
+        fun `package declarations are ignored`() {
+            val code = """
+                package org.detekt
+                fun main() {
+                    val org = 1
+                    println("foo")
+                }
+            """.trimIndent()
+            assertThat(subject.lint(code)).hasSize(1)
+        }
+    }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivatePropertySpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivatePropertySpec.kt
@@ -810,29 +810,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
     }
 
     @Nested
-    inner class `local variables` {
-        @Test
-        fun `doesn't report used local variable`() {
-            val code = """
-                fun main() {
-                    val used = 1
-                    println(used)
-                }
-            """.trimIndent()
-            assertThat(subject.lint(code)).isEmpty()
-        }
-
-        @Test
-        fun `reports unused local variable`() {
-            val code = """
-                fun main() {
-                    val unused = 1
-                    println("foo")
-                }
-            """.trimIndent()
-            assertThat(subject.lint(code)).hasSize(1)
-        }
-
+    inner class `irrelevant references are ignored` {
         @Test
         fun `package declarations are ignored`() {
             val code = """


### PR DESCRIPTION
Fixes https://github.com/detekt/detekt/issues/5934

Basically ignore package declarations when counting references for the purposes of identifying Unused Private Properties.

## Followups

I believe there are many other edge cases that could be considered; for example, the right-hand side of a dot-expression is also being considered a use reference:

```kotlin
class A (val a: String = "foo")

fun main() {
    val a = 1
    println(A().a)
}
```

Should cause an error, but it doesn't. I'm not sure if there is a better solution here other than exploring each edge case individually, but I am happy to chip down on at least the more obvious ones on followup PRs.