### PR TITLE
Remove old code from LibraryCodeMustSpecifyReturnType

### DIFF
--- a/detekt-rules-libraries/src/main/kotlin/io/gitlab/arturbosch/detekt/libraries/LibraryCodeMustSpecifyReturnType.kt
+++ b/detekt-rules-libraries/src/main/kotlin/io/gitlab/arturbosch/detekt/libraries/LibraryCodeMustSpecifyReturnType.kt
@@ -74,9 +74,6 @@ class LibraryCodeMustSpecifyReturnType(config: Config = Config.empty) : Rule(con
     }
 
     override fun visitNamedFunction(function: KtNamedFunction) {
-        if (bindingContext == BindingContext.EMPTY) {
-            return
-        }
         if (function.explicitReturnTypeRequired() && !function.isUnitOmissionAllowed()) {
             report(
                 CodeSmell(

--- a/detekt-rules-libraries/src/test/kotlin/io/gitlab/arturbosch/detekt/libraries/LibraryCodeMustSpecifyReturnTypeSpec.kt
+++ b/detekt-rules-libraries/src/test/kotlin/io/gitlab/arturbosch/detekt/libraries/LibraryCodeMustSpecifyReturnTypeSpec.kt
@@ -1,6 +1,5 @@
 package io.gitlab.arturbosch.detekt.libraries
 
-import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
@@ -14,25 +13,6 @@ import org.junit.jupiter.params.provider.ValueSource
 
 @KotlinCoreEnvironmentTest
 class LibraryCodeMustSpecifyReturnTypeSpec(val env: KotlinCoreEnvironment) {
-
-    @Test
-    fun `should not report without explicit filters set`() {
-        val subject = LibraryCodeMustSpecifyReturnType(TestConfig(Config.EXCLUDES_KEY to "**"))
-        assertThat(
-            subject.compileAndLintWithContext(
-                env,
-                """
-                    fun foo() = 5
-                    val bar = 5
-                    class A {
-                        fun b() = 2
-                        val c = 2
-                    }
-                """.trimIndent()
-            )
-        ).isEmpty()
-    }
-
     @Nested
     inner class `positive cases` {
         val subject = LibraryCodeMustSpecifyReturnType()


### PR DESCRIPTION
`LibraryCodeMustSpecifyReturnType` had some old code that is no longer needed:

- We don't exclude everything from `LibraryCodeMustSpecifyReturnType` anymore so there is no need to test it.
- The annotation on LibraryCodeMustSpecifyReturnType ensures that it only runs with type solving enabled.