### PR TITLE
Reduce LoopWithTooManyJumpStatements finding scope

### DIFF
--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/LoopWithTooManyJumpStatementsSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/LoopWithTooManyJumpStatementsSpec.kt
@@ -1,73 +1,124 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.test.TestConfig
-import io.gitlab.arturbosch.detekt.test.lint
+import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 private const val MAX_JUMP_COUNT = "maxJumpCount"
 
 class LoopWithTooManyJumpStatementsSpec {
-    val subject = LoopWithTooManyJumpStatements()
-    private val positiveCode = """
-        @Suppress("KotlinConstantConditions", "RedundantSuppression")
-        fun tooManyJumpStatements() {
-            val i = 0
-        
-            // reports 1 - too many jump statements
-            for (j in 1..2) {
-                if (i > 1) {
-                    break
-                } else {
-                    continue
-                }
-            }
-        
-            // reports 1 - too many jump statements
-            while (i < 2) {
-                if (i > 1) break else continue
-            }
-        
-            // reports 1 - too many jump statements
-            do {
-                if (i > 1) break else continue
-            } while (i < 2)
-        }
-    """.trimIndent()
 
     @Test
-    fun `reports loops with more than 1 break or continue statement`() {
-        assertThat(subject.lint(positiveCode)).hasSize(3)
+    fun `reports for loops with more than 1 break or continue statement`() {
+        val code = """
+            fun f(i: Int) {
+                for (j in 1..2) {
+                    if (i > 1) {
+                        break
+                    } else {
+                        continue
+                    }
+                }
+            }
+        """.trimIndent()
+        assertThat(LoopWithTooManyJumpStatements().compileAndLint(code)).hasSize(1)
     }
 
     @Test
-    fun `does not report when max count configuration is set to 2`() {
-        val config = TestConfig(MAX_JUMP_COUNT to "2")
-        val findings = LoopWithTooManyJumpStatements(config).lint(positiveCode)
+    fun `reports while loops with more than 1 break or continue statement`() {
+        val code = """
+            fun f(i: Int) {
+                while (i < 3) {
+                    if (i > 1) break else continue
+                }
+            }
+        """.trimIndent()
+        assertThat(LoopWithTooManyJumpStatements().compileAndLint(code)).hasSize(1)
+    }
+
+    @Test
+    fun `reports do loops with more than 1 break or continue statement`() {
+        val code = """
+            fun f(i: Int) {
+                do {
+                    if (i > 2) break else continue
+                } while (i < 1)
+            }
+        """.trimIndent()
+        assertThat(LoopWithTooManyJumpStatements().compileAndLint(code)).hasSize(1)
+    }
+
+    @Test
+    fun `does not report for loops when max count configuration is set to 2`() {
+        val code = """
+            fun f(i: Int) {
+                for (j in 1..2) {
+                    if (i > 1) {
+                        break
+                    } else {
+                        continue
+                    }
+                }
+            }
+        """.trimIndent()
+        val findings = LoopWithTooManyJumpStatements(TestConfig(MAX_JUMP_COUNT to "2")).compileAndLint(code)
         assertThat(findings).isEmpty()
     }
 
     @Test
-    fun `does not report loop with less than 1 break or continue statement`() {
+    fun `does not report while loops when max count configuration is set to 2`() {
+        val code = """
+            fun f(i: Int) {
+                while (i < 3) {
+                    if (i > 1) break else continue
+                }
+            }
+        """.trimIndent()
+        val findings = LoopWithTooManyJumpStatements(TestConfig(MAX_JUMP_COUNT to "2")).compileAndLint(code)
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report do loops when max count configuration is set to 2`() {
+        val code = """
+            fun f(i: Int) {
+                do {
+                    if (i > 2) break else continue
+                } while (i < 1)
+            }
+        """.trimIndent()
+        val findings = LoopWithTooManyJumpStatements(TestConfig(MAX_JUMP_COUNT to "2")).compileAndLint(code)
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report for loop with less than 1 break statement`() {
         val code = """
             fun onlyOneJump() {
                 for (i in 1..2) {
                     if (i > 1) break
                 }
             }
-            
+        """.trimIndent()
+        val findings = LoopWithTooManyJumpStatements().compileAndLint(code)
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report nested loop with less than 1 break or continue statement`() {
+        val code = """
             fun jumpsInNestedLoops() {
-                for (i in 1..2) {
-                    if (i > 1) break
+                for (i in 1..10) {
+                    if (i > 5) break
                     // jump statements of the inner loop must not be counted in the outer loop
-                    @Suppress("KotlinConstantConditions", "RedundantSuppression")
-                    while (i > 1) {
+                    while (i < 3) {
                         if (i > 1) continue
                     }
                 }
             }
         """.trimIndent()
-        val findings = subject.lint(code)
+        val findings = LoopWithTooManyJumpStatements().compileAndLint(code)
         assertThat(findings).isEmpty()
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/LoopWithTooManyJumpStatementsSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/LoopWithTooManyJumpStatementsSpec.kt
@@ -1,8 +1,8 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.test.TestConfig
+import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLint
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 private const val MAX_JUMP_COUNT = "maxJumpCount"
@@ -22,7 +22,7 @@ class LoopWithTooManyJumpStatementsSpec {
                 }
             }
         """.trimIndent()
-        assertThat(LoopWithTooManyJumpStatements().compileAndLint(code)).hasSize(1)
+        assertThat(LoopWithTooManyJumpStatements().compileAndLint(code)).hasTextLocations(20 to 23)
     }
 
     @Test
@@ -34,7 +34,7 @@ class LoopWithTooManyJumpStatementsSpec {
                 }
             }
         """.trimIndent()
-        assertThat(LoopWithTooManyJumpStatements().compileAndLint(code)).hasSize(1)
+        assertThat(LoopWithTooManyJumpStatements().compileAndLint(code)).hasTextLocations(20 to 25)
     }
 
     @Test
@@ -46,7 +46,7 @@ class LoopWithTooManyJumpStatementsSpec {
                 } while (i < 1)
             }
         """.trimIndent()
-        assertThat(LoopWithTooManyJumpStatements().compileAndLint(code)).hasSize(1)
+        assertThat(LoopWithTooManyJumpStatements().compileAndLint(code)).hasTextLocations(20 to 22)
     }
 
     @Test


### PR DESCRIPTION
Similar to other PRs where we reduced the scope.

Real life use case where it hides other warnings, and just plain huge yellow blob:
![image](https://github.com/detekt/detekt/assets/2906988/c21a91b2-afbf-446e-870e-347271550a02)

Contains a commit from #6107 + splits up the test cases before changing code.