### PR TITLE
Replaced "threshold" property of NestedBlockDepth rule by "allowedDepth".

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -145,7 +145,7 @@ complexity:
     ignoreArgumentsMatchingNames: false
   NestedBlockDepth:
     active: true
-    threshold: 4
+    allowedDepth: 4
   NestedScopeFunctions:
     active: false
     threshold: 1

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedBlockDepth.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedBlockDepth.kt
@@ -39,11 +39,11 @@ class NestedBlockDepth(config: Config = Config.empty) : Rule(config) {
         Debt.TWENTY_MINS
     )
 
-    @Configuration("the nested depth required to trigger rule")
-    private val threshold: Int by config(defaultValue = 4)
+    @Configuration("The maximum allowed nested block depth for a function")
+    private val allowedDepth: Int by config(defaultValue = 4)
 
     override fun visitNamedFunction(function: KtNamedFunction) {
-        val visitor = FunctionDepthVisitor(threshold)
+        val visitor = FunctionDepthVisitor(allowedDepth)
         visitor.visitNamedFunction(function)
         if (visitor.isTooDeep) {
             @Suppress("UnsafeCallOnNullableType")
@@ -51,21 +51,21 @@ class NestedBlockDepth(config: Config = Config.empty) : Rule(config) {
                 ThresholdedCodeSmell(
                     issue,
                     Entity.atName(function),
-                    Metric("SIZE", visitor.maxDepth, threshold),
+                    Metric("SIZE", visitor.maxDepth, allowedDepth),
                     "Function ${function.name} is nested too deeply."
                 )
             )
         }
     }
 
-    private class FunctionDepthVisitor(val threshold: Int) : DetektVisitor() {
+    private class FunctionDepthVisitor(val allowedDepth: Int) : DetektVisitor() {
 
         var depth = 0
         var maxDepth = 0
         var isTooDeep = false
         private fun inc() {
             depth++
-            if (depth >= threshold) {
+            if (depth > allowedDepth) {
                 isTooDeep = true
                 if (depth > maxDepth) maxDepth = depth
             }

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedBlockDepthSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedBlockDepthSpec.kt
@@ -10,9 +10,9 @@ import org.junit.jupiter.api.Test
 
 class NestedBlockDepthSpec {
 
-    val defaultThreshold = 4
-    val defaultConfig = TestConfig("threshold" to defaultThreshold)
-    val subject = NestedBlockDepth(defaultConfig)
+    private val defaultAllowedDepth = 3
+    private val defaultConfig = TestConfig("allowedDepth" to defaultAllowedDepth)
+    private val subject = NestedBlockDepth(defaultConfig)
 
     @Test
     fun `should ignore class nesting levels`() {


### PR DESCRIPTION
Replaced "threshold" property of NestedBlockDepth rule by "allowedDepth" (#3679)

The rule reported an issue when the nested depth of a function is greater or equal the value defined for the "threshold" property.
It is intended that the value defined in the rule is the maximum allowed nested depth. So the property is renamed to
"allowedDepth" and the check for reporting an issue is changed to only use greater and no longer equal.

The origin issue is https://github.com/detekt/detekt/issues/3679