### PR TITLE
Fix issues related to kotlin-stdlib's Gradle module metadata in Kotlin 1.9.20

### DIFF
--- a/detekt-api/build.gradle.kts
+++ b/detekt-api/build.gradle.kts
@@ -13,7 +13,6 @@ dependencies {
     testImplementation(projects.detektTest)
     testImplementation(libs.assertj)
 
-    testFixturesApi(libs.kotlin.stdlibJdk8)
     testFixturesCompileOnly(libs.poko.annotations)
 }
 

--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -47,7 +47,6 @@ testing {
             useJUnitJupiter(libs.versions.junit.get())
 
             dependencies {
-                compileOnly("org.jetbrains:annotations:24.0.1")
                 implementation(libs.assertj)
                 implementation(testFixtures(project(":")))
             }
@@ -74,6 +73,7 @@ dependencies {
     compileOnly(libs.kotlin.gradle)
     compileOnly(libs.kotlin.gradlePluginApi)
     testFixturesCompileOnly("org.jetbrains:annotations:24.0.1")
+    compileOnly("org.jetbrains:annotations:24.0.1")
     compileOnly("io.gitlab.arturbosch.detekt:detekt-cli:1.23.3")
 
     testKitRuntimeOnly(libs.kotlin.gradle)


### PR DESCRIPTION
Gradle module metadata is published alongside kotlin-stdlib from 1.9.20 which caused a couple of dependency issues due to our use of [`useCompileClasspathVersions`](https://docs.gradle.org/8.4/javadoc/org/gradle/api/plugins/JavaResolutionConsistency.html#useCompileClasspathVersions--) for consistent dependency resolution.

This fixes them and will unblock 1.9.20 update.