### PR TITLE
Configure DGP as a public module

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,12 +27,6 @@ allprojects {
     apply(plugin = "io.gitlab.arturbosch.detekt")
 
     detekt {
-        source.setFrom(
-            io.gitlab.arturbosch.detekt.DetektPlugin.DEFAULT_SRC_DIR_JAVA,
-            io.gitlab.arturbosch.detekt.DetektPlugin.DEFAULT_TEST_SRC_DIR_JAVA,
-            io.gitlab.arturbosch.detekt.DetektPlugin.DEFAULT_SRC_DIR_KOTLIN,
-            io.gitlab.arturbosch.detekt.DetektPlugin.DEFAULT_TEST_SRC_DIR_KOTLIN,
-        )
         buildUponDefaultConfig = true
         baseline = file("$rootDir/config/detekt/baseline.xml")
     }

--- a/detekt-generator/build.gradle.kts
+++ b/detekt-generator/build.gradle.kts
@@ -42,6 +42,7 @@ tasks.register("generateWebsite") {
         copyDetektCliUsage,
         generateDocumentation,
         ":dokkaHtmlMultiModule",
+        gradle.includedBuild("detekt-gradle-plugin").task(":dokkaHtml"),
     )
 }
 

--- a/detekt-gradle-plugin/api/detekt-gradle-plugin.api
+++ b/detekt-gradle-plugin/api/detekt-gradle-plugin.api
@@ -1,0 +1,191 @@
+public final class io/github/detekt/gradle/DetektKotlinCompilerPlugin : org/jetbrains/kotlin/gradle/plugin/KotlinCompilerPluginSupportPlugin {
+	public fun <init> ()V
+	public synthetic fun apply (Ljava/lang/Object;)V
+	public fun apply (Lorg/gradle/api/Project;)V
+	public fun applyToCompilation (Lorg/jetbrains/kotlin/gradle/plugin/KotlinCompilation;)Lorg/gradle/api/provider/Provider;
+	public fun getCompilerPluginId ()Ljava/lang/String;
+	public fun getPluginArtifact ()Lorg/jetbrains/kotlin/gradle/plugin/SubpluginArtifact;
+	public fun getPluginArtifactForNative ()Lorg/jetbrains/kotlin/gradle/plugin/SubpluginArtifact;
+	public fun isApplicable (Lorg/jetbrains/kotlin/gradle/plugin/KotlinCompilation;)Z
+}
+
+public class io/github/detekt/gradle/extensions/DetektReport {
+	public fun <init> (Ljava/lang/String;Lorg/gradle/api/model/ObjectFactory;)V
+	public final fun getDestination ()Lorg/gradle/api/file/RegularFileProperty;
+	public final fun getEnabled ()Lorg/gradle/api/provider/Property;
+	public final fun getName ()Ljava/lang/String;
+}
+
+public class io/github/detekt/gradle/extensions/KotlinCompileTaskDetektExtension {
+	public fun <init> (Lorg/gradle/api/Project;)V
+	public final fun getAllRules ()Lorg/gradle/api/provider/Property;
+	public final fun getBaseline ()Lorg/gradle/api/file/RegularFileProperty;
+	public final fun getBuildUponDefaultConfig ()Lorg/gradle/api/provider/Property;
+	public final fun getConfig ()Lorg/gradle/api/file/ConfigurableFileCollection;
+	public final fun getDebug ()Lorg/gradle/api/provider/Property;
+	public final fun getDisableDefaultRuleSets ()Lorg/gradle/api/provider/Property;
+	public final fun getExcludes ()Lorg/gradle/api/provider/SetProperty;
+	public final fun getHtml ()Lio/github/detekt/gradle/extensions/DetektReport;
+	public final fun getParallel ()Lorg/gradle/api/provider/Property;
+	public final fun getReports ()Lorg/gradle/api/NamedDomainObjectContainer;
+	public final fun getSarif ()Lio/github/detekt/gradle/extensions/DetektReport;
+	public final fun getTxt ()Lio/github/detekt/gradle/extensions/DetektReport;
+	public final fun getXml ()Lio/github/detekt/gradle/extensions/DetektReport;
+	public final fun isEnabled ()Lorg/gradle/api/provider/Property;
+}
+
+public abstract class io/gitlab/arturbosch/detekt/Detekt : org/gradle/api/tasks/SourceTask, org/gradle/api/tasks/VerificationTask {
+	public fun <init> (Lorg/gradle/api/model/ObjectFactory;Lorg/gradle/workers/WorkerExecutor;Lorg/gradle/api/provider/ProviderFactory;)V
+	public final fun check ()V
+	public final fun getAllRules ()Z
+	public final fun getAutoCorrect ()Z
+	public final fun getBasePath ()Ljava/lang/String;
+	public abstract fun getBaseline ()Lorg/gradle/api/file/RegularFileProperty;
+	public final fun getBuildUponDefaultConfig ()Z
+	public abstract fun getClasspath ()Lorg/gradle/api/file/ConfigurableFileCollection;
+	public abstract fun getConfig ()Lorg/gradle/api/file/ConfigurableFileCollection;
+	public final fun getDebug ()Z
+	public abstract fun getDetektClasspath ()Lorg/gradle/api/file/ConfigurableFileCollection;
+	public final fun getDisableDefaultRuleSets ()Z
+	public final fun getHtmlReportFile ()Lorg/gradle/api/provider/Provider;
+	public fun getIgnoreFailures ()Z
+	public abstract fun getJdkHome ()Lorg/gradle/api/file/DirectoryProperty;
+	public final fun getJvmTarget ()Ljava/lang/String;
+	public final fun getLanguageVersion ()Ljava/lang/String;
+	public final fun getMdReportFile ()Lorg/gradle/api/provider/Provider;
+	public final fun getParallel ()Z
+	public abstract fun getPluginClasspath ()Lorg/gradle/api/file/ConfigurableFileCollection;
+	public final fun getReports ()Lio/gitlab/arturbosch/detekt/extensions/DetektReports;
+	public abstract fun getReportsDir ()Lorg/gradle/api/provider/Property;
+	public final fun getSarifReportFile ()Lorg/gradle/api/provider/Provider;
+	public fun getSource ()Lorg/gradle/api/file/FileTree;
+	public final fun getTxtReportFile ()Lorg/gradle/api/provider/Provider;
+	public final fun getXmlReportFile ()Lorg/gradle/api/provider/Provider;
+	public final fun reports (Lorg/gradle/api/Action;)V
+	public final fun setAllRules (Z)V
+	public final fun setAutoCorrect (Z)V
+	public final fun setBasePath (Ljava/lang/String;)V
+	public final fun setBuildUponDefaultConfig (Z)V
+	public final fun setDebug (Z)V
+	public final fun setDisableDefaultRuleSets (Z)V
+	public fun setIgnoreFailures (Z)V
+	public final fun setJvmTarget (Ljava/lang/String;)V
+	public final fun setLanguageVersion (Ljava/lang/String;)V
+	public final fun setParallel (Z)V
+	public final fun setReports (Lio/gitlab/arturbosch/detekt/extensions/DetektReports;)V
+}
+
+public abstract class io/gitlab/arturbosch/detekt/DetektCreateBaselineTask : org/gradle/api/tasks/SourceTask {
+	public fun <init> (Lorg/gradle/workers/WorkerExecutor;Lorg/gradle/api/provider/ProviderFactory;)V
+	public final fun baseline ()V
+	public abstract fun getAllRules ()Lorg/gradle/api/provider/Property;
+	public abstract fun getAutoCorrect ()Lorg/gradle/api/provider/Property;
+	public final fun getBasePath ()Ljava/lang/String;
+	public abstract fun getBaseline ()Lorg/gradle/api/file/RegularFileProperty;
+	public abstract fun getBuildUponDefaultConfig ()Lorg/gradle/api/provider/Property;
+	public abstract fun getClasspath ()Lorg/gradle/api/file/ConfigurableFileCollection;
+	public abstract fun getConfig ()Lorg/gradle/api/file/ConfigurableFileCollection;
+	public abstract fun getDebug ()Lorg/gradle/api/provider/Property;
+	public abstract fun getDetektClasspath ()Lorg/gradle/api/file/ConfigurableFileCollection;
+	public abstract fun getDisableDefaultRuleSets ()Lorg/gradle/api/provider/Property;
+	public abstract fun getIgnoreFailures ()Lorg/gradle/api/provider/Property;
+	public abstract fun getJdkHome ()Lorg/gradle/api/file/DirectoryProperty;
+	public final fun getJvmTarget ()Ljava/lang/String;
+	public abstract fun getLanguageVersion ()Lorg/gradle/api/provider/Property;
+	public abstract fun getParallel ()Lorg/gradle/api/provider/Property;
+	public abstract fun getPluginClasspath ()Lorg/gradle/api/file/ConfigurableFileCollection;
+	public fun getSource ()Lorg/gradle/api/file/FileTree;
+	public final fun setBasePath (Ljava/lang/String;)V
+	public final fun setJvmTarget (Ljava/lang/String;)V
+}
+
+public abstract class io/gitlab/arturbosch/detekt/DetektGenerateConfigTask : org/gradle/api/DefaultTask {
+	public fun <init> (Lorg/gradle/workers/WorkerExecutor;Lorg/gradle/api/provider/ProviderFactory;)V
+	public final fun generateConfig ()V
+	public abstract fun getConfigFile ()Lorg/gradle/api/file/RegularFileProperty;
+	public abstract fun getDetektClasspath ()Lorg/gradle/api/file/ConfigurableFileCollection;
+	public abstract fun getPluginClasspath ()Lorg/gradle/api/file/ConfigurableFileCollection;
+}
+
+public final class io/gitlab/arturbosch/detekt/DetektPlugin : org/gradle/api/Plugin {
+	public fun <init> ()V
+	public synthetic fun apply (Ljava/lang/Object;)V
+	public fun apply (Lorg/gradle/api/Project;)V
+}
+
+public final class io/gitlab/arturbosch/detekt/DetektPluginKt {
+	public static final fun getSupportedKotlinVersion ()Ljava/lang/String;
+}
+
+public abstract class io/gitlab/arturbosch/detekt/extensions/CustomDetektReport {
+	public fun <init> ()V
+	public abstract fun getOutputLocation ()Lorg/gradle/api/file/RegularFileProperty;
+	public abstract fun getReportId ()Ljava/lang/String;
+	public abstract fun setReportId (Ljava/lang/String;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class io/gitlab/arturbosch/detekt/extensions/DetektExtension {
+	public abstract fun getAllRules ()Lorg/gradle/api/provider/Property;
+	public abstract fun getAutoCorrect ()Lorg/gradle/api/provider/Property;
+	public abstract fun getBasePath ()Lorg/gradle/api/file/DirectoryProperty;
+	public abstract fun getBaseline ()Lorg/gradle/api/file/RegularFileProperty;
+	public abstract fun getBuildUponDefaultConfig ()Lorg/gradle/api/provider/Property;
+	public abstract fun getConfig ()Lorg/gradle/api/file/ConfigurableFileCollection;
+	public abstract fun getDebug ()Lorg/gradle/api/provider/Property;
+	public abstract fun getDisableDefaultRuleSets ()Lorg/gradle/api/provider/Property;
+	public abstract fun getEnableCompilerPlugin ()Lorg/gradle/api/provider/Property;
+	public abstract fun getIgnoreFailures ()Lorg/gradle/api/provider/Property;
+	public abstract fun getIgnoredBuildTypes ()Lorg/gradle/api/provider/ListProperty;
+	public abstract fun getIgnoredFlavors ()Lorg/gradle/api/provider/ListProperty;
+	public abstract fun getIgnoredVariants ()Lorg/gradle/api/provider/ListProperty;
+	public abstract fun getParallel ()Lorg/gradle/api/provider/Property;
+	public abstract fun getReportsDir ()Lorg/gradle/api/file/DirectoryProperty;
+	public abstract fun getSource ()Lorg/gradle/api/file/ConfigurableFileCollection;
+	public abstract fun getToolVersion ()Lorg/gradle/api/provider/Property;
+}
+
+public abstract class io/gitlab/arturbosch/detekt/extensions/DetektReport {
+	public fun <init> (Lio/gitlab/arturbosch/detekt/extensions/DetektReportType;)V
+	public abstract fun getOutputLocation ()Lorg/gradle/api/file/RegularFileProperty;
+	public abstract fun getRequired ()Lorg/gradle/api/provider/Property;
+	public final fun getType ()Lio/gitlab/arturbosch/detekt/extensions/DetektReportType;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/gitlab/arturbosch/detekt/extensions/DetektReportType : java/lang/Enum {
+	public static final field HTML Lio/gitlab/arturbosch/detekt/extensions/DetektReportType;
+	public static final field MD Lio/gitlab/arturbosch/detekt/extensions/DetektReportType;
+	public static final field SARIF Lio/gitlab/arturbosch/detekt/extensions/DetektReportType;
+	public static final field TXT Lio/gitlab/arturbosch/detekt/extensions/DetektReportType;
+	public static final field XML Lio/gitlab/arturbosch/detekt/extensions/DetektReportType;
+	public final fun getExtension ()Ljava/lang/String;
+	public final fun getReportId ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lio/gitlab/arturbosch/detekt/extensions/DetektReportType;
+	public static fun values ()[Lio/gitlab/arturbosch/detekt/extensions/DetektReportType;
+}
+
+public class io/gitlab/arturbosch/detekt/extensions/DetektReports {
+	public fun <init> (Lorg/gradle/api/model/ObjectFactory;)V
+	public final fun custom (Lorg/gradle/api/Action;)V
+	public final fun getCustom ()Ljava/util/List;
+	public final fun getHtml ()Lio/gitlab/arturbosch/detekt/extensions/DetektReport;
+	public final fun getMd ()Lio/gitlab/arturbosch/detekt/extensions/DetektReport;
+	public final fun getObjects ()Lorg/gradle/api/model/ObjectFactory;
+	public final fun getSarif ()Lio/gitlab/arturbosch/detekt/extensions/DetektReport;
+	public final fun getTxt ()Lio/gitlab/arturbosch/detekt/extensions/DetektReport;
+	public final fun getXml ()Lio/gitlab/arturbosch/detekt/extensions/DetektReport;
+	public final fun html (Lorg/gradle/api/Action;)V
+	public final fun md (Lorg/gradle/api/Action;)V
+	public final fun sarif (Lorg/gradle/api/Action;)V
+	public final fun txt (Lorg/gradle/api/Action;)V
+	public final fun xml (Lorg/gradle/api/Action;)V
+}
+
+public abstract class io/gitlab/arturbosch/detekt/report/ReportMergeTask : org/gradle/api/DefaultTask {
+	public fun <init> ()V
+	public abstract fun getInput ()Lorg/gradle/api/file/ConfigurableFileCollection;
+	public abstract fun getOutput ()Lorg/gradle/api/file/RegularFileProperty;
+	public final fun merge ()V
+}
+

--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -3,7 +3,9 @@
 @file:Suppress("StringLiteralDuplication")
 
 import com.gradle.enterprise.gradleplugin.testretry.retry
+import org.jetbrains.dokka.gradle.DokkaTask
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
+import java.net.URL
 
 plugins {
     id("module")
@@ -14,6 +16,7 @@ plugins {
     // We use this published version of the detekt plugin to self analyse this project.
     id("io.gitlab.arturbosch.detekt") version "1.23.1"
     alias(libs.plugins.binaryCompatibilityValidator)
+    alias(libs.plugins.dokka)
 }
 
 repositories {
@@ -145,6 +148,20 @@ tasks {
 
     processTestResources {
         from(writeDetektVersionProperties)
+    }
+
+    withType<DokkaTask>().configureEach {
+        suppressInheritedMembers = true
+        failOnWarning = true
+        outputDirectory = layout.projectDirectory.dir("../website/static/kdoc/detekt-gradle-plugin")
+        notCompatibleWithConfigurationCache("https://github.com/Kotlin/dokka/issues/1217")
+
+        dokkaSourceSets.configureEach {
+            apiVersion = "1.4"
+            externalDocumentationLink {
+                url = URL("https://docs.gradle.org/current/javadoc/")
+            }
+        }
     }
 
     check {

--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -13,6 +13,7 @@ plugins {
     alias(libs.plugins.pluginPublishing)
     // We use this published version of the detekt plugin to self analyse this project.
     id("io.gitlab.arturbosch.detekt") version "1.23.1"
+    alias(libs.plugins.binaryCompatibilityValidator)
 }
 
 repositories {

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektGenerateConfigTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektGenerateConfigTask.kt
@@ -78,5 +78,5 @@ abstract class DetektGenerateConfigTask @Inject constructor(
         }
     }
 
-    interface SingleExecutionBuildService : BuildService<BuildServiceParameters.None>
+    internal interface SingleExecutionBuildService : BuildService<BuildServiceParameters.None>
 }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
@@ -145,40 +145,40 @@ class DetektPlugin : Plugin<Project> {
         }
     }
 
-    companion object {
-        const val DETEKT_TASK_NAME = "detekt"
-        const val BASELINE_TASK_NAME = "detektBaseline"
-        const val DETEKT_EXTENSION = "detekt"
+    internal companion object {
+        internal const val DETEKT_TASK_NAME = "detekt"
+        internal const val BASELINE_TASK_NAME = "detektBaseline"
+        internal const val DETEKT_EXTENSION = "detekt"
         private const val GENERATE_CONFIG = "detektGenerateConfig"
-        internal val defaultExcludes = listOf("build/")
-        internal val defaultIncludes = listOf("**/*.kt", "**/*.kts")
+        val defaultExcludes = listOf("build/")
+        val defaultIncludes = listOf("**/*.kt", "**/*.kts")
         internal const val CONFIG_DIR_NAME = "config/detekt"
         internal const val CONFIG_FILE = "detekt.yml"
 
         internal const val DETEKT_ANDROID_DISABLED_PROPERTY = "detekt.android.disabled"
         internal const val DETEKT_MULTIPLATFORM_DISABLED_PROPERTY = "detekt.multiplatform.disabled"
 
-        const val DEFAULT_SRC_DIR_JAVA = "src/main/java"
-        const val DEFAULT_TEST_SRC_DIR_JAVA = "src/test/java"
-        const val DEFAULT_SRC_DIR_KOTLIN = "src/main/kotlin"
-        const val DEFAULT_TEST_SRC_DIR_KOTLIN = "src/test/kotlin"
-        const val DEFAULT_DEBUG_VALUE = false
-        const val DEFAULT_IGNORE_FAILURES = false
-        const val DEFAULT_PARALLEL_VALUE = false
-        const val DEFAULT_AUTO_CORRECT_VALUE = false
-        const val DEFAULT_DISABLE_RULESETS_VALUE = false
-        const val DEFAULT_REPORT_ENABLED_VALUE = true
-        const val DEFAULT_ALL_RULES_VALUE = false
-        const val DEFAULT_BUILD_UPON_DEFAULT_CONFIG_VALUE = false
+        internal const val DEFAULT_SRC_DIR_JAVA = "src/main/java"
+        internal const val DEFAULT_TEST_SRC_DIR_JAVA = "src/test/java"
+        internal const val DEFAULT_SRC_DIR_KOTLIN = "src/main/kotlin"
+        internal const val DEFAULT_TEST_SRC_DIR_KOTLIN = "src/test/kotlin"
+        internal const val DEFAULT_DEBUG_VALUE = false
+        internal const val DEFAULT_IGNORE_FAILURES = false
+        internal const val DEFAULT_PARALLEL_VALUE = false
+        internal const val DEFAULT_AUTO_CORRECT_VALUE = false
+        internal const val DEFAULT_DISABLE_RULESETS_VALUE = false
+        internal const val DEFAULT_REPORT_ENABLED_VALUE = true
+        internal const val DEFAULT_ALL_RULES_VALUE = false
+        internal const val DEFAULT_BUILD_UPON_DEFAULT_CONFIG_VALUE = false
 
         // This flag is ignored unless the compiler plugin is applied to the project
-        const val DEFAULT_COMPILER_PLUGIN_ENABLED = true
+        internal const val DEFAULT_COMPILER_PLUGIN_ENABLED = true
     }
 }
 
-const val CONFIGURATION_DETEKT = "detekt"
-const val CONFIGURATION_DETEKT_PLUGINS = "detektPlugins"
-const val USE_WORKER_API = "detekt.use.worker.api"
+internal const val CONFIGURATION_DETEKT = "detekt"
+internal const val CONFIGURATION_DETEKT_PLUGINS = "detektPlugins"
+internal const val USE_WORKER_API = "detekt.use.worker.api"
 
 @Incubating
 fun getSupportedKotlinVersion(): String {

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektReport.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektReport.kt
@@ -17,7 +17,7 @@ abstract class DetektReport @Inject constructor(val type: DetektReportType) {
         return "DetektReport(type='$type', required=$required, outputLocation=$outputLocation)"
     }
 
-    companion object {
-        const val DEFAULT_FILENAME = "detekt"
+    internal companion object {
+        internal const val DEFAULT_FILENAME = "detekt"
     }
 }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektReportType.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektReportType.kt
@@ -8,7 +8,7 @@ enum class DetektReportType(val reportId: String, val extension: String) {
     SARIF("sarif", "sarif"),
     MD("md", "md");
 
-    companion object {
+    internal companion object {
         fun isWellKnownReportId(reportId: String) = reportId in values().map(DetektReportType::reportId)
     }
 }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/ClassLoaderCache.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/ClassLoaderCache.kt
@@ -4,7 +4,7 @@ import org.gradle.api.file.FileCollection
 import java.net.URLClassLoader
 import java.util.concurrent.ConcurrentHashMap
 
-fun interface ClassLoaderCache {
+internal fun interface ClassLoaderCache {
 
     fun getOrCreate(classpath: FileCollection): URLClassLoader
 }
@@ -25,4 +25,4 @@ internal class DefaultClassLoaderCache : ClassLoaderCache {
     }
 }
 
-object GlobalClassLoaderCache : ClassLoaderCache by DefaultClassLoaderCache()
+internal object GlobalClassLoaderCache : ClassLoaderCache by DefaultClassLoaderCache()

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/DetektInvoker.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/DetektInvoker.kt
@@ -32,7 +32,7 @@ internal interface DetektInvoker {
     }
 }
 
-interface DetektWorkParameters : WorkParameters {
+internal interface DetektWorkParameters : WorkParameters {
     val arguments: ListProperty<String>
     val ignoreFailures: Property<Boolean>
     val dryRun: Property<Boolean>
@@ -40,7 +40,7 @@ interface DetektWorkParameters : WorkParameters {
     val classpath: ConfigurableFileCollection
 }
 
-abstract class DetektWorkAction : WorkAction<DetektWorkParameters> {
+internal abstract class DetektWorkAction : WorkAction<DetektWorkParameters> {
     @Suppress("SwallowedException", "TooGenericExceptionCaught")
     override fun execute() {
         if (parameters.dryRun.getOrElse(false)) {

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/report/SarifReportMerger.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/report/SarifReportMerger.kt
@@ -9,7 +9,7 @@ private typealias JsonObject = MutableMap<String, Any?>
 /**
  * A naive implementation to merge SARIF assuming all inputs are written by detekt.
  */
-object SarifReportMerger {
+internal object SarifReportMerger {
 
     fun merge(inputs: Collection<File>, output: File) {
         val sarifs = inputs.filter { it.exists() }.map {

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/report/XmlReportMerger.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/report/XmlReportMerger.kt
@@ -13,7 +13,7 @@ import javax.xml.transform.stream.StreamResult
 /**
  * A naive implementation to merge xml assuming all input xml are written by detekt.
  */
-object XmlReportMerger {
+internal object XmlReportMerger {
 
     private val documentBuilder by lazy { DocumentBuilderFactory.newInstance().newDocumentBuilder() }
 

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -109,6 +109,11 @@ const config = {
             label: 'API',
           },
           {
+            href: '/kdoc/detekt-gradle-plugin/',
+            position: 'left',
+            label: 'Gradle Plugin API',
+          },
+          {
             to: "/marketplace",
             label: "Marketplace",
             position: "left",

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -104,7 +104,7 @@ const config = {
             position: 'left'
           },
           {
-            href: 'https://detekt.dev/kdoc/',
+            href: '/kdoc/',
             position: 'left',
             label: 'API',
           },


### PR DESCRIPTION
This PR:
1. Generates KDoc for DGP
2. Runs apiCheck on builds going forward so API change can be properly managed

The KDoc documentation can't be included in the root project's multi module Dokka output because DGP is currently an included build. This requires a separate link to the DGP KDoc output which should be added to the header once Vercel generates it.

KDoc output: https://detekt-ian9cjhxl-detekt.vercel.app/kdoc/detekt-gradle-plugin/