### PR TITLE
Store absolute path names as metadata with each KtFile

### DIFF
--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/Signatures.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/Signatures.kt
@@ -1,6 +1,5 @@
 package io.gitlab.arturbosch.detekt.api.internal
 
-import io.github.detekt.psi.fileName
 import org.jetbrains.kotlin.asJava.namedUnwrappedElement
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.psi.KtClassOrObject
@@ -59,7 +58,7 @@ internal fun PsiElement.buildFullSignature(): String {
         fullSignature = "$parentSignatures\$$fullSignature"
     }
 
-    val filename = this.containingFile.fileName
+    val filename = this.containingFile.name
     if (!fullSignature.startsWith(filename)) {
         fullSignature = "$filename\$$fullSignature"
     }
@@ -79,7 +78,7 @@ private fun PsiElement.searchSignature(): String {
     }.replace('\n', ' ').replace(multipleWhitespaces, " ")
 }
 
-private fun KtFile.fileSignature() = "${this.packageFqName.asString()}.${this.fileName}"
+private fun KtFile.fileSignature() = "${this.packageFqName.asString()}.${this.name}"
 
 private fun buildClassSignature(classOrObject: KtClassOrObject): String {
     var baseName = classOrObject.nameAsSafeName.asString()

--- a/detekt-compiler-plugin/build.gradle.kts
+++ b/detekt-compiler-plugin/build.gradle.kts
@@ -102,9 +102,13 @@ val testPluginKotlinc by tasks.registering(Task::class) {
     }
 
     doLast {
-        if (!kotlincExecution.standardError.asText.get().contains("warning: magicNumber:")) {
+        val stdErrOutput = kotlincExecution.standardError.asText.get()
+        if (!stdErrOutput.contains("warning: doubleMutabilityForCollection:")) {
             throw GradleException(
-                "kotlinc run with compiler plugin did not find MagicNumber issue as expected"
+                """
+                    kotlinc run with compiler plugin did not find DoubleMutabilityForCollection issue in output:
+                    $stdErrOutput
+                """.trimIndent()
             )
         }
     }

--- a/detekt-compiler-plugin/src/test/resources/hello.kt
+++ b/detekt-compiler-plugin/src/test/resources/hello.kt
@@ -1,6 +1,6 @@
 class KClass {
     fun foo() {
-        val x = 3
-        println(x)
+        var myList = mutableListOf(1,2,3)
+        println(myList)
     }
 }

--- a/detekt-parser/src/main/kotlin/io/github/detekt/parser/KtCompiler.kt
+++ b/detekt-parser/src/main/kotlin/io/github/detekt/parser/KtCompiler.kt
@@ -3,6 +3,7 @@ package io.github.detekt.parser
 import io.github.detekt.psi.BASE_PATH
 import io.github.detekt.psi.LINE_SEPARATOR
 import io.github.detekt.psi.RELATIVE_PATH
+import io.github.detekt.psi.absolutePath
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.jetbrains.kotlin.com.intellij.openapi.util.text.StringUtilRt
 import org.jetbrains.kotlin.psi.KtFile
@@ -10,6 +11,7 @@ import org.jetbrains.kotlin.psi.KtPsiFactory
 import java.nio.file.Path
 import kotlin.io.path.absolute
 import kotlin.io.path.isRegularFile
+import kotlin.io.path.name
 import kotlin.io.path.readText
 
 open class KtCompiler(
@@ -31,11 +33,12 @@ open class KtCompiler(
         val lineSeparator = content.determineLineSeparator()
 
         val psiFile = psiFileFactory.createPhysicalFile(
-            normalizedAbsolutePath.toString(),
+            normalizedAbsolutePath.name,
             StringUtilRt.convertLineSeparators(content)
         )
 
         return psiFile.apply {
+            this.absolutePath = normalizedAbsolutePath
             putUserData(LINE_SEPARATOR, lineSeparator)
             val normalizedBasePath = basePath?.absolute()?.normalize()
             normalizedBasePath?.relativize(normalizedAbsolutePath)?.let { relativePath ->

--- a/detekt-psi-utils/api/detekt-psi-utils.api
+++ b/detekt-psi-utils/api/detekt-psi-utils.api
@@ -33,7 +33,6 @@ public final class io/github/detekt/psi/KtFilesKt {
 	public static final fun basePath (Lorg/jetbrains/kotlin/com/intellij/psi/PsiFile;)Ljava/nio/file/Path;
 	public static final fun fileNameWithoutSuffix (Lorg/jetbrains/kotlin/com/intellij/psi/PsiFile;)Ljava/lang/String;
 	public static final fun getAbsolutePath (Lorg/jetbrains/kotlin/com/intellij/psi/PsiFile;)Ljava/nio/file/Path;
-	public static final fun getFileName (Lorg/jetbrains/kotlin/com/intellij/psi/PsiFile;)Ljava/lang/String;
 	public static final fun getLineAndColumnInPsiFile (Lorg/jetbrains/kotlin/com/intellij/psi/PsiFile;Lorg/jetbrains/kotlin/com/intellij/openapi/util/TextRange;)Lorg/jetbrains/kotlin/diagnostics/PsiDiagnosticUtils$LineAndColumn;
 	public static final fun relativePath (Lorg/jetbrains/kotlin/com/intellij/psi/PsiFile;)Ljava/nio/file/Path;
 	public static final fun setAbsolutePath (Lorg/jetbrains/kotlin/com/intellij/psi/PsiFile;Ljava/nio/file/Path;)V

--- a/detekt-psi-utils/api/detekt-psi-utils.api
+++ b/detekt-psi-utils/api/detekt-psi-utils.api
@@ -32,9 +32,11 @@ public final class io/github/detekt/psi/KtFilesKt {
 	public static final fun absolutePath (Lorg/jetbrains/kotlin/com/intellij/psi/PsiFile;)Ljava/nio/file/Path;
 	public static final fun basePath (Lorg/jetbrains/kotlin/com/intellij/psi/PsiFile;)Ljava/nio/file/Path;
 	public static final fun fileNameWithoutSuffix (Lorg/jetbrains/kotlin/com/intellij/psi/PsiFile;)Ljava/lang/String;
+	public static final fun getAbsolutePath (Lorg/jetbrains/kotlin/com/intellij/psi/PsiFile;)Ljava/nio/file/Path;
 	public static final fun getFileName (Lorg/jetbrains/kotlin/com/intellij/psi/PsiFile;)Ljava/lang/String;
 	public static final fun getLineAndColumnInPsiFile (Lorg/jetbrains/kotlin/com/intellij/psi/PsiFile;Lorg/jetbrains/kotlin/com/intellij/openapi/util/TextRange;)Lorg/jetbrains/kotlin/diagnostics/PsiDiagnosticUtils$LineAndColumn;
 	public static final fun relativePath (Lorg/jetbrains/kotlin/com/intellij/psi/PsiFile;)Ljava/nio/file/Path;
+	public static final fun setAbsolutePath (Lorg/jetbrains/kotlin/com/intellij/psi/PsiFile;Ljava/nio/file/Path;)V
 	public static final fun toFilePath (Lorg/jetbrains/kotlin/com/intellij/psi/PsiFile;)Lio/github/detekt/psi/FilePath;
 	public static final fun toUnifiedString (Ljava/nio/file/Path;)Ljava/lang/String;
 }

--- a/detekt-psi-utils/src/main/kotlin/io/github/detekt/psi/KtFiles.kt
+++ b/detekt-psi-utils/src/main/kotlin/io/github/detekt/psi/KtFiles.kt
@@ -6,7 +6,6 @@ import org.jetbrains.kotlin.com.intellij.psi.PsiFile
 import org.jetbrains.kotlin.diagnostics.DiagnosticUtils
 import org.jetbrains.kotlin.diagnostics.PsiDiagnosticUtils
 import org.jetbrains.kotlin.psi.UserDataProperty
-import java.io.File
 import java.nio.file.Path
 import kotlin.io.path.Path
 import kotlin.io.path.invariantSeparatorsPathString
@@ -21,15 +20,12 @@ private val KOTLIN_FILE_SUFFIXES = arrayOf(
     KOTLIN_SCRIPT_SUFFIX
 )
 
-val PsiFile.fileName: String
-    get() = name.substringAfterLast(File.separatorChar)
-
 /**
  * Removes kotlin specific file name suffixes, e.g. .kt.
  * Note, will not remove other possible/known file suffixes like '.java'
  */
 fun PsiFile.fileNameWithoutSuffix(): String {
-    val fileName = this.fileName
+    val fileName = this.name
     for (suffix in KOTLIN_FILE_SUFFIXES) {
         if (fileName.endsWith(suffix)) {
             return fileName.removeSuffix(suffix)

--- a/detekt-psi-utils/src/main/kotlin/io/github/detekt/psi/KtFiles.kt
+++ b/detekt-psi-utils/src/main/kotlin/io/github/detekt/psi/KtFiles.kt
@@ -1,9 +1,11 @@
 package io.github.detekt.psi
 
+import org.jetbrains.kotlin.com.intellij.openapi.util.Key
 import org.jetbrains.kotlin.com.intellij.openapi.util.TextRange
 import org.jetbrains.kotlin.com.intellij.psi.PsiFile
 import org.jetbrains.kotlin.diagnostics.DiagnosticUtils
 import org.jetbrains.kotlin.diagnostics.PsiDiagnosticUtils
+import org.jetbrains.kotlin.psi.UserDataProperty
 import java.io.File
 import java.nio.file.Path
 import kotlin.io.path.Path
@@ -36,7 +38,13 @@ fun PsiFile.fileNameWithoutSuffix(): String {
     return fileName
 }
 
-fun PsiFile.absolutePath(): Path = Path(name)
+var PsiFile.absolutePath: Path? by UserDataProperty(Key("absolutePath"))
+
+/*
+absolutePath will be null when the Kotlin compiler plugin is used. The file's path can be obtained from the virtual file
+instead.
+*/
+fun PsiFile.absolutePath(): Path = absolutePath ?: Path(virtualFile.path)
 
 fun PsiFile.relativePath(): Path? = getUserData(RELATIVE_PATH)?.let { Path(it) }
 


### PR DESCRIPTION
Store absolute path names as metadata with each KtFile instead of in the `name` field.

* fixes https://github.com/detekt/detekt/issues/5747
* fixes https://github.com/detekt/detekt/issues/6155