### PR TITLE
Add EnumEntryOrder rule (#6115)

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -542,6 +542,10 @@ style:
     negativeFunctionNameParts:
       - 'not'
       - 'non'
+  EnumEntryOrder:
+    active: false
+    includeAnnotations:
+      - 'io.gitlab.arturbosch.detekt.annotations.Alphabetical'
   EqualsNullCall:
     active: true
   EqualsOnSignatureLine:

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/EnumEntryOrder.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/EnumEntryOrder.kt
@@ -8,7 +8,6 @@ import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.config
-import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
 import io.gitlab.arturbosch.detekt.api.internal.Configuration
 import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.rules.identifierName
@@ -60,7 +59,6 @@ import org.jetbrains.kotlin.resolve.descriptorUtil.getSuperInterfaces
  *  </noncompliant>
  */
 @RequiresTypeResolution
-@ActiveByDefault(since = "1.24.0")
 class EnumEntryOrder(config: Config = Config.empty) : Rule(config) {
 
     override val issue: Issue = Issue(

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/EnumEntryOrder.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/EnumEntryOrder.kt
@@ -1,0 +1,157 @@
+package io.gitlab.arturbosch.detekt.rules.style
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.config
+import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
+import io.gitlab.arturbosch.detekt.api.internal.Configuration
+import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
+import io.gitlab.arturbosch.detekt.rules.identifierName
+import org.jetbrains.kotlin.backend.common.pop
+import org.jetbrains.kotlin.backend.common.push
+import org.jetbrains.kotlin.descriptors.ClassDescriptor
+import org.jetbrains.kotlin.psi.KtClassOrObject
+import org.jetbrains.kotlin.psi.KtEnumEntry
+import org.jetbrains.kotlin.resolve.BindingContext
+import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameOrNull
+import org.jetbrains.kotlin.resolve.descriptorUtil.getSuperInterfaces
+
+/**
+ * Detects enum entries declared out of alphabetical order when either the enum itself or one of its super interfaces
+ * is decorated with the configured annotation. Keeping enum entries in order, where appropriate, allows for
+ * easy scanning of a large enum and makes for smaller diffs and less merge conflicts in pull requests.
+ *
+ *  <noncompliant>
+ *  @@Alphabetical
+ *  enum class Fruit {
+ *      BANANA, APPLE
+ *  }
+ *  </noncompliant>
+ *  <compliant>
+ *  @@Alphabetical
+ *  enum class Fruit {
+ *      APPLE, BANANA
+ *  }
+ *  </compliant>
+ *  <noncompliant>
+ *  @@Alphabetical
+ *  interface Edible {
+ *      val calories: Int
+ *  }
+ *  enum class Fruit(override val calories: Int): Edible {
+ *      BANANA(100),
+ *      APPLE(75)
+ *  }
+ *  </noncompliant>
+ *  <compliant>
+ *  @@Alphabetical
+ *  interface Edible {
+ *      val calories: Int
+ *  }
+ *  enum class Fruit(override val calories: Int): Edible {
+ *      APPLE(75),
+ *      BANANA(100)
+ *  }
+ *  </noncompliant>
+ */
+@RequiresTypeResolution
+@ActiveByDefault(since = "1.24.0")
+class EnumEntryOrder(config: Config = Config.empty) : Rule(config) {
+
+    override val issue: Issue = Issue(
+        id = "EnumEntryOrder",
+        Severity.Style,
+        "Enum entries are not declared in alphabetical order.",
+        debt = Debt.FIVE_MINS
+    )
+
+    @Configuration(
+        "A list of fully-qualified names of annotations that can decorate an enum or one of its super interfaces."
+    )
+    private val includeAnnotations: List<String> by config(
+        listOf("io.gitlab.arturbosch.detekt.annotations.Alphabetical")
+    )
+
+    override fun visitClassOrObject(classOrObject: KtClassOrObject) {
+        super.visitClassOrObject(classOrObject)
+
+        val enumEntries = classOrObject.body?.enumEntries ?: return
+        if (enumEntries.isEmpty()) {
+            return
+        }
+
+        val classDescriptor = bindingContext[BindingContext.CLASS, classOrObject] ?: return
+
+        // use BFS because we assume the annotation is more likely to be found in shallower nodes
+        // when we start searching from the enum class descriptor itself
+        val classWithAnnotation =
+            classDescriptor.breadthFirstSearchInSuperInterfaces { it.anyIncludeAnnotations() } ?: return
+
+        val zipped = enumEntries.sortedBy { it.identifierName() }
+            .zip(enumEntries) { expected: KtEnumEntry, actual: KtEnumEntry ->
+                EntryPair(expected, actual)
+            }
+
+        val firstOutOfOrder =
+            zipped.firstOrNull { it.expected.identifierName() != it.actual.identifierName() } ?: return
+
+        report(
+            CodeSmell(
+                issue,
+                Entity.from(firstOutOfOrder.actual),
+                buildMessage(classOrObject, classWithAnnotation, firstOutOfOrder)
+            )
+        )
+    }
+
+    private fun ClassDescriptor.breadthFirstSearchInSuperInterfaces(
+        predicate: (ClassDescriptor) -> Boolean
+    ): ClassDescriptor? {
+        val deque = ArrayDeque(listOf(this))
+        while (deque.isNotEmpty()) {
+            val head = deque.pop()
+            if (predicate(head)) {
+                return head
+            }
+            for (superInterface in head.getSuperInterfaces()) {
+                deque.push(superInterface)
+            }
+        }
+        return null
+    }
+
+    private fun ClassDescriptor.anyIncludeAnnotations() =
+        annotations.any { it.fqName?.asString() in includeAnnotations }
+
+    private class EntryPair(
+        val expected: KtEnumEntry,
+        val actual: KtEnumEntry,
+    ) {
+        override fun toString(): String {
+            return "EntryPair(expected=${expected.name}, actual=${actual.name})"
+        }
+    }
+
+    private fun buildMessage(
+        enum: KtClassOrObject,
+        classWithAnnotation: ClassDescriptor,
+        firstOutOfOrder: EntryPair
+    ) = buildString {
+        append("Entries for enum `${enum.identifierName()}` ")
+        if (enum.fqName != classWithAnnotation.fqNameOrNull()) {
+            append("(which implements `${classWithAnnotation.name.identifier}`) ")
+        }
+        append("are not declared in alphabetical order. ")
+        append("Reorder so that `${firstOutOfOrder.expected.identifierName()}` ")
+        append("is before `${firstOutOfOrder.actual.identifierName()}`.")
+    }
+
+    companion object {
+        const val INCLUDE_ANNOTATIONS = "includeAnnotations"
+    }
+}

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/EnumEntryOrder.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/EnumEntryOrder.kt
@@ -90,13 +90,13 @@ class EnumEntryOrder(config: Config = Config.empty) : Rule(config) {
         val classWithAnnotation =
             classDescriptor.breadthFirstSearchInSuperInterfaces { it.anyIncludeAnnotations() } ?: return
 
-        val zipped = enumEntries.sortedBy { it.identifierName() }
+        val zipped = enumEntries.sortedBy { it.nameAsSafeName }
             .zip(enumEntries) { expected: KtEnumEntry, actual: KtEnumEntry ->
                 EntryPair(expected, actual)
             }
 
         val firstOutOfOrder =
-            zipped.firstOrNull { it.expected.identifierName() != it.actual.identifierName() } ?: return
+            zipped.firstOrNull { it.expected.nameAsSafeName != it.actual.nameAsSafeName } ?: return
 
         report(
             CodeSmell(

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/StyleGuideProvider.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/StyleGuideProvider.kt
@@ -111,6 +111,7 @@ class StyleGuideProvider : DefaultRuleSetProvider {
             UseSumOfInsteadOfFlatMapSize(config),
             DoubleNegativeLambda(config),
             UseLet(config),
+            EnumEntryOrder(config),
         )
     )
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/EnumEntryOrderSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/EnumEntryOrderSpec.kt
@@ -1,0 +1,291 @@
+package io.gitlab.arturbosch.detekt.rules.style
+
+import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
+import io.gitlab.arturbosch.detekt.test.TestConfig
+import io.gitlab.arturbosch.detekt.test.assertThat
+import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@KotlinCoreEnvironmentTest
+class EnumEntryOrderSpec(private val env: KotlinCoreEnvironment) {
+
+    private val subject = EnumEntryOrder(
+        TestConfig(
+            EnumEntryOrder.INCLUDE_ANNOTATIONS to listOf("com.example.Alphabetical")
+        )
+    )
+
+    @Nested
+    inner class `annotation on enum` {
+        @Test
+        fun `reports out of order`() {
+            val code = """
+                package com.example
+    
+                annotation class Alphabetical
+    
+                @Alphabetical
+                enum class Fruit {
+                    BANANA,
+                    APPLE,
+                }         
+            """.trimIndent()
+
+            val findings = subject.compileAndLintWithContext(env, code)
+            assertThat(findings).hasSize(1)
+            assertThat(findings[0]).hasSourceLocation(7, 5)
+            assertThat(findings[0]).hasMessage(
+                "Entries for enum `Fruit` are not declared in alphabetical order. " +
+                    "Reorder so that `APPLE` is before `BANANA`."
+            )
+        }
+
+        @Test
+        fun `does not report in order`() {
+            val code = """
+                package com.example
+    
+                annotation class Alphabetical
+    
+                @Alphabetical
+                enum class Fruit {
+                    APPLE,
+                    BANANA
+                }         
+            """.trimIndent()
+
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        }
+
+        @Test
+        fun `does not report empty enum`() {
+            val code = """
+                package com.example
+    
+                annotation class Alphabetical
+    
+                @Alphabetical
+                enum class Fruit
+
+                @Alphabetical
+                enum class Vegetable {
+                    ;
+                    abstract fun eat()
+                }
+            """.trimIndent()
+
+            assertThat(subject.compileAndLintWithContext(env, code))
+                .isEmpty()
+        }
+
+        @Test
+        fun `does not report nested enum`() {
+            val code = """
+                package com.example
+                    
+                annotation class Alphabetical
+                
+                @Alphabetical
+                enum class Meal {
+                    BREAKFAST,
+                    LUNCH,
+                    SUPPER,
+                    ;
+                    enum class Fruit {
+                        BANANA, APPLE
+                    }
+                }                
+            """.trimIndent()
+
+            assertThat(subject.compileAndLintWithContext(env, code))
+                .isEmpty()
+        }
+
+        @Test
+        fun `reports emoji entries out of order`() {
+            // https://en.wikipedia.org/wiki/Emoji#Unicode_blocks
+
+            @Suppress("EnumEntryName")
+            val code = """
+                package com.example
+    
+                annotation class Alphabetical
+    
+                @Alphabetical
+                enum class Fruit {
+                    `🍒`,
+                    `🍎`,
+                }         
+            """.trimIndent()
+
+            assertThat(subject.compileAndLintWithContext(env, code))
+                .hasSize(1)
+                .hasTextLocations("`🍒`,")
+        }
+
+        @Test
+        fun `reports names in backticks out of order`() {
+            @Suppress("EnumEntryName", "RemoveRedundantBackticks")
+            val code = """
+                package com.example
+    
+                annotation class Alphabetical
+    
+                @Alphabetical
+                enum class Fruit {
+                    apple,
+                    `apple`,
+                }         
+            """.trimIndent()
+
+            val findings = subject.compileAndLintWithContext(env, code)
+            assertThat(findings).hasSize(1)
+            assertThat(findings[0]).hasMessage(
+                "Entries for enum `Fruit` are not declared in alphabetical order. " +
+                    "Reorder so that ``apple`` is before `apple`."
+            )
+        }
+
+        @Test
+        fun `reports keyword names out of order`() {
+            @Suppress("EnumEntryName")
+            val code = """
+                package com.example
+    
+                annotation class Alphabetical
+    
+                @Alphabetical
+                enum class Fruit {
+                    `null`,
+                    NULL,
+                }         
+            """.trimIndent()
+
+            assertThat(subject.compileAndLintWithContext(env, code))
+                .hasSize(1)
+        }
+
+        @Test
+        fun `reports out of order for more complex enum`() {
+            val code = """
+                package com.example
+    
+                annotation class Alphabetical
+    
+                @Alphabetical
+                enum class Fruit(val id: String) {                
+                    BANANA("banana") {
+                        override val calories: Int = 100
+                        override fun eat() {
+                            println("Eating a banana!")
+                        }
+                    },
+                    APPLE("apple") {
+                        override val calories: Int = 50
+                        override fun eat() {
+                            println("Eating an apple!")
+                        }
+                    };
+            
+                    abstract val calories: Int
+            
+                    abstract fun eat()
+            
+                    fun eatAll() {
+                        println("Eating all the fruit!")
+                    }
+
+                    fun eat() {
+                        println("Eating a fruit!")
+                    }
+                }         
+            """.trimIndent()
+
+            assertThat(subject.compileAndLintWithContext(env, code))
+                .hasSize(1)
+        }
+    }
+
+    @Nested
+    inner class `annotation on supertype` {
+        @Test
+        fun `reports out of order for super interface`() {
+            val code = """
+                package com.example
+                
+                annotation class Alphabetical
+                
+                @Alphabetical
+                interface Identifiable {
+                    val id: String
+                }
+                
+                enum class Fruit(override val id: String) : Identifiable {
+                    BANANA("banana"),
+                    APPLE("apple"),
+                }
+            """.trimIndent()
+
+            val findings = subject.compileAndLintWithContext(env, code)
+            assertThat(findings).hasSize(1)
+            assertThat(findings[0]).hasMessage(
+                "Entries for enum `Fruit` (which implements `Identifiable`) are not declared " +
+                    "in alphabetical order. Reorder so that `APPLE` is before `BANANA`."
+            )
+        }
+
+        @Test
+        fun `reports out of order for super super interface`() {
+            val code = """
+                package com.example                
+
+                annotation class Alphabetical
+                
+                @Alphabetical
+                interface Identifiable {
+                    val id: String
+                }
+                
+                interface Delicious
+
+                interface PrettyPrintable : Identifiable {
+                    val prettyString: String
+                }
+                
+                enum class Fruit(override val prettyString: String, override val id: String) : PrettyPrintable, Delicious {
+                    BANANA("Yellow banana", "banana"),
+                    APPLE("Red apple", "apple"),
+                }
+            """.trimIndent()
+
+            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        }
+
+        @Test
+        fun `reports interface with recursive type parameters out of order`() {
+            val code = """
+                package com.example                
+
+                annotation class Alphabetical
+                                
+                @Alphabetical
+                interface Tree<T : Tree<T>> {
+                    fun getChildren(): List<T>
+                }
+                
+                enum class BinaryTree : Tree<BinaryTree> {
+                    NODE {
+                        override fun getChildren(): List<BinaryTree> = listOf(LEAF, LEAF)
+                    },
+                    LEAF {
+                        override fun getChildren(): List<BinaryTree> = emptyList()
+                    },
+                }
+            """.trimIndent()
+
+            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        }
+    }
+}

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/EnumEntryOrderSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/EnumEntryOrderSpec.kt
@@ -136,7 +136,7 @@ class EnumEntryOrderSpec(private val env: KotlinCoreEnvironment) {
                 @Alphabetical
                 enum class Fruit {
                     apple,
-                    `apple`,
+                    ` apple`,
                 }         
             """.trimIndent()
 
@@ -144,7 +144,7 @@ class EnumEntryOrderSpec(private val env: KotlinCoreEnvironment) {
             assertThat(findings).hasSize(1)
             assertThat(findings[0]).hasMessage(
                 "Entries for enum `Fruit` are not declared in alphabetical order. " +
-                    "Reorder so that ``apple`` is before `apple`."
+                    "Reorder so that ``apple`` is before ` apple`."
             )
         }
 
@@ -195,10 +195,6 @@ class EnumEntryOrderSpec(private val env: KotlinCoreEnvironment) {
             
                     fun eatAll() {
                         println("Eating all the fruit!")
-                    }
-
-                    fun eat() {
-                        println("Eating a fruit!")
                     }
                 }         
             """.trimIndent()

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/EnumEntryOrderSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/EnumEntryOrderSpec.kt
@@ -127,7 +127,7 @@ class EnumEntryOrderSpec(private val env: KotlinCoreEnvironment) {
 
         @Test
         fun `reports names in backticks out of order`() {
-            @Suppress("EnumEntryName", "RemoveRedundantBackticks")
+            @Suppress("EnumEntryName")
             val code = """
                 package com.example
     

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/EnumEntryOrderSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/EnumEntryOrderSpec.kt
@@ -135,8 +135,8 @@ class EnumEntryOrderSpec(private val env: KotlinCoreEnvironment) {
     
                 @Alphabetical
                 enum class Fruit {
+                    `yellow banana`,
                     apple,
-                    ` apple`,
                 }         
             """.trimIndent()
 
@@ -144,7 +144,7 @@ class EnumEntryOrderSpec(private val env: KotlinCoreEnvironment) {
             assertThat(findings).hasSize(1)
             assertThat(findings[0]).hasMessage(
                 "Entries for enum `Fruit` are not declared in alphabetical order. " +
-                    "Reorder so that ``apple`` is before ` apple`."
+                    "Reorder so that `apple` is before ``yellow banana``."
             )
         }
 


### PR DESCRIPTION
Closes #6115 where it is proposed to introduce a new rule for checking if enum entries are declared in alphabetical order.