### PR TITLE
Switch to SLF4J 2.x

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,8 +31,8 @@ android-gradle-minSupported = "com.android.tools.build:gradle:7.0.0"
 android-gradle-maxSupported = "com.android.tools.build:gradle:8.0.2"
 
 ktlintRulesetStandard = { module = "com.pinterest.ktlint:ktlint-ruleset-standard", version.ref = "ktlint"  }
-slf4j-nop = { module = "org.slf4j:slf4j-nop", version = "1.7.36" }
-slf4j-simple = { module = "org.slf4j:slf4j-simple", version = "1.7.36" }
+slf4j-nop = { module = "org.slf4j:slf4j-nop", version = "2.0.7" }
+slf4j-simple = { module = "org.slf4j:slf4j-simple", version = "2.0.7" }
 
 junit-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit" }
 


### PR DESCRIPTION
ktlint's dependencies have been updated, so detekt can now update to latest to align.

A tiny bit more information about why we've stayed on 1.x until now is here: https://github.com/detekt/detekt/pull/5238#issuecomment-1221436978