### PR TITLE
UnnecessaryAny - Add rule to prevent usage of `any { }` when simple `contains` can be …

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -726,6 +726,8 @@ style:
     allowNonStandardGrouping: false
   UnnecessaryAnnotationUseSiteTarget:
     active: false
+  UnnecessaryAny:
+    active: false
   UnnecessaryApply:
     active: true
   UnnecessaryBackticks:

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/StyleGuideProvider.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/StyleGuideProvider.kt
@@ -74,6 +74,7 @@ class StyleGuideProvider : DefaultRuleSetProvider {
             RedundantVisibilityModifierRule(config),
             RangeUntilInsteadOfRangeTo(config),
             UnnecessaryApply(config),
+            UnnecessaryAny(config),
             UnnecessaryBracesAroundTrailingLambda(config),
             UnnecessaryFilter(config),
             UnnecessaryLet(config),

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAny.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAny.kt
@@ -1,0 +1,178 @@
+package io.gitlab.arturbosch.detekt.rules.style
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
+import io.gitlab.arturbosch.detekt.rules.firstParameter
+import io.gitlab.arturbosch.detekt.rules.isCalling
+import org.jetbrains.kotlin.contracts.parsing.isEqualsDescriptor
+import org.jetbrains.kotlin.descriptors.ValueParameterDescriptor
+import org.jetbrains.kotlin.js.translate.callTranslator.getReturnType
+import org.jetbrains.kotlin.lexer.KtTokens
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.psi.KtBinaryExpression
+import org.jetbrains.kotlin.psi.KtBlockExpression
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
+import org.jetbrains.kotlin.psi.KtExpression
+import org.jetbrains.kotlin.psi.KtLambdaExpression
+import org.jetbrains.kotlin.psi.KtNameReferenceExpression
+import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.KtReferenceExpression
+import org.jetbrains.kotlin.psi.KtReturnExpression
+import org.jetbrains.kotlin.psi.psiUtil.collectDescendantsOfType
+import org.jetbrains.kotlin.resolve.BindingContext
+import org.jetbrains.kotlin.resolve.calls.util.getResolvedCall
+import org.jetbrains.kotlin.types.typeUtil.isSubtypeOf
+
+/**
+ * Turn on this rule to flag usage of `any` to check the presence of an element that can be
+ * replaced with simpler `contains` call.
+ *
+ * <noncompliant>
+ * val a = 1
+ * list.any { it == a }
+ * </noncompliant>
+ *
+ * <compliant>
+ * val a = 1
+ * list.contains(a)
+ * </compliant>
+ */
+@RequiresTypeResolution
+class UnnecessaryAny(config: Config = Config.empty) : Rule(config) {
+    override val issue: Issue = Issue(
+        javaClass.simpleName,
+        "Use `contains` instead of `any {  }` call to check the presence of the element",
+        Debt.FIVE_MINS
+    )
+
+    override fun visitCallExpression(expression: KtCallExpression) {
+        super.visitCallExpression(expression)
+        if (expression.isCallingAny() && shouldBeReported(expression)) {
+            report(
+                CodeSmell(
+                    issue,
+                    Entity.from(expression),
+                    "Use `contains` instead of `any {  }` call to check the presence of the element"
+                )
+            )
+        }
+    }
+
+    @Suppress("ReturnCount")
+    private fun shouldBeReported(expression: KtCallExpression): Boolean {
+        val valueArgument = expression.valueArguments.getOrNull(0) ?: return false
+        return when (val valueExpression = valueArgument.getArgumentExpression()) {
+            is KtLambdaExpression -> {
+                val bodyExpression = valueExpression.bodyExpression ?: return false
+                bodyExpression.isBodyContainsEligibleEqualityCheck(
+                    valueExpression.firstParameter(bindingContext)
+                )
+            }
+
+            is KtNamedFunction -> {
+                val valueParameterDescriptor =
+                    bindingContext[
+                        BindingContext.DECLARATION_TO_DESCRIPTOR, valueExpression.valueParameters[0]
+                    ] as? ValueParameterDescriptor ?: return false
+                val bodyExpression =
+                    valueExpression.bodyExpression as? KtBlockExpression
+                        ?: return valueExpression.bodyExpression?.isEligibleEqualityCheck(
+                            valueParameterDescriptor,
+                        ) == true
+                bodyExpression.isBodyContainsEligibleEqualityCheck(valueParameterDescriptor)
+            }
+
+            else -> {
+                false
+            }
+        }
+    }
+
+    private fun KtBlockExpression.isBodyContainsEligibleEqualityCheck(itParameter: ValueParameterDescriptor?): Boolean {
+        if (this.statements.isEmpty() || this.statements.size != 1) return false
+
+        val firstStatement = this.statements[0]
+        val statement = if (firstStatement is KtReturnExpression) {
+            firstStatement.returnedExpression
+        } else {
+            firstStatement
+        } ?: return false
+
+        return statement.isEligibleEqualityCheck(itParameter)
+    }
+
+    private fun KtExpression.isEligibleEqualityCheck(itParameter: ValueParameterDescriptor?): Boolean {
+        return when {
+            this is KtBinaryExpression && operationToken == KtTokens.EQEQ -> {
+                isUsageOfValueAndItCorrect(itParameter, left, right)
+            }
+
+            this is KtDotQualifiedExpression && selectorExpression.isCallingEquals() -> {
+                isUsageOfValueAndItCorrect(
+                    itParameter,
+                    receiverExpression,
+                    (selectorExpression as? KtCallExpression)?.valueArguments?.getOrNull(0)
+                        ?.getArgumentExpression()
+                )
+            }
+
+            else -> {
+                false
+            }
+        }
+    }
+
+    @Suppress("ReturnCount")
+    private fun isUsageOfValueAndItCorrect(
+        itParameterDescriptor: ValueParameterDescriptor?,
+        leftExpression: KtExpression?,
+        rightExpression: KtExpression?
+    ): Boolean {
+        leftExpression ?: return false
+        rightExpression ?: return true
+
+        fun KtExpression.getItUsageCount() =
+            collectDescendantsOfType<KtNameReferenceExpression>().count {
+                bindingContext[BindingContext.REFERENCE_TARGET, it] == itParameterDescriptor
+            }
+
+        val itRefCountInLeft = leftExpression.getItUsageCount()
+        val itRefCountInRight = rightExpression.getItUsageCount()
+        return if (itIsPresentOnOneSide(itRefCountInLeft, itRefCountInRight)) {
+            // both side `it` has been used or no side uses `it`
+            false
+        } else if (itRefCountInRight > 0) {
+            // reversing the order of parameter
+            isUsageOfValueAndItCorrect(itParameterDescriptor, rightExpression, leftExpression)
+        } else {
+            val valueExpressionType =
+                rightExpression.getResolvedCall(bindingContext)?.getReturnType() ?: return false
+            val itExpressionType =
+                leftExpression.getResolvedCall(bindingContext)?.getReturnType() ?: return false
+            leftExpression is KtReferenceExpression &&
+                valueExpressionType.isSubtypeOf(itExpressionType)
+        }
+    }
+
+    private fun itIsPresentOnOneSide(itRefCountInLeft: Int, itRefCountInRight: Int) =
+        itRefCountInLeft > 0 && itRefCountInRight > 0 ||
+            itRefCountInLeft == 0 && itRefCountInRight == 0
+
+    private fun KtCallExpression.isCallingAny(): Boolean = isCalling(anyFqName, bindingContext)
+
+    private fun KtExpression?.isCallingEquals(): Boolean {
+        this ?: return false
+        val resolvedCall = this.getResolvedCall(bindingContext) ?: return false
+        return resolvedCall.resultingDescriptor.isEqualsDescriptor()
+    }
+
+    companion object {
+        private val anyFqName = FqName("kotlin.collections.any")
+    }
+}

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAnySpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAnySpec.kt
@@ -1,0 +1,425 @@
+package io.gitlab.arturbosch.detekt.rules.style
+
+import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
+import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@KotlinCoreEnvironmentTest
+class UnnecessaryAnySpec(val env: KotlinCoreEnvironment) {
+    val subject = UnnecessaryAny()
+
+    @Test
+    fun `reports any which is used for checking presence of a element`() {
+        val code = """
+            fun test(list: List<Int>, value: Int) {
+                list.any { it == value }
+            }
+        """.trimIndent()
+        val actual = subject.compileAndLintWithContext(env, code)
+        assertThat(actual).hasSize(1)
+        assertThat(actual[0].message)
+            .isEqualTo(
+                "Use `contains` instead of `any {  }` call to check the presence of the element"
+            )
+    }
+
+    @Test
+    fun `does not report when contains is used`() {
+        val code = """
+            fun test(list: List<Int>, value: Int) {
+                list.contains(value)
+            }
+        """.trimIndent()
+        val actual = subject.compileAndLintWithContext(env, code)
+        assertThat(actual).isEmpty()
+    }
+
+    @Test
+    fun `reports any with modified value which is used for checking presence of a element`() {
+        val code = """
+            fun test(list: List<Int>, value: Int) {
+                list.any { it == value * value }
+            }
+        """.trimIndent()
+        val actual = subject.compileAndLintWithContext(env, code)
+        assertThat(actual).hasSize(1)
+    }
+
+    @Test
+    fun `does not report any with modified it which is used for checking presence of a element`() {
+        val code = """
+            fun test(list: List<Int>, value: Int) {
+                list.any { it * it == value }
+            }
+        """.trimIndent()
+        val actual = subject.compileAndLintWithContext(env, code)
+        assertThat(actual).isEmpty()
+    }
+
+    @Test
+    fun `does not report any value is used with it`() {
+        val code = """
+            fun test(list: List<Int>, value: Int) {
+                list.any { it == it * value }
+                list.any { it * value == it }
+            }
+        """.trimIndent()
+        val actual = subject.compileAndLintWithContext(env, code)
+        assertThat(actual).isEmpty()
+    }
+
+    @Test
+    fun `reports any with explicit return which is used for checking presence of a element`() {
+        val code = """
+            fun test(list: List<Int>, value: Int) {
+                list.any { return@any it == value }
+            }
+        """.trimIndent()
+        val actual = subject.compileAndLintWithContext(env, code)
+        assertThat(actual).hasSize(1)
+    }
+
+    @Test
+    fun `reports any with equals call which is used for checking presence of a element`() {
+        val code = """
+            fun test(list: List<Int>, value: Int) {
+                list.any { it.equals(value) }
+            }
+        """.trimIndent()
+        val actual = subject.compileAndLintWithContext(env, code)
+        assertThat(actual).hasSize(1)
+    }
+
+    @Test
+    fun `reports any with reverse equals call which is used for checking presence of a element`() {
+        val code = """
+            fun test(list: List<Int>, value: Int) {
+                list.any { value.equals(it) }
+            }
+        """.trimIndent()
+        val actual = subject.compileAndLintWithContext(env, code)
+        assertThat(actual).hasSize(1)
+    }
+
+    @Test
+    fun `does not report any with custom equals method for checking presence of a element`() {
+        val code = """
+            fun test(list: List<Custom>, value: Custom) {
+                list.any { it.equals(value) }
+            }
+            class Custom {
+                fun equals(value: Custom) = false
+            }
+        """.trimIndent()
+        val actual = subject.compileAndLintWithContext(env, code)
+        assertThat(actual).isEmpty()
+    }
+
+    @Test
+    fun `does not report any with safe call which is used for checking presence of a element`() {
+        val code = """
+            fun test(list: List<Int>, value: Int?) {
+                list.any { value?.equals(it) == true }
+            }
+        """.trimIndent()
+        val actual = subject.compileAndLintWithContext(env, code)
+        assertThat(actual).isEmpty()
+    }
+
+    @Test
+    fun `does not report any when it is modified`() {
+        val code = """
+            fun test(list: List<Int>, value: Int) {
+                list.any { value.equals(2 * it) }
+            }
+        """.trimIndent()
+        val actual = subject.compileAndLintWithContext(env, code)
+        assertThat(actual).isEmpty()
+    }
+
+    @Test
+    fun `does not report any when it is not used`() {
+        val code = """
+            fun test(list: List<Int>, value: Int) {
+                list.any { value == 2 }
+                list.any { 2 == value }
+            }
+        """.trimIndent()
+        val actual = subject.compileAndLintWithContext(env, code)
+        assertThat(actual).isEmpty()
+    }
+
+    @Test
+    fun `does report any when value is modified`() {
+        val code = """
+            fun test(list: List<Int>, value: Int) {
+                list.any { it.equals(2 * value) }
+            }
+        """.trimIndent()
+        val actual = subject.compileAndLintWithContext(env, code)
+        assertThat(actual).hasSize(1)
+    }
+
+    @Test
+    fun `reports any with reverse condition which is used for checking presence of a element`() {
+        val code = """
+            fun test(list: List<Int>, value: Int) {
+                list.any { value == it }
+            }
+        """.trimIndent()
+        val actual = subject.compileAndLintWithContext(env, code)
+        assertThat(actual).hasSize(1)
+    }
+
+    @Test
+    fun `reports any with multiline binary which is used for checking presence of a element`() {
+        val code = """
+            fun test(list: List<Int>, veryVeryVeryVeryVeryVeryVeryBigVariableName: Int) {
+                list.any { 
+                    it == 
+                        veryVeryVeryVeryVeryVeryVeryBigVariableName 
+                }
+            }
+        """.trimIndent()
+        val actual = subject.compileAndLintWithContext(env, code)
+        assertThat(actual).hasSize(1)
+    }
+
+    @Test
+    fun `reports any with explicit lambda signature which is used for checking presence of a element`() {
+        val code = """
+            fun test(list: List<Int>, value: Int) {
+                list.any { it: Int -> it == value }
+            }
+        """.trimIndent()
+        val actual = subject.compileAndLintWithContext(env, code)
+        assertThat(actual).hasSize(1)
+    }
+
+    @Test
+    fun `reports any with name argument lambda which is used for checking presence of a element`() {
+        val code = """
+            fun test(list: List<Int>, value: Int) {
+                list.any(predicate = { it == value })
+            }
+        """.trimIndent()
+        val actual = subject.compileAndLintWithContext(env, code)
+        assertThat(actual).hasSize(1)
+    }
+
+    @Test
+    fun `reports any with lambda inside parenthesis signature which is used for checking presence of a element`() {
+        val code = """
+            fun test(list: List<Int>, value: Int) {
+                list.any({ it == value })
+            }
+        """.trimIndent()
+        val actual = subject.compileAndLintWithContext(env, code)
+        assertThat(actual).hasSize(1)
+    }
+
+    @Test
+    fun `reports any with anonymous function which is used for checking presence of a element`() {
+        val code = """
+            fun test(list: List<Int>, value: Int) {
+                list.any(fun(it: Int): Boolean {
+                    return it == value
+                })
+            }
+        """.trimIndent()
+        val actual = subject.compileAndLintWithContext(env, code)
+        assertThat(actual).hasSize(1)
+    }
+
+    @Test
+    fun `reports any with anonymous function with expression body which is used for checking presence of a element`() {
+        val code = """
+            fun test(list: List<Int>, value: Int) {
+                list.any(fun(it: Int) = it == value)
+            }
+        """.trimIndent()
+        val actual = subject.compileAndLintWithContext(env, code)
+        assertThat(actual).hasSize(1)
+    }
+
+    @Test
+    fun `does not report any with no parameter`() {
+        val code = """
+            fun test(list: List<Int>, value: Int) {
+                list.any()
+            }
+        """.trimIndent()
+        val actual = subject.compileAndLintWithContext(env, code)
+        assertThat(actual).isEmpty()
+    }
+
+    @Test
+    fun `does not report any having extra statement`() {
+        val code = """
+            fun test(list: List<Int>, value: Int) {
+                list.any {
+                    println(it)
+                    it == value
+                }
+            }
+        """.trimIndent()
+        val actual = subject.compileAndLintWithContext(env, code)
+        assertThat(actual).isEmpty()
+    }
+
+    @Test
+    fun `does not report any having not eq condition`() {
+        val code = """
+            fun test(list: List<Int>, value: Int) {
+                list.any {
+                    it != value
+                }
+            }
+        """.trimIndent()
+        val actual = subject.compileAndLintWithContext(env, code)
+        assertThat(actual).isEmpty()
+    }
+
+    @Test
+    fun `does not report any with generic param where value is not generic`() {
+        val code = """
+            fun <M>test(list: List<M>, value: Any) {
+                list.any {
+                    it == value
+                }
+            }
+        """.trimIndent()
+        val actual = subject.compileAndLintWithContext(env, code)
+        assertThat(actual).isEmpty()
+    }
+
+    @Test
+    fun `does report any when value is nonnull subtype`() {
+        val code = """
+            fun test(list: List<Int?>, value: Int) {
+                list.any {
+                    it == value
+                }
+            }
+        """.trimIndent()
+        val actual = subject.compileAndLintWithContext(env, code)
+        assertThat(actual).hasSize(1)
+    }
+
+    @Test
+    fun `does report any when value is subtype`() {
+        val code = """
+            fun test(list: List<Number>, value: Int) {
+                list.any {
+                    it == value
+                }
+            }
+        """.trimIndent()
+        val actual = subject.compileAndLintWithContext(env, code)
+        assertThat(actual).hasSize(1)
+    }
+
+    @Test
+    fun `does not report when it needs to operated before comparison`() {
+        val code = """
+            fun test() {
+                listOf(1F).any {
+                    it.toInt() == 2
+                }
+            }
+        """.trimIndent()
+        val actual = subject.compileAndLintWithContext(env, code)
+        assertThat(actual).isEmpty()
+    }
+
+    @Test
+    fun `does report when value needs to operated before comparison`() {
+        val code = """
+            fun test() {
+                listOf(1).any {
+                    it == 2.0.toInt()
+                }
+            }
+        """.trimIndent()
+        val actual = subject.compileAndLintWithContext(env, code)
+        assertThat(actual).hasSize(1)
+    }
+
+    @Nested
+    inner class `Given predicate is a reference` {
+        @Test
+        fun `does not report any with predicate which is used for checking presence of a element`() {
+            val code = """
+                fun test(list: List<Int>, value: Int) {
+                    val predicate = { it: Int -> it == value }
+                    list.any(predicate)
+                }
+            """.trimIndent()
+            val actual = subject.compileAndLintWithContext(env, code)
+            assertThat(actual).isEmpty()
+        }
+
+        @Test
+        fun `does not report any with predicate with type which is used for checking presence of a element`() {
+            val code = """
+                fun test(list: List<Int>, value: Int) {
+                    val predicate: (Int) -> Boolean = { it == value }
+                    list.any(predicate)
+                }
+            """.trimIndent()
+            val actual = subject.compileAndLintWithContext(env, code)
+            assertThat(actual).isEmpty()
+        }
+
+        @Test
+        fun `does not report any with predicate with anonymous fun which is used for checking presence of a element`() {
+            val code = """
+                fun test(list: List<Int>, value: Int) {
+                    val predicate: (Int) -> Boolean = fun(it: Int): Boolean {
+                        return it == value
+                    }
+                    list.any(predicate)
+                }
+            """.trimIndent()
+            val actual = subject.compileAndLintWithContext(env, code)
+            assertThat(actual).isEmpty()
+        }
+
+        @Test
+        fun `does not report any with predicate with parenthesis which is used for checking presence of a element`() {
+            val code = """
+                fun test(list: List<Int>, value: Int) {
+                    val predicate = ({ it: Int -> it == value })
+                    list.any(predicate)
+                }
+            """.trimIndent()
+            val actual = subject.compileAndLintWithContext(env, code)
+            assertThat(actual).isEmpty()
+        }
+
+        @Test
+        fun `does not report any with param which is used for checking presence of a element`() {
+            val code = """
+                fun test(list: List<Int>, value: Int, predicate: (Int) -> Boolean) {
+                    list.any(predicate)
+                }
+            """.trimIndent()
+            val actual = subject.compileAndLintWithContext(env, code)
+            assertThat(actual).isEmpty()
+        }
+
+        @Test
+        fun `does not report any with param with default which is used for checking presence of a element`() {
+            val code = """
+                fun test(list: List<Int>, value: Int, predicate: (Int) -> Boolean = { it == value }) {
+                    list.any(predicate)
+                }
+            """.trimIndent()
+            val actual = subject.compileAndLintWithContext(env, code)
+            assertThat(actual).isEmpty()
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/detekt/detekt/issues/6106
