### PR TITLE
New wrapped ktlint rule NoSingleLineBlockCommentRule

### DIFF
--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/KtLintMultiRule.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/KtLintMultiRule.kt
@@ -44,6 +44,7 @@ import io.gitlab.arturbosch.detekt.formatting.wrappers.NoLineBreakAfterElse
 import io.gitlab.arturbosch.detekt.formatting.wrappers.NoLineBreakBeforeAssignment
 import io.gitlab.arturbosch.detekt.formatting.wrappers.NoMultipleSpaces
 import io.gitlab.arturbosch.detekt.formatting.wrappers.NoSemicolons
+import io.gitlab.arturbosch.detekt.formatting.wrappers.NoSingleLineBlockComment
 import io.gitlab.arturbosch.detekt.formatting.wrappers.NoTrailingSpaces
 import io.gitlab.arturbosch.detekt.formatting.wrappers.NoUnitReturn
 import io.gitlab.arturbosch.detekt.formatting.wrappers.NoUnusedImports
@@ -163,6 +164,7 @@ class KtLintMultiRule(config: Config = Config.empty) :
         NoBlankLineInList(config),
         NoConsecutiveComments(config),
         NoEmptyFirstLineInClassBody(config),
+        NoSingleLineBlockComment(config),
         ParameterListSpacing(config),
         StringTemplateIndent(config),
         TryCatchFinallySpacing(config),

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/NoSingleLineBlockComment.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/NoSingleLineBlockComment.kt
@@ -1,0 +1,28 @@
+package io.gitlab.arturbosch.detekt.formatting.wrappers
+
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfigProperty
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_SIZE_PROPERTY
+import com.pinterest.ktlint.ruleset.standard.rules.NoSingleLineBlockCommentRule
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.config
+import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
+import io.gitlab.arturbosch.detekt.api.internal.Configuration
+import io.gitlab.arturbosch.detekt.formatting.FormattingRule
+
+/**
+ * See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#no-single-line-block-comments) for documentation.
+ */
+@AutoCorrectable(since = "1.23.0")
+class NoSingleLineBlockComment(config: Config) : FormattingRule(config) {
+
+    override val wrapping = NoSingleLineBlockCommentRule()
+    override val issue = issueFor("Reports single block line comments")
+
+    @Configuration("indentation size")
+    private val indentSize by config(4)
+
+    override fun overrideEditorConfigProperties(): Map<EditorConfigProperty<*>, String> =
+        mapOf(
+            INDENT_SIZE_PROPERTY to indentSize.toString(),
+        )
+}

--- a/detekt-formatting/src/main/resources/config/config.yml
+++ b/detekt-formatting/src/main/resources/config/config.yml
@@ -147,6 +147,10 @@ formatting:
   NoSemicolons:
     active: true
     autoCorrect: true
+  NoSingleLineBlockComment:
+    active: false
+    autoCorrect: true
+    indentSize: 4
   NoTrailingSpaces:
     active: true
     autoCorrect: true

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/NoSingleLineBlockCommentSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/NoSingleLineBlockCommentSpec.kt
@@ -1,0 +1,37 @@
+package io.gitlab.arturbosch.detekt.formatting
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.formatting.wrappers.CommentWrapping
+import io.gitlab.arturbosch.detekt.formatting.wrappers.NoSingleLineBlockComment
+import io.gitlab.arturbosch.detekt.test.assertThat
+import org.junit.jupiter.api.Test
+
+class NoSingleLineBlockCommentSpec {
+    @Test
+    fun `Given a single documentation comment that start starts and end on a same line`() {
+        val code = """
+            /** Some comment */
+        """.trimIndent()
+        assertThat(NoSingleLineBlockComment(Config.empty).lint(code)).isEmpty()
+    }
+
+    @Test
+    fun `Given a single block comment that start starts and end on a same line`() {
+        val code = """
+            /* Some comment */
+        """.trimIndent()
+        assertThat(NoSingleLineBlockComment(Config.empty).lint(code)).hasSize(1)
+    }
+
+    @Test
+    fun `Given a block comment followed by a code element on the same line as the block`() {
+        val code = """
+            /* Some comment 1 */ val foo1 = "foo1"
+            /* Some comment 2 */val foo2 = "foo2"
+            /* Some comment 3 */ fun foo3() = "foo3"
+            /* Some comment 4 */fun foo4() = "foo4"
+        """.trimIndent()
+
+        assertThat(CommentWrapping(Config.empty).lint(code)).hasSize(4)
+    }
+}


### PR DESCRIPTION
Based on the ktlint dependency update in #6096 this adds a new experimental rule.