### PR TITLE
Configure wrapper task to download "all" distribution

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,6 +9,10 @@ plugins {
     alias(libs.plugins.gradleVersions)
 }
 
+tasks.wrapper {
+    distributionType = Wrapper.DistributionType.ALL
+}
+
 val detektReportMergeSarif by tasks.registering(ReportMergeTask::class) {
     output = layout.buildDirectory.file("reports/detekt/merge.sarif")
 }


### PR DESCRIPTION
This makes it easier to update the wrapper when trying out different Gradle versions.