### PR TITLE
Replaced "threshold" property of StringLiteralDuplication rule by "allowedDuplications".

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -14,7 +14,7 @@ complexity:
   StringLiteralDuplication:
     active: true
     excludes: ['**/test/**', '**/*Test.kt', '**/*Spec.kt']
-    threshold: 5
+    allowedDuplications: 5
     ignoreAnnotation: true
     excludeStringsWithLessThan5Characters: true
     ignoreStringsRegex: '$^'

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -14,7 +14,7 @@ complexity:
   StringLiteralDuplication:
     active: true
     excludes: ['**/test/**', '**/*Test.kt', '**/*Spec.kt']
-    allowedDuplications: 5
+    allowedDuplications: 4
     ignoreAnnotation: true
     excludeStringsWithLessThan5Characters: true
     ignoreStringsRegex: '$^'

--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -160,7 +160,7 @@ complexity:
   StringLiteralDuplication:
     active: false
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']
-    allowedDuplications: 3
+    allowedDuplications: 2
     ignoreAnnotation: true
     excludeStringsWithLessThan5Characters: true
     ignoreStringsRegex: '$^'

--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -160,7 +160,7 @@ complexity:
   StringLiteralDuplication:
     active: false
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']
-    threshold: 3
+    allowedDuplications: 3
     ignoreAnnotation: true
     excludeStringsWithLessThan5Characters: true
     ignoreStringsRegex: '$^'

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/StringLiteralDuplication.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/StringLiteralDuplication.kt
@@ -53,8 +53,8 @@ class StringLiteralDuplication(config: Config = Config.empty) : Rule(config) {
         Debt.FIVE_MINS
     )
 
-    @Configuration("amount of duplications to trigger rule")
-    private val threshold: Int by config(defaultValue = 3)
+    @Configuration("The maximum allowed amount of duplications.")
+    private val allowedDuplications: Int by config(defaultValue = 3)
 
     @Configuration("if values in Annotations should be ignored")
     private val ignoreAnnotation: Boolean by config(true)
@@ -75,7 +75,7 @@ class StringLiteralDuplication(config: Config = Config.empty) : Rule(config) {
                 ThresholdedCodeSmell(
                     issue,
                     main,
-                    Metric(type + name, value, threshold),
+                    Metric(type + name, value, allowedDuplications),
                     issue.description,
                     references
                 )
@@ -89,7 +89,7 @@ class StringLiteralDuplication(config: Config = Config.empty) : Rule(config) {
         private val literalReferences = HashMap<String, MutableList<KtStringTemplateExpression>>()
         private val pass: Unit = Unit
 
-        fun getLiteralsOverThreshold(): Map<String, Int> = literals.filterValues { it >= threshold }
+        fun getLiteralsOverThreshold(): Map<String, Int> = literals.filterValues { it > allowedDuplications }
         fun entitiesForLiteral(literal: String): Pair<Entity, List<Entity>> {
             val references = literalReferences[literal]
             if (references != null && references.isNotEmpty()) {

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/StringLiteralDuplication.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/StringLiteralDuplication.kt
@@ -54,7 +54,7 @@ class StringLiteralDuplication(config: Config = Config.empty) : Rule(config) {
     )
 
     @Configuration("The maximum allowed amount of duplications.")
-    private val allowedDuplications: Int by config(defaultValue = 3)
+    private val allowedDuplications: Int by config(defaultValue = 2)
 
     @Configuration("if values in Annotations should be ignored")
     private val ignoreAnnotation: Boolean by config(true)

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/StringLiteralDuplicationSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/StringLiteralDuplicationSpec.kt
@@ -14,7 +14,7 @@ private const val IGNORE_STRINGS_REGEX = "ignoreStringsRegex"
 
 class StringLiteralDuplicationSpec {
 
-    val subject = StringLiteralDuplication()
+    val subject = StringLiteralDuplication(TestConfig("allowedDuplications" to 2))
 
     @Nested
     inner class `many hardcoded strings` {
@@ -58,7 +58,7 @@ class StringLiteralDuplicationSpec {
 
         @Test
         fun `reports strings in annotations according to config`() {
-            val config = TestConfig(IGNORE_ANNOTATION to "false")
+            val config = TestConfig(IGNORE_ANNOTATION to "false", "allowedDuplications" to 2)
             assertFindingWithConfig(code, config, 1)
         }
     }
@@ -75,7 +75,7 @@ class StringLiteralDuplicationSpec {
 
         @Test
         fun `reports string with 4 characters`() {
-            val config = TestConfig(EXCLUDE_SHORT_STRING to "false")
+            val config = TestConfig(EXCLUDE_SHORT_STRING to "false", "allowedDuplications" to 2)
             assertFindingWithConfig(code, config, 1)
         }
     }


### PR DESCRIPTION
Replaced "threshold" property of StringLiteralDuplication rule by "allowedDuplications" (#3679)

The rule reported an issue when the amount of duplications is greater or equal the value defined for the "threshold" property.
It is intended that the value defined in the rule is the maximum allowed duplications. So the property is renamed to "allowedDuplications" and the check for reporting an issue is changed to only use greater and no longer equal.

The origin issue is https://github.com/detekt/detekt/issues/3679