### PR TITLE
Fix broken publishToMavenLocal

### DIFF
--- a/build-logic/src/main/kotlin/releasing.gradle.kts
+++ b/build-logic/src/main/kotlin/releasing.gradle.kts
@@ -78,7 +78,7 @@ tasks {
 tasks.register("publishToMavenLocal") {
     description = "Publish all the projects to Maven Local"
     subprojects {
-        if (this.plugins.hasPlugin("publishing")) {
+        if (this.plugins.hasPlugin("packaging")) {
             dependsOn(tasks.named("publishToMavenLocal"))
         }
     }


### PR DESCRIPTION
`publishToMavenLocal` is currently broken. It publishes only some of the artifacts. I'm fixing it here by filtering for the right precompiled plugin