### PR TITLE
Ignore complexity of local function when calculating cyclomatic complexity by default

### DIFF
--- a/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/CyclomaticComplexity.kt
+++ b/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/CyclomaticComplexity.kt
@@ -27,6 +27,7 @@ class CyclomaticComplexity(private val config: Config) : DetektVisitor() {
     class Config(
         var ignoreSimpleWhenEntries: Boolean = false,
         var ignoreNestingFunctions: Boolean = false,
+        var ignoreLocalFunctions: Boolean = false,
         var nestingFunctions: Set<String> = DEFAULT_NESTING_FUNCTIONS
     )
 
@@ -36,12 +37,17 @@ class CyclomaticComplexity(private val config: Config) : DetektVisitor() {
     override fun visitNamedFunction(function: KtNamedFunction) {
         if (!isInsideObjectLiteral(function)) {
             complexity++
-            super.visitNamedFunction(function)
+            if (!isInsideNamedFunction(function) || config.ignoreLocalFunctions) {
+                super.visitNamedFunction(function)
+            }
         }
     }
 
     private fun isInsideObjectLiteral(function: KtNamedFunction) =
         function.getStrictParentOfType<KtObjectLiteralExpression>() != null
+
+    private fun isInsideNamedFunction(function: KtNamedFunction) =
+        function.getStrictParentOfType<KtNamedFunction>() != null
 
     override fun visitBinaryExpression(expression: KtBinaryExpression) {
         if (expression.operationToken in CONDITIONALS) {

--- a/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/CyclomaticComplexitySpec.kt
+++ b/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/CyclomaticComplexitySpec.kt
@@ -116,6 +116,34 @@ class CyclomaticComplexitySpec {
     }
 
     @Nested
+    inner class `counts local functions` {
+        private val code = compileContentForTest(
+            """
+                fun test(): String {
+                    fun local(flag: boolean) = if (flag) "a" else "b"
+                    return local(true)
+                }
+            """.trimIndent()
+        )
+        @Test
+        fun `counts them by default`() {
+            assertThat(
+                CyclomaticComplexity.calculate(code)
+            ).isEqualTo(defaultFunctionComplexity + 1)
+        }
+
+        @Test
+        fun `does not count them when ignored`() {
+            assertThat(
+                CyclomaticComplexity.calculate(code) {
+                    ignoreLocalFunctions = true
+                }
+            ).isEqualTo(defaultFunctionComplexity)
+        }
+    }
+
+
+    @Nested
     inner class `ignoreSimpleWhenEntries is false` {
 
         @Test


### PR DESCRIPTION
The change fixes #5344.

When calculating the cyclomatic complexity, the flag `ignoreLocalFunctions` decides how a local function increases the complexity of the parent function.

If the flag is set to `true`, then the complexity of the parent function increases by one for each local function. Otherwise, the complexity of the parent function increases with the complexity of each local function.