### PR TITLE
Replaced "threshold" property of ComplexInterface rule by "allowedDefinitions"

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -20,7 +20,7 @@ complexity:
     ignoreStringsRegex: '$^'
   ComplexInterface:
     active: true
-    threshold: 10
+    allowedDefinitions: 10
     includeStaticDeclarations: false
     includePrivateDeclarations: false
   CyclomaticComplexMethod:

--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -100,7 +100,7 @@ complexity:
     threshold: 4
   ComplexInterface:
     active: false
-    threshold: 10
+    allowedDefinitions: 10
     includeStaticDeclarations: false
     includePrivateDeclarations: false
     ignoreOverloaded: false

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexInterface.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexInterface.kt
@@ -43,8 +43,8 @@ class ComplexInterface(
         Debt.TWENTY_MINS
     )
 
-    @Configuration("the amount of definitions in an interface to trigger the rule")
-    private val threshold: Int by config(defaultValue = 10)
+    @Configuration("The amount of allowed definitions in an interface.")
+    private val allowedDefinitions: Int by config(defaultValue = 10)
 
     @Configuration("whether static declarations should be included")
     private val includeStaticDeclarations: Boolean by config(defaultValue = false)
@@ -62,12 +62,12 @@ class ComplexInterface(
             if (includeStaticDeclarations) {
                 size += countStaticDeclarations(klass.companionObject())
             }
-            if (size >= threshold) {
+            if (size > allowedDefinitions) {
                 report(
                     ThresholdedCodeSmell(
                         issue,
                         Entity.atName(klass),
-                        Metric("SIZE: ", size, threshold),
+                        Metric("SIZE: ", size, allowedDefinitions),
                         "The interface ${klass.name} is too complex. Consider splitting it up."
                     )
                 )

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexInterfaceSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexInterfaceSpec.kt
@@ -6,14 +6,14 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
-private val defaultThreshold = "threshold" to 4
-private val staticDeclarationsConfig = TestConfig(defaultThreshold, "includeStaticDeclarations" to true)
-private val privateDeclarationsConfig = TestConfig(defaultThreshold, "includePrivateDeclarations" to true)
-private val ignoreOverloadedConfig = TestConfig(defaultThreshold, "ignoreOverloaded" to true)
+private val defaultAllowedDefinitions = "allowedDefinitions" to 3
+private val staticDeclarationsConfig = TestConfig(defaultAllowedDefinitions, "includeStaticDeclarations" to true)
+private val privateDeclarationsConfig = TestConfig(defaultAllowedDefinitions, "includePrivateDeclarations" to true)
+private val ignoreOverloadedConfig = TestConfig(defaultAllowedDefinitions, "ignoreOverloaded" to true)
 
 class ComplexInterfaceSpec {
 
-    private val subject = ComplexInterface(TestConfig(defaultThreshold))
+    private val subject = ComplexInterface(TestConfig(defaultAllowedDefinitions))
 
     @Nested
     inner class `ComplexInterface rule positives` {
@@ -227,6 +227,18 @@ class ComplexInterfaceSpec {
         @Test
         fun `does not report an empty interface`() {
             val code = "interface Empty"
+            assertThat(subject.compileAndLint(code)).isEmpty()
+        }
+
+        @Test
+        fun `does not report an interface that has exactly the allowed definitions`() {
+            val code = """
+                interface MyInterface{
+                    fun func1()
+                    fun func2()
+                    fun func3()
+                }
+            """.trimIndent()
             assertThat(subject.compileAndLint(code)).isEmpty()
         }
     }


### PR DESCRIPTION
The ComplexInterface rule reported an issue when the amount of definitions is greater or equal the value defined for the "threshold" property. It is intended that the value defined in the rule is the maximum allowed definitions. So the property is renamed to "allowedDefinitions" and the check for reporting an issue is changed to check only for greater, no longer for equal.

The origin issue is https://github.com/detekt/detekt/issues/3679