### PR TITLE
Remove safeAs function

### DIFF
--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/PropertiesAware.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/PropertiesAware.kt
@@ -1,7 +1,5 @@
 package io.gitlab.arturbosch.detekt.api
 
-import io.gitlab.arturbosch.detekt.rules.safeAs
-
 /**
  * Properties holder. Allows to store and retrieve any data.
  */
@@ -26,7 +24,7 @@ interface PropertiesAware {
 inline fun <reified T : Any> PropertiesAware.getOrNull(key: String): T? {
     val value = properties[key]
     if (value != null) {
-        return value.safeAs() ?: error("No value of type ''${T::class} for key '$key'.")
+        return value as? T ?: error("No value of type ''${T::class} for key '$key'.")
     }
     return null
 }

--- a/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/CyclomaticComplexitySpec.kt
+++ b/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/CyclomaticComplexitySpec.kt
@@ -1,10 +1,8 @@
 package io.github.detekt.metrics
 
 import io.github.detekt.test.utils.compileContentForTest
-import io.gitlab.arturbosch.detekt.rules.safeAs
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.psi.KtElement
-import org.jetbrains.kotlin.psi.KtNamed
 import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.psiUtil.getChildOfType
 import org.junit.jupiter.api.Nested
@@ -273,7 +271,7 @@ class CyclomaticComplexitySpec {
 
 private fun KtElement.getFunctionByName(name: String): KtNamedFunction {
     val node = getChildOfType<KtNamedFunction>() ?: error("Expected node of type ${KtNamedFunction::class}")
-    val identifier = node.safeAs<KtNamed>()?.nameAsName?.identifier
+    val identifier = node.nameAsName?.identifier
 
     require(identifier == name) {
         "Node should be $name, but was $identifier"

--- a/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/Junk.kt
+++ b/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/Junk.kt
@@ -37,8 +37,6 @@ fun getIntValueForPsiElement(element: PsiElement): Int? {
 
 fun KtClass.companionObject() = this.companionObjects.singleOrNull { it.isCompanion() }
 
-inline fun <reified T : Any> Any.safeAs(): T? = this as? T
-
 fun KtCallExpression.receiverIsUsed(context: BindingContext): Boolean =
     (parent as? KtQualifiedExpression)?.let {
         val scopeOfApplyCall = parent.parent

--- a/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/KtAnnotatedExtensions.kt
+++ b/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/KtAnnotatedExtensions.kt
@@ -11,7 +11,7 @@ fun KtAnnotated.hasAnnotation(
     val predicate: (KtAnnotationEntry) -> Boolean = {
         it.typeReference
             ?.typeElement
-            ?.safeAs<KtUserType>()
+            ?.let { ktTypeElement -> ktTypeElement as? KtUserType }
             ?.referencedName in names
     }
     return annotationEntries.any(predicate)

--- a/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/KtIfExpression.kt
+++ b/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/KtIfExpression.kt
@@ -6,4 +6,4 @@ import org.jetbrains.kotlin.psi.KtIfExpression
 
 fun KtIfExpression.isElseIf(): Boolean =
     parent.node.elementType == KtNodeTypes.ELSE &&
-        parent.safeAs<KtContainerNodeForControlStructureBody>()?.expression == this
+        (parent as? KtContainerNodeForControlStructureBody)?.expression == this

--- a/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/TypeUtils.kt
+++ b/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/TypeUtils.kt
@@ -80,7 +80,7 @@ fun KtExpression.isNullable(
     dataFlowValueFactory: DataFlowValueFactory,
     shouldConsiderPlatformTypeAsNullable: Boolean,
 ): Boolean {
-    val safeAccessOperation = safeAs<KtSafeQualifiedExpression>()?.operationTokenNode?.safeAs<PsiElement>()
+    val safeAccessOperation = (this as? KtSafeQualifiedExpression)?.operationTokenNode as? PsiElement
     if (safeAccessOperation != null) {
         return bindingContext.diagnostics.forElement(safeAccessOperation).none {
             it.factory == Errors.UNNECESSARY_SAFE_CALL

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DontDowncastCollectionTypes.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DontDowncastCollectionTypes.kt
@@ -8,7 +8,6 @@ import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.rules.fqNameOrNull
-import io.gitlab.arturbosch.detekt.rules.safeAs
 import org.jetbrains.kotlin.psi.KtBinaryExpressionWithTypeRHS
 import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.psi.KtIsExpression
@@ -66,7 +65,7 @@ class DontDowncastCollectionTypes(config: Config) : Rule(config) {
 
         val rhsType = right
             ?.typeElement
-            ?.safeAs<KtUserType>()
+            ?.let { it as? KtUserType }
             ?.referencedName
 
         if (lhsType in immutableTypes && rhsType in mutableTypes) {

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnreachableCatchBlock.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnreachableCatchBlock.kt
@@ -8,7 +8,6 @@ import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
 import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
-import io.gitlab.arturbosch.detekt.rules.safeAs
 import org.jetbrains.kotlin.descriptors.ClassDescriptor
 import org.jetbrains.kotlin.psi.KtCatchClause
 import org.jetbrains.kotlin.psi.KtTryExpression
@@ -69,7 +68,9 @@ class UnreachableCatchBlock(config: Config = Config.empty) : Rule(config) {
 
     private fun KtCatchClause.catchClassDescriptor(): ClassDescriptor? {
         val typeReference = catchParameter?.typeReference ?: return null
-        return bindingContext[BindingContext.TYPE, typeReference]?.constructor?.declarationDescriptor?.safeAs()
+        return bindingContext[BindingContext.TYPE, typeReference]
+            ?.constructor
+            ?.declarationDescriptor as? ClassDescriptor
     }
 
     private fun ClassDescriptor.isSubclassOf(catchClause: KtCatchClause): Boolean {

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/AlsoCouldBeApply.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/AlsoCouldBeApply.kt
@@ -7,8 +7,8 @@ import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.rules.IT_LITERAL
-import io.gitlab.arturbosch.detekt.rules.safeAs
 import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtLambdaExpression
 import org.jetbrains.kotlin.psi.KtQualifiedExpression
 
 /**
@@ -49,10 +49,10 @@ class AlsoCouldBeApply(config: Config = Config.empty) : Rule(config) {
 
         val callee = expression.calleeExpression?.takeIf { it.text == "also" } ?: return
         val lambda = expression.lambdaArguments.singleOrNull()?.getLambdaExpression()
-            ?: expression.valueArguments.singleOrNull()?.getArgumentExpression()?.safeAs()
+            ?: expression.valueArguments.singleOrNull()?.getArgumentExpression() as? KtLambdaExpression
             ?: return
         val statements = lambda.bodyExpression?.statements.orEmpty().ifEmpty { return }
-        if (statements.all { it.safeAs<KtQualifiedExpression>()?.receiverExpression?.text == IT_LITERAL }) {
+        if (statements.all { (it as? KtQualifiedExpression)?.receiverExpression?.text == IT_LITERAL }) {
             report(CodeSmell(issue, Entity.from(callee), issue.description))
         }
     }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MultilineRawStringIndentation.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MultilineRawStringIndentation.kt
@@ -13,7 +13,6 @@ import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.api.TextLocation
 import io.gitlab.arturbosch.detekt.api.config
 import io.gitlab.arturbosch.detekt.api.internal.Configuration
-import io.gitlab.arturbosch.detekt.rules.safeAs
 import org.jetbrains.kotlin.com.intellij.psi.PsiFile
 import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.psi.KtLiteralStringTemplateEntry
@@ -176,7 +175,7 @@ private fun KtStringTemplateExpression.isSurroundedByLineBreaks(): Boolean {
 }
 
 private fun KtStringTemplateEntry.isBlankOrLineBreak(): Boolean {
-    val text = safeAs<KtLiteralStringTemplateEntry>()?.text ?: return false
+    val text = (this as? KtLiteralStringTemplateEntry)?.text ?: return false
     return text.all { it.isTabChar() } || text == "\n"
 }
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/SafeCast.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/SafeCast.kt
@@ -7,7 +7,6 @@ import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
-import io.gitlab.arturbosch.detekt.rules.safeAs
 import org.jetbrains.kotlin.KtNodeTypes
 import org.jetbrains.kotlin.psi.KtBlockExpression
 import org.jetbrains.kotlin.psi.KtConstantExpression
@@ -72,7 +71,7 @@ class SafeCast(config: Config = Config.empty) : Rule(config) {
     }
 
     private fun KtExpression?.singleExpression(): KtExpression? =
-        if (this is KtBlockExpression) children.singleOrNull()?.safeAs() else this
+        if (this is KtBlockExpression) children.singleOrNull() as? KtExpression else this
 
     private fun addReport(expression: KtIfExpression) {
         report(CodeSmell(issue, Entity.from(expression), "This cast should be replaced with a safe cast: as?"))

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/TrimMultilineRawString.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/TrimMultilineRawString.kt
@@ -77,7 +77,7 @@ class TrimMultilineRawString(val config: Config) : Rule(config) {
 
 fun KtStringTemplateExpression.isRawStringWithLineBreak(): Boolean =
     text.startsWith("\"\"\"") && text.endsWith("\"\"\"") && entries.any {
-        val literalText = it.safeAs<KtLiteralStringTemplateEntry>()?.text
+        val literalText = (it as? KtLiteralStringTemplateEntry)?.text
         literalText != null && "\n" in literalText
     }
 
@@ -104,7 +104,7 @@ private fun KtStringTemplateExpression.isExpectedAsConstant(): Boolean {
 
     val parameter = expression.getStrictParentOfType<KtParameter>()
         ?.takeIf { it.defaultValue == expression }
-    val primaryConstructor = parameter?.parent?.parent?.safeAs<KtPrimaryConstructor>()
+    val primaryConstructor = parameter?.parent?.parent as? KtPrimaryConstructor
     if (primaryConstructor?.containingClass()?.isAnnotation() == true) return true
 
     return false

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/TrimMultilineRawString.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/TrimMultilineRawString.kt
@@ -9,7 +9,6 @@ import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.config
 import io.gitlab.arturbosch.detekt.api.internal.Configuration
 import io.gitlab.arturbosch.detekt.rules.isConstant
-import io.gitlab.arturbosch.detekt.rules.safeAs
 import org.jetbrains.kotlin.psi.KtAnnotationEntry
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtLiteralStringTemplateEntry
@@ -84,7 +83,7 @@ fun KtStringTemplateExpression.isRawStringWithLineBreak(): Boolean =
 fun KtStringTemplateExpression.isTrimmed(trimmingMethods: List<String>): Boolean {
     val nextCall = getQualifiedExpressionForReceiver()
         ?.selectorExpression
-        ?.safeAs<KtCallExpression>()
+        ?.let { it as? KtCallExpression }
         ?.calleeExpression
         ?.text
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateClass.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateClass.kt
@@ -8,7 +8,6 @@ import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
-import io.gitlab.arturbosch.detekt.rules.safeAs
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.psi.KtAnnotationEntry
 import org.jetbrains.kotlin.psi.KtCallExpression
@@ -159,7 +158,7 @@ class UnusedPrivateClass(config: Config = Config.empty) : Rule(config) {
         override fun visitDoubleColonExpression(expression: KtDoubleColonExpression) {
             checkReceiverForClassUsage(expression.receiverExpression)
             if (expression.isEmptyLHS) {
-                expression.safeAs<KtCallableReferenceExpression>()
+                (expression as? KtCallableReferenceExpression)
                     ?.callableReference
                     ?.takeIf { looksLikeAClassName(it.getReferencedName()) }
                     ?.let { namedClasses.add(it.getReferencedName()) }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseArrayLiteralsInAnnotations.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseArrayLiteralsInAnnotations.kt
@@ -7,7 +7,6 @@ import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
-import io.gitlab.arturbosch.detekt.rules.safeAs
 import org.jetbrains.kotlin.psi.KtAnnotationEntry
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtExpression
@@ -54,7 +53,7 @@ class UseArrayLiteralsInAnnotations(config: Config = Config.empty) : Rule(config
     }
 
     private fun KtExpression?.isArrayOfFunctionCall(): Boolean =
-        this?.safeAs<KtCallExpression>()?.calleeExpression?.text in arrayOfFunctions
+        (this as? KtCallExpression)?.calleeExpression?.text in arrayOfFunctions
 
     companion object {
         private val arrayOfFunctions = listOf(

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIsNullOrEmpty.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIsNullOrEmpty.kt
@@ -9,7 +9,6 @@ import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
 import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.rules.fqNameOrNull
-import io.gitlab.arturbosch.detekt.rules.safeAs
 import org.jetbrains.kotlin.builtins.StandardNames
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.name.FqName
@@ -71,7 +70,7 @@ class UseIsNullOrEmpty(config: Config = Config.empty) : Rule(config) {
     }
 
     private fun KtExpression.isSimpleNameExpression(): Boolean =
-        this is KtSimpleNameExpression || safeAs<KtQualifiedExpression>()?.selectorExpression is KtSimpleNameExpression
+        this is KtSimpleNameExpression || (this as? KtQualifiedExpression)?.selectorExpression is KtSimpleNameExpression
 
     private fun KtBinaryExpression.nullCheckedExpression(): KtExpression? {
         if (operationToken != KtTokens.EQEQ) return null
@@ -131,8 +130,8 @@ class UseIsNullOrEmpty(config: Config = Config.empty) : Rule(config) {
     private fun KtExpression?.isEmptyString() = this?.text == "\"\""
 
     private fun KtExpression?.isCalling(fqNames: List<FqName>): Boolean {
-        val callExpression = this?.safeAs()
-            ?: safeAs<KtDotQualifiedExpression>()?.selectorExpression?.safeAs<KtCallExpression>()
+        val callExpression = this as? KtCallExpression
+            ?: (this as? KtDotQualifiedExpression)?.selectorExpression as? KtCallExpression
             ?: return false
         return callExpression.calleeExpression?.text in fqNames.map { it.shortName().asString() } &&
             callExpression.getResolvedCall(bindingContext)?.resultingDescriptor?.fqNameOrNull() in fqNames

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/PreferToOverPairSyntax.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/PreferToOverPairSyntax.kt
@@ -7,7 +7,6 @@ import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
-import io.gitlab.arturbosch.detekt.rules.safeAs
 import org.jetbrains.kotlin.descriptors.ClassConstructorDescriptor
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.psi.KtCallExpression
@@ -54,7 +53,7 @@ class PreferToOverPairSyntax(config: Config = Config.empty) : Rule(config) {
 
     private fun KtCallExpression.isPairConstructor(): Boolean {
         val descriptor = getResolvedCall(bindingContext)?.resultingDescriptor
-        val fqName = descriptor?.safeAs<ClassConstructorDescriptor>()?.containingDeclaration?.fqNameOrNull()
+        val fqName = (descriptor as? ClassConstructorDescriptor)?.containingDeclaration?.fqNameOrNull()
         return fqName == PAIR_FQ_NAME
     }
 


### PR DESCRIPTION
There's an almost identical function in `org.jetbrains.kotlin.utils.addToStdlib` which comes with this warning:

        Usage of this function is unsafe because it does not have native compiler support
         This means that compiler won't report UNCHECKED_CAST, CAST_NEVER_SUCCEED or similar
         diagnostics in case of error cast (which can happen immediately or after some
         refactoring of class hierarchy)
        Consider using regular `as` and `as?`

https://github.com/JetBrains/kotlin/blob/v1.9.10/core/util.runtime/src/org/jetbrains/kotlin/utils/addToStdlib.kt#L94-L108