### PR TITLE
Revert "Use built in pts.enabled system property to control Gradle PTS"

### DIFF
--- a/.github/workflows/codecoverage.yaml
+++ b/.github/workflows/codecoverage.yaml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+env:
+  ORG_GRADLE_PROJECT_enablePTS: false
+
 permissions:
   contents: read
 
@@ -26,7 +29,6 @@ jobs:
         uses: gradle/gradle-build-action@842c587ad8aa4c68eeba24c396e15af4c2e9f30a # v2
         with:
           gradle-home-cache-cleanup: true
-          arguments: -Dpts.enabled=false
 
       - name: Generate Coverage Report
         run: ./gradlew jacocoMergedReport

--- a/.github/workflows/deploy-snapshot.yaml
+++ b/.github/workflows/deploy-snapshot.yaml
@@ -7,6 +7,7 @@ on:
 
 env:
   GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+  ORG_GRADLE_PROJECT_enablePTS: false
 
 permissions:
   contents: read
@@ -29,7 +30,6 @@ jobs:
         uses: gradle/gradle-build-action@842c587ad8aa4c68eeba24c396e15af4c2e9f30a # v2
         with:
           gradle-home-cache-cleanup: true
-          arguments: -Dpts.enabled=false
 
       - name: Assemble and publish artifacts to Maven Local
         run: ./gradlew publishToMavenLocal

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -11,6 +11,7 @@ env:
   GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
   GRADLE_CACHE_USERNAME: ${{ secrets.GRADLE_CACHE_USERNAME }}
   GRADLE_CACHE_PASSWORD: ${{ secrets.GRADLE_CACHE_PASSWORD }}
+  ORG_GRADLE_PROJECT_enablePTS: ${{ github.ref_name != 'main' }}
 
 permissions:
   contents: read
@@ -40,7 +41,6 @@ jobs:
         uses: gradle/gradle-build-action@842c587ad8aa4c68eeba24c396e15af4c2e9f30a # v2
         with:
           gradle-home-cache-cleanup: true
-          arguments: -Dpts.enabled=${{ github.ref_name != 'main' }}
 
       - name: Assemble and publish artifacts to Maven Local
         run: ./gradlew publishToMavenLocal

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -73,6 +73,9 @@ subprojects {
                 maxFailures = 20
             }
         }
+        predictiveSelection {
+            enabled = providers.gradleProperty("enablePTS").map(String::toBooleanStrict)
+        }
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,4 +7,4 @@ org.gradle.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8
 org.gradle.kotlin.dsl.allWarningsAsErrors=true
 
 # Enable Predictive Test Selection by default: https://docs.gradle.com/enterprise/predictive-test-selection/
-systemProp.pts.enabled=true
+enablePTS=true


### PR DESCRIPTION
Reverts detekt/detekt#6527

I naively thought that applying `arguments` to the Gradle setup step would cascade to following Gradle steps, but it doesn't. In hindsight this makes perfect sense. So the original setup we had was more suitable. It's not possible to set system properties using environment variables so we'll have a simpler setup reverting to what we had before.