### PR TITLE
Fix incomplete `requireRootInDeclaration` check in `InvalidPackageDeclaration`

### DIFF
--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/InvalidPackageDeclaration.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/InvalidPackageDeclaration.kt
@@ -11,6 +11,7 @@ import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.config
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
 import io.gitlab.arturbosch.detekt.api.internal.Configuration
+import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.psi.KtPackageDirective
 
@@ -37,24 +38,19 @@ class InvalidPackageDeclaration(config: Config = Config.empty) : Rule(config) {
 
     override fun visitPackageDirective(directive: KtPackageDirective) {
         super.visitPackageDirective(directive)
-        val declaredPath = directive.packageNames.map(KtElement::getText).toNormalizedForm()
-        if (declaredPath.isNotBlank()) {
-            val normalizedFilePath = directive.containingKtFile.absolutePath().parent.toNormalizedForm()
-            val normalizedRootPackage = packageNameToNormalizedForm(rootPackage)
-            if (requireRootInDeclaration && !declaredPath.startsWith(normalizedRootPackage)) {
+        val packageName = directive.fqName
+        if (!packageName.isRoot) {
+            val rootPackageName = FqName(rootPackage)
+            if (requireRootInDeclaration && !packageName.startsWith(rootPackageName)) {
                 directive.reportInvalidPackageDeclaration("The package declaration is missing the root package")
                 return
             }
 
-            val expectedPath =
-                if (normalizedRootPackage.isBlank()) {
-                    declaredPath
-                } else {
-                    declaredPath.substringAfter(normalizedRootPackage)
-                }
+            val normalizedFilePath = directive.containingKtFile.absolutePath().parent.toNormalizedForm()
+            val expectedPath = packageName.withoutPrefix(rootPackageName).toNormalizedForm()
 
-            val isInRootPackage = expectedPath.isBlank()
-            if (!isInRootPackage && !normalizedFilePath.endsWith(expectedPath)) {
+            val isInRootPackage = expectedPath.isEmpty()
+            if (!isInRootPackage && !normalizedFilePath.endsWith("|$expectedPath")) {
                 directive.reportInvalidPackageDeclaration(
                     "The package declaration does not match the actual file location."
                 )
@@ -68,5 +64,20 @@ class InvalidPackageDeclaration(config: Config = Config.empty) : Rule(config) {
 
     private fun <T> Iterable<T>.toNormalizedForm() = joinToString("|")
 
-    private fun packageNameToNormalizedForm(packageName: String) = packageName.split('.').toNormalizedForm()
+    private fun FqName.startsWith(other: FqName): Boolean {
+        val segments = pathSegments()
+        val otherSegments = other.pathSegments()
+        return if (otherSegments.size <= segments.size) {
+            otherSegments.indices.all { index -> segments[index] == otherSegments[index] }
+        } else {
+            false
+        }
+    }
+
+    private fun FqName.withoutPrefix(prefix: FqName): List<String> {
+        val dropCount = if (startsWith(prefix)) prefix.pathSegments().size else 0
+        return pathSegments()
+            .drop(dropCount)
+            .map { segmentName -> segmentName.asString() }
+    }
 }

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/InvalidPackageDeclarationSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/InvalidPackageDeclarationSpec.kt
@@ -167,6 +167,20 @@ class InvalidPackageDeclarationSpec {
 
             assertThat(findings).hasSize(1)
         }
+
+        @Test
+        fun `should report if declaration only shares a prefix with root package`() {
+            val source = """
+                package com.example_extra
+                
+                class C
+            """.trimIndent()
+
+            val ktFile = compileContentForTest(source, createPath("src/com/example_extra/File.kt"))
+            val findings = InvalidPackageDeclaration(config).lint(ktFile)
+
+            assertThat(findings).hasSize(1)
+        }
     }
 }
 


### PR DESCRIPTION
The old code used `String.startsWith()` to check if the package declaration is the root package or a subpackage of it. This check erroneously allows "sibling packages" that start with the root package name, e.g. "com.example_extra" when the root package name is "com.example".

This PR adds a test for that case and fixes the check to work as intended.