### PR TITLE
Replaced "threshold" property of LargeClass rule by "allowedLines"

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -125,7 +125,7 @@ complexity:
     ignoredLabels: []
   LargeClass:
     active: true
-    threshold: 600
+    allowedLines: 600
   LongMethod:
     active: true
     allowedLines: 60

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LargeClass.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LargeClass.kt
@@ -35,8 +35,8 @@ class LargeClass(config: Config = Config.empty) : Rule(config) {
         Debt.TWENTY_MINS
     )
 
-    @Configuration("the size of class required to trigger the rule")
-    private val threshold: Int by config(defaultValue = 600)
+    @Configuration("The maximum number of lines allowed per class.")
+    private val allowedLines: Int by config(defaultValue = 600)
 
     private val classToLinesCache = IdentityHashMap<KtClassOrObject, Int>()
     private val nestedClassTracking = IdentityHashMap<KtClassOrObject, HashSet<KtClassOrObject>>()
@@ -48,12 +48,12 @@ class LargeClass(config: Config = Config.empty) : Rule(config) {
 
     override fun postVisit(root: KtFile) {
         for ((clazz, lines) in classToLinesCache) {
-            if (lines >= threshold) {
+            if (lines > allowedLines) {
                 report(
                     ThresholdedCodeSmell(
                         issue,
                         Entity.atName(clazz),
-                        Metric("SIZE", lines, threshold),
+                        Metric("SIZE", lines, allowedLines),
                         "Class ${clazz.name} is too large. Consider splitting it into smaller pieces."
                     )
                 )

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LargeClassSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LargeClassSpec.kt
@@ -7,12 +7,12 @@ import io.gitlab.arturbosch.detekt.test.compileAndLint
 import io.gitlab.arturbosch.detekt.test.lint
 import org.junit.jupiter.api.Test
 
-private fun subject(threshold: Int) = LargeClass(TestConfig("threshold" to threshold))
+private fun subject(allowedLines: Int) = LargeClass(TestConfig("allowedLines" to allowedLines))
 
 class LargeClassSpec {
 
     @Test
-    fun `should detect only the nested large class which exceeds the threshold`() {
+    fun `should detect only the nested large class which exceeds the allowed lines`() {
         val code = """
             class NestedClasses {
             
@@ -37,7 +37,7 @@ class LargeClassSpec {
              */
             val aTopLevelPropertyOfNestedClasses = 0
         """.trimIndent()
-        val findings = subject(threshold = 4).lint(code)
+        val findings = subject(allowedLines = 4).lint(code)
         assertThat(findings).hasSize(1)
         assertThat(findings).hasStartSourceLocations(SourceLocation(7, 15))
     }
@@ -52,7 +52,38 @@ class LargeClassSpec {
                 println()
             }
         """.trimIndent()
-        val rule = subject(threshold = 2)
+        val rule = subject(allowedLines = 2)
+        assertThat(rule.compileAndLint(code)).isEmpty()
+    }
+
+    @Test
+    fun `should not report a class that has exactly the allowed lines`() {
+        val code = """
+            class MyClass {
+                fun f() {
+                    println()
+                    println()
+                }
+            }
+        """.trimIndent()
+
+        val rule = subject(allowedLines = 6)
+
+        assertThat(rule.compileAndLint(code)).isEmpty()
+    }
+
+    @Test
+    fun `should not report a class that has less than the allowed lines`() {
+        val code = """
+            class MyClass {
+                fun f() {
+                    println()
+                }
+            }
+        """.trimIndent()
+
+        val rule = subject(allowedLines = 6)
+
         assertThat(rule.compileAndLint(code)).isEmpty()
     }
 }


### PR DESCRIPTION
The LargeClass rule reported an issue when the amount of lines is greater or equal the value defined for the "threshold" property. It is intended that the value defined in the rule is the maximum allowed lines. So the property is renamed to "allowedLines" and the check for reporting an issue is changed to check only for greater, no longer for equal.

The origin issue is https://github.com/detekt/detekt/issues/3679