### PR TITLE
Implement rules suggesting to convert statements to expressions

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -616,6 +616,8 @@ style:
     ignoreOverridableFunction: true
     ignoreActualFunction: true
     excludedFunctions: []
+  IfStatementCouldBeExpression:
+    active: false
   LoopWithTooManyJumpStatements:
     active: true
     maxJumpCount: 1
@@ -789,6 +791,8 @@ style:
   VarCouldBeVal:
     active: true
     ignoreLateinitVar: false
+  WhenStatementCouldBeExpression:
+    active: false
   WildcardImport:
     active: true
     excludeImports:

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/IfStatementCouldBeExpression.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/IfStatementCouldBeExpression.kt
@@ -1,0 +1,91 @@
+package io.gitlab.arturbosch.detekt.rules.style
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import org.jetbrains.kotlin.psi.KtExpression
+import org.jetbrains.kotlin.psi.KtIfExpression
+
+/**
+ * Detects `if` statements that could be expressions.
+ *
+ * An `if` statement can be an expression if it has the following properties:
+ *
+ * 1. The `if` statement is exhaustive i.e. it has an `else` branch.
+ * 2. The last statement of every branch is either a `return` or an assignment to the same variable with the same operator.
+ *
+ * Refactoring the statements to expressions reduces the `return` and assignment count. This improves readability.
+ *
+ * <noncompliant>
+ *     if (a == 1) {
+ *       a = 1
+ *     } else {
+ *       a = 0
+ *     }
+ *
+ *     if (a == 1) {
+ *       return 1
+ *     } else {
+ *       return 0
+ *     }
+ * </noncompliant>
+ *
+ * <compliant>
+ *     a = if (a == 1) {
+ *       1
+ *     } else {
+ *       0
+ *     }
+ *
+ *     return if (a == 1) {
+ *       1
+ *     } else {
+ *       0
+ *     }
+ * </compliant>
+ */
+
+class IfStatementCouldBeExpression(config: Config = Config.empty) : Rule(config) {
+
+    override val issue = Issue(
+        "IfStatementCouldBeExpression",
+        "if statement could be expression. Use an if expression to reduce the return and assignment count.",
+        Debt.FIVE_MINS,
+    )
+
+    override fun visitIfExpression(expression: KtIfExpression) {
+        if (canLiftOutOf(expression)) {
+            report(CodeSmell(issue, Entity.from(expression), issue.description))
+        }
+    }
+
+    private fun canLiftOutOf(expression: KtIfExpression): Boolean {
+        val branches = getBranches(expression)
+        return isExhaustive(expression) && canLiftOut(branches)
+    }
+
+    private fun getBranches(expression: KtIfExpression): List<KtExpression> {
+        val branches = mutableListOf<KtExpression>()
+        var current: KtExpression? = expression
+        while (current is KtIfExpression) {
+            current.then?.let { branches.add(it) }
+            // Don't add `if` because it's an `else if` which we treat as one unit.
+            current.`else`?.takeIf { it !is KtIfExpression }?.let { branches.add(it) }
+            current = current.`else`
+        }
+        return branches
+    }
+
+    private fun isExhaustive(expression: KtIfExpression): Boolean {
+        var hasElse = false
+        var current: KtExpression? = expression
+        while (current is KtIfExpression && !hasElse) {
+            hasElse = current.`else` != null && current.`else` !is KtIfExpression
+            current = current.`else`
+        }
+        return hasElse
+    }
+}

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/StatementCouldBeExpression.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/StatementCouldBeExpression.kt
@@ -1,0 +1,37 @@
+package io.gitlab.arturbosch.detekt.rules.style
+
+import org.jetbrains.kotlin.lexer.KtTokens
+import org.jetbrains.kotlin.psi.KtBinaryExpression
+import org.jetbrains.kotlin.psi.KtElement
+import org.jetbrains.kotlin.psi.KtReturnExpression
+
+internal fun <T : KtElement> canLiftOut(entries: List<T>): Boolean {
+    return canLiftOutReturn(entries) || canLiftOutAssignment(entries)
+}
+
+private fun <T : KtElement> canLiftOutReturn(entries: List<T>): Boolean {
+    return entries.all { it.children[it.children.lastIndex] is KtReturnExpression }
+}
+
+private fun <T : KtElement> canLiftOutAssignment(entries: List<T>): Boolean {
+    val lastExpressionsWhichAreBinary = entries.map { it.children[it.children.lastIndex] }
+        .filterIsInstance<KtBinaryExpression>()
+    val everyLastExpressionIsBinary = lastExpressionsWhichAreBinary.size == entries.size
+    return everyLastExpressionIsBinary && areSameAssignmentToSameVariable(lastExpressionsWhichAreBinary)
+}
+
+private fun areSameAssignmentToSameVariable(expressions: List<KtBinaryExpression>): Boolean {
+    return haveSameLhs(expressions) && haveSameOperator(expressions) && haveAssignmentOperator(expressions)
+}
+
+private fun haveSameLhs(expressions: List<KtBinaryExpression>): Boolean {
+    return expressions.isEmpty() || expressions.all { expressions[0].left?.text == it.left?.text }
+}
+
+private fun haveSameOperator(expressions: List<KtBinaryExpression>): Boolean {
+    return expressions.isEmpty() || expressions.all { expressions[0].operationToken == it.operationToken }
+}
+
+private fun haveAssignmentOperator(expressions: List<KtBinaryExpression>): Boolean {
+    return expressions.all { it.operationToken in KtTokens.ALL_ASSIGNMENTS }
+}

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/StyleGuideProvider.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/StyleGuideProvider.kt
@@ -111,6 +111,8 @@ class StyleGuideProvider : DefaultRuleSetProvider {
             UseSumOfInsteadOfFlatMapSize(config),
             DoubleNegativeLambda(config),
             UseLet(config),
+            IfStatementCouldBeExpression(config),
+            WhenStatementCouldBeExpression(config),
         )
     )
 }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/WhenStatementCouldBeExpression.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/WhenStatementCouldBeExpression.kt
@@ -1,0 +1,71 @@
+package io.gitlab.arturbosch.detekt.rules.style
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
+import org.jetbrains.kotlin.cfg.WhenChecker
+import org.jetbrains.kotlin.psi.KtWhenExpression
+
+/**
+ * Detects `when` statements that could be expressions.
+ *
+ * A `when` statement can be an expression if it has the following properties:
+ *
+ * 1. The `when` statement is exhaustive i.e. it has an `else` branch or the branch conditions cover all possible cases.
+ * 2. The last statement of every branch is either a `return` or an assignment to the same variable with the same operator.
+ *
+ * Refactoring the statements to expressions reduces the `return` and assignment count. This improves readability.
+ *
+ * <noncompliant>
+ *     when (a) {
+ *       1 -> a = 1
+ *       else -> a = 0
+ *     }
+ *
+ *     when (a) {
+ *       1 -> return 1
+ *       else -> return 0
+ *     }
+ * </noncompliant>
+ *
+ * <compliant>
+ *     a = when (a) {
+ *       1 -> 1
+ *       else -> 0
+ *     }
+ *
+ *     return when (a) {
+ *       1 -> 1
+ *       else -> 0
+ *     }
+ * </compliant>
+ */
+
+@RequiresTypeResolution
+class WhenStatementCouldBeExpression(config: Config = Config.empty) : Rule(config) {
+
+    override val issue = Issue(
+        "WhenStatementCouldBeExpression",
+        "when statement could be expression. Use a when expression to reduce the return and assignment count.",
+        Debt.FIVE_MINS,
+    )
+
+    override fun visitWhenExpression(expression: KtWhenExpression) {
+        if (canLiftOutOf(expression)) {
+            report(CodeSmell(issue, Entity.from(expression), issue.description))
+        }
+    }
+
+    private fun canLiftOutOf(expression: KtWhenExpression): Boolean {
+        return isExhaustive(expression) && canLiftOut(expression.entries)
+    }
+
+    private fun isExhaustive(expression: KtWhenExpression): Boolean {
+        val missingCases = WhenChecker.getMissingCases(expression, bindingContext)
+        return missingCases.isEmpty() || expression.elseExpression != null
+    }
+}

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/IfStatementCouldBeExpressionSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/IfStatementCouldBeExpressionSpec.kt
@@ -1,0 +1,144 @@
+package io.gitlab.arturbosch.detekt.rules.style
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.test.assertThat
+import io.gitlab.arturbosch.detekt.test.compileAndLint
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class IfStatementCouldBeExpressionSpec {
+    val subject = IfStatementCouldBeExpression(Config.empty)
+
+    @Nested
+    inner class `return in if` {
+        @Test
+        fun `does not report an expression`() {
+            val code = """
+                fun f(a: Int): Int {
+                    return if (a > 1) {
+                        1
+                    } else if (a < 1) {
+                        0
+                    } else {
+                        -1
+                    }
+                }
+            """.trimIndent()
+            assertThat(subject.compileAndLint(code)).isEmpty()
+        }
+
+        @Test
+        fun `reports a statement`() {
+            val code = """
+                fun f(a: Int): Int {
+                    if (a > 1) {
+                        return 1
+                    } else if (a < 1) {
+                        return 0
+                    } else {
+                        return -1
+                    }
+                }
+            """.trimIndent()
+            assertThat(subject.compileAndLint(code)).hasSize(1)
+        }
+
+        @Test
+        fun `does not report a non exhaustive statement`() {
+            val code = """
+                fun f(a: Int): Int {
+                    if (a > 0) {
+                        return 1
+                    } else if (a == 0) {
+                        return 0
+                    }
+                    return -1
+                }
+            """.trimIndent()
+            assertThat(subject.compileAndLint(code)).isEmpty()
+        }
+    }
+
+    @Nested
+    inner class `assignment in if` {
+        @Test
+        fun `does not report an expression`() {
+            val code = """
+                var b = 42
+                fun f(a: Int) {
+                    b = if (a > 1) {
+                            1
+                        } else if (a < 1) {
+                            0        
+                        } else {
+                            -1
+                        }
+                }
+            """.trimIndent()
+            assertThat(subject.compileAndLint(code)).isEmpty()
+        }
+
+        @Test
+        fun `reports a statement`() {
+            val code = """
+                var b = 42
+                fun f(a: Int) {
+                    if (a < 1) {
+                        b = 1
+                    } else if (a > 1) {
+                        b = 0
+                    } else {
+                        b = -1
+                    }
+                }
+            """.trimIndent()
+            assertThat(subject.compileAndLint(code)).hasSize(1)
+        }
+
+        @Test
+        fun `does not report a non exhaustive statement`() {
+            val code = """
+                var b = 42
+                fun f(a: Int) {
+                    if (a > 1) {
+                        b = 1
+                    } else if (a < 1) {
+                        b = 0
+                    }
+                }
+            """.trimIndent()
+            assertThat(subject.compileAndLint(code)).isEmpty()
+        }
+
+        @Test
+        fun `does not report a statement containing assignments to different variables`() {
+            val code = """
+                var b = 42
+                var c = 36
+                fun f(a: Int) {
+                    if (a > 1) {
+                        b = 1
+                    } else {
+                        c = -1
+                    }
+                }
+            """.trimIndent()
+            assertThat(subject.compileAndLint(code)).isEmpty()
+        }
+
+        @Test
+        fun `does not report a statement containing different assignment operators`() {
+            val code = """
+                var b = 42
+                fun f(a: Int) {
+                    if (a > 1) {
+                        b = 1
+                    } else {
+                        b -= 1
+                    }
+                }
+            """.trimIndent()
+            assertThat(subject.compileAndLint(code)).isEmpty()
+        }
+    }
+}

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/WhenStatementCouldBeExpressionSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/WhenStatementCouldBeExpressionSpec.kt
@@ -1,0 +1,130 @@
+package io.gitlab.arturbosch.detekt.rules.style
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
+import io.gitlab.arturbosch.detekt.test.assertThat
+import io.gitlab.arturbosch.detekt.test.lintWithContext
+import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@KotlinCoreEnvironmentTest
+class WhenStatementCouldBeExpressionSpec(private val env: KotlinCoreEnvironment) {
+    val subject = WhenStatementCouldBeExpression(Config.empty)
+
+    @Nested
+    inner class `return in when` {
+        @Test
+        fun `does not report an expression`() {
+            val code = """
+            fun f(a: Int): Int {
+                return when (a) {
+                    1 -> 1
+                    else -> 0
+                }
+            }
+            """.trimIndent()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
+        }
+
+        @Test
+        fun `reports a statement`() {
+            val code = """
+            fun f(a: Int): Int {
+                when (a) {
+                    1 -> return 1
+                    else -> return 0
+                }
+            }
+            """.trimIndent()
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
+        }
+
+        @Test
+        fun `does not report a non exhaustive statement`() {
+            val code = """
+            fun f(a: Int): Int {
+                when (a) {
+                    1 -> return 1
+                }
+                return 0
+            }
+            """.trimIndent()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
+        }
+    }
+
+    @Nested
+    inner class `assignment in when` {
+        @Test
+        fun `does not report an expression`() {
+            val code = """
+                var b = 42
+                fun f(a: Int) {
+                    a = when (a) {
+                        1 -> 1
+                        else -> 0
+                    }
+                }
+            """.trimIndent()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
+        }
+
+        @Test
+        fun `reports a statement`() {
+            val code = """
+                fun f(a: Int) {
+                    var b = 42
+                    when (a) {
+                        1 -> b = 1
+                        else  -> b = 0
+                    }
+                }
+            """.trimIndent()
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
+        }
+
+        @Test
+        fun `does not report a non exhaustive statement`() {
+            val code = """
+                var b = 42
+                fun f(a: Int) {
+                    when (a) {
+                        1 -> b = 1
+                    }
+                    b = 0
+                }
+            """.trimIndent()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
+        }
+
+        @Test
+        fun `does not report a statement containing assignments to different variables`() {
+            val code = """
+                var b = 42
+                var c = 36
+                fun f(a: Int) {
+                    when (a) {
+                        1 -> b = 1
+                        else -> c = 0
+                    }
+                }
+            """.trimIndent()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
+        }
+
+        @Test
+        fun `does not report a statement containing different assignment operators`() {
+            val code = """
+                var b = 42
+                fun f(a: Int) {
+                    when (a) {
+                        1 -> b = 1
+                        else -> b -= 1
+                    }
+                }
+            """.trimIndent()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
+        }
+    }
+}


### PR DESCRIPTION
The rules detect `if` and `when` statements that can be converted to expressions. They check if the statements are exhaustive and if the last statements of each branch allow a conversion.

The change fixes #6233. 
