### PR TITLE
[1.x] Minor cleanup post release

### DIFF
--- a/website/src/pages/changelog.md
+++ b/website/src/pages/changelog.md
@@ -41,7 +41,7 @@ got reported by the community.
 
 ##### Contributors
 
-We would like to thank the following contributors that made this release possible: @3fle, @arturbosc, @atulgp, @kkocel, @marschwa, @pablobaxte, @t-kameyama
+We would like to thank the following contributors that made this release possible: @3flex, @arturbosch, @atulgpt, @kkocel, @marschwar, @pablobaxter, @t-kameyama
 
 #### 1.23.1 - 2023-07-30
 

--- a/website/src/remark/detektVersionReplace.js
+++ b/website/src/remark/detektVersionReplace.js
@@ -3,7 +3,7 @@ const visit = require("unist-util-visit");
 // Remark plugin that is replacing the [detekt_version] with the latest
 // released version. Please note that this field is updated automatically 
 // by the `applyDocVersion` task.
-const detektVersion = "1.23.0";
+const detektVersion = "1.23.3";
 
 const plugin = (options) => {
   const transformer = async (ast) => {


### PR DESCRIPTION
Doing a bit of cleanup to the 1.x post the 1.23.3 release:
1. The changelog had contributor username accidentally cropped
2. The `applyDocVersion` task was not executed (not a major deal as we don't practically build docs from this branch, but let's keep things as much in sync as we can).
