### PR TITLE
Mark `UseCheckOrError` rule to require type resolution.

### DIFF
--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseCheckOrError.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseCheckOrError.kt
@@ -8,6 +8,7 @@ import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
+import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.rules.arguments
 import io.gitlab.arturbosch.detekt.rules.isEmptyOrSingleStringArgument
 import io.gitlab.arturbosch.detekt.rules.isIllegalStateException
@@ -37,7 +38,7 @@ import org.jetbrains.kotlin.psi.KtThrowExpression
  * }
  * </compliant>
  */
-@Suppress("ViolatesTypeResolutionRequirements")
+@RequiresTypeResolution
 @ActiveByDefault(since = "1.21.0")
 class UseCheckOrError(config: Config = Config.empty) : Rule(config) {
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseCheckOrErrorSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseCheckOrErrorSpec.kt
@@ -3,11 +3,9 @@ package io.gitlab.arturbosch.detekt.rules.style
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLint
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
-import io.gitlab.arturbosch.detekt.test.lint
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
-import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
@@ -17,36 +15,36 @@ class UseCheckOrErrorSpec(val env: KotlinCoreEnvironment) {
     @Test
     fun `reports if a an IllegalStateException is thrown`() {
         val code = """
-            fun x() {
-                doSomething()
+            fun x(a: Int) {
+                println("something")
                 if (a < 0) throw IllegalStateException()
             }
         """.trimIndent()
-        assertThat(subject.lint(code)).hasStartSourceLocation(3, 16)
+        assertThat(subject.compileAndLintWithContext(env, code)).hasStartSourceLocation(3, 16)
     }
 
     @Test
     fun `reports if a an IllegalStateException is thrown conditionally in a block`() {
         val code = """
-            fun x() {
-                doSomething()
+            fun x(a: Int) {
+                println("something")
                 if (a < 0) {
                     throw IllegalStateException()
                 }
             }
         """.trimIndent()
-        assertThat(subject.lint(code)).hasStartSourceLocation(4, 9)
+        assertThat(subject.compileAndLintWithContext(env, code)).hasStartSourceLocation(4, 9)
     }
 
     @Test
     fun `reports if a an IllegalStateException is thrown with an error message`() {
         val code = """
-            fun x() {
-                doSomething()
+            fun x(a: Int) {
+                println("something")
                 if (a < 0) throw IllegalStateException("More details")
             }
         """.trimIndent()
-        assertThat(subject.lint(code)).hasStartSourceLocation(3, 16)
+        assertThat(subject.compileAndLintWithContext(env, code)).hasStartSourceLocation(3, 16)
     }
 
     @Test
@@ -54,56 +52,59 @@ class UseCheckOrErrorSpec(val env: KotlinCoreEnvironment) {
         val code = """
             fun x(a: Int) =
                 when (a) {
-                    1 -> doSomething()
+                    1 -> println("something")
                     else -> throw IllegalStateException()
                 }
         """.trimIndent()
-        assertThat(subject.lint(code)).hasStartSourceLocation(4, 17)
+        assertThat(subject.compileAndLintWithContext(env, code)).hasStartSourceLocation(4, 17)
     }
 
     @Test
     fun `reports if an IllegalStateException is thrown by its fully qualified name`() {
         val code = """
-            fun x() {
-                doSomething()
+            fun x(a: Int) {
+                println("something")
                 if (a < 0) throw java.lang.IllegalStateException()
             }
         """.trimIndent()
-        assertThat(subject.lint(code)).hasStartSourceLocation(3, 16)
+        assertThat(subject.compileAndLintWithContext(env, code)).hasStartSourceLocation(3, 16)
     }
 
     @Test
     fun `reports if an IllegalStateException is thrown by its fully qualified name using the kotlin type alias`() {
         val code = """
-            fun x() {
-                doSomething()
+            fun x(a: Int) {
+                println("something")
                 if (a < 0) throw kotlin.IllegalStateException()
             }
         """.trimIndent()
-        assertThat(subject.lint(code)).hasStartSourceLocation(3, 16)
+        assertThat(subject.compileAndLintWithContext(env, code)).hasStartSourceLocation(3, 16)
     }
 
     @Test
     fun `does not report if any other kind of exception is thrown`() {
         val code = """
-            fun x() {
-                doSomething()
+            class SomeBusinessException: Exception()
+
+            fun x(a: Int) {
+                println("something")
                 if (a < 0) throw SomeBusinessException()
             }
         """.trimIndent()
-        assertThat(subject.lint(code)).isEmpty()
+        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 
     @Test
     fun `does not report an issue if the exception thrown has a message and a cause`() {
         val code = """
-            private fun missing(): Nothing {
+            fun missing(cause: Exception): Nothing {
                 if  (cause != null) {
                     throw IllegalStateException("message", cause)
                 }
+                throw Exception()
             }
         """.trimIndent()
-        assertThat(subject.lint(code)).isEmpty()
+        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -113,19 +114,19 @@ class UseCheckOrErrorSpec(val env: KotlinCoreEnvironment) {
                 unsafeRunTimed(Duration.INFINITE)
                     .fold({ throw IllegalStateException("message") }, ::identity)
         """.trimIndent()
-        assertThat(subject.lint(code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
     fun `reports an issue if the exception thrown as the only action in a function`() {
-        val code = """fun doThrow() = throw IllegalStateException("message")"""
-        assertThat(subject.lint(code)).hasStartSourceLocation(1, 17)
+        val code = """fun doThrow(): Nothing = throw IllegalStateException("message")"""
+        assertThat(subject.compileAndLintWithContext(env, code)).hasStartSourceLocation(1, 26)
     }
 
     @Test
     fun `reports an issue if the exception thrown as the only action in a function block`() {
-        val code = """fun doThrow() { throw IllegalStateException("message") }"""
-        assertThat(subject.lint(code)).hasStartSourceLocation(1, 17)
+        val code = """fun doThrow(): Nothing { throw IllegalStateException("message") }"""
+        assertThat(subject.compileAndLintWithContext(env, code)).hasStartSourceLocation(1, 26)
     }
 
     @Test
@@ -138,7 +139,7 @@ class UseCheckOrErrorSpec(val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -151,11 +152,11 @@ class UseCheckOrErrorSpec(val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 
     @Test
-    fun `does not report if the exception thrown has a non-String literal argument`() {
+    fun `reports if the exception thrown has a non-literal String argument`() {
         val code = """
             fun test(throwable: Throwable) {
                 when(throwable) {
@@ -164,62 +165,19 @@ class UseCheckOrErrorSpec(val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
     }
 
-    @Nested
-    inner class `with binding context` {
-
-        @Test
-        fun `does not report if the exception thrown has a non-String argument`() {
-            val code = """
-                fun test(throwable: Throwable) {
-                    when(throwable) {
-                        is NumberFormatException -> println("a")
-                        else -> throw IllegalStateException(throwable)
-                    }
+    @Test
+    fun `reports if the exception thrown has a string literal argument`() {
+        val code = """
+            fun test(throwable: Throwable) {
+                when(throwable) {
+                    is NumberFormatException -> println("a")
+                    else -> throw IllegalStateException("b")
                 }
-            """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
-        }
-
-        @Test
-        fun `does not report if the exception thrown has a String literal argument and a non-String argument`() {
-            val code = """
-                fun test(throwable: Throwable) {
-                    when(throwable) {
-                        is NumberFormatException -> println("a")
-                        else -> throw IllegalStateException("b", throwable)
-                    }
-                }
-            """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
-        }
-
-        @Test
-        fun `reports if the exception thrown has a non-String literal argument`() {
-            val code = """
-                fun test(throwable: Throwable) {
-                    when(throwable) {
-                        is NumberFormatException -> println("a")
-                        else -> throw IllegalStateException(throwable.toString())
-                    }
-                }
-            """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
-        }
-
-        @Test
-        fun `reports if the exception thrown has a string literal argument`() {
-            val code = """
-                fun test(throwable: Throwable) {
-                    when(throwable) {
-                        is NumberFormatException -> println("a")
-                        else -> throw IllegalStateException("b")
-                    }
-                }
-            """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
-        }
+            }
+        """.trimIndent()
+        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
     }
 }


### PR DESCRIPTION
Relates to #2994 and marks the `UseCheckOrError` rule to require type resolution to avoid mixed behavior.
