### PR TITLE
Remove `type` from `Metric`

### DIFF
--- a/detekt-api/api/detekt-api.api
+++ b/detekt-api/api/detekt-api.api
@@ -43,7 +43,6 @@ public class io/gitlab/arturbosch/detekt/api/CodeSmell : io/gitlab/arturbosch/de
 	public fun getSignature ()Ljava/lang/String;
 	public fun getStartPosition ()Lio/gitlab/arturbosch/detekt/api/SourceLocation;
 	public fun messageOrDescription ()Ljava/lang/String;
-	public fun metricByType (Ljava/lang/String;)Lio/gitlab/arturbosch/detekt/api/Metric;
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -274,7 +273,6 @@ public final class io/gitlab/arturbosch/detekt/api/Finding$DefaultImpls {
 	public static fun getSeverity (Lio/gitlab/arturbosch/detekt/api/Finding;)Lio/gitlab/arturbosch/detekt/api/Severity;
 	public static fun getSignature (Lio/gitlab/arturbosch/detekt/api/Finding;)Ljava/lang/String;
 	public static fun getStartPosition (Lio/gitlab/arturbosch/detekt/api/Finding;)Lio/gitlab/arturbosch/detekt/api/SourceLocation;
-	public static fun metricByType (Lio/gitlab/arturbosch/detekt/api/Finding;Ljava/lang/String;)Lio/gitlab/arturbosch/detekt/api/Metric;
 }
 
 public abstract interface class io/gitlab/arturbosch/detekt/api/HasEntity {
@@ -296,11 +294,6 @@ public final class io/gitlab/arturbosch/detekt/api/HasEntity$DefaultImpls {
 
 public abstract interface class io/gitlab/arturbosch/detekt/api/HasMetrics {
 	public abstract fun getMetrics ()Ljava/util/List;
-	public abstract fun metricByType (Ljava/lang/String;)Lio/gitlab/arturbosch/detekt/api/Metric;
-}
-
-public final class io/gitlab/arturbosch/detekt/api/HasMetrics$DefaultImpls {
-	public static fun metricByType (Lio/gitlab/arturbosch/detekt/api/HasMetrics;Ljava/lang/String;)Lio/gitlab/arturbosch/detekt/api/Metric;
 }
 
 public final class io/gitlab/arturbosch/detekt/api/Issue {
@@ -347,23 +340,21 @@ public final class io/gitlab/arturbosch/detekt/api/Location$Companion {
 }
 
 public final class io/gitlab/arturbosch/detekt/api/Metric {
-	public fun <init> (Ljava/lang/String;DDI)V
-	public synthetic fun <init> (Ljava/lang/String;DDIILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun <init> (Ljava/lang/String;IIZI)V
-	public synthetic fun <init> (Ljava/lang/String;IIZIILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/lang/String;
+	public fun <init> (DDI)V
+	public synthetic fun <init> (DDIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (IIZI)V
+	public synthetic fun <init> (IIZIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
 	public final fun component2 ()I
-	public final fun component3 ()I
-	public final fun component4 ()Z
-	public final fun component5 ()I
-	public final fun copy (Ljava/lang/String;IIZI)Lio/gitlab/arturbosch/detekt/api/Metric;
-	public static synthetic fun copy$default (Lio/gitlab/arturbosch/detekt/api/Metric;Ljava/lang/String;IIZIILjava/lang/Object;)Lio/gitlab/arturbosch/detekt/api/Metric;
+	public final fun component3 ()Z
+	public final fun component4 ()I
+	public final fun copy (IIZI)Lio/gitlab/arturbosch/detekt/api/Metric;
+	public static synthetic fun copy$default (Lio/gitlab/arturbosch/detekt/api/Metric;IIZIILjava/lang/Object;)Lio/gitlab/arturbosch/detekt/api/Metric;
 	public final fun doubleThreshold ()D
 	public final fun doubleValue ()D
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getConversionFactor ()I
 	public final fun getThreshold ()I
-	public final fun getType ()Ljava/lang/String;
 	public final fun getValue ()I
 	public fun hashCode ()I
 	public final fun isDouble ()Z

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Findings.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Findings.kt
@@ -43,11 +43,6 @@ interface HasEntity {
  */
 interface HasMetrics {
     val metrics: List<Metric>
-
-    /**
-     * Finds the first metric matching given [type].
-     */
-    fun metricByType(type: String): Metric? = metrics.find { it.type == type }
 }
 
 /**

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Metric.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Metric.kt
@@ -5,7 +5,6 @@ package io.gitlab.arturbosch.detekt.api
  * but the conversion factor and is double attributes can be used to retrieve it as a double value.
  */
 data class Metric(
-    val type: String,
     val value: Int,
     val threshold: Int,
     val isDouble: Boolean = false,
@@ -13,12 +12,10 @@ data class Metric(
 ) {
 
     constructor(
-        type: String,
         value: Double,
         threshold: Double,
         conversionFactor: Int = DEFAULT_FLOAT_CONVERSION_FACTOR
     ) : this(
-        type,
         value = (value * conversionFactor).toInt(),
         threshold = (threshold * conversionFactor).toInt(),
         isDouble = true,

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/MetricSpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/MetricSpec.kt
@@ -8,7 +8,7 @@ class MetricSpec {
 
     @Test
     fun `should convert double values to int`() {
-        val metric = Metric("LOC", 0.33, 0.10, 100)
+        val metric = Metric(0.33, 0.10, 100)
         assertThat(metric.doubleValue()).isEqualTo(0.33)
         assertThat(metric.doubleThreshold()).isEqualTo(0.10)
     }
@@ -16,7 +16,7 @@ class MetricSpec {
     @Test
     fun `should throw error if double value is asked for int metric`() {
         assertThatIllegalStateException().isThrownBy {
-            Metric("LOC", 100, 50).doubleValue()
+            Metric(100, 50).doubleValue()
         }
     }
 }

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/CognitiveComplexMethod.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/CognitiveComplexMethod.kt
@@ -47,7 +47,7 @@ class CognitiveComplexMethod(config: Config = Config.empty) : Rule(config) {
                 ThresholdedCodeSmell(
                     issue,
                     Entity.atName(function),
-                    Metric("CC", complexity, allowedComplexity),
+                    Metric(complexity, allowedComplexity),
                     "The function ${function.nameAsSafeName} appears to be too complex " +
                         "based on Cognitive Complexity (complexity: $complexity). " +
                         "Defined maximum allowed complexity for methods is set to '$allowedComplexity'"

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexCondition.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexCondition.kt
@@ -84,7 +84,7 @@ class ComplexCondition(
                     ThresholdedCodeSmell(
                         issue,
                         Entity.from(condition),
-                        Metric("SIZE", count, allowedConditions),
+                        Metric(count, allowedConditions),
                         "This condition is too complex ($count). " +
                             "The defined maximum number of allowed conditions is set to '$allowedConditions'"
                     )

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexInterface.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexInterface.kt
@@ -65,7 +65,7 @@ class ComplexInterface(
                     ThresholdedCodeSmell(
                         issue,
                         Entity.atName(klass),
-                        Metric("SIZE: ", size, allowedDefinitions),
+                        Metric(size, allowedDefinitions),
                         "The interface ${klass.name} is too complex. Consider splitting it up."
                     )
                 )

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/CyclomaticComplexMethod.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/CyclomaticComplexMethod.kt
@@ -82,7 +82,7 @@ class CyclomaticComplexMethod(config: Config = Config.empty) : Rule(config) {
                 ThresholdedCodeSmell(
                     issue,
                     Entity.atName(function),
-                    Metric("MCC", complexity, allowedComplexity),
+                    Metric(complexity, allowedComplexity),
                     "The function ${function.nameAsSafeName} appears to be too complex " +
                         "based on Cyclomatic Complexity (complexity: $complexity). " +
                         "The maximum allowed complexity for methods is set to '$allowedComplexity'"

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LargeClass.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LargeClass.kt
@@ -51,7 +51,7 @@ class LargeClass(config: Config = Config.empty) : Rule(config) {
                     ThresholdedCodeSmell(
                         issue,
                         Entity.atName(clazz),
-                        Metric("SIZE", lines, allowedLines),
+                        Metric(lines, allowedLines),
                         "Class ${clazz.name} is too large. Consider splitting it into smaller pieces."
                     )
                 )

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongMethod.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongMethod.kt
@@ -62,7 +62,7 @@ class LongMethod(config: Config = Config.empty) : Rule(config) {
                     ThresholdedCodeSmell(
                         issue,
                         Entity.atName(function),
-                        Metric("SIZE", lines, allowedLines),
+                        Metric(lines, allowedLines),
                         "The function ${function.nameAsSafeName} is too long ($lines). " +
                             "The maximum length is $allowedLines."
                     )

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterList.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterList.kt
@@ -113,7 +113,7 @@ class LongParameterList(config: Config = Config.empty) : Rule(config) {
                 ThresholdedCodeSmell(
                     issue,
                     Entity.from(parameterList),
-                    Metric("SIZE", parameterNumber, maximumAllowedParameter),
+                    Metric(parameterNumber, maximumAllowedParameter),
                     "The $identifier($parameterPrint) has too many parameters. " +
                         "The current maximum allowed parameters are $maximumAllowedParameter."
                 )

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/MethodOverloading.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/MethodOverloading.kt
@@ -62,7 +62,7 @@ class MethodOverloading(config: Config = Config.empty) : Rule(config) {
                     ThresholdedCodeSmell(
                         issue,
                         entity,
-                        Metric("OVERLOAD SIZE: ", value, allowedOverloads),
+                        Metric(value, allowedOverloads),
                         message = "The method '$name' is overloaded $value times."
                     )
                 )

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedBlockDepth.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedBlockDepth.kt
@@ -49,7 +49,7 @@ class NestedBlockDepth(config: Config = Config.empty) : Rule(config) {
                 ThresholdedCodeSmell(
                     issue,
                     Entity.atName(function),
-                    Metric("SIZE", visitor.maxDepth, allowedDepth),
+                    Metric(visitor.maxDepth, allowedDepth),
                     "Function ${function.name} is nested too deeply."
                 )
             )

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedScopeFunctions.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedScopeFunctions.kt
@@ -70,7 +70,7 @@ class NestedScopeFunctions(config: Config = Config.empty) : Rule(config) {
         val finding = ThresholdedCodeSmell(
             issue,
             Entity.from(element),
-            Metric("SIZE", depth, allowedDepth),
+            Metric(depth, allowedDepth),
             "The scope function '${element.calleeExpression?.text}' is nested too deeply ('$depth'). " +
                 "The maximum allowed depth is set to '$allowedDepth'."
         )

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/StringLiteralDuplication.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/StringLiteralDuplication.kt
@@ -66,14 +66,13 @@ class StringLiteralDuplication(config: Config = Config.empty) : Rule(config) {
     override fun visitKtFile(file: KtFile) {
         val visitor = StringLiteralVisitor()
         file.accept(visitor)
-        val type = "SIZE: "
         for ((name, value) in visitor.getLiteralsOverThreshold()) {
             val (main, references) = visitor.entitiesForLiteral(name)
             report(
                 ThresholdedCodeSmell(
                     issue,
                     main,
-                    Metric(type + name, value, allowedDuplications),
+                    Metric(value, allowedDuplications),
                     issue.description,
                     references
                 )

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/TooManyFunctions.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/TooManyFunctions.kt
@@ -70,7 +70,7 @@ class TooManyFunctions(config: Config = Config.empty) : Rule(config) {
                 ThresholdedCodeSmell(
                     issue,
                     Entity.atPackageOrFirstDecl(file),
-                    Metric("SIZE", amountOfTopLevelFunctions, allowedFunctionsPerFile),
+                    Metric(amountOfTopLevelFunctions, allowedFunctionsPerFile),
                     "File '${file.name}' with '$amountOfTopLevelFunctions' functions detected. " +
                         "The maximum allowed functions per file is set to '$allowedFunctionsPerFile'"
                 )
@@ -94,7 +94,7 @@ class TooManyFunctions(config: Config = Config.empty) : Rule(config) {
                         ThresholdedCodeSmell(
                             issue,
                             Entity.atName(klass),
-                            Metric("SIZE", amount, allowedFunctionsPerInterface),
+                            Metric(amount, allowedFunctionsPerInterface),
                             "Interface '${klass.name}' with '$amount' functions detected. " +
                                 "The maximum allowed functions per interface is set to " +
                                 "'$allowedFunctionsPerInterface'"
@@ -108,7 +108,7 @@ class TooManyFunctions(config: Config = Config.empty) : Rule(config) {
                         ThresholdedCodeSmell(
                             issue,
                             Entity.atName(klass),
-                            Metric("SIZE", amount, allowedFunctionsPerEnum),
+                            Metric(amount, allowedFunctionsPerEnum),
                             "Enum class '${klass.name}' with '$amount' functions detected. " +
                                 "The maximum allowed functions per enum class is set to " +
                                 "'$allowedFunctionsPerEnum'"
@@ -122,7 +122,7 @@ class TooManyFunctions(config: Config = Config.empty) : Rule(config) {
                         ThresholdedCodeSmell(
                             issue,
                             Entity.atName(klass),
-                            Metric("SIZE", amount, allowedFunctionsPerClass),
+                            Metric(amount, allowedFunctionsPerClass),
                             "Class '${klass.name}' with '$amount' functions detected. " +
                                 "The maximum allowed functions per class is set to '$allowedFunctionsPerClass'"
                         )
@@ -140,7 +140,7 @@ class TooManyFunctions(config: Config = Config.empty) : Rule(config) {
                 ThresholdedCodeSmell(
                     issue,
                     Entity.atName(declaration),
-                    Metric("SIZE", amount, allowedFunctionsPerObject),
+                    Metric(amount, allowedFunctionsPerObject),
                     "Object '${declaration.name}' with '$amount' functions detected. " +
                         "The maximum allowed functions per object is set to '$allowedFunctionsPerObject'"
                 )

--- a/detekt-sample-extensions/src/main/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/rules/TooManyFunctionsTwo.kt
+++ b/detekt-sample-extensions/src/main/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/rules/TooManyFunctionsTwo.kt
@@ -36,7 +36,7 @@ class TooManyFunctionsTwo(config: Config) : Rule(config) {
                 ThresholdedCodeSmell(
                     issue,
                     entity = Entity.from(file),
-                    metric = Metric(type = "SIZE", value = amount, threshold = allowedFunctions),
+                    metric = Metric(value = amount, threshold = allowedFunctions),
                     message = "The file ${file.name} has $amount function declarations. " +
                         "The maximum number of allowed functions is specified with $allowedFunctions.",
                     references = emptyList()


### PR DESCRIPTION
The value "type" was never used on `Metric` so we can remove it.