### PR TITLE
Fix reporting unused imports at file level

### DIFF
--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingRule.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingRule.kt
@@ -5,15 +5,19 @@ import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CODE_STYLE_PROPERT
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfig
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfigProperty
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_STYLE_PROPERTY
+import io.github.detekt.psi.toFilePath
 import io.gitlab.arturbosch.detekt.api.CodeSmell
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.CorrectableCodeSmell
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Location
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.SingleAssign
+import io.gitlab.arturbosch.detekt.api.SourceLocation
+import io.gitlab.arturbosch.detekt.api.TextLocation
 import org.ec4j.core.model.Property
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.JavaDummyElement
@@ -83,8 +87,17 @@ abstract class FormattingRule(config: Config) : Rule(config) {
         return EditorConfig(properties)
     }
 
-    private fun emitFinding(message: String, canBeAutoCorrected: Boolean, node: ASTNode) {
-        val entity = Entity.from(node.psi)
+    private fun emitFinding(offset: Int, message: String, canBeAutoCorrected: Boolean, node: ASTNode) {
+        // Always convert KtLint offsets to lines/columns.
+        // The node used to report the finding may be not the same used for the offset (e.g. in NoUnusedImports).
+        val (line, column) = positionByOffset(offset)
+        val location = Location(
+            SourceLocation(line, column),
+            // Use offset + 1 since ktlint always reports a single location.
+            TextLocation(offset, offset + 1),
+            root.toFilePath()
+        )
+        val entity = Entity.from(node.psi, location)
 
         if (canBeAutoCorrected) {
             report(CorrectableCodeSmell(issue, entity, message, autoCorrectEnabled = autoCorrect))
@@ -94,14 +107,14 @@ abstract class FormattingRule(config: Config) : Rule(config) {
     }
 
     private fun beforeVisitChildNodes(node: ASTNode) {
-        wrapping.beforeVisitChildNodes(node, autoCorrect) { _, errorMessage, canBeAutoCorrected ->
-            emitFinding(errorMessage, canBeAutoCorrected, node)
+        wrapping.beforeVisitChildNodes(node, autoCorrect) { offset, errorMessage, canBeAutoCorrected ->
+            emitFinding(offset, errorMessage, canBeAutoCorrected, node)
         }
     }
 
     private fun afterVisitChildNodes(node: ASTNode) {
-        wrapping.afterVisitChildNodes(node, autoCorrect) { _, errorMessage, canBeAutoCorrected ->
-            emitFinding(errorMessage, canBeAutoCorrected, node)
+        wrapping.afterVisitChildNodes(node, autoCorrect) { offset, errorMessage, canBeAutoCorrected ->
+            emitFinding(offset, errorMessage, canBeAutoCorrected, node)
         }
     }
 

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/IndentationSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/IndentationSpec.kt
@@ -34,8 +34,8 @@ class IndentationSpec {
             @Test
             fun `places finding location to the indentation`() {
                 assertThat(subject.compileAndLint(code))
-                    .hasStartSourceLocation(1, 13)
-                    .hasTextLocations(12 to 14)
+                    .hasStartSourceLocation(2, 1)
+                    .hasTextLocations(13 to 14)
             }
         }
 

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/MaximumLineLengthSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/MaximumLineLengthSpec.kt
@@ -63,7 +63,7 @@ class MaximumLineLengthSpec {
         // exceeded lines in block comments.
         assertThat(findings)
             .hasSize(2)
-            .hasStartSourceLocations(SourceLocation(7, 8), SourceLocation(13, 12))
+            .hasStartSourceLocations(SourceLocation(8, 1), SourceLocation(14, 1))
     }
 
     @Test

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/NoUnusedImportsSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/NoUnusedImportsSpec.kt
@@ -1,0 +1,41 @@
+package io.gitlab.arturbosch.detekt.formatting
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.SourceLocation
+import io.gitlab.arturbosch.detekt.formatting.wrappers.NoUnusedImports
+import io.gitlab.arturbosch.detekt.test.assertThat
+import io.gitlab.arturbosch.detekt.test.lint
+import org.junit.jupiter.api.Test
+
+class NoUnusedImportsSpec {
+
+    @Test
+    fun `regression - findings are reported at the import not the file node`() {
+        val code = """
+            package testData
+
+            import java.util.HashMap
+            import java.util.HashSet
+            import java.util.ArrayList
+
+            class Poko(
+
+            ) {
+
+
+            }
+
+            fun f() = 5
+        """.trimIndent()
+
+        val findings = NoUnusedImports(Config.empty).lint(code)
+
+        assertThat(findings)
+            .hasSize(3)
+            .hasStartSourceLocations(
+                SourceLocation(3, 1),
+                SourceLocation(4, 1),
+                SourceLocation(5, 1)
+            )
+    }
+}

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/WrappingSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/WrappingSpec.kt
@@ -31,7 +31,7 @@ class WrappingSpec {
 
         assertThat(subject.compileAndLint(code))
             .hasSize(1)
-            .hasStartSourceLocation(1, 13)
-            .hasTextLocations(12 to 20)
+            .hasStartSourceLocation(1, 12)
+            .hasTextLocations(11 to 12)
     }
 }


### PR DESCRIPTION
This PR was triggered by users of the IntelliJ plugin getting every unused import reported at the file level which clutters the editor: https://github.com/detekt/detekt-intellij-plugin/issues/486#issuecomment-1676916223

![Screenshot from 2023-08-14 19-57-14](https://github.com/detekt/detekt/assets/20924106/0430085a-94b4-4f36-9933-13a1f0d60b4b)

This PR partly reverts the change to the emit logic of https://github.com/detekt/detekt/pull/5876/files#diff-9cf77f9ffcbf036bf5044d1ef99728b56aad97854246f3473f69d54b4b929380.
Emiting at the node is wrong in the case of the NoUnusedImports rule as in `beforeVisitChildNodes` the import usages are calculated and only reported in `afterVisitChildNodes` from the file node (because `fileNode.imports` access is easy I suppose). 

With this revert the lines are again calculated with the offset function and lead to the same results as our MaxLineLength rule:
![Screenshot from 2023-08-14 20-16-34](https://github.com/detekt/detekt/assets/20924106/1698eede-4f89-484a-9d18-77626cd7f027)

The other changed test cases are also now correct again e,g, the tested code for indentation rule is
`val code = "fun main() {\n println()\n}"` so `.hasStartSourceLocation(1, 13)` could not be correct due to the line breaks.

Fixes #6105