### PR TITLE
chore: Make misspelled property error message more actionable

### DIFF
--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/validation/InvalidPropertiesConfigValidator.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/validation/InvalidPropertiesConfigValidator.kt
@@ -79,7 +79,7 @@ internal class InvalidPropertiesConfigValidator(
 
         internal fun propertyDoesNotExists(prop: String): Notification =
             SimpleNotification(
-                "Property '$prop' is misspelled or does not exist." +
+                "Property '$prop' is misspelled or does not exist. " +
                     "This error may also indicate a detekt plugin is necessary to handle the '$prop' key."
             )
 

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/validation/InvalidPropertiesConfigValidator.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/validation/InvalidPropertiesConfigValidator.kt
@@ -78,7 +78,10 @@ internal class InvalidPropertiesConfigValidator(
     companion object {
 
         internal fun propertyDoesNotExists(prop: String): Notification =
-            SimpleNotification("Property '$prop' is misspelled or does not exist.")
+            SimpleNotification(
+                "Property '$prop' is misspelled or does not exist." +
+                    "This error may also indicate a detekt plugin is necessary to handle the '$prop' key."
+            )
 
         internal fun nestedConfigurationExpected(prop: String): Notification =
             SimpleNotification("Nested config expected for '$prop'.")


### PR DESCRIPTION
Basically this change:

```diff
- Property 'formatting' is misspelled or does not exist.
+ Property 'formatting' is misspelled or does not exist. This error may also indicate a detekt plugin is necessary to handle the 'formatting' key.
```

Typically this error happens when a key in the config has no known handling. The cause can be simply the key is indeed misspelled, the key is simply invalid, or that a plugin is necessary to handle this key.

Fixes #6492

<!-- A similar PR may already be submitted! -->
<!-- Please search among the [Pull requests](https://github.com/detekt/detekt/pulls) before creating one. -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Link to relevant issues if possible. -->

<!-- For more information, see the [CONTRIBUTING guide](https://github.com/detekt/detekt/blob/main/.github/CONTRIBUTING.md). -->
