### PR TITLE
Improvement to compiler plugin page

### DIFF
--- a/website/docs/gettingstarted/compilerplugin.mdx
+++ b/website/docs/gettingstarted/compilerplugin.mdx
@@ -8,7 +8,7 @@ summary:
 sidebar_position: 7
 ---
 
-You can integrate detekt in your project using the Detekt Compiler Plugin instead of the classic [Detekt Gradle Plugin](/docs/gettingstarted/gradle). Detekt offers a compiler plugin for K1 which allows you to run detekt as part of the Kotlin compilation process using [type resolution](/docs/gettingstarted/type-resolution). This allows you to run detekt on your code without having separate tasks to invoke and results in much faster execution of detekt, especially if you have been using type resolution with the Gradle plugin.
+You can integrate detekt in your project using the Detekt Compiler Plugin instead of the classic [Detekt Gradle Plugin](/docs/gettingstarted/gradle). Detekt offers a compiler plugin for K1 which allows you to run detekt as part of the Kotlin compilation process using [type resolution](/docs/gettingstarted/type-resolution). This allows you to run detekt on your code without having separate tasks to invoke and results in much faster execution of detekt, especially if you use type resolution with the Gradle plugin.
 
 :::caution
 

--- a/website/docs/gettingstarted/compilerplugin.mdx
+++ b/website/docs/gettingstarted/compilerplugin.mdx
@@ -8,7 +8,7 @@ summary:
 sidebar_position: 7
 ---
 
-You can integrate detekt in your project using the Detekt Compiler Plugin instead of the classic [Detekt Gradle Plugin](/docs/gettingstarted/gradle). Detekt offers a compiler plugin for K1 which allows you to run detekt as part of the Kotlin compilation process. This allows you to run detekt on your code without having separate tasks to invoke and results in much faster execution of detekt, especially if you're using [type resolution](/docs/gettingstarted/type-resolution).
+You can integrate detekt in your project using the Detekt Compiler Plugin instead of the classic [Detekt Gradle Plugin](/docs/gettingstarted/gradle). Detekt offers a compiler plugin for K1 which allows you to run detekt as part of the Kotlin compilation process using [type resolution](/docs/gettingstarted/type-resolution). This allows you to run detekt on your code without having separate tasks to invoke and results in much faster execution of detekt, especially if you have been using type resolution with the Gradle plugin.
 
 :::caution
 
@@ -55,7 +55,7 @@ detekt {
     debug = false
 
     // Kill switch to turn off the Compiler Plugin execution entirely.
-    enableCompilerPlugin = true
+    enableCompilerPlugin.set(true)
 }
 ```
 
@@ -102,4 +102,4 @@ BUILD SUCCESSFUL in 1s
 
 ## Known Issues
 
-1. The rule `InvalidPackageDeckaration` is known to not be working well with the Compiler Plugin [#5747](https://github.com/detekt/detekt/issues/5747).
+1. The rule `InvalidPackageDeclaration` is known to not be working well with the Compiler Plugin [#5747](https://github.com/detekt/detekt/issues/5747).


### PR DESCRIPTION
* reworded to make it explicit that the compiler pluging is using TR
* fixed configuration directive for Gradle 8.1.1 using Kotlin DSL
* fixed typo in issue workaround

<!-- A similar PR may already be submitted! -->
<!-- Please search among the [Pull requests](https://github.com/detekt/detekt/pulls) before creating one. -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Link to relevant issues if possible. -->

<!-- For more information, see the [CONTRIBUTING guide](https://github.com/detekt/detekt/blob/main/.github/CONTRIBUTING.md). -->
