### PR TITLE
Reflect Java 20 support in CLI help output

### DIFF
--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt
@@ -172,7 +172,7 @@ class CliArgs {
     @Parameter(
         names = ["--jvm-target"],
         description = "EXPERIMENTAL: Target version of the generated JVM bytecode that was generated during " +
-            "compilation and is now being used for type resolution (1.8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18 or 19)"
+            "compilation and is now being used for type resolution (1.8, 9, 10, ..., 20)"
     )
     var jvmTarget: String = JvmTarget.DEFAULT.description
 


### PR DESCRIPTION
Java 20 targets were supported once #6258 was merged. This PR updates the CLI help output to match the supported target versions.