### PR TITLE
Deprecate OptionalWhenBraces rule

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -662,8 +662,6 @@ style:
     active: true
   OptionalUnit:
     active: false
-  OptionalWhenBraces:
-    active: false
   PreferToOverPairSyntax:
     active: false
   ProtectedMemberInFinalClass:

--- a/detekt-core/src/main/resources/deprecation.properties
+++ b/detekt-core/src/main/resources/deprecation.properties
@@ -22,6 +22,7 @@ style>FunctionOnlyReturningConstant>excludeAnnotatedFunction=Use `ignoreAnnotate
 style>LibraryCodeMustSpecifyReturnType=Rule migrated to `libraries` ruleset plugin
 style>LibraryEntitiesShouldNotBePublic=Rule migrated to `libraries` ruleset plugin
 style>MandatoryBracesIfStatements=Use `BracesOnIfStatements` with `always` configuration instead
+style>OptionalWhenBraces=Same functionality is implemented in BracesOnWhenStatements
 style>UnderscoresInNumericLiterals>acceptableDecimalLength=Use `acceptableLength` instead
 style>UnnecessaryAbstractClass>excludeAnnotatedClasses=Use `ignoreAnnotated` instead
 style>UseDataClass>excludeAnnotatedClasses=Use `ignoreAnnotated` instead

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/OptionalWhenBraces.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/OptionalWhenBraces.kt
@@ -33,6 +33,7 @@ import org.jetbrains.kotlin.psi.psiUtil.allChildren
  * }
  * </compliant>
  */
+@Deprecated("Same functionality is implemented in BracesOnWhenStatements")
 class OptionalWhenBraces(config: Config = Config.empty) : Rule(config) {
 
     override val issue: Issue = Issue(

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/StyleGuideProvider.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/StyleGuideProvider.kt
@@ -19,7 +19,7 @@ class StyleGuideProvider : DefaultRuleSetProvider {
 
     override val ruleSetId: String = "style"
 
-    @Suppress("LongMethod")
+    @Suppress("LongMethod", "DEPRECATION")
     override fun instance(config: Config): RuleSet = RuleSet(
         ruleSetId,
         listOf(

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/OptionalWhenBracesSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/OptionalWhenBracesSpec.kt
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 class OptionalWhenBracesSpec {
+    @Suppress("DEPRECATION")
     val subject = OptionalWhenBraces()
 
     @Test


### PR DESCRIPTION
Part of #6153.

`OptionalWhenBraces` is not needed anymore, because the new rule `BracesOnWhenStatements` implements the same functionality.

Deprecated for release/1.x branch.