### PR TITLE
Create DetektBasePlugin

### DIFF
--- a/detekt-gradle-plugin/api/detekt-gradle-plugin.api
+++ b/detekt-gradle-plugin/api/detekt-gradle-plugin.api
@@ -1,3 +1,9 @@
+public final class dev/detekt/gradle/plugin/DetektBasePlugin : org/gradle/api/Plugin {
+	public fun <init> ()V
+	public synthetic fun apply (Ljava/lang/Object;)V
+	public fun apply (Lorg/gradle/api/Project;)V
+}
+
 public final class io/github/detekt/gradle/DetektKotlinCompilerPlugin : org/jetbrains/kotlin/gradle/plugin/KotlinCompilerPluginSupportPlugin {
 	public fun <init> ()V
 	public synthetic fun apply (Ljava/lang/Object;)V

--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -87,6 +87,13 @@ gradlePlugin {
     website = "https://detekt.dev"
     vcsUrl = "https://github.com/detekt/detekt"
     plugins {
+        create("detektBasePlugin") {
+            id = "dev.detekt.gradle.base"
+            implementationClass = "dev.detekt.gradle.plugin.DetektBasePlugin"
+            displayName = "Static code analysis for Kotlin"
+            description = "Static code analysis for Kotlin"
+            tags = listOf("kotlin", "detekt", "code-analysis", "linter", "codesmells", "android")
+        }
         create("detektPlugin") {
             id = "io.gitlab.arturbosch.detekt"
             implementationClass = "io.gitlab.arturbosch.detekt.DetektPlugin"

--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -101,16 +101,6 @@ gradlePlugin {
             description = "Static code analysis for Kotlin"
             tags = listOf("kotlin", "detekt", "code-analysis", "linter", "codesmells", "android")
         }
-    }
-    // Source sets that require the Gradle TestKit dependency
-    testSourceSets(
-        sourceSets["testFixtures"],
-        sourceSets["functionalTest"],
-    )
-}
-
-gradlePlugin {
-    plugins {
         create("detektCompilerPlugin") {
             id = "io.github.detekt.gradle.compiler-plugin"
             implementationClass = "io.github.detekt.gradle.DetektKotlinCompilerPlugin"
@@ -119,6 +109,11 @@ gradlePlugin {
             tags = listOf("kotlin", "detekt", "code-analysis", "linter", "codesmells", "android")
         }
     }
+    // Source sets that require the Gradle TestKit dependency
+    testSourceSets(
+        sourceSets["testFixtures"],
+        sourceSets["functionalTest"],
+    )
 }
 
 // Some functional tests reference internal functions in the Gradle plugin. This should become unnecessary as further

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/DetektBasePlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/DetektBasePlugin.kt
@@ -56,20 +56,20 @@ class DetektBasePlugin : Plugin<Project> {
         internal const val CONFIG_DIR_NAME = "config/detekt"
         internal const val CONFIG_FILE = "detekt.yml"
 
-        internal const val DEFAULT_SRC_DIR_JAVA = "src/main/java"
-        internal const val DEFAULT_TEST_SRC_DIR_JAVA = "src/test/java"
-        internal const val DEFAULT_SRC_DIR_KOTLIN = "src/main/kotlin"
-        internal const val DEFAULT_TEST_SRC_DIR_KOTLIN = "src/test/kotlin"
-        internal const val DEFAULT_DEBUG_VALUE = false
-        internal const val DEFAULT_IGNORE_FAILURES = false
-        internal const val DEFAULT_PARALLEL_VALUE = false
-        internal const val DEFAULT_AUTO_CORRECT_VALUE = false
-        internal const val DEFAULT_DISABLE_RULESETS_VALUE = false
-        internal const val DEFAULT_ALL_RULES_VALUE = false
-        internal const val DEFAULT_BUILD_UPON_DEFAULT_CONFIG_VALUE = false
+        private const val DEFAULT_SRC_DIR_JAVA = "src/main/java"
+        private const val DEFAULT_TEST_SRC_DIR_JAVA = "src/test/java"
+        private const val DEFAULT_SRC_DIR_KOTLIN = "src/main/kotlin"
+        private const val DEFAULT_TEST_SRC_DIR_KOTLIN = "src/test/kotlin"
+        private const val DEFAULT_DEBUG_VALUE = false
+        private const val DEFAULT_IGNORE_FAILURES = false
+        private const val DEFAULT_PARALLEL_VALUE = false
+        private const val DEFAULT_AUTO_CORRECT_VALUE = false
+        private const val DEFAULT_DISABLE_RULESETS_VALUE = false
+        private const val DEFAULT_ALL_RULES_VALUE = false
+        private const val DEFAULT_BUILD_UPON_DEFAULT_CONFIG_VALUE = false
 
         // This flag is ignored unless the compiler plugin is applied to the project
-        internal const val DEFAULT_COMPILER_PLUGIN_ENABLED = true
+        private const val DEFAULT_COMPILER_PLUGIN_ENABLED = true
     }
 }
 

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/DetektBasePlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/DetektBasePlugin.kt
@@ -41,6 +41,14 @@ class DetektBasePlugin : Plugin<Project> {
         if (defaultConfigFile.exists()) {
             extension.config.setFrom(project.files(defaultConfigFile))
         }
+
+        project.configurations.create(CONFIGURATION_DETEKT_PLUGINS).let { configuration ->
+            configuration.isVisible = false
+            configuration.isTransitive = true
+            configuration.description = "The $CONFIGURATION_DETEKT_PLUGINS libraries to be used for this project."
+            configuration.isCanBeResolved = true
+            configuration.isCanBeConsumed = false
+        }
     }
 
     internal companion object {
@@ -64,3 +72,5 @@ class DetektBasePlugin : Plugin<Project> {
         internal const val DEFAULT_COMPILER_PLUGIN_ENABLED = true
     }
 }
+
+internal const val CONFIGURATION_DETEKT_PLUGINS = "detektPlugins"

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/DetektBasePlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/DetektBasePlugin.kt
@@ -1,0 +1,10 @@
+package dev.detekt.gradle.plugin
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+class DetektBasePlugin : Plugin<Project> {
+    override fun apply(project: Project) {
+
+    }
+}

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/DetektBasePlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/DetektBasePlugin.kt
@@ -2,9 +2,11 @@ package dev.detekt.gradle.plugin
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.plugins.ReportingBasePlugin
 
 class DetektBasePlugin : Plugin<Project> {
     override fun apply(project: Project) {
+        project.pluginManager.apply(ReportingBasePlugin::class.java)
 
     }
 }

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/DetektBasePlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/DetektBasePlugin.kt
@@ -1,12 +1,66 @@
 package dev.detekt.gradle.plugin
 
+import io.gitlab.arturbosch.detekt.extensions.DetektExtension
+import io.gitlab.arturbosch.detekt.extensions.loadDetektVersion
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.plugins.ReportingBasePlugin
+import org.gradle.api.reporting.ReportingExtension
 
 class DetektBasePlugin : Plugin<Project> {
     override fun apply(project: Project) {
         project.pluginManager.apply(ReportingBasePlugin::class.java)
 
+        val extension = project.extensions.create(DETEKT_EXTENSION, DetektExtension::class.java)
+
+        with(extension) {
+            toolVersion.convention(loadDetektVersion(DetektExtension::class.java.classLoader))
+            ignoreFailures.convention(DEFAULT_IGNORE_FAILURES)
+            source.setFrom(
+                DEFAULT_SRC_DIR_JAVA,
+                DEFAULT_TEST_SRC_DIR_JAVA,
+                DEFAULT_SRC_DIR_KOTLIN,
+                DEFAULT_TEST_SRC_DIR_KOTLIN,
+            )
+            baseline.convention(project.layout.projectDirectory.file("detekt-baseline.xml"))
+            enableCompilerPlugin.convention(DEFAULT_COMPILER_PLUGIN_ENABLED)
+            debug.convention(DEFAULT_DEBUG_VALUE)
+            parallel.convention(DEFAULT_PARALLEL_VALUE)
+            allRules.convention(DEFAULT_ALL_RULES_VALUE)
+            buildUponDefaultConfig.convention(DEFAULT_BUILD_UPON_DEFAULT_CONFIG_VALUE)
+            disableDefaultRuleSets.convention(DEFAULT_DISABLE_RULESETS_VALUE)
+            autoCorrect.convention(DEFAULT_AUTO_CORRECT_VALUE)
+            reportsDir.convention(
+                project.extensions.getByType(ReportingExtension::class.java).baseDirectory.dir("detekt")
+            )
+            basePath.convention(project.rootProject.layout.projectDirectory)
+        }
+
+        val defaultConfigFile =
+            project.file("${project.rootProject.layout.projectDirectory.dir(CONFIG_DIR_NAME)}/$CONFIG_FILE")
+        if (defaultConfigFile.exists()) {
+            extension.config.setFrom(project.files(defaultConfigFile))
+        }
+    }
+
+    internal companion object {
+        internal const val DETEKT_EXTENSION = "detekt"
+        internal const val CONFIG_DIR_NAME = "config/detekt"
+        internal const val CONFIG_FILE = "detekt.yml"
+
+        internal const val DEFAULT_SRC_DIR_JAVA = "src/main/java"
+        internal const val DEFAULT_TEST_SRC_DIR_JAVA = "src/test/java"
+        internal const val DEFAULT_SRC_DIR_KOTLIN = "src/main/kotlin"
+        internal const val DEFAULT_TEST_SRC_DIR_KOTLIN = "src/test/kotlin"
+        internal const val DEFAULT_DEBUG_VALUE = false
+        internal const val DEFAULT_IGNORE_FAILURES = false
+        internal const val DEFAULT_PARALLEL_VALUE = false
+        internal const val DEFAULT_AUTO_CORRECT_VALUE = false
+        internal const val DEFAULT_DISABLE_RULESETS_VALUE = false
+        internal const val DEFAULT_ALL_RULES_VALUE = false
+        internal const val DEFAULT_BUILD_UPON_DEFAULT_CONFIG_VALUE = false
+
+        // This flag is ignored unless the compiler plugin is applied to the project
+        internal const val DEFAULT_COMPILER_PLUGIN_ENABLED = true
     }
 }

--- a/detekt-gradle-plugin/src/main/kotlin/io/github/detekt/gradle/DetektKotlinCompilerPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/github/detekt/gradle/DetektKotlinCompilerPlugin.kt
@@ -1,17 +1,14 @@
 package io.github.detekt.gradle
 
 import dev.detekt.gradle.plugin.DetektBasePlugin
+import dev.detekt.gradle.plugin.DetektBasePlugin.Companion.DETEKT_EXTENSION
 import io.github.detekt.gradle.extensions.KotlinCompileTaskDetektExtension
 import io.gitlab.arturbosch.detekt.CONFIGURATION_DETEKT_PLUGINS
 import io.gitlab.arturbosch.detekt.DetektPlugin
-import io.gitlab.arturbosch.detekt.DetektPlugin.Companion.CONFIG_DIR_NAME
-import io.gitlab.arturbosch.detekt.DetektPlugin.Companion.CONFIG_FILE
-import io.gitlab.arturbosch.detekt.DetektPlugin.Companion.DETEKT_EXTENSION
 import io.gitlab.arturbosch.detekt.extensions.DetektExtension
 import org.gradle.api.Project
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.provider.Provider
-import org.gradle.api.reporting.ReportingExtension
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilerPluginSupportPlugin
 import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
@@ -30,21 +27,7 @@ class DetektKotlinCompilerPlugin : KotlinCompilerPluginSupportPlugin {
     override fun apply(target: Project) {
         target.pluginManager.apply(DetektBasePlugin::class.java)
 
-        val extension =
-            target.extensions.findByType(DetektExtension::class.java) ?: target.extensions.create(
-                DETEKT_EXTENSION,
-                DetektExtension::class.java
-            )
-
-        extension.reportsDir.convention(
-            target.extensions.getByType(ReportingExtension::class.java).baseDirectory.dir("detekt")
-        )
-
-        val defaultConfigFile =
-            target.file("${target.rootProject.layout.projectDirectory.dir(CONFIG_DIR_NAME)}/$CONFIG_FILE")
-        if (defaultConfigFile.exists()) {
-            extension.config.setFrom(target.files(defaultConfigFile))
-        }
+        val extension = target.extensions.getByType(DetektExtension::class.java)
 
         target.configurations.maybeCreate(CONFIGURATION_DETEKT_PLUGINS).apply {
             isVisible = false

--- a/detekt-gradle-plugin/src/main/kotlin/io/github/detekt/gradle/DetektKotlinCompilerPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/github/detekt/gradle/DetektKotlinCompilerPlugin.kt
@@ -1,5 +1,6 @@
 package io.github.detekt.gradle
 
+import dev.detekt.gradle.plugin.DetektBasePlugin
 import io.github.detekt.gradle.extensions.KotlinCompileTaskDetektExtension
 import io.gitlab.arturbosch.detekt.CONFIGURATION_DETEKT_PLUGINS
 import io.gitlab.arturbosch.detekt.DetektPlugin
@@ -28,6 +29,7 @@ import java.util.Properties
 class DetektKotlinCompilerPlugin : KotlinCompilerPluginSupportPlugin {
 
     override fun apply(target: Project) {
+        target.pluginManager.apply(DetektBasePlugin::class.java)
         target.pluginManager.apply(ReportingBasePlugin::class.java)
 
         val extension =

--- a/detekt-gradle-plugin/src/main/kotlin/io/github/detekt/gradle/DetektKotlinCompilerPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/github/detekt/gradle/DetektKotlinCompilerPlugin.kt
@@ -10,7 +10,6 @@ import io.gitlab.arturbosch.detekt.DetektPlugin.Companion.DETEKT_EXTENSION
 import io.gitlab.arturbosch.detekt.extensions.DetektExtension
 import org.gradle.api.Project
 import org.gradle.api.file.ConfigurableFileCollection
-import org.gradle.api.plugins.ReportingBasePlugin
 import org.gradle.api.provider.Provider
 import org.gradle.api.reporting.ReportingExtension
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
@@ -30,7 +29,6 @@ class DetektKotlinCompilerPlugin : KotlinCompilerPluginSupportPlugin {
 
     override fun apply(target: Project) {
         target.pluginManager.apply(DetektBasePlugin::class.java)
-        target.pluginManager.apply(ReportingBasePlugin::class.java)
 
         val extension =
             target.extensions.findByType(DetektExtension::class.java) ?: target.extensions.create(

--- a/detekt-gradle-plugin/src/main/kotlin/io/github/detekt/gradle/DetektKotlinCompilerPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/github/detekt/gradle/DetektKotlinCompilerPlugin.kt
@@ -1,9 +1,9 @@
 package io.github.detekt.gradle
 
+import dev.detekt.gradle.plugin.CONFIGURATION_DETEKT_PLUGINS
 import dev.detekt.gradle.plugin.DetektBasePlugin
 import dev.detekt.gradle.plugin.DetektBasePlugin.Companion.DETEKT_EXTENSION
 import io.github.detekt.gradle.extensions.KotlinCompileTaskDetektExtension
-import io.gitlab.arturbosch.detekt.CONFIGURATION_DETEKT_PLUGINS
 import io.gitlab.arturbosch.detekt.DetektPlugin
 import io.gitlab.arturbosch.detekt.extensions.DetektExtension
 import org.gradle.api.Project
@@ -28,12 +28,6 @@ class DetektKotlinCompilerPlugin : KotlinCompilerPluginSupportPlugin {
         target.pluginManager.apply(DetektBasePlugin::class.java)
 
         val extension = target.extensions.getByType(DetektExtension::class.java)
-
-        target.configurations.maybeCreate(CONFIGURATION_DETEKT_PLUGINS).apply {
-            isVisible = false
-            isTransitive = true
-            description = "The $CONFIGURATION_DETEKT_PLUGINS libraries to be used for this project."
-        }
 
         target.tasks.withType(KotlinCompile::class.java).configureEach { task ->
             task.extensions.create(DETEKT_EXTENSION, KotlinCompileTaskDetektExtension::class.java, target).apply {

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
@@ -10,8 +10,6 @@ import io.gitlab.arturbosch.detekt.internal.DetektPlain
 import org.gradle.api.Incubating
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.plugins.ReportingBasePlugin
-import org.gradle.api.reporting.ReportingExtension
 import java.net.URL
 import java.util.jar.Manifest
 
@@ -19,7 +17,6 @@ class DetektPlugin : Plugin<Project> {
 
     override fun apply(project: Project) {
         project.pluginManager.apply(DetektBasePlugin::class.java)
-        project.pluginManager.apply(ReportingBasePlugin::class.java)
         val extension =
             project.extensions.findByType(DetektExtension::class.java) ?: project.extensions.create(
                 DETEKT_EXTENSION,

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
@@ -1,8 +1,9 @@
 package io.gitlab.arturbosch.detekt
 
 import dev.detekt.gradle.plugin.DetektBasePlugin
+import dev.detekt.gradle.plugin.DetektBasePlugin.Companion.CONFIG_DIR_NAME
+import dev.detekt.gradle.plugin.DetektBasePlugin.Companion.CONFIG_FILE
 import io.gitlab.arturbosch.detekt.extensions.DetektExtension
-import io.gitlab.arturbosch.detekt.extensions.loadDetektVersion
 import io.gitlab.arturbosch.detekt.internal.DetektAndroid
 import io.gitlab.arturbosch.detekt.internal.DetektJvm
 import io.gitlab.arturbosch.detekt.internal.DetektMultiplatform
@@ -17,40 +18,8 @@ class DetektPlugin : Plugin<Project> {
 
     override fun apply(project: Project) {
         project.pluginManager.apply(DetektBasePlugin::class.java)
-        val extension =
-            project.extensions.findByType(DetektExtension::class.java) ?: project.extensions.create(
-                DETEKT_EXTENSION,
-                DetektExtension::class.java
-            )
 
-        with(extension) {
-            toolVersion.convention(loadDetektVersion(DetektExtension::class.java.classLoader))
-            ignoreFailures.convention(DEFAULT_IGNORE_FAILURES)
-            source.setFrom(
-                DEFAULT_SRC_DIR_JAVA,
-                DEFAULT_TEST_SRC_DIR_JAVA,
-                DEFAULT_SRC_DIR_KOTLIN,
-                DEFAULT_TEST_SRC_DIR_KOTLIN,
-            )
-            baseline.convention(project.layout.projectDirectory.file("detekt-baseline.xml"))
-            enableCompilerPlugin.convention(DEFAULT_COMPILER_PLUGIN_ENABLED)
-            debug.convention(DEFAULT_DEBUG_VALUE)
-            parallel.convention(DEFAULT_PARALLEL_VALUE)
-            allRules.convention(DEFAULT_ALL_RULES_VALUE)
-            buildUponDefaultConfig.convention(DEFAULT_BUILD_UPON_DEFAULT_CONFIG_VALUE)
-            disableDefaultRuleSets.convention(DEFAULT_DISABLE_RULESETS_VALUE)
-            autoCorrect.convention(DEFAULT_AUTO_CORRECT_VALUE)
-            reportsDir.convention(
-                project.extensions.getByType(ReportingExtension::class.java).baseDirectory.dir("detekt")
-            )
-            basePath.convention(project.rootProject.layout.projectDirectory)
-        }
-
-        val defaultConfigFile =
-            project.file("${project.rootProject.layout.projectDirectory.dir(CONFIG_DIR_NAME)}/$CONFIG_FILE")
-        if (defaultConfigFile.exists()) {
-            extension.config.setFrom(project.files(defaultConfigFile))
-        }
+        val extension = project.extensions.getByType(DetektExtension::class.java)
 
         configurePluginDependencies(project, extension)
         setTaskDefaults(project)
@@ -147,31 +116,14 @@ class DetektPlugin : Plugin<Project> {
     internal companion object {
         internal const val DETEKT_TASK_NAME = "detekt"
         internal const val BASELINE_TASK_NAME = "detektBaseline"
-        internal const val DETEKT_EXTENSION = "detekt"
         private const val GENERATE_CONFIG = "detektGenerateConfig"
         val defaultExcludes = listOf("build/")
         val defaultIncludes = listOf("**/*.kt", "**/*.kts")
-        internal const val CONFIG_DIR_NAME = "config/detekt"
-        internal const val CONFIG_FILE = "detekt.yml"
 
         internal const val DETEKT_ANDROID_DISABLED_PROPERTY = "detekt.android.disabled"
         internal const val DETEKT_MULTIPLATFORM_DISABLED_PROPERTY = "detekt.multiplatform.disabled"
 
-        internal const val DEFAULT_SRC_DIR_JAVA = "src/main/java"
-        internal const val DEFAULT_TEST_SRC_DIR_JAVA = "src/test/java"
-        internal const val DEFAULT_SRC_DIR_KOTLIN = "src/main/kotlin"
-        internal const val DEFAULT_TEST_SRC_DIR_KOTLIN = "src/test/kotlin"
-        internal const val DEFAULT_DEBUG_VALUE = false
-        internal const val DEFAULT_IGNORE_FAILURES = false
-        internal const val DEFAULT_PARALLEL_VALUE = false
-        internal const val DEFAULT_AUTO_CORRECT_VALUE = false
-        internal const val DEFAULT_DISABLE_RULESETS_VALUE = false
         internal const val DEFAULT_REPORT_ENABLED_VALUE = true
-        internal const val DEFAULT_ALL_RULES_VALUE = false
-        internal const val DEFAULT_BUILD_UPON_DEFAULT_CONFIG_VALUE = false
-
-        // This flag is ignored unless the compiler plugin is applied to the project
-        internal const val DEFAULT_COMPILER_PLUGIN_ENABLED = true
     }
 }
 

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt
 
+import dev.detekt.gradle.plugin.CONFIGURATION_DETEKT_PLUGINS
 import dev.detekt.gradle.plugin.DetektBasePlugin
 import dev.detekt.gradle.plugin.DetektBasePlugin.Companion.CONFIG_DIR_NAME
 import dev.detekt.gradle.plugin.DetektBasePlugin.Companion.CONFIG_FILE
@@ -74,14 +75,6 @@ class DetektPlugin : Plugin<Project> {
     }
 
     private fun configurePluginDependencies(project: Project, extension: DetektExtension) {
-        project.configurations.maybeCreate(CONFIGURATION_DETEKT_PLUGINS).let { configuration ->
-            configuration.isVisible = false
-            configuration.isTransitive = true
-            configuration.description = "The $CONFIGURATION_DETEKT_PLUGINS libraries to be used for this project."
-            configuration.isCanBeResolved = true
-            configuration.isCanBeConsumed = false
-        }
-
         project.configurations.create(CONFIGURATION_DETEKT) { configuration ->
             configuration.isVisible = false
             configuration.isTransitive = true
@@ -128,7 +121,6 @@ class DetektPlugin : Plugin<Project> {
 }
 
 internal const val CONFIGURATION_DETEKT = "detekt"
-internal const val CONFIGURATION_DETEKT_PLUGINS = "detektPlugins"
 internal const val USE_WORKER_API = "detekt.use.worker.api"
 
 @Incubating

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt
 
+import dev.detekt.gradle.plugin.DetektBasePlugin
 import io.gitlab.arturbosch.detekt.extensions.DetektExtension
 import io.gitlab.arturbosch.detekt.extensions.loadDetektVersion
 import io.gitlab.arturbosch.detekt.internal.DetektAndroid
@@ -17,6 +18,7 @@ import java.util.jar.Manifest
 class DetektPlugin : Plugin<Project> {
 
     override fun apply(project: Project) {
+        project.pluginManager.apply(DetektBasePlugin::class.java)
         project.pluginManager.apply(ReportingBasePlugin::class.java)
         val extension =
             project.extensions.findByType(DetektExtension::class.java) ?: project.extensions.create(


### PR DESCRIPTION
Create DetektBasePlugin for DGP. This is used to apply configuration that's common to the Gradle plugin for the Kotlin compiler plugin as well as the classic plugin, which removes some duplication and should make it easier to reason about the responsibilities of each plugin.

The base plugin is responsible for creating the project extension and configuring it, as well as creating the `detektPlugins` configuration (which is used by both other plugins). The classic plugin sets up the detekt tasks for each compilation. The compiler plugin configures the compiler plugin tasks.