### PR TITLE
Switch to kctfork for Kotlin compilation testing

### DIFF
--- a/detekt-compiler-plugin/src/test/kotlin/io/github/detekt/compiler/plugin/util/CompilerAssertions.kt
+++ b/detekt-compiler-plugin/src/test/kotlin/io/github/detekt/compiler/plugin/util/CompilerAssertions.kt
@@ -1,14 +1,14 @@
 package io.github.detekt.compiler.plugin.util
 
-import com.tschuchort.compiletesting.KotlinCompilation
+import com.tschuchort.compiletesting.JvmCompilationResult
 import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.COMPILATION_ERROR
 import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.OK
 import org.assertj.core.api.AbstractObjectAssert
 
-fun assertThat(result: KotlinCompilation.Result) = CompilationAssert(result)
+fun assertThat(result: JvmCompilationResult) = CompilationAssert(result)
 
-class CompilationAssert(private val result: KotlinCompilation.Result) :
-    AbstractObjectAssert<CompilationAssert, KotlinCompilation.Result>(result, CompilationAssert::class.java) {
+class CompilationAssert(private val result: JvmCompilationResult) :
+    AbstractObjectAssert<CompilationAssert, JvmCompilationResult>(result, CompilationAssert::class.java) {
 
     private val detektMessages = result.messages.split("\n")
         .dropWhile { "Running detekt" !in it }

--- a/detekt-compiler-plugin/src/test/kotlin/io/github/detekt/compiler/plugin/util/CompilerTestUtils.kt
+++ b/detekt-compiler-plugin/src/test/kotlin/io/github/detekt/compiler/plugin/util/CompilerTestUtils.kt
@@ -1,5 +1,6 @@
 package io.github.detekt.compiler.plugin.util
 
+import com.tschuchort.compiletesting.JvmCompilationResult
 import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.SourceFile
 import io.github.detekt.compiler.plugin.DetektCompilerPluginRegistrar
@@ -7,7 +8,7 @@ import org.intellij.lang.annotations.Language
 
 object CompilerTestUtils {
 
-    fun compile(@Language("kotlin") vararg kotlinSources: String): KotlinCompilation.Result {
+    fun compile(@Language("kotlin") vararg kotlinSources: String): JvmCompilationResult {
         val sourceFiles = kotlinSources.map {
             SourceFile.kotlin("KClass.kt", it, trimIndent = true)
         }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -40,7 +40,7 @@ classgraph = "io.github.classgraph:classgraph:4.8.163"
 mockk = "io.mockk:mockk:1.13.7"
 snakeyaml = "org.snakeyaml:snakeyaml-engine:2.7"
 jcommander = "org.jcommander:jcommander:1.83"
-kotlinCompileTesting = { module = "com.github.tschuchortdev:kotlin-compile-testing", version = "1.5.0" }
+kotlinCompileTesting = { module = "dev.zacsweers.kctfork:core", version = "0.4.0" }
 poko-annotations = { module = "dev.drewhamilton.poko:poko-annotations", version.ref = "poko" }
 
 [plugins]


### PR DESCRIPTION
The original project doesn't seem to be actively maintained. It's safe to assume that Zac will continue to maintain this fork for the foreseeable future.

The fork is already updated for 1.9.20. Sticking with the original project will block us for 1.9.20 due to https://github.com/tschuchortdev/kotlin-compile-testing/issues/390.