### PR TITLE
Replace sarif4k usage with Groovy JSON from gradleApi() in detekt-gradle-plugin

### DIFF
--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -70,9 +70,6 @@ dependencies {
     compileOnly(libs.kotlin.gradle)
     compileOnly(libs.kotlin.gradlePluginApi)
     testFixturesCompileOnly("org.jetbrains:annotations:24.0.1")
-    implementation(libs.sarif4k) {
-        exclude("org.jetbrains.kotlin")
-    }
     compileOnly("io.gitlab.arturbosch.detekt:detekt-cli:1.22.0")
 
     testKitRuntimeOnly(libs.kotlin.gradle)

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/report/SarifReportMerger.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/report/SarifReportMerger.kt
@@ -4,7 +4,7 @@ import groovy.json.JsonOutput
 import groovy.json.JsonSlurper
 import java.io.File
 
-private typealias JsonObject = MutableMap<String, Any>
+private typealias JsonObject = MutableMap<String, Any?>
 
 /**
  * A naive implementation to merge SARIF assuming all inputs are written by detekt.
@@ -16,7 +16,7 @@ object SarifReportMerger {
             @Suppress("UNCHECKED_CAST")
             (JsonSlurper().parse(it) as JsonObject)
         }
-        val mergedResults = sarifs.flatMap { it.runs.single().results }
+        val mergedResults = sarifs.flatMap { it.runs.single().results.orEmpty() }
         val mergedSarif = sarifs[0].apply { this.runs.single().results = mergedResults }
         output.writeText(JsonOutput.prettyPrint(JsonOutput.toJson(mergedSarif)))
     }
@@ -26,9 +26,9 @@ private val JsonObject.runs: List<JsonObject>
     @Suppress("UNCHECKED_CAST")
     get() = this["runs"] as List<JsonObject>
 
-private var JsonObject.results: List<JsonObject>
+private var JsonObject.results: List<JsonObject>?
     @Suppress("UNCHECKED_CAST")
-    get() = this["results"] as List<JsonObject>
+    get() = this["results"] as List<JsonObject>?
     set(value) {
         this["results"] = value
     }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/report/SarifReportMerger.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/report/SarifReportMerger.kt
@@ -22,12 +22,9 @@ object SarifReportMerger {
     }
 }
 
-private var JsonObject.runs: List<JsonObject>
+private val JsonObject.runs: List<JsonObject>
     @Suppress("UNCHECKED_CAST")
     get() = this["runs"] as List<JsonObject>
-    set(value) {
-        this["runs"] = value
-    }
 
 private var JsonObject.results: List<JsonObject>
     @Suppress("UNCHECKED_CAST")

--- a/detekt-gradle-plugin/src/test/resources/output.sarif.json
+++ b/detekt-gradle-plugin/src/test/resources/output.sarif.json
@@ -1,156 +1,157 @@
 {
-  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
-  "version": "2.1.0",
-  "runs": [
-    {
-      "originalUriBaseIds": {
-        "%SRCROOT%": {
-          "uri": "file:///Users/tester/detekt/"
+    "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+    "version": "2.1.0",
+    "runs": [
+        {
+            "originalUriBaseIds": {
+                "%SRCROOT%": {
+                    "uri": "file:///Users/tester/detekt/"
+                }
+            },
+            "results": [
+                {
+                    "level": "warning",
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "TestFile.kt",
+                                    "uriBaseId": "%SRCROOT%"
+                                },
+                                "region": {
+                                    "startColumn": 1,
+                                    "startLine": 1
+                                }
+                            }
+                        }
+                    ],
+                    "message": {
+                        "text": "TestMessage"
+                    },
+                    "ruleId": "detekt.TestSmellA.TestSmellA"
+                },
+                {
+                    "level": "warning",
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "TestFile.kt",
+                                    "uriBaseId": "%SRCROOT%"
+                                },
+                                "region": {
+                                    "startColumn": 1,
+                                    "startLine": 1
+                                }
+                            }
+                        }
+                    ],
+                    "message": {
+                        "text": "TestMessage"
+                    },
+                    "ruleId": "detekt.TestSmellB.TestSmellB"
+                },
+                {
+                    "level": "warning",
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "TestFile.kt",
+                                    "uriBaseId": "%SRCROOT%"
+                                },
+                                "region": {
+                                    "startColumn": 1,
+                                    "startLine": 1
+                                }
+                            }
+                        }
+                    ],
+                    "message": {
+                        "text": "TestMessage"
+                    },
+                    "ruleId": "detekt.TestSmellC.TestSmellC"
+                },
+                {
+                    "level": "warning",
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "TestFile.kt",
+                                    "uriBaseId": "%SRCROOT%"
+                                },
+                                "region": {
+                                    "startColumn": 1,
+                                    "startLine": 1
+                                }
+                            }
+                        }
+                    ],
+                    "message": {
+                        "text": "TestMessage"
+                    },
+                    "ruleId": "detekt.TestSmellD.TestSmellD"
+                },
+                {
+                    "level": "warning",
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "TestFile.kt",
+                                    "uriBaseId": "%SRCROOT%"
+                                },
+                                "region": {
+                                    "startColumn": 1,
+                                    "startLine": 1
+                                }
+                            }
+                        }
+                    ],
+                    "message": {
+                        "text": "TestMessage"
+                    },
+                    "ruleId": "detekt.TestSmellE.TestSmellE"
+                },
+                {
+                    "level": "warning",
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "TestFile.kt",
+                                    "uriBaseId": "%SRCROOT%"
+                                },
+                                "region": {
+                                    "startColumn": 1,
+                                    "startLine": 1
+                                }
+                            }
+                        }
+                    ],
+                    "message": {
+                        "text": "TestMessage"
+                    },
+                    "ruleId": "detekt.TestSmellF.TestSmellF"
+                }
+            ],
+            "tool": {
+                "driver": {
+                    "downloadUri": "https://github.com/detekt/detekt/releases/download/v1.0.0/detekt",
+                    "fullName": "detekt",
+                    "guid": "022ca8c2-f6a2-4c95-b107-bb72c43263f3",
+                    "informationUri": "https://detekt.dev",
+                    "language": "en",
+                    "name": "detekt",
+                    "organization": "detekt",
+                    "rules": [
+                        
+                    ],
+                    "semanticVersion": "1.0.0",
+                    "version": "1.0.0"
+                }
+            }
         }
-      },
-      "results": [
-        {
-          "level": "warning",
-          "locations": [
-            {
-              "physicalLocation": {
-                "artifactLocation": {
-                  "uri": "TestFile.kt",
-                  "uriBaseId": "%SRCROOT%"
-                },
-                "region": {
-                  "startColumn": 1,
-                  "startLine": 1
-                }
-              }
-            }
-          ],
-          "message": {
-            "text": "TestMessage"
-          },
-          "ruleId": "detekt.TestSmellA.TestSmellA"
-        },
-        {
-          "level": "warning",
-          "locations": [
-            {
-              "physicalLocation": {
-                "artifactLocation": {
-                  "uri": "TestFile.kt",
-                  "uriBaseId": "%SRCROOT%"
-                },
-                "region": {
-                  "startColumn": 1,
-                  "startLine": 1
-                }
-              }
-            }
-          ],
-          "message": {
-            "text": "TestMessage"
-          },
-          "ruleId": "detekt.TestSmellB.TestSmellB"
-        },
-        {
-          "level": "warning",
-          "locations": [
-            {
-              "physicalLocation": {
-                "artifactLocation": {
-                  "uri": "TestFile.kt",
-                  "uriBaseId": "%SRCROOT%"
-                },
-                "region": {
-                  "startColumn": 1,
-                  "startLine": 1
-                }
-              }
-            }
-          ],
-          "message": {
-            "text": "TestMessage"
-          },
-          "ruleId": "detekt.TestSmellC.TestSmellC"
-        },
-        {
-          "level": "warning",
-          "locations": [
-            {
-              "physicalLocation": {
-                "artifactLocation": {
-                  "uri": "TestFile.kt",
-                  "uriBaseId": "%SRCROOT%"
-                },
-                "region": {
-                  "startColumn": 1,
-                  "startLine": 1
-                }
-              }
-            }
-          ],
-          "message": {
-            "text": "TestMessage"
-          },
-          "ruleId": "detekt.TestSmellD.TestSmellD"
-        },
-        {
-          "level": "warning",
-          "locations": [
-            {
-              "physicalLocation": {
-                "artifactLocation": {
-                  "uri": "TestFile.kt",
-                  "uriBaseId": "%SRCROOT%"
-                },
-                "region": {
-                  "startColumn": 1,
-                  "startLine": 1
-                }
-              }
-            }
-          ],
-          "message": {
-            "text": "TestMessage"
-          },
-          "ruleId": "detekt.TestSmellE.TestSmellE"
-        },
-        {
-          "level": "warning",
-          "locations": [
-            {
-              "physicalLocation": {
-                "artifactLocation": {
-                  "uri": "TestFile.kt",
-                  "uriBaseId": "%SRCROOT%"
-                },
-                "region": {
-                  "startColumn": 1,
-                  "startLine": 1
-                }
-              }
-            }
-          ],
-          "message": {
-            "text": "TestMessage"
-          },
-          "ruleId": "detekt.TestSmellF.TestSmellF"
-        }
-      ],
-      "tool": {
-        "driver": {
-          "downloadUri": "https://github.com/detekt/detekt/releases/download/v1.0.0/detekt",
-          "fullName": "detekt",
-          "guid": "022ca8c2-f6a2-4c95-b107-bb72c43263f3",
-          "informationUri": "https://detekt.dev",
-          "language": "en",
-          "name": "detekt",
-          "organization": "detekt",
-          "rules": [
-          ],
-          "semanticVersion": "1.0.0",
-          "version": "1.0.0"
-        }
-      }
-    }
-  ]
+    ]
 }


### PR DESCRIPTION
Fixes #5864

Note: I didn't find a clear GSON or Jackson API, so used Groovy's API which was readily on the classpath.