### PR TITLE
Replaced "threshold" property of ComplexCondition rule by "allowedComplexity"

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -97,7 +97,7 @@ complexity:
     threshold: 15
   ComplexCondition:
     active: true
-    threshold: 4
+    allowedComplexity: 4
   ComplexInterface:
     active: false
     threshold: 10

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexCondition.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexCondition.kt
@@ -51,8 +51,8 @@ class ComplexCondition(
         Debt.TWENTY_MINS
     )
 
-    @Configuration("the number of conditions which will trigger the rule")
-    private val threshold: Int by config(defaultValue = 4)
+    @Configuration("Maximum allowed complexity for conditions.")
+    private val allowedComplexity: Int by config(defaultValue = 4)
 
     override fun visitIfExpression(expression: KtIfExpression) {
         val condition = expression.condition
@@ -81,14 +81,14 @@ class ComplexCondition(
             }
             val conditionString = longestBinExpr.text
             val count = frequency(conditionString, "&&") + frequency(conditionString, "||") + 1
-            if (count >= threshold) {
+            if (count > allowedComplexity) {
                 report(
                     ThresholdedCodeSmell(
                         issue,
                         Entity.from(condition),
-                        Metric("SIZE", count, threshold),
+                        Metric("SIZE", count, allowedComplexity),
                         "This condition is too complex ($count). " +
-                            "Defined complexity threshold for conditions is set to '$threshold'"
+                            "The defined maximum complexity for conditions is set to '$allowedComplexity'"
                     )
                 )
             }

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexConditionSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexConditionSpec.kt
@@ -1,22 +1,66 @@
 package io.gitlab.arturbosch.detekt.rules.complexity
 
+import io.gitlab.arturbosch.detekt.test.TestConfig
+import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLint
-import org.assertj.core.api.Assertions.assertThat
+import io.gitlab.arturbosch.detekt.test.isThresholded
 import org.junit.jupiter.api.Test
 
 class ComplexConditionSpec {
 
-    val code = """
-        val a = if (5 > 4 && 4 < 6 || (3 < 5 || 2 < 5)) { 42 } else { 24 }
-        
-        fun complexConditions() {
-            while (5 > 4 && 4 < 6 || (3 < 5 || 2 < 5)) {}
-            do { } while (5 > 4 && 4 < 6 || (3 < 5 || 2 < 5))
-        }
-    """.trimIndent()
+    private val testConfig = TestConfig("allowedComplexity" to 4)
 
     @Test
-    fun `reports some complex conditions`() {
-        assertThat(ComplexCondition().compileAndLint(code)).hasSize(3)
+    fun `should report complex conditions exceeding allowed complexity`() {
+        // given
+        val code = """
+                    val a = if (5 > 4 && 4 < 6 || (3 < 5 || 2 < 5)) { 42 } else { 24 }
+                    
+                    fun complexConditions() {
+                        while (5 > 4 && 4 < 6 || (3 < 5 || 2 < 5) && 2 % 2 == 0) {}
+                        do { } while (5 > 4 && 4 < 6 || (3 < 5 || 2 < 5))
+                    }
+                    """.trimIndent()
+
+        // when
+        val actual = ComplexCondition(testConfig).compileAndLint(code)
+
+        // then
+        assertThat(actual).hasSize(1)
+        assertThat(actual.first()).isThresholded().withValue(5)
+    }
+
+    @Test
+    fun `should not report conditions that has exact the allowed complexity`() {
+        // given
+        val code = """
+                    val a = if (5 > 4 && 4 < 6 || (3 < 5 || 2 < 5)) { 42 } else { 24 }
+                    
+                    fun complexConditions() {
+                        while (5 > 4 && 4 < 6 || (3 < 5 || 2 < 5)) {}
+                    }
+                    """.trimIndent()
+
+        // when
+        val actual = ComplexCondition(testConfig).compileAndLint(code)
+
+        // then
+        assertThat(actual).isEmpty()
+    }
+
+    @Test
+    fun `should not report conditions that are below the allowed complexity`() {
+        // given
+        val code = """
+                    fun simpleCondition(): Boolean {
+                       return true
+                    }
+                    """.trimIndent()
+
+        // when
+        val actual = ComplexCondition(testConfig).compileAndLint(code)
+
+        // then
+        assertThat(actual).isEmpty()
     }
 }


### PR DESCRIPTION
The ComplexCondition rule reported an issue when the complexity is greater or equal the value defined for the "threshold" property. It is intended that the value defined in the rule is the maximum allowed complexity. So the property is renamed to "allowedComplexity" and the check for reporting an issue is changed to check only for greater, no longer for equal.

The origin issue is https://github.com/detekt/detekt/issues/3679