### PR TITLE
UnconditionalJumpStatementInLoop: don't report a conditional break in a single body expression

### DIFF
--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnconditionalJumpStatementInLoop.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnconditionalJumpStatementInLoop.kt
@@ -9,6 +9,7 @@ import io.gitlab.arturbosch.detekt.api.Rule
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtBinaryExpression
+import org.jetbrains.kotlin.psi.KtBlockExpression
 import org.jetbrains.kotlin.psi.KtBreakExpression
 import org.jetbrains.kotlin.psi.KtContinueExpression
 import org.jetbrains.kotlin.psi.KtLoopExpression
@@ -55,8 +56,13 @@ class UnconditionalJumpStatementInLoop(config: Config = Config.empty) : Rule(con
         super.visitLoopExpression(loopExpression)
     }
 
-    private fun KtLoopExpression.hasJumpStatements(): Boolean =
-        body?.isJumpStatement() == true || body?.children?.any { it.isJumpStatement() } == true
+    private fun KtLoopExpression.hasJumpStatements(): Boolean {
+        val body = this.body ?: return false
+        return when (body) {
+            is KtBlockExpression -> body.children.any { it.isJumpStatement() }
+            else -> body.isJumpStatement()
+        }
+    }
 
     private fun PsiElement.isJumpStatement(): Boolean =
         this is KtReturnExpression && !isFollowedByElvisJump() && !isAfterConditionalJumpStatement() ||

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnconditionalJumpStatementInLoopSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnconditionalJumpStatementInLoopSpec.kt
@@ -352,4 +352,17 @@ class UnconditionalJumpStatementInLoopSpec {
 
         assertThat(findings).isEmpty()
     }
+
+    // https://github.com/detekt/detekt/issues/6442
+    @Test
+    fun `does not report a conditional break in a single body expression`() {
+        val code = """
+            import java.util.concurrent.BlockingQueue
+            
+            fun <T> BlockingQueue<T>.pollEach(action: (T) -> Unit) {
+                while (true) this.poll()?.let { action(it) } ?: break
+            }
+        """.trimIndent()
+        assertThat(subject.compileAndLint(code)).isEmpty()
+    }
 }


### PR DESCRIPTION
Fixes #6442 

<!-- A similar PR may already be submitted! -->
<!-- Please search among the [Pull requests](https://github.com/detekt/detekt/pulls) before creating one. -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Link to relevant issues if possible. -->

<!-- For more information, see the [CONTRIBUTING guide](https://github.com/detekt/detekt/blob/main/.github/CONTRIBUTING.md). -->
