### PR TITLE
Add documentation for all supported suppression formats

### DIFF
--- a/website/docs/introduction/suppressing-rules.md
+++ b/website/docs/introduction/suppressing-rules.md
@@ -19,15 +19,15 @@ object Constants {
 }
 ```
 
-It is also possible to prefix the rule id with either `detekt` and/or the ruleset id such as `@Suppress("detekt:LongMethod")` or `@Suppress("complexity:LongParameterList")`. 
+It is also possible to prefix the rule id with `detekt` and/or the ruleset id such as `@Suppress("detekt:LongMethod")` or `@Suppress("complexity:LongParameterList")`. 
 
 The following table shows the various supported suppression formats.
 
-| Example Suppression                                                                                                     | Description                                               | Notes                                        |
-|-------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------|----------------------------------------------|
-| ~~`all`~~, ~~`detekt:all`~~, ~~`detekt.all`~~                                                                           | Suppresses all detekt findings.                           | These suppressions are deprecated.           |
-| `style`, `detekt:style`, ~~`detekt.style`~~                                                                             | Suppresses all findings from rules in the style rule set. | Support for the `.` separator is deprecated. |
-| `MagicNumber`, `style:MagicNumber`, ~~`style.MagicNumber`~~, `detekt:style:MagicNumber`, ~~`detekt.style.MagicNumber`~~ | Suppresses all MagicNumber rule findings.                 | Support for the `.` separator is deprecated. |
+| Example Suppression                                                                                             | Description                                               |
+|-----------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------|
+| `all`, `detekt:all`, `detekt.all`                                                                               | Suppresses all detekt findings.                           |
+| `style`, `detekt:style`, `detekt.style`                                                                         | Suppresses all findings from rules in the style rule set. |
+| `MagicNumber`, `style:MagicNumber`, `style.MagicNumber`, `detekt:style:MagicNumber`, `detekt.style.MagicNumber` | Suppresses all MagicNumber rule findings.                 |
 
 Some rules like `TooManyFunctions` can only be suppressed by using a file level annotation `@file:Suppress("TooManyFunctions")`.
 

--- a/website/docs/introduction/suppressing-rules.md
+++ b/website/docs/introduction/suppressing-rules.md
@@ -8,9 +8,7 @@ sidebar_position: 6
 _detekt_ supports the Java (`@SuppressWarnings`) and Kotlin (`@Suppress`) style suppression. 
 If both annotations are present, Kotlin's annotation is favored! 
 
-To suppress an issue, the id of the issue must be written inside the values field of the annotation.
-Furthermore, the ruleset plus rulename can be used to suppress issues (e.g. `@Suppress("LongMethod", "complexity.LongParameterList", ...)`).
-The issue-id is also exactly the id of the reporting rule.
+To suppress an issue, the id of the rule must be written inside the values field of the annotation (e.g. `@Suppress("LongMethod")`).
 
 If a `LargeClass` is reported, but that is totally fine for you codebase, then just annotate it:
 
@@ -21,7 +19,17 @@ object Constants {
 }
 ```
 
-Some rules like `TooManyFunctions` can be suppressed by using a file level annotation `@file:Suppress("TooManyFunctions")`.
+It is also possible to prefix the rule id with either `detekt` and/or the ruleset id such as `@Suppress("detekt:LongMethod")` or `@Suppress("complexity:LongParameterList")`. 
+
+The following table shows the various supported suppression formats.
+
+| Example Suppression                                                                                                     | Description                                               | Notes                                        |
+|-------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------|----------------------------------------------|
+| ~~`all`~~, ~~`detekt:all`~~, ~~`detekt.all`~~                                                                           | Suppresses all detekt findings.                           | These suppressions are deprecated.           |
+| `style`, `detekt:style`, ~~`detekt.style`~~                                                                             | Suppresses all findings from rules in the style rule set. | Support for the `.` separator is deprecated. |
+| `MagicNumber`, `style:MagicNumber`, ~~`style.MagicNumber`~~, `detekt:style:MagicNumber`, ~~`detekt.style.MagicNumber`~~ | Suppresses all MagicNumber rule findings.                 | Support for the `.` separator is deprecated. |
+
+Some rules like `TooManyFunctions` can only be suppressed by using a file level annotation `@file:Suppress("TooManyFunctions")`.
 
 **Formatting rules suppression**
 


### PR DESCRIPTION
Fixes #6000 

~~This PR is meant to support the discussion about suppression formats now and in the future. Specifically we need to decide:~~

* ~~do we want to drop support for the `all` suppression~~
* ~~do we want to keep supporting `.` and `:` as separators and if not which one should we drop~~

~~If you prefer a discussion thread to make those decisions, I am glad to open one.~~