### PR TITLE
Replaced "threshold" property of CyclomaticComplexMethod rule by "allowedComplexity"

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -106,7 +106,7 @@ complexity:
     ignoreOverloaded: false
   CyclomaticComplexMethod:
     active: true
-    threshold: 15
+    allowedComplexity: 15
     ignoreSingleWhenExpression: false
     ignoreSimpleWhenEntries: false
     ignoreNestingFunctions: false

--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -106,7 +106,7 @@ complexity:
     ignoreOverloaded: false
   CyclomaticComplexMethod:
     active: true
-    allowedComplexity: 15
+    allowedComplexity: 14
     ignoreSingleWhenExpression: false
     ignoreSimpleWhenEntries: false
     ignoreNestingFunctions: false

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/CyclomaticComplexMethod.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/CyclomaticComplexMethod.kt
@@ -49,8 +49,8 @@ class CyclomaticComplexMethod(config: Config = Config.empty) : Rule(config) {
 
     override val defaultRuleIdAliases: Set<String> = setOf("ComplexMethod")
 
-    @Configuration("McCabe's Cyclomatic Complexity (MCC) number for a method.")
-    private val threshold: Int by config(defaultValue = 15)
+    @Configuration("The maximum allowed McCabe's Cyclomatic Complexity (MCC) for a method.")
+    private val allowedComplexity: Int by config(defaultValue = 15)
 
     @Configuration("Ignores a complex method if it only contains a single when expression.")
     private val ignoreSingleWhenExpression: Boolean by config(false)
@@ -75,15 +75,15 @@ class CyclomaticComplexMethod(config: Config = Config.empty) : Rule(config) {
             this.nestingFunctions = this@CyclomaticComplexMethod.nestingFunctions
         }
 
-        if (complexity >= threshold) {
+        if (complexity > allowedComplexity) {
             report(
                 ThresholdedCodeSmell(
                     issue,
                     Entity.atName(function),
-                    Metric("MCC", complexity, threshold),
+                    Metric("MCC", complexity, allowedComplexity),
                     "The function ${function.nameAsSafeName} appears to be too complex " +
                         "based on Cyclomatic Complexity (complexity: $complexity). " +
-                        "Defined complexity threshold for methods is set to '$threshold'"
+                        "The maximum allowed complexity for methods is set to '$allowedComplexity'"
                 )
             )
         }

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/CyclomaticComplexMethod.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/CyclomaticComplexMethod.kt
@@ -50,7 +50,7 @@ class CyclomaticComplexMethod(config: Config = Config.empty) : Rule(config) {
     override val defaultRuleIdAliases: Set<String> = setOf("ComplexMethod")
 
     @Configuration("The maximum allowed McCabe's Cyclomatic Complexity (MCC) for a method.")
-    private val allowedComplexity: Int by config(defaultValue = 15)
+    private val allowedComplexity: Int by config(defaultValue = 14)
 
     @Configuration("Ignores a complex method if it only contains a single when expression.")
     private val ignoreSingleWhenExpression: Boolean by config(false)

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/CyclomaticComplexMethodSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/CyclomaticComplexMethodSpec.kt
@@ -211,7 +211,7 @@ class CyclomaticComplexMethodSpec {
                     if (i == 1) {
                     }
                 }
-            """.trimMargin()
+            """.trimIndent()
 
             val findings = subject.lint(code)
 

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/CyclomaticComplexMethodSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/CyclomaticComplexMethodSpec.kt
@@ -9,7 +9,7 @@ import io.gitlab.arturbosch.detekt.test.lint
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
-private val defaultThreshold = "threshold" to "1"
+private val defaultAllowedComplexity = "allowedComplexity" to "1"
 
 class CyclomaticComplexMethodSpec {
 
@@ -20,7 +20,7 @@ class CyclomaticComplexMethodSpec {
 
         @Test
         fun `counts different loops`() {
-            val findings = CyclomaticComplexMethod(TestConfig(defaultThreshold)).compileAndLint(
+            val findings = CyclomaticComplexMethod(TestConfig(defaultAllowedComplexity)).compileAndLint(
                 """
                     fun test() {
                         for (i in 1..10) {}
@@ -36,7 +36,7 @@ class CyclomaticComplexMethodSpec {
 
         @Test
         fun `counts catch blocks`() {
-            val findings = CyclomaticComplexMethod(TestConfig(defaultThreshold)).compileAndLint(
+            val findings = CyclomaticComplexMethod(TestConfig(defaultAllowedComplexity)).compileAndLint(
                 """
                     fun test() {
                         try {} catch(e: IllegalArgumentException) {} catch(e: Exception) {} finally {}
@@ -49,7 +49,7 @@ class CyclomaticComplexMethodSpec {
 
         @Test
         fun `counts nested conditional statements`() {
-            val findings = CyclomaticComplexMethod(TestConfig(defaultThreshold)).compileAndLint(
+            val findings = CyclomaticComplexMethod(TestConfig(defaultAllowedComplexity)).compileAndLint(
                 """
                     fun test() {
                         try {
@@ -84,31 +84,31 @@ class CyclomaticComplexMethodSpec {
 
         @Test
         fun `counts three with nesting function 'forEach'`() {
-            val config = TestConfig(defaultThreshold, "ignoreNestingFunctions" to "false")
+            val config = TestConfig(defaultAllowedComplexity, "ignoreNestingFunctions" to "false")
             assertExpectedComplexityValue(code, config, expectedValue = 3)
         }
 
         @Test
         fun `can ignore nesting functions like 'forEach'`() {
-            val config = TestConfig(defaultThreshold, "ignoreNestingFunctions" to "true")
+            val config = TestConfig(defaultAllowedComplexity, "ignoreNestingFunctions" to "true")
             assertExpectedComplexityValue(code, config, expectedValue = 2)
         }
 
         @Test
         fun `skips all if if the nested functions is empty`() {
-            val config = TestConfig(defaultThreshold, "nestingFunctions" to "")
+            val config = TestConfig(defaultAllowedComplexity, "nestingFunctions" to "")
             assertExpectedComplexityValue(code, config, expectedValue = 2)
         }
 
         @Test
         fun `skips 'forEach' as it is not specified`() {
-            val config = TestConfig(defaultThreshold, "nestingFunctions" to "let,apply,also")
+            val config = TestConfig(defaultAllowedComplexity, "nestingFunctions" to "let,apply,also")
             assertExpectedComplexityValue(code, config, expectedValue = 2)
         }
 
         @Test
         fun `skips 'forEach' as it is not specified list`() {
-            val config = TestConfig(defaultThreshold, "nestingFunctions" to listOf("let", "apply", "also"))
+            val config = TestConfig(defaultAllowedComplexity, "nestingFunctions" to listOf("let", "apply", "also"))
             assertExpectedComplexityValue(code, config, expectedValue = 2)
         }
     }
@@ -170,7 +170,7 @@ class CyclomaticComplexMethodSpec {
         @Test
         fun `does not report complex methods with a single when expression`() {
             val config = TestConfig(
-                "threshold" to "4",
+                "allowedComplexity" to "4",
                 "ignoreSingleWhenExpression" to "true",
             )
             val subject = CyclomaticComplexMethod(config)
@@ -180,16 +180,42 @@ class CyclomaticComplexMethodSpec {
 
         @Test
         fun `reports all complex methods`() {
-            val config = TestConfig("threshold" to "4")
+            val config = TestConfig("allowedComplexity" to "4")
             val subject = CyclomaticComplexMethod(config)
 
-            assertThat(subject.lint(code)).hasStartSourceLocations(
+            val findings = subject.lint(code)
+
+            assertThat(findings).hasSize(5)
+            assertThat(findings).hasStartSourceLocations(
                 SourceLocation(2, 5),
                 SourceLocation(11, 5),
                 SourceLocation(21, 5),
                 SourceLocation(31, 5),
                 SourceLocation(39, 5)
             )
+        }
+
+        @Test
+        fun `does not report function that has exactly the allowed complexity`() {
+            val config = TestConfig("allowedComplexity" to "6")
+            val subject = CyclomaticComplexMethod(config)
+
+            val code = """
+|                fun complexMethodWith2Statements(i: Int) {
+                    when (i) {
+                        1 -> print("one")
+                        2 -> print("two")
+                        3 -> print("three")
+                        else -> print(i)
+                    }
+                    if (i == 1) {
+                    }
+                }
+            """.trimMargin()
+
+            val findings = subject.lint(code)
+
+            assertThat(findings).isEmpty()
         }
 
         @Test


### PR DESCRIPTION
The CyclomaticComplexMethod rule reported an issue when the cyclomatic complexity is greater or equal the value defined for the "threshold" property. It is intended that the value defined in the rule is the maximum allowed cyclomatic complexity. So the property is renamed to "allowedComplexity" and the check for reporting an issue is changed to check only for greater, no longer for equal.

The origin issue is https://github.com/detekt/detekt/issues/3679