### PR TITLE
Fix ExpressionBodySyntax not checking property getters/setters

### DIFF
--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExpressionBodySyntax.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExpressionBodySyntax.kt
@@ -12,8 +12,10 @@ import io.gitlab.arturbosch.detekt.api.internal.Configuration
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtBinaryExpression
 import org.jetbrains.kotlin.psi.KtBlockExpression
+import org.jetbrains.kotlin.psi.KtDeclarationWithBody
 import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.KtProperty
 import org.jetbrains.kotlin.psi.KtReturnExpression
 import org.jetbrains.kotlin.psi.psiUtil.anyDescendantOfType
 
@@ -50,8 +52,19 @@ class ExpressionBodySyntax(config: Config = Config.empty) : Rule(config) {
     @Configuration("include return statements with line wraps in it")
     private val includeLineWrapping: Boolean by config(false)
 
+    override fun visitProperty(property: KtProperty) {
+        super.visitProperty(property)
+        property.getter?.checkForExpressionBodySyntax()
+        property.setter?.checkForExpressionBodySyntax()
+    }
+
     override fun visitNamedFunction(function: KtNamedFunction) {
-        val stmt = function.bodyExpression
+        super.visitNamedFunction(function)
+        function.checkForExpressionBodySyntax()
+    }
+
+    private fun KtDeclarationWithBody.checkForExpressionBodySyntax() {
+        val stmt = bodyExpression
             ?.singleReturnStatement()
             ?.takeUnless { it.containsReturnStmtsInNullableArguments() }
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExpressionBodySyntaxSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExpressionBodySyntaxSpec.kt
@@ -29,6 +29,35 @@ class ExpressionBodySyntaxSpec {
         }
 
         @Test
+        fun `reports return statements in property getter and setter`() {
+            val code = """
+                class Test {
+                    var b: Boolean
+                        get() {
+                            return true
+                        }
+                        set(value) {
+                            return
+                        }
+                }
+            """.trimIndent()
+            assertThat(subject.compileAndLint(code)).hasSize(2)
+        }
+
+        @Test
+        fun `does not report properties with no getter or setter body`() {
+            val code = """
+                class Test {
+                    var b1: Boolean = false
+                        get
+                        set
+                    var b2: Boolean = false
+                }
+            """.trimIndent()
+            assertThat(subject.compileAndLint(code)).isEmpty()
+        }
+
+        @Test
         fun `reports return statement with method chain`() {
             assertThat(
                 subject.compileAndLint(


### PR DESCRIPTION
Closes #5936
