### PR TITLE
Enable Gradle Predictive Test Selection by default

### DIFF
--- a/.github/workflows/codecoverage.yaml
+++ b/.github/workflows/codecoverage.yaml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+env:
+  ORG_GRADLE_PROJECT_enablePTS: false
+
 permissions:
   contents: read
 

--- a/.github/workflows/deploy-snapshot.yaml
+++ b/.github/workflows/deploy-snapshot.yaml
@@ -7,6 +7,7 @@ on:
 
 env:
   GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+  ORG_GRADLE_PROJECT_enablePTS: false
 
 permissions:
   contents: read

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -11,6 +11,7 @@ env:
   GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
   GRADLE_CACHE_USERNAME: ${{ secrets.GRADLE_CACHE_USERNAME }}
   GRADLE_CACHE_PASSWORD: ${{ secrets.GRADLE_CACHE_PASSWORD }}
+  ORG_GRADLE_PROJECT_enablePTS: ${{ github.ref_name != 'main' }}
 
 permissions:
   contents: read
@@ -40,7 +41,7 @@ jobs:
         uses: gradle/gradle-build-action@40b6781dcdec2762ad36556682ac74e31030cfe2 # v2
         with:
           gradle-home-cache-cleanup: true
-          arguments: build -x detekt publishToMavenLocal -PenablePTS=${{ github.event_name == 'pull_request' }}
+          arguments: build -x detekt publishToMavenLocal
 
       - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3
         with:

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,6 +5,5 @@ org.gradle.caching=true
 org.gradle.configuration-cache=true
 org.gradle.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8
 
-# Allows to enable/disable Predictive Test Selection: https://docs.gradle.com/enterprise/predictive-test-selection/
-# disable by default
-enablePTS=false
+# Enable Predictive Test Selection by default: https://docs.gradle.com/enterprise/predictive-test-selection/
+enablePTS=true


### PR DESCRIPTION
Thanks to changes in Gradle Enterprise Gradle Plugin 3.13.1, we should be able to use Predictive Test Selection and the Build Cache together, and get benefit from both.

From https://docs.gradle.com/enterprise/predictive-test-selection/#build_cache:

> Predictive Test Selection is complementary to Gradle Enterprise Build Cache.
>
> When Predictive Test Selection is enabled, test tasks/goals will store their results in the build cache if build caching is enabled, all tests are selected for execution, and the task/goal was successful. The results from running only a subset of all tests or failing tests are never stored in the build cache. Test tasks/goals will aim to reuse the test results from a prior build invocation if the build cache is enabled, regardless of whether Predictive Test Selection is currently enabled or not (requires Gradle 8.2+ and Gradle Enterprise Gradle plugin 3.13.1+ or Gradle Enterprise Maven extension 1.16+).
>
> On a cache miss, rerunning the same test suite for the same code-under-test with Predictive Test Selection enabled, previously selected tests that passed will not be selected again. Instead, Predictive Test Selection will select different tests, and typically fewer, for subsequent executions.

PTS is now enabled by default, except on the main branch or when generating code coverage statistics for Codecov.

Closes #6073

