### PR TITLE
Add UseLet style rule

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -259,6 +259,8 @@ style:
     active: true
   UseIsNullOrEmpty:
     active: true
+  UseLet:
+    active: true
   UseOrEmpty:
     active: true
   UseRequire:

--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -761,6 +761,8 @@ style:
     ignoreWhenContainingVariableDeclaration: false
   UseIsNullOrEmpty:
     active: true
+  UseLet:
+    active: false
   UseOrEmpty:
     active: true
   UseRequire:

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/StyleGuideProvider.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/StyleGuideProvider.kt
@@ -110,6 +110,7 @@ class StyleGuideProvider : DefaultRuleSetProvider {
             AlsoCouldBeApply(config),
             UseSumOfInsteadOfFlatMapSize(config),
             DoubleNegativeLambda(config),
+            UseLet(config),
         )
     )
 }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseLet.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseLet.kt
@@ -1,0 +1,58 @@
+package io.gitlab.arturbosch.detekt.rules.style
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.rules.isNonNullCheck
+import io.gitlab.arturbosch.detekt.rules.isNullCheck
+import org.jetbrains.kotlin.psi.KtBinaryExpression
+import org.jetbrains.kotlin.psi.KtExpression
+import org.jetbrains.kotlin.psi.KtIfExpression
+import org.jetbrains.kotlin.psi.KtPsiUtil
+import org.jetbrains.kotlin.psi.psiUtil.lastBlockStatementOrThis
+
+/**
+ * `if` expressions that either check for not-null and return `null` in the false case or check for `null` and returns
+ * `null` in the truthy case are better represented as `?.let {}` blocks.
+ *
+ * <noncompliant>
+ * if (x != null) { x.transform() } else null
+ * if (x == null) null else y
+ * </noncompliant>
+ *
+ * <compliant>
+ * x?.let { it.transform() }
+ * x?.let { y }
+ * </compliant>
+ */
+class UseLet(
+    config: Config = Config.empty
+) : Rule(config) {
+    override val issue = Issue(
+        javaClass.simpleName,
+        Severity.Style,
+        "Use `?.let {}` instead of if/else with a null block when checking for nullable values",
+        Debt.FIVE_MINS
+    )
+
+    private fun isExpressionNull(branch: KtExpression?): Boolean {
+        return branch?.let {
+            KtPsiUtil.isNullConstant(it.lastBlockStatementOrThis())
+        } ?: false
+    }
+
+    override fun visitIfExpression(expression: KtIfExpression) {
+        super.visitIfExpression(expression)
+        val condition = expression.condition as? KtBinaryExpression ?: return
+
+        if (condition.isNullCheck() && isExpressionNull(expression.then)) {
+            report(CodeSmell(issue, Entity.from(expression), issue.description))
+        } else if (condition.isNonNullCheck() && isExpressionNull(expression.`else`)) {
+            report(CodeSmell(issue, Entity.from(expression), issue.description))
+        }
+    }
+}

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseLet.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseLet.kt
@@ -47,7 +47,7 @@ class UseLet(
             else -> null
         }
 
-        return statement?.let { KtPsiUtil.isNullConstant(it) } ?: return false
+        return statement?.let { KtPsiUtil.isNullConstant(it) } ?: false
     }
 
     override fun visitIfExpression(expression: KtIfExpression) {

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UselessCallOnNotNull.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UselessCallOnNotNull.kt
@@ -25,8 +25,10 @@ import org.jetbrains.kotlin.types.isNullable
  * https://github.com/JetBrains/kotlin/blob/f5d0a38629e7d2e7017ee645dc4d4bee60614e93/idea/src/org/jetbrains/kotlin/idea/inspections/collections/UselessCallOnNotNullInspection.kt
  */
 /**
- * In many cases the use of an if/else block that simply returns null can be replaced with a `?.let {}` statement for
- * cleaner code.
+ * The Kotlin stdlib provides some functions that are designed to operate on references that may be null. These
+ * functions can also be called on non-nullable references or on collections or sequences that are known to be empty -
+ * the calls are redundant in this case and can be removed or should be changed to a call that does not check whether
+ * the value is null or not.
  *
  * <noncompliant>
  * val testList = listOf("string").orEmpty()

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UselessCallOnNotNull.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UselessCallOnNotNull.kt
@@ -25,10 +25,8 @@ import org.jetbrains.kotlin.types.isNullable
  * https://github.com/JetBrains/kotlin/blob/f5d0a38629e7d2e7017ee645dc4d4bee60614e93/idea/src/org/jetbrains/kotlin/idea/inspections/collections/UselessCallOnNotNullInspection.kt
  */
 /**
- * The Kotlin stdlib provides some functions that are designed to operate on references that may be null. These
- * functions can also be called on non-nullable references or on collections or sequences that are known to be empty -
- * the calls are redundant in this case and can be removed or should be changed to a call that does not check whether
- * the value is null or not.
+ * In many cases the use of an if/else block that simply returns null can be replaced with a `?.let {}` statement for
+ * cleaner code.
  *
  * <noncompliant>
  * val testList = listOf("string").orEmpty()

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseLetSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseLetSpec.kt
@@ -24,10 +24,10 @@ class UseLetSpec {
         )
 
         val exprs = listOf(
-            Pair("1", false),
-            Pair("null", true),
-            Pair("{ 1 }", false),
-            Pair("{ null }", true)
+            "1" to false,
+            "null" to true,
+            "{ 1 }" to false,
+            "{ null }" to true,
         )
 
         return conditions.flatMap { (condition, isNonNullCheck, isNullCheck) ->

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseLetSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseLetSpec.kt
@@ -1,0 +1,67 @@
+package io.gitlab.arturbosch.detekt.rules.style
+
+import io.gitlab.arturbosch.detekt.test.assertThat
+import io.gitlab.arturbosch.detekt.test.compileAndLint
+import org.junit.jupiter.api.DynamicTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestFactory
+
+class UseLetSpec {
+
+    val subject = UseLet()
+
+    @TestFactory
+    fun `it forbids all != null else null combinations`(): Iterable<DynamicTest> {
+        val conditions = listOf(
+            Triple("1 == null", false, true),
+            Triple("null == 1", false, true),
+            Triple("1 == 1", false, false),
+            Triple("null == null", false, true),
+            Triple("1 != null", true, false),
+            Triple("null != 1", true, false),
+            Triple("1 != 1", false, false),
+            Triple("null != null", true, false),
+        )
+
+        val exprs = listOf(
+            Pair("1", false),
+            Pair("null", true),
+            Pair("{ 1 }", false),
+            Pair("{ null }", true)
+        )
+
+        return conditions.flatMap { (condition, isNonNullCheck, isNullCheck) ->
+            exprs.flatMap { (left, leftIsNull) ->
+                exprs.map { (right, rightIsNull) ->
+                    DynamicTest.dynamicTest("($condition) $left else $right") {
+                        val expr = "fun test() = if ($condition) $left else $right"
+                        val shouldFail = (isNonNullCheck && rightIsNull) || (isNullCheck && leftIsNull)
+                        val findings = subject.compileAndLint(expr)
+                        if (shouldFail) {
+                            assertThat(findings).hasSize(1)
+                            assertThat(findings[0]).hasMessage(subject.issue.description)
+                        } else {
+                            assertThat(findings).isEmpty()
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `it allows the following expressions (currently)`() {
+        val findings = subject.compileAndLint(
+            """
+                fun testCallToCreateTempFile() {
+                    val x: String? = "abc"
+                    if (x == null) println(x) else null
+                    if (x is String) println(x)
+                    if (x != null) { println(x) }
+                }
+            """.trimIndent()
+        )
+
+        assertThat(findings).isEmpty()
+    }
+}

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseLetSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseLetSpec.kt
@@ -50,6 +50,24 @@ class UseLetSpec {
     }
 
     @Test
+    fun `do not capture blocks that have multiple expressions`() {
+        val findings = subject.compileAndLint(
+            """
+                fun testCallToCreateTempFile(s: String?) {
+                    val x = if (s == null) {
+                        println("foo")
+                        null
+                    } else {
+                        "x"
+                    }
+                }
+            """.trimIndent()
+        )
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
     fun `it allows the following expressions (currently)`() {
         val findings = subject.compileAndLint(
             """


### PR DESCRIPTION
I asked a question about my rule in the [#detekt channel](https://kotlinlang.slack.com/archives/C88E12QH4/p1683758297010539), and there seemed to be some appetite for the rule. This is what my rule currently looks like.

I found that in a code base I was working with, there were a lot of instances of `if (x != null) { do_something(x) } else null` and wanted to encourage the use of `?.let` in this specific case. The plugin also looks for `if (x == null) { null } else do_something(x)` as we had some of that too.