### PR TITLE
Remove deprecated constructors for `Location`

### DIFF
--- a/detekt-api/api/detekt-api.api
+++ b/detekt-api/api/detekt-api.api
@@ -350,22 +350,17 @@ public final class io/gitlab/arturbosch/detekt/api/LazyRegex : kotlin/properties
 public final class io/gitlab/arturbosch/detekt/api/Location : io/gitlab/arturbosch/detekt/api/Compactable {
 	public static final field Companion Lio/gitlab/arturbosch/detekt/api/Location$Companion;
 	public fun <init> (Lio/gitlab/arturbosch/detekt/api/SourceLocation;Lio/gitlab/arturbosch/detekt/api/SourceLocation;Lio/gitlab/arturbosch/detekt/api/TextLocation;Lio/github/detekt/psi/FilePath;)V
-	public fun <init> (Lio/gitlab/arturbosch/detekt/api/SourceLocation;Lio/gitlab/arturbosch/detekt/api/TextLocation;Lio/github/detekt/psi/FilePath;)V
-	public fun <init> (Lio/gitlab/arturbosch/detekt/api/SourceLocation;Lio/gitlab/arturbosch/detekt/api/TextLocation;Ljava/lang/String;)V
-	public fun <init> (Lio/gitlab/arturbosch/detekt/api/SourceLocation;Lio/gitlab/arturbosch/detekt/api/TextLocation;Ljava/lang/String;Lio/github/detekt/psi/FilePath;)V
-	public synthetic fun <init> (Lio/gitlab/arturbosch/detekt/api/SourceLocation;Lio/gitlab/arturbosch/detekt/api/TextLocation;Ljava/lang/String;Lio/github/detekt/psi/FilePath;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun <init> (Lio/gitlab/arturbosch/detekt/api/SourceLocation;Lio/gitlab/arturbosch/detekt/api/TextLocation;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Lio/gitlab/arturbosch/detekt/api/SourceLocation;Lio/gitlab/arturbosch/detekt/api/SourceLocation;Lio/gitlab/arturbosch/detekt/api/TextLocation;Lio/github/detekt/psi/FilePath;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun compact ()Ljava/lang/String;
 	public fun compactWithSignature ()Ljava/lang/String;
 	public final fun component1 ()Lio/gitlab/arturbosch/detekt/api/SourceLocation;
-	public final fun component2 ()Lio/gitlab/arturbosch/detekt/api/TextLocation;
-	public final fun component3 ()Ljava/lang/String;
+	public final fun component2 ()Lio/gitlab/arturbosch/detekt/api/SourceLocation;
+	public final fun component3 ()Lio/gitlab/arturbosch/detekt/api/TextLocation;
 	public final fun component4 ()Lio/github/detekt/psi/FilePath;
-	public final fun copy (Lio/gitlab/arturbosch/detekt/api/SourceLocation;Lio/gitlab/arturbosch/detekt/api/TextLocation;Ljava/lang/String;Lio/github/detekt/psi/FilePath;)Lio/gitlab/arturbosch/detekt/api/Location;
-	public static synthetic fun copy$default (Lio/gitlab/arturbosch/detekt/api/Location;Lio/gitlab/arturbosch/detekt/api/SourceLocation;Lio/gitlab/arturbosch/detekt/api/TextLocation;Ljava/lang/String;Lio/github/detekt/psi/FilePath;ILjava/lang/Object;)Lio/gitlab/arturbosch/detekt/api/Location;
+	public final fun copy (Lio/gitlab/arturbosch/detekt/api/SourceLocation;Lio/gitlab/arturbosch/detekt/api/SourceLocation;Lio/gitlab/arturbosch/detekt/api/TextLocation;Lio/github/detekt/psi/FilePath;)Lio/gitlab/arturbosch/detekt/api/Location;
+	public static synthetic fun copy$default (Lio/gitlab/arturbosch/detekt/api/Location;Lio/gitlab/arturbosch/detekt/api/SourceLocation;Lio/gitlab/arturbosch/detekt/api/SourceLocation;Lio/gitlab/arturbosch/detekt/api/TextLocation;Lio/github/detekt/psi/FilePath;ILjava/lang/Object;)Lio/gitlab/arturbosch/detekt/api/Location;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getEndSource ()Lio/gitlab/arturbosch/detekt/api/SourceLocation;
-	public final fun getFile ()Ljava/lang/String;
 	public final fun getFilePath ()Lio/github/detekt/psi/FilePath;
 	public final fun getSource ()Lio/gitlab/arturbosch/detekt/api/SourceLocation;
 	public final fun getText ()Lio/gitlab/arturbosch/detekt/api/TextLocation;

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Location.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Location.kt
@@ -9,60 +9,16 @@ import org.jetbrains.kotlin.diagnostics.PsiDiagnosticUtils
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.psiUtil.endOffset
 import org.jetbrains.kotlin.psi.psiUtil.startOffset
-import kotlin.io.path.Path
 
 /**
  * Specifies a position within a source code fragment.
  */
-data class Location
-@Deprecated("Consider relative path by passing a [FilePath]")
-@JvmOverloads
-constructor(
+data class Location(
     val source: SourceLocation,
+    val endSource: SourceLocation = source,
     val text: TextLocation,
-    @Deprecated(
-        "Use filePath instead",
-        ReplaceWith(
-            "filePath.absolutePath.toString()"
-        )
-    )
-    val file: String,
-    val filePath: FilePath = FilePath.fromAbsolute(Path(file))
+    val filePath: FilePath
 ) : Compactable {
-    var endSource: SourceLocation = source
-        private set
-
-    @Suppress("DEPRECATION")
-    constructor(
-        source: SourceLocation,
-        text: TextLocation,
-        filePath: FilePath
-    ) : this(source, text, filePath.absolutePath.toString(), filePath)
-
-    @Suppress("DEPRECATION")
-    constructor(
-        source: SourceLocation,
-        endSource: SourceLocation,
-        text: TextLocation,
-        filePath: FilePath,
-    ) : this(source, text, filePath.absolutePath.toString(), filePath) {
-        this.endSource = endSource
-    }
-
-    @Suppress("DEPRECATION")
-    @Deprecated(
-        "locationString was removed and won't get passed to the main constructor. Use queries on 'ktElement' instead.",
-        ReplaceWith(
-            "Location(source, text, file)",
-            "io.gitlab.arturbosch.detekt.api.Location"
-        )
-    )
-    constructor(
-        source: SourceLocation,
-        text: TextLocation,
-        @Suppress("UNUSED_PARAMETER") locationString: String,
-        file: String
-    ) : this(source, text, file)
 
     override fun compact(): String = "${filePath.absolutePath}:$source"
 

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/Builders.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/Builders.kt
@@ -26,7 +26,11 @@ internal fun buildFinding(element: KtElement?): Finding = CodeSmell(
 private fun buildEmptyEntity(): Entity = Entity(
     name = "",
     signature = "",
-    location = Location(SourceLocation(0, 0), TextLocation(0, 0), FilePath.fromAbsolute(Path("/"))),
+    location = Location(
+        source = SourceLocation(0, 0),
+        text = TextLocation(0, 0),
+        filePath = FilePath.fromAbsolute(Path("/"))
+    ),
     ktElement = null,
 )
 

--- a/detekt-report-sarif/src/test/kotlin/io/github/detekt/report/sarif/SarifOutputReportSpec.kt
+++ b/detekt-report-sarif/src/test/kotlin/io/github/detekt/report/sarif/SarifOutputReportSpec.kt
@@ -91,8 +91,8 @@ class SarifOutputReportSpec {
 
         val refEntity = TestRule().compileAndLint(Snippet.code).first().entity
         val location = Location(
-            SourceLocation(startLine, startColumn),
-            TextLocation(
+            source = SourceLocation(startLine, startColumn),
+            text = TextLocation(
                 startLine + (startColumn - 1) * Snippet.lineLength,
                 endColumn + (endLine - 1) * Snippet.lineLength
             ),
@@ -128,8 +128,8 @@ class SarifOutputReportSpec {
 
         val refEntity = TestRule().compileAndLint(Snippet.code).first().entity
         val location = Location(
-            SourceLocation(startLine, startColumn),
-            TextLocation(
+            source = SourceLocation(startLine, startColumn),
+            text = TextLocation(
                 startLine + (startColumn - 1) * Snippet.lineLength,
                 endColumn + (endLine - 1) * Snippet.lineLength
             ),

--- a/detekt-report-xml/src/test/kotlin/io/github/detekt/report/xml/XmlOutputFormatSpec.kt
+++ b/detekt-report-xml/src/test/kotlin/io/github/detekt/report/xml/XmlOutputFormatSpec.kt
@@ -28,18 +28,18 @@ class XmlOutputFormatSpec {
         "Sample1",
         "",
         Location(
-            SourceLocation(11, 1),
-            TextLocation(0, 10),
-            FilePath.fromAbsolute(Path("src/main/com/sample/Sample1.kt"))
+            source = SourceLocation(11, 1),
+            text = TextLocation(0, 10),
+            filePath = FilePath.fromAbsolute(Path("src/main/com/sample/Sample1.kt"))
         )
     )
     private val entity2 = Entity(
         "Sample2",
         "",
         Location(
-            SourceLocation(22, 2),
-            TextLocation(0, 20),
-            FilePath.fromAbsolute(Path("src/main/com/sample/Sample2.kt"))
+            source = SourceLocation(22, 2),
+            text = TextLocation(0, 20),
+            filePath = FilePath.fromAbsolute(Path("src/main/com/sample/Sample2.kt"))
         )
     )
     private val outputFormat = XmlOutputReport()

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/NewLineAtEndOfFile.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/NewLineAtEndOfFile.kt
@@ -39,7 +39,11 @@ class NewLineAtEndOfFile(config: Config = Config.empty) : Rule(config) {
             )
             val sourceLocation = SourceLocation(coords?.line ?: 0, coords?.column ?: 0)
             val textLocation = TextLocation(file.endOffset, file.endOffset)
-            val location = Location(sourceLocation, textLocation, file.containingFile.toFilePath())
+            val location = Location(
+                source = sourceLocation,
+                text = textLocation,
+                filePath = file.containingFile.toFilePath()
+            )
             report(
                 CodeSmell(
                     issue,


### PR DESCRIPTION
This removes all deprecated secondary constructors for the `Location` class
