### PR TITLE
Remove obsolete `ThresholdRule` documentation generation logic

### DIFF
--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleVisitor.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleVisitor.kt
@@ -173,7 +173,6 @@ internal class RuleVisitor(textReplacements: Map<String, String>) : DetektVisito
             // which needs output of this class.
             "Rule", // io.gitlab.arturbosch.detekt.api.Rule
             "FormattingRule", // io.gitlab.arturbosch.detekt.formatting.FormattingRule
-            "ThresholdRule", // io.gitlab.arturbosch.detekt.api.ThresholdRule
             "EmptyRule", // io.gitlab.arturbosch.detekt.rules.empty.EmptyRule
         )
 

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleCollectorSpec.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleCollectorSpec.kt
@@ -13,6 +13,8 @@ import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 
 class RuleCollectorSpec {
 
@@ -37,13 +39,12 @@ class RuleCollectorSpec {
         assertThat(items).isEmpty()
     }
 
-    @Test
-    fun `throws when a class extends Rule but has no valid documentation`() {
-        val rules = listOf("Rule", "FormattingRule", "ThresholdRule", "EmptyRule")
-        for (rule in rules) {
-            val code = "class SomeRandomClass : $rule"
-            assertThatExceptionOfType(InvalidDocumentationException::class.java).isThrownBy { subject.run(code) }
-        }
+    @ParameterizedTest
+    @ValueSource(strings = ["Rule", "FormattingRule", "EmptyRule"])
+    fun `throws when a class extends Rule but has no valid documentation`(rule: String) {
+        val code = "class SomeRandomClass : $rule"
+        assertThatExceptionOfType(InvalidDocumentationException::class.java)
+            .isThrownBy { subject.run(code) }
     }
 
     @Test


### PR DESCRIPTION
This is a follow up to #6393 where the `ThresholdRule` was removed. This removes some code that refers to that abstract rule.
