### PR TITLE
Implement rules introduced in ktlint 0.50.0

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -79,6 +79,8 @@ formatting:
     active: false
   ParameterListSpacing:
     active: true
+  StatementWrapping:
+    active: true
   TypeParameterListSpacing:
     active: true
 

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -69,6 +69,8 @@ formatting:
   active: true
   android: false
   autoCorrect: true
+  BinaryExpressionWrapping:
+    active: true
   ContextReceiverMapping:
     active: true
   Filename:

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingProvider.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingProvider.kt
@@ -44,6 +44,7 @@ import io.gitlab.arturbosch.detekt.formatting.wrappers.NoBlankLinesInChainedMeth
 import io.gitlab.arturbosch.detekt.formatting.wrappers.NoConsecutiveBlankLines
 import io.gitlab.arturbosch.detekt.formatting.wrappers.NoConsecutiveComments
 import io.gitlab.arturbosch.detekt.formatting.wrappers.NoEmptyClassBody
+import io.gitlab.arturbosch.detekt.formatting.wrappers.NoEmptyFile
 import io.gitlab.arturbosch.detekt.formatting.wrappers.NoEmptyFirstLineInClassBody
 import io.gitlab.arturbosch.detekt.formatting.wrappers.NoEmptyFirstLineInMethodBlock
 import io.gitlab.arturbosch.detekt.formatting.wrappers.NoLineBreakAfterElse
@@ -182,6 +183,7 @@ class FormattingProvider : RuleSetProvider {
             MultilineExpressionWrapping(config),
             NoBlankLineInList(config),
             NoConsecutiveComments(config),
+            NoEmptyFile(config),
             NoEmptyFirstLineInClassBody(config),
             ParameterListSpacing(config),
             StringTemplateIndent(config),

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingProvider.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingProvider.kt
@@ -9,6 +9,7 @@ import io.gitlab.arturbosch.detekt.api.internal.ruleSetConfig
 import io.gitlab.arturbosch.detekt.formatting.wrappers.AnnotationOnSeparateLine
 import io.gitlab.arturbosch.detekt.formatting.wrappers.AnnotationSpacing
 import io.gitlab.arturbosch.detekt.formatting.wrappers.ArgumentListWrapping
+import io.gitlab.arturbosch.detekt.formatting.wrappers.BinaryExpressionWrapping
 import io.gitlab.arturbosch.detekt.formatting.wrappers.BlockCommentInitialStarAlignment
 import io.gitlab.arturbosch.detekt.formatting.wrappers.ChainWrapping
 import io.gitlab.arturbosch.detekt.formatting.wrappers.ClassName
@@ -169,6 +170,7 @@ class FormattingProvider : RuleSetProvider {
             Wrapping(config),
 
             // Wrappers for ktlint-ruleset-experimental rules. Disabled by default.
+            BinaryExpressionWrapping(config),
             ContextReceiverMapping(config),
             DiscouragedCommentLocation(config),
             EnumWrapping(config),

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingProvider.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingProvider.kt
@@ -10,6 +10,7 @@ import io.gitlab.arturbosch.detekt.formatting.wrappers.AnnotationOnSeparateLine
 import io.gitlab.arturbosch.detekt.formatting.wrappers.AnnotationSpacing
 import io.gitlab.arturbosch.detekt.formatting.wrappers.ArgumentListWrapping
 import io.gitlab.arturbosch.detekt.formatting.wrappers.BinaryExpressionWrapping
+import io.gitlab.arturbosch.detekt.formatting.wrappers.BlankLineBeforeDeclaration
 import io.gitlab.arturbosch.detekt.formatting.wrappers.BlockCommentInitialStarAlignment
 import io.gitlab.arturbosch.detekt.formatting.wrappers.ChainWrapping
 import io.gitlab.arturbosch.detekt.formatting.wrappers.ClassName
@@ -171,6 +172,7 @@ class FormattingProvider : RuleSetProvider {
 
             // Wrappers for ktlint-ruleset-experimental rules. Disabled by default.
             BinaryExpressionWrapping(config),
+            BlankLineBeforeDeclaration(config),
             ContextReceiverMapping(config),
             DiscouragedCommentLocation(config),
             EnumWrapping(config),

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingProvider.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingProvider.kt
@@ -77,6 +77,7 @@ import io.gitlab.arturbosch.detekt.formatting.wrappers.SpacingAroundUnaryOperato
 import io.gitlab.arturbosch.detekt.formatting.wrappers.SpacingBetweenDeclarationsWithAnnotations
 import io.gitlab.arturbosch.detekt.formatting.wrappers.SpacingBetweenDeclarationsWithComments
 import io.gitlab.arturbosch.detekt.formatting.wrappers.SpacingBetweenFunctionNameAndOpeningParenthesis
+import io.gitlab.arturbosch.detekt.formatting.wrappers.StatementWrapping
 import io.gitlab.arturbosch.detekt.formatting.wrappers.StringTemplate
 import io.gitlab.arturbosch.detekt.formatting.wrappers.StringTemplateIndent
 import io.gitlab.arturbosch.detekt.formatting.wrappers.TrailingCommaOnCallSite
@@ -186,6 +187,7 @@ class FormattingProvider : RuleSetProvider {
             NoEmptyFile(config),
             NoEmptyFirstLineInClassBody(config),
             ParameterListSpacing(config),
+            StatementWrapping(config),
             StringTemplateIndent(config),
             TryCatchFinallySpacing(config),
             TypeArgumentListSpacing(config),

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/BinaryExpressionWrapping.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/BinaryExpressionWrapping.kt
@@ -1,0 +1,36 @@
+package io.gitlab.arturbosch.detekt.formatting.wrappers
+
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfigProperty
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_SIZE_PROPERTY
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.MAX_LINE_LENGTH_PROPERTY
+import com.pinterest.ktlint.ruleset.standard.rules.BinaryExpressionWrappingRule
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.config
+import io.gitlab.arturbosch.detekt.api.configWithAndroidVariants
+import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
+import io.gitlab.arturbosch.detekt.api.internal.Configuration
+import io.gitlab.arturbosch.detekt.formatting.FormattingRule
+
+/**
+ * See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#binary-expression-wrapping) for
+ * documentation.
+ */
+@AutoCorrectable(since = "2.0.0")
+class BinaryExpressionWrapping(config: Config) : FormattingRule(config) {
+
+    override val wrapping = BinaryExpressionWrappingRule()
+    override val issue =
+        issueFor("Wrap binary expression at the operator reference if the binary expression does not fit on the line")
+
+    @Configuration("maximum line length")
+    private val maxLineLength: Int by configWithAndroidVariants(120, 100)
+
+    @Configuration("indentation size")
+    private val indentSize by config(4)
+
+    override fun overrideEditorConfigProperties(): Map<EditorConfigProperty<*>, String> =
+        mapOf(
+            INDENT_SIZE_PROPERTY to indentSize.toString(),
+            MAX_LINE_LENGTH_PROPERTY to maxLineLength.toString()
+        )
+}

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/BlankLineBeforeDeclaration.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/BlankLineBeforeDeclaration.kt
@@ -1,0 +1,21 @@
+package io.gitlab.arturbosch.detekt.formatting.wrappers
+
+import com.pinterest.ktlint.ruleset.standard.rules.BlankLineBeforeDeclarationRule
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
+import io.gitlab.arturbosch.detekt.formatting.FormattingRule
+
+/**
+ * See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#blank-line-before-declarations) for
+ * documentation.
+ */
+@AutoCorrectable(since = "2.0.0")
+class BlankLineBeforeDeclaration(config: Config) : FormattingRule(config) {
+
+    override val wrapping = BlankLineBeforeDeclarationRule()
+    override val issue =
+        issueFor(
+            "A blank line is required before any class or function declaration, and before any list of top level or " +
+                "class properties."
+        )
+}

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/NoEmptyFile.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/NoEmptyFile.kt
@@ -1,0 +1,14 @@
+package io.gitlab.arturbosch.detekt.formatting.wrappers
+
+import com.pinterest.ktlint.ruleset.standard.rules.NoEmptyFileRule
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.formatting.FormattingRule
+
+/**
+ * See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#no-empty-file) for documentation.
+ */
+class NoEmptyFile(config: Config) : FormattingRule(config) {
+
+    override val wrapping = NoEmptyFileRule()
+    override val issue = issueFor("Kotlin files must contain at least one declaration")
+}

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/StatementWrapping.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/StatementWrapping.kt
@@ -1,0 +1,30 @@
+package io.gitlab.arturbosch.detekt.formatting.wrappers
+
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfigProperty
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_SIZE_PROPERTY
+import com.pinterest.ktlint.ruleset.standard.rules.StatementWrapping
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.config
+import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
+import io.gitlab.arturbosch.detekt.api.internal.Configuration
+import io.gitlab.arturbosch.detekt.formatting.FormattingRule
+
+/**
+ * See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#statement-wrapping) for
+ * documentation.
+ */
+@AutoCorrectable(since = "2.0.0")
+class StatementWrapping(config: Config) : FormattingRule(config) {
+
+    override val wrapping = StatementWrapping()
+    override val issue =
+        issueFor("Block body statements must be placed on a different line than the braces of the body block.")
+
+    @Configuration("indentation size")
+    private val indentSize by config(4)
+
+    override fun overrideEditorConfigProperties(): Map<EditorConfigProperty<*>, String> =
+        mapOf(
+            INDENT_SIZE_PROPERTY to indentSize.toString(),
+        )
+}

--- a/detekt-formatting/src/main/resources/config/config.yml
+++ b/detekt-formatting/src/main/resources/config/config.yml
@@ -241,6 +241,10 @@ formatting:
   SpacingBetweenFunctionNameAndOpeningParenthesis:
     active: true
     autoCorrect: true
+  StatementWrapping:
+    active: false
+    autoCorrect: true
+    indentSize: 4
   StringTemplate:
     active: true
     autoCorrect: true

--- a/detekt-formatting/src/main/resources/config/config.yml
+++ b/detekt-formatting/src/main/resources/config/config.yml
@@ -19,6 +19,9 @@ formatting:
     autoCorrect: true
     maxLineLength: 120
     indentSize: 4
+  BlankLineBeforeDeclaration:
+    active: false
+    autoCorrect: true
   BlockCommentInitialStarAlignment:
     active: true
     autoCorrect: true

--- a/detekt-formatting/src/main/resources/config/config.yml
+++ b/detekt-formatting/src/main/resources/config/config.yml
@@ -136,6 +136,8 @@ formatting:
   NoEmptyClassBody:
     active: true
     autoCorrect: true
+  NoEmptyFile:
+    active: false
   NoEmptyFirstLineInClassBody:
     active: false
     autoCorrect: true

--- a/detekt-formatting/src/main/resources/config/config.yml
+++ b/detekt-formatting/src/main/resources/config/config.yml
@@ -14,6 +14,11 @@ formatting:
     autoCorrect: true
     indentSize: 4
     maxLineLength: 120
+  BinaryExpressionWrapping:
+    active: false
+    autoCorrect: true
+    maxLineLength: 120
+    indentSize: 4
   BlockCommentInitialStarAlignment:
     active: true
     autoCorrect: true

--- a/detekt-report-md/src/main/kotlin/io/github/detekt/report/md/MdOutputReport.kt
+++ b/detekt-report-md/src/main/kotlin/io/github/detekt/report/md/MdOutputReport.kt
@@ -134,13 +134,17 @@ private fun MarkdownContent.renderFinding(finding: Finding): String {
 
     val message = if (finding.message.isNotEmpty()) {
         codeBlock("") { finding.message }
-    } else { "" }
+    } else {
+        ""
+    }
 
     val psiFile = finding.entity.ktElement?.containingFile
     val snippet = if (psiFile != null) {
         val lineSequence = psiFile.text.splitToSequence('\n')
         snippetCode(lineSequence, finding.startPosition)
-    } else { "" }
+    } else {
+        ""
+    }
 
     return "$location\n$message\n$snippet"
 }

--- a/detekt-tooling/src/test/kotlin/io/github/detekt/tooling/api/FunctionMatcherSpec.kt
+++ b/detekt-tooling/src/test/kotlin/io/github/detekt/tooling/api/FunctionMatcherSpec.kt
@@ -51,8 +51,8 @@ class FunctionMatcherSpec(private val env: KotlinCoreEnvironment) {
                 ),
             ),
             TestCase(
-                testDescription = "should return method name and params list for full signature method with multiple params " +
-                    "where method name has spaces and special characters",
+                testDescription = "should return method name and params list for full signature method with multiple " +
+                    "params where method name has spaces and special characters",
                 functionSignature = "io.gitlab.arturbosch.detekt.SomeClass.`some , method`(kotlin.String)",
                 expectedFunctionMatcher = FunctionMatcher.WithParameters(
                     "io.gitlab.arturbosch.detekt.SomeClass.some , method",


### PR DESCRIPTION
Four new rules:
- BinaryExpressionWrapping
- BlankLineBeforeDeclaration
- NoEmptyFile
- StatementWrapping

I enabled StatementWrapping and BinaryExpressionWrapping on the detekt code base. BlankLineBeforeDeclaration flagged too many issues and I've raised https://github.com/pinterest/ktlint/issues/2109 to see if a change can be made. detekt already has EmptyKtFile so there's no need to enable NoEmptyFile.