### PR TITLE
Mark `SpreadOperator` rule to require type resolution.

### DIFF
--- a/detekt-rules-performance/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/SpreadOperator.kt
+++ b/detekt-rules-performance/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/SpreadOperator.kt
@@ -8,13 +8,11 @@ import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
+import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import org.jetbrains.kotlin.descriptors.ConstructorDescriptor
 import org.jetbrains.kotlin.descriptors.ParameterDescriptor
-import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.KtValueArgument
 import org.jetbrains.kotlin.psi.KtValueArgumentList
-import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
-import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.CompileTimeConstantUtils
 import org.jetbrains.kotlin.resolve.DescriptorUtils
 import org.jetbrains.kotlin.resolve.calls.components.isVararg
@@ -26,8 +24,8 @@ import org.jetbrains.kotlin.resolve.calls.util.getResolvedCall
  * https://sites.google.com/a/athaydes.com/renato-athaydes/posts/kotlinshiddencosts-benchmarks
  *
  * The Kotlin compiler since v1.1.60 has an optimization that skips the array copy when an array constructor
- * function is used to create the arguments that are passed to the vararg parameter. When type resolution is enabled in
- * detekt this case will not be flagged by the rule since it doesn't suffer the performance penalty of an array copy.
+ * function is used to create the arguments that are passed to the vararg parameter. This case will not be flagged
+ * by the rule since it doesn't suffer the performance penalty of an array copy.
  *
  * <noncompliant>
  * val strs = arrayOf("value one", "value two")
@@ -50,7 +48,7 @@ import org.jetbrains.kotlin.resolve.calls.util.getResolvedCall
  * }
  * </compliant>
  */
-@Suppress("ViolatesTypeResolutionRequirements")
+@RequiresTypeResolution
 @ActiveByDefault(since = "1.0.0")
 class SpreadOperator(config: Config = Config.empty) : Rule(config) {
 
@@ -70,37 +68,18 @@ class SpreadOperator(config: Config = Config.empty) : Rule(config) {
             .forEach { checkCanSkipArrayCopy(it, list) }
     }
 
-    // Check for non type resolution case if call vararg argument is exactly the vararg parameter.
-    // In this case Kotlin 1.1.60+ does not create an additional copy.
-    // Note: this does not check the control flow like the type solution case does.
-    // It will not report corner cases like shadowed variables.
-    // This is okay as our users are encouraged to use type resolution for better results.
-    private fun isSimplePassThroughVararg(arg: KtValueArgument): Boolean {
-        val argumentName = arg.getArgumentExpression()?.text
-        return arg.getStrictParentOfType<KtNamedFunction>()
-            ?.valueParameters
-            ?.any { it.isVarArg && it.name == argumentName } == true
-    }
-
     private fun checkCanSkipArrayCopy(arg: KtValueArgument, argsList: KtValueArgumentList) {
-        if (bindingContext == BindingContext.EMPTY) {
-            if (isSimplePassThroughVararg(arg)) {
-                return
-            }
-            report(CodeSmell(issue, Entity.from(argsList), issue.description))
-        } else {
-            if (arg.canSkipArrayCopyForSpreadArgument()) {
-                return
-            }
-            report(
-                CodeSmell(
-                    issue,
-                    Entity.from(argsList),
-                    "Used in this way a spread operator causes a full copy of the array to be created before " +
-                        "calling a method. This may result in a performance penalty."
-                )
-            )
+        if (arg.canSkipArrayCopyForSpreadArgument()) {
+            return
         }
+        report(
+            CodeSmell(
+                issue,
+                Entity.from(argsList),
+                "Used in this way a spread operator causes a full copy of the array to be created before " +
+                    "calling a method. This may result in a performance penalty."
+            )
+        )
     }
 
     /**

--- a/detekt-rules-performance/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/SpreadOperatorSpec.kt
+++ b/detekt-rules-performance/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/SpreadOperatorSpec.kt
@@ -17,10 +17,10 @@ class SpreadOperatorSpec(val env: KotlinCoreEnvironment) {
     @Test
     fun `reports when array copy required using named parameters`() {
         val code = """
-                val xsArray = intArrayOf(1)
-                fun foo(vararg xs: Int) {}
-                val testVal = foo(xs = *xsArray)
-            """.trimIndent()
+            val xsArray = intArrayOf(1)
+            fun foo(vararg xs: Int) {}
+            val testVal = foo(xs = *xsArray)
+        """.trimIndent()
         val actual = subject.compileAndLintWithContext(env, code)
         assertThat(actual).hasSize(1)
         assertThat(actual.first().message).isEqualTo(errorMessage)
@@ -29,10 +29,10 @@ class SpreadOperatorSpec(val env: KotlinCoreEnvironment) {
     @Test
     fun `reports when array copy required without using named parameters`() {
         val code = """
-                val xsArray = intArrayOf(1)
-                fun foo(vararg xs: Int) {}
-                val testVal = foo(*xsArray)
-            """.trimIndent()
+            val xsArray = intArrayOf(1)
+            fun foo(vararg xs: Int) {}
+            val testVal = foo(*xsArray)
+        """.trimIndent()
         val actual = subject.compileAndLintWithContext(env, code)
         assertThat(actual).hasSize(1)
         assertThat(actual.first().message).isEqualTo(errorMessage)
@@ -41,79 +41,79 @@ class SpreadOperatorSpec(val env: KotlinCoreEnvironment) {
     @Test
     fun `doesn't report when using array constructor with spread operator`() {
         val code = """
-                fun foo(vararg xs: Int) {}
-                val testVal = foo(xs = *intArrayOf(1))
-            """.trimIndent()
+            fun foo(vararg xs: Int) {}
+            val testVal = foo(xs = *intArrayOf(1))
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 
     @Test
     fun `doesn't report when using array constructor with spread operator when varargs parameter comes first`() {
         val code = """
-                fun <T> asList(vararg ts: T, stringValue: String): List<Int> = listOf(1,2,3)
-                val list = asList(-1, 0, *arrayOf(1, 2, 3), 4, stringValue = "5")
-            """.trimIndent()
+            fun <T> asList(vararg ts: T, stringValue: String): List<Int> = listOf(1,2,3)
+            val list = asList(-1, 0, *arrayOf(1, 2, 3), 4, stringValue = "5")
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 
     @Test
     fun `doesn't report when passing values directly`() {
         val code = """
-                fun <T> asList(vararg ts: T, stringValue: String): List<Int> = listOf(1,2,3)
-                val list = asList(-1, 0, 1, 2, 3, 4, stringValue = "5")
-            """.trimIndent()
+            fun <T> asList(vararg ts: T, stringValue: String): List<Int> = listOf(1,2,3)
+            val list = asList(-1, 0, 1, 2, 3, 4, stringValue = "5")
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 
     @Test
     fun `doesn't report when function doesn't take a vararg parameter`() {
         val code = """
-                fun test0(strs: Array<String>) {
-                    test(strs)
-                }
-                
-                fun test(strs: Array<String>) {
-                    strs.forEach { println(it) }
-                }
-            """.trimIndent()
+            fun test0(strs: Array<String>) {
+                test(strs)
+            }
+            
+            fun test(strs: Array<String>) {
+                strs.forEach { println(it) }
+            }
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 
     @Test
     fun `doesn't report with expression inside params`() {
         val code = """
-                fun test0(strs: Array<String>) {
-                    test(2*2)
-                }
-                
-                fun test(test : Int) {
-                    println(test)
-                }
-            """.trimIndent()
+            fun test0(strs: Array<String>) {
+                test(2*2)
+            }
+            
+            fun test(test : Int) {
+                println(test)
+            }
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 
     @Test
     fun `respects pass through of vararg parameter - #3145`() {
         val code = """
-                fun b(vararg bla: Int) = Unit
-                fun a(vararg bla: Int) {
-                    b(*bla)
-                }
-            """.trimIndent()
+            fun b(vararg bla: Int) = Unit
+            fun a(vararg bla: Int) {
+                b(*bla)
+            }
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 
     @Test
     fun `reports shadowed vararg declaration which may lead to array copy - #3145`() {
         val code = """
-                fun b(vararg bla: String) = Unit
-                
-                fun a(vararg bla: Int) {
-                    val bla = arrayOf("")
-                    b(*bla)
-                }
-            """.trimIndent()
+            fun b(vararg bla: String) = Unit
+            
+            fun a(vararg bla: Int) {
+                val bla = arrayOf("")
+                b(*bla)
+            }
+        """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
     }
 }

--- a/detekt-rules-performance/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/SpreadOperatorSpec.kt
+++ b/detekt-rules-performance/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/SpreadOperatorSpec.kt
@@ -1,197 +1,73 @@
 package io.gitlab.arturbosch.detekt.rules.performance
 
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
-import io.gitlab.arturbosch.detekt.test.compileAndLint
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
-import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
 class SpreadOperatorSpec(val env: KotlinCoreEnvironment) {
 
-    val subject = SpreadOperator()
+    private val subject = SpreadOperator()
 
-    /**
-     * This rule has different behaviour depending on whether type resolution is enabled in detekt or not. The two
-     * `context` blocks are there to test behaviour when type resolution is enabled and type resolution is disabled
-     * as different warning messages are shown in each case.
-     */
-    @Nested
-    inner class `with type resolution` {
+    private val errorMessage = "Used in this way a spread operator causes a full copy of the array to" +
+        " be created before calling a method. This may result in a performance penalty."
 
-        val typeResolutionEnabledMessage = "Used in this way a spread operator causes a full copy of the array to" +
-            " be created before calling a method. This may result in a performance penalty."
-
-        @Test
-        fun `reports when array copy required using named parameters`() {
-            val code = """
+    @Test
+    fun `reports when array copy required using named parameters`() {
+        val code = """
                 val xsArray = intArrayOf(1)
                 fun foo(vararg xs: Int) {}
                 val testVal = foo(xs = *xsArray)
             """.trimIndent()
-            val actual = subject.compileAndLintWithContext(env, code)
-            assertThat(actual).hasSize(1)
-            assertThat(actual.first().message).isEqualTo(typeResolutionEnabledMessage)
-        }
-
-        @Test
-        fun `reports when array copy required without using named parameters`() {
-            val code = """
-                val xsArray = intArrayOf(1)
-                fun foo(vararg xs: Int) {}
-                val testVal = foo(*xsArray)
-            """.trimIndent()
-            val actual = subject.compileAndLintWithContext(env, code)
-            assertThat(actual).hasSize(1)
-            assertThat(actual.first().message).isEqualTo(typeResolutionEnabledMessage)
-        }
-
-        @Test
-        fun `doesn't report when using array constructor with spread operator`() {
-            val code = """
-                fun foo(vararg xs: Int) {}
-                val testVal = foo(xs = *intArrayOf(1))
-            """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
-        }
-
-        @Test
-        fun `doesn't report when using array constructor with spread operator when varargs parameter comes first`() {
-            val code = """
-                fun <T> asList(vararg ts: T, stringValue: String): List<Int> = listOf(1,2,3)
-                val list = asList(-1, 0, *arrayOf(1, 2, 3), 4, stringValue = "5")
-            """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
-        }
-
-        @Test
-        fun `doesn't report when passing values directly`() {
-            val code = """
-                fun <T> asList(vararg ts: T, stringValue: String): List<Int> = listOf(1,2,3)
-                val list = asList(-1, 0, 1, 2, 3, 4, stringValue = "5")
-            """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
-        }
-
-        @Test
-        fun `doesn't report when function doesn't take a vararg parameter`() {
-            val code = """
-                fun test0(strs: Array<String>) {
-                    test(strs)
-                }
-                
-                fun test(strs: Array<String>) {
-                    strs.forEach { println(it) }
-                }
-            """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
-        }
-
-        @Test
-        fun `doesn't report with expression inside params`() {
-            val code = """
-                fun test0(strs: Array<String>) {
-                    test(2*2)
-                }
-                
-                fun test(test : Int) {
-                    println(test)
-                }
-            """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
-        }
-
-        @Test
-        fun `respects pass through of vararg parameter - #3145`() {
-            val code = """
-                fun b(vararg bla: Int) = Unit
-                fun a(vararg bla: Int) {
-                    b(*bla)
-                }
-            """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
-        }
-
-        @Test
-        fun `reports shadowed vararg declaration which may lead to array copy - #3145`() {
-            val code = """
-                fun b(vararg bla: String) = Unit
-                
-                fun a(vararg bla: Int) {
-                    val bla = arrayOf("")
-                    b(*bla)
-                }
-            """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
-        }
+        val actual = subject.compileAndLintWithContext(env, code)
+        assertThat(actual).hasSize(1)
+        assertThat(actual.first().message).isEqualTo(errorMessage)
     }
 
-    @Nested
-    inner class `without type resolution` {
-
-        val typeResolutionDisabledMessage = "In most cases using a spread operator causes a full copy of the " +
-            "array to be created before calling a method. This may result in a performance penalty."
-
-        @Test
-        fun `reports when array copy required using named parameters`() {
-            val code = """
-                val xsArray = intArrayOf(1)
-                fun foo(vararg xs: Int) {}
-                val testVal = foo(xs = *xsArray)
-            """.trimIndent()
-            val actual = subject.compileAndLint(code)
-            assertThat(actual).hasSize(1)
-            assertThat(actual.first().message).isEqualTo(typeResolutionDisabledMessage)
-        }
-
-        @Test
-        fun `reports when array copy required without using named parameters`() {
-            val code = """
+    @Test
+    fun `reports when array copy required without using named parameters`() {
+        val code = """
                 val xsArray = intArrayOf(1)
                 fun foo(vararg xs: Int) {}
                 val testVal = foo(*xsArray)
             """.trimIndent()
-            val actual = subject.compileAndLint(code)
-            assertThat(actual).hasSize(1)
-            assertThat(actual.first().message).isEqualTo(typeResolutionDisabledMessage)
-        }
+        val actual = subject.compileAndLintWithContext(env, code)
+        assertThat(actual).hasSize(1)
+        assertThat(actual.first().message).isEqualTo(errorMessage)
+    }
 
-        @Test
-        fun `doesn't report when using array constructor with spread operator`() {
-            val code = """
+    @Test
+    fun `doesn't report when using array constructor with spread operator`() {
+        val code = """
                 fun foo(vararg xs: Int) {}
                 val testVal = foo(xs = *intArrayOf(1))
             """.trimIndent()
-            val actual = subject.compileAndLint(code)
-            assertThat(actual).hasSize(1)
-            assertThat(actual.first().message).isEqualTo(typeResolutionDisabledMessage)
-        }
+        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+    }
 
-        @Test
-        fun `doesn't report when using array constructor with spread operator when varargs parameter comes first`() {
-            val code = """
+    @Test
+    fun `doesn't report when using array constructor with spread operator when varargs parameter comes first`() {
+        val code = """
                 fun <T> asList(vararg ts: T, stringValue: String): List<Int> = listOf(1,2,3)
                 val list = asList(-1, 0, *arrayOf(1, 2, 3), 4, stringValue = "5")
             """.trimIndent()
-            val actual = subject.compileAndLint(code)
-            assertThat(actual).hasSize(1)
-            assertThat(actual.first().message).isEqualTo(typeResolutionDisabledMessage)
-        }
+        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+    }
 
-        @Test
-        fun `doesn't report when passing values directly`() {
-            val code = """
+    @Test
+    fun `doesn't report when passing values directly`() {
+        val code = """
                 fun <T> asList(vararg ts: T, stringValue: String): List<Int> = listOf(1,2,3)
                 val list = asList(-1, 0, 1, 2, 3, 4, stringValue = "5")
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
-        }
+        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+    }
 
-        @Test
-        fun `doesn't report when function doesn't take a vararg parameter`() {
-            val code = """
+    @Test
+    fun `doesn't report when function doesn't take a vararg parameter`() {
+        val code = """
                 fun test0(strs: Array<String>) {
                     test(strs)
                 }
@@ -200,12 +76,12 @@ class SpreadOperatorSpec(val env: KotlinCoreEnvironment) {
                     strs.forEach { println(it) }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
-        }
+        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+    }
 
-        @Test
-        fun `doesn't report with expression inside params`() {
-            val code = """
+    @Test
+    fun `doesn't report with expression inside params`() {
+        val code = """
                 fun test0(strs: Array<String>) {
                     test(2*2)
                 }
@@ -214,23 +90,23 @@ class SpreadOperatorSpec(val env: KotlinCoreEnvironment) {
                     println(test)
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
-        }
+        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+    }
 
-        @Test
-        fun `respects pass through of vararg parameter - #3145`() {
-            val code = """
+    @Test
+    fun `respects pass through of vararg parameter - #3145`() {
+        val code = """
                 fun b(vararg bla: Int) = Unit
                 fun a(vararg bla: Int) {
                     b(*bla)
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
-        }
+        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+    }
 
-        @Test
-        fun `does not report shadowed vararg declaration, we except this false negative here - #3145`() {
-            val code = """
+    @Test
+    fun `reports shadowed vararg declaration which may lead to array copy - #3145`() {
+        val code = """
                 fun b(vararg bla: String) = Unit
                 
                 fun a(vararg bla: Int) {
@@ -238,7 +114,6 @@ class SpreadOperatorSpec(val env: KotlinCoreEnvironment) {
                     b(*bla)
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
-        }
+        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
     }
 }


### PR DESCRIPTION
This relates to #2994 and removes the mixed behavior from the `SpreadOperator` rule.  

I am not completely sure that this should be done here, as the only thing the type resolution adds is to avoid false positives.  