### PR TITLE
Rename `EmptyKtFile` to `EmptyKotlinFile`

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -221,7 +221,7 @@ empty-blocks:
     active: true
   EmptyInitBlock:
     active: true
-  EmptyKtFile:
+  EmptyKotlinFile:
     active: true
   EmptySecondaryConstructor:
     active: true

--- a/detekt-rules-empty/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyCodeProvider.kt
+++ b/detekt-rules-empty/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyCodeProvider.kt
@@ -27,7 +27,7 @@ class EmptyCodeProvider : DefaultRuleSetProvider {
             EmptyFunctionBlock(config),
             EmptyIfBlock(config),
             EmptyInitBlock(config),
-            EmptyKtFile(config),
+            EmptyKotlinFile(config),
             EmptySecondaryConstructor(config),
             EmptyTryBlock(config),
             EmptyWhenBlock(config),

--- a/detekt-rules-empty/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyKotlinFile.kt
+++ b/detekt-rules-empty/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyKotlinFile.kt
@@ -7,10 +7,10 @@ import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
 import org.jetbrains.kotlin.psi.KtFile
 
 /**
- * Reports empty Kotlin (.kt) files. Empty blocks of code serve no purpose and should be removed.
+ * Reports empty Kotlin (.kt, .kts) files. Empty blocks of code serve no purpose and should be removed.
  */
 @ActiveByDefault(since = "1.0.0")
-class EmptyKtFile(config: Config) : EmptyRule(config) {
+class EmptyKotlinFile(config: Config) : EmptyRule(config) {
 
     override fun visitKtFile(file: KtFile) {
         if (file.text.isNullOrBlank()) {

--- a/detekt-rules-empty/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyCodeSpec.kt
+++ b/detekt-rules-empty/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyCodeSpec.kt
@@ -129,8 +129,8 @@ class EmptyCodeSpec {
     }
 
     @Test
-    fun `reports an empty kt file`() {
-        val rule = EmptyKtFile(Config.empty)
+    fun `reports an empty kotlin file`() {
+        val rule = EmptyKotlinFile(Config.empty)
         assertThat(rule.lint("")).hasSize(1)
     }
 


### PR DESCRIPTION
This PR closes https://github.com/detekt/detekt/issues/6254 and:
1. Renames `EmptyKtFile` to `EmptyKotlinFile`
2. Updates `default-detekt-config.yml` to have this new name.