### PR TITLE
Ensure paths are not used in tests where plain filenames are required

### DIFF
--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/EntitySpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/EntitySpec.kt
@@ -1,6 +1,6 @@
 package io.gitlab.arturbosch.detekt.api
 
-import io.github.detekt.test.utils.compileContentForTest
+import io.github.detekt.test.utils.compileForTest
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtNamedFunction
@@ -12,20 +12,8 @@ import kotlin.io.path.Path
 
 class EntitySpec {
 
-    private val path = Path("/full/path/to/Test.kt")
-    private val code = compileContentForTest(
-        """
-            package test
-            
-            class C : Any() {
-            
-                private fun memberFun(): Int = 5
-            }
-            
-            fun topLevelFun(number: Int) = Unit
-        """.trimIndent(),
-        path.toString()
-    )
+    private val path = Path("src/test/resources/EntitySpecFixture.kt").toAbsolutePath()
+    private val code = compileForTest(path)
 
     @Nested
     inner class `Named functions` {
@@ -37,7 +25,7 @@ class EntitySpec {
             val memberFunction = functions.first { it.name == "memberFun" }
 
             assertThat(Entity.atName(memberFunction).signature)
-                .isEqualTo("Test.kt\$C\$private fun memberFun(): Int")
+                .isEqualTo("EntitySpecFixture.kt\$C\$private fun memberFun(): Int")
         }
 
         @Test
@@ -45,7 +33,7 @@ class EntitySpec {
             val topLevelFunction = functions.first { it.name == "topLevelFun" }
 
             assertThat(Entity.atName(topLevelFunction).signature)
-                .isEqualTo("Test.kt\$fun topLevelFun(number: Int)")
+                .isEqualTo("EntitySpecFixture.kt\$fun topLevelFun(number: Int)")
         }
 
         @Test
@@ -63,7 +51,7 @@ class EntitySpec {
 
         @Test
         fun `includes full class signature`() {
-            assertThat(Entity.atName(clazz).signature).isEqualTo("Test.kt\$C : Any")
+            assertThat(Entity.atName(clazz).signature).isEqualTo("EntitySpecFixture.kt\$C : Any")
         }
 
         @Test
@@ -77,13 +65,15 @@ class EntitySpec {
 
         @Test
         fun `includes package and file name in entity signature`() {
-            assertThat(Entity.from(code).signature).isEqualTo("Test.kt\$test.Test.kt")
-            assertThat(Entity.atPackageOrFirstDecl(code).signature).isEqualTo("Test.kt\$test.Test.kt")
+            val expectedResult = "EntitySpecFixture.kt\$test.EntitySpecFixture.kt"
+
+            assertThat(Entity.from(code).signature).isEqualTo(expectedResult)
+            assertThat(Entity.atPackageOrFirstDecl(code).signature).isEqualTo(expectedResult)
         }
 
         @Test
         fun `includes file name in entity compact`() {
-            val expectedResult = "[Test.kt] at $path:1:1"
+            val expectedResult = "[EntitySpecFixture.kt] at $path:1:1"
 
             assertThat(Entity.from(code).compact()).isEqualTo(expectedResult)
             assertThat(Entity.atPackageOrFirstDecl(code).compact()).isEqualTo(expectedResult)

--- a/detekt-api/src/test/resources/EntitySpecFixture.kt
+++ b/detekt-api/src/test/resources/EntitySpecFixture.kt
@@ -1,0 +1,8 @@
+package test
+
+class C : Any() {
+
+    private fun memberFun(): Int = 5
+}
+
+fun topLevelFun(number: Int) = Unit

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingRuleSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingRuleSpec.kt
@@ -1,6 +1,8 @@
 package io.gitlab.arturbosch.detekt.formatting
 
+import io.github.detekt.test.utils.compileForTest
 import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.formatting.wrappers.ChainWrapping
 import io.gitlab.arturbosch.detekt.formatting.wrappers.NoLineBreakBeforeAssignment
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLint
@@ -80,16 +82,14 @@ class FormattingRuleSpec {
 
     @Test
     fun `#3063_ formatting issues have an absolute path`() {
-        val expectedPath = Path("/root/kotlin/test.kt").toString()
+        val expectedPath = Path("src/test/resources/configTests/chain-wrapping-before.kt").toAbsolutePath()
 
-        val findings = subject.lint(
-            """
-                fun main()
-                = Unit
-            """.trimIndent(),
-            expectedPath
-        )
+        val rule = ChainWrapping(Config.empty)
+        rule.visitFile(compileForTest(expectedPath))
+        assertThat(rule.findings).isNotNull()
 
-        assertJThat(findings.first().location.filePath.absolutePath.toString()).isEqualTo(expectedPath)
+        val findings = rule.findings
+
+        assertJThat(findings.first().location.filePath.absolutePath.toString()).isEqualTo(expectedPath.toString())
     }
 }

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/MaximumLineLengthSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/MaximumLineLengthSpec.kt
@@ -8,7 +8,6 @@ import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import kotlin.io.path.Path
 import org.assertj.core.api.Assertions.assertThat as assertJThat
 
 class MaximumLineLengthSpec {
@@ -37,7 +36,7 @@ class MaximumLineLengthSpec {
         fun `reports issues with the filename in signature`() {
             val finding = subject.lint(
                 code,
-                Path("home", "test", "Test.kt").toString()
+                "Test.kt"
             ).first()
 
             assertJThat(finding.entity.signature).isEqualTo("Test.kt\$fun")

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/TestFiles.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/TestFiles.kt
@@ -10,6 +10,9 @@ import java.io.File
 import kotlin.io.path.toPath
 
 fun FormattingRule.lint(@Language("kotlin") content: String, fileName: String = "Test.kt"): List<Finding> {
+    require('/' !in fileName && '\\' !in fileName) {
+        "filename must be a file name only and not contain any path elements"
+    }
     val root = compileContentForTest(content, fileName)
     this.visit(root)
     return this.findings

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/InvalidPackageDeclarationSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/InvalidPackageDeclarationSpec.kt
@@ -1,12 +1,11 @@
 package io.gitlab.arturbosch.detekt.rules.naming
 
-import io.github.detekt.test.utils.compileContentForTest
+import io.github.detekt.test.utils.compileForTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lint
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import java.nio.file.FileSystems
 import kotlin.io.path.Path
 
 private const val ROOT_PACKAGE = "rootPackage"
@@ -16,13 +15,7 @@ class InvalidPackageDeclarationSpec {
 
     @Test
     fun `should pass if package declaration is correct`() {
-        val source = """
-            package foo.bar
-            
-            class C
-        """.trimIndent()
-
-        val ktFile = compileContentForTest(source, createPath("project/src/foo/bar/File.kt"))
+        val ktFile = compileForTest(Path("src/test/resources/InvalidPackageDeclarationSpec/src/foo/bar/correct.kt"))
         val findings = InvalidPackageDeclaration().lint(ktFile)
 
         assertThat(findings).isEmpty()
@@ -30,15 +23,7 @@ class InvalidPackageDeclarationSpec {
 
     @Test
     fun `should ignore the issue by alias suppression`() {
-        val source = """
-            @file:Suppress("PackageDirectoryMismatch")
-            
-            package foo
-            
-            class C
-        """.trimIndent()
-
-        val ktFile = compileContentForTest(source, createPath("project/src/bar/File.kt"))
+        val ktFile = compileForTest(Path("src/test/resources/InvalidPackageDeclarationSpec/src/bar/suppressed.kt"))
         val findings = InvalidPackageDeclaration().lint(ktFile)
 
         assertThat(findings).isEmpty()
@@ -46,9 +31,7 @@ class InvalidPackageDeclarationSpec {
 
     @Test
     fun `should report if package declaration does not match source location`() {
-        val source = "package foo\n\nclass C"
-
-        val ktFile = compileContentForTest(source, createPath("project/src/bar/File.kt"))
+        val ktFile = compileForTest(Path("src/test/resources/InvalidPackageDeclarationSpec/src/bar/incorrect.kt"))
         val findings = InvalidPackageDeclaration().lint(ktFile)
 
         assertThat(findings).hasSize(1)
@@ -62,13 +45,7 @@ class InvalidPackageDeclarationSpec {
 
         @Test
         fun `should pass if file is located within the root package`() {
-            val source = """
-                package com.example
-                
-                class C
-            """.trimIndent()
-
-            val ktFile = compileContentForTest(source, createPath("src/File.kt"))
+            val ktFile = compileForTest(Path("src/test/resources/InvalidPackageDeclarationSpec/src/File.kt"))
             val findings = InvalidPackageDeclaration(config).lint(ktFile)
 
             assertThat(findings).isEmpty()
@@ -76,13 +53,7 @@ class InvalidPackageDeclarationSpec {
 
         @Test
         fun `should pass if file is located relative to root package`() {
-            val source = """
-                package com.example.foo.bar
-                
-                class C
-            """.trimIndent()
-
-            val ktFile = compileContentForTest(source, createPath("src/foo/bar/File.kt"))
+            val ktFile = compileForTest(Path("src/test/resources/InvalidPackageDeclarationSpec/src/foo/bar/File.kt"))
             val findings = InvalidPackageDeclaration(config).lint(ktFile)
 
             assertThat(findings).isEmpty()
@@ -90,13 +61,10 @@ class InvalidPackageDeclarationSpec {
 
         @Test
         fun `should pass if file is located in directory corresponding to package declaration`() {
-            val source = """
-                package com.example.foo.bar
-                
-                class C
-            """.trimIndent()
-
-            val ktFile = compileContentForTest(source, createPath("src/com/example/foo/bar/File.kt"))
+            val ktFile =
+                compileForTest(
+                    Path("src/test/resources/InvalidPackageDeclarationSpec/src/com/example/foo/bar/File.kt")
+                )
             val findings = InvalidPackageDeclaration(config).lint(ktFile)
 
             assertThat(findings).isEmpty()
@@ -104,13 +72,10 @@ class InvalidPackageDeclarationSpec {
 
         @Test
         fun `should report if package declaration does not match`() {
-            val source = """
-                package com.example.foo.baz
-                
-                class C
-            """.trimIndent()
-
-            val ktFile = compileContentForTest(source, createPath("src/foo/bar/File.kt"))
+            val ktFile =
+                compileForTest(
+                    Path("src/test/resources/InvalidPackageDeclarationSpec/src/foo/bar/MismatchedDeclaration.kt")
+                )
             val findings = InvalidPackageDeclaration(config).lint(ktFile)
 
             assertThat(findings).hasSize(1)
@@ -118,13 +83,8 @@ class InvalidPackageDeclarationSpec {
 
         @Test
         fun `should report if file path matches root package but package declaration differs`() {
-            val source = """
-                package io.foo.bar
-                
-                class C
-            """.trimIndent()
-
-            val ktFile = compileContentForTest(source, createPath("src/com/example/File.kt"))
+            val ktFile =
+                compileForTest(Path("src/test/resources/InvalidPackageDeclarationSpec/src/com/example/File.kt"))
             val findings = InvalidPackageDeclaration(config).lint(ktFile)
 
             assertThat(findings).hasSize(1)
@@ -138,18 +98,16 @@ class InvalidPackageDeclarationSpec {
 
         @Test
         fun `should pass if declaration starts with root package`() {
-            val source = """
-                package com.example.foo.bar
-                
-                class C
-            """.trimIndent()
-
-            val ktFileWithRelativePath = compileContentForTest(source, createPath("src/foo/bar/File.kt"))
+            val ktFileWithRelativePath =
+                compileForTest(Path("src/test/resources/InvalidPackageDeclarationSpec/src/foo/bar/File.kt"))
             val findingsForRelativePath = InvalidPackageDeclaration(config).lint(ktFileWithRelativePath)
 
             assertThat(findingsForRelativePath).isEmpty()
 
-            val ktFileWithFullPath = compileContentForTest(source, createPath("src/com/example/foo/bar/File.kt"))
+            val ktFileWithFullPath =
+                compileForTest(
+                    Path("src/test/resources/InvalidPackageDeclarationSpec/src/com/example/foo/bar/File.kt")
+                )
             val findingsForFullPath = InvalidPackageDeclaration(config).lint(ktFileWithFullPath)
 
             assertThat(findingsForFullPath).isEmpty()
@@ -157,13 +115,10 @@ class InvalidPackageDeclarationSpec {
 
         @Test
         fun `should report if root package is missing`() {
-            val source = """
-                package foo.bar
-                
-                class C
-            """.trimIndent()
-
-            val ktFile = compileContentForTest(source, createPath("src/foo/bar/File.kt"))
+            val ktFile =
+                compileForTest(
+                    Path("src/test/resources/InvalidPackageDeclarationSpec/src/foo/bar/rootPackageMissing.kt")
+                )
             val findings = InvalidPackageDeclaration(config).lint(ktFile)
 
             assertThat(findings).hasSize(1)
@@ -171,23 +126,11 @@ class InvalidPackageDeclarationSpec {
 
         @Test
         fun `should report if declaration only shares a prefix with root package`() {
-            val source = """
-                package com.example_extra
-                
-                class C
-            """.trimIndent()
-
-            val ktFile = compileContentForTest(source, createPath("src/com/example_extra/File.kt"))
+            val ktFile =
+                compileForTest(Path("src/test/resources/InvalidPackageDeclarationSpec/src/com/example_extra/File.kt"))
             val findings = InvalidPackageDeclaration(config).lint(ktFile)
 
             assertThat(findings).hasSize(1)
         }
     }
-}
-
-private fun createPath(universalPath: String): String {
-    val pathSegments = universalPath.split('/')
-    val aRootPath = FileSystems.getDefault().rootDirectories.first()
-    val path = Path(aRootPath.toString(), *pathSegments.toTypedArray())
-    return path.toString()
 }

--- a/detekt-rules-naming/src/test/resources/InvalidPackageDeclarationSpec/src/File.kt
+++ b/detekt-rules-naming/src/test/resources/InvalidPackageDeclarationSpec/src/File.kt
@@ -1,0 +1,3 @@
+package com.example
+
+class C

--- a/detekt-rules-naming/src/test/resources/InvalidPackageDeclarationSpec/src/bar/incorrect.kt
+++ b/detekt-rules-naming/src/test/resources/InvalidPackageDeclarationSpec/src/bar/incorrect.kt
@@ -1,0 +1,3 @@
+package foo
+
+class C

--- a/detekt-rules-naming/src/test/resources/InvalidPackageDeclarationSpec/src/bar/suppressed.kt
+++ b/detekt-rules-naming/src/test/resources/InvalidPackageDeclarationSpec/src/bar/suppressed.kt
@@ -1,0 +1,5 @@
+@file:Suppress("PackageDirectoryMismatch")
+
+package foo
+
+class C

--- a/detekt-rules-naming/src/test/resources/InvalidPackageDeclarationSpec/src/com/example/File.kt
+++ b/detekt-rules-naming/src/test/resources/InvalidPackageDeclarationSpec/src/com/example/File.kt
@@ -1,0 +1,3 @@
+package io.foo.bar
+
+class C

--- a/detekt-rules-naming/src/test/resources/InvalidPackageDeclarationSpec/src/com/example/foo/bar/File.kt
+++ b/detekt-rules-naming/src/test/resources/InvalidPackageDeclarationSpec/src/com/example/foo/bar/File.kt
@@ -1,0 +1,3 @@
+package com.example.foo.bar
+
+class C

--- a/detekt-rules-naming/src/test/resources/InvalidPackageDeclarationSpec/src/com/example_extra/File.kt
+++ b/detekt-rules-naming/src/test/resources/InvalidPackageDeclarationSpec/src/com/example_extra/File.kt
@@ -1,0 +1,3 @@
+package com.example_extra
+
+class C

--- a/detekt-rules-naming/src/test/resources/InvalidPackageDeclarationSpec/src/foo/bar/File.kt
+++ b/detekt-rules-naming/src/test/resources/InvalidPackageDeclarationSpec/src/foo/bar/File.kt
@@ -1,0 +1,3 @@
+package com.example.foo.bar
+
+class C

--- a/detekt-rules-naming/src/test/resources/InvalidPackageDeclarationSpec/src/foo/bar/MismatchedDeclaration.kt
+++ b/detekt-rules-naming/src/test/resources/InvalidPackageDeclarationSpec/src/foo/bar/MismatchedDeclaration.kt
@@ -1,0 +1,3 @@
+package com.example.foo.baz
+
+class C

--- a/detekt-rules-naming/src/test/resources/InvalidPackageDeclarationSpec/src/foo/bar/correct.kt
+++ b/detekt-rules-naming/src/test/resources/InvalidPackageDeclarationSpec/src/foo/bar/correct.kt
@@ -1,0 +1,3 @@
+package foo.bar
+
+class C

--- a/detekt-rules-naming/src/test/resources/InvalidPackageDeclarationSpec/src/foo/bar/rootPackageMissing.kt
+++ b/detekt-rules-naming/src/test/resources/InvalidPackageDeclarationSpec/src/foo/bar/rootPackageMissing.kt
@@ -1,0 +1,3 @@
+package foo.bar
+
+class C

--- a/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/CompileExtensions.kt
+++ b/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/CompileExtensions.kt
@@ -10,8 +10,12 @@ import java.nio.file.Path
 fun compileContentForTest(
     @Language("kotlin") content: String,
     filename: String = TEST_FILENAME
-): KtFile =
-    KtTestCompiler.compileFromContent(content, filename)
+): KtFile {
+    require('/' !in filename && '\\' !in filename) {
+        "filename must be a file name only and not contain any path elements"
+    }
+    return KtTestCompiler.compileFromContent(content, filename)
+}
 
 /**
  * Use this method if you test a kt file/class in the test resources.

--- a/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/KtTestCompiler.kt
+++ b/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/KtTestCompiler.kt
@@ -35,11 +35,15 @@ internal object KtTestCompiler : KtCompiler() {
 
     fun compile(path: Path) = compile(root, path)
 
-    fun compileFromContent(@Language("kotlin") content: String, filename: String = TEST_FILENAME): KtFile =
-        psiFileFactory.createPhysicalFile(
+    fun compileFromContent(@Language("kotlin") content: String, filename: String = TEST_FILENAME): KtFile {
+        require('/' !in filename && '\\' !in filename) {
+            "filename must be a file name only and not contain any path elements"
+        }
+        return psiFileFactory.createPhysicalFile(
             filename,
             StringUtilRt.convertLineSeparators(content)
         )
+    }
 
     /**
      * Not sure why but this function only works from this context.


### PR DESCRIPTION
When using KtPsiFactory to create files it uses methods from PsiFileFactory. The methods used to create new files use a filename argument and not a path argument. These methods have been called incorrectly in detekt in various ways - this PR ensures that tests will stop using incorrect values.

Includes a test change that's required as part of the fix for #5747 which can be made independently.