### PR TITLE
Don't relocate contester package

### DIFF
--- a/detekt-compiler-plugin/build.gradle.kts
+++ b/detekt-compiler-plugin/build.gradle.kts
@@ -39,7 +39,6 @@ javaComponent.withVariantsFromConfiguration(configurations["shadowRuntimeElement
 tasks.shadowJar.configure {
     relocate("org.jetbrains.kotlin.com.intellij", "com.intellij")
     relocate("org.snakeyaml.engine", "dev.detekt.shaded.snakeyaml")
-    relocate("io.github.davidburstrom.contester", "dev.detekt.shaded.contester")
     mergeServiceFiles()
     dependencies {
         include(dependency("io.gitlab.arturbosch.detekt:.*"))


### PR DESCRIPTION
This dependency has been removed so relocation is no longer required.

This should have been done in #6255.