### PR TITLE
Implement parentPath accessor in concrete config implementations

### DIFF
--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/AllRulesConfig.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/AllRulesConfig.kt
@@ -10,6 +10,9 @@ internal data class AllRulesConfig(
     private val defaultConfig: Config
 ) : Config, ValidatableConfiguration {
 
+    override val parentPath: String?
+        get() = originalConfig.parentPath ?: defaultConfig.parentPath
+
     override fun subConfig(key: String) =
         AllRulesConfig(originalConfig.subConfig(key), defaultConfig.subConfig(key))
 

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/CompositeConfig.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/CompositeConfig.kt
@@ -11,6 +11,9 @@ import io.gitlab.arturbosch.detekt.core.config.validation.validateConfig
 class CompositeConfig(private val lookFirst: Config, private val lookSecond: Config) :
     Config, ValidatableConfiguration {
 
+    override val parentPath: String?
+        get() = lookFirst.parentPath ?: lookSecond.parentPath
+
     override fun subConfig(key: String): Config =
         CompositeConfig(lookFirst.subConfig(key), lookSecond.subConfig(key))
 

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/DisabledAutoCorrectConfig.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/DisabledAutoCorrectConfig.kt
@@ -8,6 +8,9 @@ import io.gitlab.arturbosch.detekt.core.config.validation.validateConfig
 @Suppress("UNCHECKED_CAST")
 class DisabledAutoCorrectConfig(private val wrapped: Config) : Config, ValidatableConfiguration {
 
+    override val parentPath: String?
+        get() = wrapped.parentPath
+
     override fun subConfig(key: String): Config = DisabledAutoCorrectConfig(wrapped.subConfig(key))
 
     override fun <T : Any> valueOrDefault(key: String, default: T): T = when (key) {

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/AllRulesConfigSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/AllRulesConfigSpec.kt
@@ -1,0 +1,36 @@
+package io.gitlab.arturbosch.detekt.core.config
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.test.yamlConfig
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class AllRulesConfigSpec {
+    @Nested
+    inner class ParentPath {
+        private val rulesetId = "style"
+        private val rulesetConfig = yamlConfig("/configs/single-rule-in-style-ruleset.yml").subConfig(rulesetId)
+        private val emptyConfig = Config.empty
+
+        @Test
+        fun `is derived from the original config`() {
+            val subject = AllRulesConfig(
+                originalConfig = rulesetConfig,
+                defaultConfig = emptyConfig,
+            )
+            val actual = subject.parentPath
+            assertThat(actual).isEqualTo(rulesetId)
+        }
+
+        @Test
+        fun `is derived from the default config if unavailable in original config`() {
+            val subject = AllRulesConfig(
+                originalConfig = emptyConfig,
+                defaultConfig = rulesetConfig,
+            )
+            val actual = subject.parentPath
+            assertThat(actual).isEqualTo(rulesetId)
+        }
+    }
+}

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/CompositeConfigSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/CompositeConfigSpec.kt
@@ -3,13 +3,17 @@ package io.gitlab.arturbosch.detekt.core.config
 import io.gitlab.arturbosch.detekt.test.yamlConfig
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 class CompositeConfigSpec {
 
-    private val second = yamlConfig("composite-test.yml")
-    private val first = yamlConfig("detekt.yml")
-    private val compositeConfig = CompositeConfig(second, first)
+    private val overrideConfig = yamlConfig("composite-test.yml")
+    private val defaultConfig = yamlConfig("detekt.yml")
+    private val compositeConfig = CompositeConfig(
+        lookFirst = overrideConfig,
+        lookSecond = defaultConfig
+    )
 
     @Test
     fun `should have style sub config with active false which is overridden in second config regardless of default value`() {
@@ -19,7 +23,7 @@ class CompositeConfigSpec {
     }
 
     @Test
-    fun `should have code smell sub config with LongMethod threshold 20 from _first_ config`() {
+    fun `should have code smell sub config with LongMethod threshold 20 from _default_ config`() {
         val codeSmellConfig = compositeConfig.subConfig("code-smell").subConfig("LongMethod")
         assertThat(codeSmellConfig.valueOrDefault("threshold", -1)).isEqualTo(20)
     }
@@ -47,5 +51,23 @@ class CompositeConfigSpec {
             config.valueOrDefault("active", true)
         }.isInstanceOf(IllegalStateException::class.java)
             .hasMessageContaining(expectedErrorMessage)
+    }
+
+    @Nested
+    inner class ParentPath {
+
+        @Test
+        fun `is derived from the _override_ config if available`() {
+            val subject = compositeConfig.subConfig("style")
+            val actual = subject.parentPath
+            assertThat(actual).isEqualTo("style")
+        }
+
+        @Test
+        fun `is derived from the default config if unavailable in original config`() {
+            val subject = compositeConfig.subConfig("code-smell")
+            val actual = subject.parentPath
+            assertThat(actual).isEqualTo("code-smell")
+        }
     }
 }

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/DisabledAutoCorrectConfigSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/DisabledAutoCorrectConfigSpec.kt
@@ -1,0 +1,17 @@
+package io.gitlab.arturbosch.detekt.core.config
+
+import io.gitlab.arturbosch.detekt.test.yamlConfig
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class DisabledAutoCorrectConfigSpec {
+    private val rulesetId = "style"
+    private val rulesetConfig = yamlConfig("/configs/single-rule-in-style-ruleset.yml").subConfig(rulesetId)
+
+    @Test
+    fun `parent path is derived from wrapped config`() {
+        val subject = DisabledAutoCorrectConfig(rulesetConfig)
+        val actual = subject.parentPath
+        assertThat(actual).isEqualTo(rulesetId)
+    }
+}

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/YamlConfigSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/YamlConfigSpec.kt
@@ -61,6 +61,14 @@ class YamlConfigSpec {
                     "Value \"{WildcardImport={active=true}, NoElseInWhenExpression={active=true}, MagicNumber={active=true, ignoreNumbers=[-1, 0, 1, 2]}}\" set for config parameter \"style\" is not of required type String."
                 )
         }
+
+        @Test
+        fun `parent path of ruleset config is ruleset id`() {
+            val rulesetId = "style"
+            val subject = config.subConfig(rulesetId)
+            val actual = subject.parentPath
+            assertThat(actual).isEqualTo(rulesetId)
+        }
     }
 
     @Nested

--- a/detekt-core/src/test/resources/configs/single-rule-in-style-ruleset.yml
+++ b/detekt-core/src/test/resources/configs/single-rule-in-style-ruleset.yml
@@ -1,0 +1,3 @@
+style:
+  MaxLineLength:
+    maxLineLength: 100


### PR DESCRIPTION
Fixes #5976 

The suppressions that use the rule set ids require the parent path of the rule set to be determined correctly. The AllRulesConfig, CompositeConfig and DisabledAutoCorrectConfig did not implement this and always returned null. 