### PR TITLE
Don't report FunctionNaming when the function's name equals to the return type's name with type arguments

### DIFF
--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNaming.kt
@@ -12,6 +12,7 @@ import io.gitlab.arturbosch.detekt.api.internal.Configuration
 import io.gitlab.arturbosch.detekt.rules.isOverride
 import io.gitlab.arturbosch.detekt.rules.naming.util.isContainingExcludedClassOrObject
 import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.KtUserType
 
 /**
  * Reports function names that do not follow the specified naming convention.
@@ -50,7 +51,7 @@ class FunctionNaming(config: Config = Config.empty) : Rule(config) {
         val functionName = function.nameIdentifier?.text ?: return
         if (!function.isContainingExcludedClassOrObject(excludeClassPattern) &&
             !functionName.matches(functionPattern) &&
-            functionName != function.typeReference?.text
+            functionName != function.returnTypeName()
         ) {
             report(
                 CodeSmell(
@@ -61,6 +62,8 @@ class FunctionNaming(config: Config = Config.empty) : Rule(config) {
             )
         }
     }
+
+    private fun KtNamedFunction.returnTypeName() = (typeReference?.typeElement as? KtUserType)?.referencedName
 
     companion object {
         const val FUNCTION_PATTERN = "functionPattern"

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNamingSpec.kt
@@ -77,6 +77,15 @@ class FunctionNamingSpec {
     }
 
     @Test
+    fun `does not report when the function's name equals to the return type's name with type arguments`() {
+        val code = """
+            interface Foo<T>
+            fun <T> Foo(): Foo<T> = object : Foo<T> {}
+        """.trimIndent()
+        assertThat(FunctionNaming().compileAndLint(code)).isEmpty()
+    }
+
+    @Test
     fun `flags functions with bad names inside overridden functions by default`() {
         val code = """
             class C : I {


### PR DESCRIPTION
Fixes #6601