### PR TITLE
Mark `MemberNameEqualsClassName` rule to require type resolution.

### DIFF
--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MemberNameEqualsClassName.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MemberNameEqualsClassName.kt
@@ -12,6 +12,7 @@ import io.gitlab.arturbosch.detekt.api.config
 import io.gitlab.arturbosch.detekt.api.configWithFallback
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
 import io.gitlab.arturbosch.detekt.api.internal.Configuration
+import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.rules.isOverride
 import org.jetbrains.kotlin.psi.KtBlockExpression
 import org.jetbrains.kotlin.psi.KtClass
@@ -52,7 +53,7 @@ import org.jetbrains.kotlin.resolve.BindingContext
  * }
  * </compliant>
  */
-@Suppress("ViolatesTypeResolutionRequirements")
+@RequiresTypeResolution
 @ActiveByDefault(since = "1.2.0")
 class MemberNameEqualsClassName(config: Config = Config.empty) : Rule(config) {
 

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MemberNameEqualsClassNameSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MemberNameEqualsClassNameSpec.kt
@@ -7,7 +7,6 @@ import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
-import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
@@ -267,9 +266,8 @@ class MemberNameEqualsClassNameSpec(val env: KotlinCoreEnvironment) {
             assertThat(MemberNameEqualsClassName().compileAndLintWithContext(env, code)).isEmpty()
         }
 
-        @Nested
-        @DisplayName("doesn't report a body-less factory function")
-        inner class IgnoreBodylessFactoryFunction {
+        @Test
+        fun `doesn't report a body-less factory function`() {
             val code = """
                 open class A {
                   companion object {
@@ -282,15 +280,7 @@ class MemberNameEqualsClassNameSpec(val env: KotlinCoreEnvironment) {
                 class C: A()
             """.trimIndent()
 
-            @Test
-            fun `with type solving`() {
-                assertThat(MemberNameEqualsClassName().compileAndLintWithContext(env, code)).isEmpty()
-            }
-
-            @Test
-            fun `without type solving`() {
-                assertThat(MemberNameEqualsClassName().compileAndLint(code)).isEmpty()
-            }
+            assertThat(MemberNameEqualsClassName().compileAndLintWithContext(env, code)).isEmpty()
         }
     }
 }


### PR DESCRIPTION
relates to #2994 

This rule had a mixed behavior. With type resolution the rule would flag factory methods with the name of the class when the (inferred) return type is in fact something else.