### PR TITLE
Replaced "threshold" property of CouldBeSequence rule by "allowedOperations".

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -385,7 +385,7 @@ performance:
     active: true
   CouldBeSequence:
     active: false
-    allowedOperations: 3
+    allowedOperations: 2
   ForEachOnRange:
     active: true
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']

--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -385,7 +385,7 @@ performance:
     active: true
   CouldBeSequence:
     active: false
-    threshold: 3
+    allowedOperations: 3
   ForEachOnRange:
     active: true
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']

--- a/detekt-rules-performance/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/CouldBeSequence.kt
+++ b/detekt-rules-performance/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/CouldBeSequence.kt
@@ -42,7 +42,7 @@ class CouldBeSequence(config: Config = Config.empty) : Rule(config) {
     )
 
     @Configuration("The maximum number of allowed chained collection operations.")
-    private val allowedOperations: Int by config(defaultValue = 3)
+    private val allowedOperations: Int by config(defaultValue = 2)
 
     private val visitedCallExpressions = mutableListOf<KtExpression>()
 

--- a/detekt-rules-performance/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/CouldBeSequence.kt
+++ b/detekt-rules-performance/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/CouldBeSequence.kt
@@ -41,8 +41,8 @@ class CouldBeSequence(config: Config = Config.empty) : Rule(config) {
         Debt.FIVE_MINS
     )
 
-    @Configuration("the number of chained collection operations required to trigger rule")
-    private val threshold: Int by config(defaultValue = 3)
+    @Configuration("The maximum number of allowed chained collection operations.")
+    private val allowedOperations: Int by config(defaultValue = 3)
 
     private val visitedCallExpressions = mutableListOf<KtExpression>()
 
@@ -55,7 +55,7 @@ class CouldBeSequence(config: Config = Config.empty) : Rule(config) {
 
         var counter = 1
         var nextCall = expression.nextChainedCall()
-        while (counter < threshold && nextCall != null) {
+        while (counter <= allowedOperations && nextCall != null) {
             visitedCallExpressions += nextCall
             if (!nextCall.isCalling(operationsFqNames)) {
                 break
@@ -65,7 +65,7 @@ class CouldBeSequence(config: Config = Config.empty) : Rule(config) {
             nextCall = nextCall.nextChainedCall()
         }
 
-        if (counter >= threshold) {
+        if (counter > allowedOperations) {
             val message = "${expression.text} could be .asSequence().${expression.text}"
             report(CodeSmell(issue, Entity.from(expression), message))
         }

--- a/detekt-rules-performance/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/CouldBeSequenceSpec.kt
+++ b/detekt-rules-performance/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/CouldBeSequenceSpec.kt
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
 class CouldBeSequenceSpec(val env: KotlinCoreEnvironment) {
-    val subject = CouldBeSequence(TestConfig("threshold" to 3))
+    private val subject = CouldBeSequence(TestConfig("allowedOperations" to 2))
 
     @Test
     fun `long collection chain should be sequence`() {
@@ -24,6 +24,19 @@ class CouldBeSequenceSpec(val env: KotlinCoreEnvironment) {
             }
         """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+    }
+
+    @Test
+    fun `does not report issue for amount of operations that are exactly the allowed number`() {
+        val code = """
+            val myCollection = listOf(1, 2, 3, 4, 5, 6, 7, 8)
+            val processed = myCollection.filter {
+                it % 2 == 0
+            }.map {
+                it*2
+            }
+        """.trimIndent()
+        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 
     @Test


### PR DESCRIPTION
Replaced "threshold" property of CouldBeSequence rule by "allowedOperations" (#3679)

The rule reported an issue when the numbe of operations on a collection is greater or equal the value defined for the "threshold" property.
It is intended that the value defined in the rule is the maximum allowed number of operations. So the property is renamed to
"allowedOperations" and the check for reporting an issue is changed to only use greater and no longer equal.

The origin issue is https://github.com/detekt/detekt/issues/3679