### PR TITLE
Simplify storing metadata with KtFiles

### DIFF
--- a/detekt-api/api/detekt-api.api
+++ b/detekt-api/api/detekt-api.api
@@ -203,11 +203,9 @@ public class io/gitlab/arturbosch/detekt/api/DetektVisitor : org/jetbrains/kotli
 	public fun <init> ()V
 }
 
-public abstract interface class io/gitlab/arturbosch/detekt/api/Detektion {
+public abstract interface class io/gitlab/arturbosch/detekt/api/Detektion : org/jetbrains/kotlin/com/intellij/openapi/util/UserDataHolder {
 	public abstract fun add (Lio/gitlab/arturbosch/detekt/api/Notification;)V
 	public abstract fun add (Lio/gitlab/arturbosch/detekt/api/ProjectMetric;)V
-	public abstract fun addData (Lorg/jetbrains/kotlin/com/intellij/openapi/util/Key;Ljava/lang/Object;)V
-	public abstract fun getData (Lorg/jetbrains/kotlin/com/intellij/openapi/util/Key;)Ljava/lang/Object;
 	public abstract fun getFindings ()Ljava/util/Map;
 	public abstract fun getMetrics ()Ljava/util/Collection;
 	public abstract fun getNotifications ()Ljava/util/Collection;

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Detektion.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Detektion.kt
@@ -1,25 +1,15 @@
 package io.gitlab.arturbosch.detekt.api
 
-import org.jetbrains.kotlin.com.intellij.openapi.util.Key
+import org.jetbrains.kotlin.com.intellij.openapi.util.UserDataHolder
 
 /**
  * Storage for all kinds of findings and additional information
  * which needs to be transferred from the detekt engine to the user.
  */
-interface Detektion {
+interface Detektion : UserDataHolder {
     val findings: Map<RuleSetId, List<Finding>>
     val notifications: Collection<Notification>
     val metrics: Collection<ProjectMetric>
-
-    /**
-     * Retrieves a value stored by the given key of the result.
-     */
-    fun <V> getData(key: Key<V>): V?
-
-    /**
-     * Stores an arbitrary value inside the result bound to the given key.
-     */
-    fun <V> addData(key: Key<V>, value: V)
 
     /**
      * Stores a notification in the result.

--- a/detekt-api/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/test/TestDetektion.kt
+++ b/detekt-api/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/test/TestDetektion.kt
@@ -5,26 +5,19 @@ import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.api.Notification
 import io.gitlab.arturbosch.detekt.api.ProjectMetric
 import org.jetbrains.kotlin.com.intellij.openapi.util.Key
-import org.jetbrains.kotlin.com.intellij.util.keyFMap.KeyFMap
+import org.jetbrains.kotlin.com.intellij.openapi.util.UserDataHolderBase
 
-open class TestDetektion(vararg findings: Finding) : Detektion {
+open class TestDetektion(vararg findings: Finding) : Detektion, UserDataHolderBase() {
 
     override val findings: Map<String, List<Finding>> = findings.groupBy { it.id }
     override val metrics: Collection<ProjectMetric> get() = _metrics
     override val notifications: List<Notification> get() = _notifications
 
-    private var userData = KeyFMap.EMPTY_MAP
     private val _metrics = mutableListOf<ProjectMetric>()
     private val _notifications = mutableListOf<Notification>()
 
-    override fun <V> getData(key: Key<V>): V? = userData.get(key)
-
-    override fun <V> addData(key: Key<V>, value: V) {
-        userData = userData.plus(key, requireNotNull(value))
-    }
-
     fun <V> removeData(key: Key<V>) {
-        userData = userData.minus(key)
+        putUserData(key, null)
     }
 
     override fun add(notification: Notification) {

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/DetektResult.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/DetektResult.kt
@@ -5,11 +5,10 @@ import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.api.Notification
 import io.gitlab.arturbosch.detekt.api.ProjectMetric
 import io.gitlab.arturbosch.detekt.api.RuleSetId
-import org.jetbrains.kotlin.com.intellij.openapi.util.Key
-import org.jetbrains.kotlin.com.intellij.util.keyFMap.KeyFMap
+import org.jetbrains.kotlin.com.intellij.openapi.util.UserDataHolderBase
 
 @Suppress("DataClassShouldBeImmutable")
-data class DetektResult(override val findings: Map<RuleSetId, List<Finding>>) : Detektion {
+data class DetektResult(override val findings: Map<RuleSetId, List<Finding>>) : Detektion, UserDataHolderBase() {
 
     private val _notifications = ArrayList<Notification>()
     override val notifications: Collection<Notification> = _notifications
@@ -17,19 +16,11 @@ data class DetektResult(override val findings: Map<RuleSetId, List<Finding>>) : 
     private val _metrics = ArrayList<ProjectMetric>()
     override val metrics: Collection<ProjectMetric> = _metrics
 
-    private var userData = KeyFMap.EMPTY_MAP
-
     override fun add(projectMetric: ProjectMetric) {
         _metrics.add(projectMetric)
     }
 
     override fun add(notification: Notification) {
         _notifications.add(notification)
-    }
-
-    override fun <V> getData(key: Key<V>): V? = userData[key]
-
-    override fun <V> addData(key: Key<V>, value: V) {
-        userData = userData.plus(key, requireNotNull(value))
     }
 }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/KtFileModifier.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/KtFileModifier.kt
@@ -1,7 +1,7 @@
 package io.gitlab.arturbosch.detekt.core
 
-import io.github.detekt.psi.LINE_SEPARATOR
 import io.github.detekt.psi.absolutePath
+import io.github.detekt.psi.lineSeparator
 import io.gitlab.arturbosch.detekt.api.Detektion
 import io.gitlab.arturbosch.detekt.api.FileProcessListener
 import io.gitlab.arturbosch.detekt.api.Notification
@@ -24,8 +24,7 @@ class KtFileModifier : FileProcessListener {
     }
 
     private fun KtFile.unnormalizeContent(): String {
-        val lineSeparator = getUserData(LINE_SEPARATOR)
-        requireNotNull(lineSeparator) {
+        val lineSeparator = requireNotNull(this.lineSeparator) {
             "No line separator entry for ktFile ${javaFileFacadeFqName.asString()}"
         }
         return StringUtilRt.convertLineSeparators(text, lineSeparator)

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/IssueExtension.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/IssueExtension.kt
@@ -14,7 +14,7 @@ private const val WEIGHTS = "weights"
 internal const val MAX_ISSUES_KEY: String = "maxIssues"
 
 internal fun Detektion.getOrComputeWeightedAmountOfIssues(config: Config): Int {
-    val maybeAmount = this.getData(WEIGHTED_ISSUES_COUNT_KEY)
+    val maybeAmount = this.getUserData(WEIGHTED_ISSUES_COUNT_KEY)
     if (maybeAmount != null) {
         return maybeAmount
     }
@@ -32,7 +32,7 @@ internal fun Detektion.getOrComputeWeightedAmountOfIssues(config: Config): Int {
     }
 
     val amount = smells.sumOf { it.weighted() }
-    this.addData(WEIGHTED_ISSUES_COUNT_KEY, amount)
+    this.putUserData(WEIGHTED_ISSUES_COUNT_KEY, amount)
     return amount
 }
 

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/ComplexityReportSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/ComplexityReportSpec.kt
@@ -35,10 +35,10 @@ class ComplexityReportSpec {
 private fun createDetektion(): Detektion = DetektResult(mapOf("Key" to listOf(createFinding())))
 
 private fun addData(detektion: Detektion) {
-    detektion.addData(complexityKey, 2)
-    detektion.addData(CognitiveComplexity.KEY, 2)
-    detektion.addData(linesKey, 10)
-    detektion.addData(sourceLinesKey, 6)
-    detektion.addData(logicalLinesKey, 5)
-    detektion.addData(commentLinesKey, 4)
+    detektion.putUserData(complexityKey, 2)
+    detektion.putUserData(CognitiveComplexity.KEY, 2)
+    detektion.putUserData(linesKey, 10)
+    detektion.putUserData(sourceLinesKey, 6)
+    detektion.putUserData(logicalLinesKey, 5)
+    detektion.putUserData(commentLinesKey, 4)
 }

--- a/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/ComplexityMetric.kt
+++ b/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/ComplexityMetric.kt
@@ -9,11 +9,11 @@ import io.gitlab.arturbosch.detekt.api.Detektion
 
 class ComplexityMetric(detektion: Detektion) {
 
-    val mcc = detektion.getData(complexityKey)
-    val cognitiveComplexity = detektion.getData(CognitiveComplexity.KEY)
-    val loc = detektion.getData(linesKey)
-    val sloc = detektion.getData(sourceLinesKey)
-    val lloc = detektion.getData(logicalLinesKey)
-    val cloc = detektion.getData(commentLinesKey)
+    val mcc = detektion.getUserData(complexityKey)
+    val cognitiveComplexity = detektion.getUserData(CognitiveComplexity.KEY)
+    val loc = detektion.getUserData(linesKey)
+    val sloc = detektion.getUserData(sourceLinesKey)
+    val lloc = detektion.getUserData(logicalLinesKey)
+    val cloc = detektion.getUserData(commentLinesKey)
     val findings = detektion.findings.entries
 }

--- a/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/processors/AbstractProcessor.kt
+++ b/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/processors/AbstractProcessor.kt
@@ -20,6 +20,6 @@ abstract class AbstractProcessor : FileProcessListener {
         val count = files
             .mapNotNull { it.getUserData(key) }
             .sum()
-        result.addData(key, count)
+        result.putUserData(key, count)
     }
 }

--- a/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/ComplexityReportGeneratorSpec.kt
+++ b/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/ComplexityReportGeneratorSpec.kt
@@ -62,7 +62,7 @@ internal class ComplexityReportGeneratorSpec {
             detektion.removeData(logicalLinesKey)
             assertThat(generateComplexityReport(detektion)).isNull()
 
-            detektion.addData(logicalLinesKey, 0)
+            detektion.putUserData(logicalLinesKey, 0)
             assertThat(generateComplexityReport(detektion)).isNull()
         }
 
@@ -71,7 +71,7 @@ internal class ComplexityReportGeneratorSpec {
             detektion.removeData(sourceLinesKey)
             assertThat(generateComplexityReport(detektion)).isNull()
 
-            detektion.addData(sourceLinesKey, 0)
+            detektion.putUserData(sourceLinesKey, 0)
             assertThat(generateComplexityReport(detektion)).isNull()
         }
 
@@ -84,12 +84,12 @@ internal class ComplexityReportGeneratorSpec {
 }
 
 private fun TestDetektion.withTestData(): TestDetektion {
-    addData(complexityKey, 2)
-    addData(CognitiveComplexity.KEY, 2)
-    addData(linesKey, 1000)
-    addData(sourceLinesKey, 6)
-    addData(logicalLinesKey, 5)
-    addData(commentLinesKey, 4)
+    putUserData(complexityKey, 2)
+    putUserData(CognitiveComplexity.KEY, 2)
+    putUserData(linesKey, 1000)
+    putUserData(sourceLinesKey, 6)
+    putUserData(logicalLinesKey, 5)
+    putUserData(commentLinesKey, 4)
     return this
 }
 

--- a/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/processors/MetricProcessorTester.kt
+++ b/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/processors/MetricProcessorTester.kt
@@ -6,7 +6,7 @@ import io.gitlab.arturbosch.detekt.api.Notification
 import io.gitlab.arturbosch.detekt.api.ProjectMetric
 import io.gitlab.arturbosch.detekt.api.RuleSetId
 import org.jetbrains.kotlin.com.intellij.openapi.util.Key
-import org.jetbrains.kotlin.com.intellij.util.keyFMap.KeyFMap
+import org.jetbrains.kotlin.com.intellij.openapi.util.UserDataHolderBase
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.resolve.BindingContext
 
@@ -22,24 +22,16 @@ class MetricProcessorTester(
             onProcessComplete(file, emptyMap(), BindingContext.EMPTY)
             onFinish(listOf(file), result, BindingContext.EMPTY)
         }
-        return checkNotNull(result.getData(key))
+        return checkNotNull(result.getUserData(key))
     }
 }
 
-private class MetricResults : Detektion {
+private class MetricResults : Detektion, UserDataHolderBase() {
     override val findings: Map<RuleSetId, List<Finding>>
         get() = throw UnsupportedOperationException()
     override val notifications: Collection<Notification>
         get() = throw UnsupportedOperationException()
     override val metrics: MutableList<ProjectMetric> = mutableListOf()
-
-    private var data = KeyFMap.EMPTY_MAP
-
-    override fun <V> getData(key: Key<V>): V? = data[key]
-
-    override fun <V> addData(key: Key<V>, value: V) {
-        data = data.plus(key, requireNotNull(value))
-    }
 
     override fun add(notification: Notification) {
         throw UnsupportedOperationException()

--- a/detekt-parser/src/main/kotlin/io/github/detekt/parser/KtCompiler.kt
+++ b/detekt-parser/src/main/kotlin/io/github/detekt/parser/KtCompiler.kt
@@ -42,8 +42,8 @@ open class KtCompiler(
             this.lineSeparator = lineSeparator
             val normalizedBasePath = basePath?.absolute()?.normalize()
             normalizedBasePath?.relativize(normalizedAbsolutePath)?.let { relativePath ->
-                this.basePath = normalizedBasePath.absolute().toString()
-                this.relativePath = relativePath.toString()
+                this.basePath = normalizedBasePath.absolute()
+                this.relativePath = relativePath
             }
         }
     }

--- a/detekt-parser/src/main/kotlin/io/github/detekt/parser/KtCompiler.kt
+++ b/detekt-parser/src/main/kotlin/io/github/detekt/parser/KtCompiler.kt
@@ -1,9 +1,9 @@
 package io.github.detekt.parser
 
-import io.github.detekt.psi.BASE_PATH
-import io.github.detekt.psi.LINE_SEPARATOR
-import io.github.detekt.psi.RELATIVE_PATH
 import io.github.detekt.psi.absolutePath
+import io.github.detekt.psi.basePath
+import io.github.detekt.psi.lineSeparator
+import io.github.detekt.psi.relativePath
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.jetbrains.kotlin.com.intellij.openapi.util.text.StringUtilRt
 import org.jetbrains.kotlin.psi.KtFile
@@ -39,11 +39,11 @@ open class KtCompiler(
 
         return psiFile.apply {
             this.absolutePath = normalizedAbsolutePath
-            putUserData(LINE_SEPARATOR, lineSeparator)
+            this.lineSeparator = lineSeparator
             val normalizedBasePath = basePath?.absolute()?.normalize()
             normalizedBasePath?.relativize(normalizedAbsolutePath)?.let { relativePath ->
-                putUserData(BASE_PATH, normalizedBasePath.absolute().toString())
-                putUserData(RELATIVE_PATH, relativePath.toString())
+                this.basePath = normalizedBasePath.absolute().toString()
+                this.relativePath = relativePath.toString()
             }
         }
     }

--- a/detekt-parser/src/test/kotlin/io/github/detekt/parser/KtCompilerSpec.kt
+++ b/detekt-parser/src/test/kotlin/io/github/detekt/parser/KtCompilerSpec.kt
@@ -1,8 +1,8 @@
 package io.github.detekt.parser
 
-import io.github.detekt.psi.BASE_PATH
-import io.github.detekt.psi.LINE_SEPARATOR
-import io.github.detekt.psi.RELATIVE_PATH
+import io.github.detekt.psi.basePath
+import io.github.detekt.psi.lineSeparator
+import io.github.detekt.psi.relativePath
 import io.github.detekt.test.utils.resourceAsPath
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatIllegalArgumentException
@@ -22,10 +22,10 @@ class KtCompilerSpec {
         fun `Kotlin file with LF line separators has extra user data`() {
             val ktFile = ktCompiler.compile(path, path.resolve("DefaultLf.kt"))
 
-            assertThat(ktFile.getUserData(LINE_SEPARATOR)).isEqualTo("\n")
-            assertThat(ktFile.getUserData(RELATIVE_PATH))
+            assertThat(ktFile.lineSeparator).isEqualTo("\n")
+            assertThat(ktFile.relativePath)
                 .isEqualTo("DefaultLf.kt")
-            assertThat(ktFile.getUserData(BASE_PATH))
+            assertThat(ktFile.basePath)
                 .endsWith("cases")
         }
 
@@ -33,10 +33,10 @@ class KtCompilerSpec {
         fun `Kotlin file with CRLF line separators has extra user data`() {
             val ktFile = ktCompiler.compile(path, path.resolve("DefaultCrLf.kt"))
 
-            assertThat(ktFile.getUserData(LINE_SEPARATOR)).isEqualTo("\r\n")
-            assertThat(ktFile.getUserData(RELATIVE_PATH))
+            assertThat(ktFile.lineSeparator).isEqualTo("\r\n")
+            assertThat(ktFile.relativePath)
                 .isEqualTo("DefaultCrLf.kt")
-            assertThat(ktFile.getUserData(BASE_PATH))
+            assertThat(ktFile.basePath)
                 .endsWith("cases")
         }
 
@@ -44,18 +44,18 @@ class KtCompilerSpec {
         fun `Kotlin file with LF line separators does not store extra data for relative path if not provided`() {
             val ktFile = ktCompiler.compile(null, path.resolve("DefaultLf.kt"))
 
-            assertThat(ktFile.getUserData(LINE_SEPARATOR)).isEqualTo("\n")
-            assertThat(ktFile.getUserData(RELATIVE_PATH)).isNull()
-            assertThat(ktFile.getUserData(BASE_PATH)).isNull()
+            assertThat(ktFile.lineSeparator).isEqualTo("\n")
+            assertThat(ktFile.relativePath).isNull()
+            assertThat(ktFile.basePath).isNull()
         }
 
         @Test
         fun `Kotlin file with CRLF line separators does not store extra data for relative path if not provided`() {
             val ktFile = ktCompiler.compile(null, path.resolve("DefaultCrLf.kt"))
 
-            assertThat(ktFile.getUserData(LINE_SEPARATOR)).isEqualTo("\r\n")
-            assertThat(ktFile.getUserData(RELATIVE_PATH)).isNull()
-            assertThat(ktFile.getUserData(BASE_PATH)).isNull()
+            assertThat(ktFile.lineSeparator).isEqualTo("\r\n")
+            assertThat(ktFile.relativePath).isNull()
+            assertThat(ktFile.basePath).isNull()
         }
 
         @Test

--- a/detekt-parser/src/test/kotlin/io/github/detekt/parser/KtCompilerSpec.kt
+++ b/detekt-parser/src/test/kotlin/io/github/detekt/parser/KtCompilerSpec.kt
@@ -10,6 +10,7 @@ import org.jetbrains.kotlin.com.intellij.psi.PsiErrorElement
 import org.jetbrains.kotlin.psi.KtTreeVisitorVoid
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import kotlin.io.path.Path
 
 class KtCompilerSpec {
     @Nested
@@ -24,9 +25,9 @@ class KtCompilerSpec {
 
             assertThat(ktFile.lineSeparator).isEqualTo("\n")
             assertThat(ktFile.relativePath)
-                .isEqualTo("DefaultLf.kt")
+                .isEqualTo(Path("DefaultLf.kt"))
             assertThat(ktFile.basePath)
-                .endsWith("cases")
+                .endsWith(Path("cases"))
         }
 
         @Test
@@ -35,9 +36,9 @@ class KtCompilerSpec {
 
             assertThat(ktFile.lineSeparator).isEqualTo("\r\n")
             assertThat(ktFile.relativePath)
-                .isEqualTo("DefaultCrLf.kt")
+                .isEqualTo(Path("DefaultCrLf.kt"))
             assertThat(ktFile.basePath)
-                .endsWith("cases")
+                .endsWith(Path("cases"))
         }
 
         @Test

--- a/detekt-psi-utils/api/detekt-psi-utils.api
+++ b/detekt-psi-utils/api/detekt-psi-utils.api
@@ -21,9 +21,12 @@ public final class io/github/detekt/psi/FilePath$Companion {
 }
 
 public final class io/github/detekt/psi/KeysKt {
-	public static final fun getBASE_PATH ()Lorg/jetbrains/kotlin/com/intellij/openapi/util/Key;
-	public static final fun getLINE_SEPARATOR ()Lorg/jetbrains/kotlin/com/intellij/openapi/util/Key;
-	public static final fun getRELATIVE_PATH ()Lorg/jetbrains/kotlin/com/intellij/openapi/util/Key;
+	public static final fun getBasePath (Lorg/jetbrains/kotlin/com/intellij/psi/PsiFile;)Ljava/lang/String;
+	public static final fun getLineSeparator (Lorg/jetbrains/kotlin/com/intellij/psi/PsiFile;)Ljava/lang/String;
+	public static final fun getRelativePath (Lorg/jetbrains/kotlin/com/intellij/psi/PsiFile;)Ljava/lang/String;
+	public static final fun setBasePath (Lorg/jetbrains/kotlin/com/intellij/psi/PsiFile;Ljava/lang/String;)V
+	public static final fun setLineSeparator (Lorg/jetbrains/kotlin/com/intellij/psi/PsiFile;Ljava/lang/String;)V
+	public static final fun setRelativePath (Lorg/jetbrains/kotlin/com/intellij/psi/PsiFile;Ljava/lang/String;)V
 }
 
 public final class io/github/detekt/psi/KtFilesKt {

--- a/detekt-psi-utils/api/detekt-psi-utils.api
+++ b/detekt-psi-utils/api/detekt-psi-utils.api
@@ -33,11 +33,9 @@ public final class io/github/detekt/psi/KtFilesKt {
 	public static final field KOTLIN_SCRIPT_SUFFIX Ljava/lang/String;
 	public static final field KOTLIN_SUFFIX Ljava/lang/String;
 	public static final fun absolutePath (Lorg/jetbrains/kotlin/com/intellij/psi/PsiFile;)Ljava/nio/file/Path;
-	public static final fun basePath (Lorg/jetbrains/kotlin/com/intellij/psi/PsiFile;)Ljava/nio/file/Path;
 	public static final fun fileNameWithoutSuffix (Lorg/jetbrains/kotlin/com/intellij/psi/PsiFile;)Ljava/lang/String;
 	public static final fun getAbsolutePath (Lorg/jetbrains/kotlin/com/intellij/psi/PsiFile;)Ljava/nio/file/Path;
 	public static final fun getLineAndColumnInPsiFile (Lorg/jetbrains/kotlin/com/intellij/psi/PsiFile;Lorg/jetbrains/kotlin/com/intellij/openapi/util/TextRange;)Lorg/jetbrains/kotlin/diagnostics/PsiDiagnosticUtils$LineAndColumn;
-	public static final fun relativePath (Lorg/jetbrains/kotlin/com/intellij/psi/PsiFile;)Ljava/nio/file/Path;
 	public static final fun setAbsolutePath (Lorg/jetbrains/kotlin/com/intellij/psi/PsiFile;Ljava/nio/file/Path;)V
 	public static final fun toFilePath (Lorg/jetbrains/kotlin/com/intellij/psi/PsiFile;)Lio/github/detekt/psi/FilePath;
 	public static final fun toUnifiedString (Ljava/nio/file/Path;)Ljava/lang/String;

--- a/detekt-psi-utils/api/detekt-psi-utils.api
+++ b/detekt-psi-utils/api/detekt-psi-utils.api
@@ -21,12 +21,12 @@ public final class io/github/detekt/psi/FilePath$Companion {
 }
 
 public final class io/github/detekt/psi/KeysKt {
-	public static final fun getBasePath (Lorg/jetbrains/kotlin/com/intellij/psi/PsiFile;)Ljava/lang/String;
+	public static final fun getBasePath (Lorg/jetbrains/kotlin/com/intellij/psi/PsiFile;)Ljava/nio/file/Path;
 	public static final fun getLineSeparator (Lorg/jetbrains/kotlin/com/intellij/psi/PsiFile;)Ljava/lang/String;
-	public static final fun getRelativePath (Lorg/jetbrains/kotlin/com/intellij/psi/PsiFile;)Ljava/lang/String;
-	public static final fun setBasePath (Lorg/jetbrains/kotlin/com/intellij/psi/PsiFile;Ljava/lang/String;)V
+	public static final fun getRelativePath (Lorg/jetbrains/kotlin/com/intellij/psi/PsiFile;)Ljava/nio/file/Path;
+	public static final fun setBasePath (Lorg/jetbrains/kotlin/com/intellij/psi/PsiFile;Ljava/nio/file/Path;)V
 	public static final fun setLineSeparator (Lorg/jetbrains/kotlin/com/intellij/psi/PsiFile;Ljava/lang/String;)V
-	public static final fun setRelativePath (Lorg/jetbrains/kotlin/com/intellij/psi/PsiFile;Ljava/lang/String;)V
+	public static final fun setRelativePath (Lorg/jetbrains/kotlin/com/intellij/psi/PsiFile;Ljava/nio/file/Path;)V
 }
 
 public final class io/github/detekt/psi/KtFilesKt {

--- a/detekt-psi-utils/src/main/kotlin/io/github/detekt/psi/Keys.kt
+++ b/detekt-psi-utils/src/main/kotlin/io/github/detekt/psi/Keys.kt
@@ -3,7 +3,8 @@ package io.github.detekt.psi
 import org.jetbrains.kotlin.com.intellij.openapi.util.Key
 import org.jetbrains.kotlin.com.intellij.psi.PsiFile
 import org.jetbrains.kotlin.psi.UserDataProperty
+import java.nio.file.Path
 
-var PsiFile.relativePath: String? by UserDataProperty(Key("relativePath"))
-var PsiFile.basePath: String? by UserDataProperty(Key("basePath"))
+var PsiFile.relativePath: Path? by UserDataProperty(Key("relativePath"))
+var PsiFile.basePath: Path? by UserDataProperty(Key("basePath"))
 var PsiFile.lineSeparator: String? by UserDataProperty(Key("lineSeparator"))

--- a/detekt-psi-utils/src/main/kotlin/io/github/detekt/psi/Keys.kt
+++ b/detekt-psi-utils/src/main/kotlin/io/github/detekt/psi/Keys.kt
@@ -1,7 +1,9 @@
 package io.github.detekt.psi
 
 import org.jetbrains.kotlin.com.intellij.openapi.util.Key
+import org.jetbrains.kotlin.com.intellij.psi.PsiFile
+import org.jetbrains.kotlin.psi.UserDataProperty
 
-val RELATIVE_PATH: Key<String> = Key("relativePath")
-val BASE_PATH: Key<String> = Key("basePath")
-val LINE_SEPARATOR: Key<String> = Key("lineSeparator")
+var PsiFile.relativePath: String? by UserDataProperty(Key("relativePath"))
+var PsiFile.basePath: String? by UserDataProperty(Key("basePath"))
+var PsiFile.lineSeparator: String? by UserDataProperty(Key("lineSeparator"))

--- a/detekt-psi-utils/src/main/kotlin/io/github/detekt/psi/KtFiles.kt
+++ b/detekt-psi-utils/src/main/kotlin/io/github/detekt/psi/KtFiles.kt
@@ -42,10 +42,6 @@ instead.
 */
 fun PsiFile.absolutePath(): Path = absolutePath ?: Path(virtualFile.path)
 
-fun PsiFile.relativePath(): Path? = relativePath
-
-fun PsiFile.basePath(): Path? = basePath
-
 /**
  * Represents both absolute path and relative path if available.
  */
@@ -76,8 +72,6 @@ data class FilePath constructor(
 }
 
 fun PsiFile.toFilePath(): FilePath {
-    val relativePath = relativePath()
-    val basePath = basePath()
     return when {
         basePath != null && relativePath != null -> FilePath(
             absolutePath = absolutePath(),

--- a/detekt-psi-utils/src/main/kotlin/io/github/detekt/psi/KtFiles.kt
+++ b/detekt-psi-utils/src/main/kotlin/io/github/detekt/psi/KtFiles.kt
@@ -42,9 +42,9 @@ instead.
 */
 fun PsiFile.absolutePath(): Path = absolutePath ?: Path(virtualFile.path)
 
-fun PsiFile.relativePath(): Path? = relativePath?.let { Path(it) }
+fun PsiFile.relativePath(): Path? = relativePath
 
-fun PsiFile.basePath(): Path? = basePath?.let { Path(it) }
+fun PsiFile.basePath(): Path? = basePath
 
 /**
  * Represents both absolute path and relative path if available.

--- a/detekt-psi-utils/src/main/kotlin/io/github/detekt/psi/KtFiles.kt
+++ b/detekt-psi-utils/src/main/kotlin/io/github/detekt/psi/KtFiles.kt
@@ -42,9 +42,9 @@ instead.
 */
 fun PsiFile.absolutePath(): Path = absolutePath ?: Path(virtualFile.path)
 
-fun PsiFile.relativePath(): Path? = getUserData(RELATIVE_PATH)?.let { Path(it) }
+fun PsiFile.relativePath(): Path? = relativePath?.let { Path(it) }
 
-fun PsiFile.basePath(): Path? = getUserData(BASE_PATH)?.let { Path(it) }
+fun PsiFile.basePath(): Path? = basePath?.let { Path(it) }
 
 /**
  * Represents both absolute path and relative path if available.

--- a/detekt-report-html/src/test/kotlin/io/github/detekt/report/html/HtmlOutputReportSpec.kt
+++ b/detekt-report-html/src/test/kotlin/io/github/detekt/report/html/HtmlOutputReportSpec.kt
@@ -150,12 +150,12 @@ class HtmlOutputReportSpec {
     @Test
     fun `renders the complexity report correctly`() {
         val detektion = TestDetektion()
-        detektion.addData(complexityKey, 10)
-        detektion.addData(CognitiveComplexity.KEY, 10)
-        detektion.addData(sourceLinesKey, 20)
-        detektion.addData(logicalLinesKey, 10)
-        detektion.addData(commentLinesKey, 2)
-        detektion.addData(linesKey, 2222)
+        detektion.putUserData(complexityKey, 10)
+        detektion.putUserData(CognitiveComplexity.KEY, 10)
+        detektion.putUserData(sourceLinesKey, 20)
+        detektion.putUserData(logicalLinesKey, 10)
+        detektion.putUserData(commentLinesKey, 2)
+        detektion.putUserData(linesKey, 2222)
         val result = htmlReport.render(detektion)
         assertThat(result).contains("<li>2,222 lines of code (loc)</li>")
         assertThat(result).contains("<li>20 source lines of code (sloc)</li>")

--- a/detekt-report-md/src/test/kotlin/io/github/detekt/report/md/MdOutputReportSpec.kt
+++ b/detekt-report-md/src/test/kotlin/io/github/detekt/report/md/MdOutputReportSpec.kt
@@ -204,12 +204,12 @@ private fun createTestDetektionWithMultipleSmells(): Detektion {
             createFinding(issueB, entity3, "")
         )
     ).also {
-        it.addData(complexityKey, 10)
-        it.addData(CognitiveComplexity.KEY, 10)
-        it.addData(sourceLinesKey, 20)
-        it.addData(logicalLinesKey, 10)
-        it.addData(commentLinesKey, 2)
-        it.addData(linesKey, 2222)
+        it.putUserData(complexityKey, 10)
+        it.putUserData(CognitiveComplexity.KEY, 10)
+        it.putUserData(sourceLinesKey, 20)
+        it.putUserData(logicalLinesKey, 10)
+        it.putUserData(commentLinesKey, 2)
+        it.putUserData(linesKey, 2222)
     }
 }
 

--- a/detekt-sample-extensions/src/main/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/processors/QualifiedNameProcessor.kt
+++ b/detekt-sample-extensions/src/main/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/processors/QualifiedNameProcessor.kt
@@ -23,7 +23,7 @@ class QualifiedNameProcessor : FileProcessListener {
         val fqNames = files
             .mapNotNull { it.getUserData(fqNamesKey) }
             .flatMapTo(HashSet()) { it }
-        result.addData(fqNamesKey, fqNames)
+        result.putUserData(fqNamesKey, fqNames)
     }
 
     class ClassNameVisitor : DetektVisitor() {

--- a/detekt-sample-extensions/src/main/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/reports/Reports.kt
+++ b/detekt-sample-extensions/src/main/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/reports/Reports.kt
@@ -4,7 +4,7 @@ import io.gitlab.arturbosch.detekt.api.Detektion
 import io.gitlab.arturbosch.detekt.sample.extensions.processors.fqNamesKey
 
 fun qualifiedNamesReport(detektion: Detektion): String? {
-    val fqNames = detektion.getData(fqNamesKey)
+    val fqNames = detektion.getUserData(fqNamesKey)
     if (fqNames.isNullOrEmpty()) return null
 
     return with(StringBuilder()) {

--- a/detekt-sample-extensions/src/test/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/processors/QualifiedNameProcessorSpec.kt
+++ b/detekt-sample-extensions/src/test/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/processors/QualifiedNameProcessorSpec.kt
@@ -6,8 +6,7 @@ import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.api.Notification
 import io.gitlab.arturbosch.detekt.api.ProjectMetric
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.kotlin.com.intellij.openapi.util.Key
-import org.jetbrains.kotlin.com.intellij.util.keyFMap.KeyFMap
+import org.jetbrains.kotlin.com.intellij.openapi.util.UserDataHolderBase
 import org.jetbrains.kotlin.resolve.BindingContext
 import org.junit.jupiter.api.Test
 
@@ -20,7 +19,7 @@ class QualifiedNameProcessorSpec {
         processor.onProcess(ktFile, BindingContext.EMPTY)
         processor.onFinish(listOf(ktFile), result, BindingContext.EMPTY)
 
-        val data = result.getData(fqNamesKey)
+        val data = result.getUserData(fqNamesKey)
         assertThat(data).contains(
             "io.gitlab.arturbosch.detekt.sample.Foo",
             "io.gitlab.arturbosch.detekt.sample.Bar",
@@ -29,18 +28,11 @@ class QualifiedNameProcessorSpec {
     }
 }
 
-private val result = object : Detektion {
+private val result = object : Detektion, UserDataHolderBase() {
 
     override val findings: Map<String, List<Finding>> = emptyMap()
     override val notifications: Collection<Notification> = emptyList()
     override val metrics: Collection<ProjectMetric> = emptyList()
-
-    private var userData = KeyFMap.EMPTY_MAP
-    override fun <V> getData(key: Key<V>): V? = userData[key]
-
-    override fun <V> addData(key: Key<V>, value: V) {
-        userData = userData.plus(key, requireNotNull(value))
-    }
 
     override fun add(notification: Notification) {
         throw UnsupportedOperationException("not implemented")

--- a/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/internal/EmptyContainer.kt
+++ b/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/internal/EmptyContainer.kt
@@ -13,8 +13,8 @@ object EmptyContainer : Detektion {
     override val notifications: Collection<Notification> = emptyList()
     override val metrics: Collection<ProjectMetric> = emptyList()
 
-    override fun <V> getData(key: Key<V>): V? = throw UnsupportedOperationException()
-    override fun <V> addData(key: Key<V>, value: V) = throw UnsupportedOperationException()
+    override fun <V> getUserData(key: Key<V>): V? = throw UnsupportedOperationException()
+    override fun <V> putUserData(key: Key<V>, value: V?) = throw UnsupportedOperationException()
     override fun add(notification: Notification) = throw UnsupportedOperationException()
     override fun add(projectMetric: ProjectMetric) = throw UnsupportedOperationException()
 }


### PR DESCRIPTION
Use `UserDataHolder` interface and some of the available extension properties as well as `UserDataHolderBase` base class to simplify storing metadata with KtFiles.