### PR TITLE
Remove deprecated DefaultContext

### DIFF
--- a/detekt-api/api/detekt-api.api
+++ b/detekt-api/api/detekt-api.api
@@ -189,14 +189,6 @@ public final class io/gitlab/arturbosch/detekt/api/Debt$Companion {
 	public final fun getTWENTY_MINS ()Lio/gitlab/arturbosch/detekt/api/Debt;
 }
 
-public class io/gitlab/arturbosch/detekt/api/DefaultContext : io/gitlab/arturbosch/detekt/api/Context {
-	public fun <init> ()V
-	public final fun clearFindings ()V
-	public fun getFindings ()Ljava/util/List;
-	public fun report (Lio/gitlab/arturbosch/detekt/api/Finding;Ljava/util/Set;Ljava/lang/String;)V
-	public fun report (Ljava/util/List;Ljava/util/Set;Ljava/lang/String;)V
-}
-
 public class io/gitlab/arturbosch/detekt/api/DetektVisitor : org/jetbrains/kotlin/psi/KtTreeVisitorVoid {
 	public fun <init> ()V
 }

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Context.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Context.kt
@@ -1,6 +1,5 @@
 package io.gitlab.arturbosch.detekt.api
 
-import io.gitlab.arturbosch.detekt.api.internal.isSuppressedBy
 import org.jetbrains.kotlin.psi.KtFile
 
 /**
@@ -37,36 +36,4 @@ interface Context {
      * Normally this is done on every new [KtFile] analyzed and should be called by clients.
      */
     fun clearFindings()
-}
-
-/**
- * Default [Context] implementation.
- */
-@Deprecated("You should not use this class directly. Use or extend Context instead.")
-open class DefaultContext : Context {
-
-    /**
-     * Returns a copy of violations for this rule.
-     */
-    override val findings: List<Finding>
-        get() = _findings.toList()
-
-    private val _findings: MutableList<Finding> = mutableListOf()
-
-    /**
-     * Reports a single code smell finding.
-     *
-     * Before adding a finding, it is checked if it is not suppressed
-     * by @Suppress or @SuppressWarnings annotations.
-     */
-    override fun report(finding: Finding, aliases: Set<String>, ruleSetId: RuleSetId?) {
-        val ktElement = finding.entity.ktElement
-        if (ktElement == null || !ktElement.isSuppressedBy(finding.id, aliases, ruleSetId)) {
-            _findings.add(finding)
-        }
-    }
-
-    final override fun clearFindings() {
-        _findings.clear()
-    }
 }


### PR DESCRIPTION
Part of the effort to remove deprecated code for the 2.0 release.

This removes the deprecated `DefaultContext` object.