### PR TITLE
Use Node 18 on CI

### DIFF
--- a/.github/workflows/danger.yaml
+++ b/.github/workflows/danger.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3
         with:
-          node-version: "16"
+          node-version: "18"
           cache: "yarn"
           cache-dependency-path: "website/yarn.lock"
 

--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3
         with:
-          node-version: '16'
+          node-version: '18'
           cache: 'yarn'
           cache-dependency-path: 'website/yarn.lock'
 


### PR DESCRIPTION
Node 16 is EOL: https://nodejs.org/en/blog/announcements/nodejs16-eol

Node 18 is the current LTS version.