### PR TITLE
Better example for UseLet rule

### DIFF
--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseLet.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseLet.kt
@@ -20,12 +20,12 @@ import org.jetbrains.kotlin.psi.KtPsiUtil
  * `null` in the truthy case are better represented as `?.let {}` blocks.
  *
  * <noncompliant>
- * if (x != null) { x.transform() } else null
+ * if (x != null) { transform(x) } else null
  * if (x == null) null else y
  * </noncompliant>
  *
  * <compliant>
- * x?.let { it.transform() }
+ * x?.let { transform(it) }
  * x?.let { y }
  * </compliant>
  */

--- a/website/versioned_docs/version-1.23.0/rules/style.md
+++ b/website/versioned_docs/version-1.23.0/rules/style.md
@@ -2886,14 +2886,14 @@ if (x.isNullOrEmpty()) return
 #### Noncompliant Code:
 
 ```kotlin
-if (x != null) { x.transform() } else null
+if (x != null) { transform(x) } else null
 if (x == null) null else y
 ```
 
 #### Compliant Code:
 
 ```kotlin
-x?.let { it.transform() }
+x?.let { transform(it) }
 x?.let { y }
 ```
 

--- a/website/versioned_docs/version-1.23.1/rules/style.md
+++ b/website/versioned_docs/version-1.23.1/rules/style.md
@@ -2888,14 +2888,14 @@ if (x.isNullOrEmpty()) return
 #### Noncompliant Code:
 
 ```kotlin
-if (x != null) { x.transform() } else null
+if (x != null) { transform(x) } else null
 if (x == null) null else y
 ```
 
 #### Compliant Code:
 
 ```kotlin
-x?.let { it.transform() }
+x?.let { transform(it) }
 x?.let { y }
 ```
 


### PR DESCRIPTION
Fixes #6552

Added a better example for `UseLet` rule, that can't be rewritten in a shorter form.