### PR TITLE
Prevent import statements from counting as references for UnusedPrivateProperty

### DIFF
--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateProperty.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateProperty.kt
@@ -15,6 +15,7 @@ import io.gitlab.arturbosch.detekt.rules.isActual
 import io.gitlab.arturbosch.detekt.rules.isExpect
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtImportDirective
 import org.jetbrains.kotlin.psi.KtNamedDeclaration
 import org.jetbrains.kotlin.psi.KtPackageDirective
 import org.jetbrains.kotlin.psi.KtParameter
@@ -142,6 +143,7 @@ private class UnusedPrivatePropertyVisitor(private val allowedNames: Regex) : De
     private fun skipNode(expression: KtReferenceExpression): Boolean {
         return when {
             expression.isPackageDirective() -> true
+            expression.isImportDirective() -> true
             else -> false
         }
     }
@@ -149,4 +151,8 @@ private class UnusedPrivatePropertyVisitor(private val allowedNames: Regex) : De
 
 private fun PsiElement.isPackageDirective(): Boolean {
     return this is KtPackageDirective || parent?.isPackageDirective() == true
+}
+
+private fun PsiElement.isImportDirective(): Boolean {
+    return this is KtImportDirective || parent?.isImportDirective() == true
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivatePropertySpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivatePropertySpec.kt
@@ -817,10 +817,32 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                 package org.detekt
                 fun main() {
                     val org = 1
+                    val detekt = 1
                     println("foo")
                 }
             """.trimIndent()
-            assertThat(subject.lint(code)).hasSize(1)
+
+            val results = subject.lint(code)
+            assertThat(results).hasSize(2)
+            assertThat(results).anyMatch { it.message == "Private property `org` is unused." }
+            assertThat(results).anyMatch { it.message == "Private property `detekt` is unused." }
+        }
+
+        @Test
+        fun `import declarations are ignored`() {
+            val code = """
+                import org.detekt.Foo
+                fun main() {
+                    val org = 1
+                    val detekt = 1
+                    println("foo")
+                }
+            """.trimIndent()
+
+            val results = subject.lint(code)
+            assertThat(results).hasSize(2)
+            assertThat(results).anyMatch { it.message == "Private property `org` is unused." }
+            assertThat(results).anyMatch { it.message == "Private property `detekt` is unused." }
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/detekt/detekt/issues/5941

Basically ignore import statements when counting references for the purposes of identifying Unused Private Properties.

Also took the opportunity to improve the previous test `package declarations are ignored` a bit.