### PR TITLE
Fix typo in ReturnCount rule documentation

### DIFF
--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCount.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCount.kt
@@ -20,7 +20,7 @@ import org.jetbrains.kotlin.psi.psiUtil.collectDescendantsOfType
 import org.jetbrains.kotlin.psi.psiUtil.getParentOfType
 
 /**
- * Restrict the number of return methods allowed in methods.
+ * Restrict the number of returns allowed in methods.
  *
  * Having many exit points in a function can be confusing and impacts readability of the
  * code.


### PR DESCRIPTION
Fix what appears to be a small typo in the documentation for the ReturnCount rule.
