### PR TITLE
Move `SimpleNotification` to core

### DIFF
--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/validation/ConfigValidation.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/validation/ConfigValidation.kt
@@ -5,13 +5,13 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.ConfigValidator
 import io.gitlab.arturbosch.detekt.api.Notification
 import io.gitlab.arturbosch.detekt.api.Notification.Level
-import io.gitlab.arturbosch.detekt.api.internal.SimpleNotification
 import io.gitlab.arturbosch.detekt.core.NL
 import io.gitlab.arturbosch.detekt.core.ProcessingSettings
 import io.gitlab.arturbosch.detekt.core.config.YamlConfig
 import io.gitlab.arturbosch.detekt.core.extensions.loadExtensions
 import io.gitlab.arturbosch.detekt.core.reporting.red
 import io.gitlab.arturbosch.detekt.core.reporting.yellow
+import io.gitlab.arturbosch.detekt.core.util.SimpleNotification
 
 /**
  * Known existing properties on rules which may be absent in the default-detekt-config.yml.

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/validation/DeprecatedPropertiesConfigValidator.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/validation/DeprecatedPropertiesConfigValidator.kt
@@ -1,8 +1,8 @@
 package io.gitlab.arturbosch.detekt.core.config.validation
 
 import io.gitlab.arturbosch.detekt.api.Notification
-import io.gitlab.arturbosch.detekt.api.internal.SimpleNotification
 import io.gitlab.arturbosch.detekt.core.config.YamlConfig
+import io.gitlab.arturbosch.detekt.core.util.SimpleNotification
 
 internal class DeprecatedPropertiesConfigValidator(
     private val deprecatedProperties: Set<DeprecatedProperty>,

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/validation/InvalidPropertiesConfigValidator.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/validation/InvalidPropertiesConfigValidator.kt
@@ -1,8 +1,8 @@
 package io.gitlab.arturbosch.detekt.core.config.validation
 
 import io.gitlab.arturbosch.detekt.api.Notification
-import io.gitlab.arturbosch.detekt.api.internal.SimpleNotification
 import io.gitlab.arturbosch.detekt.core.config.YamlConfig
+import io.gitlab.arturbosch.detekt.core.util.SimpleNotification
 
 internal class InvalidPropertiesConfigValidator(
     private val baseline: YamlConfig,

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/validation/MissingRulesConfigValidator.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/validation/MissingRulesConfigValidator.kt
@@ -3,8 +3,8 @@ package io.gitlab.arturbosch.detekt.core.config.validation
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Notification
 import io.gitlab.arturbosch.detekt.api.RuleSetProvider
-import io.gitlab.arturbosch.detekt.api.internal.SimpleNotification
 import io.gitlab.arturbosch.detekt.core.config.YamlConfig
+import io.gitlab.arturbosch.detekt.core.util.SimpleNotification
 import java.util.ServiceLoader
 
 internal class MissingRulesConfigValidator(

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/OutputFacade.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/OutputFacade.kt
@@ -4,8 +4,8 @@ import io.github.detekt.tooling.api.spec.ReportsSpec
 import io.gitlab.arturbosch.detekt.api.Detektion
 import io.gitlab.arturbosch.detekt.api.UnstableApi
 import io.gitlab.arturbosch.detekt.api.getOrNull
-import io.gitlab.arturbosch.detekt.api.internal.SimpleNotification
 import io.gitlab.arturbosch.detekt.core.ProcessingSettings
+import io.gitlab.arturbosch.detekt.core.util.SimpleNotification
 
 @OptIn(UnstableApi::class)
 class OutputFacade(

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/util/SimpleNotification.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/util/SimpleNotification.kt
@@ -1,8 +1,8 @@
-package io.gitlab.arturbosch.detekt.api.internal
+package io.gitlab.arturbosch.detekt.core.util
 
 import io.gitlab.arturbosch.detekt.api.Notification
 
-data class SimpleNotification(
+internal data class SimpleNotification(
     override val message: String,
     override val level: Notification.Level = Notification.Level.Error
 ) : Notification {

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/validation/CheckConfigurationSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/validation/CheckConfigurationSpec.kt
@@ -7,10 +7,10 @@ import io.gitlab.arturbosch.detekt.api.ConfigValidator
 import io.gitlab.arturbosch.detekt.api.Notification
 import io.gitlab.arturbosch.detekt.api.RuleSet
 import io.gitlab.arturbosch.detekt.api.RuleSetProvider
-import io.gitlab.arturbosch.detekt.api.internal.SimpleNotification
 import io.gitlab.arturbosch.detekt.core.createNullLoggingSpec
 import io.gitlab.arturbosch.detekt.core.createProcessingSettings
 import io.gitlab.arturbosch.detekt.core.tooling.getDefaultConfiguration
+import io.gitlab.arturbosch.detekt.core.util.SimpleNotification
 import io.gitlab.arturbosch.detekt.test.yamlConfigFromContent
 import org.assertj.core.api.Assertions.assertThatCode
 import org.junit.jupiter.api.Test

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/NotificationReportSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/NotificationReportSpec.kt
@@ -1,7 +1,7 @@
 package io.gitlab.arturbosch.detekt.core.reporting.console
 
-import io.gitlab.arturbosch.detekt.api.internal.SimpleNotification
 import io.gitlab.arturbosch.detekt.core.NL
+import io.gitlab.arturbosch.detekt.core.util.SimpleNotification
 import io.gitlab.arturbosch.detekt.test.TestDetektion
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test


### PR DESCRIPTION
`SimpleNotification` was at `api-internal` but we don't need it there. It is only used at `core`. For that reason I'm moving it.