### PR TITLE
Remove knownPatterns from tooling API

### DIFF
--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Spec.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Spec.kt
@@ -36,7 +36,6 @@ internal fun CliArgs.createSpec(output: Appendable, error: Appendable): Processi
         config {
             useDefaultConfig = args.buildUponDefaultConfig
             shouldValidateBeforeAnalysis = null
-            knownPatterns = emptyList()
             // ^^ cli does not have these properties yet; specified in yaml config for now
             configPaths = config?.let { MultipleExistingPathConverter().convert(it) }.orEmpty()
             resources = configResource?.let { MultipleClasspathResourceConverter().convert(it) }.orEmpty()

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Spec.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Spec.kt
@@ -36,7 +36,6 @@ internal fun CliArgs.createSpec(output: Appendable, error: Appendable): Processi
         config {
             useDefaultConfig = args.buildUponDefaultConfig
             shouldValidateBeforeAnalysis = null
-            // ^^ cli does not have these properties yet; specified in yaml config for now
             configPaths = config?.let { MultipleExistingPathConverter().convert(it) }.orEmpty()
             resources = configResource?.let { MultipleClasspathResourceConverter().convert(it) }.orEmpty()
         }

--- a/detekt-tooling/api/detekt-tooling.api
+++ b/detekt-tooling/api/detekt-tooling.api
@@ -123,7 +123,6 @@ public abstract interface class io/github/detekt/tooling/api/spec/CompilerSpec {
 
 public abstract interface class io/github/detekt/tooling/api/spec/ConfigSpec {
 	public abstract fun getConfigPaths ()Ljava/util/Collection;
-	public abstract fun getKnownPatterns ()Ljava/util/Collection;
 	public abstract fun getResources ()Ljava/util/Collection;
 	public abstract fun getShouldValidateBeforeAnalysis ()Ljava/lang/Boolean;
 	public abstract fun getUseDefaultConfig ()Z
@@ -251,12 +250,10 @@ public final class io/github/detekt/tooling/dsl/ConfigSpecBuilder : io/github/de
 	public fun build ()Lio/github/detekt/tooling/api/spec/ConfigSpec;
 	public synthetic fun build ()Ljava/lang/Object;
 	public final fun getConfigPaths ()Ljava/util/Collection;
-	public final fun getKnownPatterns ()Ljava/util/Collection;
 	public final fun getResources ()Ljava/util/Collection;
 	public final fun getShouldValidateBeforeAnalysis ()Ljava/lang/Boolean;
 	public final fun getUseDefaultConfig ()Z
 	public final fun setConfigPaths (Ljava/util/Collection;)V
-	public final fun setKnownPatterns (Ljava/util/Collection;)V
 	public final fun setResources (Ljava/util/Collection;)V
 	public final fun setShouldValidateBeforeAnalysis (Ljava/lang/Boolean;)V
 	public final fun setUseDefaultConfig (Z)V

--- a/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/api/spec/ConfigSpec.kt
+++ b/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/api/spec/ConfigSpec.kt
@@ -13,13 +13,6 @@ interface ConfigSpec {
     val shouldValidateBeforeAnalysis: Boolean?
 
     /**
-     * Property patterns which should be excluded from validation.
-     *
-     * Nested yaml properties are separated with a '>': e.g. '.*>.*>excludeThisProp', 'customPart>.*'
-     */
-    val knownPatterns: Collection<String>
-
-    /**
      * Rely on detekt to configure meaningful defaults.
      *
      * Additional configuration overwrite single properties of the default file.

--- a/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/dsl/ConfigSpecBuilder.kt
+++ b/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/dsl/ConfigSpecBuilder.kt
@@ -8,7 +8,6 @@ import java.nio.file.Path
 class ConfigSpecBuilder : Builder<ConfigSpec> {
 
     var shouldValidateBeforeAnalysis: Boolean? = null
-    var knownPatterns: Collection<String> = emptyList()
 
     var useDefaultConfig: Boolean = false // false to be backwards compatible in 1.X
     var resources: Collection<URL> = emptyList()
@@ -16,7 +15,6 @@ class ConfigSpecBuilder : Builder<ConfigSpec> {
 
     override fun build(): ConfigSpec = ConfigModel(
         shouldValidateBeforeAnalysis,
-        knownPatterns,
         useDefaultConfig,
         resources,
         configPaths
@@ -25,7 +23,6 @@ class ConfigSpecBuilder : Builder<ConfigSpec> {
 
 private data class ConfigModel(
     override val shouldValidateBeforeAnalysis: Boolean?,
-    override val knownPatterns: Collection<String>,
     override val useDefaultConfig: Boolean,
     override val resources: Collection<URL>,
     override val configPaths: Collection<Path>


### PR DESCRIPTION
This is not used anywhere in detekt so can be removed from the API.

This is a breaking change as this alters the API but functionally there is no impact.