### PR TITLE
Disable deprecated rules when using `allRules` flag.

### DIFF
--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Analyzer.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Analyzer.kt
@@ -16,6 +16,8 @@ import io.gitlab.arturbosch.detekt.api.internal.whichJava
 import io.gitlab.arturbosch.detekt.api.internal.whichOS
 import io.gitlab.arturbosch.detekt.core.config.AllRulesConfig
 import io.gitlab.arturbosch.detekt.core.config.DisabledAutoCorrectConfig
+import io.gitlab.arturbosch.detekt.core.config.validation.DeprecatedRule
+import io.gitlab.arturbosch.detekt.core.config.validation.loadDeprecations
 import io.gitlab.arturbosch.detekt.core.rules.associateRuleIdsToRuleSetIds
 import io.gitlab.arturbosch.detekt.core.rules.isActive
 import io.gitlab.arturbosch.detekt.core.rules.shouldAnalyzeFile
@@ -193,7 +195,12 @@ internal fun ProcessingSpec.workaroundConfiguration(config: Config): Config = wi
 
     if (rulesSpec.activateAllRules) {
         val defaultConfig = getDefaultConfiguration()
-        declaredConfig = AllRulesConfig(declaredConfig ?: defaultConfig, defaultConfig)
+        val deprecatedRules = loadDeprecations().filterIsInstance<DeprecatedRule>().toSet()
+        declaredConfig = AllRulesConfig(
+            originalConfig = declaredConfig ?: defaultConfig,
+            defaultConfig = defaultConfig,
+            deprecatedRules = deprecatedRules
+        )
     }
 
     if (!rulesSpec.autoCorrect) {

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/AllRulesConfig.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/AllRulesConfig.kt
@@ -1,35 +1,41 @@
 package io.gitlab.arturbosch.detekt.core.config
 
 import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.core.config.validation.DeprecatedRule
 import io.gitlab.arturbosch.detekt.core.config.validation.ValidatableConfiguration
 import io.gitlab.arturbosch.detekt.core.config.validation.validateConfig
 
 @Suppress("UNCHECKED_CAST")
 internal data class AllRulesConfig(
     private val originalConfig: Config,
-    private val defaultConfig: Config
+    private val defaultConfig: Config,
+    private val deprecatedRules: Set<DeprecatedRule> = emptySet()
 ) : Config, ValidatableConfiguration {
 
     override val parentPath: String?
         get() = originalConfig.parentPath ?: defaultConfig.parentPath
 
     override fun subConfig(key: String) =
-        AllRulesConfig(originalConfig.subConfig(key), defaultConfig.subConfig(key))
+        AllRulesConfig(originalConfig.subConfig(key), defaultConfig.subConfig(key), deprecatedRules)
 
     override fun <T : Any> valueOrDefault(key: String, default: T): T {
         return when (key) {
-            Config.ACTIVE_KEY -> originalConfig.valueOrDefault(key, true) as T
+            Config.ACTIVE_KEY -> if (isDeprecated()) false as T else originalConfig.valueOrDefault(key, true) as T
             else -> originalConfig.valueOrDefault(key, defaultConfig.valueOrDefault(key, default))
         }
     }
 
     override fun <T : Any> valueOrNull(key: String): T? {
         return when (key) {
-            Config.ACTIVE_KEY -> originalConfig.valueOrNull(key) ?: true as? T
+            Config.ACTIVE_KEY -> if (isDeprecated()) false as T else originalConfig.valueOrNull(key) ?: true as? T
             else -> originalConfig.valueOrNull(key) ?: defaultConfig.valueOrNull(key)
         }
     }
 
     override fun validate(baseline: Config, excludePatterns: Set<Regex>) =
         validateConfig(originalConfig, baseline, excludePatterns)
+
+    private fun isDeprecated(): Boolean = deprecatedRules.any { parentPath == it.toPath() }
+
+    private fun DeprecatedRule.toPath() = "$ruleSetId > $ruleId"
 }

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/AllRulesConfigSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/AllRulesConfigSpec.kt
@@ -1,23 +1,26 @@
 package io.gitlab.arturbosch.detekt.core.config
 
 import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.core.config.validation.DeprecatedRule
 import io.gitlab.arturbosch.detekt.test.yamlConfig
+import io.gitlab.arturbosch.detekt.test.yamlConfigFromContent
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 class AllRulesConfigSpec {
+    private val emptyYamlConfig = yamlConfigFromContent("")
+
     @Nested
     inner class ParentPath {
         private val rulesetId = "style"
         private val rulesetConfig = yamlConfig("/configs/single-rule-in-style-ruleset.yml").subConfig(rulesetId)
-        private val emptyConfig = Config.empty
 
         @Test
         fun `is derived from the original config`() {
             val subject = AllRulesConfig(
                 originalConfig = rulesetConfig,
-                defaultConfig = emptyConfig,
+                defaultConfig = emptyYamlConfig,
             )
             val actual = subject.parentPath
             assertThat(actual).isEqualTo(rulesetId)
@@ -26,11 +29,46 @@ class AllRulesConfigSpec {
         @Test
         fun `is derived from the default config if unavailable in original config`() {
             val subject = AllRulesConfig(
-                originalConfig = emptyConfig,
+                originalConfig = emptyYamlConfig,
                 defaultConfig = rulesetConfig,
             )
             val actual = subject.parentPath
             assertThat(actual).isEqualTo(rulesetId)
+        }
+    }
+
+
+    @Nested
+    inner class DeactivateDeprecatedRule {
+
+        @Test
+        fun `rule is active if not deprecated`() {
+            val subject = AllRulesConfig(
+                originalConfig = emptyYamlConfig,
+                defaultConfig = emptyYamlConfig,
+                deprecatedRules = emptySet()
+            )
+                .subConfig("ruleset")
+                .subConfig("ARule")
+
+            val actual = subject.valueOrDefault(Config.ACTIVE_KEY, false)
+
+            assertThat(actual).isTrue
+        }
+
+        @Test
+        fun `rule is inactive if deprecated`() {
+            val subject = AllRulesConfig(
+                originalConfig = emptyYamlConfig,
+                defaultConfig = emptyYamlConfig,
+                deprecatedRules = setOf(DeprecatedRule("ruleset", "ARule", ""))
+            )
+                .subConfig("ruleset")
+                .subConfig("ARule")
+
+            val actual = subject.valueOrDefault(Config.ACTIVE_KEY, false)
+
+            assertThat(actual).isFalse
         }
     }
 }

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/AllRulesConfigSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/AllRulesConfigSpec.kt
@@ -37,7 +37,6 @@ class AllRulesConfigSpec {
         }
     }
 
-
     @Nested
     inner class DeactivateDeprecatedRule {
 


### PR DESCRIPTION
fixes #6336

This deactivates all deprecated rules when running with the `allRules` flag to allow `warningAsError` to be set to `true`.
