### PR TITLE
Fix build issues

### DIFF
--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -37,11 +37,17 @@ jobs:
           java-version: ${{ matrix.jdk }}
           distribution: 'temurin'
 
+      - name: Assemble and publish artifacts to Maven Local
+        uses: gradle/gradle-build-action@243af859f8ca30903d9d7f7936897ca0358ba691 # v2
+        with:
+          gradle-home-cache-cleanup: true
+          arguments: publishToMavenLocal
+
       - name: Build detekt
         uses: gradle/gradle-build-action@243af859f8ca30903d9d7f7936897ca0358ba691 # v2
         with:
           gradle-home-cache-cleanup: true
-          arguments: build -x detekt publishToMavenLocal
+          arguments: build -x detekt
 
       - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3
         with:

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektAndroidSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektAndroidSpec.kt
@@ -737,9 +737,9 @@ private fun createGradleRunnerAndSetupProject(
     mainBuildFileContent = """
         subprojects {
             repositories {
+                mavenLocal()
                 mavenCentral()
                 google()
-                mavenLocal()
             }
         }
     """.trimIndent(),

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektMultiplatformSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektMultiplatformSpec.kt
@@ -348,9 +348,9 @@ private fun setupProject(projectLayoutAction: ProjectLayout.() -> Unit): DslGrad
         mainBuildFileContent = """
             subprojects {
                 repositories {
+                    mavenLocal()
                     mavenCentral()
                     google()
-                    mavenLocal()
                 }
             }
         """.trimIndent(),

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektReportMergeSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektReportMergeSpec.kt
@@ -55,13 +55,13 @@ class DetektReportMergeSpec {
             assertThat(result.output).containsIgnoringWhitespaces(
                 """
                     Execution failed for task ':child1:detekt'.
-                    > Analysis failed with 2 weighted issues.
+                    > Analysis failed with 2 issues.
                 """.trimIndent()
             )
             assertThat(result.output).containsIgnoringWhitespaces(
                 """
                     Execution failed for task ':child2:detekt'.
-                    > Analysis failed with 4 weighted issues.
+                    > Analysis failed with 4 issues.
                 """.trimIndent()
             )
             assertThat(projectFile("build/reports/detekt/detekt.sarif")).doesNotExist()
@@ -121,13 +121,13 @@ class DetektReportMergeSpec {
             assertThat(result.output).containsIgnoringWhitespaces(
                 """
                     Execution failed for task ':child1:detekt'.
-                    > Analysis failed with 2 weighted issues.
+                    > Analysis failed with 2 issues.
                 """.trimIndent()
             )
             assertThat(result.output).containsIgnoringWhitespaces(
                 """
                     Execution failed for task ':child2:detekt'.
-                    > Analysis failed with 4 weighted issues.
+                    > Analysis failed with 4 issues.
                 """.trimIndent()
             )
             assertThat(projectFile("build/reports/detekt/detekt.xml")).doesNotExist()

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektTaskSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektTaskSpec.kt
@@ -45,7 +45,7 @@ class DetektTaskSpec {
             .build()
 
         gradleRunner.runDetektTaskAndExpectFailure { result ->
-            assertThat(result.output).contains("Analysis failed with 15 weighted issues.")
+            assertThat(result.output).contains("Analysis failed with 15 issues.")
         }
     }
 }

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/JvmSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/JvmSpec.kt
@@ -14,7 +14,7 @@ class JvmSpec {
             .withArguments("detektMain")
             .buildAndFail()
 
-        assertThat(result.output).contains("failed with 3 weighted issues.")
+        assertThat(result.output).contains("failed with 3 issues.")
         assertThat(result.output).contains(
             "Do not directly exit the process outside the `main` function. Throw an exception(...)"
         )

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/report/ReportMergeSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/report/ReportMergeSpec.kt
@@ -151,9 +151,9 @@ class ReportMergeSpec {
             
             allprojects {
                 repositories {
+                    mavenLocal()
                     mavenCentral()
                     google()
-                    mavenLocal()
                 }
             }
             

--- a/detekt-gradle-plugin/src/functionalTest/resources/jvm/build.gradle
+++ b/detekt-gradle-plugin/src/functionalTest/resources/jvm/build.gradle
@@ -4,8 +4,8 @@ plugins {
 }
 
 repositories {
-    mavenCentral()
     mavenLocal()
+    mavenCentral()
 }
 
 tasks.detektMain {

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektGenerateConfigTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektGenerateConfigTask.kt
@@ -78,6 +78,5 @@ abstract class DetektGenerateConfigTask @Inject constructor(
         }
     }
 
-    @Suppress("UnnecessaryAbstractClass")
-    abstract class SingleExecutionBuildService : BuildService<BuildServiceParameters.None>
+    interface SingleExecutionBuildService : BuildService<BuildServiceParameters.None>
 }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
@@ -21,6 +21,7 @@ class DetektPlugin : Plugin<Project> {
             )
 
         extension.reportsDir = project.extensions.getByType(ReportingExtension::class.java).file("detekt")
+        extension.basePath = project.layout.projectDirectory.asFile.absolutePath
 
         val defaultConfigFile =
             project.file("${project.rootProject.layout.projectDirectory.dir(CONFIG_DIR_NAME)}/$CONFIG_FILE")

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
@@ -21,7 +21,7 @@ class DetektPlugin : Plugin<Project> {
             )
 
         extension.reportsDir = project.extensions.getByType(ReportingExtension::class.java).file("detekt")
-        extension.basePath = project.layout.projectDirectory.asFile.absolutePath
+        extension.basePath = project.rootProject.layout.projectDirectory.asFile.absolutePath
 
         val defaultConfigFile =
             project.file("${project.rootProject.layout.projectDirectory.dir(CONFIG_DIR_NAME)}/$CONFIG_FILE")

--- a/detekt-gradle-plugin/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/testkit/DslGradleRunner.kt
+++ b/detekt-gradle-plugin/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/testkit/DslGradleRunner.kt
@@ -43,8 +43,6 @@ constructor(
 
     @Language("yaml")
     private val configFileContent = """
-        build:
-          maxIssues: 5
         style:
           MagicNumber:
             active: true


### PR DESCRIPTION
Fix build issues with the Gradle plugin by:
- Ensuring artifacts are published to Maven Local before running functional tests
- Moving `mavenLocal` to the first position in the `repositories` block in build files in the functional tests
- Fixing issues that weren't caught when CI was run on recent PRs due to the faulty setup