### PR TITLE
Update dependency org.jetbrains.kotlinx:kotlinx-html-jvm to v0.9.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,7 +19,7 @@ kotlin-mainKts = { module = "org.jetbrains.kotlin:kotlin-main-kts", version.ref 
 kotlin-stdlibJdk8 = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlin" }
 kotlin-reflection = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
 
-kotlinx-html = "org.jetbrains.kotlinx:kotlinx-html-jvm:0.8.1"
+kotlinx-html = "org.jetbrains.kotlinx:kotlinx-html-jvm:0.9.0"
 kotlinx-coroutines = "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.1"
 
 # This represents the the oldest AGP version that is supported by detekt.


### PR DESCRIPTION
Part of https://github.com/detekt/detekt/pull/6238 but split into individual PRs.

Closes #6248