### PR TITLE
Migrate to maintained semver4j fork

### DIFF
--- a/build-logic/src/main/kotlin/releasing.gradle.kts
+++ b/build-logic/src/main/kotlin/releasing.gradle.kts
@@ -1,4 +1,4 @@
-import com.vdurmont.semver4j.Semver
+import org.semver4j.Semver
 
 plugins {
     id("com.github.breadmoirai.github-release")

--- a/build-logic/src/main/kotlin/releasing.gradle.kts
+++ b/build-logic/src/main/kotlin/releasing.gradle.kts
@@ -86,9 +86,18 @@ fun updateVersion(increment: (Semver) -> Semver) {
 }
 
 tasks {
-    register("incrementPatch") { doLast { updateVersion { it.nextPatch() } } }
-    register("incrementMinor") { doLast { updateVersion { it.nextMinor() } } }
-    register("incrementMajor") { doLast { updateVersion { it.nextMajor() } } }
+    register("incrementPatch") {
+        notCompatibleWithConfigurationCache("cannot serialize Gradle script object references")
+        doLast { updateVersion { it.nextPatch() } }
+    }
+    register("incrementMinor") {
+        notCompatibleWithConfigurationCache("cannot serialize Gradle script object references")
+        doLast { updateVersion { it.nextMinor() } }
+    }
+    register("incrementMajor") {
+        notCompatibleWithConfigurationCache("cannot serialize Gradle script object references")
+        doLast { updateVersion { it.nextMajor() } }
+    }
 
     register<UpdateVersionInFileTask>("applyDocVersion") {
         fileToUpdate = file("$rootDir/website/src/remark/detektVersionReplace.js")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ junit = "5.10.0"
 poko = "0.15.0"
 
 [libraries]
-semver4j = "com.vdurmont:semver4j:3.1.0"
+semver4j = "org.semver4j:semver4j:5.2.1"
 
 kotlin-compiler = { module = "org.jetbrains.kotlin:kotlin-compiler", version.ref = "kotlin" }
 kotlin-compilerEmbeddable = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable", version.ref = "kotlin" }


### PR DESCRIPTION
The original has not been updated since September 2019.

I have tested the following tasks successfully:
* incrementPatch
* incrementMinor
* incrementMajor