### PR TITLE
Allow documenting public fun name when same private variable is present

### DIFF
--- a/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/KDocReferencesNonPublicProperty.kt
+++ b/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/KDocReferencesNonPublicProperty.kt
@@ -87,10 +87,9 @@ class KDocReferencesNonPublicProperty(config: Config = Config.empty) : Rule(conf
         }
     }
 
-    override fun visitProperty(property: KtProperty) {
-        super.visitProperty(property)
-
-        property.getTopmostParentOfType<KtClass>()?.registerProperty(property)
+    override fun visitNamedDeclaration(declaration: KtNamedDeclaration) {
+        super.visitNamedDeclaration(declaration)
+        declaration.getTopmostParentOfType<KtClass>()?.registerProperty(declaration)
     }
 
     private fun KtClass.registerProperty(declaration: KtNamedDeclaration) {

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/KDocReferencesNonPublicPropertySpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/KDocReferencesNonPublicPropertySpec.kt
@@ -196,4 +196,29 @@ class KDocReferencesNonPublicPropertySpec {
         """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
+
+    @Test
+    fun `does not report public function when same named private var is present - #6162`() {
+        val code = """
+            /**
+             * [peek] - public fun
+             * [Inner.innerPeek] - public fun
+             * [Object.objectPeek] - public fun
+             */
+            class Test {
+                private var peek: Int = 0
+                private var innerPeek: Int = 0
+                private var objectPeek: Int = 0
+                private var companionPeek: Int = 0
+                fun peek() = System.currentTimeMillis()
+                inner class Inner {
+                    fun innerPeek() = System.currentTimeMillis()
+                }
+                object Object {
+                    fun objectPeek() = System.currentTimeMillis()
+                }
+            }
+        """.trimIndent()
+        assertThat(subject.compileAndLint(code)).isEmpty()
+    }
 }

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/KDocReferencesNonPublicPropertySpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/KDocReferencesNonPublicPropertySpec.kt
@@ -210,12 +210,12 @@ class KDocReferencesNonPublicPropertySpec {
                 private var innerPeek: Int = 0
                 private var objectPeek: Int = 0
                 private var companionPeek: Int = 0
-                fun peek() = System.currentTimeMillis()
+                fun peek() = 0
                 inner class Inner {
-                    fun innerPeek() = System.currentTimeMillis()
+                    fun innerPeek() = 0
                 }
                 object Object {
-                    fun objectPeek() = System.currentTimeMillis()
+                    fun objectPeek() = 0
                 }
             }
         """.trimIndent()


### PR DESCRIPTION
Extend the previous logic by traversing to `visitNamedDeclaration`

Fixes: https://github.com/detekt/detekt/issues/6162
