### PR TITLE
Consolidate bots to @detekt-ci

### DIFF
--- a/.github/workflows/danger.yaml
+++ b/.github/workflows/danger.yaml
@@ -36,4 +36,4 @@ jobs:
         working-directory: bots/
         run: yarn danger ci
         env:
-          DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DANGER_GITHUB_API_TOKEN: ${{ secrets.DETEKT_CI_GITHUB_USER_TOKEN }}

--- a/.github/workflows/detekt-with-type-resolution.yaml
+++ b/.github/workflows/detekt-with-type-resolution.yaml
@@ -41,6 +41,7 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: build/detekt-report.sarif
+          token: ${{ secrets.DETEKT_CI_GITHUB_USER_TOKEN }}
 
 
   gradle:
@@ -69,3 +70,4 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: build/reports/detekt/merge.sarif
+          token: ${{ secrets.DETEKT_CI_GITHUB_USER_TOKEN }}

--- a/.github/workflows/detekt-with-type-resolution.yaml
+++ b/.github/workflows/detekt-with-type-resolution.yaml
@@ -41,7 +41,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: build/detekt-report.sarif
-          token: ${{ secrets.DETEKT_CI_GITHUB_USER_TOKEN }}
 
 
   gradle:
@@ -70,4 +69,3 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: build/reports/detekt/merge.sarif
-          token: ${{ secrets.DETEKT_CI_GITHUB_USER_TOKEN }}

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -12,4 +12,4 @@ jobs:
     steps:
       - uses: actions/labeler@ba790c862c380240c6d5e7427be5ace9a05c754b # v4
         with:
-          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          repo-token: "${{ secrets.DETEKT_CI_GITHUB_USER_TOKEN }}"

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/stale@1160a2240286f5da8ec72b1c0816ce2481aabf84 # v8
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ secrets.DETEKT_CI_GITHUB_USER_TOKEN }}
           days-before-stale: 90
           stale-issue-message: 'This issue is stale because it has been open 90 days with no activity. Please comment or this will be closed in 7 days.'
           stale-pr-message: 'This PR is stale because it has been open 90 days with no activity. Please comment or this will be closed in 7 days.'
@@ -25,7 +25,7 @@ jobs:
           exempt-milestones: Future Breaking Changes in Major Versions
       - uses: actions/stale@1160a2240286f5da8ec72b1c0816ce2481aabf84 # v8
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ secrets.DETEKT_CI_GITHUB_USER_TOKEN }}
           days-before-stale: 30
           stale-issue-message: 'This issue is waiting for authors feedback since 30 days. Please comment providing the requested feedback or this issue will be closed in 7 days.'
           stale-pr-message: 'This PR is waiting for authors feedback since 30 days. Please comment providing the requested feedback or this PR will be closed in 7 days.'


### PR DESCRIPTION
Currently, we do have a variety of different bots interacting on our repo: GitHub Actions, Danger and GitHub Code Scanning.

I'm moving all of them to use @detekt-ci's GitHub user token instead.