### PR TITLE
Replaced "threshold" property of NestedScopeFunctions rule by "allowedDepth".

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -148,7 +148,7 @@ complexity:
     threshold: 4
   NestedScopeFunctions:
     active: false
-    threshold: 1
+    allowedDepth: 1
     functions:
       - 'kotlin.apply'
       - 'kotlin.run'

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedScopeFunctions.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedScopeFunctions.kt
@@ -53,8 +53,8 @@ class NestedScopeFunctions(config: Config = Config.empty) : Rule(config) {
         Debt.FIVE_MINS
     )
 
-    @Configuration("Number of nested scope functions allowed.")
-    private val threshold: Int by config(defaultValue = 1)
+    @Configuration("The maximum allowed depth for nested scope functions.")
+    private val allowedDepth: Int by config(defaultValue = 1)
 
     @Configuration(
         "Set of scope function names which add complexity. " +
@@ -72,9 +72,9 @@ class NestedScopeFunctions(config: Config = Config.empty) : Rule(config) {
         val finding = ThresholdedCodeSmell(
             issue,
             Entity.from(element),
-            Metric("SIZE", depth, threshold),
+            Metric("SIZE", depth, allowedDepth),
             "The scope function '${element.calleeExpression?.text}' is nested too deeply ('$depth'). " +
-                "Complexity threshold is set to '$threshold'."
+                "The maximum allowed depth is set to '$allowedDepth'."
         )
         report(finding)
     }
@@ -112,7 +112,7 @@ class NestedScopeFunctions(config: Config = Config.empty) : Rule(config) {
         }
 
         private fun reportIfOverThreshold(expression: KtCallExpression) {
-            if (depth > threshold) {
+            if (depth > allowedDepth) {
                 report(expression, depth)
             }
         }

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedScopeFunctionsSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedScopeFunctionsSpec.kt
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.Test
 class NestedScopeFunctionsSpec(private val env: KotlinCoreEnvironment) {
 
     private val defaultConfig = TestConfig(
-        "threshold" to 1,
+        "allowedDepth" to 1,
         "functions" to listOf("kotlin.run", "kotlin.with")
     )
     private val subject = NestedScopeFunctions(defaultConfig)
@@ -91,6 +91,18 @@ class NestedScopeFunctionsSpec(private val env: KotlinCoreEnvironment) {
         expectNoFindings()
     }
 
+    @Test
+    fun `should not report scope functions that have exactly the allowed depth`() {
+        givenCode = """
+            fun f() {
+                1.run {
+                }
+            }
+        """.trimIndent()
+        whenLintRuns()
+        expectNoFindings()
+    }
+
     private fun whenLintRuns() {
         actual = subject.compileAndLintWithContext(env, givenCode)
     }
@@ -101,7 +113,7 @@ class NestedScopeFunctionsSpec(private val env: KotlinCoreEnvironment) {
 
     private fun expectFunctionInMsg(scopeFunction: String) {
         val expected = "The scope function '$scopeFunction' is nested too deeply ('2'). " +
-            "Complexity threshold is set to '1'."
+            "The maximum allowed depth is set to '1'."
         assertThat(actual[0]).hasMessage(expected)
     }
 


### PR DESCRIPTION
Replaced "threshold" property of NestedScopeFunctions rule by "allowedDepth" (#3679)

The rule already correctly reported an issue if the depth of scope functions ts is greater than the
the number of the "allowedDepth" property. So the property is only renamed, no change
in functionality.

The origin issue is https://github.com/detekt/detekt/issues/3679