### PR TITLE
Replaced "threshold" property of CognitiveComplexMethod rule by "allowedComplexity"

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -94,7 +94,7 @@ complexity:
   active: true
   CognitiveComplexMethod:
     active: false
-    threshold: 15
+    allowedComplexity: 15
   ComplexCondition:
     active: true
     threshold: 4

--- a/detekt-generator/src/test/resources/ruleset1/src/main/kotlin/CognitiveComplexMethod.kt
+++ b/detekt-generator/src/test/resources/ruleset1/src/main/kotlin/CognitiveComplexMethod.kt
@@ -21,10 +21,10 @@ class CognitiveComplexMethod(config: Config = Config.empty) : Rule(config) {
         Debt.TWENTY_MINS
     )
 
-    @Configuration("Cognitive Complexity number for a method.")
-    private val threshold: Int by config(defaultValue = 15)
+    @Configuration("Maximum Cognitive Complexity allowed for a method.")
+    private val allowedComplexity: Int by config(defaultValue = 15)
 
     override fun visitNamedFunction(function: KtNamedFunction) {
-        if (false) println(threshold)
+        println(allowedComplexity)
     }
 }

--- a/detekt-generator/src/test/resources/ruleset1/src/main/kotlin/CognitiveComplexMethod.kt
+++ b/detekt-generator/src/test/resources/ruleset1/src/main/kotlin/CognitiveComplexMethod.kt
@@ -24,7 +24,8 @@ class CognitiveComplexMethod(config: Config = Config.empty) : Rule(config) {
     @Configuration("Maximum Cognitive Complexity allowed for a method.")
     private val allowedComplexity: Int by config(defaultValue = 15)
 
+    @SuppressWarnings("EmptyFunctionBlock")
     override fun visitNamedFunction(function: KtNamedFunction) {
-        println(allowedComplexity)
+        // This is just for testing purpose
     }
 }

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/CognitiveComplexMethod.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/CognitiveComplexMethod.kt
@@ -38,21 +38,21 @@ class CognitiveComplexMethod(config: Config = Config.empty) : Rule(config) {
         Debt.TWENTY_MINS
     )
 
-    @Configuration("Cognitive Complexity number for a method.")
-    private val threshold: Int by config(defaultValue = 15)
+    @Configuration("Maximum Cognitive Complexity allowed for a method.")
+    private val allowedComplexity: Int by config(defaultValue = 15)
 
     override fun visitNamedFunction(function: KtNamedFunction) {
         val complexity = CognitiveComplexity.calculate(function)
 
-        if (complexity >= threshold) {
+        if (complexity > allowedComplexity) {
             report(
                 ThresholdedCodeSmell(
                     issue,
                     Entity.atName(function),
-                    Metric("CC", complexity, threshold),
+                    Metric("CC", complexity, allowedComplexity),
                     "The function ${function.nameAsSafeName} appears to be too complex " +
                         "based on Cognitive Complexity (complexity: $complexity). " +
-                        "Defined complexity threshold for methods is set to '$threshold'"
+                        "Defined maximum allowed complexity for methods is set to '$allowedComplexity'"
                 )
             )
         }

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/CognitiveComplexMethodSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/CognitiveComplexMethodSpec.kt
@@ -9,10 +9,10 @@ import org.junit.jupiter.api.Test
 
 class CognitiveComplexMethodSpec {
 
-    private val testConfig = TestConfig("threshold" to "1")
+    private val testConfig = TestConfig("allowedComplexity" to "1")
 
     @Test
-    fun `should report complex function`() {
+    fun `should report complex function exceeding the allowed complexity`() {
         val code = """
             fun sumOfPrimes(max: Int): Int { // total cognitive complexity is 7
                 var total = 0
@@ -35,7 +35,21 @@ class CognitiveComplexMethodSpec {
     }
 
     @Test
-    fun `should not report simple function`() {
+    fun `should not report function that has exactly the allowed complexity`() {
+        val code = """
+            fun divide(a: Int, b: Int): Int { // total cognitive complexity is 1
+                if(b != 0) {
+                    return a / b
+                }
+                return 0
+            }
+        """.trimIndent()
+        val findings = CognitiveComplexMethod(testConfig).compileAndLint(code)
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `should not report function that has less than the allowed complexity`() {
         val code = """
             fun add(a: Int, b: Int): Int { // total cognitive complexity is 0
                 return a + b


### PR DESCRIPTION
The CognitiveComplexMethod rule reported an issue when the Cognitive Complexity of a method is greater or equal the value defined for the "threshold" property. It is intended that the value defined in the rule is the maximum allowed Cognitive Complexity. So the property is renamed to "allowedComplexity" and the check for reporting an issue is changed to only check for greater, no longer for equal.

The origin issue is https://github.com/detekt/detekt/issues/3679