### PR TITLE
Replaced "threshold" property of MethodOverloading rule by "allowedOverloads"

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -138,7 +138,7 @@ complexity:
     ignoreAnnotatedParameter: []
   MethodOverloading:
     active: false
-    threshold: 6
+    allowedOverloads: 6
   NamedArguments:
     active: false
     threshold: 3

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/MethodOverloadingSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/MethodOverloadingSpec.kt
@@ -7,8 +7,8 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 class MethodOverloadingSpec {
-    val defaultThreshold = 3
-    val defaultConfig = TestConfig("threshold" to defaultThreshold)
+    private val defaultAllowedOverloads = 2
+    private val defaultConfig = TestConfig("allowedOverloads" to defaultAllowedOverloads)
 
     val subject = MethodOverloading(defaultConfig)
 
@@ -257,6 +257,19 @@ class MethodOverloadingSpec {
     fun `does not report a class without a body`() {
         val code = "class A"
         assertThat(subject.compileAndLint(code)).isEmpty()
+    }
+
+    @Test
+    fun `does not report a method that has exactly the allowed overloads`() {
+        val code = """
+             class Test {              
+                 fun f(i: Int) {}
+                 fun f(i: Int, j: Int) {}
+             }
+        """.trimIndent()
+        val actual = subject.compileAndLint(code)
+
+        assertThat(actual).isEmpty()
     }
 
     @Test


### PR DESCRIPTION
Replaced "threshold" property of MethodOverloading rule by "allowedOverloads" (#3679)

The rule reported an issue when the amount of overloads of methods is greater or equal the value defined for the "threshold" property.
It is intended that the value defined in the rule is the maximum allowed overloads. So the property is renamed to
"allowedOverloads" and the check for reporting an issue is changed to only use greater and no longer equal.

The origin issue is https://github.com/detekt/detekt/issues/3679