### PR TITLE
Use more appropriate methods to compile KtFiles

### DIFF
--- a/detekt-compiler-plugin/build.gradle.kts
+++ b/detekt-compiler-plugin/build.gradle.kts
@@ -105,7 +105,10 @@ val testPluginKotlinc by tasks.registering(Task::class) {
         val stdErrOutput = kotlincExecution.standardError.asText.get()
         if (!stdErrOutput.contains("warning: doubleMutabilityForCollection:")) {
             throw GradleException(
-                "kotlinc run with compiler plugin did not find DoubleMutabilityForCollection issue as expected in output:\n$stdErrOutput"
+                """
+                    kotlinc run with compiler plugin did not find DoubleMutabilityForCollection issue in output:
+                    $stdErrOutput
+                """.trimIndent()
             )
         }
     }

--- a/detekt-compiler-plugin/build.gradle.kts
+++ b/detekt-compiler-plugin/build.gradle.kts
@@ -102,9 +102,10 @@ val testPluginKotlinc by tasks.registering(Task::class) {
     }
 
     doLast {
-        if (!kotlincExecution.standardError.asText.get().contains("warning: magicNumber:")) {
+        val stdErrOutput = kotlincExecution.standardError.asText.get()
+        if (!stdErrOutput.contains("warning: doubleMutabilityForCollection:")) {
             throw GradleException(
-                "kotlinc run with compiler plugin did not find MagicNumber issue as expected"
+                "kotlinc run with compiler plugin did not find DoubleMutabilityForCollection issue as expected in output:\n$stdErrOutput"
             )
         }
     }

--- a/detekt-compiler-plugin/src/test/resources/hello.kt
+++ b/detekt-compiler-plugin/src/test/resources/hello.kt
@@ -1,6 +1,6 @@
 class KClass {
     fun foo() {
-        val x = 3
-        println(x)
+        var myList = mutableListOf(1,2,3)
+        println(myList)
     }
 }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/KtTreeCompiler.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/KtTreeCompiler.kt
@@ -15,7 +15,7 @@ import kotlin.streams.asSequence
 class KtTreeCompiler(
     private val settings: ProcessingSettings,
     projectSpec: ProjectSpec,
-    private val compiler: KtCompiler = KtCompiler(settings.environment)
+    internal val compiler: KtCompiler = KtCompiler(settings.environment)
 ) {
 
     private val basePath: Path? = projectSpec.basePath

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/tooling/ParsingStrategy.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/tooling/ParsingStrategy.kt
@@ -21,6 +21,5 @@ fun pathToKtFile(path: Path): ParsingStrategy = { settings ->
 }
 
 val inputPathsToKtFiles: ParsingStrategy = { settings ->
-    val compiler = KtTreeCompiler(settings, settings.spec.projectSpec)
-    settings.spec.projectSpec.inputPaths.flatMap(compiler::compile)
+    KtTreeCompiler(settings, settings.spec.projectSpec).compiler.environment.getSourceFiles()
 }

--- a/detekt-parser/src/main/kotlin/io/github/detekt/parser/KtCompiler.kt
+++ b/detekt-parser/src/main/kotlin/io/github/detekt/parser/KtCompiler.kt
@@ -13,7 +13,7 @@ import kotlin.io.path.isRegularFile
 import kotlin.io.path.readText
 
 open class KtCompiler(
-    protected val environment: KotlinCoreEnvironment = createKotlinCoreEnvironment(printStream = System.err)
+    val environment: KotlinCoreEnvironment = createKotlinCoreEnvironment(printStream = System.err)
 ) {
 
     protected val psiFileFactory = KtPsiFactory(environment.project, markGenerated = false)

--- a/detekt-psi-utils/src/main/kotlin/io/github/detekt/psi/KtFiles.kt
+++ b/detekt-psi-utils/src/main/kotlin/io/github/detekt/psi/KtFiles.kt
@@ -36,7 +36,7 @@ fun PsiFile.fileNameWithoutSuffix(): String {
     return fileName
 }
 
-fun PsiFile.absolutePath(): Path = Path(name)
+fun PsiFile.absolutePath(): Path = Path(virtualFile.path)
 
 fun PsiFile.relativePath(): Path? = getUserData(RELATIVE_PATH)?.let { Path(it) }
 


### PR DESCRIPTION
Update detekt core to ensure KtFiles are created using standard methods in the compiler. This means paths and filenames are correctly stored in each KtFile so this fixes #5747 and fixes #6155.