### PR TITLE
Use pluginManagement to include builds

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,8 +2,10 @@ import com.gradle.enterprise.gradleplugin.internal.extension.BuildScanExtensionW
 
 rootProject.name = "detekt"
 
-includeBuild("build-logic")
-includeBuild("detekt-gradle-plugin")
+pluginManagement {
+    includeBuild("build-logic")
+    includeBuild("detekt-gradle-plugin")
+}
 
 include("code-coverage-report")
 include("detekt-api")


### PR DESCRIPTION
This seems to be required to include detekt project in a composite build without errors.

`includeBuild` in pluginManagement was de-incubated in Gradle 8.