### PR TITLE
Fix broken POM file for detetk-compiler-plugin

### DIFF
--- a/build-logic/src/main/kotlin/packaging.gradle.kts
+++ b/build-logic/src/main/kotlin/packaging.gradle.kts
@@ -30,31 +30,32 @@ publishing {
     // We don't need to configure publishing for the Gradle plugin.
     if (project.name != "detekt-gradle-plugin") {
         publications.register<MavenPublication>(DETEKT_PUBLICATION) {
-            groupId = "io.gitlab.arturbosch.detekt"
-            artifactId = project.name
             from(components["java"])
-            version = Versions.currentOrSnapshot()
-            pom {
-                description.set("Static code analysis for Kotlin")
-                name.set("detekt")
-                url.set("https://detekt.dev")
-                licenses {
-                    license {
-                        name.set("The Apache Software License, Version 2.0")
-                        url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
-                        distribution.set("repo")
-                    }
+        }
+    }
+    publications.withType<MavenPublication> {
+        artifactId = project.name
+        version = Versions.currentOrSnapshot()
+        pom {
+            description.set("Static code analysis for Kotlin")
+            name.set("detekt")
+            url.set("https://detekt.dev")
+            licenses {
+                license {
+                    name.set("The Apache Software License, Version 2.0")
+                    url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+                    distribution.set("repo")
                 }
-                developers {
-                    developer {
-                        id.set("detekt Developers")
-                        name.set("detekt Developers")
-                        email.set("info@detekt.dev")
-                    }
+            }
+            developers {
+                developer {
+                    id.set("detekt Developers")
+                    name.set("detekt Developers")
+                    email.set("info@detekt.dev")
                 }
-                scm {
-                    url.set("https://github.com/detekt/detekt")
-                }
+            }
+            scm {
+                url.set("https://github.com/detekt/detekt")
             }
         }
     }

--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -106,6 +106,8 @@ gradlePlugin {
         create("detektCompilerPlugin") {
             id = "io.github.detekt.gradle.compiler-plugin"
             implementationClass = "io.github.detekt.gradle.DetektKotlinCompilerPlugin"
+            displayName = "Static code analysis for Kotlin"
+            description = "Static code analysis for Kotlin"
             tags.set(listOf("kotlin", "detekt", "code-analysis", "linter", "codesmells", "android"))
         }
     }
@@ -177,33 +179,6 @@ tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach 
         // Note: Currently there are warnings for detekt-gradle-plugin that seemingly can't be fixed
         //       until Gradle releases an update (https://github.com/gradle/gradle/issues/16345)
         allWarningsAsErrors.set(false)
-    }
-}
-
-publishing {
-    publications.withType<MavenPublication> {
-        pom {
-            description.set("The official Detekt Gradle Plugin")
-            name.set("detekt-gradle-plugin")
-            url.set("https://detekt.dev")
-            licenses {
-                license {
-                    name.set("The Apache Software License, Version 2.0")
-                    url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
-                    distribution.set("repo")
-                }
-            }
-            developers {
-                developer {
-                    id.set("detekt Developers")
-                    name.set("detekt Developers")
-                    email.set("info@detekt.dev")
-                }
-            }
-            scm {
-                url.set("https://github.com/detekt/detekt")
-            }
-        }
     }
 }
 


### PR DESCRIPTION
The pomfile of `detetk-compiler-plugin` Plugin's marker is broken as it doesn't satisfy Maven Central's POM requirements (has no description and no display name).
I'm fixing it here.
