### PR TITLE
Convert DGP tasks to use Property API

### DIFF
--- a/detekt-gradle-plugin/api/detekt-gradle-plugin.api
+++ b/detekt-gradle-plugin/api/detekt-gradle-plugin.api
@@ -56,7 +56,7 @@ public abstract class io/gitlab/arturbosch/detekt/Detekt : org/gradle/api/tasks/
 	public abstract fun getParallel ()Lorg/gradle/api/provider/Property;
 	public abstract fun getPluginClasspath ()Lorg/gradle/api/file/ConfigurableFileCollection;
 	public final fun getReports ()Lio/gitlab/arturbosch/detekt/extensions/DetektReports;
-	public abstract fun getReportsDir ()Lorg/gradle/api/provider/Property;
+	public abstract fun getReportsDir ()Lorg/gradle/api/file/DirectoryProperty;
 	public final fun getSarifReportFile ()Lorg/gradle/api/provider/Provider;
 	public fun getSource ()Lorg/gradle/api/file/FileTree;
 	public final fun getTxtReportFile ()Lorg/gradle/api/provider/Provider;

--- a/detekt-gradle-plugin/api/detekt-gradle-plugin.api
+++ b/detekt-gradle-plugin/api/detekt-gradle-plugin.api
@@ -34,26 +34,26 @@ public class io/github/detekt/gradle/extensions/KotlinCompileTaskDetektExtension
 	public final fun isEnabled ()Lorg/gradle/api/provider/Property;
 }
 
-public abstract class io/gitlab/arturbosch/detekt/Detekt : org/gradle/api/tasks/SourceTask, org/gradle/api/tasks/VerificationTask {
+public abstract class io/gitlab/arturbosch/detekt/Detekt : org/gradle/api/tasks/SourceTask {
 	public fun <init> (Lorg/gradle/api/model/ObjectFactory;Lorg/gradle/workers/WorkerExecutor;Lorg/gradle/api/provider/ProviderFactory;)V
 	public final fun check ()V
-	public final fun getAllRules ()Z
-	public final fun getAutoCorrect ()Z
-	public final fun getBasePath ()Ljava/lang/String;
+	public abstract fun getAllRules ()Lorg/gradle/api/provider/Property;
+	public abstract fun getAutoCorrect ()Lorg/gradle/api/provider/Property;
+	public abstract fun getBasePath ()Lorg/gradle/api/provider/Property;
 	public abstract fun getBaseline ()Lorg/gradle/api/file/RegularFileProperty;
-	public final fun getBuildUponDefaultConfig ()Z
+	public abstract fun getBuildUponDefaultConfig ()Lorg/gradle/api/provider/Property;
 	public abstract fun getClasspath ()Lorg/gradle/api/file/ConfigurableFileCollection;
 	public abstract fun getConfig ()Lorg/gradle/api/file/ConfigurableFileCollection;
-	public final fun getDebug ()Z
+	public abstract fun getDebug ()Lorg/gradle/api/provider/Property;
 	public abstract fun getDetektClasspath ()Lorg/gradle/api/file/ConfigurableFileCollection;
-	public final fun getDisableDefaultRuleSets ()Z
+	public abstract fun getDisableDefaultRuleSets ()Lorg/gradle/api/provider/Property;
 	public final fun getHtmlReportFile ()Lorg/gradle/api/provider/Provider;
-	public fun getIgnoreFailures ()Z
+	public abstract fun getIgnoreFailures ()Lorg/gradle/api/provider/Property;
 	public abstract fun getJdkHome ()Lorg/gradle/api/file/DirectoryProperty;
-	public final fun getJvmTarget ()Ljava/lang/String;
-	public final fun getLanguageVersion ()Ljava/lang/String;
+	public abstract fun getJvmTarget ()Lorg/gradle/api/provider/Property;
+	public abstract fun getLanguageVersion ()Lorg/gradle/api/provider/Property;
 	public final fun getMdReportFile ()Lorg/gradle/api/provider/Provider;
-	public final fun getParallel ()Z
+	public abstract fun getParallel ()Lorg/gradle/api/provider/Property;
 	public abstract fun getPluginClasspath ()Lorg/gradle/api/file/ConfigurableFileCollection;
 	public final fun getReports ()Lio/gitlab/arturbosch/detekt/extensions/DetektReports;
 	public abstract fun getReportsDir ()Lorg/gradle/api/provider/Property;
@@ -62,16 +62,6 @@ public abstract class io/gitlab/arturbosch/detekt/Detekt : org/gradle/api/tasks/
 	public final fun getTxtReportFile ()Lorg/gradle/api/provider/Provider;
 	public final fun getXmlReportFile ()Lorg/gradle/api/provider/Provider;
 	public final fun reports (Lorg/gradle/api/Action;)V
-	public final fun setAllRules (Z)V
-	public final fun setAutoCorrect (Z)V
-	public final fun setBasePath (Ljava/lang/String;)V
-	public final fun setBuildUponDefaultConfig (Z)V
-	public final fun setDebug (Z)V
-	public final fun setDisableDefaultRuleSets (Z)V
-	public fun setIgnoreFailures (Z)V
-	public final fun setJvmTarget (Ljava/lang/String;)V
-	public final fun setLanguageVersion (Ljava/lang/String;)V
-	public final fun setParallel (Z)V
 	public final fun setReports (Lio/gitlab/arturbosch/detekt/extensions/DetektReports;)V
 }
 
@@ -80,7 +70,7 @@ public abstract class io/gitlab/arturbosch/detekt/DetektCreateBaselineTask : org
 	public final fun baseline ()V
 	public abstract fun getAllRules ()Lorg/gradle/api/provider/Property;
 	public abstract fun getAutoCorrect ()Lorg/gradle/api/provider/Property;
-	public final fun getBasePath ()Ljava/lang/String;
+	public abstract fun getBasePath ()Lorg/gradle/api/provider/Property;
 	public abstract fun getBaseline ()Lorg/gradle/api/file/RegularFileProperty;
 	public abstract fun getBuildUponDefaultConfig ()Lorg/gradle/api/provider/Property;
 	public abstract fun getClasspath ()Lorg/gradle/api/file/ConfigurableFileCollection;
@@ -90,13 +80,11 @@ public abstract class io/gitlab/arturbosch/detekt/DetektCreateBaselineTask : org
 	public abstract fun getDisableDefaultRuleSets ()Lorg/gradle/api/provider/Property;
 	public abstract fun getIgnoreFailures ()Lorg/gradle/api/provider/Property;
 	public abstract fun getJdkHome ()Lorg/gradle/api/file/DirectoryProperty;
-	public final fun getJvmTarget ()Ljava/lang/String;
+	public abstract fun getJvmTarget ()Lorg/gradle/api/provider/Property;
 	public abstract fun getLanguageVersion ()Lorg/gradle/api/provider/Property;
 	public abstract fun getParallel ()Lorg/gradle/api/provider/Property;
 	public abstract fun getPluginClasspath ()Lorg/gradle/api/file/ConfigurableFileCollection;
 	public fun getSource ()Lorg/gradle/api/file/FileTree;
-	public final fun setBasePath (Ljava/lang/String;)V
-	public final fun setJvmTarget (Ljava/lang/String;)V
 }
 
 public abstract class io/gitlab/arturbosch/detekt/DetektGenerateConfigTask : org/gradle/api/DefaultTask {

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektTaskGroovyDslSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektTaskGroovyDslSpec.kt
@@ -56,7 +56,7 @@ class DetektTaskGroovyDslSpec {
                 buildUponDefaultConfig = true
                 allRules = false
                 autoCorrect = false
-                basePath = projectDir
+                basePath = projectDir.absolutePath
                 reports {
                     xml {
                         required.set(true)
@@ -101,7 +101,7 @@ class DetektTaskGroovyDslSpec {
                 buildUponDefaultConfig = true
                 allRules = false
                 autoCorrect = false
-                basePath = projectDir
+                basePath = projectDir.absolutePath
             }
         """.trimIndent()
         val groovyBuilder = DslTestBuilder.groovy()

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -53,7 +53,6 @@ import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.options.Option
 import org.gradle.language.base.plugins.LifecycleBasePlugin
 import org.gradle.workers.WorkerExecutor
-import java.io.File
 import javax.inject.Inject
 
 @CacheableTask
@@ -127,7 +126,7 @@ abstract class Detekt @Inject constructor(
     var reports: DetektReports = objects.newInstance(DetektReports::class.java)
 
     @get:Internal
-    abstract val reportsDir: Property<File>
+    abstract val reportsDir: DirectoryProperty
 
     val xmlReportFile: Provider<RegularFile>
         @OutputFile
@@ -249,8 +248,8 @@ abstract class Detekt @Inject constructor(
         val isEnabled = report.required.getOrElse(DetektPlugin.DEFAULT_REPORT_ENABLED_VALUE)
         val provider = objects.fileProperty()
         if (isEnabled) {
-            val destination = report.outputLocation.asFile.orNull ?: reportsDir.getOrElse(defaultReportsDir.asFile)
-                .resolve("${DetektReport.DEFAULT_FILENAME}.${report.type.extension}")
+            val destination = report.outputLocation.orNull ?: reportsDir.getOrElse(defaultReportsDir)
+                .file("${DetektReport.DEFAULT_FILENAME}.${report.type.extension}")
             provider.set(destination)
         }
         return provider

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -50,7 +50,6 @@ import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.SkipWhenEmpty
 import org.gradle.api.tasks.SourceTask
 import org.gradle.api.tasks.TaskAction
-import org.gradle.api.tasks.VerificationTask
 import org.gradle.api.tasks.options.Option
 import org.gradle.language.base.plugins.LifecycleBasePlugin
 import org.gradle.workers.WorkerExecutor
@@ -62,7 +61,7 @@ abstract class Detekt @Inject constructor(
     private val objects: ObjectFactory,
     private val workerExecutor: WorkerExecutor,
     private val providers: ProviderFactory,
-) : SourceTask(), VerificationTask {
+) : SourceTask() {
 
     @get:Classpath
     abstract val detektClasspath: ConfigurableFileCollection
@@ -86,80 +85,43 @@ abstract class Detekt @Inject constructor(
 
     @get:Input
     @get:Optional
-    internal abstract val languageVersionProp: Property<String>
-    var languageVersion: String
-        @Internal
-        get() = languageVersionProp.get()
-        set(value) = languageVersionProp.set(value)
+    abstract val languageVersion: Property<String>
 
     @get:Input
     @get:Optional
-    internal abstract val jvmTargetProp: Property<String>
-    var jvmTarget: String
-        @Internal
-        get() = jvmTargetProp.get()
-        set(value) = jvmTargetProp.set(value)
+    abstract val jvmTarget: Property<String>
 
     @get:Internal
     abstract val jdkHome: DirectoryProperty
 
-    @get:Internal
-    internal abstract val debugProp: Property<Boolean>
-    var debug: Boolean
-        @Console
-        get() = debugProp.getOrElse(false)
-        set(value) = debugProp.set(value)
+    @get:Console
+    abstract val debug: Property<Boolean>
 
     @get:Internal
-    internal abstract val parallelProp: Property<Boolean>
-    var parallel: Boolean
-        @Internal
-        get() = parallelProp.getOrElse(false)
-        set(value) = parallelProp.set(value)
+    abstract val parallel: Property<Boolean>
 
-    @get:Internal
-    internal abstract val disableDefaultRuleSetsProp: Property<Boolean>
-    var disableDefaultRuleSets: Boolean
-        @Input
-        get() = disableDefaultRuleSetsProp.getOrElse(false)
-        set(value) = disableDefaultRuleSetsProp.set(value)
+    @get:Input
+    abstract val disableDefaultRuleSets: Property<Boolean>
 
-    @get:Internal
-    internal abstract val buildUponDefaultConfigProp: Property<Boolean>
-    var buildUponDefaultConfig: Boolean
-        @Input
-        get() = buildUponDefaultConfigProp.getOrElse(false)
-        set(value) = buildUponDefaultConfigProp.set(value)
+    @get:Input
+    abstract val buildUponDefaultConfig: Property<Boolean>
 
-    @get:Internal
-    internal abstract val allRulesProp: Property<Boolean>
-    var allRules: Boolean
-        @Input
-        get() = allRulesProp.getOrElse(false)
-        set(value) = allRulesProp.set(value)
+    @get:Input
+    abstract val allRules: Property<Boolean>
 
-    @get:Internal
-    internal abstract val ignoreFailuresProp: Property<Boolean>
+    @get:Input
+    abstract val ignoreFailures: Property<Boolean>
 
-    @get:Internal
-    internal abstract val autoCorrectProp: Property<Boolean>
-
-    @set:Option(option = "auto-correct", description = "Allow rules to auto correct code if they support it")
-    var autoCorrect: Boolean
-        @Input
-        get() = autoCorrectProp.getOrElse(false)
-        set(value) = autoCorrectProp.set(value)
+    @get:Input
+    @get:Option(option = "auto-correct", description = "Allow rules to auto correct code if they support it")
+    abstract val autoCorrect: Property<Boolean>
 
     /**
      * Respect only the file path for incremental build. Using @InputFile respects both file path and content.
      */
     @get:Input
     @get:Optional
-    internal abstract val basePathProp: Property<String>
-    var basePath: String
-        @Internal
-        get() = basePathProp.getOrElse("")
-        set(value) = basePathProp.set(value)
+    abstract val basePath: Property<String>
 
     @get:Internal
     var reports: DetektReports = objects.newInstance(DetektReports::class.java)
@@ -212,8 +174,8 @@ abstract class Detekt @Inject constructor(
         get() = listOf(
             InputArgument(source),
             ClasspathArgument(classpath),
-            LanguageVersionArgument(languageVersionProp.orNull),
-            JvmTargetArgument(jvmTargetProp.orNull),
+            LanguageVersionArgument(languageVersion.orNull),
+            JvmTargetArgument(jvmTarget.orNull),
             JdkHomeArgument(jdkHome),
             ConfigArgument(config),
             BaselineArgument(baseline.orNull),
@@ -222,13 +184,13 @@ abstract class Detekt @Inject constructor(
             DefaultReportArgument(DetektReportType.TXT, txtReportFile.orNull),
             DefaultReportArgument(DetektReportType.SARIF, sarifReportFile.orNull),
             DefaultReportArgument(DetektReportType.MD, mdReportFile.orNull),
-            DebugArgument(debugProp.getOrElse(false)),
-            ParallelArgument(parallelProp.getOrElse(false)),
-            BuildUponDefaultConfigArgument(buildUponDefaultConfigProp.getOrElse(false)),
-            AllRulesArgument(allRulesProp.getOrElse(false)),
-            AutoCorrectArgument(autoCorrectProp.getOrElse(false)),
-            BasePathArgument(basePathProp.orNull),
-            DisableDefaultRuleSetArgument(disableDefaultRuleSetsProp.getOrElse(false))
+            DebugArgument(debug.getOrElse(false)),
+            ParallelArgument(parallel.getOrElse(false)),
+            BuildUponDefaultConfigArgument(buildUponDefaultConfig.getOrElse(false)),
+            AllRulesArgument(allRules.getOrElse(false)),
+            AutoCorrectArgument(autoCorrect.getOrElse(false)),
+            BasePathArgument(basePath.orNull),
+            DisableDefaultRuleSetArgument(disableDefaultRuleSets.getOrElse(false))
         ).plus(convertCustomReportsToArguments()).flatMap(CliArgument::toArgument)
 
     @InputFiles
@@ -236,13 +198,6 @@ abstract class Detekt @Inject constructor(
     @IgnoreEmptyDirectories
     @PathSensitive(PathSensitivity.RELATIVE)
     override fun getSource(): FileTree = super.getSource()
-
-    @Input
-    override fun getIgnoreFailures(): Boolean = ignoreFailuresProp.getOrElse(false)
-
-    override fun setIgnoreFailures(value: Boolean) {
-        ignoreFailuresProp.set(value)
-    }
 
     fun reports(configure: Action<DetektReports>) {
         configure.execute(reports)
@@ -267,7 +222,7 @@ abstract class Detekt @Inject constructor(
             logger.info("Executing $name using DetektInvoker")
             DetektInvoker.create(isDryRun = isDryRun.orNull.toBoolean()).invokeCli(
                 arguments = arguments,
-                ignoreFailures = ignoreFailures,
+                ignoreFailures = ignoreFailures.get(),
                 classpath = detektClasspath.plus(pluginClasspath),
                 taskName = name
             )

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
@@ -102,19 +102,11 @@ abstract class DetektCreateBaselineTask @Inject constructor(
      */
     @get:Input
     @get:Optional
-    internal abstract val basePathProp: Property<String>
-    var basePath: String
-        @Internal
-        get() = basePathProp.get()
-        set(value) = basePathProp.set(value)
+    abstract val basePath: Property<String>
 
     @get:Input
     @get:Optional
-    internal abstract val jvmTargetProp: Property<String>
-    var jvmTarget: String
-        @Internal
-        get() = jvmTargetProp.get()
-        set(value) = jvmTargetProp.set(value)
+    abstract val jvmTarget: Property<String>
 
     @get:Input
     @get:Optional
@@ -129,7 +121,7 @@ abstract class DetektCreateBaselineTask @Inject constructor(
             CreateBaselineArgument,
             ClasspathArgument(classpath),
             LanguageVersionArgument(languageVersion.orNull),
-            JvmTargetArgument(jvmTargetProp.orNull),
+            JvmTargetArgument(jvmTarget.orNull),
             JdkHomeArgument(jdkHome),
             BaselineArgument(baseline.get()),
             InputArgument(source),
@@ -139,7 +131,7 @@ abstract class DetektCreateBaselineTask @Inject constructor(
             BuildUponDefaultConfigArgument(buildUponDefaultConfig.getOrElse(false)),
             AutoCorrectArgument(autoCorrect.getOrElse(false)),
             AllRulesArgument(allRules.getOrElse(false)),
-            BasePathArgument(basePathProp.orNull),
+            BasePathArgument(basePath.orNull),
             DisableDefaultRuleSetArgument(disableDefaultRuleSets.getOrElse(false))
         ).flatMap(CliArgument::toArgument)
 

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektPlain.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektPlain.kt
@@ -22,7 +22,7 @@ internal class DetektPlain(private val project: Project) {
             setSource(existingInputDirectoriesProvider(project, extension))
             setIncludes(DetektPlugin.defaultIncludes)
             setExcludes(DetektPlugin.defaultExcludes)
-            reportsDir.convention(extension.reportsDir.asFile)
+            reportsDir.convention(extension.reportsDir)
         }
 
         tasks.matching { it.name == LifecycleBasePlugin.CHECK_TASK_NAME }.configureEach {

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/SharedTasks.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/SharedTasks.kt
@@ -23,22 +23,22 @@ internal fun Project.registerDetektTask(
             val service = project.extensions.getByType(JavaToolchainService::class.java)
             val defaultLauncher = service.launcherFor(toolchain)
             it.jdkHome.convention(defaultLauncher.map { launcher -> launcher.metadata.installationPath })
-            it.jvmTargetProp.convention(
+            it.jvmTarget.convention(
                 defaultLauncher.map { launcher ->
                     JavaVersion.toVersion(launcher.metadata.languageVersion.asInt()).toString()
                 }
             )
         }
 
-        it.debugProp.convention(extension.debug)
-        it.parallelProp.convention(extension.parallel)
-        it.disableDefaultRuleSetsProp.convention(extension.disableDefaultRuleSets)
-        it.buildUponDefaultConfigProp.convention(extension.buildUponDefaultConfig)
-        it.autoCorrectProp.convention(extension.autoCorrect)
+        it.debug.convention(extension.debug)
+        it.parallel.convention(extension.parallel)
+        it.disableDefaultRuleSets.convention(extension.disableDefaultRuleSets)
+        it.buildUponDefaultConfig.convention(extension.buildUponDefaultConfig)
+        it.autoCorrect.convention(extension.autoCorrect)
         it.config.setFrom(provider { extension.config })
-        it.ignoreFailuresProp.convention(extension.ignoreFailures)
-        it.basePathProp.convention(extension.basePath.map { basePath -> basePath.asFile.absolutePath })
-        it.allRulesProp.convention(extension.allRules)
+        it.ignoreFailures.convention(extension.ignoreFailures)
+        it.basePath.convention(extension.basePath.map { basePath -> basePath.asFile.absolutePath })
+        it.allRules.convention(extension.allRules)
         configuration(it)
     }
 
@@ -55,7 +55,7 @@ internal fun Project.registerCreateBaselineTask(
             val service = project.extensions.getByType(JavaToolchainService::class.java)
             val defaultLauncher = service.launcherFor(toolchain)
             it.jdkHome.convention(defaultLauncher.map { launcher -> launcher.metadata.installationPath })
-            it.jvmTargetProp.convention(
+            it.jvmTarget.convention(
                 defaultLauncher.map { launcher ->
                     JavaVersion.toVersion(launcher.metadata.languageVersion.asInt()).toString()
                 }
@@ -68,7 +68,7 @@ internal fun Project.registerCreateBaselineTask(
         it.disableDefaultRuleSets.convention(extension.disableDefaultRuleSets)
         it.buildUponDefaultConfig.convention(extension.buildUponDefaultConfig)
         it.autoCorrect.convention(extension.autoCorrect)
-        it.basePathProp.convention(extension.basePath.map { basePath -> basePath.asFile.absolutePath })
+        it.basePath.convention(extension.basePath.map { basePath -> basePath.asFile.absolutePath })
         it.allRules.convention(extension.allRules)
         configuration(it)
     }

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektJvmSpec.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/DetektJvmSpec.kt
@@ -26,8 +26,8 @@ class DetektJvmSpec {
                 }
             }
             tasks.named("detektTest", Detekt::class.java) {
-                it.jvmTarget = "1.8"
-                it.languageVersion = "1.6"
+                it.jvmTarget.set("1.8")
+                it.languageVersion.set("1.6")
             }
         },
     ).also(DslGradleRunner::setupProject)

--- a/website/docs/gettingstarted/gradle.mdx
+++ b/website/docs/gettingstarted/gradle.mdx
@@ -367,11 +367,11 @@ tasks.withType(io.gitlab.arturbosch.detekt.DetektCreateBaselineTask).configureEa
 
 ```kotlin
 tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
-    this.jvmTarget = "1.8"
+    jvmTarget.set("1.8")
     jdkHome.set(file("path/to/jdkHome"))
 }
 tasks.withType<io.gitlab.arturbosch.detekt.DetektCreateBaselineTask>().configureEach {
-    this.jvmTarget = "1.8"
+    jvmTarget.set("1.8")
     jdkHome.set(file("path/to/jdkHome"))
 }
 ```
@@ -451,7 +451,7 @@ tasks.register<io.gitlab.arturbosch.detekt.Detekt>("myDetekt") {
     description = "Runs a custom detekt build."
     setSource(files("src/main/kotlin", "src/test/kotlin"))
     config.setFrom(files("$rootDir/config.yml"))
-    debug = true
+    debug.set(true)
     reports {
         xml {
             destination = file("build/reports/mydetekt.xml")


### PR DESCRIPTION
https://github.com/detekt/detekt/issues/1931 fix part 2 (part 1 was done in #6496). Migrates remaining task properties to use Gradle's property API.

Closes #1931 