### PR TITLE
Fix Gradle 8.3 deprecation of Project#getBuildDir

### DIFF
--- a/build-logic/src/main/kotlin/releasing.gradle.kts
+++ b/build-logic/src/main/kotlin/releasing.gradle.kts
@@ -37,16 +37,14 @@ githubRelease {
             changelog.trim()
         }
     )
-    val cliBuildDir = project(":detekt-cli").buildDir
+    val cliBuildDir = project(":detekt-cli").layout.buildDirectory
     releaseAssets.setFrom(
-        cliBuildDir.resolve("libs/detekt-cli-$version-all.jar"),
-        cliBuildDir.resolve("distributions/detekt-cli-$version.zip"),
-        project(":detekt-formatting").buildDir.resolve("libs/detekt-formatting-$version.jar"),
-        project(":detekt-generator").buildDir.resolve("libs/detekt-generator-$version-all.jar"),
-        project(":detekt-rules-libraries").buildDir
-            .resolve("libs/detekt-rules-libraries-$version.jar"),
-        project(":detekt-rules-ruleauthors").buildDir
-            .resolve("libs/detekt-rules-ruleauthors-$version.jar")
+        cliBuildDir.file("libs/detekt-cli-$version-all.jar"),
+        cliBuildDir.file("distributions/detekt-cli-$version.zip"),
+        project(":detekt-formatting").layout.buildDirectory.file("libs/detekt-formatting-$version.jar"),
+        project(":detekt-generator").layout.buildDirectory.file("libs/detekt-generator-$version-all.jar"),
+        project(":detekt-rules-libraries").layout.buildDirectory.file("libs/detekt-rules-libraries-$version.jar"),
+        project(":detekt-rules-ruleauthors").layout.buildDirectory.file("libs/detekt-rules-ruleauthors-$version.jar")
     )
 }
 

--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -133,7 +133,7 @@ tasks {
     val writeDetektVersionProperties by registering(WriteProperties::class) {
         description = "Write the properties file with the detekt version to be used by the plugin."
         encoding = "UTF-8"
-        destinationFile = file("$buildDir/detekt-versions.properties")
+        destinationFile = layout.buildDirectory.file("detekt-versions.properties")
         property("detektVersion", project.version)
         property("detektCompilerPluginVersion", project.version)
     }


### PR DESCRIPTION
This will fail the build on the upgrade to Gradle 8.3 since we fail on warnings.