### PR TITLE
Make sure contributors are filtered correctly in the changelog

### DIFF
--- a/scripts/github-milestone-report.main.kts
+++ b/scripts/github-milestone-report.main.kts
@@ -54,7 +54,6 @@ class GithubMilestoneReport : CliktCommand() {
         val ghMilestone: GHMilestone = ghRepository.getMilestone(milestoneId)
         var ghIssues: List<GHIssue> = ghRepository.getIssues(GHIssueState.CLOSED, ghMilestone)
             .filter { it.pullRequest != null }
-        val ghContributors = ghIssues.map { it.user.login }.distinct().sorted()
 
         if (filterExisting) {
             val changeLogContent = File("./website/src/pages/changelog.md").readText()
@@ -64,6 +63,7 @@ class GithubMilestoneReport : CliktCommand() {
         if (filterPickRequests) {
             ghIssues = ghIssues.filter { "pick request" in it.labels.map { it.name } }
         }
+        val ghContributors = ghIssues.map { it.user.login }.distinct().sorted()
 
         val milestoneTitle = ghMilestone.title.trim()
         val groups = ghIssues.groupBy { issue ->

--- a/website/src/pages/changelog.md
+++ b/website/src/pages/changelog.md
@@ -35,7 +35,7 @@ got reported by the community.
 
 ##### Contributors
 
-We would like to thank the following contributors that made this release possible: @3flex, @BraisGabin, @ErdoganSeref, @Goooler, @Hexcles, @LeoColman, @PoisonedYouth, @TWiStErRob, @VirtualParticle, @arturbosch, @atulgpt, @bric3, @chao2zhang, @cortinico, @dzirbel, @eygraber, @kkocel, @lexa-diky, @marschwar, @matejdro, @mdemianova, @pablobaxter, @rmarquis, @segunfamisa, @severn-everett, @t-kameyama
+We would like to thank the following contributors that made this release possible: @3fle, @arturbosc, @atulgp, @kkocel, @marschwa, @pablobaxte, @t-kameyama
 
 #### 1.23.1 - 2023-07-30
 


### PR DESCRIPTION
We should fetch contributors username after we filtered the PRs that go in the changelog, not before.