### PR TITLE
Mark `UseDataClass` rule to require type resolution.

### DIFF
--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseDataClass.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseDataClass.kt
@@ -10,6 +10,7 @@ import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.config
 import io.gitlab.arturbosch.detekt.api.internal.Configuration
+import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.rules.isOpen
 import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtFile
@@ -45,7 +46,7 @@ import org.jetbrains.kotlin.types.KotlinType
  * class A(val b: B) : I by b
  * </compliant>
  */
-@Suppress("ViolatesTypeResolutionRequirements")
+@RequiresTypeResolution
 class UseDataClass(config: Config = Config.empty) : Rule(config) {
 
     override val issue: Issue = Issue(

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseDataClassSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseDataClassSpec.kt
@@ -4,7 +4,6 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLint
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
 import io.gitlab.arturbosch.detekt.test.lint
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
@@ -32,7 +31,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                     object Obj
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -42,7 +41,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                     val c = 2 * b
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -54,7 +53,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -62,7 +61,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
             val code = """
                 class NoDataClassCandidateWithOnlyPrivateCtor1 private constructor(val i: Int)
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -72,7 +71,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                     private constructor(i: Int)
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -83,7 +82,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                     data class Error(val error: Throwable) : NoDataClassBecauseItsSealed()
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -93,7 +92,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                     FIRST(1), SECOND(2);
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -101,7 +100,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
             val code = """
                 annotation class AnnotationNoDataClass(val i: Int)
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -116,7 +115,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -129,7 +128,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                 data class DataClass(override val i: Int): SimpleInterface
             """.trimIndent()
 
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -144,7 +143,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                 class DataClass(override val i: Int, override val j: Int): SimpleInterface, BaseClass(j)
             """.trimIndent()
 
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -155,7 +154,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                 class A(val b: B) : I by b
             """.trimIndent()
 
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
     }
 
@@ -168,7 +167,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                 class DataClassCandidate1(val i: Int)
             """.trimIndent()
 
-            val findings = subject.compileAndLint(code)
+            val findings = subject.compileAndLintWithContext(env, code)
 
             assertThat(findings).hasSize(1)
             assertThat(findings).hasStartSourceLocation(1, 7)
@@ -182,7 +181,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                     val i2: Int = 0
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).hasSize(1)
+            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -192,7 +191,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                     private constructor(i: Int) : this(i.toString())
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).hasSize(1)
+            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -202,7 +201,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                     constructor(i: Int) : this(i.toString())
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).hasSize(1)
+            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -220,7 +219,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).hasSize(1)
+            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -230,7 +229,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                 class DataClass(val i: Int): SimpleInterface
             """.trimIndent()
 
-            assertThat(subject.compileAndLint(code)).hasSize(1)
+            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -243,7 +242,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                 class DataClass(override val i: Int): SimpleInterface
             """.trimIndent()
 
-            assertThat(subject.compileAndLint(code)).hasSize(1)
+            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
     }
 
@@ -329,7 +328,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
         fun `does not report class with mutable constructor parameter`() {
             val code = """class DataClassCandidateWithVar(var i: Int)"""
             val config = TestConfig(ALLOW_VARS to "true")
-            assertThat(UseDataClass(config).compileAndLint(code)).isEmpty()
+            assertThat(UseDataClass(config).compileAndLintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -340,7 +339,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
             val config = TestConfig(ALLOW_VARS to "true")
-            assertThat(UseDataClass(config).compileAndLint(code)).isEmpty()
+            assertThat(UseDataClass(config).compileAndLintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -351,7 +350,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
             val config = TestConfig(ALLOW_VARS to "true")
-            assertThat(UseDataClass(config).compileAndLint(code)).isEmpty()
+            assertThat(UseDataClass(config).compileAndLintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -362,7 +361,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
             val config = TestConfig(ALLOW_VARS to "true")
-            assertThat(UseDataClass(config).compileAndLint(code)).isEmpty()
+            assertThat(UseDataClass(config).compileAndLintWithContext(env, code)).isEmpty()
         }
     }
 
@@ -389,7 +388,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
             class AnnotatedClass(val i: Int) {}
         """.trimIndent()
         val config = TestConfig(EXCLUDE_ANNOTATED_CLASSES to "kotlin.*")
-        assertThat(UseDataClass(config).compileAndLint(code)).isEmpty()
+        assertThat(UseDataClass(config).compileAndLintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -402,7 +401,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -417,7 +416,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -427,6 +426,6 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                 inner class Inner(val x: Int)
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 }


### PR DESCRIPTION
Relates to #2994 and marks the `UseDataClass` to require type resolution. 

Type resolution is only needed to exclude classes that define a copy method that is different to the copy method generated by data classes.

<!-- A similar PR may already be submitted! -->
<!-- Please search among the [Pull requests](https://github.com/detekt/detekt/pulls) before creating one. -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Link to relevant issues if possible. -->

<!-- For more information, see the [CONTRIBUTING guide](https://github.com/detekt/detekt/blob/main/.github/CONTRIBUTING.md). -->
