### PR TITLE
Convert DGP extension to use Property API

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,10 +21,10 @@ allprojects {
 
     detekt {
         source.setFrom(
-            io.gitlab.arturbosch.detekt.extensions.DetektExtension.DEFAULT_SRC_DIR_JAVA,
-            io.gitlab.arturbosch.detekt.extensions.DetektExtension.DEFAULT_TEST_SRC_DIR_JAVA,
-            io.gitlab.arturbosch.detekt.extensions.DetektExtension.DEFAULT_SRC_DIR_KOTLIN,
-            io.gitlab.arturbosch.detekt.extensions.DetektExtension.DEFAULT_TEST_SRC_DIR_KOTLIN,
+            io.gitlab.arturbosch.detekt.DetektPlugin.DEFAULT_SRC_DIR_JAVA,
+            io.gitlab.arturbosch.detekt.DetektPlugin.DEFAULT_TEST_SRC_DIR_JAVA,
+            io.gitlab.arturbosch.detekt.DetektPlugin.DEFAULT_SRC_DIR_KOTLIN,
+            io.gitlab.arturbosch.detekt.DetektPlugin.DEFAULT_TEST_SRC_DIR_KOTLIN,
         )
         buildUponDefaultConfig = true
         baseline = file("$rootDir/config/detekt/baseline.xml")

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/CreateBaselineTaskDslSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/CreateBaselineTaskDslSpec.kt
@@ -54,29 +54,6 @@ class CreateBaselineTaskDslSpec {
             assertThat(projectFile(DEFAULT_BASELINE_FILENAME)).exists()
         }
     }
-
-    @Test
-    fun `detektBaseline task can not be executed when baseline file is specified null`() {
-        val detektConfig = """
-            detekt {
-                baseline = null
-            }
-        """.trimIndent()
-        val gradleRunner = DslTestBuilder.kotlin()
-            .withProjectLayout(
-                ProjectLayout(
-                    numberOfSourceFilesInRootPerSourceDir = 1,
-                    numberOfCodeSmellsInRootPerSourceDir = 1,
-                )
-            )
-            .withDetektConfig(detektConfig)
-            .build()
-
-        gradleRunner.runTasksAndExpectFailure("detektBaseline") { result ->
-            assertThat(result.output).contains("property 'baseline' doesn't have a configured value")
-            assertThat(projectFile(DEFAULT_BASELINE_FILENAME)).doesNotExist()
-        }
-    }
 }
 
 private const val DEFAULT_BASELINE_FILENAME = "detekt-baseline.xml"

--- a/detekt-gradle-plugin/src/main/kotlin/io/github/detekt/gradle/DetektKotlinCompilerPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/github/detekt/gradle/DetektKotlinCompilerPlugin.kt
@@ -53,12 +53,12 @@ class DetektKotlinCompilerPlugin : KotlinCompilerPluginSupportPlugin {
         target.tasks.withType(KotlinCompile::class.java).configureEach { task ->
             task.extensions.create(DETEKT_EXTENSION, KotlinCompileTaskDetektExtension::class.java, target).apply {
                 isEnabled.convention(extension.enableCompilerPlugin)
-                baseline.convention(target.layout.file(target.provider { extension.baseline }))
-                debug.convention(target.provider { extension.debug })
-                buildUponDefaultConfig.convention(target.provider { extension.buildUponDefaultConfig })
-                allRules.convention(target.provider { extension.allRules })
-                disableDefaultRuleSets.convention(target.provider { extension.disableDefaultRuleSets })
-                parallel.convention(target.provider { extension.parallel })
+                baseline.convention(extension.baseline)
+                debug.convention(extension.debug)
+                buildUponDefaultConfig.convention(extension.buildUponDefaultConfig)
+                allRules.convention(extension.allRules)
+                disableDefaultRuleSets.convention(extension.disableDefaultRuleSets)
+                parallel.convention(extension.parallel)
                 config.from(extension.config)
                 excludes.convention(DetektPlugin.defaultExcludes)
             }

--- a/detekt-gradle-plugin/src/main/kotlin/io/github/detekt/gradle/DetektKotlinCompilerPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/github/detekt/gradle/DetektKotlinCompilerPlugin.kt
@@ -36,7 +36,9 @@ class DetektKotlinCompilerPlugin : KotlinCompilerPluginSupportPlugin {
                 DetektExtension::class.java
             )
 
-        extension.reportsDir = target.extensions.getByType(ReportingExtension::class.java).file("detekt")
+        extension.reportsDir.convention(
+            target.extensions.getByType(ReportingExtension::class.java).baseDirectory.dir("detekt")
+        )
 
         val defaultConfigFile =
             target.file("${target.rootProject.layout.projectDirectory.dir(CONFIG_DIR_NAME)}/$CONFIG_FILE")
@@ -91,11 +93,7 @@ class DetektKotlinCompilerPlugin : KotlinCompilerPluginSupportPlugin {
             taskExtension.reports.all { report ->
                 report.enabled.convention(true)
                 report.destination.convention(
-                    project.layout.projectDirectory.file(
-                        project.providers.provider {
-                            File(projectExtension.reportsDir, "${kotlinCompilation.name}.${report.name}").absolutePath
-                        }
-                    )
+                    projectExtension.reportsDir.file("${kotlinCompilation.name}.${report.name}")
                 )
 
                 if (report.enabled.get()) {

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -1,6 +1,5 @@
 package io.gitlab.arturbosch.detekt
 
-import io.gitlab.arturbosch.detekt.extensions.DetektExtension
 import io.gitlab.arturbosch.detekt.extensions.DetektReport
 import io.gitlab.arturbosch.detekt.extensions.DetektReportType
 import io.gitlab.arturbosch.detekt.extensions.DetektReports
@@ -292,7 +291,7 @@ abstract class Detekt @Inject constructor(
     private fun getTargetFileProvider(
         report: DetektReport
     ): RegularFileProperty {
-        val isEnabled = report.required.getOrElse(DetektExtension.DEFAULT_REPORT_ENABLED_VALUE)
+        val isEnabled = report.required.getOrElse(DetektPlugin.DEFAULT_REPORT_ENABLED_VALUE)
         val provider = objects.fileProperty()
         if (isEnabled) {
             val destination = report.outputLocation.asFile.orNull ?: reportsDir.getOrElse(defaultReportsDir.asFile)

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
@@ -22,7 +22,7 @@ class DetektPlugin : Plugin<Project> {
             )
 
         with(extension) {
-            toolVersion = loadDetektVersion(DetektExtension::class.java.classLoader)
+            toolVersion.convention(loadDetektVersion(DetektExtension::class.java.classLoader))
             source.setFrom(
                 DEFAULT_SRC_DIR_JAVA,
                 DEFAULT_TEST_SRC_DIR_JAVA,
@@ -37,7 +37,9 @@ class DetektPlugin : Plugin<Project> {
             buildUponDefaultConfig.convention(DEFAULT_BUILD_UPON_DEFAULT_CONFIG_VALUE)
             disableDefaultRuleSets.convention(DEFAULT_DISABLE_RULESETS_VALUE)
             autoCorrect.convention(DEFAULT_AUTO_CORRECT_VALUE)
-            reportsDir = project.extensions.getByType(ReportingExtension::class.java).file("detekt")
+            reportsDir.convention(
+                project.extensions.getByType(ReportingExtension::class.java).baseDirectory.dir("detekt")
+            )
             basePath.convention(project.rootProject.layout.projectDirectory)
         }
 
@@ -116,7 +118,7 @@ class DetektPlugin : Plugin<Project> {
             configuration.isCanBeConsumed = false
 
             configuration.defaultDependencies { dependencySet ->
-                val version = extension.toolVersion
+                val version = extension.toolVersion.get()
                 dependencySet.add(project.dependencies.create("io.gitlab.arturbosch.detekt:detekt-cli:$version"))
             }
         }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
@@ -29,19 +29,16 @@ class DetektPlugin : Plugin<Project> {
                 DEFAULT_SRC_DIR_KOTLIN,
                 DEFAULT_TEST_SRC_DIR_KOTLIN,
             )
-            baseline = project.file("detekt-baseline.xml")
+            baseline.convention(project.layout.projectDirectory.file("detekt-baseline.xml"))
             enableCompilerPlugin.convention(DEFAULT_COMPILER_PLUGIN_ENABLED)
-            debug = DEFAULT_DEBUG_VALUE
-            parallel = DEFAULT_PARALLEL_VALUE
-            allRules = DEFAULT_ALL_RULES_VALUE
-            buildUponDefaultConfig = DEFAULT_BUILD_UPON_DEFAULT_CONFIG_VALUE
-            disableDefaultRuleSets = DEFAULT_DISABLE_RULESETS_VALUE
-            autoCorrect = DEFAULT_AUTO_CORRECT_VALUE
-            ignoredVariants = emptyList()
-            ignoredBuildTypes = emptyList()
-            ignoredFlavors = emptyList()
+            debug.convention(DEFAULT_DEBUG_VALUE)
+            parallel.convention(DEFAULT_PARALLEL_VALUE)
+            allRules.convention(DEFAULT_ALL_RULES_VALUE)
+            buildUponDefaultConfig.convention(DEFAULT_BUILD_UPON_DEFAULT_CONFIG_VALUE)
+            disableDefaultRuleSets.convention(DEFAULT_DISABLE_RULESETS_VALUE)
+            autoCorrect.convention(DEFAULT_AUTO_CORRECT_VALUE)
             reportsDir = project.extensions.getByType(ReportingExtension::class.java).file("detekt")
-            basePath = project.rootProject.layout.projectDirectory.asFile.absolutePath
+            basePath.convention(project.rootProject.layout.projectDirectory)
         }
 
         val defaultConfigFile =

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
@@ -1,6 +1,7 @@
 package io.gitlab.arturbosch.detekt
 
 import io.gitlab.arturbosch.detekt.extensions.DetektExtension
+import io.gitlab.arturbosch.detekt.extensions.loadDetektVersion
 import io.gitlab.arturbosch.detekt.internal.DetektAndroid
 import io.gitlab.arturbosch.detekt.internal.DetektJvm
 import io.gitlab.arturbosch.detekt.internal.DetektMultiplatform
@@ -20,8 +21,28 @@ class DetektPlugin : Plugin<Project> {
                 DetektExtension::class.java
             )
 
-        extension.reportsDir = project.extensions.getByType(ReportingExtension::class.java).file("detekt")
-        extension.basePath = project.rootProject.layout.projectDirectory.asFile.absolutePath
+        with(extension) {
+            toolVersion = loadDetektVersion(DetektExtension::class.java.classLoader)
+            source.setFrom(
+                DEFAULT_SRC_DIR_JAVA,
+                DEFAULT_TEST_SRC_DIR_JAVA,
+                DEFAULT_SRC_DIR_KOTLIN,
+                DEFAULT_TEST_SRC_DIR_KOTLIN,
+            )
+            baseline = project.file("detekt-baseline.xml")
+            enableCompilerPlugin.convention(DEFAULT_COMPILER_PLUGIN_ENABLED)
+            debug = DEFAULT_DEBUG_VALUE
+            parallel = DEFAULT_PARALLEL_VALUE
+            allRules = DEFAULT_ALL_RULES_VALUE
+            buildUponDefaultConfig = DEFAULT_BUILD_UPON_DEFAULT_CONFIG_VALUE
+            disableDefaultRuleSets = DEFAULT_DISABLE_RULESETS_VALUE
+            autoCorrect = DEFAULT_AUTO_CORRECT_VALUE
+            ignoredVariants = emptyList()
+            ignoredBuildTypes = emptyList()
+            ignoredFlavors = emptyList()
+            reportsDir = project.extensions.getByType(ReportingExtension::class.java).file("detekt")
+            basePath = project.rootProject.layout.projectDirectory.asFile.absolutePath
+        }
 
         val defaultConfigFile =
             project.file("${project.rootProject.layout.projectDirectory.dir(CONFIG_DIR_NAME)}/$CONFIG_FILE")
@@ -133,6 +154,21 @@ class DetektPlugin : Plugin<Project> {
 
         internal const val DETEKT_ANDROID_DISABLED_PROPERTY = "detekt.android.disabled"
         internal const val DETEKT_MULTIPLATFORM_DISABLED_PROPERTY = "detekt.multiplatform.disabled"
+
+        const val DEFAULT_SRC_DIR_JAVA = "src/main/java"
+        const val DEFAULT_TEST_SRC_DIR_JAVA = "src/test/java"
+        const val DEFAULT_SRC_DIR_KOTLIN = "src/main/kotlin"
+        const val DEFAULT_TEST_SRC_DIR_KOTLIN = "src/test/kotlin"
+        const val DEFAULT_DEBUG_VALUE = false
+        const val DEFAULT_PARALLEL_VALUE = false
+        const val DEFAULT_AUTO_CORRECT_VALUE = false
+        const val DEFAULT_DISABLE_RULESETS_VALUE = false
+        const val DEFAULT_REPORT_ENABLED_VALUE = true
+        const val DEFAULT_ALL_RULES_VALUE = false
+        const val DEFAULT_BUILD_UPON_DEFAULT_CONFIG_VALUE = false
+
+        // This flag is ignored unless the compiler plugin is applied to the project
+        const val DEFAULT_COMPILER_PLUGIN_ENABLED = true
     }
 }
 

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
@@ -23,6 +23,7 @@ class DetektPlugin : Plugin<Project> {
 
         with(extension) {
             toolVersion.convention(loadDetektVersion(DetektExtension::class.java.classLoader))
+            ignoreFailures.convention(DEFAULT_IGNORE_FAILURES)
             source.setFrom(
                 DEFAULT_SRC_DIR_JAVA,
                 DEFAULT_TEST_SRC_DIR_JAVA,
@@ -159,6 +160,7 @@ class DetektPlugin : Plugin<Project> {
         const val DEFAULT_SRC_DIR_KOTLIN = "src/main/kotlin"
         const val DEFAULT_TEST_SRC_DIR_KOTLIN = "src/test/kotlin"
         const val DEFAULT_DEBUG_VALUE = false
+        const val DEFAULT_IGNORE_FAILURES = false
         const val DEFAULT_PARALLEL_VALUE = false
         const val DEFAULT_AUTO_CORRECT_VALUE = false
         const val DEFAULT_DISABLE_RULESETS_VALUE = false

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
@@ -9,6 +9,7 @@ import java.io.InputStream
 import java.net.URL
 import java.util.Properties
 
+@Suppress("ComplexInterface")
 interface DetektExtension {
 
     val toolVersion: Property<String>

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
@@ -1,20 +1,14 @@
 package io.gitlab.arturbosch.detekt.extensions
 
 import org.gradle.api.file.ConfigurableFileCollection
-import org.gradle.api.model.ObjectFactory
 import org.gradle.api.plugins.quality.CodeQualityExtension
 import org.gradle.api.provider.Property
 import java.io.File
 import java.io.InputStream
 import java.net.URL
 import java.util.Properties
-import javax.inject.Inject
 
-open class DetektExtension @Inject constructor(objects: ObjectFactory) : CodeQualityExtension() {
-
-    init {
-        toolVersion = loadDetektVersion(DetektExtension::class.java.classLoader)
-    }
+abstract class DetektExtension : CodeQualityExtension() {
 
     var ignoreFailures: Boolean
         @JvmName("ignoreFailures_")
@@ -25,72 +19,44 @@ open class DetektExtension @Inject constructor(objects: ObjectFactory) : CodeQua
             isIgnoreFailures = value
         }
 
-    val source: ConfigurableFileCollection = objects.fileCollection()
-        .from(
-            DEFAULT_SRC_DIR_JAVA,
-            DEFAULT_TEST_SRC_DIR_JAVA,
-            DEFAULT_SRC_DIR_KOTLIN,
-            DEFAULT_TEST_SRC_DIR_KOTLIN,
-        )
+    abstract val source: ConfigurableFileCollection
 
-    var baseline: File? = objects
-        .fileProperty()
-        .fileValue(File("detekt-baseline.xml"))
-        .get()
-        .asFile
+    abstract var baseline: File?
 
-    var basePath: String? = null
+    abstract var basePath: String?
 
-    val enableCompilerPlugin: Property<Boolean> =
-        objects.property(Boolean::class.java).convention(DEFAULT_COMPILER_PLUGIN_ENABLED)
+    abstract val enableCompilerPlugin: Property<Boolean>
 
-    val config: ConfigurableFileCollection = objects.fileCollection()
+    abstract val config: ConfigurableFileCollection
 
-    var debug: Boolean = DEFAULT_DEBUG_VALUE
+    abstract var debug: Boolean
 
-    var parallel: Boolean = DEFAULT_PARALLEL_VALUE
+    abstract var parallel: Boolean
 
-    var allRules: Boolean = DEFAULT_ALL_RULES_VALUE
+    abstract var allRules: Boolean
 
-    var buildUponDefaultConfig: Boolean = DEFAULT_BUILD_UPON_DEFAULT_CONFIG_VALUE
+    abstract var buildUponDefaultConfig: Boolean
 
-    var disableDefaultRuleSets: Boolean = DEFAULT_DISABLE_RULESETS_VALUE
+    abstract var disableDefaultRuleSets: Boolean
 
-    var autoCorrect: Boolean = DEFAULT_AUTO_CORRECT_VALUE
+    abstract var autoCorrect: Boolean
 
     /**
      * List of Android build variants for which no detekt task should be created.
      *
      * This is a combination of build types and flavors, such as fooDebug or barRelease.
      */
-    var ignoredVariants: List<String> = emptyList()
+    abstract var ignoredVariants: List<String>
 
     /**
      * List of Android build types for which no detekt task should be created.
      */
-    var ignoredBuildTypes: List<String> = emptyList()
+    abstract var ignoredBuildTypes: List<String>
 
     /**
      * List of Android build flavors for which no detekt task should be created
      */
-    var ignoredFlavors: List<String> = emptyList()
-
-    companion object {
-        const val DEFAULT_SRC_DIR_JAVA = "src/main/java"
-        const val DEFAULT_TEST_SRC_DIR_JAVA = "src/test/java"
-        const val DEFAULT_SRC_DIR_KOTLIN = "src/main/kotlin"
-        const val DEFAULT_TEST_SRC_DIR_KOTLIN = "src/test/kotlin"
-        const val DEFAULT_DEBUG_VALUE = false
-        const val DEFAULT_PARALLEL_VALUE = false
-        const val DEFAULT_AUTO_CORRECT_VALUE = false
-        const val DEFAULT_DISABLE_RULESETS_VALUE = false
-        const val DEFAULT_REPORT_ENABLED_VALUE = true
-        const val DEFAULT_ALL_RULES_VALUE = false
-        const val DEFAULT_BUILD_UPON_DEFAULT_CONFIG_VALUE = false
-
-        // This flag is ignored unless the compiler plugin is applied to the project
-        const val DEFAULT_COMPILER_PLUGIN_ENABLED = true
-    }
+    abstract var ignoredFlavors: List<String>
 }
 
 internal fun loadDetektVersion(classLoader: ClassLoader): String {

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
@@ -9,52 +9,52 @@ import java.io.InputStream
 import java.net.URL
 import java.util.Properties
 
-abstract class DetektExtension {
+interface DetektExtension {
 
-    abstract val toolVersion: Property<String>
+    val toolVersion: Property<String>
 
-    abstract val ignoreFailures: Property<Boolean>
+    val ignoreFailures: Property<Boolean>
 
-    abstract val reportsDir: DirectoryProperty
+    val reportsDir: DirectoryProperty
 
-    abstract val source: ConfigurableFileCollection
+    val source: ConfigurableFileCollection
 
-    abstract val baseline: RegularFileProperty
+    val baseline: RegularFileProperty
 
-    abstract val basePath: DirectoryProperty
+    val basePath: DirectoryProperty
 
-    abstract val enableCompilerPlugin: Property<Boolean>
+    val enableCompilerPlugin: Property<Boolean>
 
-    abstract val config: ConfigurableFileCollection
+    val config: ConfigurableFileCollection
 
-    abstract val debug: Property<Boolean>
+    val debug: Property<Boolean>
 
-    abstract val parallel: Property<Boolean>
+    val parallel: Property<Boolean>
 
-    abstract val allRules: Property<Boolean>
+    val allRules: Property<Boolean>
 
-    abstract val buildUponDefaultConfig: Property<Boolean>
+    val buildUponDefaultConfig: Property<Boolean>
 
-    abstract val disableDefaultRuleSets: Property<Boolean>
+    val disableDefaultRuleSets: Property<Boolean>
 
-    abstract val autoCorrect: Property<Boolean>
+    val autoCorrect: Property<Boolean>
 
     /**
      * List of Android build variants for which no detekt task should be created.
      *
      * This is a combination of build types and flavors, such as fooDebug or barRelease.
      */
-    abstract val ignoredVariants: ListProperty<String>
+    val ignoredVariants: ListProperty<String>
 
     /**
      * List of Android build types for which no detekt task should be created.
      */
-    abstract val ignoredBuildTypes: ListProperty<String>
+    val ignoredBuildTypes: ListProperty<String>
 
     /**
      * List of Android build flavors for which no detekt task should be created
      */
-    abstract val ignoredFlavors: ListProperty<String>
+    val ignoredFlavors: ListProperty<String>
 }
 
 internal fun loadDetektVersion(classLoader: ClassLoader): String {

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
@@ -1,9 +1,11 @@
 package io.gitlab.arturbosch.detekt.extensions
 
 import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.plugins.quality.CodeQualityExtension
+import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
-import java.io.File
 import java.io.InputStream
 import java.net.URL
 import java.util.Properties
@@ -21,42 +23,42 @@ abstract class DetektExtension : CodeQualityExtension() {
 
     abstract val source: ConfigurableFileCollection
 
-    abstract var baseline: File?
+    abstract val baseline: RegularFileProperty
 
-    abstract var basePath: String?
+    abstract val basePath: DirectoryProperty
 
     abstract val enableCompilerPlugin: Property<Boolean>
 
     abstract val config: ConfigurableFileCollection
 
-    abstract var debug: Boolean
+    abstract val debug: Property<Boolean>
 
-    abstract var parallel: Boolean
+    abstract val parallel: Property<Boolean>
 
-    abstract var allRules: Boolean
+    abstract val allRules: Property<Boolean>
 
-    abstract var buildUponDefaultConfig: Boolean
+    abstract val buildUponDefaultConfig: Property<Boolean>
 
-    abstract var disableDefaultRuleSets: Boolean
+    abstract val disableDefaultRuleSets: Property<Boolean>
 
-    abstract var autoCorrect: Boolean
+    abstract val autoCorrect: Property<Boolean>
 
     /**
      * List of Android build variants for which no detekt task should be created.
      *
      * This is a combination of build types and flavors, such as fooDebug or barRelease.
      */
-    abstract var ignoredVariants: List<String>
+    abstract val ignoredVariants: ListProperty<String>
 
     /**
      * List of Android build types for which no detekt task should be created.
      */
-    abstract var ignoredBuildTypes: List<String>
+    abstract val ignoredBuildTypes: ListProperty<String>
 
     /**
      * List of Android build flavors for which no detekt task should be created
      */
-    abstract var ignoredFlavors: List<String>
+    abstract val ignoredFlavors: ListProperty<String>
 }
 
 internal fun loadDetektVersion(classLoader: ClassLoader): String {

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
@@ -3,23 +3,19 @@ package io.gitlab.arturbosch.detekt.extensions
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
-import org.gradle.api.plugins.quality.CodeQualityExtension
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import java.io.InputStream
 import java.net.URL
 import java.util.Properties
 
-abstract class DetektExtension : CodeQualityExtension() {
+abstract class DetektExtension {
 
-    var ignoreFailures: Boolean
-        @JvmName("ignoreFailures_")
-        get() = isIgnoreFailures
+    abstract val toolVersion: Property<String>
 
-        @JvmName("ignoreFailures_")
-        set(value) {
-            isIgnoreFailures = value
-        }
+    abstract val ignoreFailures: Property<Boolean>
+
+    abstract val reportsDir: DirectoryProperty
 
     abstract val source: ConfigurableFileCollection
 

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektAndroid.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektAndroid.kt
@@ -106,9 +106,9 @@ internal class DetektAndroid(private val project: Project) {
     }
 
     private fun DetektExtension.matchesIgnoredConfiguration(variant: BaseVariant): Boolean =
-        ignoredVariants.contains(variant.name) ||
-            ignoredBuildTypes.contains(variant.buildType.name) ||
-            ignoredFlavors.contains(variant.flavorName)
+        ignoredVariants.get().contains(variant.name) ||
+            ignoredBuildTypes.get().contains(variant.buildType.name) ||
+            ignoredFlavors.get().contains(variant.flavorName)
 }
 
 internal fun Project.registerAndroidDetektTask(
@@ -128,7 +128,7 @@ internal fun Project.registerAndroidDetektTask(
         )
         // If a baseline file is configured as input file, it must exist to be configured, otherwise the task fails.
         // We try to find the configured baseline or alternatively a specific variant matching this task.
-        extension.baseline?.existingVariantOrBaseFile(variant.name)?.let { baselineFile ->
+        extension.baseline.asFile.orNull?.existingVariantOrBaseFile(variant.name)?.let { baselineFile ->
             baseline.convention(layout.file(project.provider { baselineFile }))
         }
         setReportOutputConventions(reports, extension, variant.name)
@@ -150,7 +150,7 @@ internal fun Project.registerAndroidCreateBaselineTask(
             bootClasspath,
             javaCompileDestination(variant),
         )
-        val variantBaselineFile = extension.baseline?.addVariantName(variant.name)
+        val variantBaselineFile = extension.baseline.asFile.orNull?.addVariantName(variant.name)
         baseline.convention(project.layout.file(project.provider { variantBaselineFile }))
         description = "EXPERIMENTAL: Creates detekt baseline for ${variant.name} classes with type resolution"
     }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektJvm.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektJvm.kt
@@ -29,7 +29,7 @@ internal class DetektJvm(private val project: Project) {
             classpath.setFrom(compilation.output.classesDirs, compilation.compileDependencyFiles)
             // If a baseline file is configured as input file, it must exist to be configured, otherwise the task fails.
             // We try to find the configured baseline or alternatively a specific variant matching this task.
-            extension.baseline?.existingVariantOrBaseFile(compilation.name)?.let { baselineFile ->
+            extension.baseline.asFile.orNull?.existingVariantOrBaseFile(compilation.name)?.let { baselineFile ->
                 baseline.convention(layout.file(provider { baselineFile }))
             }
             setReportOutputConventions(reports, extension, compilation.name)
@@ -45,7 +45,7 @@ internal class DetektJvm(private val project: Project) {
         registerCreateBaselineTask(DetektPlugin.BASELINE_TASK_NAME + compilation.name.capitalize(), extension) {
             setSource(inputSource)
             classpath.setFrom(compilation.output.classesDirs, compilation.compileDependencyFiles)
-            val variantBaselineFile = extension.baseline?.addVariantName(compilation.name)
+            val variantBaselineFile = extension.baseline.asFile.orNull?.addVariantName(compilation.name)
             baseline.convention(layout.file(provider { variantBaselineFile }))
             description = "EXPERIMENTAL: Creates detekt baseline for ${compilation.name} classes with type resolution"
         }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektMultiplatform.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektMultiplatform.kt
@@ -101,9 +101,9 @@ internal class DetektMultiplatform(private val project: Project) {
             // If a baseline file is configured as input file, it must exist to be configured, otherwise the task fails.
             // We try to find the configured baseline or alternatively a specific variant matching this task.
             if (runWithTypeResolution) {
-                extension.baseline?.existingVariantOrBaseFile(compilation.name)
+                extension.baseline.asFile.orNull?.existingVariantOrBaseFile(compilation.name)
             } else {
-                extension.baseline?.takeIf { it.exists() }
+                extension.baseline.asFile.orNull?.takeIf { it.exists() }
             }?.let { baselineFile ->
                 baseline.convention(layout.file(provider { baselineFile }))
             }
@@ -124,9 +124,9 @@ internal class DetektMultiplatform(private val project: Project) {
                 classpath.setFrom(compilation.output.classesDirs, compilation.compileDependencyFiles)
             }
             val variantBaselineFile = if (runWithTypeResolution) {
-                extension.baseline?.addVariantName(compilation.name)
+                extension.baseline.asFile.orNull?.addVariantName(compilation.name)
             } else {
-                extension.baseline
+                extension.baseline.get().asFile
             }
             baseline.convention(
                 layout.file(provider { variantBaselineFile })

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektMultiplatform.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektMultiplatform.kt
@@ -14,7 +14,6 @@ import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType.androidJvm
 import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType.jvm
 import org.jetbrains.kotlin.gradle.plugin.KotlinTarget
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinJvmAndroidCompilation
-import java.io.File
 
 internal class DetektMultiplatform(private val project: Project) {
 
@@ -141,7 +140,7 @@ internal class DetektMultiplatform(private val project: Project) {
     }
 }
 
-internal fun Project.setReportOutputConventions(reports: DetektReports, extension: DetektExtension, name: String) {
+internal fun setReportOutputConventions(reports: DetektReports, extension: DetektExtension, name: String) {
     setReportOutputConvention(extension, reports.xml, name, "xml")
     setReportOutputConvention(extension, reports.html, name, "html")
     setReportOutputConvention(extension, reports.txt, name, "txt")
@@ -149,19 +148,13 @@ internal fun Project.setReportOutputConventions(reports: DetektReports, extensio
     setReportOutputConvention(extension, reports.md, name, "md")
 }
 
-private fun Project.setReportOutputConvention(
+private fun setReportOutputConvention(
     extension: DetektExtension,
     report: DetektReport,
     name: String,
     format: String
 ) {
-    report.outputLocation.convention(
-        layout.projectDirectory.file(
-            providers.provider {
-                File(extension.reportsDir, "$name.$format").absolutePath
-            }
-        )
-    )
+    report.outputLocation.convention(extension.reportsDir.file("$name.$format"))
 }
 
 // We currently run type resolution only for Jvm & Android targets as

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektPlain.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektPlain.kt
@@ -16,7 +16,7 @@ internal class DetektPlain(private val project: Project) {
 
     private fun Project.registerDetektTask(extension: DetektExtension) {
         val detektTaskProvider = registerDetektTask(DetektPlugin.DETEKT_TASK_NAME, extension) {
-            extension.baseline?.takeIf { it.exists() }?.let { baselineFile ->
+            extension.baseline.asFile.orNull?.takeIf { it.exists() }?.let { baselineFile ->
                 baseline.convention(project.layout.file(project.provider { baselineFile }))
             }
             setSource(existingInputDirectoriesProvider(project, extension))
@@ -32,7 +32,7 @@ internal class DetektPlain(private val project: Project) {
 
     private fun Project.registerCreateBaselineTask(extension: DetektExtension) {
         registerCreateBaselineTask(DetektPlugin.BASELINE_TASK_NAME, extension) {
-            baseline.convention(project.layout.file(project.provider { extension.baseline }))
+            baseline.convention(extension.baseline)
             setSource(existingInputDirectoriesProvider(project, extension))
         }
     }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektPlain.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektPlain.kt
@@ -22,7 +22,7 @@ internal class DetektPlain(private val project: Project) {
             setSource(existingInputDirectoriesProvider(project, extension))
             setIncludes(DetektPlugin.defaultIncludes)
             setExcludes(DetektPlugin.defaultExcludes)
-            reportsDir.convention(project.provider { extension.reportsDir })
+            reportsDir.convention(extension.reportsDir.asFile)
         }
 
         tasks.matching { it.name == LifecycleBasePlugin.CHECK_TASK_NAME }.configureEach {

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/SharedTasks.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/SharedTasks.kt
@@ -37,7 +37,7 @@ internal fun Project.registerDetektTask(
         it.autoCorrectProp.convention(extension.autoCorrect)
         it.config.setFrom(provider { extension.config })
         it.ignoreFailuresProp.convention(extension.ignoreFailures)
-        it.basePathProp.convention(extension.basePath.map { basePath -> basePath.asFile.toRelativeString(projectDir) })
+        it.basePathProp.convention(extension.basePath.map { basePath -> basePath.asFile.absolutePath })
         it.allRulesProp.convention(extension.allRules)
         configuration(it)
     }
@@ -68,7 +68,7 @@ internal fun Project.registerCreateBaselineTask(
         it.disableDefaultRuleSets.convention(extension.disableDefaultRuleSets)
         it.buildUponDefaultConfig.convention(extension.buildUponDefaultConfig)
         it.autoCorrect.convention(extension.autoCorrect)
-        it.basePathProp.convention(extension.basePath.map { basePath -> basePath.asFile.toRelativeString(projectDir) })
+        it.basePathProp.convention(extension.basePath.map { basePath -> basePath.asFile.absolutePath })
         it.allRules.convention(extension.allRules)
         configuration(it)
     }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/SharedTasks.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/SharedTasks.kt
@@ -30,15 +30,15 @@ internal fun Project.registerDetektTask(
             )
         }
 
-        it.debugProp.convention(provider { extension.debug })
-        it.parallelProp.convention(provider { extension.parallel })
-        it.disableDefaultRuleSetsProp.convention(provider { extension.disableDefaultRuleSets })
-        it.buildUponDefaultConfigProp.convention(provider { extension.buildUponDefaultConfig })
-        it.autoCorrectProp.convention(provider { extension.autoCorrect })
+        it.debugProp.convention(extension.debug)
+        it.parallelProp.convention(extension.parallel)
+        it.disableDefaultRuleSetsProp.convention(extension.disableDefaultRuleSets)
+        it.buildUponDefaultConfigProp.convention(extension.buildUponDefaultConfig)
+        it.autoCorrectProp.convention(extension.autoCorrect)
         it.config.setFrom(provider { extension.config })
         it.ignoreFailuresProp.convention(project.provider { extension.ignoreFailures })
-        it.basePathProp.convention(extension.basePath)
-        it.allRulesProp.convention(provider { extension.allRules })
+        it.basePathProp.convention(extension.basePath.map { basePath -> basePath.asFile.toRelativeString(projectDir) })
+        it.allRulesProp.convention(extension.allRules)
         configuration(it)
     }
 
@@ -63,12 +63,12 @@ internal fun Project.registerCreateBaselineTask(
         }
 
         it.config.setFrom(project.provider { extension.config })
-        it.debug.convention(project.provider { extension.debug })
-        it.parallel.convention(project.provider { extension.parallel })
-        it.disableDefaultRuleSets.convention(project.provider { extension.disableDefaultRuleSets })
-        it.buildUponDefaultConfig.convention(project.provider { extension.buildUponDefaultConfig })
-        it.autoCorrect.convention(project.provider { extension.autoCorrect })
-        it.basePathProp.convention(extension.basePath)
-        it.allRules.convention(provider { extension.allRules })
+        it.debug.convention(extension.debug)
+        it.parallel.convention(extension.parallel)
+        it.disableDefaultRuleSets.convention(extension.disableDefaultRuleSets)
+        it.buildUponDefaultConfig.convention(extension.buildUponDefaultConfig)
+        it.autoCorrect.convention(extension.autoCorrect)
+        it.basePathProp.convention(extension.basePath.map { basePath -> basePath.asFile.toRelativeString(projectDir) })
+        it.allRules.convention(extension.allRules)
         configuration(it)
     }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/SharedTasks.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/SharedTasks.kt
@@ -36,7 +36,7 @@ internal fun Project.registerDetektTask(
         it.buildUponDefaultConfigProp.convention(extension.buildUponDefaultConfig)
         it.autoCorrectProp.convention(extension.autoCorrect)
         it.config.setFrom(provider { extension.config })
-        it.ignoreFailuresProp.convention(project.provider { extension.ignoreFailures })
+        it.ignoreFailuresProp.convention(extension.ignoreFailures)
         it.basePathProp.convention(extension.basePath.map { basePath -> basePath.asFile.toRelativeString(projectDir) })
         it.allRulesProp.convention(extension.allRules)
         configuration(it)

--- a/website/docs/introduction/baseline.md
+++ b/website/docs/introduction/baseline.md
@@ -66,7 +66,7 @@ task detektProjectBaseline(type: io.gitlab.arturbosch.detekt.DetektCreateBaselin
 subprojects {
     detekt {
         // ...
-        baseline = file("${rootProject.projectDir}/config/baseline.xml")
+        baseline.set(file("${rootProject.projectDir}/config/baseline.xml"))
         // ...
     }
 }

--- a/website/docs/introduction/reporting.md
+++ b/website/docs/introduction/reporting.md
@@ -67,6 +67,14 @@ The severity will be computed in the priority order:
 In a shared codebase, it is often required to use relative path so that all developers and tooling
 have a consistent view. This can be enabled by CLI option `--base-path` or Gradle as the following:
 
+### Kotlin DSL
+```kotlin
+detekt {
+    basePath.set(projectDir)
+}
+```
+
+### Groovy DSL
 ```groovy
 detekt {
     basePath = projectDir


### PR DESCRIPTION
#1931 fix part 1 - addressing extension side. Follow up PRs will migrate tasks.

Thanks to the simple property assignment in Kotlin DSL scripts feature [introduced in Gradle 8.1](https://docs.gradle.org/8.1.1/release-notes.html#experimental-simple-property-assignment-in-kotlin-dsl-scripts), this will have a minimal impact on users who are using a modern Gradle version. The feature will be stable from Gradle 8.4.