### PR TITLE
Standardize rule code sample spacing

### DIFF
--- a/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/InjectDispatcher.kt
+++ b/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/InjectDispatcher.kt
@@ -27,13 +27,13 @@ import org.jetbrains.kotlin.types.typeUtil.supertypes
  *
  * <noncompliant>
  * fun myFunc() {
- *  coroutineScope(Dispatchers.IO)
+ *     coroutineScope(Dispatchers.IO)
  * }
  * </noncompliant>
  *
  * <compliant>
  * fun myFunc(dispatcher: CoroutineDispatcher = Dispatchers.IO) {
- *  coroutineScope(dispatcher)
+ *     coroutineScope(dispatcher)
  * }
  *
  * class MyRepository(dispatchers: CoroutineDispatcher = Dispatchers.IO)

--- a/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunWithCoroutineScopeReceiver.kt
+++ b/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunWithCoroutineScopeReceiver.kt
@@ -26,7 +26,7 @@ import org.jetbrains.kotlin.types.typeUtil.supertypes
  * <noncompliant>
  * suspend fun CoroutineScope.foo() {
  *     launch {
- *       delay(1.seconds)
+ *         delay(1.seconds)
  *     }
  * }
  * </noncompliant>
@@ -34,14 +34,14 @@ import org.jetbrains.kotlin.types.typeUtil.supertypes
  * <compliant>
  * fun CoroutineScope.foo() {
  *     launch {
- *       delay(1.seconds)
+ *         delay(1.seconds)
  *     }
  * }
  *
  * // Alternative
  * suspend fun foo() = coroutineScope {
  *     launch {
- *       delay(1.seconds)
+ *         delay(1.seconds)
  *     }
  * }
  * </compliant>

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedParameter.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedParameter.kt
@@ -34,13 +34,13 @@ import org.jetbrains.kotlin.psi.psiUtil.isProtected
  *
  * <noncompliant>
  * fun foo(unused: String) {
- *   println()
+ *     println()
  * }
  * </noncompliant>
  *
  * <compliant>
  * fun foo(used: String) {
- *   println(used)
+ *     println(used)
  * }
  * </compliant>
  */

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateProperty.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateProperty.kt
@@ -35,17 +35,17 @@ import org.jetbrains.kotlin.psi.psiUtil.isPrivate
  *
  * <noncompliant>
  * class Foo {
- *   private val unused = "unused"
+ *     private val unused = "unused"
  * }
  * </noncompliant>
  *
  * <compliant>
  * class Foo {
- *   private val used = "used"
+ *     private val used = "used"
  *
- *   fun greet() {
- *     println(used)
- *   }
+ *     fun greet() {
+ *         println(used)
+ *     }
  * }
  * </compliant>
  */


### PR DESCRIPTION
Fix some cases where rule kdoc had insufficient spacing (less than 4 spaces), which appears to remove the spacing entirely from the generated documentation; for example: https://detekt.dev/docs/rules/coroutines#injectdispatcher. Most rules already use 4 spaces for their code samples, this brings in line a few others I noticed, but I'm not certain it's an exhaustive fix.