### PR TITLE
Fixed documentation on `SarifOutputReport` + docs out `OutputReport::name`

### DIFF
--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/OutputReport.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/OutputReport.kt
@@ -17,7 +17,7 @@ abstract class OutputReport : Extension {
     abstract val ending: String
 
     /**
-     * Name of the report. Is used to exclude this report in the yaml config.
+     * Human-readable name of the report.
      */
     open val name: String?
         get() = this::class.simpleName

--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -48,7 +48,7 @@ output-reports:
   # - 'XmlOutputReport'
   # - 'HtmlOutputReport'
   # - 'MdOutputReport'
-  # - 'SarifOutputReport'
+  # - 'sarif'
 
 comments:
   active: true

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/defaultconfig/ConfigPrinter.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/defaultconfig/ConfigPrinter.kt
@@ -90,6 +90,6 @@ object ConfigPrinter : DocumentationPrinter<List<RuleSetPage>> {
           # - 'XmlOutputReport'
           # - 'HtmlOutputReport'
           # - 'MdOutputReport'
-          # - 'SarifOutputReport'
+          # - 'sarif'
     """.trimIndent()
 }

--- a/website/docs/introduction/configurations.md
+++ b/website/docs/introduction/configurations.md
@@ -142,7 +142,7 @@ output-reports:
   #  - 'HtmlOutputReport'
   #  - 'TxtOutputReport'
   #  - 'XmlOutputReport'
-  #  - 'SarifOutputReport'
+  #  - 'sarif'
   #  - 'MdOutputReport'
 ```
 

--- a/website/versioned_docs/version-1.21.0/introduction/configurations.md
+++ b/website/versioned_docs/version-1.21.0/introduction/configurations.md
@@ -125,7 +125,7 @@ output-reports:
   #  - 'HtmlOutputReport'
   #  - 'TxtOutputReport'
   #  - 'XmlOutputReport'
-  #  - 'SarifOutputReport'
+  #  - 'sarif'
   #  - 'MdOutputReport'
 ```
 

--- a/website/versioned_docs/version-1.22.0/introduction/configurations.md
+++ b/website/versioned_docs/version-1.22.0/introduction/configurations.md
@@ -142,7 +142,7 @@ output-reports:
   #  - 'HtmlOutputReport'
   #  - 'TxtOutputReport'
   #  - 'XmlOutputReport'
-  #  - 'SarifOutputReport'
+  #  - 'sarif'
   #  - 'MdOutputReport'
 ```
 

--- a/website/versioned_docs/version-1.23.0/introduction/configurations.md
+++ b/website/versioned_docs/version-1.23.0/introduction/configurations.md
@@ -142,7 +142,7 @@ output-reports:
   #  - 'HtmlOutputReport'
   #  - 'TxtOutputReport'
   #  - 'XmlOutputReport'
-  #  - 'SarifOutputReport'
+  #  - 'sarif'
   #  - 'MdOutputReport'
 ```
 


### PR DESCRIPTION
Also fixed documentation for legacy versions. This behavior was at most introduced some time in 2020, so old docs where also incorrect