### PR TITLE
Add a test for catching undocumented public interfaces

### DIFF
--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicClassSpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicClassSpec.kt
@@ -236,6 +236,20 @@ class UndocumentedPublicClassSpec {
     }
 
     @Test
+    fun `should report for uncommented interface`() {
+        val code = """
+            fun interface Interface {
+                /**
+                * This method has a comment but
+                * the parent interface does not
+                */
+                fun abstractMethod()
+            }
+        """.trimIndent()
+        assertThat(subject.compileAndLint(code)).hasSize(1)
+    }
+
+    @Test
     fun `does not report protected class by default`() {
         val code = """
             protected class Test {


### PR DESCRIPTION
This PR adds a test in UndocumentedPublicClassSpec that validated behavior for catching uncommented public interfaces, which did not exist before. I wrote this for myself to validate this assumption because I did not see it in the test file already.

I realize that this is already covered in the documentation: "This rule reports public classes, objects and interfaces". But I missed that on initial read and went to the test to check my assumption
