### PR TITLE
Mark `ImplicitDefaultLocale` rule to require type resolution.

### DIFF
--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ImplicitDefaultLocale.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ImplicitDefaultLocale.kt
@@ -8,6 +8,7 @@ import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
+import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import org.jetbrains.kotlin.builtins.KotlinBuiltIns.isStringOrNullableString
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
@@ -42,8 +43,8 @@ import org.jetbrains.kotlin.resolve.calls.util.getType
  * str.toLowerCase(Locale.US)
  * </compliant>
  */
-@Suppress("ViolatesTypeResolutionRequirements")
 @ActiveByDefault(since = "1.16.0")
+@RequiresTypeResolution
 class ImplicitDefaultLocale(config: Config = Config.empty) : Rule(config) {
 
     override val issue = Issue(


### PR DESCRIPTION
This marks the rule to require type resolution to avoid different behavior when run with and without type resolution. 

Previously the rule detected violating usages of `String.format` with and without type resolution but violating usages of  `toLowerCase` and `toUpperCase` where only detected with type resolution.

This relates to #2994 