### PR TITLE
Reduce eager POM task creation

### DIFF
--- a/build-logic/src/main/kotlin/packaging.gradle.kts
+++ b/build-logic/src/main/kotlin/packaging.gradle.kts
@@ -57,8 +57,8 @@ publishing {
     }
 }
 
-tasks.withType<GenerateMavenPom> {
-    if (JavaVersion.current() == JavaVersion.VERSION_1_8) {
+if (JavaVersion.current() == JavaVersion.VERSION_1_8) {
+    tasks.withType<GenerateMavenPom>().configureEach {
         notCompatibleWithConfigurationCache("https://github.com/gradle/gradle/issues/24765")
     }
 }


### PR DESCRIPTION
While reading a Gradle issue @3flex opened, I stumbled upon https://github.com/detekt/detekt/pull/5996/files#diff-8a7fc388e89cfbc32780b6887c089aeb9fecbb1e231a51c553e2c87388af7148R60, which as far as I remember is eager. Also swapped `if` with `withType` since there's no need to add the callback on newer versions of Java, JVM running Gradle is not going to change, not even when Toolchains are used.

<!-- A similar PR may already be submitted! -->
<!-- Please search among the [Pull requests](https://github.com/detekt/detekt/pulls) before creating one. -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Link to relevant issues if possible. -->

<!-- For more information, see the [CONTRIBUTING guide](https://github.com/detekt/detekt/blob/main/.github/CONTRIBUTING.md). -->
