### PR TITLE
Remove withAutoCorrect from ConfigAware

### DIFF
--- a/detekt-api/api/detekt-api.api
+++ b/detekt-api/api/detekt-api.api
@@ -102,7 +102,6 @@ public abstract interface class io/gitlab/arturbosch/detekt/api/ConfigAware : io
 	public abstract fun subConfig (Ljava/lang/String;)Lio/gitlab/arturbosch/detekt/api/Config;
 	public abstract fun valueOrDefault (Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun valueOrNull (Ljava/lang/String;)Ljava/lang/Object;
-	public abstract fun withAutoCorrect (Lkotlin/jvm/functions/Function0;)V
 }
 
 public final class io/gitlab/arturbosch/detekt/api/ConfigAware$DefaultImpls {
@@ -112,7 +111,6 @@ public final class io/gitlab/arturbosch/detekt/api/ConfigAware$DefaultImpls {
 	public static fun subConfig (Lio/gitlab/arturbosch/detekt/api/ConfigAware;Ljava/lang/String;)Lio/gitlab/arturbosch/detekt/api/Config;
 	public static fun valueOrDefault (Lio/gitlab/arturbosch/detekt/api/ConfigAware;Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun valueOrNull (Lio/gitlab/arturbosch/detekt/api/ConfigAware;Ljava/lang/String;)Ljava/lang/Object;
-	public static fun withAutoCorrect (Lio/gitlab/arturbosch/detekt/api/ConfigAware;Lkotlin/jvm/functions/Function0;)V
 }
 
 public final class io/gitlab/arturbosch/detekt/api/ConfigPropertyKt {
@@ -494,7 +492,6 @@ public abstract class io/gitlab/arturbosch/detekt/api/Rule : io/gitlab/arturbosc
 	public fun valueOrDefault (Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun valueOrNull (Ljava/lang/String;)Ljava/lang/Object;
 	public fun visitCondition (Lorg/jetbrains/kotlin/psi/KtFile;)Z
-	public fun withAutoCorrect (Lkotlin/jvm/functions/Function0;)V
 }
 
 public final class io/gitlab/arturbosch/detekt/api/RuleSet {

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/ConfigAware.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/ConfigAware.kt
@@ -47,17 +47,6 @@ interface ConfigAware : Config {
      */
     val active: Boolean get() = valueOrDefault(Config.ACTIVE_KEY, false)
 
-    /**
-     * If your rule supports to automatically correct the misbehaviour of underlying smell,
-     * specify your code inside this method call, to allow the user of your rule to trigger auto correction
-     * only when needed.
-     */
-    fun withAutoCorrect(block: () -> Unit) {
-        if (autoCorrect) {
-            block()
-        }
-    }
-
     override fun subConfig(key: String): Config =
         ruleConfig.subConfig(key)
 

--- a/website/docs/introduction/extensions.md
+++ b/website/docs/introduction/extensions.md
@@ -247,9 +247,3 @@ after your extension sub project is built.
 you created a pure kotlin module which has no Android dependencies. `apply plugin: "kotlin"` is enough to make it work.
 - Sometimes when you run detekt task, you may not see the violations detected by your custom rules. In this case open a terminal and run
 `./gradlew --stop` to stop gradle daemons and run the task again.
-
-#### autoCorrect property
-
-In detekt you can write custom rules which can manipulate your code base.
-For this a cli flag `--auto-correct` and the gradle plugin property `autoCorrect` exists.
-Only write auto correcting code within the `Rule#withAutoCorrect()`-function.


### PR DESCRIPTION
This is not called by detekt at any point, so should be removed from the API.