### PR TITLE
Consider deprecated rules as inactive when running `allRules`

### DIFF
--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Analyzer.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Analyzer.kt
@@ -209,10 +209,9 @@ internal fun ProcessingSpec.workaroundConfiguration(config: Config): Config = wi
     return declaredConfig ?: getDefaultConfiguration()
 }
 
-internal fun loadDeprecatedRuleIds(): Set<String> {
-    return loadDeprecations().keys
+internal fun loadDeprecatedRuleIds(): Set<String> =
+    loadDeprecations().keys
         .map { it.split(">") }
         .filter { it.size == 2 }
         .map { it.joinToString(" > ") }
         .toSet()
-}

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Analyzer.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Analyzer.kt
@@ -194,7 +194,16 @@ internal fun ProcessingSpec.workaroundConfiguration(config: Config): Config = wi
 
     if (rulesSpec.activateAllRules) {
         val defaultConfig = getDefaultConfiguration()
-        declaredConfig = AllRulesConfig(declaredConfig ?: defaultConfig, defaultConfig)
+        declaredConfig = AllRulesConfig(
+            originalConfig = declaredConfig ?: defaultConfig,
+            defaultConfig = defaultConfig,
+            deprecatedRuleIds = setOf(
+                "style > OptionalWhenBraces",
+                "potential-bugs > DuplicateCaseInWhenExpression",
+                "potential-bugs > MissingWhenCase",
+                "potential-bugs > RedundantElseInWhen"
+            )
+        )
     }
 
     if (!rulesSpec.autoCorrect) {

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Analyzer.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Analyzer.kt
@@ -16,6 +16,7 @@ import io.gitlab.arturbosch.detekt.api.internal.whichJava
 import io.gitlab.arturbosch.detekt.api.internal.whichOS
 import io.gitlab.arturbosch.detekt.core.config.AllRulesConfig
 import io.gitlab.arturbosch.detekt.core.config.DisabledAutoCorrectConfig
+import io.gitlab.arturbosch.detekt.core.config.validation.loadDeprecations
 import io.gitlab.arturbosch.detekt.core.rules.associateRuleIdsToRuleSetIds
 import io.gitlab.arturbosch.detekt.core.rules.isActive
 import io.gitlab.arturbosch.detekt.core.rules.shouldAnalyzeFile
@@ -197,12 +198,7 @@ internal fun ProcessingSpec.workaroundConfiguration(config: Config): Config = wi
         declaredConfig = AllRulesConfig(
             originalConfig = declaredConfig ?: defaultConfig,
             defaultConfig = defaultConfig,
-            deprecatedRuleIds = setOf(
-                "style > OptionalWhenBraces",
-                "potential-bugs > DuplicateCaseInWhenExpression",
-                "potential-bugs > MissingWhenCase",
-                "potential-bugs > RedundantElseInWhen"
-            )
+            deprecatedRuleIds = loadDeprecatedRuleIds()
         )
     }
 
@@ -211,4 +207,12 @@ internal fun ProcessingSpec.workaroundConfiguration(config: Config): Config = wi
     }
 
     return declaredConfig ?: getDefaultConfiguration()
+}
+
+internal fun loadDeprecatedRuleIds(): Set<String> {
+    return loadDeprecations().keys
+        .map { it.split(">") }
+        .filter { it.size == 2 }
+        .map { it.joinToString(" > ") }
+        .toSet()
 }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/AllRulesConfig.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/AllRulesConfig.kt
@@ -7,29 +7,38 @@ import io.gitlab.arturbosch.detekt.core.config.validation.validateConfig
 @Suppress("UNCHECKED_CAST")
 internal data class AllRulesConfig(
     private val originalConfig: Config,
-    private val defaultConfig: Config
+    private val defaultConfig: Config,
+    private val deprecatedRuleIds: Set<String> = emptySet()
 ) : Config, ValidatableConfiguration {
 
     override val parentPath: String?
         get() = originalConfig.parentPath ?: defaultConfig.parentPath
 
     override fun subConfig(key: String) =
-        AllRulesConfig(originalConfig.subConfig(key), defaultConfig.subConfig(key))
+        AllRulesConfig(
+            originalConfig = originalConfig.subConfig(key),
+            defaultConfig = defaultConfig.subConfig(key),
+            deprecatedRuleIds = deprecatedRuleIds
+        )
 
     override fun <T : Any> valueOrDefault(key: String, default: T): T {
         return when (key) {
-            Config.ACTIVE_KEY -> originalConfig.valueOrDefault(key, true) as T
+            Config.ACTIVE_KEY -> if (isDeprecated()) false as T else originalConfig.valueOrDefault(key, true) as T
             else -> originalConfig.valueOrDefault(key, defaultConfig.valueOrDefault(key, default))
         }
     }
 
     override fun <T : Any> valueOrNull(key: String): T? {
         return when (key) {
-            Config.ACTIVE_KEY -> originalConfig.valueOrNull(key) ?: true as? T
+            Config.ACTIVE_KEY -> if (isDeprecated()) false as T else originalConfig.valueOrNull(key) ?: true as? T
             else -> originalConfig.valueOrNull(key) ?: defaultConfig.valueOrNull(key)
         }
     }
 
     override fun validate(baseline: Config, excludePatterns: Set<Regex>) =
         validateConfig(originalConfig, baseline, excludePatterns)
+
+    private fun isDeprecated(): Boolean {
+        return parentPath?.let { deprecatedRuleIds.contains(it) } ?: false
+    }
 }

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/LoadDeprecatedRuleIdsSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/LoadDeprecatedRuleIdsSpec.kt
@@ -1,0 +1,18 @@
+package io.gitlab.arturbosch.detekt.core
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class LoadDeprecatedRuleIdsSpec {
+    @Test
+    fun loadDeprecatedRules() {
+        // rule id as used by config path mechanism uses 'ruleSetId > ruleId' pattern (with space)
+        val ruleIdPattern = """^[-\w]+ > \w+$""".toRegex()
+
+        val actual = loadDeprecatedRuleIds()
+
+        assertThat(actual)
+            .isNotEmpty()
+            .allMatch { ruleId -> ruleIdPattern.matches(ruleId as String) }
+    }
+}

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/AllRulesConfigSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/AllRulesConfigSpec.kt
@@ -2,22 +2,24 @@ package io.gitlab.arturbosch.detekt.core.config
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.yamlConfig
+import io.gitlab.arturbosch.detekt.test.yamlConfigFromContent
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 class AllRulesConfigSpec {
+    private val emptyYamlConfig = yamlConfigFromContent("")
+
     @Nested
     inner class ParentPath {
         private val rulesetId = "style"
         private val rulesetConfig = yamlConfig("/configs/single-rule-in-style-ruleset.yml").subConfig(rulesetId)
-        private val emptyConfig = Config.empty
 
         @Test
         fun `is derived from the original config`() {
             val subject = AllRulesConfig(
                 originalConfig = rulesetConfig,
-                defaultConfig = emptyConfig,
+                defaultConfig = emptyYamlConfig,
             )
             val actual = subject.parentPath
             assertThat(actual).isEqualTo(rulesetId)
@@ -26,11 +28,45 @@ class AllRulesConfigSpec {
         @Test
         fun `is derived from the default config if unavailable in original config`() {
             val subject = AllRulesConfig(
-                originalConfig = emptyConfig,
+                originalConfig = emptyYamlConfig,
                 defaultConfig = rulesetConfig,
             )
             val actual = subject.parentPath
             assertThat(actual).isEqualTo(rulesetId)
+        }
+    }
+
+    @Nested
+    inner class DeactivateDeprecatedRule {
+
+        @Test
+        fun `rule is active if not deprecated`() {
+            val subject = AllRulesConfig(
+                originalConfig = emptyYamlConfig,
+                defaultConfig = emptyYamlConfig,
+                deprecatedRuleIds = emptySet()
+            )
+                .subConfig("ruleset")
+                .subConfig("ARule")
+
+            val actual = subject.valueOrDefault(Config.ACTIVE_KEY, false)
+
+            assertThat(actual).isTrue
+        }
+
+        @Test
+        fun `rule is inactive if deprecated`() {
+            val subject = AllRulesConfig(
+                originalConfig = emptyYamlConfig,
+                defaultConfig = emptyYamlConfig,
+                deprecatedRuleIds = setOf("ruleset > ARule")
+            )
+                .subConfig("ruleset")
+                .subConfig("ARule")
+
+            val actual = subject.valueOrDefault(Config.ACTIVE_KEY, false)
+
+            assertThat(actual).isFalse
         }
     }
 }


### PR DESCRIPTION
(quick) fixes #6336 

**Note: This PR targets the `release/1.x` branch instead of `main`.** 

Following [this suggestion](https://github.com/detekt/detekt/issues/6336#issuecomment-1674944509) I hacked something up that should fix the issue short term. The idea is that all deprecated rules are considered as inactive in case detekt is run with the `allRules` option. We should probably find a better solution for the main branch.