### PR TITLE
Prepare Detekt 1.23.1

### DIFF
--- a/build-logic/src/main/kotlin/Versions.kt
+++ b/build-logic/src/main/kotlin/Versions.kt
@@ -2,7 +2,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 object Versions {
 
-    const val DETEKT: String = "1.23.0"
+    const val DETEKT: String = "1.23.1"
     const val SNAPSHOT_NAME: String = "main"
     val JVM_TARGET: JvmTarget = JvmTarget.JVM_1_8
 


### PR DESCRIPTION
We're making a `1.23` point release to add support for Kotlin 1.9, Java 20 and fix some of the issues that got reported on 1.23.
