### PR TITLE
Stop applying treeCopyHandler extension in analysis environment

### DIFF
--- a/detekt-compiler-plugin/build.gradle.kts
+++ b/detekt-compiler-plugin/build.gradle.kts
@@ -48,7 +48,6 @@ tasks.shadowJar.configure {
         include(dependency("io.gitlab.arturbosch.detekt:.*"))
         include(dependency("io.github.detekt:.*"))
         include(dependency("org.snakeyaml:snakeyaml-engine"))
-        include(dependency("io.github.davidburstrom.contester:contester-breakpoint"))
     }
 }
 

--- a/detekt-parser/build.gradle.kts
+++ b/detekt-parser/build.gradle.kts
@@ -7,8 +7,6 @@ plugins {
 dependencies {
     api(libs.kotlin.compilerEmbeddable)
     implementation(projects.detektPsiUtils)
-    implementation(libs.contester.breakpoint)
-    testImplementation(libs.contester.driver)
     testImplementation(projects.detektTestUtils)
     testImplementation(libs.assertj)
 }

--- a/detekt-parser/src/main/kotlin/io/github/detekt/parser/DetektPomModel.kt
+++ b/detekt-parser/src/main/kotlin/io/github/detekt/parser/DetektPomModel.kt
@@ -1,44 +1,18 @@
 package io.github.detekt.parser
 
-import io.github.davidburstrom.contester.ConTesterBreakpoint
-import org.jetbrains.kotlin.com.intellij.openapi.extensions.ExtensionPoint
-import org.jetbrains.kotlin.com.intellij.openapi.extensions.Extensions.getRootArea
-import org.jetbrains.kotlin.com.intellij.openapi.project.Project
 import org.jetbrains.kotlin.com.intellij.openapi.util.UserDataHolderBase
 import org.jetbrains.kotlin.com.intellij.pom.PomModel
 import org.jetbrains.kotlin.com.intellij.pom.PomModelAspect
 import org.jetbrains.kotlin.com.intellij.pom.PomTransaction
 import org.jetbrains.kotlin.com.intellij.pom.impl.PomTransactionBase
 import org.jetbrains.kotlin.com.intellij.pom.tree.TreeAspect
-import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.TreeCopyHandler
 import sun.reflect.ReflectionFactory
 
 /**
- * Adapted from https://github.com/pinterest/ktlint/blob/master/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/internal/KotlinPsiFileFactory.kt
+ * Adapted from https://github.com/pinterest/ktlint/blob/0.50.0/ktlint-rule-engine/src/main/kotlin/com/pinterest/ktlint/rule/engine/internal/KotlinPsiFileFactory.kt
  * Licenced under the MIT licence - https://github.com/pinterest/ktlint/blob/master/LICENSE
  */
-class DetektPomModel(project: Project) : UserDataHolderBase(), PomModel {
-
-    init {
-        val extension = "org.jetbrains.kotlin.com.intellij.treeCopyHandler"
-        val extensionClass = TreeCopyHandler::class.java.name
-        @Suppress("DEPRECATION")
-        for (extensionArea in listOf(project.extensionArea, getRootArea())) {
-            // Addresses https://github.com/detekt/detekt/issues/4609
-            synchronized(extensionArea) {
-                if (!extensionArea.hasExtensionPoint(extension)) {
-                    ConTesterBreakpoint.defineBreakpoint("DetektPomModel.registerExtensionPoint") {
-                        extensionArea == getRootArea()
-                    }
-                    extensionArea.registerExtensionPoint(
-                        extension,
-                        extensionClass,
-                        ExtensionPoint.Kind.INTERFACE
-                    )
-                }
-            }
-        }
-    }
+object DetektPomModel : UserDataHolderBase(), PomModel {
 
     override fun runTransaction(transaction: PomTransaction) {
         val transactionCandidate = transaction as? PomTransactionBase

--- a/detekt-parser/src/main/kotlin/io/github/detekt/parser/KotlinEnvironmentUtils.kt
+++ b/detekt-parser/src/main/kotlin/io/github/detekt/parser/KotlinEnvironmentUtils.kt
@@ -71,7 +71,7 @@ fun createKotlinCoreEnvironment(
         "MockProject type expected, actual - ${projectCandidate.javaClass.simpleName}"
     }
 
-    project.registerService(PomModel::class.java, DetektPomModel(project))
+    project.registerService(PomModel::class.java, DetektPomModel)
 
     return environment
 }

--- a/detekt-parser/src/test/kotlin/io/github/detekt/parser/KtCompilerSpec.kt
+++ b/detekt-parser/src/test/kotlin/io/github/detekt/parser/KtCompilerSpec.kt
@@ -1,6 +1,5 @@
 package io.github.detekt.parser
 
-import io.github.davidburstrom.contester.ConTesterDriver
 import io.github.detekt.psi.BASE_PATH
 import io.github.detekt.psi.LINE_SEPARATOR
 import io.github.detekt.psi.RELATIVE_PATH
@@ -9,25 +8,10 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 import org.jetbrains.kotlin.com.intellij.psi.PsiErrorElement
 import org.jetbrains.kotlin.psi.KtTreeVisitorVoid
-import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 class KtCompilerSpec {
-    @AfterEach
-    internal fun tearDown() {
-        ConTesterDriver.cleanUp()
-    }
-
-    @Test
-    fun `parallel construction of KtCompilers should be thread safe`() {
-        val thread1 = ConTesterDriver.thread { KtCompiler() }
-        val thread2 = ConTesterDriver.thread { KtCompiler() }
-        ConTesterDriver.runToBreakpoint(thread1, "DetektPomModel.registerExtensionPoint")
-        ConTesterDriver.runUntilBlockedOrTerminated(thread2)
-        ConTesterDriver.join(thread1)
-    }
-
     @Nested
     inner class `Kotlin Compiler` {
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,6 @@ jacoco = "0.8.10"
 kotlin = "1.8.22"
 ktlint = "0.50.0"
 junit = "5.9.3"
-contester = "0.2.0"
 
 [libraries]
 githubRelease-gradle = "com.github.breadmoirai:github-release:2.4.1"
@@ -42,8 +41,6 @@ reflections = "org.reflections:reflections:0.10.2"
 mockk = "io.mockk:mockk:1.13.5"
 snakeyaml = "org.snakeyaml:snakeyaml-engine:2.6"
 jcommander = "com.beust:jcommander:1.82"
-contester-breakpoint = { module = "io.github.davidburstrom.contester:contester-breakpoint", version.ref = "contester" }
-contester-driver = { module = "io.github.davidburstrom.contester:contester-driver", version.ref = "contester" }
 kotlinCompileTesting = { module = "com.github.tschuchortdev:kotlin-compile-testing", version = "1.5.0" }
 
 [plugins]


### PR DESCRIPTION
This was previously used by ktlint to support autocorrect for some rules, but is being phased out due to https://github.com/pinterest/ktlint/issues/1981. detekt should do the same. This has no impact on any core rules, or the formatting module (since ktlint no longer depends on this extension as of ktlint v0.50.0).

This will impact third party rule sets, only if:
- they support autocorrect, and
- autocorrect support relies on the treeCopyHandler extension

ktlint rules were updated to remove the dependency on treeCopyHandler, so affected third party detekt rule sets can do the same.

This is all being caused by upstream changes in Kotlin. There's some very useful analysis in https://github.com/pinterest/ktlint/pull/2044 that can be reviewed by anyone affected downstream by this change.

Fixes #5636