### PR TITLE
Stop using data classes in public API

### DIFF
--- a/detekt-api/api/detekt-api.api
+++ b/detekt-api/api/detekt-api.api
@@ -165,16 +165,9 @@ public final class io/gitlab/arturbosch/detekt/api/Debt {
 	public fun <init> ()V
 	public fun <init> (III)V
 	public synthetic fun <init> (IIIILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()I
-	public final fun component2 ()I
-	public final fun component3 ()I
-	public final fun copy (III)Lio/gitlab/arturbosch/detekt/api/Debt;
-	public static synthetic fun copy$default (Lio/gitlab/arturbosch/detekt/api/Debt;IIIILjava/lang/Object;)Lio/gitlab/arturbosch/detekt/api/Debt;
-	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDays ()I
 	public final fun getHours ()I
 	public final fun getMins ()I
-	public fun hashCode ()I
 	public final fun plus (Lio/gitlab/arturbosch/detekt/api/Debt;)Lio/gitlab/arturbosch/detekt/api/Debt;
 	public fun toString ()Ljava/lang/String;
 }
@@ -203,17 +196,10 @@ public final class io/gitlab/arturbosch/detekt/api/Entity : io/gitlab/arturbosch
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lio/gitlab/arturbosch/detekt/api/Location;Lorg/jetbrains/kotlin/psi/KtElement;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun compact ()Ljava/lang/String;
 	public fun compactWithSignature ()Ljava/lang/String;
-	public final fun component2 ()Ljava/lang/String;
-	public final fun component3 ()Lio/gitlab/arturbosch/detekt/api/Location;
-	public final fun component4 ()Lorg/jetbrains/kotlin/psi/KtElement;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lio/gitlab/arturbosch/detekt/api/Location;Lorg/jetbrains/kotlin/psi/KtElement;)Lio/gitlab/arturbosch/detekt/api/Entity;
-	public static synthetic fun copy$default (Lio/gitlab/arturbosch/detekt/api/Entity;Ljava/lang/String;Ljava/lang/String;Lio/gitlab/arturbosch/detekt/api/Location;Lorg/jetbrains/kotlin/psi/KtElement;ILjava/lang/Object;)Lio/gitlab/arturbosch/detekt/api/Entity;
-	public fun equals (Ljava/lang/Object;)Z
 	public final fun getKtElement ()Lorg/jetbrains/kotlin/psi/KtElement;
 	public final fun getLocation ()Lio/gitlab/arturbosch/detekt/api/Location;
+	public final fun getName ()Ljava/lang/String;
 	public final fun getSignature ()Ljava/lang/String;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
 }
 
 public final class io/gitlab/arturbosch/detekt/api/Entity$Companion {
@@ -298,16 +284,9 @@ public abstract interface class io/gitlab/arturbosch/detekt/api/HasMetrics {
 
 public final class io/gitlab/arturbosch/detekt/api/Issue {
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lio/gitlab/arturbosch/detekt/api/Debt;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Ljava/lang/String;
-	public final fun component3 ()Lio/gitlab/arturbosch/detekt/api/Debt;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lio/gitlab/arturbosch/detekt/api/Debt;)Lio/gitlab/arturbosch/detekt/api/Issue;
-	public static synthetic fun copy$default (Lio/gitlab/arturbosch/detekt/api/Issue;Ljava/lang/String;Ljava/lang/String;Lio/gitlab/arturbosch/detekt/api/Debt;ILjava/lang/Object;)Lio/gitlab/arturbosch/detekt/api/Issue;
-	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDebt ()Lio/gitlab/arturbosch/detekt/api/Debt;
 	public final fun getDescription ()Ljava/lang/String;
 	public final fun getId ()Ljava/lang/String;
-	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -317,19 +296,10 @@ public final class io/gitlab/arturbosch/detekt/api/Location : io/gitlab/arturbos
 	public synthetic fun <init> (Lio/gitlab/arturbosch/detekt/api/SourceLocation;Lio/gitlab/arturbosch/detekt/api/SourceLocation;Lio/gitlab/arturbosch/detekt/api/TextLocation;Lio/github/detekt/psi/FilePath;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun compact ()Ljava/lang/String;
 	public fun compactWithSignature ()Ljava/lang/String;
-	public final fun component1 ()Lio/gitlab/arturbosch/detekt/api/SourceLocation;
-	public final fun component2 ()Lio/gitlab/arturbosch/detekt/api/SourceLocation;
-	public final fun component3 ()Lio/gitlab/arturbosch/detekt/api/TextLocation;
-	public final fun component4 ()Lio/github/detekt/psi/FilePath;
-	public final fun copy (Lio/gitlab/arturbosch/detekt/api/SourceLocation;Lio/gitlab/arturbosch/detekt/api/SourceLocation;Lio/gitlab/arturbosch/detekt/api/TextLocation;Lio/github/detekt/psi/FilePath;)Lio/gitlab/arturbosch/detekt/api/Location;
-	public static synthetic fun copy$default (Lio/gitlab/arturbosch/detekt/api/Location;Lio/gitlab/arturbosch/detekt/api/SourceLocation;Lio/gitlab/arturbosch/detekt/api/SourceLocation;Lio/gitlab/arturbosch/detekt/api/TextLocation;Lio/github/detekt/psi/FilePath;ILjava/lang/Object;)Lio/gitlab/arturbosch/detekt/api/Location;
-	public fun equals (Ljava/lang/Object;)Z
 	public final fun getEndSource ()Lio/gitlab/arturbosch/detekt/api/SourceLocation;
 	public final fun getFilePath ()Lio/github/detekt/psi/FilePath;
 	public final fun getSource ()Lio/gitlab/arturbosch/detekt/api/SourceLocation;
 	public final fun getText ()Lio/gitlab/arturbosch/detekt/api/TextLocation;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
 }
 
 public final class io/gitlab/arturbosch/detekt/api/Location$Companion {
@@ -344,19 +314,11 @@ public final class io/gitlab/arturbosch/detekt/api/Metric {
 	public synthetic fun <init> (DDIILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (IIZI)V
 	public synthetic fun <init> (IIZIILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()I
-	public final fun component2 ()I
-	public final fun component3 ()Z
-	public final fun component4 ()I
-	public final fun copy (IIZI)Lio/gitlab/arturbosch/detekt/api/Metric;
-	public static synthetic fun copy$default (Lio/gitlab/arturbosch/detekt/api/Metric;IIZIILjava/lang/Object;)Lio/gitlab/arturbosch/detekt/api/Metric;
 	public final fun doubleThreshold ()D
 	public final fun doubleValue ()D
-	public fun equals (Ljava/lang/Object;)Z
 	public final fun getConversionFactor ()I
 	public final fun getThreshold ()I
 	public final fun getValue ()I
-	public fun hashCode ()I
 	public final fun isDouble ()Z
 	public fun toString ()Ljava/lang/String;
 }
@@ -488,14 +450,8 @@ public final class io/gitlab/arturbosch/detekt/api/SingleAssign {
 
 public final class io/gitlab/arturbosch/detekt/api/SourceLocation {
 	public fun <init> (II)V
-	public final fun component1 ()I
-	public final fun component2 ()I
-	public final fun copy (II)Lio/gitlab/arturbosch/detekt/api/SourceLocation;
-	public static synthetic fun copy$default (Lio/gitlab/arturbosch/detekt/api/SourceLocation;IIILjava/lang/Object;)Lio/gitlab/arturbosch/detekt/api/SourceLocation;
-	public fun equals (Ljava/lang/Object;)Z
 	public final fun getColumn ()I
 	public final fun getLine ()I
-	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -507,14 +463,8 @@ public final class io/gitlab/arturbosch/detekt/api/SplitPatternKt {
 
 public final class io/gitlab/arturbosch/detekt/api/TextLocation {
 	public fun <init> (II)V
-	public final fun component1 ()I
-	public final fun component2 ()I
-	public final fun copy (II)Lio/gitlab/arturbosch/detekt/api/TextLocation;
-	public static synthetic fun copy$default (Lio/gitlab/arturbosch/detekt/api/TextLocation;IIILjava/lang/Object;)Lio/gitlab/arturbosch/detekt/api/TextLocation;
-	public fun equals (Ljava/lang/Object;)Z
 	public final fun getEnd ()I
 	public final fun getStart ()I
-	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -533,24 +483,12 @@ public abstract interface annotation class io/gitlab/arturbosch/detekt/api/Unsta
 public final class io/gitlab/arturbosch/detekt/api/ValueWithReason {
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lio/gitlab/arturbosch/detekt/api/ValueWithReason;
-	public static synthetic fun copy$default (Lio/gitlab/arturbosch/detekt/api/ValueWithReason;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/gitlab/arturbosch/detekt/api/ValueWithReason;
-	public fun equals (Ljava/lang/Object;)Z
 	public final fun getReason ()Ljava/lang/String;
 	public final fun getValue ()Ljava/lang/String;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
 }
 
 public final class io/gitlab/arturbosch/detekt/api/ValuesWithReason : java/lang/Iterable, kotlin/jvm/internal/markers/KMappedMarker {
-	public final fun copy (Ljava/util/List;)Lio/gitlab/arturbosch/detekt/api/ValuesWithReason;
-	public static synthetic fun copy$default (Lio/gitlab/arturbosch/detekt/api/ValuesWithReason;Ljava/util/List;ILjava/lang/Object;)Lio/gitlab/arturbosch/detekt/api/ValuesWithReason;
-	public fun equals (Ljava/lang/Object;)Z
-	public fun hashCode ()I
 	public fun iterator ()Ljava/util/Iterator;
-	public fun toString ()Ljava/lang/String;
 }
 
 public final class io/gitlab/arturbosch/detekt/api/ValuesWithReasonKt {

--- a/detekt-api/api/detekt-api.api
+++ b/detekt-api/api/detekt-api.api
@@ -450,8 +450,10 @@ public final class io/gitlab/arturbosch/detekt/api/SingleAssign {
 
 public final class io/gitlab/arturbosch/detekt/api/SourceLocation {
 	public fun <init> (II)V
+	public fun equals (Ljava/lang/Object;)Z
 	public final fun getColumn ()I
 	public final fun getLine ()I
+	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -463,8 +465,10 @@ public final class io/gitlab/arturbosch/detekt/api/SplitPatternKt {
 
 public final class io/gitlab/arturbosch/detekt/api/TextLocation {
 	public fun <init> (II)V
+	public fun equals (Ljava/lang/Object;)Z
 	public final fun getEnd ()I
 	public final fun getStart ()I
+	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -483,12 +487,18 @@ public abstract interface annotation class io/gitlab/arturbosch/detekt/api/Unsta
 public final class io/gitlab/arturbosch/detekt/api/ValueWithReason {
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
 	public final fun getReason ()Ljava/lang/String;
 	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class io/gitlab/arturbosch/detekt/api/ValuesWithReason : java/lang/Iterable, kotlin/jvm/internal/markers/KMappedMarker {
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
 	public fun iterator ()Ljava/util/Iterator;
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class io/gitlab/arturbosch/detekt/api/ValuesWithReasonKt {

--- a/detekt-api/build.gradle.kts
+++ b/detekt-api/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     alias(libs.plugins.dokka)
     `java-test-fixtures`
     alias(libs.plugins.binaryCompatibilityValidator)
+    alias(libs.plugins.poko)
 }
 
 dependencies {
@@ -16,6 +17,7 @@ dependencies {
     testImplementation(libs.assertj)
 
     testFixturesApi(libs.kotlin.stdlibJdk8)
+    testFixturesCompileOnly(libs.poko.annotations)
 }
 
 detekt {

--- a/detekt-api/build.gradle.kts
+++ b/detekt-api/build.gradle.kts
@@ -18,6 +18,10 @@ dependencies {
     testFixturesApi(libs.kotlin.stdlibJdk8)
 }
 
+detekt {
+    config.from("config/detekt.yml")
+}
+
 val javaComponent = components["java"] as AdhocComponentWithVariants
 listOf(configurations.testFixturesApiElements, configurations.testFixturesRuntimeElements).forEach { config ->
     config.configure {

--- a/detekt-api/config/detekt.yml
+++ b/detekt-api/config/detekt.yml
@@ -1,0 +1,3 @@
+libraries:
+  ForbiddenPublicDataClass:
+    active: true

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Debt.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Debt.kt
@@ -4,7 +4,7 @@ package io.gitlab.arturbosch.detekt.api
  * Debt describes the estimated amount of work needed to fix a given issue.
  */
 @Suppress("MagicNumber")
-data class Debt(val days: Int = 0, val hours: Int = 0, val mins: Int = 0) {
+class Debt(val days: Int = 0, val hours: Int = 0, val mins: Int = 0) {
 
     init {
         require(days >= 0 && hours >= 0 && mins >= 0)

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Debt.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Debt.kt
@@ -3,7 +3,6 @@ package io.gitlab.arturbosch.detekt.api
 /**
  * Debt describes the estimated amount of work needed to fix a given issue.
  */
-@Suppress("MagicNumber")
 class Debt(val days: Int = 0, val hours: Int = 0, val mins: Int = 0) {
 
     init {

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Entity.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Entity.kt
@@ -11,8 +11,8 @@ import org.jetbrains.kotlin.psi.psiUtil.getNonStrictParentOfType
 /**
  * Stores information about a specific code fragment.
  */
-data class Entity(
-    private val name: String,
+class Entity(
+    val name: String,
     val signature: String,
     val location: Location,
     val ktElement: KtElement? = null

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Issue.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Issue.kt
@@ -5,7 +5,7 @@ import io.gitlab.arturbosch.detekt.api.internal.validateIdentifier
 /**
  * An issue represents a problem in the codebase.
  */
-data class Issue(
+class Issue(
     val id: String,
     val description: String,
     val debt: Debt

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Location.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Location.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.api
 
+import dev.drewhamilton.poko.Poko
 import io.github.detekt.psi.FilePath
 import io.github.detekt.psi.getLineAndColumnInPsiFile
 import io.github.detekt.psi.toFilePath
@@ -64,6 +65,7 @@ class Location(
 /**
  * Stores line and column information of a location.
  */
+@Poko
 class SourceLocation(val line: Int, val column: Int) {
     override fun toString(): String = "$line:$column"
 }
@@ -71,6 +73,7 @@ class SourceLocation(val line: Int, val column: Int) {
 /**
  * Stores character start and end positions of a text file.
  */
+@Poko
 class TextLocation(val start: Int, val end: Int) {
     override fun toString(): String = "$start:$end"
 }

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Location.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Location.kt
@@ -13,7 +13,7 @@ import org.jetbrains.kotlin.psi.psiUtil.startOffset
 /**
  * Specifies a position within a source code fragment.
  */
-data class Location(
+class Location(
     val source: SourceLocation,
     val endSource: SourceLocation = source,
     val text: TextLocation,
@@ -64,13 +64,13 @@ data class Location(
 /**
  * Stores line and column information of a location.
  */
-data class SourceLocation(val line: Int, val column: Int) {
+class SourceLocation(val line: Int, val column: Int) {
     override fun toString(): String = "$line:$column"
 }
 
 /**
  * Stores character start and end positions of a text file.
  */
-data class TextLocation(val start: Int, val end: Int) {
+class TextLocation(val start: Int, val end: Int) {
     override fun toString(): String = "$start:$end"
 }

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Metric.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Metric.kt
@@ -4,7 +4,7 @@ package io.gitlab.arturbosch.detekt.api
  * Metric type, can be an integer or double value. Internally it is stored as an integer,
  * but the conversion factor and is double attributes can be used to retrieve it as a double value.
  */
-data class Metric(
+class Metric(
     val value: Int,
     val threshold: Int,
     val isDouble: Boolean = false,

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/ValuesWithReason.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/ValuesWithReason.kt
@@ -1,5 +1,7 @@
 package io.gitlab.arturbosch.detekt.api
 
+import dev.drewhamilton.poko.Poko
+
 /**
  * This factory method can be used by rule authors to specify one or many configuration values along with an
  * explanation for each value. For example:
@@ -31,6 +33,7 @@ fun valuesWithReason(values: List<ValueWithReason>): ValuesWithReason {
  * [ValuesWithReason] is essentially the same as [List] of [ValueWithReason]. Due to type erasure we cannot use the
  * list directly. Instances of this type should always created using the [valuesWithReason] factory method.
  */
+@Poko
 class ValuesWithReason internal constructor(private val values: List<ValueWithReason>) :
     Iterable<ValueWithReason> by values
 
@@ -39,4 +42,5 @@ class ValuesWithReason internal constructor(private val values: List<ValueWithRe
  * @property value the actual value that is configured
  * @property reason an optional explanation for the configured value
  */
+@Poko
 class ValueWithReason(val value: String, val reason: String? = null)

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/ValuesWithReason.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/ValuesWithReason.kt
@@ -31,7 +31,7 @@ fun valuesWithReason(values: List<ValueWithReason>): ValuesWithReason {
  * [ValuesWithReason] is essentially the same as [List] of [ValueWithReason]. Due to type erasure we cannot use the
  * list directly. Instances of this type should always created using the [valuesWithReason] factory method.
  */
-data class ValuesWithReason internal constructor(private val values: List<ValueWithReason>) :
+class ValuesWithReason internal constructor(private val values: List<ValueWithReason>) :
     Iterable<ValueWithReason> by values
 
 /**
@@ -39,4 +39,4 @@ data class ValuesWithReason internal constructor(private val values: List<ValueW
  * @property value the actual value that is configured
  * @property reason an optional explanation for the configured value
  */
-data class ValueWithReason(val value: String, val reason: String? = null)
+class ValueWithReason(val value: String, val reason: String? = null)

--- a/detekt-compiler-plugin/src/main/kotlin/io/github/detekt/compiler/plugin/internal/MessageCollectorExtensions.kt
+++ b/detekt-compiler-plugin/src/main/kotlin/io/github/detekt/compiler/plugin/internal/MessageCollectorExtensions.kt
@@ -33,11 +33,15 @@ fun MessageCollector.reportFindings(result: Detektion) {
 }
 
 fun Finding.renderAsCompilerWarningMessage(): Pair<String, CompilerMessageLocation?> {
-    val (line, column) = entity.location.source
     val location = MessageUtil.psiElementToMessageLocation(entity.ktElement)
 
     val sourceLocation = location?.let {
-        CompilerMessageLocation.create(location.path, line, column, location.lineContent)
+        CompilerMessageLocation.create(
+            location.path,
+            entity.location.source.line,
+            entity.location.source.column,
+            location.lineContent
+        )
     }
 
     return "$id: ${messageOrDescription()}" to sourceLocation

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/CorrectableRulesFirstSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/CorrectableRulesFirstSpec.kt
@@ -19,14 +19,14 @@ class CorrectableRulesFirstSpec {
         var actualLastRuleId = ""
 
         class First(config: Config) : Rule(config) {
-            override val issue: Issue = justAnIssue.copy(id = "NonCorrectable")
+            override val issue: Issue = Issue("NonCorrectable", justAnIssue.description, justAnIssue.debt)
             override fun visitClass(klass: KtClass) {
                 actualLastRuleId = issue.id
             }
         }
 
         class Last(config: Config) : Rule(config) {
-            override val issue: Issue = justAnIssue.copy(id = "Correctable")
+            override val issue: Issue = Issue("Correctable", justAnIssue.description, justAnIssue.debt)
             override fun visitClass(klass: KtClass) {
                 actualLastRuleId = issue.id
             }

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/CorrectableRulesFirstSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/CorrectableRulesFirstSpec.kt
@@ -26,7 +26,7 @@ class CorrectableRulesFirstSpec {
         }
 
         class Last(config: Config) : Rule(config) {
-            override val issue: Issue = Issue("Correctable", justAnIssue.description, justAnIssue.debt)
+            override val issue: Issue = Issue("Correctable", "", Debt.FIVE_MINS)
             override fun visitClass(klass: KtClass) {
                 actualLastRuleId = issue.id
             }

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/CorrectableRulesFirstSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/CorrectableRulesFirstSpec.kt
@@ -48,9 +48,3 @@ class CorrectableRulesFirstSpec {
         assertThat(actualLastRuleId).isEqualTo("NonCorrectable")
     }
 }
-
-private val justAnIssue = Issue(
-    "JustAnIssue",
-    "",
-    Debt.FIVE_MINS
-)

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/CorrectableRulesFirstSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/CorrectableRulesFirstSpec.kt
@@ -19,7 +19,7 @@ class CorrectableRulesFirstSpec {
         var actualLastRuleId = ""
 
         class First(config: Config) : Rule(config) {
-            override val issue: Issue = Issue("NonCorrectable", justAnIssue.description, justAnIssue.debt)
+            override val issue: Issue = Issue("NonCorrectable", "", Debt.FIVE_MINS)
             override fun visitClass(klass: KtClass) {
                 actualLastRuleId = issue.id
             }

--- a/detekt-psi-utils/api/detekt-psi-utils.api
+++ b/detekt-psi-utils/api/detekt-psi-utils.api
@@ -2,17 +2,9 @@ public final class io/github/detekt/psi/FilePath {
 	public static final field Companion Lio/github/detekt/psi/FilePath$Companion;
 	public fun <init> (Ljava/nio/file/Path;Ljava/nio/file/Path;Ljava/nio/file/Path;)V
 	public synthetic fun <init> (Ljava/nio/file/Path;Ljava/nio/file/Path;Ljava/nio/file/Path;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/nio/file/Path;
-	public final fun component2 ()Ljava/nio/file/Path;
-	public final fun component3 ()Ljava/nio/file/Path;
-	public final fun copy (Ljava/nio/file/Path;Ljava/nio/file/Path;Ljava/nio/file/Path;)Lio/github/detekt/psi/FilePath;
-	public static synthetic fun copy$default (Lio/github/detekt/psi/FilePath;Ljava/nio/file/Path;Ljava/nio/file/Path;Ljava/nio/file/Path;ILjava/lang/Object;)Lio/github/detekt/psi/FilePath;
-	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAbsolutePath ()Ljava/nio/file/Path;
 	public final fun getBasePath ()Ljava/nio/file/Path;
 	public final fun getRelativePath ()Ljava/nio/file/Path;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
 }
 
 public final class io/github/detekt/psi/FilePath$Companion {

--- a/detekt-psi-utils/build.gradle.kts
+++ b/detekt-psi-utils/build.gradle.kts
@@ -11,6 +11,10 @@ dependencies {
     testImplementation(projects.detektTest)
 }
 
+detekt {
+    config.from("config/detekt.yml")
+}
+
 apiValidation {
     ignoredPackages.add("io.github.detekt.psi.internal")
 }

--- a/detekt-psi-utils/config/detekt.yml
+++ b/detekt-psi-utils/config/detekt.yml
@@ -1,0 +1,3 @@
+libraries:
+  ForbiddenPublicDataClass:
+    active: true

--- a/detekt-psi-utils/src/main/kotlin/io/github/detekt/psi/KtFiles.kt
+++ b/detekt-psi-utils/src/main/kotlin/io/github/detekt/psi/KtFiles.kt
@@ -39,7 +39,7 @@ fun PsiFile.absolutePath(): Path = absolutePath ?: Path(virtualFile.path)
 /**
  * Represents both absolute path and relative path if available.
  */
-data class FilePath constructor(
+class FilePath constructor(
     val absolutePath: Path,
     val basePath: Path? = null,
     val relativePath: Path? = null

--- a/detekt-report-sarif/src/test/kotlin/io/github/detekt/report/sarif/SarifOutputReportSpec.kt
+++ b/detekt-report-sarif/src/test/kotlin/io/github/detekt/report/sarif/SarifOutputReportSpec.kt
@@ -99,7 +99,7 @@ class SarifOutputReportSpec {
         val result = TestDetektion(
             createFinding(
                 ruleName = "TestSmellB",
-                entity = refEntity.copy(location = location),
+                entity = Entity(refEntity.name, refEntity.signature, location, refEntity.ktElement),
                 severity = Severity.WARNING
             )
         )
@@ -136,7 +136,7 @@ class SarifOutputReportSpec {
         val result = TestDetektion(
             createFinding(
                 ruleName = "TestSmellB",
-                entity = refEntity.copy(location = location),
+                entity = Entity(refEntity.name, refEntity.signature, location, refEntity.ktElement),
                 severity = Severity.WARNING
             )
         )

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MatchingDeclarationName.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MatchingDeclarationName.kt
@@ -80,11 +80,11 @@ class MatchingDeclarationName(config: Config = Config.empty) : Rule(config) {
             val declarationName = declaration.name
             val filename = file.fileNameWithoutSuffix(multiplatformTargets)
             if (declarationName != filename && hasNoMatchingTypeAlias(filename)) {
-                val entity = Entity.atName(declaration).copy(ktElement = file)
+                val entity = Entity.atName(declaration)
                 report(
                     CodeSmell(
                         issue,
-                        entity,
+                        Entity(entity.name, entity.signature, entity.location, file),
                         "The file name '$filename' " +
                             "does not match the name of the single top-level declaration '$declarationName'."
                     )

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenAnnotation.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenAnnotation.kt
@@ -7,6 +7,7 @@ import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Location
 import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.TextLocation
 import io.gitlab.arturbosch.detekt.api.ValueWithReason
 import io.gitlab.arturbosch.detekt.api.config
 import io.gitlab.arturbosch.detekt.api.internal.Configuration
@@ -90,10 +91,11 @@ class ForbiddenAnnotation(config: Config = Config.empty) : Rule(config) {
                 "The annotation `${forbidden.value}` has been forbidden in the detekt config."
             }
             val location = Location.from(element).let { location ->
-                location.copy(
-                    text = location.text.copy(
-                        end = element.children.firstOrNull()?.endOffset ?: location.text.end
-                    )
+                Location(
+                    location.source,
+                    location.endSource,
+                    TextLocation(location.text.start, element.children.firstOrNull()?.endOffset ?: location.text.end),
+                    location.filePath
                 )
             }
             report(CodeSmell(issue, Entity.from(element, location), message))

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/TrailingWhitespace.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/TrailingWhitespace.kt
@@ -5,7 +5,9 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Location
 import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.TextLocation
 import io.gitlab.arturbosch.detekt.rules.isPartOfString
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.psi.KtFile
@@ -36,9 +38,14 @@ class TrailingWhitespace(config: Config = Config.empty) : Rule(config) {
                 val ktElement = findFirstKtElementInParentsOrNull(file, offset, line)
                 if (ktElement == null || !ktElement.isPartOfString()) {
                     val entity = Entity.from(file, offset - trailingWhitespaces).let { entity ->
-                        entity.copy(
-                            location = entity.location.copy(
-                                text = entity.location.text.copy(end = offset)
+                        Entity(
+                            entity.name,
+                            entity.signature,
+                            location = Location(
+                                entity.location.source,
+                                entity.location.endSource,
+                                TextLocation(entity.location.text.start, offset),
+                                entity.location.filePath
                             )
                         )
                     }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAnnotationUseSiteTarget.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAnnotationUseSiteTarget.kt
@@ -7,6 +7,7 @@ import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Location
 import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.TextLocation
 import org.jetbrains.kotlin.psi.KtAnnotationEntry
 import org.jetbrains.kotlin.psi.KtAnnotationUseSiteTarget
 import org.jetbrains.kotlin.psi.KtPrimaryConstructor
@@ -58,7 +59,12 @@ class UnnecessaryAnnotationUseSiteTarget(config: Config = Config.empty) : Rule(c
 
     private fun report(useSite: KtAnnotationUseSiteTarget, message: String) {
         val location = Location.from(useSite).let { location ->
-            location.copy(text = location.text.copy(end = location.text.end + 1))
+            Location(
+                location.source,
+                location.endSource,
+                TextLocation(location.text.start, location.text.end + 1),
+                location.filePath
+            )
         }
         report(CodeSmell(issue, Entity.from(useSite, location), message))
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,7 @@ jacoco = "0.8.10"
 kotlin = "1.9.10"
 ktlint = "0.50.0"
 junit = "5.10.0"
+poko = "0.15.0"
 
 [libraries]
 semver4j = "com.vdurmont:semver4j:3.1.0"
@@ -40,6 +41,7 @@ mockk = "io.mockk:mockk:1.13.7"
 snakeyaml = "org.snakeyaml:snakeyaml-engine:2.7"
 jcommander = "com.beust:jcommander:1.82"
 kotlinCompileTesting = { module = "com.github.tschuchortdev:kotlin-compile-testing", version = "1.5.0" }
+poko-annotations = { module = "dev.drewhamilton.poko:poko-annotations", version.ref = "poko" }
 
 [plugins]
 kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
@@ -48,6 +50,7 @@ dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 download = { id = "de.undercouch.download", version = "5.5.0" }
 gradleVersions = { id = "com.github.ben-manes.versions", version = "0.48.0" }
 pluginPublishing = { id = "com.gradle.plugin-publish", version = "1.2.1" }
+poko = { id = "dev.drewhamilton.poko", version.ref = "poko" }
 nexusPublish = { id = "io.github.gradle-nexus.publish-plugin", version = "1.3.0" }
 shadow = { id = "com.github.johnrengelman.shadow", version = "8.1.1" }
 githubRelease = { id = "com.github.breadmoirai.github-release", version = "2.4.1" }


### PR DESCRIPTION
https://kotlinlang.org/docs/jvm-api-guidelines-backward-compatibility.html#don-t-use-data-classes-in-an-api

> it's better not to use data classes in your API because almost any change in them breaks source, binary, or behavioral compatibility.

Instead I've introduced the Poko plugin where required because calling code used equality checks. This plugin generates overrides for `equals`,  `hashCode` and `toString` but does not generate the `componentX` or `copy` functions that lead to backwards compatibility issues.