### PR TITLE
Remove deprecated config property `excludeAnnotatedProperties` in `LateinitUsage`

### DIFF
--- a/detekt-core/src/main/resources/deprecation.properties
+++ b/detekt-core/src/main/resources/deprecation.properties
@@ -12,7 +12,6 @@ naming>MemberNameEqualsClassName>ignoreOverriddenFunction=Use `ignoreOverridden`
 naming>VariableNaming>ignoreOverridden=This configuration is ignored and will be removed in the future
 potential-bugs>DuplicateCaseInWhenExpression=Rule deprecated as compiler performs this check by default
 potential-bugs>IgnoredReturnValue>restrictToAnnotatedMethods=Use `restrictToConfig` instead
-potential-bugs>LateinitUsage>excludeAnnotatedProperties=Use `ignoreAnnotated` instead
 potential-bugs>MissingWhenCase=Rule deprecated as compiler performs this check by default
 potential-bugs>RedundantElseInWhen=Rule deprecated as compiler performs this check by default
 style>ForbiddenComment>customMessage=Use `comments` and provide `reason` against each `value`.

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/LateinitUsage.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/LateinitUsage.kt
@@ -1,6 +1,5 @@
 package io.gitlab.arturbosch.detekt.rules.bugs
 
-import io.gitlab.arturbosch.detekt.api.AnnotationExcluder
 import io.gitlab.arturbosch.detekt.api.CodeSmell
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
@@ -28,7 +27,6 @@ import org.jetbrains.kotlin.psi.psiUtil.containingClass
  * }
  * </noncompliant>
  */
-@Suppress("ViolatesTypeResolutionRequirements")
 class LateinitUsage(config: Config = Config.empty) : Rule(config) {
 
     override val issue = Issue(
@@ -38,12 +36,6 @@ class LateinitUsage(config: Config = Config.empty) : Rule(config) {
             "is error prone, try using constructor injection or delegation.",
         Debt.TWENTY_MINS
     )
-
-    @Configuration("Allows you to provide a list of annotations that disable this check.")
-    @Deprecated("Use `ignoreAnnotated` instead")
-    private val excludeAnnotatedProperties: List<Regex> by config(emptyList<String>()) { list ->
-        list.map { it.replace(".", "\\.").replace("*", ".*").toRegex() }
-    }
 
     @Configuration("Allows you to disable the rule for a list of classes")
     private val ignoreOnClassesPattern: Regex by config("", String::toRegex)
@@ -61,14 +53,7 @@ class LateinitUsage(config: Config = Config.empty) : Rule(config) {
 
         super.visit(root)
 
-        val annotationExcluder = AnnotationExcluder(
-            root,
-            @Suppress("DEPRECATION") excludeAnnotatedProperties,
-            bindingContext,
-        )
-
-        properties.filterNot { annotationExcluder.shouldExclude(it.annotationEntries) }
-            .filterNot { it.containingClass()?.name?.matches(ignoreOnClassesPattern) == true }
+        properties.filterNot { it.containingClass()?.name?.matches(ignoreOnClassesPattern) == true }
             .forEach {
                 report(CodeSmell(issue, Entity.from(it), "Usages of lateinit should be avoided."))
             }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/LateinitUsageSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/LateinitUsageSpec.kt
@@ -4,7 +4,6 @@ import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
-import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import java.util.regex.PatternSyntaxException
 
@@ -15,57 +14,13 @@ class LateinitUsageSpec {
         
         class SomeRandomTest {
             lateinit var v1: String
-            @SinceKotlin("1.0.0") lateinit var v2: String
+            @SinceKotlin("1.0.0") private lateinit var v2: String
         }
     """.trimIndent()
 
     @Test
     fun `should report lateinit usages`() {
         val findings = LateinitUsage().compileAndLint(code)
-        assertThat(findings).hasSize(2)
-    }
-
-    @Test
-    @DisplayName("should only report lateinit property with no @SinceKotlin annotation")
-    fun `should only report lateinit property with no SinceKotlin annotation`() {
-        val findings =
-            LateinitUsage(TestConfig(EXCLUDE_ANNOTATED_PROPERTIES to listOf("SinceKotlin"))).compileAndLint(code)
-        assertThat(findings).hasSize(1)
-    }
-
-    @Test
-    @DisplayName("should only report lateinit properties not matching kotlin.*")
-    fun `should only report lateinit properties not matching any kotlin annotation`() {
-        val findings =
-            LateinitUsage(TestConfig(EXCLUDE_ANNOTATED_PROPERTIES to listOf("kotlin.*"))).compileAndLint(code)
-        assertThat(findings).hasSize(1)
-    }
-
-    @Test
-    fun `should only report lateinit properties matching kotlin_SinceKotlin`() {
-        val config = TestConfig(EXCLUDE_ANNOTATED_PROPERTIES to listOf("kotlin.SinceKotlin"))
-        val findings = LateinitUsage(config).compileAndLint(code)
-        assertThat(findings).hasSize(1)
-    }
-
-    @Test
-    fun `should only report lateinit property with no @SinceKotlin annotation with config string`() {
-        val findings =
-            LateinitUsage(TestConfig(EXCLUDE_ANNOTATED_PROPERTIES to "SinceKotlin")).compileAndLint(code)
-        assertThat(findings).hasSize(1)
-    }
-
-    @Test
-    fun `should only report lateinit property with no @SinceKotlin annotation containing whitespaces with config string`() {
-        val findings =
-            LateinitUsage(TestConfig(EXCLUDE_ANNOTATED_PROPERTIES to " SinceKotlin ")).compileAndLint(code)
-        assertThat(findings).hasSize(1)
-    }
-
-    @Test
-    fun `should report lateinit properties not matching the exclude pattern`() {
-        val findings =
-            LateinitUsage(TestConfig(EXCLUDE_ANNOTATED_PROPERTIES to "IgnoreThis")).compileAndLint(code)
         assertThat(findings).hasSize(2)
     }
 
@@ -101,5 +56,4 @@ class LateinitUsageSpec {
     }
 }
 
-private const val EXCLUDE_ANNOTATED_PROPERTIES = "excludeAnnotatedProperties"
 private const val IGNORE_ON_CLASSES_PATTERN = "ignoreOnClassesPattern"


### PR DESCRIPTION
This removes the `excludeAnnotatedProperties` config property as this was the only reason this rule used the binding context without declaring to require type resolution. This could end up with mixed exclution behavior. This PR relates to #2994 and will conflict with #6193.
