### PR TITLE
Remove `Metric`s from `Finding`s

### DIFF
--- a/detekt-api/api/detekt-api.api
+++ b/detekt-api/api/detekt-api.api
@@ -26,8 +26,8 @@ public abstract class io/gitlab/arturbosch/detekt/api/BaseRule : io/gitlab/artur
 }
 
 public class io/gitlab/arturbosch/detekt/api/CodeSmell : io/gitlab/arturbosch/detekt/api/Finding {
-	public fun <init> (Lio/gitlab/arturbosch/detekt/api/Issue;Lio/gitlab/arturbosch/detekt/api/Entity;Ljava/lang/String;Ljava/util/List;Ljava/util/List;)V
-	public synthetic fun <init> (Lio/gitlab/arturbosch/detekt/api/Issue;Lio/gitlab/arturbosch/detekt/api/Entity;Ljava/lang/String;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lio/gitlab/arturbosch/detekt/api/Issue;Lio/gitlab/arturbosch/detekt/api/Entity;Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Lio/gitlab/arturbosch/detekt/api/Issue;Lio/gitlab/arturbosch/detekt/api/Entity;Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun compact ()Ljava/lang/String;
 	public fun compactWithSignature ()Ljava/lang/String;
 	public fun getCharPosition ()Lio/gitlab/arturbosch/detekt/api/TextLocation;
@@ -37,7 +37,6 @@ public class io/gitlab/arturbosch/detekt/api/CodeSmell : io/gitlab/arturbosch/de
 	public final fun getIssue ()Lio/gitlab/arturbosch/detekt/api/Issue;
 	public fun getLocation ()Lio/gitlab/arturbosch/detekt/api/Location;
 	public fun getMessage ()Ljava/lang/String;
-	public fun getMetrics ()Ljava/util/List;
 	public fun getReferences ()Ljava/util/List;
 	public fun getSeverity ()Lio/gitlab/arturbosch/detekt/api/Severity;
 	public fun getSignature ()Ljava/lang/String;
@@ -154,8 +153,8 @@ public final class io/gitlab/arturbosch/detekt/api/Context$DefaultImpls {
 }
 
 public class io/gitlab/arturbosch/detekt/api/CorrectableCodeSmell : io/gitlab/arturbosch/detekt/api/CodeSmell {
-	public fun <init> (Lio/gitlab/arturbosch/detekt/api/Issue;Lio/gitlab/arturbosch/detekt/api/Entity;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Z)V
-	public synthetic fun <init> (Lio/gitlab/arturbosch/detekt/api/Issue;Lio/gitlab/arturbosch/detekt/api/Entity;Ljava/lang/String;Ljava/util/List;Ljava/util/List;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lio/gitlab/arturbosch/detekt/api/Issue;Lio/gitlab/arturbosch/detekt/api/Entity;Ljava/lang/String;Ljava/util/List;Z)V
+	public synthetic fun <init> (Lio/gitlab/arturbosch/detekt/api/Issue;Lio/gitlab/arturbosch/detekt/api/Entity;Ljava/lang/String;Ljava/util/List;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getAutoCorrectEnabled ()Z
 	public fun toString ()Ljava/lang/String;
 }
@@ -242,7 +241,7 @@ public final class io/gitlab/arturbosch/detekt/api/FileProcessListener$DefaultIm
 	public static fun onStart (Lio/gitlab/arturbosch/detekt/api/FileProcessListener;Ljava/util/List;Lorg/jetbrains/kotlin/resolve/BindingContext;)V
 }
 
-public abstract interface class io/gitlab/arturbosch/detekt/api/Finding : io/gitlab/arturbosch/detekt/api/Compactable, io/gitlab/arturbosch/detekt/api/HasEntity, io/gitlab/arturbosch/detekt/api/HasMetrics {
+public abstract interface class io/gitlab/arturbosch/detekt/api/Finding : io/gitlab/arturbosch/detekt/api/Compactable, io/gitlab/arturbosch/detekt/api/HasEntity {
 	public abstract fun getId ()Ljava/lang/String;
 	public abstract fun getIssue ()Lio/gitlab/arturbosch/detekt/api/Issue;
 	public abstract fun getMessage ()Ljava/lang/String;
@@ -276,10 +275,6 @@ public final class io/gitlab/arturbosch/detekt/api/HasEntity$DefaultImpls {
 	public static fun getLocation (Lio/gitlab/arturbosch/detekt/api/HasEntity;)Lio/gitlab/arturbosch/detekt/api/Location;
 	public static fun getSignature (Lio/gitlab/arturbosch/detekt/api/HasEntity;)Ljava/lang/String;
 	public static fun getStartPosition (Lio/gitlab/arturbosch/detekt/api/HasEntity;)Lio/gitlab/arturbosch/detekt/api/SourceLocation;
-}
-
-public abstract interface class io/gitlab/arturbosch/detekt/api/HasMetrics {
-	public abstract fun getMetrics ()Ljava/util/List;
 }
 
 public final class io/gitlab/arturbosch/detekt/api/Issue {

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/CodeSmell.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/CodeSmell.kt
@@ -14,7 +14,6 @@ open class CodeSmell(
     final override val issue: Issue,
     override val entity: Entity,
     override val message: String,
-    override val metrics: List<Metric> = emptyList(),
     override val references: List<Entity> = emptyList()
 ) : Finding {
 
@@ -32,7 +31,6 @@ open class CodeSmell(
         return "CodeSmell(issue=$issue, " +
             "entity=$entity, " +
             "message=$message, " +
-            "metrics=$metrics, " +
             "references=$references, " +
             "severity=$severity, " +
             "id='$id')"
@@ -50,14 +48,12 @@ open class CorrectableCodeSmell(
     issue: Issue,
     entity: Entity,
     message: String,
-    metrics: List<Metric> = emptyList(),
     references: List<Entity> = emptyList(),
     val autoCorrectEnabled: Boolean
 ) : CodeSmell(
     issue,
     entity,
     message,
-    metrics,
     references
 ) {
     override fun toString(): String {
@@ -66,7 +62,6 @@ open class CorrectableCodeSmell(
             "issue=$issue, " +
             "entity=$entity, " +
             "message=$message, " +
-            "metrics=$metrics, " +
             "references=$references, " +
             "severity=$severity, " +
             "id='$id')"
@@ -89,7 +84,6 @@ open class ThresholdedCodeSmell(
     issue,
     entity,
     message,
-    metrics = listOf(metric),
     references = references
 ) {
     override fun compact(): String = "$id - $metric - ${entity.compact()}"

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Findings.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Findings.kt
@@ -7,7 +7,7 @@ package io.gitlab.arturbosch.detekt.api
  * Basic behaviour of a finding is that is can be assigned to an id and a source code position described as
  * an entity. Metrics and entity references can also considered for deeper characterization.
  */
-interface Finding : Compactable, HasEntity, HasMetrics {
+interface Finding : Compactable, HasEntity {
     val id: String
     val issue: Issue
     val references: List<Entity>
@@ -36,13 +36,6 @@ interface HasEntity {
         get() = location.filePath.absolutePath.toString()
     val signature: String
         get() = entity.signature
-}
-
-/**
- * Adds metric container behaviour.
- */
-interface HasMetrics {
-    val metrics: List<Metric>
 }
 
 /**


### PR DESCRIPTION
This code is never used so it can be removed.