### PR TITLE
Use gradle-build-action to setup Gradle

### DIFF
--- a/.github/workflows/codecoverage.yaml
+++ b/.github/workflows/codecoverage.yaml
@@ -25,11 +25,13 @@ jobs:
           java-version: 17
           distribution: 'temurin'
 
-      - name: Generate Coverage Report
+      - name: Setup Gradle
         uses: gradle/gradle-build-action@ef76a971e2fa3f867b617efd72f2fbd72cf6f8bc # v2
         with:
           gradle-home-cache-cleanup: true
-          arguments: jacocoMergedReport
+
+      - name: Generate Coverage Report
+        run: ./gradlew jacocoMergedReport
         env:
           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
 

--- a/.github/workflows/deploy-snapshot.yaml
+++ b/.github/workflows/deploy-snapshot.yaml
@@ -26,25 +26,21 @@ jobs:
           java-version: 17
           distribution: "temurin"
 
-      - name: Assemble and publish artifacts to Maven Local
+      - name: Setup Gradle
         uses: gradle/gradle-build-action@ef76a971e2fa3f867b617efd72f2fbd72cf6f8bc # v2
         with:
           gradle-home-cache-cleanup: true
-          arguments: publishToMavenLocal
+
+      - name: Assemble and publish artifacts to Maven Local
+        run: ./gradlew publishToMavenLocal
 
       - name: Build detekt
-        uses: gradle/gradle-build-action@ef76a971e2fa3f867b617efd72f2fbd72cf6f8bc # v2
-        with:
-          gradle-home-cache-cleanup: true
-          arguments: build
+        run: ./gradlew build
 
       - name: Deploy Snapshot
-        uses: gradle/gradle-build-action@ef76a971e2fa3f867b617efd72f2fbd72cf6f8bc # v2
         env:
           ORG_GRADLE_PROJECT_SIGNING_KEY: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_KEY }}
           ORG_GRADLE_PROJECT_SIGNING_PWD: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_PWD }}
           ORG_GRADLE_PROJECT_SONATYPE_USERNAME: ${{ secrets.ORG_GRADLE_PROJECT_SONATYPE_USERNAME }}
           ORG_GRADLE_PROJECT_SONATYPE_PASSWORD: ${{ secrets.ORG_GRADLE_PROJECT_SONATYPE_PASSWORD }}
-        with:
-          gradle-home-cache-cleanup: true
-          arguments: publishAllToSonatypeSnapshot -Dsnapshot=true --stacktrace
+        run: ./gradlew publishAllToSonatypeSnapshot -Dsnapshot=true --stacktrace

--- a/.github/workflows/detekt-with-type-resolution.yaml
+++ b/.github/workflows/detekt-with-type-resolution.yaml
@@ -30,11 +30,13 @@ jobs:
           java-version: 17
           distribution: 'temurin'
 
-      - name: Run detekt-cli with argsfile
+      - name: Setup Gradle
         uses: gradle/gradle-build-action@ef76a971e2fa3f867b617efd72f2fbd72cf6f8bc # v2
         with:
           gradle-home-cache-cleanup: true
-          arguments: :detekt-cli:runWithArgsFile
+
+      - name: Run detekt-cli with argsfile
+        run: ./gradlew :detekt-cli:runWithArgsFile
 
       - name: Upload SARIF to GitHub using the upload-sarif action
         uses: github/codeql-action/upload-sarif@00e563ead9f72a8461b24876bee2d0c2e8bd2ee8 # v2
@@ -58,11 +60,13 @@ jobs:
           java-version: 17
           distribution: 'temurin'
 
-      - name: Run analysis
+      - name: Setup Gradle
         uses: gradle/gradle-build-action@ef76a971e2fa3f867b617efd72f2fbd72cf6f8bc # v2
         with:
           gradle-home-cache-cleanup: true
-          arguments: detektMain detektTest detektFunctionalTest detektTestFixtures detektReportMergeSarif --continue
+
+      - name: Run analysis
+        run: ./gradlew detektMain detektTest detektFunctionalTest detektTestFixtures detektReportMergeSarif --continue
 
       - name: Upload SARIF to GitHub using the upload-sarif action
         uses: github/codeql-action/upload-sarif@00e563ead9f72a8461b24876bee2d0c2e8bd2ee8 # v2

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -37,17 +37,16 @@ jobs:
           java-version: ${{ matrix.jdk }}
           distribution: 'temurin'
 
-      - name: Assemble and publish artifacts to Maven Local
+      - name: Setup Gradle
         uses: gradle/gradle-build-action@ef76a971e2fa3f867b617efd72f2fbd72cf6f8bc # v2
         with:
           gradle-home-cache-cleanup: true
-          arguments: publishToMavenLocal
+
+      - name: Assemble and publish artifacts to Maven Local
+        run: ./gradlew publishToMavenLocal
 
       - name: Build detekt
-        uses: gradle/gradle-build-action@ef76a971e2fa3f867b617efd72f2fbd72cf6f8bc # v2
-        with:
-          gradle-home-cache-cleanup: true
-          arguments: build -x detekt
+        run: ./gradlew build -x detekt
 
       - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3
         with:
@@ -67,11 +66,13 @@ jobs:
           java-version: 17
           distribution: 'temurin'
 
-      - name: Verify Generated Detekt Config File
+      - name: Setup Gradle
         uses: gradle/gradle-build-action@ef76a971e2fa3f867b617efd72f2fbd72cf6f8bc # v2
         with:
           gradle-home-cache-cleanup: true
-          arguments: verifyGeneratorOutput
+
+      - name: Verify Generated Detekt Config File
+        run: ./gradlew verifyGeneratorOutput
 
   compile-test-snippets:
     runs-on: ubuntu-latest
@@ -85,11 +86,13 @@ jobs:
           java-version: 17
           distribution: 'temurin'
 
-      - name: Build and compile test snippets
+      - name: Setup Gradle
         uses: gradle/gradle-build-action@ef76a971e2fa3f867b617efd72f2fbd72cf6f8bc # v2
         with:
           gradle-home-cache-cleanup: true
-          arguments: test -Pcompile-test-snippets=true
+
+      - name: Build and compile test snippets
+        run: ./gradlew test -Pcompile-test-snippets=true
 
   warnings-as-errors:
     runs-on: ubuntu-latest
@@ -103,8 +106,10 @@ jobs:
           java-version: 17
           distribution: 'temurin'
 
-      - name: Run with allWarningsAsErrors
+      - name: Setup Gradle
         uses: gradle/gradle-build-action@ef76a971e2fa3f867b617efd72f2fbd72cf6f8bc # v2
         with:
           gradle-home-cache-cleanup: true
-          arguments: compileKotlin compileTestKotlin compileTestFixturesKotlin -PwarningsAsErrors=true
+
+      - name: Run with allWarningsAsErrors
+        run: ./gradlew compileKotlin compileTestKotlin compileTestFixturesKotlin -PwarningsAsErrors=true

--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -26,6 +26,11 @@ jobs:
           java-version: 17
           distribution: 'temurin'
 
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@ef76a971e2fa3f867b617efd72f2fbd72cf6f8bc # v2
+        with:
+          gradle-home-cache-cleanup: true
+
       - name: Setup Node
         uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3
         with:
@@ -34,10 +39,7 @@ jobs:
           cache-dependency-path: 'website/yarn.lock'
 
       - name: Run generateWebsite
-        uses: gradle/gradle-build-action@ef76a971e2fa3f867b617efd72f2fbd72cf6f8bc # v2
-        with:
-          gradle-home-cache-cleanup: true
-          arguments: :detekt-generator:generateWebsite
+        run: ./gradlew :detekt-generator:generateWebsite
 
       - name: Install Yarn Dependencies
         working-directory: website/


### PR DESCRIPTION
This means all builds can be run with a standard 'run' action. This the recommended way to use the action: https://github.com/gradle/gradle-build-action/blob/3bfe3a46584a206fb8361cdedd0647b0c4204232/README.md#use-the-action-to-setup-gradle