### PR TITLE
Potential new rule: DoubleNegativeLambda

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -524,6 +524,10 @@ style:
   DestructuringDeclarationWithTooManyEntries:
     active: true
     maxDestructuringEntries: 3
+  DoubleNegativeLambda:
+    active: false
+    negativeFunctions:
+      - 'takeUnless'
   EqualsNullCall:
     active: true
   EqualsOnSignatureLine:

--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -529,6 +529,8 @@ style:
     negativeFunctions:
       - reason: 'Use `takeIf` instead.'
         value: 'takeUnless'
+      - reason: 'Use `all` instead.'
+        value: 'none'
     negativeFunctionNameParts:
       - 'not'
       - 'non'

--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -527,7 +527,7 @@ style:
   DoubleNegativeLambda:
     active: false
     negativeFunctions:
-      - reason: 'takeIf'
+      - reason: 'Use `takeIf` instead.'
         value: 'takeUnless'
     negativeFunctionNameParts:
       - 'not'

--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -528,6 +528,9 @@ style:
     active: false
     negativeFunctions:
       - 'takeUnless'
+    negativeFunctionNameParts:
+      - 'not'
+      - 'non'
   EqualsNullCall:
     active: true
   EqualsOnSignatureLine:

--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -527,7 +527,8 @@ style:
   DoubleNegativeLambda:
     active: false
     negativeFunctions:
-      - 'takeUnless'
+      - reason: 'takeIf'
+        value: 'takeUnless'
     negativeFunctionNameParts:
       - 'not'
       - 'non'

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/DoubleNegativeLambda.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/DoubleNegativeLambda.kt
@@ -58,6 +58,7 @@ class DoubleNegativeLambda(config: Config = Config.empty) : Rule(config) {
     private val negativeFunctions: List<NegativeFunction> by config(
         valuesWithReason(
             "takeUnless" to "Use `takeIf` instead.",
+            "none" to "Use `all` instead.",
         )
     ) { list ->
         list.map { NegativeFunction(simpleName = it.value, recommendation = it.reason) }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/DoubleNegativeLambda.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/DoubleNegativeLambda.kt
@@ -71,7 +71,7 @@ class DoubleNegativeLambda(config: Config = Config.empty) : Rule(config) {
     override fun visitCallExpression(expression: KtCallExpression) {
         super.visitCallExpression(expression)
         val calleeExpression = expression.calleeExpression?.text ?: return
-        val forbiddenFunction = negativeFunctions.firstOrNull { it.name == calleeExpression } ?: return
+        val negativeFunction = negativeFunctions.firstOrNull { it.name == calleeExpression } ?: return
         val lambdaExpression = expression.lambdaArguments.firstOrNull() ?: return
 
         val forbiddenChildren = lambdaExpression.collectDescendantsOfType<KtExpression> {
@@ -83,7 +83,7 @@ class DoubleNegativeLambda(config: Config = Config.empty) : Rule(config) {
                 CodeSmell(
                     issue,
                     Entity.from(expression),
-                    formatMessage(forbiddenChildren, forbiddenFunction)
+                    formatMessage(forbiddenChildren, negativeFunction)
                 )
             )
         }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/DoubleNegativeLambda.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/DoubleNegativeLambda.kt
@@ -1,0 +1,95 @@
+package io.gitlab.arturbosch.detekt.rules.style
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.config
+import io.gitlab.arturbosch.detekt.api.internal.Configuration
+import org.jetbrains.kotlin.lexer.KtTokens
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtExpression
+import org.jetbrains.kotlin.psi.KtOperationReferenceExpression
+import org.jetbrains.kotlin.psi.psiUtil.collectDescendantsOfType
+
+/**
+ * Detects negation in lambda blocks where the function name is also in the negative (like `takeUnless`).
+ * A double negative is harder to read than a positive. In particular, if there are multiple conditions with `&&` etc. inside
+ * the lambda, then the reader may need to unpack these using DeMorgan's laws. Consider rewriting the lambda to use a positive version
+ * of the function (like `takeIf`).
+ *
+ * <noncompliant>
+ * Random.Default.nextInt().takeUnless { !it.isEven() }
+ * </noncompliant>
+ * <compliant>
+ * Random.Default.nextInt().takeIf { it.isOdd() }
+ * </compliant>
+ */
+class DoubleNegativeLambda(config: Config = Config.empty) : Rule(config) {
+
+    override val issue = Issue(
+        "DoubleNegativeLambdaBlock",
+        Severity.Style,
+        "Double negative from a function name expressed in the negative (like `takeUnless`) with a lambda block " +
+            "that also contains negation. This is more readable when rewritten using a positive form of the function " +
+            "(like `takeIf`).",
+        Debt.FIVE_MINS,
+    )
+
+    private val splitCamelCaseRegex = "(?<=[a-z])(?=[A-Z])".toRegex()
+
+    private val negationTokens = listOf(
+        KtTokens.EXCL,
+        KtTokens.EXCLEQ,
+        KtTokens.EXCLEQEQEQ,
+        KtTokens.NOT_IN,
+        KtTokens.NOT_IS,
+    )
+
+    private val negatingFunctionNameParts = listOf("not", "non")
+
+    @Configuration("Function names expressed in the negative that can form double negatives with their lambda blocks.")
+    private val negativeFunctions: Set<String> by config(listOf("takeUnless")) { it.toSet() }
+
+    override fun visitCallExpression(expression: KtCallExpression) {
+        super.visitCallExpression(expression)
+        val calleeExpression = expression.calleeExpression?.text ?: return
+
+        if (calleeExpression in negativeFunctions) {
+            val lambdaExpression = expression.lambdaArguments.firstOrNull() ?: return
+            val forbiddenChildren = lambdaExpression.collectDescendantsOfType<KtExpression> {
+                it.isForbiddenNegation()
+            }
+
+            if (forbiddenChildren.isNotEmpty()) {
+                report(
+                    CodeSmell(
+                        issue,
+                        Entity.from(expression),
+                        "Double negative through using ${forbiddenChildren.joinInBackTicks()} inside a " +
+                            "`$calleeExpression` lambda. Rewrite in the positive."
+                    )
+                )
+            }
+        }
+    }
+
+    private fun KtExpression.isForbiddenNegation(): Boolean {
+        return when (this) {
+            is KtOperationReferenceExpression -> operationSignTokenType in negationTokens
+            is KtCallExpression -> text == "not()" || text.split(splitCamelCaseRegex).map { it.lowercase() }
+                .any { it in negatingFunctionNameParts }
+
+            else -> false
+        }
+    }
+
+    private fun List<KtExpression>.joinInBackTicks() = joinToString { "`${it.text}`" }
+
+    companion object {
+        const val NEGATIVE_FUNCTIONS = "negativeFunctions"
+    }
+}

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/DoubleNegativeLambda.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/DoubleNegativeLambda.kt
@@ -59,7 +59,7 @@ class DoubleNegativeLambda(config: Config = Config.empty) : Rule(config) {
             "takeUnless" to "takeIf",
         )
     ) { list ->
-        list.map { NegativeFunction(name = it.value, positiveCounterpart = it.reason) }
+        list.map { NegativeFunction(simpleName = it.value, positiveCounterpart = it.reason) }
     }
 
     @Configuration(
@@ -71,10 +71,10 @@ class DoubleNegativeLambda(config: Config = Config.empty) : Rule(config) {
     override fun visitCallExpression(expression: KtCallExpression) {
         super.visitCallExpression(expression)
         val calleeExpression = expression.calleeExpression?.text ?: return
-        val negativeFunction = negativeFunctions.firstOrNull { it.name == calleeExpression } ?: return
-        val lambdaExpression = expression.lambdaArguments.firstOrNull() ?: return
+        val negativeFunction = negativeFunctions.firstOrNull { it.simpleName == calleeExpression } ?: return
+        val lambdaArgument = expression.lambdaArguments.firstOrNull() ?: return
 
-        val forbiddenChildren = lambdaExpression.collectDescendantsOfType<KtExpression> {
+        val forbiddenChildren = lambdaArgument.collectDescendantsOfType<KtExpression> {
             it.isForbiddenNegation()
         }
 
@@ -104,7 +104,7 @@ class DoubleNegativeLambda(config: Config = Config.empty) : Rule(config) {
         negativeFunction: NegativeFunction,
     ) = buildString {
         append("Double negative through using ${forbiddenChildren.joinInBackTicks()} inside a ")
-        append("`${negativeFunction.name}` lambda. ")
+        append("`${negativeFunction.simpleName}` lambda. ")
         append("Rewrite in the positive")
         if (negativeFunction.positiveCounterpart != null) {
             append(" with `${negativeFunction.positiveCounterpart}`.")
@@ -119,7 +119,7 @@ class DoubleNegativeLambda(config: Config = Config.empty) : Rule(config) {
      * A function that can form a double negative with its lambda.
      */
     private data class NegativeFunction(
-        val name: String,
+        val simpleName: String,
         val positiveCounterpart: String?,
     )
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/DoubleNegativeLambda.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/DoubleNegativeLambda.kt
@@ -52,14 +52,15 @@ class DoubleNegativeLambda(config: Config = Config.empty) : Rule(config) {
 
     @Configuration(
         "Function names expressed in the negative that can form double negatives with their lambda blocks. " +
-            "These are grouped together with the positive counterpart of the function, or `null` if this is unknown."
+            "These are grouped together with a recommendation to use a positive counterpart, or `null` if this is " +
+            "unknown."
     )
     private val negativeFunctions: List<NegativeFunction> by config(
         valuesWithReason(
-            "takeUnless" to "takeIf",
+            "takeUnless" to "Use `takeIf` instead.",
         )
     ) { list ->
-        list.map { NegativeFunction(simpleName = it.value, positiveCounterpart = it.reason) }
+        list.map { NegativeFunction(simpleName = it.value, recommendation = it.reason) }
     }
 
     @Configuration(
@@ -105,11 +106,10 @@ class DoubleNegativeLambda(config: Config = Config.empty) : Rule(config) {
     ) = buildString {
         append("Double negative through using ${forbiddenChildren.joinInBackTicks()} inside a ")
         append("`${negativeFunction.simpleName}` lambda. ")
-        append("Rewrite in the positive")
-        if (negativeFunction.positiveCounterpart != null) {
-            append(" with `${negativeFunction.positiveCounterpart}`.")
+        if (negativeFunction.recommendation != null) {
+            append(negativeFunction.recommendation)
         } else {
-            append(".")
+            append("Rewrite in the positive.")
         }
     }
 
@@ -120,7 +120,7 @@ class DoubleNegativeLambda(config: Config = Config.empty) : Rule(config) {
      */
     private data class NegativeFunction(
         val simpleName: String,
-        val positiveCounterpart: String?,
+        val recommendation: String?,
     )
 
     companion object {

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/DoubleNegativeLambda.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/DoubleNegativeLambda.kt
@@ -23,10 +23,10 @@ import org.jetbrains.kotlin.psi.psiUtil.collectDescendantsOfType
  * of the function (like `takeIf`).
  *
  * <noncompliant>
- * Random.Default.nextInt().takeUnless { !it.isEven() }
+ * fun Int.evenOrNull() = takeUnless { it % 2 != 0 }
  * </noncompliant>
  * <compliant>
- * Random.Default.nextInt().takeIf { it.isOdd() }
+ * fun Int.evenOrNull() = takeIf { it % 2 == 0 }
  * </compliant>
  */
 class DoubleNegativeLambda(config: Config = Config.empty) : Rule(config) {

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/DoubleNegativeLambda.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/DoubleNegativeLambda.kt
@@ -49,10 +49,13 @@ class DoubleNegativeLambda(config: Config = Config.empty) : Rule(config) {
         KtTokens.NOT_IS,
     )
 
-    private val negatingFunctionNameParts = listOf("not", "non")
-
     @Configuration("Function names expressed in the negative that can form double negatives with their lambda blocks.")
     private val negativeFunctions: Set<String> by config(listOf("takeUnless")) { it.toSet() }
+
+    @Configuration(
+        "Function name parts to look for in the lambda block when deciding if the lambda contains a negative."
+    )
+    private val negativeFunctionNameParts: Set<String> by config(listOf("not", "non")) { it.toSet() }
 
     override fun visitCallExpression(expression: KtCallExpression) {
         super.visitCallExpression(expression)
@@ -81,7 +84,7 @@ class DoubleNegativeLambda(config: Config = Config.empty) : Rule(config) {
         return when (this) {
             is KtOperationReferenceExpression -> operationSignTokenType in negationTokens
             is KtCallExpression -> text == "not()" || text.split(splitCamelCaseRegex).map { it.lowercase() }
-                .any { it in negatingFunctionNameParts }
+                .any { it in negativeFunctionNameParts }
 
             else -> false
         }
@@ -91,5 +94,6 @@ class DoubleNegativeLambda(config: Config = Config.empty) : Rule(config) {
 
     companion object {
         const val NEGATIVE_FUNCTIONS = "negativeFunctions"
+        const val NEGATIVE_FUNCTION_NAME_PARTS = "negativeFunctionNameParts"
     }
 }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/DoubleNegativeLambda.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/DoubleNegativeLambda.kt
@@ -31,7 +31,7 @@ import org.jetbrains.kotlin.psi.psiUtil.collectDescendantsOfType
 class DoubleNegativeLambda(config: Config = Config.empty) : Rule(config) {
 
     override val issue = Issue(
-        "DoubleNegativeLambdaBlock",
+        "DoubleNegativeLambda",
         Severity.Style,
         "Double negative from a function name expressed in the negative (like `takeUnless`) with a lambda block " +
             "that also contains negation. This is more readable when rewritten using a positive form of the function " +

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/StyleGuideProvider.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/StyleGuideProvider.kt
@@ -106,6 +106,7 @@ class StyleGuideProvider : DefaultRuleSetProvider {
             MaxChainedCallsOnSameLine(config),
             AlsoCouldBeApply(config),
             UseSumOfInsteadOfFlatMapSize(config),
+            DoubleNegativeLambda(config),
         )
     )
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/DoubleNegativeLambdaSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/DoubleNegativeLambdaSpec.kt
@@ -28,7 +28,7 @@ class DoubleNegativeLambdaSpec {
         val code = """
             import kotlin.random.Random
             fun Int.isEven() = this % 2 == 0
-            val rand = kotlin.random.Random.Default.nextInt().takeUnless { it > 0 && !it.isEven() }
+            val rand = Random.Default.nextInt().takeUnless { it > 0 && !it.isEven() }
         """.trimIndent()
 
         assertThat(subject.compileAndLint(code)).hasSize(1)
@@ -39,7 +39,7 @@ class DoubleNegativeLambdaSpec {
         val code = """
             import kotlin.random.Random
             fun Int.isEven() = this % 2 == 0
-            val rand = kotlin.random.Random.Default.nextInt().takeUnless { !(it == 0 || it.isEven()) }
+            val rand = Random.Default.nextInt().takeUnless { !(it == 0 || it.isEven()) }
         """.trimIndent()
 
         assertThat(subject.compileAndLint(code)).hasSize(1)
@@ -50,7 +50,7 @@ class DoubleNegativeLambdaSpec {
         val code = """
             import kotlin.random.Random
             fun Int.isEven() = this % 2 == 0
-            val rand = kotlin.random.Random.Default.nextInt().takeUnless { it.isEven().takeIf { i -> !i } }
+            val rand = Random.Default.nextInt().takeUnless { it.isEven().takeIf { i -> !i } ?: false }
         """.trimIndent()
 
         assertThat(subject.compileAndLint(code)).hasSize(1)
@@ -61,13 +61,13 @@ class DoubleNegativeLambdaSpec {
         val code = """
             import kotlin.random.Random
             fun Int.isEven() = this % 2 == 0
-            val rand = kotlin.random.Random.Default.nextInt().takeUnless { it.isEven().takeUnless { i -> !i } }
+            val rand = Random.Default.nextInt().takeUnless { it.isEven().takeUnless { i -> !i } ?: false }
         """.trimIndent()
 
         val findings = subject.compileAndLint(code)
         assertThat(findings).hasSize(2)
-        assertThat(findings[0]).hasSourceLocation(3, 76) // second takeUnless
-        assertThat(findings[1]).hasSourceLocation(3, 51) // first takeUnless
+        assertThat(findings[0]).hasSourceLocation(3, 62) // second takeUnless
+        assertThat(findings[1]).hasSourceLocation(3, 37) // first takeUnless
     }
 
     @Test
@@ -75,7 +75,7 @@ class DoubleNegativeLambdaSpec {
         val code = """
             import kotlin.random.Random
             fun Int.isNotZero() = this != 0
-            val rand = kotlin.random.Random.Default.nextInt().takeUnless { it.isNotZero() }
+            val rand = Random.Default.nextInt().takeUnless { it.isNotZero() }
         """.trimIndent()
 
         assertThat(subject.compileAndLint(code)).hasSize(1)

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/DoubleNegativeLambdaSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/DoubleNegativeLambdaSpec.kt
@@ -213,7 +213,7 @@ class DoubleNegativeLambdaSpec {
         assertThat(findings).hasStartSourceLocation(3, 37)
         assertThat(findings).hasEndSourceLocation(3, 74)
         assertThat(findings[0]).hasMessage(
-            "Double negative through using `!in`, `!=` inside a `takeUnless` lambda. Rewrite in the positive with `takeIf`."
+            "Double negative through using `!in`, `!=` inside a `takeUnless` lambda. Use `takeIf` instead."
         )
     }
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/DoubleNegativeLambdaSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/DoubleNegativeLambdaSpec.kt
@@ -35,6 +35,17 @@ class DoubleNegativeLambdaSpec {
     }
 
     @Test
+    fun `reports logical not prefixing brackets`() {
+        val code = """
+            import kotlin.random.Random
+            fun Int.isEven() = this % 2 == 0
+            val rand = kotlin.random.Random.Default.nextInt().takeUnless { !(it == 0 || it.isEven()) }
+        """.trimIndent()
+
+        assertThat(subject.compileAndLint(code)).hasSize(1)
+    }
+
+    @Test
     fun `reports function with 'not' in the name`() {
         val code = """
             import kotlin.random.Random

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/DoubleNegativeLambdaSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/DoubleNegativeLambdaSpec.kt
@@ -1,0 +1,154 @@
+package io.gitlab.arturbosch.detekt.rules.style
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.test.TestConfig
+import io.gitlab.arturbosch.detekt.test.assertThat
+import io.gitlab.arturbosch.detekt.test.compileAndLint
+import org.junit.jupiter.api.Test
+
+class DoubleNegativeLambdaSpec {
+
+    private val subject = DoubleNegativeLambda(Config.empty)
+
+    @Test
+    fun `reports simple logical not`() {
+        val code = """
+            fun Int.isEven() = this % 2 == 0
+            val rand = Random.Default.nextInt().takeUnless { !it.isEven() }
+        """.trimIndent()
+
+        assertThat(subject.compileAndLint(code)).hasSize(1)
+    }
+
+    @Test
+    fun `reports logical not in binary expression`() {
+        val code = """
+            fun Int.isEven() = this % 2 == 0
+            val rand = Random.Default.nextInt().takeUnless { it > 0 && !it.isEven() }
+        """.trimIndent()
+
+        assertThat(subject.compileAndLint(code)).hasSize(1)
+    }
+
+    @Test
+    fun `reports function with 'not' in the name`() {
+        val code = """
+            fun Int.isNotZero() = this != 0
+            val rand = Random.Default.nextInt().takeUnless { it.isNotZero() }
+        """.trimIndent()
+
+        assertThat(subject.compileAndLint(code)).hasSize(1)
+    }
+
+    @Test
+    fun `reports zero-param function with 'non' in the name`() {
+        val code = """
+            fun Int.isNonNegative() = 0 < this
+            val rand = Random.Default.nextInt().takeUnless { it.isNonNegative() }
+        """.trimIndent()
+
+        assertThat(subject.compileAndLint(code)).hasSize(1)
+    }
+
+    @Test
+    fun `reports single-param function with 'non' in the name`() {
+        val code = """
+            fun Int.isNotGreaterThan(other: Int) = other < this
+            val rand = Random.Default.nextInt().takeUnless { it.isNotGreaterThan(0) }
+        """.trimIndent()
+
+        assertThat(subject.compileAndLint(code)).hasSize(1)
+    }
+
+    @Test
+    fun `reports not equal`() {
+        val code = """
+            val rand = Random.Default.nextInt().takeUnless { it != 0 }
+        """.trimIndent()
+
+        assertThat(subject.compileAndLint(code)).hasSize(1)
+    }
+
+    @Test
+    fun `reports not equal by reference`() {
+        val code = """
+            val rand = Random.Default.nextInt().takeUnless { it !== 0 }
+        """.trimIndent()
+
+        assertThat(subject.compileAndLint(code)).hasSize(1)
+    }
+
+    @Test
+    fun `reports !in`() {
+        val code = """
+            val rand = Random.Default.nextInt().takeUnless { it !in 1..3 }
+        """.trimIndent()
+
+        assertThat(subject.compileAndLint(code)).hasSize(1)
+    }
+
+    @Test
+    fun `reports !is`() {
+        val code = """
+            val list = listOf(3, "a", true)
+            val maybeBoolean = list.firstOrNull().takeUnless { it !is Boolean }
+        """.trimIndent()
+        assertThat(subject.compileAndLint(code)).hasSize(1)
+    }
+
+    @Test
+    fun `reports use of operator fun not`() {
+        val code = """
+            val rand = Random.Default.nextInt().takeUnless { (it > 0).not() }
+        """.trimIndent()
+
+        assertThat(subject.compileAndLint(code)).hasSize(1)
+    }
+
+    @Test
+    fun `does not report function with 'not' in part of the name`() {
+        val code = """
+            fun String.hasAnnotations() = this.contains("annotations")
+            val nonAnnotated = "".takeUnless { it.hasAnnotations() }
+        """.trimIndent()
+
+        assertThat(subject.compileAndLint(code)).isEmpty()
+    }
+
+    @Test
+    fun `does not report non-null assert in takeUnless`() {
+        val code = """
+            val list: List<String?> = listOf("", null, "a")
+            val filteredList = list.takeUnless { it!!.isEmpty() }
+        """.trimIndent()
+
+        assertThat(subject.compileAndLint(code)).isEmpty()
+    }
+
+    @Test
+    fun `reports function name from config`() {
+        val config = TestConfig(DoubleNegativeLambda.NEGATIVE_FUNCTIONS to listOf("none", "filterNot"))
+        val code = """
+            fun Int.isEven() = this % 2 == 0
+            val isValid = list(1, 2, 3).filterNot { !it.isEven() }.none { it != 0 }
+        """.trimIndent()
+
+        assertThat(DoubleNegativeLambda(config).compileAndLint(code)).hasSize(2)
+    }
+
+    @Test
+    fun `reports multiple negations in message`() {
+        val code = """
+            val list: List<Int> = listOf(1, 2, 3)
+            val rand = Random.Default.nextInt().takeUnless { it !in list && it != 0 }
+        """.trimIndent()
+
+        val findings = subject.compileAndLint(code)
+        assertThat(findings).hasSize(1)
+        assertThat(findings).hasStartSourceLocation(2, 37)
+        assertThat(findings).hasEndSourceLocation(2, 74)
+        assertThat(findings[0]).hasMessage(
+            "Double negative through using `!in`, `!=` inside a `takeUnless` lambda. Rewrite in the positive."
+        )
+    }
+}

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/DoubleNegativeLambdaSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/DoubleNegativeLambdaSpec.kt
@@ -134,7 +134,7 @@ class DoubleNegativeLambdaSpec {
     }
 
     @Test
-    fun `reports function name from config`() {
+    fun `reports negative function name from config`() {
         val config = TestConfig(DoubleNegativeLambda.NEGATIVE_FUNCTIONS to listOf("none", "filterNot"))
         val code = """
             fun Int.isEven() = this % 2 == 0
@@ -142,6 +142,18 @@ class DoubleNegativeLambdaSpec {
         """.trimIndent()
 
         assertThat(DoubleNegativeLambda(config).compileAndLint(code)).hasSize(2)
+    }
+
+    @Test
+    fun `reports negative function name parts from config`() {
+        val config = TestConfig(DoubleNegativeLambda.NEGATIVE_FUNCTION_NAME_PARTS to listOf("isnt"))
+        val code = """
+            import kotlin.random.Random
+            fun Int.isntOdd() = this % 2 == 0
+            val rand = Random.Default.nextInt().takeUnless { it.isntOdd() }
+        """.trimIndent()
+
+        assertThat(DoubleNegativeLambda(config).compileAndLint(code)).hasSize(1)
     }
 
     @Test

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/DoubleNegativeLambdaSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/DoubleNegativeLambdaSpec.kt
@@ -13,6 +13,7 @@ class DoubleNegativeLambdaSpec {
     @Test
     fun `reports simple logical not`() {
         val code = """
+            import kotlin.random.Random
             fun Int.isEven() = this % 2 == 0
             val rand = Random.Default.nextInt().takeUnless { !it.isEven() }
         """.trimIndent()
@@ -23,8 +24,9 @@ class DoubleNegativeLambdaSpec {
     @Test
     fun `reports logical not in binary expression`() {
         val code = """
+            import kotlin.random.Random
             fun Int.isEven() = this % 2 == 0
-            val rand = Random.Default.nextInt().takeUnless { it > 0 && !it.isEven() }
+            val rand = kotlin.random.Random.Default.nextInt().takeUnless { it > 0 && !it.isEven() }
         """.trimIndent()
 
         assertThat(subject.compileAndLint(code)).hasSize(1)
@@ -33,8 +35,9 @@ class DoubleNegativeLambdaSpec {
     @Test
     fun `reports function with 'not' in the name`() {
         val code = """
+            import kotlin.random.Random
             fun Int.isNotZero() = this != 0
-            val rand = Random.Default.nextInt().takeUnless { it.isNotZero() }
+            val rand = kotlin.random.Random.Default.nextInt().takeUnless { it.isNotZero() }
         """.trimIndent()
 
         assertThat(subject.compileAndLint(code)).hasSize(1)
@@ -43,6 +46,7 @@ class DoubleNegativeLambdaSpec {
     @Test
     fun `reports zero-param function with 'non' in the name`() {
         val code = """
+            import kotlin.random.Random
             fun Int.isNonNegative() = 0 < this
             val rand = Random.Default.nextInt().takeUnless { it.isNonNegative() }
         """.trimIndent()
@@ -53,6 +57,7 @@ class DoubleNegativeLambdaSpec {
     @Test
     fun `reports single-param function with 'non' in the name`() {
         val code = """
+            import kotlin.random.Random            
             fun Int.isNotGreaterThan(other: Int) = other < this
             val rand = Random.Default.nextInt().takeUnless { it.isNotGreaterThan(0) }
         """.trimIndent()
@@ -63,6 +68,7 @@ class DoubleNegativeLambdaSpec {
     @Test
     fun `reports not equal`() {
         val code = """
+            import kotlin.random.Random
             val rand = Random.Default.nextInt().takeUnless { it != 0 }
         """.trimIndent()
 
@@ -72,6 +78,7 @@ class DoubleNegativeLambdaSpec {
     @Test
     fun `reports not equal by reference`() {
         val code = """
+            import kotlin.random.Random
             val rand = Random.Default.nextInt().takeUnless { it !== 0 }
         """.trimIndent()
 
@@ -81,6 +88,7 @@ class DoubleNegativeLambdaSpec {
     @Test
     fun `reports !in`() {
         val code = """
+            import kotlin.random.Random
             val rand = Random.Default.nextInt().takeUnless { it !in 1..3 }
         """.trimIndent()
 
@@ -99,6 +107,7 @@ class DoubleNegativeLambdaSpec {
     @Test
     fun `reports use of operator fun not`() {
         val code = """
+            import kotlin.random.Random
             val rand = Random.Default.nextInt().takeUnless { (it > 0).not() }
         """.trimIndent()
 
@@ -118,8 +127,7 @@ class DoubleNegativeLambdaSpec {
     @Test
     fun `does not report non-null assert in takeUnless`() {
         val code = """
-            val list: List<String?> = listOf("", null, "a")
-            val filteredList = list.takeUnless { it!!.isEmpty() }
+            val x = "".takeUnless { it!!.isEmpty() }
         """.trimIndent()
 
         assertThat(subject.compileAndLint(code)).isEmpty()
@@ -139,14 +147,15 @@ class DoubleNegativeLambdaSpec {
     @Test
     fun `reports multiple negations in message`() {
         val code = """
+            import kotlin.random.Random
             val list: List<Int> = listOf(1, 2, 3)
             val rand = Random.Default.nextInt().takeUnless { it !in list && it != 0 }
         """.trimIndent()
 
         val findings = subject.compileAndLint(code)
         assertThat(findings).hasSize(1)
-        assertThat(findings).hasStartSourceLocation(2, 37)
-        assertThat(findings).hasEndSourceLocation(2, 74)
+        assertThat(findings).hasStartSourceLocation(3, 37)
+        assertThat(findings).hasEndSourceLocation(3, 74)
         assertThat(findings[0]).hasMessage(
             "Double negative through using `!in`, `!=` inside a `takeUnless` lambda. Rewrite in the positive."
         )

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/DoubleNegativeLambdaSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/DoubleNegativeLambdaSpec.kt
@@ -138,7 +138,7 @@ class DoubleNegativeLambdaSpec {
         val config = TestConfig(DoubleNegativeLambda.NEGATIVE_FUNCTIONS to listOf("none", "filterNot"))
         val code = """
             fun Int.isEven() = this % 2 == 0
-            val isValid = list(1, 2, 3).filterNot { !it.isEven() }.none { it != 0 }
+            val isValid = listOf(1, 2, 3).filterNot { !it.isEven() }.none { it != 0 }
         """.trimIndent()
 
         assertThat(DoubleNegativeLambda(config).compileAndLint(code)).hasSize(2)


### PR DESCRIPTION
# Potential new rule: DoubleNegativeLambda

## Rationale

There was recently a popular post on Y-Combinator Hacker News arguing against the use of `unless` in Ruby.

https://news.ycombinator.com/item?id=33965933

It is arguing that:
1. Double negatives are hard to read: (`takeUnless { !it.isOdd() }` vs `takeIf { it.isEven() }`)
2. It's easy for a nice simple `takeUnless { it.isEven() }` to become complex when some edge case is found and an extra condition is added so it becomes something like `takeUnless { it.isEven() && !it.isAlreadyAccountedFor() }`. Now the reader needs to unpack this expression using DeMorgan's laws

I am wondering if you would be interested in a rule that checks for double negatives like this using `takeUnless`? (it's okay if 'no', can keep it private)

## Considerations

* Should it check for `filterNot` and `none` by default as well?

To me, negatives in a `filterNot` block seem less harmful than in a `takeUnless` block. I looked for examples and I found this one [in KotlinPoet](https://github.com/square/kotlinpoet/blob/master/interop/kotlinx-metadata/src/main/kotlin/com/squareup/kotlinpoet/metadata/specs/KotlinPoetMetadataSpecs.kt#L572):

```kotlin
addModifiers(
        flags.modalities
          .filterNot { it == FINAL && !isOverride } // Final is the default
          .filterNot { it == OPEN && isOverride } // Overrides are implicitly open
          .filterNot { it == OPEN && isInInterface }, // interface methods are implicitly open
      )
```
It doesn't seem to benefit a lot from being rewritten in the positive as `filter { it != FINAL || isOverride }` 

* Should it account for functions in backticks? 

One could argue that in addition to detecting simple function names with "not" and "non" in them, it should also try and catch negation in functions with back ticks to report cases like `takeUnless { it.`isn't a word`() }`. I thought it would add a bit of complexity to the rule and detecting negation in a backtick function name would make it a harder problem where we would be trying to solve the problem of detecting negation in English which has so many different ways (isn't, can't, won't etc.)

* Should it use type resolution to find functions using FQN?

To me, functions like `takeUnless` are quite rare. I think it would be unusual to want to distinguish between one or the other.

## Disclosure

I used ChatGPT4 to help me write the rule and was thinking of writing an article about my experience (Chat GPT was not that helpful here despite Detekt code seemingly being in the training data).

Attaching images of prompts and responses for transparency:
https://user-images.githubusercontent.com/11054916/227701241-3e245ea6-bc80-48cb-a7bf-87cd4cbd65fd.png
https://user-images.githubusercontent.com/11054916/227701292-3949810e-af48-4a1d-8e92-e394b4dd39b8.png
https://user-images.githubusercontent.com/11054916/227701325-88c87fd0-ae47-42b6-9eba-bbd84c47b2c9.png
https://user-images.githubusercontent.com/11054916/227701353-d659c1ba-52ab-4823-859f-952f6f5d9155.png
https://user-images.githubusercontent.com/11054916/227701385-5d8c549d-e8b7-4731-92e9-b68ca6187cd1.png
https://user-images.githubusercontent.com/11054916/227701400-c8d409ef-4046-47a7-8e89-3d9e9692dc91.png
https://user-images.githubusercontent.com/11054916/227701424-f4d294d9-2d1e-466e-9492-30406e697d52.png
https://user-images.githubusercontent.com/11054916/227701439-94f86de1-363e-4edc-8979-259ab9393012.png
https://user-images.githubusercontent.com/11054916/227701454-8802f70f-9060-4c04-ba7d-cf8082bbe8fe.png
https://user-images.githubusercontent.com/11054916/227701474-1c2484a1-0ade-467f-b205-8d2f8eec1249.png
https://user-images.githubusercontent.com/11054916/227701485-7cd2e21e-d46d-4e9c-91ac-b18804c5e76e.png
https://user-images.githubusercontent.com/11054916/227701499-49eaa96d-a87c-4383-96ad-89abec25407a.png
https://user-images.githubusercontent.com/11054916/227701509-6895ef2d-9d6e-443b-a9ee-e2ef4418d3e3.png
