### PR TITLE
Remove deprecated secondary constructors of AnnotationExcluder

### DIFF
--- a/detekt-api/api/detekt-api.api
+++ b/detekt-api/api/detekt-api.api
@@ -1,6 +1,4 @@
 public final class io/gitlab/arturbosch/detekt/api/AnnotationExcluder {
-	public fun <init> (Lorg/jetbrains/kotlin/psi/KtFile;Lio/gitlab/arturbosch/detekt/api/SplitPattern;)V
-	public fun <init> (Lorg/jetbrains/kotlin/psi/KtFile;Ljava/util/List;)V
 	public fun <init> (Lorg/jetbrains/kotlin/psi/KtFile;Ljava/util/List;Lorg/jetbrains/kotlin/resolve/BindingContext;)V
 	public final fun shouldExclude (Ljava/util/List;)Z
 }

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/AnnotationExcluder.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/AnnotationExcluder.kt
@@ -21,26 +21,6 @@ class AnnotationExcluder(
 
     private val fullQualifiedNameGuesser = FullQualifiedNameGuesser(root)
 
-    @Deprecated("Use AnnotationExcluder(List<Regex>, KtFile) instead")
-    constructor(root: KtFile, excludes: SplitPattern) : this(
-        root,
-        excludes.mapAll { it }
-            .map { it.replace(".", "\\.").replace("*", ".*").toRegex() },
-        BindingContext.EMPTY,
-    )
-
-    @Deprecated("Use AnnotationExcluder(List<Regex>, KtFile) instead")
-    constructor(
-        root: KtFile,
-        excludes: List<String>,
-    ) : this(
-        root,
-        excludes.map {
-            it.replace(".", "\\.").replace("*", ".*").toRegex()
-        },
-        BindingContext.EMPTY,
-    )
-
     /**
      * Is true if any given annotation name is declared in the SplitPattern
      * which basically describes entries to exclude.

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/AnnotationExcluderSpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/AnnotationExcluderSpec.kt
@@ -75,26 +75,6 @@ class AnnotationExcluderSpec(private val env: KotlinCoreEnvironment) {
 
             assertThat(excluder.shouldExclude(listOf(ktAnnotation))).isTrue()
         }
-
-        @Test
-        fun `should exclude when the annotation was found with SplitPattern`() {
-            val (file, ktAnnotation) = createKtFile("@SinceKotlin")
-
-            @Suppress("DEPRECATION")
-            val excluder = AnnotationExcluder(file, SplitPattern("SinceKotlin"))
-
-            assertThat(excluder.shouldExclude(listOf(ktAnnotation))).isTrue()
-        }
-
-        @Test
-        fun `should exclude when the annotation was found with List of Strings`() {
-            val (file, ktAnnotation) = createKtFile("@SinceKotlin")
-
-            @Suppress("DEPRECATION")
-            val excluder = AnnotationExcluder(file, listOf("SinceKo*"))
-
-            assertThat(excluder.shouldExclude(listOf(ktAnnotation))).isTrue()
-        }
     }
 
     @Nested


### PR DESCRIPTION
Part of the effort to remove deprecated code for the 2.0 release.

This removes those secondary constructors from the `AnnotationExcluder` that are markes as deprecated.