### PR TITLE
Prepare release 1.23.3

### DIFF
--- a/build-logic/src/main/kotlin/Versions.kt
+++ b/build-logic/src/main/kotlin/Versions.kt
@@ -2,7 +2,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 object Versions {
 
-    const val DETEKT: String = "1.23.2"
+    const val DETEKT: String = "1.23.3"
     const val SNAPSHOT_NAME: String = "main"
     val JVM_TARGET: JvmTarget = JvmTarget.JVM_1_8
 

--- a/website/src/pages/changelog.md
+++ b/website/src/pages/changelog.md
@@ -6,7 +6,13 @@ keywords: [changelog, release-notes, migration]
 
 # Changelog and Migration Guide
 
+#### 1.23.3 - 2023-10-31
+
+This is a point release for Detekt `1.23.0`. The changelog is equivalent to `1.23.2`.
+
 #### 1.23.2 - 2023-10-29
+
+**Note: please use version 1.23.3 instead as Kotlin 1.9.10 support was added there**
 
 This is a point release for Detekt `1.23.0`, where we added support for Kotlin `1.9.10` and fixed several bugs that
 got reported by the community.


### PR DESCRIPTION
The Kotlin 1.9.10 bump was missing on the release/1.x branch.
I've included it (see here https://github.com/detekt/detekt/tree/release/1.x) and I'm about to do another patch release.