### PR TITLE
Remove dependency on mavenLocal() for functionalTests

### DIFF
--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -11,8 +11,7 @@ plugins {
     `java-test-fixtures`
     idea
     alias(libs.plugins.pluginPublishing)
-    // We use this published version of the detekt plugin to self analyse this project.
-    id("io.gitlab.arturbosch.detekt") version "1.22.0"
+    alias(libs.plugins.detekt.self.inspection)
 }
 
 repositories {
@@ -140,13 +139,23 @@ tasks {
         property("detektVersion", project.version)
         property("detektCompilerPluginVersion", project.version)
     }
+    val writeDetektTestVersionProperties by registering(WriteProperties::class) {
+        description = "Write the properties file with the detekt version to be used by functional tests of the plugin."
+        encoding = "UTF-8"
+        destinationFile.set(file("$buildDir/detekt-test-versions.properties"))
+        property("detektTestVersion", libs.versions.detekt.self.inspection.get())
+    }
 
     processResources {
         from(writeDetektVersionProperties)
     }
 
     processTestResources {
-        from(writeDetektVersionProperties)
+        from(writeDetektVersionProperties, writeDetektTestVersionProperties)
+    }
+
+    named("processFunctionalTestResources", ProcessResources::class) {
+        from(writeDetektVersionProperties, writeDetektTestVersionProperties)
     }
 
     check {

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektAndroidSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektAndroidSpec.kt
@@ -739,7 +739,6 @@ private fun createGradleRunnerAndSetupProject(
             repositories {
                 mavenCentral()
                 google()
-                mavenLocal()
             }
         }
     """.trimIndent(),

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektJvmSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektJvmSpec.kt
@@ -20,7 +20,6 @@ class DetektJvmSpec {
                 }
                 repositories {
                     mavenCentral()
-                    mavenLocal()
                 }
                 detekt {
                     reports {
@@ -59,7 +58,6 @@ class DetektJvmSpec {
                 }
                 repositories {
                     mavenCentral()
-                    mavenLocal()
                 }
                 tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
                     reports {

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektMultiplatformSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektMultiplatformSpec.kt
@@ -350,7 +350,6 @@ private fun setupProject(projectLayoutAction: ProjectLayout.() -> Unit): DslGrad
                 repositories {
                     mavenCentral()
                     google()
-                    mavenLocal()
                 }
             }
         """.trimIndent(),

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektTaskDslSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektTaskDslSpec.kt
@@ -1,7 +1,7 @@
 package io.gitlab.arturbosch.detekt
 
 import io.gitlab.arturbosch.detekt.extensions.DetektReportType
-import io.gitlab.arturbosch.detekt.extensions.loadDetektVersion
+import io.gitlab.arturbosch.detekt.internal.loadDetektVersion
 import io.gitlab.arturbosch.detekt.testkit.DslTestBuilder.Companion.kotlin
 import io.gitlab.arturbosch.detekt.testkit.ProjectLayout
 import org.assertj.core.api.Assertions.assertThat
@@ -530,7 +530,11 @@ class DetektTaskDslSpec {
             }
         """.trimIndent()
         private val builder = kotlin().dryRun()
-        private val gradleRunner = builder.withDetektConfig(config).build()
+        private val gradleRunner = builder
+            .withDetektConfig(config)
+            // For this specific test we want to make sure that the version used is the one from the DSL we provide.
+            .withCustomArgs("-Pdetekt.internal.tool.version.override=")
+            .build()
         private val result = gradleRunner.runTasks("dependencies", "--offline", "--configuration", "detekt")
 
         @Test

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/JvmSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/JvmSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt
 
+import io.gitlab.arturbosch.detekt.testkit.loadTestDetektVersion
 import io.gitlab.arturbosch.detekt.testkit.withResourceDir
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.GradleRunner
@@ -11,7 +12,7 @@ class JvmSpec {
         val result = GradleRunner.create()
             .withResourceDir("jvm")
             .withPluginClasspath()
-            .withArguments("detektMain")
+            .withArguments("detektMain", "-Pdetekt.internal.tool.version.override=${loadTestDetektVersion()}")
             .buildAndFail()
 
         assertThat(result.output).contains("failed with 3 weighted issues.")

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/report/ReportMergeSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/report/ReportMergeSpec.kt
@@ -157,7 +157,6 @@ class ReportMergeSpec {
                 repositories {
                     mavenCentral()
                     google()
-                    mavenLocal()
                 }
             }
             

--- a/detekt-gradle-plugin/src/functionalTest/resources/jvm/build.gradle
+++ b/detekt-gradle-plugin/src/functionalTest/resources/jvm/build.gradle
@@ -5,7 +5,6 @@ plugins {
 
 repositories {
     mavenCentral()
-    mavenLocal()
 }
 
 tasks.detektMain {

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
@@ -96,7 +96,12 @@ class DetektPlugin : Plugin<Project> {
             configuration.isCanBeConsumed = false
 
             configuration.defaultDependencies { dependencySet ->
-                val version = extension.toolVersion
+                val versionOverride = (project.findProperty(DETEKT_INTERNAL_TEST_VERSION) as? String)
+                val version = if ((versionOverride)?.isNotBlank() == true) {
+                    versionOverride
+                } else {
+                    extension.toolVersion
+                }
                 dependencySet.add(project.dependencies.create("io.gitlab.arturbosch.detekt:detekt-cli:$version"))
             }
         }
@@ -131,6 +136,7 @@ class DetektPlugin : Plugin<Project> {
 
         internal const val DETEKT_ANDROID_DISABLED_PROPERTY = "detekt.android.disabled"
         internal const val DETEKT_MULTIPLATFORM_DISABLED_PROPERTY = "detekt.multiplatform.disabled"
+        internal const val DETEKT_INTERNAL_TEST_VERSION = "detekt.internal.tool.version.override"
     }
 }
 

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
@@ -1,14 +1,12 @@
 package io.gitlab.arturbosch.detekt.extensions
 
+import io.gitlab.arturbosch.detekt.internal.loadDetektVersion
 import org.gradle.api.Action
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.plugins.quality.CodeQualityExtension
 import org.gradle.api.provider.Property
 import java.io.File
-import java.io.InputStream
-import java.net.URL
-import java.util.Properties
 import javax.inject.Inject
 
 open class DetektExtension @Inject constructor(objects: ObjectFactory) : CodeQualityExtension() {
@@ -124,37 +122,4 @@ open class DetektExtension @Inject constructor(objects: ObjectFactory) : CodeQua
         // This flag is ignored unless the compiler plugin is applied to the project
         const val DEFAULT_COMPILER_PLUGIN_ENABLED = true
     }
-}
-
-internal fun loadDetektVersion(classLoader: ClassLoader): String {
-    // Other Gradle plugins can also have a versions.properties.
-    val distinctVersions = classLoader
-        .getResources("detekt-versions.properties")
-        .toList()
-        .mapNotNull { versions ->
-            Properties().run {
-                load(versions.openSafeStream())
-                getProperty("detektVersion")
-            }
-        }
-        .distinct()
-    return distinctVersions.singleOrNull() ?: error(
-        "You're importing two detekt plugins which have different versions. " +
-            "(${distinctVersions.joinToString()}) Make sure to align the versions."
-    )
-}
-
-// Copy-paste from io.github.detekt.utils.openSafeStream in Resources.kt.
-// Can't use that function, because gradle-plugin is minimising dependencies: see #4748.
-private fun URL.openSafeStream(): InputStream {
-    return openConnection()
-        /*
-         * Due to https://bugs.openjdk.java.net/browse/JDK-6947916 and https://bugs.openjdk.java.net/browse/JDK-8155607,
-         * it is necessary to disallow caches to maintain stability on JDK 8 and 11 (and possibly more).
-         * Otherwise, simultaneous invocations of detekt in the same VM can fail spuriously. A similar bug is referenced in
-         * https://github.com/detekt/detekt/issues/3396. The performance regression is likely unnoticeable.
-         * Due to https://github.com/detekt/detekt/issues/4332 it is included for all JDKs.
-         */
-        .apply { useCaches = false }
-        .getInputStream()
 }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/VersionUtil.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/VersionUtil.kt
@@ -1,0 +1,42 @@
+package io.gitlab.arturbosch.detekt.internal
+
+import java.io.InputStream
+import java.net.URL
+import java.util.Properties
+
+fun loadDetektVersion(
+    classLoader: ClassLoader,
+    propertyFileName: String = "detekt-versions.properties",
+    propertyName: String = "detektVersion"
+): String {
+    // Other Gradle plugins can also have a versions.properties.
+    val distinctVersions = classLoader
+        .getResources(propertyFileName)
+        .toList()
+        .mapNotNull { versions ->
+            Properties().run {
+                load(versions.openSafeStream())
+                getProperty(propertyName)
+            }
+        }
+        .distinct()
+    return distinctVersions.singleOrNull() ?: error(
+        "You're importing two detekt plugins which have different versions. " +
+            "(${distinctVersions.joinToString()}) Make sure to align the versions."
+    )
+}
+
+// Copy-paste from io.github.detekt.utils.openSafeStream in Resources.kt.
+// Can't use that function, because gradle-plugin is minimising dependencies: see #4748.
+private fun URL.openSafeStream(): InputStream {
+    return openConnection()
+        /*
+         * Due to https://bugs.openjdk.java.net/browse/JDK-6947916 and https://bugs.openjdk.java.net/browse/JDK-8155607,
+         * it is necessary to disallow caches to maintain stability on JDK 8 and 11 (and possibly more).
+         * Otherwise, simultaneous invocations of detekt in the same VM can fail spuriously. A similar bug is referenced in
+         * https://github.com/detekt/detekt/issues/3396. The performance regression is likely unnoticeable.
+         * Due to https://github.com/detekt/detekt/issues/4332 it is included for all JDKs.
+         */
+        .apply { useCaches = false }
+        .getInputStream()
+}

--- a/detekt-gradle-plugin/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/testkit/DslGradleRunner.kt
+++ b/detekt-gradle-plugin/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/testkit/DslGradleRunner.kt
@@ -24,6 +24,7 @@ constructor(
     val gradleVersionOrNone: String? = null,
     val dryRun: Boolean = false,
     val jvmArgs: String = "-Xmx2g -XX:MaxMetaspaceSize=1g",
+    val customArgs: String = "",
     val projectScript: Project.() -> Unit = {}
 ) {
 
@@ -138,6 +139,10 @@ constructor(
             add("-Dorg.gradle.jvmargs=$jvmArgs")
             if (dryRun) {
                 add("-Pdetekt-dry-run=true")
+            }
+            add("-Pdetekt.internal.tool.version.override=${loadTestDetektVersion()}")
+            if (customArgs.isNotBlank()) {
+                add(customArgs)
             }
             addAll(tasks.toList())
         }

--- a/detekt-gradle-plugin/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/testkit/DslTestBuilder.kt
+++ b/detekt-gradle-plugin/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/testkit/DslTestBuilder.kt
@@ -12,7 +12,6 @@ abstract class DslTestBuilder {
     @Language("gradle.kts")
     val gradleRepositories = """
         repositories {
-            mavenLocal()
             mavenCentral()
         }
     """.trimIndent()
@@ -23,6 +22,7 @@ abstract class DslTestBuilder {
     private var baselineFile: String? = null
     private var configFile: String? = null
     private var gradleVersion: String? = null
+    private var customArgs: String = ""
     private var dryRun: Boolean = false
 
     fun withDetektConfig(@Language("gradle.kts") config: String): DslTestBuilder {
@@ -50,6 +50,11 @@ abstract class DslTestBuilder {
         return this
     }
 
+    fun withCustomArgs(args: String): DslTestBuilder {
+        customArgs = args
+        return this
+    }
+
     fun dryRun(): DslTestBuilder {
         dryRun = true
         return this
@@ -63,6 +68,7 @@ abstract class DslTestBuilder {
             configFileOrNone = configFile,
             baselineFiles = baselineFile?.let { listOf(it) }.orEmpty(),
             gradleVersionOrNone = gradleVersion,
+            customArgs = customArgs,
             dryRun = dryRun,
         )
         runner.setupProject()

--- a/detekt-gradle-plugin/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/testkit/Helpers.kt
+++ b/detekt-gradle-plugin/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/testkit/Helpers.kt
@@ -1,5 +1,7 @@
 package io.gitlab.arturbosch.detekt.testkit
 
+import io.gitlab.arturbosch.detekt.DetektPlugin
+import io.gitlab.arturbosch.detekt.internal.loadDetektVersion
 import org.gradle.api.Task
 import org.intellij.lang.annotations.Language
 
@@ -30,3 +32,10 @@ fun String.reIndent(level: Int = 0, baseIndent: Int = 3): String =
 
 fun joinGradleBlocks(@Language("gradle.kts") vararg blocks: String): String =
     blocks.joinToString(separator = "\n\n")
+
+fun loadTestDetektVersion(): String =
+    loadDetektVersion(
+        DetektPlugin::class.java.classLoader,
+        "detekt-test-versions.properties",
+        "detektTestVersion"
+    )

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,6 +5,8 @@ kotlin = "1.8.21"
 ktlint = "0.49.0"
 junit = "5.9.3"
 contester = "0.2.0"
+# Version used to self-inpsect and format the Gradle Plugin.
+detekt-self-inspection = "1.22.0"
 
 [libraries]
 githubRelease-gradle = "com.github.breadmoirai:github-release:2.4.1"
@@ -53,3 +55,4 @@ download = { id = "de.undercouch.download", version = "5.4.0" }
 gradleVersions = { id = "com.github.ben-manes.versions", version = "0.46.0" }
 pluginPublishing = { id = "com.gradle.plugin-publish", version = "1.2.0" }
 shadow = { id = "com.github.johnrengelman.shadow", version = "8.1.1" }
+detekt-self-inspection  = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt-self-inspection" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ kotlin = "1.8.21"
 ktlint = "0.49.0"
 junit = "5.9.3"
 contester = "0.2.0"
-# Version used to self-inpsect and format the Gradle Plugin.
+# Version used to self-inspect and format the Gradle Plugin.
 detekt-self-inspection = "1.22.0"
 
 [libraries]


### PR DESCRIPTION
Our tests should not depend on `mavenLocal()` at all.
The problem is that `detekt-gradle-plugin` is applying a dependency on `detekt-cli` using the version defined here: 
https://github.com/detekt/detekt/blob/2eccd64bd8f8e71e688a222444356c945896c48f/build-logic/src/main/kotlin/Versions.kt#L5

So whenever that version gets bumped, test starts to fail unless you `publishToMavenLocal` as they'll try to find the next version on Maven Central, which won't be there.

That's also the reason why sometimes those PRs:
- https://github.com/detekt/detekt/pull/6056 

fail on CI as they can't find the newer artifact for `detekt-cli` on Maven Central yet.

This is blocking any automation of the release process essentially, and we should move away from it. See:
- https://github.com/detekt/detekt/discussions/4696

In this PR I'm moving away from using the project version to apply the `detekt-cli` to use the latest published stable. This allows those tests to rely just on `mavenCentral()`.
The dependency will be updated by Renovate bot as we release stable versions (we're doing the same thing for the formatting of the `detekt-gradle-plugin` itself).


