### PR TITLE
Replaced "thresholdX" properties of TooManyFunctions rule by "allowedFunctionsX".

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -167,11 +167,11 @@ complexity:
   TooManyFunctions:
     active: true
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']
-    allowedFunctionsInFiles: 11
-    allowedFunctionsInClasses: 11
-    allowedFunctionsInInterfaces: 11
-    allowedFunctionsInObjects: 11
-    allowedFunctionsInEnums: 11
+    allowedFunctionsPerFile: 11
+    allowedFunctionsPerClass: 11
+    allowedFunctionsPerInterface: 11
+    allowedFunctionsPerObject: 11
+    allowedFunctionsPerEnum: 11
     ignoreDeprecated: false
     ignorePrivate: false
     ignoreOverridden: false

--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -167,11 +167,11 @@ complexity:
   TooManyFunctions:
     active: true
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']
-    thresholdInFiles: 11
-    thresholdInClasses: 11
-    thresholdInInterfaces: 11
-    thresholdInObjects: 11
-    thresholdInEnums: 11
+    allowedFunctionsInFiles: 11
+    allowedFunctionsInClasses: 11
+    allowedFunctionsInInterfaces: 11
+    allowedFunctionsInObjects: 11
+    allowedFunctionsInEnums: 11
     ignoreDeprecated: false
     ignorePrivate: false
     ignoreOverridden: false

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/TooManyFunctions.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/TooManyFunctions.kt
@@ -39,20 +39,20 @@ class TooManyFunctions(config: Config = Config.empty) : Rule(config) {
         Debt.TWENTY_MINS
     )
 
-    @Configuration("The maximum allowed functions in files")
-    private val allowedFunctionsInFiles: Int by config(DEFAULT_THRESHOLD)
+    @Configuration("The maximum allowed functions per file")
+    private val allowedFunctionsPerFile: Int by config(DEFAULT_THRESHOLD)
 
-    @Configuration("The maximum allowed functions in classes")
-    private val allowedFunctionsInClasses: Int by config(DEFAULT_THRESHOLD)
+    @Configuration("The maximum allowed functions per class")
+    private val allowedFunctionsPerClass: Int by config(DEFAULT_THRESHOLD)
 
-    @Configuration("The maximum allowed functions in interfaces")
-    private val allowedFunctionsInInterfaces: Int by config(DEFAULT_THRESHOLD)
+    @Configuration("The maximum allowed functions per interface")
+    private val allowedFunctionsPerInterface: Int by config(DEFAULT_THRESHOLD)
 
-    @Configuration("The maximum allowed functions in objects")
-    private val allowedFunctionsInObjects: Int by config(DEFAULT_THRESHOLD)
+    @Configuration("The maximum allowed function per object")
+    private val allowedFunctionsPerObject: Int by config(DEFAULT_THRESHOLD)
 
     @Configuration("The maximum allowed functions in enums")
-    private val allowedFunctionsInEnums: Int by config(DEFAULT_THRESHOLD)
+    private val allowedFunctionsPerEnum: Int by config(DEFAULT_THRESHOLD)
 
     @Configuration("ignore deprecated functions")
     private val ignoreDeprecated: Boolean by config(false)
@@ -67,14 +67,14 @@ class TooManyFunctions(config: Config = Config.empty) : Rule(config) {
 
     override fun visitKtFile(file: KtFile) {
         super.visitKtFile(file)
-        if (amountOfTopLevelFunctions > allowedFunctionsInFiles) {
+        if (amountOfTopLevelFunctions > allowedFunctionsPerFile) {
             report(
                 ThresholdedCodeSmell(
                     issue,
                     Entity.atPackageOrFirstDecl(file),
-                    Metric("SIZE", amountOfTopLevelFunctions, allowedFunctionsInFiles),
+                    Metric("SIZE", amountOfTopLevelFunctions, allowedFunctionsPerFile),
                     "File '${file.name}' with '$amountOfTopLevelFunctions' functions detected. " +
-                        "The maximum allowed functions inside files is set to '$allowedFunctionsInFiles'"
+                        "The maximum allowed functions per file is set to '$allowedFunctionsPerFile'"
                 )
             )
         }
@@ -91,42 +91,42 @@ class TooManyFunctions(config: Config = Config.empty) : Rule(config) {
         val amount = calcFunctions(klass)
         when {
             klass.isInterface() -> {
-                if (amount > allowedFunctionsInInterfaces) {
+                if (amount > allowedFunctionsPerInterface) {
                     report(
                         ThresholdedCodeSmell(
                             issue,
                             Entity.atName(klass),
-                            Metric("SIZE", amount, allowedFunctionsInInterfaces),
+                            Metric("SIZE", amount, allowedFunctionsPerInterface),
                             "Interface '${klass.name}' with '$amount' functions detected. " +
-                                "The maximum allowed functions inside interfaces is set to " +
-                                "'$allowedFunctionsInInterfaces'"
+                                "The maximum allowed functions per interface is set to " +
+                                "'$allowedFunctionsPerInterface'"
                         )
                     )
                 }
             }
             klass.isEnum() -> {
-                if (amount > allowedFunctionsInEnums) {
+                if (amount > allowedFunctionsPerEnum) {
                     report(
                         ThresholdedCodeSmell(
                             issue,
                             Entity.atName(klass),
-                            Metric("SIZE", amount, allowedFunctionsInEnums),
+                            Metric("SIZE", amount, allowedFunctionsPerEnum),
                             "Enum class '${klass.name}' with '$amount' functions detected. " +
-                                "The maximum allowed functions inside enum classes is set to " +
-                                "'$allowedFunctionsInEnums'"
+                                "The maximum allowed functions per enum class is set to " +
+                                "'$allowedFunctionsPerEnum'"
                         )
                     )
                 }
             }
             else -> {
-                if (amount > allowedFunctionsInClasses) {
+                if (amount > allowedFunctionsPerClass) {
                     report(
                         ThresholdedCodeSmell(
                             issue,
                             Entity.atName(klass),
-                            Metric("SIZE", amount, allowedFunctionsInClasses),
+                            Metric("SIZE", amount, allowedFunctionsPerClass),
                             "Class '${klass.name}' with '$amount' functions detected. " +
-                                "The maximum allowed functions inside classes is set to '$allowedFunctionsInClasses'"
+                                "The maximum allowed functions per class is set to '$allowedFunctionsPerClass'"
                         )
                     )
                 }
@@ -137,14 +137,14 @@ class TooManyFunctions(config: Config = Config.empty) : Rule(config) {
 
     override fun visitObjectDeclaration(declaration: KtObjectDeclaration) {
         val amount = calcFunctions(declaration)
-        if (amount > allowedFunctionsInObjects) {
+        if (amount > allowedFunctionsPerObject) {
             report(
                 ThresholdedCodeSmell(
                     issue,
                     Entity.atName(declaration),
-                    Metric("SIZE", amount, allowedFunctionsInObjects),
+                    Metric("SIZE", amount, allowedFunctionsPerObject),
                     "Object '${declaration.name}' with '$amount' functions detected. " +
-                        "The maximum allowed functions inside objects is set to '$allowedFunctionsInObjects'"
+                        "The maximum allowed functions per object is set to '$allowedFunctionsPerObject'"
                 )
             )
         }

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/TooManyFunctions.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/TooManyFunctions.kt
@@ -39,20 +39,20 @@ class TooManyFunctions(config: Config = Config.empty) : Rule(config) {
         Debt.TWENTY_MINS
     )
 
-    @Configuration("threshold in files")
-    private val thresholdInFiles: Int by config(DEFAULT_THRESHOLD)
+    @Configuration("The maximum allowed functions in files")
+    private val allowedFunctionsInFiles: Int by config(DEFAULT_THRESHOLD)
 
-    @Configuration("threshold in classes")
-    private val thresholdInClasses: Int by config(DEFAULT_THRESHOLD)
+    @Configuration("The maximum allowed functions in classes")
+    private val allowedFunctionsInClasses: Int by config(DEFAULT_THRESHOLD)
 
-    @Configuration("threshold in interfaces")
-    private val thresholdInInterfaces: Int by config(DEFAULT_THRESHOLD)
+    @Configuration("The maximum allowed functions in interfaces")
+    private val allowedFunctionsInInterfaces: Int by config(DEFAULT_THRESHOLD)
 
-    @Configuration("threshold in objects")
-    private val thresholdInObjects: Int by config(DEFAULT_THRESHOLD)
+    @Configuration("The maximum allowed functions in objects")
+    private val allowedFunctionsInObjects: Int by config(DEFAULT_THRESHOLD)
 
-    @Configuration("threshold in enums")
-    private val thresholdInEnums: Int by config(DEFAULT_THRESHOLD)
+    @Configuration("The maximum allowed functions in enums")
+    private val allowedFunctionsInEnums: Int by config(DEFAULT_THRESHOLD)
 
     @Configuration("ignore deprecated functions")
     private val ignoreDeprecated: Boolean by config(false)
@@ -67,14 +67,14 @@ class TooManyFunctions(config: Config = Config.empty) : Rule(config) {
 
     override fun visitKtFile(file: KtFile) {
         super.visitKtFile(file)
-        if (amountOfTopLevelFunctions >= thresholdInFiles) {
+        if (amountOfTopLevelFunctions > allowedFunctionsInFiles) {
             report(
                 ThresholdedCodeSmell(
                     issue,
                     Entity.atPackageOrFirstDecl(file),
-                    Metric("SIZE", amountOfTopLevelFunctions, thresholdInFiles),
+                    Metric("SIZE", amountOfTopLevelFunctions, allowedFunctionsInFiles),
                     "File '${file.name}' with '$amountOfTopLevelFunctions' functions detected. " +
-                        "Defined threshold inside files is set to '$thresholdInFiles'"
+                        "The maximum allowed functions inside files is set to '$allowedFunctionsInFiles'"
                 )
             )
         }
@@ -91,42 +91,42 @@ class TooManyFunctions(config: Config = Config.empty) : Rule(config) {
         val amount = calcFunctions(klass)
         when {
             klass.isInterface() -> {
-                if (amount >= thresholdInInterfaces) {
+                if (amount > allowedFunctionsInInterfaces) {
                     report(
                         ThresholdedCodeSmell(
                             issue,
                             Entity.atName(klass),
-                            Metric("SIZE", amount, thresholdInInterfaces),
+                            Metric("SIZE", amount, allowedFunctionsInInterfaces),
                             "Interface '${klass.name}' with '$amount' functions detected. " +
-                                "Defined threshold inside interfaces is set to " +
-                                "'$thresholdInInterfaces'"
+                                "The maximum allowed functions inside interfaces is set to " +
+                                "'$allowedFunctionsInInterfaces'"
                         )
                     )
                 }
             }
             klass.isEnum() -> {
-                if (amount >= thresholdInEnums) {
+                if (amount > allowedFunctionsInEnums) {
                     report(
                         ThresholdedCodeSmell(
                             issue,
                             Entity.atName(klass),
-                            Metric("SIZE", amount, thresholdInEnums),
+                            Metric("SIZE", amount, allowedFunctionsInEnums),
                             "Enum class '${klass.name}' with '$amount' functions detected. " +
-                                "Defined threshold inside enum classes is set to " +
-                                "'$thresholdInEnums'"
+                                "The maximum allowed functions inside enum classes is set to " +
+                                "'$allowedFunctionsInEnums'"
                         )
                     )
                 }
             }
             else -> {
-                if (amount >= thresholdInClasses) {
+                if (amount > allowedFunctionsInClasses) {
                     report(
                         ThresholdedCodeSmell(
                             issue,
                             Entity.atName(klass),
-                            Metric("SIZE", amount, thresholdInClasses),
+                            Metric("SIZE", amount, allowedFunctionsInClasses),
                             "Class '${klass.name}' with '$amount' functions detected. " +
-                                "Defined threshold inside classes is set to '$thresholdInClasses'"
+                                "The maximum allowed functions inside classes is set to '$allowedFunctionsInClasses'"
                         )
                     )
                 }
@@ -137,14 +137,14 @@ class TooManyFunctions(config: Config = Config.empty) : Rule(config) {
 
     override fun visitObjectDeclaration(declaration: KtObjectDeclaration) {
         val amount = calcFunctions(declaration)
-        if (amount >= thresholdInObjects) {
+        if (amount > allowedFunctionsInObjects) {
             report(
                 ThresholdedCodeSmell(
                     issue,
                     Entity.atName(declaration),
-                    Metric("SIZE", amount, thresholdInObjects),
+                    Metric("SIZE", amount, allowedFunctionsInObjects),
                     "Object '${declaration.name}' with '$amount' functions detected. " +
-                        "Defined threshold inside objects is set to '$thresholdInObjects'"
+                        "The maximum allowed functions inside objects is set to '$allowedFunctionsInObjects'"
                 )
             )
         }

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/TooManyFunctionsSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/TooManyFunctionsSpec.kt
@@ -6,11 +6,11 @@ import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
-private const val ALLOWED_FUNCTIONS_IN_FILES = "allowedFunctionsInFiles"
-private const val ALLOWED_FUNCTIONS_IN_CLASSES = "allowedFunctionsInClasses"
-private const val ALLOWED_FUNCTIONS_IN_INTERFACES = "allowedFunctionsInInterfaces"
-private const val ALLOWED_FUNCTIONS_IN_OBJECTS = "allowedFunctionsInObjects"
-private const val ALLOWED_FUNCTIONS_IN_ENUMS = "allowedFunctionsInEnums"
+private const val ALLOWED_FUNCTIONS_PER_FILE = "allowedFunctionsPerFile"
+private const val ALLOWED_FUNCTIONS_PER_CLASS = "allowedFunctionsPerClass"
+private const val ALLOWED_FUNCTIONS_PER_INTERFACE = "allowedFunctionsPerInterface"
+private const val ALLOWED_FUNCTIONS_PER_OBJECT = "allowedFunctionsPerObject"
+private const val ALLOWED_FUNCTIONS_PER_ENUM = "allowedFunctionsPerEnum"
 private const val IGNORE_DEPRECATED = "ignoreDeprecated"
 private const val IGNORE_PRIVATE = "ignorePrivate"
 private const val IGNORE_OVERRIDDEN = "ignoreOverridden"
@@ -18,19 +18,20 @@ private const val IGNORE_OVERRIDDEN = "ignoreOverridden"
 class TooManyFunctionsSpec {
     val rule = TooManyFunctions(
         TestConfig(
-            ALLOWED_FUNCTIONS_IN_CLASSES to "0",
-            ALLOWED_FUNCTIONS_IN_ENUMS to "0",
-            ALLOWED_FUNCTIONS_IN_FILES to "0",
-            ALLOWED_FUNCTIONS_IN_INTERFACES to "0",
-            ALLOWED_FUNCTIONS_IN_OBJECTS to "0",
+            ALLOWED_FUNCTIONS_PER_CLASS to "1",
+            ALLOWED_FUNCTIONS_PER_ENUM to "1",
+            ALLOWED_FUNCTIONS_PER_FILE to "1",
+            ALLOWED_FUNCTIONS_PER_INTERFACE to "1",
+            ALLOWED_FUNCTIONS_PER_OBJECT to "1",
         )
     )
 
     @Test
-    fun `finds one function in class`() {
+    fun `finds two functions in class`() {
         val code = """
             class A {
                 fun a() = Unit
+                fun b() = Unit
             }
         """.trimIndent()
 
@@ -40,10 +41,11 @@ class TooManyFunctionsSpec {
     }
 
     @Test
-    fun `finds one function in object`() {
+    fun `finds two functions in object`() {
         val code = """
             object O {
                 fun o() = Unit
+                fun p() = Unit
             }
         """.trimIndent()
 
@@ -53,10 +55,11 @@ class TooManyFunctionsSpec {
     }
 
     @Test
-    fun `finds one function in interface`() {
+    fun `finds two functions in interface`() {
         val code = """
             interface I {
                 fun i()
+                fun j()
             }
         """.trimIndent()
 
@@ -66,11 +69,12 @@ class TooManyFunctionsSpec {
     }
 
     @Test
-    fun `finds one function in enum`() {
+    fun `finds two functions in enum`() {
         val code = """
             enum class E {
                 A;
                 fun e() {}
+                fun f() {}
             }
         """.trimIndent()
 
@@ -80,8 +84,11 @@ class TooManyFunctionsSpec {
     }
 
     @Test
-    fun `finds one function in file`() {
-        val code = "fun f() = Unit"
+    fun `finds two functions in file`() {
+        val code = """
+            fun f() = Unit
+            fun g() = Unit
+        """.trimIndent()
 
         assertThat(rule.compileAndLint(code)).hasSize(1)
     }
@@ -102,11 +109,12 @@ class TooManyFunctionsSpec {
     }
 
     @Test
-    fun `finds one function in nested class`() {
+    fun `finds two functions in nested class`() {
         val code = """
             class A {
                 class B {
                     fun a() = Unit
+                    fun b() = Unit
                 }
             }
         """.trimIndent()
@@ -122,10 +130,16 @@ class TooManyFunctionsSpec {
             @Deprecated("")
             fun f() {
             }
+            @Deprecated("")
+            fun g() {
+            }
             
             class A {
                 @Deprecated("")
                 fun f() {
+                }
+                @Deprecated("")
+                fun g() {
                 }
             }
         """.trimIndent()
@@ -139,8 +153,8 @@ class TooManyFunctionsSpec {
         fun `finds no deprecated functions`() {
             val configuredRule = TooManyFunctions(
                 TestConfig(
-                    ALLOWED_FUNCTIONS_IN_CLASSES to "1",
-                    ALLOWED_FUNCTIONS_IN_FILES to "1",
+                    ALLOWED_FUNCTIONS_PER_CLASS to "1",
+                    ALLOWED_FUNCTIONS_PER_FILE to "1",
                     IGNORE_DEPRECATED to "true",
                 )
             )
@@ -154,6 +168,7 @@ class TooManyFunctionsSpec {
         val code = """
             class A {
                 private fun f() {}
+                private fun g() {}
             }
         """.trimIndent()
 
@@ -166,8 +181,8 @@ class TooManyFunctionsSpec {
         fun `finds no private functions`() {
             val configuredRule = TooManyFunctions(
                 TestConfig(
-                    ALLOWED_FUNCTIONS_IN_CLASSES to "1",
-                    ALLOWED_FUNCTIONS_IN_FILES to "1",
+                    ALLOWED_FUNCTIONS_PER_CLASS to "1",
+                    ALLOWED_FUNCTIONS_PER_FILE to "1",
                     IGNORE_PRIVATE to "true",
                 )
             )
@@ -200,8 +215,8 @@ class TooManyFunctionsSpec {
             """.trimIndent()
             val configuredRule = TooManyFunctions(
                 TestConfig(
-                    ALLOWED_FUNCTIONS_IN_CLASSES to "1",
-                    ALLOWED_FUNCTIONS_IN_FILES to "1",
+                    ALLOWED_FUNCTIONS_PER_CLASS to "1",
+                    ALLOWED_FUNCTIONS_PER_FILE to "1",
                     IGNORE_PRIVATE to "true",
                     IGNORE_DEPRECATED to "true",
                     IGNORE_OVERRIDDEN to "true",
@@ -230,8 +245,8 @@ class TooManyFunctionsSpec {
         fun `should not report class with overridden functions, if ignoreOverridden is enabled`() {
             val configuredRule = TooManyFunctions(
                 TestConfig(
-                    ALLOWED_FUNCTIONS_IN_CLASSES to "1",
-                    ALLOWED_FUNCTIONS_IN_FILES to "1",
+                    ALLOWED_FUNCTIONS_PER_CLASS to "1",
+                    ALLOWED_FUNCTIONS_PER_FILE to "1",
                     IGNORE_OVERRIDDEN to "true",
                 )
             )
@@ -242,8 +257,8 @@ class TooManyFunctionsSpec {
         fun `should count overridden functions, if ignoreOverridden is disabled`() {
             val configuredRule = TooManyFunctions(
                 TestConfig(
-                    ALLOWED_FUNCTIONS_IN_CLASSES to "1",
-                    ALLOWED_FUNCTIONS_IN_FILES to "1",
+                    ALLOWED_FUNCTIONS_PER_CLASS to "1",
+                    ALLOWED_FUNCTIONS_PER_FILE to "1",
                     IGNORE_OVERRIDDEN to "false",
                 )
             )

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/TooManyFunctionsSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/TooManyFunctionsSpec.kt
@@ -6,11 +6,11 @@ import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
-private const val THRESHOLD_IN_FILES = "thresholdInFiles"
-private const val THRESHOLD_IN_CLASSES = "thresholdInClasses"
-private const val THRESHOLD_IN_INTERFACES = "thresholdInInterfaces"
-private const val THRESHOLD_IN_OBJECTS = "thresholdInObjects"
-private const val THRESHOLD_IN_ENUMS = "thresholdInEnums"
+private const val ALLOWED_FUNCTIONS_IN_FILES = "allowedFunctionsInFiles"
+private const val ALLOWED_FUNCTIONS_IN_CLASSES = "allowedFunctionsInClasses"
+private const val ALLOWED_FUNCTIONS_IN_INTERFACES = "allowedFunctionsInInterfaces"
+private const val ALLOWED_FUNCTIONS_IN_OBJECTS = "allowedFunctionsInObjects"
+private const val ALLOWED_FUNCTIONS_IN_ENUMS = "allowedFunctionsInEnums"
 private const val IGNORE_DEPRECATED = "ignoreDeprecated"
 private const val IGNORE_PRIVATE = "ignorePrivate"
 private const val IGNORE_OVERRIDDEN = "ignoreOverridden"
@@ -18,11 +18,11 @@ private const val IGNORE_OVERRIDDEN = "ignoreOverridden"
 class TooManyFunctionsSpec {
     val rule = TooManyFunctions(
         TestConfig(
-            THRESHOLD_IN_CLASSES to "1",
-            THRESHOLD_IN_ENUMS to "1",
-            THRESHOLD_IN_FILES to "1",
-            THRESHOLD_IN_INTERFACES to "1",
-            THRESHOLD_IN_OBJECTS to "1",
+            ALLOWED_FUNCTIONS_IN_CLASSES to "0",
+            ALLOWED_FUNCTIONS_IN_ENUMS to "0",
+            ALLOWED_FUNCTIONS_IN_FILES to "0",
+            ALLOWED_FUNCTIONS_IN_INTERFACES to "0",
+            ALLOWED_FUNCTIONS_IN_OBJECTS to "0",
         )
     )
 
@@ -139,8 +139,8 @@ class TooManyFunctionsSpec {
         fun `finds no deprecated functions`() {
             val configuredRule = TooManyFunctions(
                 TestConfig(
-                    THRESHOLD_IN_CLASSES to "1",
-                    THRESHOLD_IN_FILES to "1",
+                    ALLOWED_FUNCTIONS_IN_CLASSES to "1",
+                    ALLOWED_FUNCTIONS_IN_FILES to "1",
                     IGNORE_DEPRECATED to "true",
                 )
             )
@@ -166,8 +166,8 @@ class TooManyFunctionsSpec {
         fun `finds no private functions`() {
             val configuredRule = TooManyFunctions(
                 TestConfig(
-                    THRESHOLD_IN_CLASSES to "1",
-                    THRESHOLD_IN_FILES to "1",
+                    ALLOWED_FUNCTIONS_IN_CLASSES to "1",
+                    ALLOWED_FUNCTIONS_IN_FILES to "1",
                     IGNORE_PRIVATE to "true",
                 )
             )
@@ -200,8 +200,8 @@ class TooManyFunctionsSpec {
             """.trimIndent()
             val configuredRule = TooManyFunctions(
                 TestConfig(
-                    THRESHOLD_IN_CLASSES to "1",
-                    THRESHOLD_IN_FILES to "1",
+                    ALLOWED_FUNCTIONS_IN_CLASSES to "1",
+                    ALLOWED_FUNCTIONS_IN_FILES to "1",
                     IGNORE_PRIVATE to "true",
                     IGNORE_DEPRECATED to "true",
                     IGNORE_OVERRIDDEN to "true",
@@ -230,8 +230,8 @@ class TooManyFunctionsSpec {
         fun `should not report class with overridden functions, if ignoreOverridden is enabled`() {
             val configuredRule = TooManyFunctions(
                 TestConfig(
-                    THRESHOLD_IN_CLASSES to "1",
-                    THRESHOLD_IN_FILES to "1",
+                    ALLOWED_FUNCTIONS_IN_CLASSES to "1",
+                    ALLOWED_FUNCTIONS_IN_FILES to "1",
                     IGNORE_OVERRIDDEN to "true",
                 )
             )
@@ -242,8 +242,8 @@ class TooManyFunctionsSpec {
         fun `should count overridden functions, if ignoreOverridden is disabled`() {
             val configuredRule = TooManyFunctions(
                 TestConfig(
-                    THRESHOLD_IN_CLASSES to "1",
-                    THRESHOLD_IN_FILES to "1",
+                    ALLOWED_FUNCTIONS_IN_CLASSES to "1",
+                    ALLOWED_FUNCTIONS_IN_FILES to "1",
                     IGNORE_OVERRIDDEN to "false",
                 )
             )

--- a/detekt-sample-extensions/src/main/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/rules/TooManyFunctions.kt
+++ b/detekt-sample-extensions/src/main/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/rules/TooManyFunctions.kt
@@ -26,13 +26,13 @@ class TooManyFunctions(config: Config) : Rule(config) {
 
     override fun visitKtFile(file: KtFile) {
         super.visitKtFile(file)
-        if (amount > THRESHOLD) {
+        if (amount > ALLOWED_FUNCTIONS) {
             report(
                 CodeSmell(
                     issue,
                     Entity.atPackageOrFirstDecl(file),
                     message = "The file ${file.name} has $amount function declarations. " +
-                        "Threshold is specified with $THRESHOLD."
+                        "The maximum number of allowed functions is specified with $ALLOWED_FUNCTIONS."
                 )
             )
         }
@@ -45,6 +45,6 @@ class TooManyFunctions(config: Config) : Rule(config) {
     }
 
     companion object {
-        private const val THRESHOLD = 10
+        private const val ALLOWED_FUNCTIONS = 10
     }
 }

--- a/detekt-sample-extensions/src/main/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/rules/TooManyFunctionsTwo.kt
+++ b/detekt-sample-extensions/src/main/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/rules/TooManyFunctionsTwo.kt
@@ -27,20 +27,20 @@ class TooManyFunctionsTwo(config: Config) : Rule(config) {
         Debt(hours = 1)
     )
 
-    private val threshold: Int by config(defaultValue = 10)
+    private val allowedFunctions: Int by config(defaultValue = 10)
 
     private var amount: Int = 0
 
     override fun visitKtFile(file: KtFile) {
         super.visitKtFile(file)
-        if (amount > threshold) {
+        if (amount > allowedFunctions) {
             report(
                 ThresholdedCodeSmell(
                     issue,
                     entity = Entity.from(file),
-                    metric = Metric(type = "SIZE", value = amount, threshold = threshold),
+                    metric = Metric(type = "SIZE", value = amount, threshold = allowedFunctions),
                     message = "The file ${file.name} has $amount function declarations. " +
-                        "Threshold is specified with $threshold.",
+                        "The maximum number of allowed functions is specified with $allowedFunctions.",
                     references = emptyList()
                 )
             )


### PR DESCRIPTION
Replaced "thresholdX" property of TooManyFunctions rule by "allowedFunctionsX" (#3679)

The rule reported an issue when the number of functions is greater or equal the value defined for the "threshold" property.
It is intended that the value defined in the rule is the maximum allowed number of functions. So the property is renamed to
"allowedFunctionsX" and the check for reporting an issue is changed to only use greater and no longer equal.

The origin issue is https://github.com/detekt/detekt/issues/3679