### PR TITLE
Add missing jdkHome and languageVersion properties to DetektCreateBaselineTask

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
@@ -108,6 +108,14 @@ abstract class DetektCreateBaselineTask @Inject constructor(
 
     @get:Input
     @get:Optional
+    internal abstract val languageVersionProp: Property<String>
+    var languageVersion: String
+        @Internal
+        get() = languageVersionProp.get()
+        set(value) = languageVersionProp.set(value)
+
+    @get:Input
+    @get:Optional
     internal abstract val jvmTargetProp: Property<String>
     var jvmTarget: String
         @Internal
@@ -122,7 +130,9 @@ abstract class DetektCreateBaselineTask @Inject constructor(
         get() = listOf(
             CreateBaselineArgument,
             ClasspathArgument(classpath),
+            LanguageVersionArgument(languageVersionProp.orNull),
             JvmTargetArgument(jvmTargetProp.orNull),
+            JdkHomeArgument(jdkHome),
             BaselineArgument(baseline.get()),
             InputArgument(source),
             ConfigArgument(config),

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
@@ -14,7 +14,9 @@ import io.gitlab.arturbosch.detekt.invoke.DetektInvoker
 import io.gitlab.arturbosch.detekt.invoke.DetektWorkAction
 import io.gitlab.arturbosch.detekt.invoke.DisableDefaultRuleSetArgument
 import io.gitlab.arturbosch.detekt.invoke.InputArgument
+import io.gitlab.arturbosch.detekt.invoke.JdkHomeArgument
 import io.gitlab.arturbosch.detekt.invoke.JvmTargetArgument
+import io.gitlab.arturbosch.detekt.invoke.LanguageVersionArgument
 import io.gitlab.arturbosch.detekt.invoke.ParallelArgument
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
@@ -110,19 +110,15 @@ abstract class DetektCreateBaselineTask @Inject constructor(
 
     @get:Input
     @get:Optional
-    internal abstract val languageVersionProp: Property<String>
-    var languageVersion: String
-        @Internal
-        get() = languageVersionProp.get()
-        set(value) = languageVersionProp.set(value)
-
-    @get:Input
-    @get:Optional
     internal abstract val jvmTargetProp: Property<String>
     var jvmTarget: String
         @Internal
         get() = jvmTargetProp.get()
         set(value) = jvmTargetProp.set(value)
+
+    @get:Input
+    @get:Optional
+    abstract val languageVersion: Property<String>
 
     @get:Internal
     abstract val jdkHome: DirectoryProperty
@@ -132,7 +128,7 @@ abstract class DetektCreateBaselineTask @Inject constructor(
         get() = listOf(
             CreateBaselineArgument,
             ClasspathArgument(classpath),
-            LanguageVersionArgument(languageVersionProp.orNull),
+            LanguageVersionArgument(languageVersion.orNull),
             JvmTargetArgument(jvmTargetProp.orNull),
             JdkHomeArgument(jdkHome),
             BaselineArgument(baseline.get()),


### PR DESCRIPTION
This is a minimal version of https://github.com/detekt/detekt/pull/6214 to fix #6167 only in a point release (1.23.1) given that 2.x will come with major changes in these tasks.