### PR TITLE
Remove deprecated functions `FileProcessListener`

### DIFF
--- a/detekt-api/api/detekt-api.api
+++ b/detekt-api/api/detekt-api.api
@@ -253,13 +253,9 @@ public final class io/gitlab/arturbosch/detekt/api/Extension$DefaultImpls {
 }
 
 public abstract interface class io/gitlab/arturbosch/detekt/api/FileProcessListener : io/gitlab/arturbosch/detekt/api/Extension {
-	public abstract fun onFinish (Ljava/util/List;Lio/gitlab/arturbosch/detekt/api/Detektion;)V
 	public abstract fun onFinish (Ljava/util/List;Lio/gitlab/arturbosch/detekt/api/Detektion;Lorg/jetbrains/kotlin/resolve/BindingContext;)V
-	public abstract fun onProcess (Lorg/jetbrains/kotlin/psi/KtFile;)V
 	public abstract fun onProcess (Lorg/jetbrains/kotlin/psi/KtFile;Lorg/jetbrains/kotlin/resolve/BindingContext;)V
-	public abstract fun onProcessComplete (Lorg/jetbrains/kotlin/psi/KtFile;Ljava/util/Map;)V
 	public abstract fun onProcessComplete (Lorg/jetbrains/kotlin/psi/KtFile;Ljava/util/Map;Lorg/jetbrains/kotlin/resolve/BindingContext;)V
-	public abstract fun onStart (Ljava/util/List;)V
 	public abstract fun onStart (Ljava/util/List;Lorg/jetbrains/kotlin/resolve/BindingContext;)V
 }
 
@@ -268,13 +264,9 @@ public final class io/gitlab/arturbosch/detekt/api/FileProcessListener$DefaultIm
 	public static fun getPriority (Lio/gitlab/arturbosch/detekt/api/FileProcessListener;)I
 	public static fun init (Lio/gitlab/arturbosch/detekt/api/FileProcessListener;Lio/gitlab/arturbosch/detekt/api/Config;)V
 	public static fun init (Lio/gitlab/arturbosch/detekt/api/FileProcessListener;Lio/gitlab/arturbosch/detekt/api/SetupContext;)V
-	public static fun onFinish (Lio/gitlab/arturbosch/detekt/api/FileProcessListener;Ljava/util/List;Lio/gitlab/arturbosch/detekt/api/Detektion;)V
 	public static fun onFinish (Lio/gitlab/arturbosch/detekt/api/FileProcessListener;Ljava/util/List;Lio/gitlab/arturbosch/detekt/api/Detektion;Lorg/jetbrains/kotlin/resolve/BindingContext;)V
-	public static fun onProcess (Lio/gitlab/arturbosch/detekt/api/FileProcessListener;Lorg/jetbrains/kotlin/psi/KtFile;)V
 	public static fun onProcess (Lio/gitlab/arturbosch/detekt/api/FileProcessListener;Lorg/jetbrains/kotlin/psi/KtFile;Lorg/jetbrains/kotlin/resolve/BindingContext;)V
-	public static fun onProcessComplete (Lio/gitlab/arturbosch/detekt/api/FileProcessListener;Lorg/jetbrains/kotlin/psi/KtFile;Ljava/util/Map;)V
 	public static fun onProcessComplete (Lio/gitlab/arturbosch/detekt/api/FileProcessListener;Lorg/jetbrains/kotlin/psi/KtFile;Ljava/util/Map;Lorg/jetbrains/kotlin/resolve/BindingContext;)V
-	public static fun onStart (Lio/gitlab/arturbosch/detekt/api/FileProcessListener;Ljava/util/List;)V
 	public static fun onStart (Lio/gitlab/arturbosch/detekt/api/FileProcessListener;Ljava/util/List;Lorg/jetbrains/kotlin/resolve/BindingContext;)V
 }
 

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/FileProcessListener.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/FileProcessListener.kt
@@ -16,61 +16,19 @@ interface FileProcessListener : Extension {
      * Use this to gather some additional information for the real onProcess function.
      * This calculation should be lightweight as this method is called from the main thread.
      */
-    @Deprecated(
-        "Use alternative with a binding context.",
-        ReplaceWith("onStart(files, bindingContext)")
-    )
-    fun onStart(files: List<KtFile>) {
-    }
-
-    /**
-     * Use this to gather some additional information for the real onProcess function.
-     * This calculation should be lightweight as this method is called from the main thread.
-     */
-    @Suppress("DEPRECATION")
-    fun onStart(files: List<KtFile>, bindingContext: BindingContext) {
-        onStart(files)
-    }
+    fun onStart(files: List<KtFile>, bindingContext: BindingContext) {}
 
     /**
      * Called when processing of a file begins.
      * This method is called from a thread pool thread. Heavy computations allowed.
      */
-    @Deprecated(
-        "Use alternative with a binding context.",
-        ReplaceWith("onProcess(file, bindingContext)")
-    )
-    fun onProcess(file: KtFile) {
-    }
-
-    /**
-     * Called when processing of a file begins.
-     * This method is called from a thread pool thread. Heavy computations allowed.
-     */
-    @Suppress("DEPRECATION")
-    fun onProcess(file: KtFile, bindingContext: BindingContext) {
-        onProcess(file)
-    }
+    fun onProcess(file: KtFile, bindingContext: BindingContext) {}
 
     /**
      * Called when processing of a file completes.
      * This method is called from a thread pool thread. Heavy computations allowed.
      */
-    @Deprecated(
-        "Use alternative with a binding context.",
-        ReplaceWith("onProcessComplete(file, findings, bindingContext)")
-    )
-    fun onProcessComplete(file: KtFile, findings: Map<String, List<Finding>>) {
-    }
-
-    /**
-     * Called when processing of a file completes.
-     * This method is called from a thread pool thread. Heavy computations allowed.
-     */
-    @Suppress("DEPRECATION")
-    fun onProcessComplete(file: KtFile, findings: Map<String, List<Finding>>, bindingContext: BindingContext) {
-        onProcessComplete(file, findings)
-    }
+    fun onProcessComplete(file: KtFile, findings: Map<String, List<Finding>>, bindingContext: BindingContext) {}
 
     /**
      * Mainly use this method to save computed metrics from KtFile's to the {@link Detektion} container.
@@ -78,21 +36,5 @@ interface FileProcessListener : Extension {
      *
      * This method is called before any [ReportingExtension].
      */
-    @Deprecated(
-        "Use alternative with a binding context.",
-        ReplaceWith("onFinish(files, result, bindingContext)")
-    )
-    fun onFinish(files: List<KtFile>, result: Detektion) {
-    }
-
-    /**
-     * Mainly use this method to save computed metrics from KtFile's to the {@link Detektion} container.
-     * Do not do heavy computations here as this method is called from the main thread.
-     *
-     * This method is called before any [ReportingExtension].
-     */
-    @Suppress("DEPRECATION")
-    fun onFinish(files: List<KtFile>, result: Detektion, bindingContext: BindingContext) {
-        onFinish(files, result)
-    }
+    fun onFinish(files: List<KtFile>, result: Detektion, bindingContext: BindingContext) {}
 }


### PR DESCRIPTION
This removes the functions without a binding context from the `FileProcessListener`.