### PR TITLE
Compile compiler plugin against kotlin-compiler-embeddable

### DIFF
--- a/detekt-compiler-plugin/build.gradle.kts
+++ b/detekt-compiler-plugin/build.gradle.kts
@@ -19,7 +19,7 @@ plugins {
 }
 
 dependencies {
-    compileOnly(libs.kotlin.compiler)
+    compileOnly(libs.kotlin.compilerEmbeddable)
 
     implementation(projects.detektApi)
     implementation(projects.detektTooling)

--- a/detekt-compiler-plugin/src/main/kotlin/io/github/detekt/compiler/plugin/DetektAnalysisExtension.kt
+++ b/detekt-compiler-plugin/src/main/kotlin/io/github/detekt/compiler/plugin/DetektAnalysisExtension.kt
@@ -1,11 +1,11 @@
 package io.github.detekt.compiler.plugin
 
-import com.intellij.openapi.project.Project
 import io.github.detekt.compiler.plugin.internal.DetektService
 import io.github.detekt.compiler.plugin.internal.info
 import io.github.detekt.tooling.api.spec.ProcessingSpec
 import org.jetbrains.kotlin.analyzer.AnalysisResult
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
+import org.jetbrains.kotlin.com.intellij.openapi.project.Project
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.resolve.BindingTrace


### PR DESCRIPTION
Partially reverts #5765

Fixes #6007 