### PR TITLE
[bugfix] AnnotationOnSeparateLine in snippets

### DIFF
--- a/website/docs/introduction/suppressing-rules.md
+++ b/website/docs/introduction/suppressing-rules.md
@@ -39,6 +39,7 @@ Rules inside this ruleset are wrappers around KtLint rules, and we don't have th
 
 ```kotlin
 @file:Suppress("MaximumLineLength")
+
 package com.example
 
 object AClassWithLongLines {

--- a/website/versioned_docs/version-1.21.0/introduction/suppressing-rules.md
+++ b/website/versioned_docs/version-1.21.0/introduction/suppressing-rules.md
@@ -31,6 +31,7 @@ Rules inside this ruleset are wrappers around KtLint rules, and we don't have th
 
 ```kotlin
 @file:Suppress("MaximumLineLength")
+
 package com.example
 
 object AClassWithLongLines {

--- a/website/versioned_docs/version-1.22.0/introduction/suppressing-rules.md
+++ b/website/versioned_docs/version-1.22.0/introduction/suppressing-rules.md
@@ -31,6 +31,7 @@ Rules inside this ruleset are wrappers around KtLint rules, and we don't have th
 
 ```kotlin
 @file:Suppress("MaximumLineLength")
+
 package com.example
 
 object AClassWithLongLines {

--- a/website/versioned_docs/version-1.23.0/introduction/suppressing-rules.md
+++ b/website/versioned_docs/version-1.23.0/introduction/suppressing-rules.md
@@ -39,6 +39,7 @@ Rules inside this ruleset are wrappers around KtLint rules, and we don't have th
 
 ```kotlin
 @file:Suppress("MaximumLineLength")
+
 package com.example
 
 object AClassWithLongLines {

--- a/website/versioned_docs/version-1.23.1/introduction/suppressing-rules.md
+++ b/website/versioned_docs/version-1.23.1/introduction/suppressing-rules.md
@@ -39,6 +39,7 @@ Rules inside this ruleset are wrappers around KtLint rules, and we don't have th
 
 ```kotlin
 @file:Suppress("MaximumLineLength")
+
 package com.example
 
 object AClassWithLongLines {


### PR DESCRIPTION
Snippets from suppressing-rules.md are created with AnnotationOnSeparateLine error.
