### PR TITLE
Avoid applying java-library plugin in DGP functional tests

### DIFF
--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/report/ReportMergeSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/report/ReportMergeSpec.kt
@@ -24,7 +24,6 @@ class ReportMergeSpec {
                 numberOfSourceFilesPerSourceDir = 2,
                 buildFileContent = """
                     ${builder.gradleSubprojectsApplyPlugins.reIndent(baseIndent = 5)}
-                    plugins.apply("java-library")
                 """.trimIndent()
             )
             addSubmodule(
@@ -32,7 +31,6 @@ class ReportMergeSpec {
                 numberOfSourceFilesPerSourceDir = 2,
                 buildFileContent = """
                     ${builder.gradleSubprojectsApplyPlugins.reIndent(baseIndent = 5)}
-                    plugins.apply("java-library")
                 """.trimIndent()
             )
         }

--- a/detekt-gradle-plugin/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/testkit/DslTestBuilder.kt
+++ b/detekt-gradle-plugin/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/testkit/DslTestBuilder.kt
@@ -89,7 +89,7 @@ private class GroovyBuilder : DslTestBuilder() {
     @Language("gradle")
     override val gradlePlugins = """
         plugins {
-            id 'java-library'
+            id 'org.jetbrains.kotlin.jvm'
             id "io.gitlab.arturbosch.detekt"
         }
     """.trimIndent()
@@ -118,7 +118,7 @@ private class KotlinBuilder : DslTestBuilder() {
     @Language("gradle.kts")
     override val gradlePlugins = """
         plugins {
-            `java-library`
+            kotlin("jvm")
             id("io.gitlab.arturbosch.detekt")
         }
     """.trimIndent()


### PR DESCRIPTION
Tests should use Kotlin JVM plugin instead as needed.