### PR TITLE
Fix #6334: githubRelease.releaseAssets: migrate from hardcoded paths to cross-project artifact dependencies

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -8,10 +8,10 @@ repositories {
 }
 
 dependencies {
-    implementation(libs.kotlin.gradle)
-    implementation(libs.githubRelease.gradle)
-    implementation(libs.semver4j.gradle)
-    implementation(libs.nexusPublish.gradle)
+    implementation(libs.plugins.kotlin.asDependency())
+    implementation(libs.plugins.githubRelease.asDependency())
+    implementation(libs.semver4j)
+    implementation(libs.plugins.nexusPublish.asDependency())
 }
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
@@ -23,3 +23,6 @@ tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach 
         allWarningsAsErrors = providers.gradleProperty("warningsAsErrors").orNull.toBoolean()
     }
 }
+
+fun Provider<PluginDependency>.asDependency(): Provider<String> =
+    this.map { "${it.pluginId}:${it.pluginId}.gradle.plugin:${it.version}" }

--- a/build-logic/src/main/kotlin/releasing.gradle.kts
+++ b/build-logic/src/main/kotlin/releasing.gradle.kts
@@ -16,6 +16,11 @@ nexusPublishing {
     }
 }
 
+val releaseArtifacts: Configuration by configurations.creating {
+    isCanBeConsumed = false
+    isCanBeResolved = true
+}
+
 val version = Versions.currentOrSnapshot()
 
 githubRelease {
@@ -37,15 +42,31 @@ githubRelease {
             changelog.trim()
         }
     )
-    val cliBuildDir = project(":detekt-cli").layout.buildDirectory
-    releaseAssets.setFrom(
-        cliBuildDir.file("libs/detekt-cli-$version-all.jar"),
-        cliBuildDir.file("distributions/detekt-cli-$version.zip"),
-        project(":detekt-formatting").layout.buildDirectory.file("libs/detekt-formatting-$version.jar"),
-        project(":detekt-generator").layout.buildDirectory.file("libs/detekt-generator-$version-all.jar"),
-        project(":detekt-rules-libraries").layout.buildDirectory.file("libs/detekt-rules-libraries-$version.jar"),
-        project(":detekt-rules-ruleauthors").layout.buildDirectory.file("libs/detekt-rules-ruleauthors-$version.jar")
-    )
+    releaseAssets.setFrom(releaseArtifacts)
+}
+
+dependencies {
+    releaseArtifacts(project(":detekt-cli")) {
+        targetConfiguration = "shadow" // com.github.jengelman.gradle.plugins.shadow.ShadowBasePlugin.CONFIGURATION_NAME
+    }
+    releaseArtifacts(project(":detekt-cli")) {
+        targetConfiguration = "shadowDist"
+    }
+    releaseArtifacts(project(":detekt-generator")) {
+        targetConfiguration = "shadow" // com.github.jengelman.gradle.plugins.shadow.ShadowBasePlugin.CONFIGURATION_NAME
+    }
+    releaseArtifacts(project(":detekt-formatting")) {
+        targetConfiguration = Dependency.DEFAULT_CONFIGURATION
+        isTransitive = false
+    }
+    releaseArtifacts(project(":detekt-rules-libraries")) {
+        targetConfiguration = Dependency.DEFAULT_CONFIGURATION
+        isTransitive = false
+    }
+    releaseArtifacts(project(":detekt-rules-ruleauthors")) {
+        targetConfiguration = Dependency.DEFAULT_CONFIGURATION
+        isTransitive = false
+    }
 }
 
 fun updateVersion(increment: (Semver) -> Semver) {

--- a/detekt-cli/build.gradle.kts
+++ b/detekt-cli/build.gradle.kts
@@ -113,3 +113,9 @@ tasks {
 
     artifacts.add(generatedCliUsage.name, cliUsage)
 }
+
+val shadowDist: Configuration by configurations.creating {
+    isCanBeConsumed = true
+    isCanBeResolved = false
+}
+artifacts.add(shadowDist.name, tasks.shadowDistZip)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,9 +6,7 @@ ktlint = "0.50.0"
 junit = "5.10.0"
 
 [libraries]
-githubRelease-gradle = "com.github.breadmoirai:github-release:2.4.1"
-nexusPublish-gradle = "io.github.gradle-nexus:publish-plugin:1.3.0"
-semver4j-gradle = "com.vdurmont:semver4j:3.1.0"
+semver4j = "com.vdurmont:semver4j:3.1.0"
 
 kotlin-compiler = { module = "org.jetbrains.kotlin:kotlin-compiler", version.ref = "kotlin" }
 kotlin-compilerEmbeddable = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable", version.ref = "kotlin" }
@@ -44,9 +42,12 @@ jcommander = "com.beust:jcommander:1.82"
 kotlinCompileTesting = { module = "com.github.tschuchortdev:kotlin-compile-testing", version = "1.5.0" }
 
 [plugins]
+kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 binaryCompatibilityValidator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version = "0.13.2" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 download = { id = "de.undercouch.download", version = "5.4.0" }
 gradleVersions = { id = "com.github.ben-manes.versions", version = "0.47.0" }
 pluginPublishing = { id = "com.gradle.plugin-publish", version = "1.2.0" }
+nexusPublish = { id = "io.github.gradle-nexus.publish-plugin", version = "1.3.0" }
 shadow = { id = "com.github.johnrengelman.shadow", version = "8.1.1" }
+githubRelease = { id = "com.github.breadmoirai.github-release", version = "2.4.1" }

--- a/website/blog/2020-09-27-additional-diff-config-task.md
+++ b/website/blog/2020-09-27-additional-diff-config-task.md
@@ -28,7 +28,7 @@ import io.gitlab.arturbosch.detekt.DetektGenerateConfigTask
 
 val createDetektConfigForDiff by tasks.registering(DetektGenerateConfigTask::class) {
     description = "Generate newest default detekt config"
-    config.setFrom(buildDir.resolve("detekt-diff.yaml"))
+    config.setFrom(layout.buildDirectory.file("detekt-diff.yaml"))
 
     doFirst {
       // optionally delete the old config diff file first 

--- a/website/versioned_docs/version-1.21.0/introduction/reporting.md
+++ b/website/versioned_docs/version-1.21.0/introduction/reporting.md
@@ -113,7 +113,7 @@ subprojects {
 
 ```kotlin
 val reportMerge by tasks.registering(io.gitlab.arturbosch.detekt.report.ReportMergeTask::class) { 
-  output.set(rootProject.buildDir.resolve("reports/detekt/merge.xml")) // or "reports/detekt/merge.sarif"
+  output.set(rootProject.layout.buildDirectory.file("reports/detekt/merge.xml")) // or "reports/detekt/merge.sarif"
 }
 
 subprojects {


### PR DESCRIPTION
Fixes #6334

Testing: `gradlew githubRelease -Pgithub.token=... --console=verbose`

<details><summary>release/1.x</summary>

```
> Task :githubRelease
:githubRelease [This task is a dry run. All API calls that would modify the repo are disabled. API calls that access the repo information are not disabled. Use this to show what actions would be executed.]
:githubRelease [CHECKING FOR PREVIOUS RELEASE]
:githubRelease [EXISTING RELEASE FOUND https://github.com/detekt/detekt/releases/tag/v1.23.1]
:githubRelease [DELETING RELEASE v1.23.1]
:githubRelease [CREATING NEW RELEASE
{
    tag_name               = v1.23.1
    target_commitish       = main
    name                   = v1.23.1
    generate_release_notes = false
    body                   = <omitted>
    draft                  = true
    prerelease             = true
}]
:githubRelease [UPLOADING P:\projects\contrib\github-detekt\detekt-cli\build\libs\detekt-cli-1.23.1-all.jar]
:githubRelease [UPLOADING P:\projects\contrib\github-detekt\detekt-cli\build\distributions\detekt-cli-1.23.1.zip]
:githubRelease [UPLOADING P:\projects\contrib\github-detekt\detekt-formatting\build\libs\detekt-formatting-1.23.1.jar]
:githubRelease [UPLOADING P:\projects\contrib\github-detekt\detekt-generator\build\libs\detekt-generator-1.23.1-all.jar]
:githubRelease [UPLOADING P:\projects\contrib\github-detekt\detekt-rules-libraries\build\libs\detekt-rules-libraries-1.23.1.jar]
:githubRelease [UPLOADING P:\projects\contrib\github-detekt\detekt-rules-ruleauthors\build\libs\detekt-rules-ruleauthors-1.23.1.jar]

BUILD SUCCESSFUL in 1s
1 actionable task: 1 executed

```

</details>

<details><summary>This branch</summary>

<details><summary>All the tasks that are added because the artifacts are now being built.</summary>

```
> Task :detekt-psi-utils:processResources NO-SOURCE
> Task :detekt-metrics:processResources NO-SOURCE
> Task :detekt-parser:processResources NO-SOURCE
> Task :detekt-api:processResources NO-SOURCE
> Task :detekt-rules:processResources NO-SOURCE
> Task :detekt-rules:compileKotlin NO-SOURCE
> Task :detekt-utils:processResources NO-SOURCE
> Task :detekt-tooling:processResources NO-SOURCE
> Task :detekt-rules-exceptions:processResources UP-TO-DATE
> Task :detekt-cli:processResources UP-TO-DATE
> Task :detekt-rules-errorprone:processResources UP-TO-DATE
> Task :detekt-report-txt:processResources UP-TO-DATE
> Task :detekt-rules-coroutines:processResources UP-TO-DATE
> Task :detekt-report-sarif:processResources UP-TO-DATE
> Task :detekt-rules-documentation:processResources UP-TO-DATE
> Task :detekt-rules-complexity:processResources UP-TO-DATE
> Task :detekt-rules-empty:processResources UP-TO-DATE
> Task :detekt-report-xml:processResources UP-TO-DATE
> Task :detekt-report-md:processResources UP-TO-DATE
> Task :detekt-generator:processResources NO-SOURCE
> Task :detekt-rules-naming:processResources UP-TO-DATE
> Task :detekt-core:processResources UP-TO-DATE
> Task :detekt-rules-performance:processResources UP-TO-DATE
> Task :detekt-rules-style:processResources UP-TO-DATE
> Task :detekt-report-html:processResources UP-TO-DATE
> Task :detekt-rules-libraries:sourcesJar UP-TO-DATE
> Task :detekt-rules:compileJava NO-SOURCE
> Task :detekt-rules-ruleauthors:sourcesJar UP-TO-DATE
> Task :detekt-rules:classes UP-TO-DATE
> Task :detekt-utils:compileKotlin UP-TO-DATE
> Task :detekt-psi-utils:compileKotlin UP-TO-DATE
> Task :detekt-utils:compileJava NO-SOURCE
> Task :detekt-psi-utils:compileJava NO-SOURCE
> Task :detekt-rules:jar UP-TO-DATE
> Task :detekt-psi-utils:classes UP-TO-DATE
> Task :detekt-utils:classes UP-TO-DATE
> Task :detekt-utils:jar UP-TO-DATE
> Task :detekt-psi-utils:jar UP-TO-DATE
> Task :detekt-parser:compileKotlin UP-TO-DATE
> Task :detekt-api:compileKotlin UP-TO-DATE
> Task :detekt-parser:compileJava NO-SOURCE
> Task :detekt-api:compileJava NO-SOURCE
> Task :detekt-api:classes UP-TO-DATE
> Task :detekt-parser:classes UP-TO-DATE
> Task :detekt-api:jar UP-TO-DATE
> Task :detekt-parser:jar UP-TO-DATE
> Task :detekt-report-txt:compileKotlin UP-TO-DATE
> Task :detekt-report-xml:compileKotlin UP-TO-DATE
> Task :detekt-rules-ruleauthors:compileKotlin UP-TO-DATE
> Task :detekt-metrics:compileKotlin UP-TO-DATE
> Task :detekt-rules-coroutines:compileKotlin UP-TO-DATE
> Task :detekt-rules-documentation:compileKotlin UP-TO-DATE
> Task :detekt-rules-empty:compileKotlin UP-TO-DATE
> Task :detekt-tooling:compileKotlin UP-TO-DATE
> Task :detekt-rules-naming:compileKotlin UP-TO-DATE
> Task :detekt-rules-libraries:compileKotlin UP-TO-DATE
> Task :detekt-rules-performance:compileKotlin UP-TO-DATE
> Task :detekt-rules-exceptions:compileKotlin UP-TO-DATE
> Task :detekt-formatting:compileKotlin UP-TO-DATE
> Task :detekt-report-txt:compileJava NO-SOURCE
> Task :detekt-report-xml:compileJava NO-SOURCE
> Task :detekt-report-xml:classes UP-TO-DATE
> Task :detekt-rules-coroutines:compileJava NO-SOURCE
> Task :detekt-rules-exceptions:compileJava NO-SOURCE
> Task :detekt-rules-documentation:compileJava NO-SOURCE
> Task :detekt-formatting:compileJava NO-SOURCE
> Task :detekt-rules-performance:compileJava NO-SOURCE
> Task :detekt-rules-naming:compileJava NO-SOURCE
> Task :detekt-report-txt:classes UP-TO-DATE
> Task :detekt-rules-ruleauthors:compileJava NO-SOURCE
> Task :detekt-rules-coroutines:classes UP-TO-DATE
> Task :detekt-rules-documentation:classes UP-TO-DATE
> Task :detekt-tooling:compileJava NO-SOURCE
> Task :detekt-tooling:classes UP-TO-DATE
> Task :detekt-metrics:compileJava NO-SOURCE
> Task :detekt-metrics:classes UP-TO-DATE
> Task :detekt-rules-exceptions:classes UP-TO-DATE
> Task :detekt-rules-performance:classes UP-TO-DATE
> Task :detekt-rules-naming:classes UP-TO-DATE
> Task :detekt-rules-empty:compileJava NO-SOURCE
> Task :detekt-rules-libraries:compileJava NO-SOURCE
> Task :detekt-rules-documentation:jar UP-TO-DATE
> Task :detekt-rules-empty:classes UP-TO-DATE
> Task :detekt-rules-coroutines:jar UP-TO-DATE
> Task :detekt-rules-performance:jar UP-TO-DATE
> Task :detekt-report-xml:jar UP-TO-DATE
> Task :detekt-rules-exceptions:jar UP-TO-DATE
> Task :detekt-metrics:jar UP-TO-DATE
> Task :detekt-tooling:jar UP-TO-DATE
> Task :detekt-report-sarif:compileKotlin UP-TO-DATE
> Task :detekt-report-txt:jar UP-TO-DATE
> Task :detekt-cli:compileKotlin UP-TO-DATE
> Task :detekt-rules-errorprone:compileKotlin UP-TO-DATE
> Task :detekt-rules-naming:jar UP-TO-DATE
> Task :detekt-rules-empty:jar UP-TO-DATE
> Task :detekt-report-sarif:compileJava NO-SOURCE
> Task :detekt-cli:compileJava NO-SOURCE
> Task :detekt-cli:classes UP-TO-DATE
> Task :detekt-rules-errorprone:compileJava NO-SOURCE
> Task :detekt-report-sarif:classes UP-TO-DATE
> Task :detekt-report-html:compileKotlin UP-TO-DATE
> Task :detekt-rules-errorprone:classes UP-TO-DATE
> Task :detekt-cli:jar UP-TO-DATE
> Task :detekt-rules-style:compileKotlin UP-TO-DATE
> Task :detekt-rules-complexity:compileKotlin UP-TO-DATE
> Task :detekt-report-md:compileKotlin UP-TO-DATE
> Task :detekt-report-sarif:jar UP-TO-DATE
> Task :detekt-report-html:compileJava NO-SOURCE
> Task :detekt-report-html:classes UP-TO-DATE
> Task :detekt-report-md:compileJava NO-SOURCE
> Task :detekt-rules-complexity:compileJava NO-SOURCE
> Task :detekt-report-md:classes UP-TO-DATE
> Task :detekt-rules-style:compileJava NO-SOURCE
> Task :detekt-rules-style:classes UP-TO-DATE
> Task :detekt-rules-errorprone:jar UP-TO-DATE
> Task :detekt-report-html:jar UP-TO-DATE
> Task :detekt-generator:compileKotlin UP-TO-DATE
> Task :detekt-rules-complexity:classes UP-TO-DATE
> Task :detekt-report-md:jar UP-TO-DATE
> Task :detekt-rules-style:jar UP-TO-DATE
> Task :detekt-generator:compileJava NO-SOURCE
> Task :detekt-rules-complexity:jar UP-TO-DATE
> Task :detekt-generator:classes UP-TO-DATE
> Task :detekt-core:compileKotlin UP-TO-DATE
> Task :detekt-core:compileJava NO-SOURCE
> Task :detekt-core:classes UP-TO-DATE
> Task :detekt-core:jar UP-TO-DATE
> Task :detekt-generator:shadowJar UP-TO-DATE
> Task :detekt-cli:shadowJar UP-TO-DATE
> Task :detekt-generator:generateDocumentation UP-TO-DATE
> Task :detekt-cli:startShadowScripts UP-TO-DATE
> Task :detekt-rules-ruleauthors:processResources UP-TO-DATE
> Task :detekt-rules-libraries:processResources UP-TO-DATE
> Task :detekt-rules-libraries:classes UP-TO-DATE
> Task :detekt-cli:shadowDistZip UP-TO-DATE
> Task :detekt-rules-ruleauthors:classes UP-TO-DATE
> Task :detekt-formatting:processResources UP-TO-DATE
> Task :detekt-formatting:classes UP-TO-DATE
> Task :detekt-rules-libraries:jar UP-TO-DATE
> Task :detekt-rules-ruleauthors:jar UP-TO-DATE
> Task :detekt-formatting:jar UP-TO-DATE
```

</details>

```
> Task :githubRelease
:githubRelease [This task is a dry run. All API calls that would modify the repo are disabled. API calls that access the repo information are not disabled. Use this to show what actions would be executed.]
:githubRelease [CHECKING FOR PREVIOUS RELEASE]
:githubRelease [EXISTING RELEASE FOUND https://github.com/detekt/detekt/releases/tag/v1.23.1]
:githubRelease [DELETING RELEASE v1.23.1]
:githubRelease [CREATING NEW RELEASE
{
    tag_name               = v1.23.1
    target_commitish       = main
    name                   = v1.23.1
    generate_release_notes = false
    body                   = <omitted>
    draft                  = true
    prerelease             = true
}]
:githubRelease [UPLOADING P:\projects\contrib\github-detekt\detekt-cli\build\libs\detekt-cli-1.23.1-all.jar]
:githubRelease [UPLOADING P:\projects\contrib\github-detekt\detekt-cli\build\distributions\detekt-cli-1.23.1.zip]
:githubRelease [UPLOADING P:\projects\contrib\github-detekt\detekt-generator\build\libs\detekt-generator-1.23.1-all.jar]
:githubRelease [UPLOADING P:\projects\contrib\github-detekt\detekt-formatting\build\libs\detekt-formatting-1.23.1.jar]
:githubRelease [UPLOADING P:\projects\contrib\github-detekt\detekt-rules-libraries\build\libs\detekt-rules-libraries-1.23.1.jar]
:githubRelease [UPLOADING P:\projects\contrib\github-detekt\detekt-rules-ruleauthors\build\libs\detekt-rules-ruleauthors-1.23.1.jar]

BUILD SUCCESSFUL in 1s
79 actionable tasks: 1 executed, 78 up-to-date
```

</details>