### PR TITLE
Changed name of "FunctionMinLength" rule to "FunctionNameMinLength"

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -325,7 +325,7 @@ naming:
   FunctionMaxLength:
     active: false
     maximumFunctionNameLength: 30
-  FunctionMinLength:
+  FunctionNameMinLength:
     active: false
     minimumFunctionNameLength: 3
   FunctionNaming:

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNameMinLength.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNameMinLength.kt
@@ -17,7 +17,7 @@ import org.jetbrains.kotlin.psi.KtNamedFunction
 /**
  * Reports when very short function names are used.
  */
-class FunctionMinLength(config: Config = Config.empty) : Rule(config) {
+class FunctionNameMinLength(config: Config = Config.empty) : Rule(config) {
 
     override val issue = Issue(
         javaClass.simpleName,

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingProvider.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NamingProvider.kt
@@ -31,7 +31,7 @@ class NamingProvider : DefaultRuleSetProvider {
             ObjectPropertyNaming(config),
             FunctionParameterNaming(config),
             FunctionNaming(config),
-            FunctionMinLength(config),
+            FunctionNameMinLength(config),
             FunctionMaxLength(config),
             VariableMaxLength(config),
             VariableMinLength(config),

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionMinNameLengthSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionMinNameLengthSpec.kt
@@ -5,19 +5,19 @@ import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
-class FunctionMinLengthSpec {
+class FunctionMinNameLengthSpec {
 
     @Test
     fun `should report a function name that is too short`() {
         val code = "fun a() = 3"
-        assertThat(FunctionMinLength().compileAndLint(code)).hasSize(1)
+        assertThat(FunctionNameMinLength().compileAndLint(code)).hasSize(1)
     }
 
     @Test
     fun `should report a function name that is too short base on config`() {
         val code = "fun four() = 3"
         assertThat(
-            FunctionMinLength(TestConfig("minimumFunctionNameLength" to 5))
+            FunctionNameMinLength(TestConfig("minimumFunctionNameLength" to 5))
                 .compileAndLint(code)
         ).hasSize(1)
     }
@@ -25,7 +25,7 @@ class FunctionMinLengthSpec {
     @Test
     fun `should not report a function name that is okay`() {
         val code = "fun three() = 3"
-        assertThat(FunctionMinLength().compileAndLint(code)).isEmpty()
+        assertThat(FunctionNameMinLength().compileAndLint(code)).isEmpty()
     }
 
     @Test
@@ -34,10 +34,10 @@ class FunctionMinLengthSpec {
             class C : I {
                 override fun tooShortButShouldNotBeReportedByDefault() {}
             }
-            interface I { @Suppress("FunctionMinLength") fun tooShortButShouldNotBeReportedByDefault() }
+            interface I { @Suppress("FunctionNameMinLength") fun tooShortButShouldNotBeReportedByDefault() }
         """.trimIndent()
         assertThat(
-            FunctionMinLength(
+            FunctionNameMinLength(
                 TestConfig("minimumFunctionNameLength" to 50)
             ).compileAndLint(code)
         ).isEmpty()
@@ -52,7 +52,7 @@ class FunctionMinLengthSpec {
             }
         """.trimIndent()
         assertThat(
-            FunctionMinLength(
+            FunctionNameMinLength(
                 TestConfig("minimumFunctionNameLength" to 5)
             ).compileAndLint(code)
         ).isEmpty()


### PR DESCRIPTION
According to the proposal in [PR](https://github.com/detekt/detekt/pull/6131) renamed "FunctionMinLength" rule to "FunctionNameMinLength" to be more expressive and also to be consistent to renaming of "FunctionMaxLength" rule to "FunctionNameMaxLength"

initial action is part of #6035 