### PR TITLE
Don't apply base plugin to code coverage module

### DIFF
--- a/code-coverage-report/build.gradle.kts
+++ b/code-coverage-report/build.gradle.kts
@@ -1,5 +1,4 @@
 plugins {
-    id("base")
     id("jacoco-report-aggregation")
 }
 


### PR DESCRIPTION
This is not required since #5846 was merged.