### PR TITLE
Stop overriding project version when publishing

### DIFF
--- a/build-logic/src/main/kotlin/packaging.gradle.kts
+++ b/build-logic/src/main/kotlin/packaging.gradle.kts
@@ -31,7 +31,6 @@ publishing {
     }
     publications.withType<MavenPublication> {
         artifactId = project.name
-        version = Versions.currentOrSnapshot()
         pom {
             description.set("Static code analysis for Kotlin")
             name.set("detekt")


### PR DESCRIPTION
detekt-compiler-plugin has a unique versioning scheme which should not be overridden when publishing.

The most recent release was set to version `1.23.0-RC1` when it should have been `1.8.20-1.23.0-RC1`.