### PR TITLE
Remove redundant association of functional test compilation to main compilation

### DIFF
--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -114,12 +114,6 @@ gradlePlugin {
     }
 }
 
-// Some functional tests reference internal functions in the Gradle plugin. This should become unnecessary as further
-// updates are made to the functional test suite.
-kotlin.target.compilations.getByName("functionalTest") {
-    associateWith(target.compilations.getByName("main"))
-}
-
 // Manually inject dependency to gradle-testkit since the default injected plugin classpath is from `main.runtime`.
 tasks.pluginUnderTestMetadata {
     pluginClasspath.from(testKitRuntimeOnly)


### PR DESCRIPTION
From Kotlin 1.9.20 test fixtures have access to internal declarations in main source set and test sources have access to internal declarations in test fixtures source set: https://kotlinlang.org/docs/whatsnew1920.html#support-for-test-fixtures-to-access-internal-declarations