### PR TITLE
Detekt Gradle Plugin should no longer use an invalid cache

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/ClassLoaderCache.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/ClassLoaderCache.kt
@@ -4,8 +4,9 @@ import org.gradle.api.file.FileCollection
 import java.net.URLClassLoader
 import java.util.concurrent.ConcurrentHashMap
 
-fun interface ClassLoaderCache {
+interface ClassLoaderCache {
 
+    fun invalidate(classpath: FileCollection)
     fun getOrCreate(classpath: FileCollection): URLClassLoader
 }
 
@@ -13,9 +14,18 @@ internal class DefaultClassLoaderCache : ClassLoaderCache {
 
     private val classpathFilesHashWithLoaders = ConcurrentHashMap<Int, URLClassLoader>()
 
+    private fun getHashCode(classpath: FileCollection): Int {
+        val classpathFiles = classpath.files
+        return HashSet(classpathFiles).hashCode()
+    }
+
+    override fun invalidate(classpath: FileCollection) {
+        classpathFilesHashWithLoaders.remove(getHashCode(classpath))
+    }
+
     override fun getOrCreate(classpath: FileCollection): URLClassLoader {
         val classpathFiles = classpath.files
-        val classpathHashCode = HashSet(classpathFiles).hashCode()
+        val classpathHashCode = getHashCode(classpath)
         return classpathFilesHashWithLoaders.getOrPut(classpathHashCode) {
             URLClassLoader(
                 classpathFiles.map { it.toURI().toURL() }.toTypedArray(),


### PR DESCRIPTION
Detekt Gradle Plugin uses an invalid Class loader cache and an invalid JarFile cache. Once the Jar is modified, the cache should be invalidated, or some should be disabled.

The Service API uses `URL`, which leads to using `JarFileFactory` on handing jars, with no convenient way of modifying whether the Jar file should be cached. As the code in ServiceLoader is already written for `openStream()` to occur at all times, the practical solution is to disable cache process-wide. 

This only occurs on DetektInvoker and isn't an issue with the Worker API. 

- fixes #2957 ([Way to reproduce](https://github.com/detekt/detekt/issues/2957#issuecomment-1132145945))
- fixes #3396 

#2582 & #2411 re-occurred, and this should fix it again with the `InputChanges` API