### PR TITLE
Removed default implementation `Extension::id`

### DIFF
--- a/detekt-api/api/detekt-api.api
+++ b/detekt-api/api/detekt-api.api
@@ -123,7 +123,6 @@ public abstract interface class io/gitlab/arturbosch/detekt/api/ConfigValidator 
 }
 
 public final class io/gitlab/arturbosch/detekt/api/ConfigValidator$DefaultImpls {
-	public static fun getId (Lio/gitlab/arturbosch/detekt/api/ConfigValidator;)Ljava/lang/String;
 	public static fun getPriority (Lio/gitlab/arturbosch/detekt/api/ConfigValidator;)I
 	public static fun init (Lio/gitlab/arturbosch/detekt/api/ConfigValidator;Lio/gitlab/arturbosch/detekt/api/Config;)V
 	public static fun init (Lio/gitlab/arturbosch/detekt/api/ConfigValidator;Lio/gitlab/arturbosch/detekt/api/SetupContext;)V
@@ -131,7 +130,6 @@ public final class io/gitlab/arturbosch/detekt/api/ConfigValidator$DefaultImpls 
 
 public abstract class io/gitlab/arturbosch/detekt/api/ConsoleReport : io/gitlab/arturbosch/detekt/api/Extension {
 	public fun <init> ()V
-	public fun getId ()Ljava/lang/String;
 	public fun getPriority ()I
 	public fun init (Lio/gitlab/arturbosch/detekt/api/Config;)V
 	public fun init (Lio/gitlab/arturbosch/detekt/api/SetupContext;)V
@@ -217,7 +215,6 @@ public abstract interface class io/gitlab/arturbosch/detekt/api/Extension {
 }
 
 public final class io/gitlab/arturbosch/detekt/api/Extension$DefaultImpls {
-	public static fun getId (Lio/gitlab/arturbosch/detekt/api/Extension;)Ljava/lang/String;
 	public static fun getPriority (Lio/gitlab/arturbosch/detekt/api/Extension;)I
 	public static fun init (Lio/gitlab/arturbosch/detekt/api/Extension;Lio/gitlab/arturbosch/detekt/api/Config;)V
 	public static fun init (Lio/gitlab/arturbosch/detekt/api/Extension;Lio/gitlab/arturbosch/detekt/api/SetupContext;)V
@@ -231,7 +228,6 @@ public abstract interface class io/gitlab/arturbosch/detekt/api/FileProcessListe
 }
 
 public final class io/gitlab/arturbosch/detekt/api/FileProcessListener$DefaultImpls {
-	public static fun getId (Lio/gitlab/arturbosch/detekt/api/FileProcessListener;)Ljava/lang/String;
 	public static fun getPriority (Lio/gitlab/arturbosch/detekt/api/FileProcessListener;)I
 	public static fun init (Lio/gitlab/arturbosch/detekt/api/FileProcessListener;Lio/gitlab/arturbosch/detekt/api/Config;)V
 	public static fun init (Lio/gitlab/arturbosch/detekt/api/FileProcessListener;Lio/gitlab/arturbosch/detekt/api/SetupContext;)V
@@ -326,7 +322,6 @@ public final class io/gitlab/arturbosch/detekt/api/Notification$Level : java/lan
 public abstract class io/gitlab/arturbosch/detekt/api/OutputReport : io/gitlab/arturbosch/detekt/api/Extension {
 	public fun <init> ()V
 	public abstract fun getEnding ()Ljava/lang/String;
-	public fun getId ()Ljava/lang/String;
 	public fun getPriority ()I
 	public fun init (Lio/gitlab/arturbosch/detekt/api/Config;)V
 	public fun init (Lio/gitlab/arturbosch/detekt/api/SetupContext;)V
@@ -357,7 +352,6 @@ public abstract interface class io/gitlab/arturbosch/detekt/api/ReportingExtensi
 }
 
 public final class io/gitlab/arturbosch/detekt/api/ReportingExtension$DefaultImpls {
-	public static fun getId (Lio/gitlab/arturbosch/detekt/api/ReportingExtension;)Ljava/lang/String;
 	public static fun getPriority (Lio/gitlab/arturbosch/detekt/api/ReportingExtension;)I
 	public static fun init (Lio/gitlab/arturbosch/detekt/api/ReportingExtension;Lio/gitlab/arturbosch/detekt/api/Config;)V
 	public static fun init (Lio/gitlab/arturbosch/detekt/api/ReportingExtension;Lio/gitlab/arturbosch/detekt/api/SetupContext;)V

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Extension.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Extension.kt
@@ -13,7 +13,7 @@ interface Extension {
     /**
      * Name of the extension.
      */
-    val id: String get() = javaClass.simpleName
+    val id: String
 
     /**
      * Is used to run extensions in a specific order.

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/DetektProgressListener.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/DetektProgressListener.kt
@@ -11,6 +11,8 @@ class DetektProgressListener : FileProcessListener {
 
     private lateinit var outPrinter: Appendable
 
+    override val id: String = "DetektProgressListener"
+
     @OptIn(UnstableApi::class)
     override fun init(context: SetupContext) {
         this.outPrinter = context.outputChannel

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/KtFileModifier.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/KtFileModifier.kt
@@ -14,6 +14,8 @@ import kotlin.io.path.writeText
 
 class KtFileModifier : FileProcessListener {
 
+    override val id: String = "KtFileModifier"
+
     override fun onFinish(files: List<KtFile>, result: Detektion, bindingContext: BindingContext) {
         files.filter { it.modificationStamp > 0 }
             .map { it.absolutePath() to it.unnormalizeContent() }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineResultMapping.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineResultMapping.kt
@@ -15,6 +15,8 @@ class BaselineResultMapping : ReportingExtension {
     private var baselineFile: Path? = null
     private var createBaseline: Boolean = false
 
+    override val id: String = "BaselineResultMapping"
+
     override fun init(context: SetupContext) {
         baselineFile = context.getOrNull(DETEKT_BASELINE_PATH_KEY)
         createBaseline = context.getOrNull(DETEKT_BASELINE_CREATION_KEY) ?: false

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/validation/DefaultPropertiesConfigValidator.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/validation/DefaultPropertiesConfigValidator.kt
@@ -13,6 +13,8 @@ internal class DefaultPropertiesConfigValidator(
     private val baseline: Config,
 ) : ConfigValidator {
 
+    override val id: String = "DefaultPropertiesConfigValidator"
+
     override fun validate(config: Config): Collection<Notification> {
         fun patterns(): Set<Regex> {
             val pluginExcludes = RuleSetLocator(settings).load()

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/validation/DeprecatedPropertiesConfigValidator.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/validation/DeprecatedPropertiesConfigValidator.kt
@@ -7,6 +7,9 @@ import io.gitlab.arturbosch.detekt.core.util.SimpleNotification
 internal class DeprecatedPropertiesConfigValidator(
     private val deprecatedProperties: Set<DeprecatedProperty>,
 ) : AbstractYamlConfigValidator() {
+
+    override val id: String = "DeprecatedPropertiesConfigValidator"
+
     override fun validate(
         configToValidate: YamlConfig,
         settings: ValidationSettings

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/validation/InvalidPropertiesConfigValidator.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/validation/InvalidPropertiesConfigValidator.kt
@@ -9,9 +9,12 @@ internal class InvalidPropertiesConfigValidator(
     deprecatedProperties: Set<DeprecatedProperty>,
     private val excludePatterns: Set<Regex>,
 ) : AbstractYamlConfigValidator() {
+
     private val deprecatedPropertyPaths: Set<String> = deprecatedProperties
         .map { "${it.ruleSetId}>${it.ruleId}>${it.propertyName}" }
         .toSet()
+
+    override val id: String = "InvalidPropertiesConfigValidator"
 
     override fun validate(
         configToValidate: YamlConfig,

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/validation/MissingRulesConfigValidator.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/validation/MissingRulesConfigValidator.kt
@@ -12,6 +12,8 @@ internal class MissingRulesConfigValidator(
     private val excludePatterns: Set<Regex>,
 ) : AbstractYamlConfigValidator() {
 
+    override val id: String = "MissingRulesConfigValidator"
+
     override fun validate(
         configToValidate: YamlConfig,
         settings: ValidationSettings

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/ComplexityReport.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/ComplexityReport.kt
@@ -11,6 +11,7 @@ import io.gitlab.arturbosch.detekt.api.Detektion
  */
 class ComplexityReport : ConsoleReport() {
 
+    override val id: String = "ComplexityReport"
     override val priority: Int = 20
 
     override fun render(detektion: Detektion): String? {

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/FileBasedFindingsReport.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/FileBasedFindingsReport.kt
@@ -10,6 +10,8 @@ import io.gitlab.arturbosch.detekt.core.reporting.printFindings
  */
 class FileBasedFindingsReport : AbstractFindingsReport() {
 
+    override val id: String = "FileBasedFindingsReport"
+
     override fun render(findings: Map<RuleSetId, List<Finding>>): String {
         val findingsPerFile = findings.values
             .flatten()

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/FindingsReport.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/FindingsReport.kt
@@ -10,5 +10,7 @@ import io.gitlab.arturbosch.detekt.core.reporting.printFindings
  */
 class FindingsReport : AbstractFindingsReport() {
 
+    override val id: String = "FindingsReport"
+
     override fun render(findings: Map<RuleSetId, List<Finding>>): String = printFindings(findings)
 }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/LiteFindingsReport.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/LiteFindingsReport.kt
@@ -9,6 +9,8 @@ import io.gitlab.arturbosch.detekt.api.RuleSetId
  */
 class LiteFindingsReport : AbstractFindingsReport() {
 
+    override val id: String = "LiteFindingsReport"
+
     override fun render(findings: Map<RuleSetId, List<Finding>>): String {
         return buildString {
             findings.values.flatten().forEach { finding ->

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/NotificationReport.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/NotificationReport.kt
@@ -10,6 +10,7 @@ import io.gitlab.arturbosch.detekt.api.Detektion
 class NotificationReport : ConsoleReport() {
 
     override val id: String = "NotificationReport"
+
     /**
      * Print notifications before the build failure report but after all other reports.
      * This allows to compute intermediate messages based on detekt results and do not rely on 'println'.

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/NotificationReport.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/NotificationReport.kt
@@ -9,6 +9,7 @@ import io.gitlab.arturbosch.detekt.api.Detektion
  */
 class NotificationReport : ConsoleReport() {
 
+    override val id: String = "NotificationReport"
     /**
      * Print notifications before the build failure report but after all other reports.
      * This allows to compute intermediate messages based on detekt results and do not rely on 'println'.

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/ProjectStatisticsReport.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/ProjectStatisticsReport.kt
@@ -9,6 +9,7 @@ import io.gitlab.arturbosch.detekt.api.Detektion
  */
 class ProjectStatisticsReport : ConsoleReport() {
 
+    override val id: String = "ProjectStatisticsReport"
     override val priority: Int = 10
 
     override fun render(detektion: Detektion): String? {

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/TopLevelAutoCorrectSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/TopLevelAutoCorrectSpec.kt
@@ -46,6 +46,8 @@ class TopLevelAutoCorrectSpec {
         }
 
         val contentChangedListener = object : FileProcessListener {
+            override val id: String = "ContentChangedListener"
+
             override fun onFinish(files: List<KtFile>, result: Detektion, bindingContext: BindingContext) {
                 assertThat(files).hasSize(1)
                 assertThat(files[0].text).isNotEqualToIgnoringWhitespace(fileContentBeforeAutoCorrect)

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/validation/AbstractYamlConfigValidatorSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/validation/AbstractYamlConfigValidatorSpec.kt
@@ -37,7 +37,11 @@ internal class AbstractYamlConfigValidatorSpec {
     }
 
     private class SettingsCapturingValidatorAbstract : AbstractYamlConfigValidator() {
+
+        override val id: String = "SettingsCapturingValidatorAbstract"
+
         lateinit var validationSettings: ValidationSettings
+
         override fun validate(
             configToValidate: YamlConfig,
             settings: ValidationSettings

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/validation/CheckConfigurationSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/validation/CheckConfigurationSpec.kt
@@ -121,6 +121,8 @@ class SampleRuleProvider : RuleSetProvider {
 
 class SampleConfigValidator : ConfigValidator {
 
+    override val id: String = "SampleConfigValidator"
+
     override fun validate(config: Config): Collection<Notification> {
         val result = mutableListOf<Notification>()
         runCatching {

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/OutputReportsSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/OutputReportsSpec.kt
@@ -126,7 +126,10 @@ class OutputReportsSpec {
 }
 
 class TestOutputReport : OutputReport() {
+
+    override val id: String = "TestOutputReport"
     override val ending: String = "yml"
+
     override fun render(detektion: Detektion): String? {
         throw UnsupportedOperationException("not implemented")
     }

--- a/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/processors/ClassCountProcessor.kt
+++ b/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/processors/ClassCountProcessor.kt
@@ -8,6 +8,7 @@ import org.jetbrains.kotlin.psi.psiUtil.collectDescendantsOfType
 
 class ClassCountProcessor : AbstractProjectMetricProcessor() {
 
+    override val id: String = "ClassCountProcessor"
     override val visitor = ClassCountVisitor()
     override val key = numberOfClassesKey
 }

--- a/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/processors/FunctionCountProcessor.kt
+++ b/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/processors/FunctionCountProcessor.kt
@@ -8,6 +8,7 @@ import org.jetbrains.kotlin.psi.psiUtil.collectDescendantsOfType
 
 class FunctionCountProcessor : AbstractProjectMetricProcessor() {
 
+    override val id: String = "FunctionCountProcessor"
     override val visitor = FunctionCountVisitor()
     override val key = numberOfFunctionsKey
 }

--- a/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/processors/KtFileCountProcessor.kt
+++ b/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/processors/KtFileCountProcessor.kt
@@ -6,6 +6,7 @@ import org.jetbrains.kotlin.psi.KtFile
 
 class KtFileCountProcessor : AbstractProjectMetricProcessor() {
 
+    override val id: String = "KtFileCountProcessor"
     override val visitor = KtFileCountVisitor()
     override val key = numberOfFilesKey
 }

--- a/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/processors/PackageCountProcessor.kt
+++ b/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/processors/PackageCountProcessor.kt
@@ -13,6 +13,8 @@ class PackageCountProcessor : FileProcessListener {
     private val visitor = PackageCountVisitor()
     private val key = numberOfPackagesKey
 
+    override val id: String = "PackageCountProcessor"
+
     override fun onProcess(file: KtFile, bindingContext: BindingContext) {
         file.accept(visitor)
     }

--- a/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/processors/ProjectCLOCProcessor.kt
+++ b/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/processors/ProjectCLOCProcessor.kt
@@ -8,6 +8,7 @@ import org.jetbrains.kotlin.psi.KtFile
 
 class ProjectCLOCProcessor : AbstractProcessor() {
 
+    override val id: String = "ProjectCLOCProcessor"
     override val key = commentLinesKey
     override val visitor = CLOCVisitor()
 }

--- a/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/processors/ProjectCognitiveComplexityProcessor.kt
+++ b/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/processors/ProjectCognitiveComplexityProcessor.kt
@@ -6,6 +6,8 @@ import org.jetbrains.kotlin.psi.KtFile
 
 class ProjectCognitiveComplexityProcessor : AbstractProcessor() {
 
+    override val id: String = "ProjectCognitiveComplexityProcessor"
+
     override val visitor = object : DetektVisitor() {
 
         override fun visitKtFile(file: KtFile) {

--- a/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/processors/ProjectComplexityProcessor.kt
+++ b/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/processors/ProjectComplexityProcessor.kt
@@ -7,6 +7,7 @@ import org.jetbrains.kotlin.psi.KtFile
 
 class ProjectComplexityProcessor : AbstractProcessor() {
 
+    override val id: String = "ProjectComplexityProcessor"
     override val visitor = ComplexityVisitor()
     override val key = complexityKey
 }

--- a/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/processors/ProjectLLOCProcessor.kt
+++ b/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/processors/ProjectLLOCProcessor.kt
@@ -7,6 +7,7 @@ import org.jetbrains.kotlin.psi.KtFile
 
 class ProjectLLOCProcessor : AbstractProcessor() {
 
+    override val id: String = "ProjectLLOCProcessor"
     override val visitor = LLOCVisitor()
     override val key = logicalLinesKey
 }

--- a/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/processors/ProjectLOCProcessor.kt
+++ b/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/processors/ProjectLOCProcessor.kt
@@ -6,6 +6,7 @@ import org.jetbrains.kotlin.psi.KtFile
 
 class ProjectLOCProcessor : AbstractProcessor() {
 
+    override val id: String = "ProjectLOCProcessor"
     override val visitor: DetektVisitor = LOCVisitor()
     override val key = linesKey
 }

--- a/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/processors/ProjectSLOCProcessor.kt
+++ b/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/processors/ProjectSLOCProcessor.kt
@@ -6,6 +6,7 @@ import org.jetbrains.kotlin.psi.KtFile
 
 class ProjectSLOCProcessor : AbstractProcessor() {
 
+    override val id: String = "ProjectSLOCProcessor"
     override val visitor: DetektVisitor = SLOCVisitor()
     override val key: Key<Int> = sourceLinesKey
 }

--- a/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/processors/PropertyCountProcessor.kt
+++ b/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/processors/PropertyCountProcessor.kt
@@ -8,6 +8,7 @@ import org.jetbrains.kotlin.psi.psiUtil.collectDescendantsOfType
 
 class PropertyCountProcessor : AbstractProjectMetricProcessor() {
 
+    override val id: String = "PropertyCountProcessor"
     override val visitor = PropertyCountVisitor()
     override val key = numberOfFieldsKey
 }

--- a/detekt-report-html/src/main/kotlin/io/github/detekt/report/html/HtmlOutputReport.kt
+++ b/detekt-report-html/src/main/kotlin/io/github/detekt/report/html/HtmlOutputReport.kt
@@ -46,8 +46,8 @@ private const val DETEKT_WEBSITE_BASE_URL = "https://detekt.dev"
  */
 class HtmlOutputReport : OutputReport() {
 
+    override val id: String = "HtmlOutputReport"
     override val ending = "html"
-
     override val name = "HTML report"
 
     override fun render(detektion: Detektion) =

--- a/detekt-report-md/src/main/kotlin/io/github/detekt/report/md/MdOutputReport.kt
+++ b/detekt-report-md/src/main/kotlin/io/github/detekt/report/md/MdOutputReport.kt
@@ -34,8 +34,9 @@ private const val EXTRA_LINES_IN_SNIPPET = 3
  * [See](https://detekt.dev/docs/introduction/configurations/#output-reports)
  */
 class MdOutputReport : OutputReport() {
-    override val ending: String = "md"
 
+    override val id: String = "MdOutputReport"
+    override val ending: String = "md"
     override val name = "Markdown report"
 
     override fun render(detektion: Detektion) = markdown {

--- a/detekt-report-txt/src/main/kotlin/io/github/detekt/report/txt/TxtOutputReport.kt
+++ b/detekt-report-txt/src/main/kotlin/io/github/detekt/report/txt/TxtOutputReport.kt
@@ -9,8 +9,8 @@ import io.gitlab.arturbosch.detekt.api.OutputReport
  */
 class TxtOutputReport : OutputReport() {
 
+    override val id: String = "TxtOutputReport"
     override val ending: String = "txt"
-
     override val name = "plain text report"
 
     override fun render(detektion: Detektion): String {

--- a/detekt-report-xml/src/main/kotlin/io/github/detekt/report/xml/XmlOutputReport.kt
+++ b/detekt-report-xml/src/main/kotlin/io/github/detekt/report/xml/XmlOutputReport.kt
@@ -12,8 +12,8 @@ import kotlin.io.path.invariantSeparatorsPathString
  */
 class XmlOutputReport : OutputReport() {
 
+    override val id: String = "XmlOutputReport"
     override val ending = "xml"
-
     override val name = "Checkstyle XML report"
 
     private val Finding.severityLabel: String

--- a/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/LicenceHeaderLoaderExtension.kt
+++ b/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/LicenceHeaderLoaderExtension.kt
@@ -25,6 +25,8 @@ class LicenceHeaderLoaderExtension : FileProcessListener {
     private lateinit var config: Config
     private var configPath: Path? = null
 
+    override val id: String = "LicenceHeaderLoaderExtension"
+
     override fun init(context: SetupContext) {
         this.config = context.config
         this.configPath = context.configUris.lastOrNull()?.toPath()

--- a/detekt-sample-extensions/src/main/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/SampleConfigValidator.kt
+++ b/detekt-sample-extensions/src/main/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/SampleConfigValidator.kt
@@ -6,6 +6,8 @@ import io.gitlab.arturbosch.detekt.api.Notification
 
 class SampleConfigValidator : ConfigValidator {
 
+    override val id: String = "SampleConfigValidator"
+
     override fun validate(config: Config): Collection<Notification> {
         val result = mutableListOf<Notification>()
         runCatching {

--- a/detekt-sample-extensions/src/main/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/processors/NumberOfLoopsProcessor.kt
+++ b/detekt-sample-extensions/src/main/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/processors/NumberOfLoopsProcessor.kt
@@ -9,6 +9,7 @@ import org.jetbrains.kotlin.resolve.BindingContext
 
 class NumberOfLoopsProcessor : FileProcessListener {
 
+    override val id: String = "NumberOfLoopsProcessor"
     override fun onProcess(file: KtFile, bindingContext: BindingContext) {
         val visitor = LoopVisitor()
         file.accept(visitor)

--- a/detekt-sample-extensions/src/main/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/processors/QualifiedNameProcessor.kt
+++ b/detekt-sample-extensions/src/main/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/processors/QualifiedNameProcessor.kt
@@ -10,6 +10,8 @@ import org.jetbrains.kotlin.resolve.BindingContext
 
 class QualifiedNameProcessor : FileProcessListener {
 
+    override val id: String = "QualifiedNameProcessor"
+
     override fun onProcess(file: KtFile, bindingContext: BindingContext) {
         val packageName = file.packageFqName.asString()
         val nameVisitor = ClassNameVisitor()

--- a/detekt-sample-extensions/src/main/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/reports/QualifiedNamesConsoleReport.kt
+++ b/detekt-sample-extensions/src/main/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/reports/QualifiedNamesConsoleReport.kt
@@ -5,6 +5,8 @@ import io.gitlab.arturbosch.detekt.api.Detektion
 
 class QualifiedNamesConsoleReport : ConsoleReport() {
 
+    override val id: String = "QualifiedNamesConsoleReport"
+
     override fun render(detektion: Detektion): String? {
         return qualifiedNamesReport(detektion)
     }

--- a/detekt-sample-extensions/src/main/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/reports/QualifiedNamesOutputReport.kt
+++ b/detekt-sample-extensions/src/main/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/reports/QualifiedNamesOutputReport.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.api.OutputReport
 
 class QualifiedNamesOutputReport : OutputReport() {
 
+    override val id: String = "QualifiedNamesOutputReport"
     override val ending: String = "txt"
 
     override fun render(detektion: Detektion): String? {


### PR DESCRIPTION
- Removed default implementation `Extension::id`
- Added implementations of `val id: String` to every child. No ids should be changed from previous values
