### PR TITLE
Add functions to ExitOutsideMain rule

### DIFF
--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ExitOutsideMainSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ExitOutsideMainSpec.kt
@@ -32,6 +32,26 @@ class ExitOutsideMainSpec(private val env: KotlinCoreEnvironment) {
     }
 
     @Test
+    fun `reports Runtime_exit used outside main()`() {
+        val code = """
+            fun f() {
+                Runtime.getRuntime().exit(0)
+            }
+        """.trimIndent()
+        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+    }
+
+    @Test
+    fun `reports Runtime_halt used outside main()`() {
+        val code = """
+            fun f() {
+                Runtime.getRuntime().halt(0)
+            }
+        """.trimIndent()
+        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+    }
+
+    @Test
     fun `does not report exitProcess used in main()`() {
         val code = """
             import kotlin.system.exitProcess


### PR DESCRIPTION
The following are also considered to be "exit"-functions.
* Runtime.exit()
* Runtime.halt()

That's the reason for adding them to be flagged by this rule.
