### PR TITLE
Handle sequence of overridden methods

### DIFF
--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCall.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCall.kt
@@ -12,7 +12,6 @@ import io.gitlab.arturbosch.detekt.api.config
 import io.gitlab.arturbosch.detekt.api.internal.Configuration
 import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.valuesWithReason
-import org.jetbrains.kotlin.descriptors.CallableDescriptor
 import org.jetbrains.kotlin.descriptors.FunctionDescriptor
 import org.jetbrains.kotlin.descriptors.PropertyDescriptor
 import org.jetbrains.kotlin.descriptors.SyntheticPropertyDescriptor
@@ -26,6 +25,7 @@ import org.jetbrains.kotlin.psi.KtPrefixExpression
 import org.jetbrains.kotlin.psi.psiUtil.isDotSelector
 import org.jetbrains.kotlin.resolve.calls.util.getCalleeExpressionIfAny
 import org.jetbrains.kotlin.resolve.calls.util.getResolvedCall
+import org.jetbrains.kotlin.resolve.descriptorUtil.overriddenTreeUniqueAsSequence
 
 /**
  * Reports all method or constructor invocations that are forbidden.
@@ -113,14 +113,20 @@ class ForbiddenMethodCall(config: Config = Config.empty) : Rule(config) {
     }
 
     private fun check(expression: KtExpression) {
-        val descriptors = expression.getResolvedCall(bindingContext)?.resultingDescriptor?.let {
-            val foundDescriptors = if (it is PropertyDescriptor) {
-                listOfNotNull(it.unwrappedGetMethod, it.unwrappedSetMethod)
-            } else {
-                listOf(it)
-            }
-            foundDescriptors + foundDescriptors.flatMap(CallableDescriptor::getOverriddenDescriptors)
-        } ?: return
+        val descriptors =
+            expression.getResolvedCall(bindingContext)?.resultingDescriptor?.let { callableDescriptor ->
+                val foundDescriptors = if (callableDescriptor is PropertyDescriptor) {
+                    listOfNotNull(
+                        callableDescriptor.unwrappedGetMethod,
+                        callableDescriptor.unwrappedSetMethod
+                    )
+                } else {
+                    listOf(callableDescriptor)
+                }
+                foundDescriptors.flatMap {
+                    it.overriddenTreeUniqueAsSequence(true).toList()
+                }
+            }?.toSet() ?: return
 
         for (descriptor in descriptors) {
             methods.find { it.value.match(descriptor) }?.let { forbidden ->

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCallSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCallSpec.kt
@@ -434,6 +434,62 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
     }
 
     @Test
+    fun `should report class grandparent interface default method is not allowed`() {
+        val code = """
+            package org.example.com
+            open class SimpleComparator : Comparator<String> {
+                override fun compare(p0: String?, p1: String?): Int {
+                    return 0
+                }
+            }
+
+            class ComplexComparator : SimpleComparator() {
+                override fun compare(p0: String?, p1: String?): Int {
+                    return 0
+                }
+            }
+            
+            fun foo(bar1: ComplexComparator) {
+                bar1.reversed()
+                val bar2 = ComplexComparator()
+                bar2.reversed()
+            }
+        """.trimIndent()
+        val findings = ForbiddenMethodCall(
+            TestConfig(METHODS to listOf("java.util.Comparator.reversed"))
+        ).compileAndLintWithContext(env, code)
+        assertThat(findings).hasSize(2)
+    }
+
+    @Test
+    fun `should report class when grandparent default interface is not allowed extending other class`() {
+        val code = """
+            package org.example.com
+            open class Parent
+            open class SimpleComparator : Parent(), Comparator<String> {
+                override fun compare(p0: String?, p1: String?): Int {
+                    return 0
+                }
+            }
+
+            class ComplexComparator : SimpleComparator() {
+                override fun compare(p0: String?, p1: String?): Int {
+                    return 0
+                }
+            }
+            
+            fun foo(i: ComplexComparator) {
+                val bar = ComplexComparator()
+                bar.reversed()
+            }
+        """.trimIndent()
+        val findings = ForbiddenMethodCall(
+            TestConfig(METHODS to listOf("java.util.Comparator.reversed"))
+        ).compileAndLintWithContext(env, code)
+        assertThat(findings).hasSize(1)
+    }
+
+    @Test
     fun `should report functions with lambda params`() {
         val code = """
             package org.example

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCallSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCallSpec.kt
@@ -478,7 +478,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
                 }
             }
             
-            fun foo(i: ComplexComparator) {
+            fun foo() {
                 val bar = ComplexComparator()
                 bar.reversed()
             }


### PR DESCRIPTION
Use `overriddenTreeUniqueAsSequence` of overridden methods which gives all the methods even for the parent classes

Fixes https://github.com/detekt/detekt/issues/6474
