### PR TITLE
Replaced "threshold" property of NamedArgumentsRule rule by "allowedArguments".

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -141,7 +141,7 @@ complexity:
     threshold: 6
   NamedArguments:
     active: false
-    threshold: 3
+    allowedArguments: 3
     ignoreArgumentsMatchingNames: false
   NestedBlockDepth:
     active: true

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NamedArguments.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NamedArguments.kt
@@ -41,17 +41,17 @@ class NamedArguments(config: Config = Config.empty) : Rule(config) {
         Debt.FIVE_MINS
     )
 
-    @Configuration("number of arguments that triggers this inspection")
-    private val threshold: Int by config(defaultValue = 3)
+    @Configuration("The allowed number of arguments for a function.")
+    private val allowedArguments: Int by config(defaultValue = 3)
 
     @Configuration("ignores when argument values are the same as the parameter names")
     private val ignoreArgumentsMatchingNames: Boolean by config(defaultValue = false)
 
     override fun visitCallExpression(expression: KtCallExpression) {
         val valueArguments = expression.valueArguments.filterNot { it is KtLambdaArgument }
-        if (valueArguments.size > threshold && expression.canNameArguments()) {
+        if (valueArguments.size > allowedArguments && expression.canNameArguments()) {
             val message = "This function call has ${valueArguments.size} arguments. To call a function with more " +
-                "than $threshold arguments you should set the name of each argument."
+                "than $allowedArguments arguments you should set the name of each argument."
             report(CodeSmell(issue, Entity.from(expression), message))
         } else {
             super.visitCallExpression(expression)

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NamedArgumentsSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NamedArgumentsSpec.kt
@@ -10,8 +10,8 @@ import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
 class NamedArgumentsSpec(val env: KotlinCoreEnvironment) {
-    val defaultThreshold = 2
-    val defaultConfig = TestConfig("threshold" to defaultThreshold)
+    private val defaultAllowedArguments = 2
+    private val defaultConfig = TestConfig("allowedArguments" to defaultAllowedArguments)
     val subject = NamedArguments(defaultConfig)
 
     @Test
@@ -215,7 +215,7 @@ class NamedArgumentsSpec(val env: KotlinCoreEnvironment) {
         @Nested
         inner class `ignoreArgumentsMatchingNames is true` {
             val subject =
-                NamedArguments(TestConfig("threshold" to 2, "ignoreArgumentsMatchingNames" to true))
+                NamedArguments(TestConfig("allowedArguments" to 2, "ignoreArgumentsMatchingNames" to true))
 
             @Test
             fun `all arguments are the same as the parameter names`() {


### PR DESCRIPTION
Replaced "threshold" property of NamedArgumentsRule rule by "allowedArguments" (#3679)

The rule already correctly reported an issue if the amount of arguments is greater than the
the number of the "allowedArguments" property. So the property is only renamed, no change
in functionality.

The origin issue is https://github.com/detekt/detekt/issues/3679