### PR TITLE
Fix false +ve when lambda is un-inferrable

### DIFF
--- a/detekt-psi-utils/api/detekt-psi-utils.api
+++ b/detekt-psi-utils/api/detekt-psi-utils.api
@@ -150,6 +150,8 @@ public final class io/gitlab/arturbosch/detekt/rules/ThrowExtensionsKt {
 }
 
 public final class io/gitlab/arturbosch/detekt/rules/TraversingKt {
+	public static final fun getParentExpressionRemovingParenthesis (Lorg/jetbrains/kotlin/com/intellij/psi/PsiElement;Z)Lorg/jetbrains/kotlin/com/intellij/psi/PsiElement;
+	public static synthetic fun getParentExpressionRemovingParenthesis$default (Lorg/jetbrains/kotlin/com/intellij/psi/PsiElement;ZILjava/lang/Object;)Lorg/jetbrains/kotlin/com/intellij/psi/PsiElement;
 	public static final fun isPublicInherited (Lorg/jetbrains/kotlin/psi/KtNamedDeclaration;)Z
 	public static final fun isPublicInherited (Lorg/jetbrains/kotlin/psi/KtNamedDeclaration;Z)Z
 }

--- a/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/Traversing.kt
+++ b/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/Traversing.kt
@@ -3,7 +3,9 @@ package io.gitlab.arturbosch.detekt.rules
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.psi.KtNamedDeclaration
+import org.jetbrains.kotlin.psi.KtParenthesizedExpression
 import org.jetbrains.kotlin.psi.psiUtil.containingClassOrObject
+import org.jetbrains.kotlin.psi.psiUtil.getParentOfTypesAndPredicate
 import org.jetbrains.kotlin.psi.psiUtil.isPublic
 
 /**
@@ -19,6 +21,12 @@ inline fun <reified T : KtElement, reified S : KtElement> KtElement.parentsOfTyp
             current = current.parent
         }
     }
+
+fun PsiElement.getParentExpressionRemovingParenthesis(strict: Boolean = true): PsiElement? =
+    this.getParentOfTypesAndPredicate(
+        strict,
+        PsiElement::class.java,
+    ) { it !is KtParenthesizedExpression }
 
 fun KtNamedDeclaration.isPublicInherited(): Boolean = isPublicInherited(false)
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitItLambdaParameter.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitItLambdaParameter.kt
@@ -9,6 +9,8 @@ import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
 import io.gitlab.arturbosch.detekt.rules.IT_LITERAL
+import io.gitlab.arturbosch.detekt.rules.getParentExpressionRemovingParenthesis
+import org.jetbrains.kotlin.psi.KtCallableReferenceExpression
 import org.jetbrains.kotlin.psi.KtLambdaExpression
 
 /**
@@ -53,6 +55,7 @@ class ExplicitItLambdaParameter(val config: Config) : Rule(config) {
 
     override fun visitLambdaExpression(lambdaExpression: KtLambdaExpression) {
         super.visitLambdaExpression(lambdaExpression)
+        if (lambdaExpression.getParentExpressionRemovingParenthesis() is KtCallableReferenceExpression) return
         val parameterNames = lambdaExpression.valueParameters.map { it.name }
         if (IT_LITERAL in parameterNames) {
             val message = if (parameterNames.size == 1) {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitItLambdaParameterSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitItLambdaParameterSpec.kt
@@ -34,6 +34,38 @@ class ExplicitItLambdaParameterSpec {
             )
             assertThat(findings).hasSize(1)
         }
+
+        @Test
+        fun `does not report when parameter type is declared explicitly for un-inferrable lambda`() {
+            val findings = subject.compileAndLint(
+                """
+                    fun f1(): (Int) -> Int {
+                        return { it: Int -> it.inc() }::invoke
+                    }
+
+                    fun f2(): (Int) -> Int {
+                        return { value: Int -> value.inc() }::invoke
+                    }
+
+                    fun f3(): (((Int) -> Int) -> Unit) -> (Int) -> Int {
+                        return { it: Int -> it.inc() }::also
+                    }
+                """.trimIndent()
+            )
+            assertThat(findings).isEmpty()
+        }
+
+        @Test
+        fun `does not report when parameter type is declared explicitly for un-inferrable lambda wrapped in paren`() {
+            val findings = subject.compileAndLint(
+                """
+                    fun f(): (Int) -> Int {
+                        return ({ it: Int -> it.inc() })::invoke
+                    }
+                """.trimIndent()
+            )
+            assertThat(findings).isEmpty()
+        }
     }
 
     @Nested
@@ -77,6 +109,18 @@ class ExplicitItLambdaParameterSpec {
                 """.trimIndent()
             )
             assertThat(findings).hasSize(1)
+        }
+
+        @Test
+        fun `does not report when parameter type is declared explicitly for multi params un-inferrable lambda`() {
+            val findings = subject.compileAndLint(
+                """
+                    fun f(): (Int, Int) -> Int {
+                        return { it: Int, a: Int -> (it + a).inc() }::invoke
+                    }
+                """.trimIndent()
+            )
+            assertThat(findings).isEmpty()
         }
     }
 }


### PR DESCRIPTION
Fixes: https://github.com/detekt/detekt/issues/6364
