### PR TITLE
Dynamically insert the version into ktlint rule links

### DIFF
--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/AnnotationOnSeparateLine.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/AnnotationOnSeparateLine.kt
@@ -11,7 +11,7 @@ import io.gitlab.arturbosch.detekt.api.internal.Configuration
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#annotation-formatting) for documentation.
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#annotation-formatting) for documentation.
  */
 @AutoCorrectable(since = "1.0.0")
 @ActiveByDefault(since = "1.22.0")

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/AnnotationSpacing.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/AnnotationSpacing.kt
@@ -7,7 +7,7 @@ import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#annotation-spacing) for documentation.
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#annotation-spacing) for documentation.
  */
 @AutoCorrectable(since = "1.0.0")
 @ActiveByDefault(since = "1.22.0")

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/ArgumentListWrapping.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/ArgumentListWrapping.kt
@@ -13,7 +13,7 @@ import io.gitlab.arturbosch.detekt.api.internal.Configuration
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#argument-list-wrapping) for documentation.
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#argument-list-wrapping) for documentation.
  */
 @AutoCorrectable(since = "1.0.0")
 @ActiveByDefault(since = "1.22.0")

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/BlockCommentInitialStarAlignment.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/BlockCommentInitialStarAlignment.kt
@@ -7,7 +7,7 @@ import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#block-comment-initial-star-alignment) for
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#block-comment-initial-star-alignment) for
  * documentation.
  */
 @ActiveByDefault(since = "1.23.0")

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/ChainWrapping.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/ChainWrapping.kt
@@ -11,7 +11,7 @@ import io.gitlab.arturbosch.detekt.api.internal.Configuration
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#chain-wrapping) for documentation.
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#chain-wrapping) for documentation.
  */
 @ActiveByDefault(since = "1.0.0")
 @AutoCorrectable(since = "1.0.0")

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/ClassName.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/ClassName.kt
@@ -5,7 +5,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#classobject-naming) for
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#classobject-naming) for
  * documentation.
  */
 class ClassName(config: Config) : FormattingRule(config) {

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/CommentSpacing.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/CommentSpacing.kt
@@ -7,7 +7,7 @@ import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#comment-spacing) for documentation.
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#comment-spacing) for documentation.
  */
 @ActiveByDefault(since = "1.0.0")
 @AutoCorrectable(since = "1.0.0")

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/CommentWrapping.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/CommentWrapping.kt
@@ -11,7 +11,7 @@ import io.gitlab.arturbosch.detekt.api.internal.Configuration
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#comment-wrapping) for documentation.
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#comment-wrapping) for documentation.
  */
 @ActiveByDefault(since = "1.23.0")
 @AutoCorrectable(since = "1.20.0")

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/ContextReceiverMapping.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/ContextReceiverMapping.kt
@@ -12,7 +12,7 @@ import io.gitlab.arturbosch.detekt.api.internal.Configuration
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#content-receiver-wrapping) for documentation.
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/experimental/#content-receiver-wrapping) for documentation.
  */
 @AutoCorrectable(since = "1.23.0")
 class ContextReceiverMapping(config: Config) : FormattingRule(config) {

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/DiscouragedCommentLocation.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/DiscouragedCommentLocation.kt
@@ -6,7 +6,7 @@ import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#discouraged-comment-location) for
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/experimental/#discouraged-comment-location) for
  * documentation.
  */
 @AutoCorrectable(since = "1.20.0")

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/EnumEntryNameCase.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/EnumEntryNameCase.kt
@@ -7,7 +7,7 @@ import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#enum-entry) for documentation.
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#enum-entry) for documentation.
  */
 @AutoCorrectable(since = "1.4.0")
 @ActiveByDefault(since = "1.22.0")

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/EnumWrapping.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/EnumWrapping.kt
@@ -10,7 +10,7 @@ import io.gitlab.arturbosch.detekt.api.internal.Configuration
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#enum-wrapping) for documentation.
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/experimental/#enum-wrapping) for documentation.
  */
 @AutoCorrectable(since = "1.23.0")
 class EnumWrapping(config: Config) : FormattingRule(config) {

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/Filename.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/Filename.kt
@@ -6,7 +6,7 @@ import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#file-name) for documentation.
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#file-name) for documentation.
  *
  * This rules overlaps with [naming>MatchingDeclarationName](https://detekt.dev/naming.html#matchingdeclarationname)
  * from the standard rules, make sure to enable just one.

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/FinalNewline.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/FinalNewline.kt
@@ -11,7 +11,7 @@ import io.gitlab.arturbosch.detekt.api.internal.Configuration
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#final-newline) for documentation.
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#final-newline) for documentation.
  *
  * This rules overlaps with [style>NewLineAtEndOfFile](https://detekt.dev/style.html#newlineatendoffile)
  * from the standard rules, make sure to enable just one. The pro of this rule is that it can auto-correct the issue.

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/FunKeywordSpacing.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/FunKeywordSpacing.kt
@@ -7,7 +7,7 @@ import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#fun-keyword-spacing) for documentation.
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#fun-keyword-spacing) for documentation.
  */
 @ActiveByDefault(since = "1.23.0")
 @AutoCorrectable(since = "1.20.0")

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/FunctionName.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/FunctionName.kt
@@ -5,7 +5,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#function-naming) for
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/experimental/#function-naming) for
  * documentation.
  */
 class FunctionName(config: Config) : FormattingRule(config) {

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/FunctionReturnTypeSpacing.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/FunctionReturnTypeSpacing.kt
@@ -11,7 +11,7 @@ import io.gitlab.arturbosch.detekt.api.internal.Configuration
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#function-return-type-spacing) for
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#function-return-type-spacing) for
  * documentation.
  */
 @ActiveByDefault(since = "1.23.0")

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/FunctionSignature.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/FunctionSignature.kt
@@ -12,7 +12,7 @@ import io.gitlab.arturbosch.detekt.api.internal.Configuration
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#function-signature) for
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/experimental/#function-signature) for
  * documentation.
  */
 @AutoCorrectable(since = "1.22.0")

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/FunctionStartOfBodySpacing.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/FunctionStartOfBodySpacing.kt
@@ -7,7 +7,7 @@ import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#function-start-of-body-spacing) for
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#function-start-of-body-spacing) for
  * documentation.
  */
 @ActiveByDefault(since = "1.23.0")

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/FunctionTypeReferenceSpacing.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/FunctionTypeReferenceSpacing.kt
@@ -7,7 +7,7 @@ import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#function-type-reference-spacing) for
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#function-type-reference-spacing) for
  * documentation.
  */
 @ActiveByDefault(since = "1.23.0")

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/IfElseBracing.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/IfElseBracing.kt
@@ -10,7 +10,7 @@ import io.gitlab.arturbosch.detekt.api.internal.Configuration
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#if-else-bracing) for documentation.
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/experimental/#if-else-bracing) for documentation.
  */
 @AutoCorrectable(since = "1.23.0")
 class IfElseBracing(config: Config) : FormattingRule(config) {

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/IfElseWrapping.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/IfElseWrapping.kt
@@ -10,7 +10,7 @@ import io.gitlab.arturbosch.detekt.api.internal.Configuration
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#if-else-wrapping) for documentation.
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/experimental/#if-else-wrapping) for documentation.
  */
 @AutoCorrectable(since = "1.23.0")
 class IfElseWrapping(config: Config) : FormattingRule(config) {

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/ImportOrdering.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/ImportOrdering.kt
@@ -11,7 +11,7 @@ import io.gitlab.arturbosch.detekt.api.internal.Configuration
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#import-ordering) for documentation.
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#import-ordering) for documentation.
  *
  * For defining import layout patterns see the [KtLint Source Code](https://github.com/pinterest/ktlint/blob/a6ca5b2edf95cc70a138a9470cfb6c4fd5d9d3ce/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/ImportOrderingRule.kt)
  */

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/Indentation.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/Indentation.kt
@@ -11,7 +11,7 @@ import io.gitlab.arturbosch.detekt.api.internal.Configuration
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#indentation) for documentation.
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#indentation) for documentation.
  */
 @ActiveByDefault(since = "1.19.0")
 @AutoCorrectable(since = "1.0.0")

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/KdocWrapping.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/KdocWrapping.kt
@@ -11,7 +11,7 @@ import io.gitlab.arturbosch.detekt.api.internal.Configuration
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#kdoc-wrapping) for documentation.
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#kdoc-wrapping) for documentation.
  */
 @ActiveByDefault(since = "1.23.0")
 @AutoCorrectable(since = "1.20.0")

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/MaximumLineLength.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/MaximumLineLength.kt
@@ -11,7 +11,7 @@ import io.gitlab.arturbosch.detekt.api.internal.Configuration
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#max-line-length) for documentation.
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#max-line-length) for documentation.
  *
  * This rules overlaps with [style>MaxLineLength](https://detekt.dev/style.html#maxlinelength)
  * from the standard rules, make sure to enable just one or keep them aligned. The pro of this rule is that it can

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/ModifierListSpacing.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/ModifierListSpacing.kt
@@ -7,7 +7,7 @@ import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#modifier-list-spacing) for documentation.
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#modifier-list-spacing) for documentation.
  */
 @ActiveByDefault(since = "1.23.0")
 @AutoCorrectable(since = "1.20.0")

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/ModifierOrdering.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/ModifierOrdering.kt
@@ -7,7 +7,7 @@ import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#modifier-order) for documentation.
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#modifier-order) for documentation.
  *
  * This rules overlaps with [style>ModifierOrder](https://detekt.dev/style.html#modifierorder)
  * from the standard rules, make sure to enable just one. The pro of this rule is that it can auto-correct the issue.

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/MultiLineIfElse.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/MultiLineIfElse.kt
@@ -11,7 +11,7 @@ import io.gitlab.arturbosch.detekt.api.internal.Configuration
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#multiline-if-else) for documentation.
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#multiline-if-else) for documentation.
  */
 @AutoCorrectable(since = "1.0.0")
 @ActiveByDefault(since = "1.22.0")

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/MultilineExpressionWrapping.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/MultilineExpressionWrapping.kt
@@ -10,7 +10,7 @@ import io.gitlab.arturbosch.detekt.api.internal.Configuration
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#multiline-expression-wrapping) for
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/experimental/#multiline-expression-wrapping) for
  * documentation.
  */
 @AutoCorrectable(since = "1.23.0")

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/NoBlankLineBeforeRbrace.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/NoBlankLineBeforeRbrace.kt
@@ -7,7 +7,7 @@ import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#no-blank-lines-before) for documentation.
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#no-blank-lines-before) for documentation.
  */
 @ActiveByDefault(since = "1.0.0")
 @AutoCorrectable(since = "1.0.0")

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/NoBlankLineInList.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/NoBlankLineInList.kt
@@ -6,7 +6,7 @@ import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#no-blank-lines-in-list) for documentation.
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/experimental/#no-blank-lines-in-list) for documentation.
  */
 @AutoCorrectable(since = "1.23.0")
 class NoBlankLineInList(config: Config) : FormattingRule(config) {

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/NoBlankLinesInChainedMethodCalls.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/NoBlankLinesInChainedMethodCalls.kt
@@ -7,7 +7,7 @@ import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#no-blank-lines-in-chained-method-calls) for
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#no-blank-lines-in-chained-method-calls) for
  * documentation.
  */
 @ActiveByDefault(since = "1.22.0")

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/NoConsecutiveBlankLines.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/NoConsecutiveBlankLines.kt
@@ -7,7 +7,7 @@ import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#no-consecutive-blank-lines) for documentation.
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#no-consecutive-blank-lines) for documentation.
  */
 @ActiveByDefault(since = "1.0.0")
 @AutoCorrectable(since = "1.0.0")

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/NoConsecutiveComments.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/NoConsecutiveComments.kt
@@ -5,7 +5,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#disallow-consecutive-comments) for documentation.
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/experimental/#disallow-consecutive-comments) for documentation.
  */
 class NoConsecutiveComments(config: Config) : FormattingRule(config) {
 

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/NoEmptyClassBody.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/NoEmptyClassBody.kt
@@ -7,7 +7,7 @@ import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#no-empty-class-bodies) for documentation.
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#no-empty-class-bodies) for documentation.
  */
 @ActiveByDefault(since = "1.0.0")
 @AutoCorrectable(since = "1.0.0")

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/NoEmptyFirstLineInClassBody.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/NoEmptyFirstLineInClassBody.kt
@@ -10,7 +10,7 @@ import io.gitlab.arturbosch.detekt.api.internal.Configuration
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#disallow-empty-lines-at-start-of-class-body)
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/experimental/#disallow-empty-lines-at-start-of-class-body)
  * for documentation.
  */
 @AutoCorrectable(since = "1.23.0")

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/NoEmptyFirstLineInMethodBlock.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/NoEmptyFirstLineInMethodBlock.kt
@@ -7,7 +7,7 @@ import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#no-leading-empty-lines-in-method-blocks) for
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#no-leading-empty-lines-in-method-blocks) for
  * documentation.
  */
 @AutoCorrectable(since = "1.4.0")

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/NoLineBreakAfterElse.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/NoLineBreakAfterElse.kt
@@ -7,7 +7,7 @@ import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#no-line-break-after-else) for documentation.
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#no-line-break-after-else) for documentation.
  */
 @ActiveByDefault(since = "1.0.0")
 @AutoCorrectable(since = "1.0.0")

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/NoLineBreakBeforeAssignment.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/NoLineBreakBeforeAssignment.kt
@@ -7,7 +7,7 @@ import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#no-line-break-before-assignment) for
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#no-line-break-before-assignment) for
  * documentation.
  */
 @ActiveByDefault(since = "1.0.0")

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/NoMultipleSpaces.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/NoMultipleSpaces.kt
@@ -7,7 +7,7 @@ import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#no-multi-spaces) for documentation.
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#no-multi-spaces) for documentation.
  */
 @ActiveByDefault(since = "1.0.0")
 @AutoCorrectable(since = "1.0.0")

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/NoSemicolons.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/NoSemicolons.kt
@@ -7,7 +7,7 @@ import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#no-semicolons) for documentation.
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#no-semicolons) for documentation.
  */
 @ActiveByDefault(since = "1.0.0")
 @AutoCorrectable(since = "1.0.0")

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/NoSingleLineBlockComment.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/NoSingleLineBlockComment.kt
@@ -10,7 +10,7 @@ import io.gitlab.arturbosch.detekt.api.internal.Configuration
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#no-single-line-block-comments) for documentation.
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/experimental/#no-single-line-block-comments) for documentation.
  */
 @AutoCorrectable(since = "1.23.0")
 class NoSingleLineBlockComment(config: Config) : FormattingRule(config) {

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/NoTrailingSpaces.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/NoTrailingSpaces.kt
@@ -7,7 +7,7 @@ import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#no-trailing-whitespaces) for documentation.
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#no-trailing-whitespaces) for documentation.
  */
 @ActiveByDefault(since = "1.0.0")
 @AutoCorrectable(since = "1.0.0")

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/NoUnitReturn.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/NoUnitReturn.kt
@@ -7,7 +7,7 @@ import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#no-unit-as-return-type) for documentation.
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#no-unit-as-return-type) for documentation.
  */
 @ActiveByDefault(since = "1.0.0")
 @AutoCorrectable(since = "1.0.0")

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/NoUnusedImports.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/NoUnusedImports.kt
@@ -7,7 +7,7 @@ import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#no-unused-imports) for documentation.
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#no-unused-imports) for documentation.
  */
 @ActiveByDefault(since = "1.0.0")
 @AutoCorrectable(since = "1.0.0")

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/NoWildcardImports.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/NoWildcardImports.kt
@@ -9,7 +9,7 @@ import io.gitlab.arturbosch.detekt.api.internal.Configuration
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#no-wildcard-imports) for documentation.
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#no-wildcard-imports) for documentation.
  */
 @ActiveByDefault(since = "1.0.0")
 class NoWildcardImports(config: Config) : FormattingRule(config) {

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/NullableTypeSpacing.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/NullableTypeSpacing.kt
@@ -7,7 +7,7 @@ import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#nullable-type-spacing) for
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#nullable-type-spacing) for
  * documentation.
  */
 @ActiveByDefault(since = "1.23.0")

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/PackageName.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/PackageName.kt
@@ -7,7 +7,7 @@ import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#no-underscores-in-package-names) for
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#no-underscores-in-package-names) for
  * documentation.
  */
 @AutoCorrectable(since = "1.0.0")

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/PackageName.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/PackageName.kt
@@ -7,7 +7,7 @@ import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#no-underscores-in-package-names) for
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#package-name) for
  * documentation.
  */
 @AutoCorrectable(since = "1.0.0")

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/ParameterListSpacing.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/ParameterListSpacing.kt
@@ -6,7 +6,7 @@ import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#parameter-list-spacing) for
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/experimental/#parameter-list-spacing) for
  * documentation.
  */
 @AutoCorrectable(since = "1.22.0")

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/ParameterListWrapping.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/ParameterListWrapping.kt
@@ -13,7 +13,7 @@ import io.gitlab.arturbosch.detekt.api.internal.Configuration
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#parameter-list-wrapping) for documentation.
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#parameter-list-wrapping) for documentation.
  */
 @ActiveByDefault(since = "1.0.0")
 @AutoCorrectable(since = "1.0.0")

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/ParameterWrapping.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/ParameterWrapping.kt
@@ -13,7 +13,7 @@ import io.gitlab.arturbosch.detekt.api.internal.Configuration
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#parameter-wrapping) for documentation.
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#parameter-wrapping) for documentation.
  */
 @AutoCorrectable(since = "1.23.0")
 @ActiveByDefault(since = "1.23.0")

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/PropertyName.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/PropertyName.kt
@@ -5,7 +5,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#property-naming) for
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/experimental/#property-naming) for
  * documentation.
  */
 class PropertyName(config: Config) : FormattingRule(config) {

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/PropertyWrapping.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/PropertyWrapping.kt
@@ -13,7 +13,7 @@ import io.gitlab.arturbosch.detekt.api.internal.Configuration
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#property-wrapping) for documentation.
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#property-wrapping) for documentation.
  */
 @AutoCorrectable(since = "1.23.0")
 @ActiveByDefault(since = "1.23.0")

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingAroundAngleBrackets.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingAroundAngleBrackets.kt
@@ -7,7 +7,7 @@ import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#angle-bracket-spacing) for documentation.
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#angle-bracket-spacing) for documentation.
  */
 @AutoCorrectable(since = "1.16.0")
 @ActiveByDefault(since = "1.22.0")

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingAroundColon.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingAroundColon.kt
@@ -7,7 +7,7 @@ import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#colon-spacing) for documentation.
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#colon-spacing) for documentation.
  */
 @ActiveByDefault(since = "1.0.0")
 @AutoCorrectable(since = "1.0.0")

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingAroundComma.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingAroundComma.kt
@@ -7,7 +7,7 @@ import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#comma-spacing) for documentation.
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#comma-spacing) for documentation.
  */
 @ActiveByDefault(since = "1.0.0")
 @AutoCorrectable(since = "1.0.0")

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingAroundCurly.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingAroundCurly.kt
@@ -7,7 +7,7 @@ import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#curly-spacing) for documentation.
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#curly-spacing) for documentation.
  */
 @ActiveByDefault(since = "1.0.0")
 @AutoCorrectable(since = "1.0.0")

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingAroundDot.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingAroundDot.kt
@@ -7,7 +7,7 @@ import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#dot-spacing) for documentation.
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#dot-spacing) for documentation.
  */
 @ActiveByDefault(since = "1.0.0")
 @AutoCorrectable(since = "1.0.0")

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingAroundDoubleColon.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingAroundDoubleColon.kt
@@ -7,7 +7,7 @@ import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#double-colon-spacing) for documentation.
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#double-colon-spacing) for documentation.
  */
 @AutoCorrectable(since = "1.10.0")
 @ActiveByDefault(since = "1.22.0")

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingAroundKeyword.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingAroundKeyword.kt
@@ -7,7 +7,7 @@ import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#keyword-spacing) for documentation.
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#keyword-spacing) for documentation.
  */
 @ActiveByDefault(since = "1.0.0")
 @AutoCorrectable(since = "1.0.0")

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingAroundOperators.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingAroundOperators.kt
@@ -7,7 +7,7 @@ import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#operator-spacing) for documentation.
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#operator-spacing) for documentation.
  */
 @ActiveByDefault(since = "1.0.0")
 @AutoCorrectable(since = "1.0.0")

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingAroundParens.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingAroundParens.kt
@@ -7,7 +7,7 @@ import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#parenthesis-spacing) for documentation.
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#parenthesis-spacing) for documentation.
  */
 @ActiveByDefault(since = "1.0.0")
 @AutoCorrectable(since = "1.0.0")

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingAroundRangeOperator.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingAroundRangeOperator.kt
@@ -7,7 +7,7 @@ import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#range-spacing) for documentation.
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#range-spacing) for documentation.
  */
 @ActiveByDefault(since = "1.0.0")
 @AutoCorrectable(since = "1.0.0")

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingAroundUnaryOperator.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingAroundUnaryOperator.kt
@@ -7,7 +7,7 @@ import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#unary-operator-spacing) for documentation.
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#unary-operator-spacing) for documentation.
  */
 @AutoCorrectable(since = "1.16.0")
 @ActiveByDefault(since = "1.22.0")

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingBetweenDeclarationsWithAnnotations.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingBetweenDeclarationsWithAnnotations.kt
@@ -7,7 +7,7 @@ import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#blank-line-between-declarations-with-annotations)
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#blank-line-between-declarations-with-annotations)
  * for documentation.
  */
 @AutoCorrectable(since = "1.10.0")

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingBetweenDeclarationsWithComments.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingBetweenDeclarationsWithComments.kt
@@ -7,7 +7,7 @@ import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#blank-line-between-declaration-with-comments)
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#blank-line-between-declaration-with-comments)
  * for documentation.
  */
 @AutoCorrectable(since = "1.10.0")

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingBetweenFunctionNameAndOpeningParenthesis.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingBetweenFunctionNameAndOpeningParenthesis.kt
@@ -7,7 +7,7 @@ import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#spacing-between-function-name-and-opening-parenthesis) for
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#spacing-between-function-name-and-opening-parenthesis) for
  * documentation.
  */
 @ActiveByDefault(since = "1.23.0")

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/StringTemplate.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/StringTemplate.kt
@@ -7,7 +7,7 @@ import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#string-template) for documentation.
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#string-template) for documentation.
  */
 @ActiveByDefault(since = "1.0.0")
 @AutoCorrectable(since = "1.0.0")

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/StringTemplateIndent.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/StringTemplateIndent.kt
@@ -10,7 +10,7 @@ import io.gitlab.arturbosch.detekt.api.internal.Configuration
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#string-template-indent) for documentation.
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/experimental/#string-template-indent) for documentation.
  */
 @AutoCorrectable(since = "1.23.0")
 class StringTemplateIndent(config: Config) : FormattingRule(config) {

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/TrailingCommaOnCallSite.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/TrailingCommaOnCallSite.kt
@@ -9,7 +9,7 @@ import io.gitlab.arturbosch.detekt.api.internal.Configuration
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/) for documentation.
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/) for documentation.
  *
  * The default config comes from ktlint and follows these conventions:
  * - [Kotlin coding convention](https://kotlinlang.org/docs/coding-conventions.html#trailing-commas) recommends

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/TrailingCommaOnCallSite.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/TrailingCommaOnCallSite.kt
@@ -9,7 +9,7 @@ import io.gitlab.arturbosch.detekt.api.internal.Configuration
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/) for documentation.
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#trailing-comma-on-call-site) for documentation.
  *
  * The default config comes from ktlint and follows these conventions:
  * - [Kotlin coding convention](https://kotlinlang.org/docs/coding-conventions.html#trailing-commas) recommends

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/TrailingCommaOnDeclarationSite.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/TrailingCommaOnDeclarationSite.kt
@@ -9,7 +9,7 @@ import io.gitlab.arturbosch.detekt.api.internal.Configuration
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/) for documentation.
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/) for documentation.
  *
  * The default config comes from ktlint and follows these conventions:
  * - [Kotlin coding convention](https://kotlinlang.org/docs/coding-conventions.html#trailing-commas) recommends

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/TrailingCommaOnDeclarationSite.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/TrailingCommaOnDeclarationSite.kt
@@ -9,7 +9,7 @@ import io.gitlab.arturbosch.detekt.api.internal.Configuration
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/) for documentation.
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#trailing-comma-on-declaration-site) for documentation.
  *
  * The default config comes from ktlint and follows these conventions:
  * - [Kotlin coding convention](https://kotlinlang.org/docs/coding-conventions.html#trailing-commas) recommends

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/TryCatchFinallySpacing.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/TryCatchFinallySpacing.kt
@@ -10,7 +10,7 @@ import io.gitlab.arturbosch.detekt.api.internal.Configuration
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#try-catch-finally-spacing) for
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/experimental/#try-catch-finally-spacing) for
  * documentation.
  */
 @AutoCorrectable(since = "1.23.0")

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/TypeArgumentListSpacing.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/TypeArgumentListSpacing.kt
@@ -10,7 +10,7 @@ import io.gitlab.arturbosch.detekt.api.internal.Configuration
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#type-argument-list-spacing) for
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/experimental/#type-argument-list-spacing) for
  * documentation.
  */
 @AutoCorrectable(since = "1.20.0")

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/TypeParameterListSpacing.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/TypeParameterListSpacing.kt
@@ -10,7 +10,7 @@ import io.gitlab.arturbosch.detekt.api.internal.Configuration
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#type-parameter-list-spacing) for
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/experimental/#type-parameter-list-spacing) for
  * documentation.
  */
 @AutoCorrectable(since = "1.22.0")

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/UnnecessaryParenthesesBeforeTrailingLambda.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/UnnecessaryParenthesesBeforeTrailingLambda.kt
@@ -7,7 +7,7 @@ import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#unnecessary-parenthesis-before-trailing-lambda)
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#unnecessary-parenthesis-before-trailing-lambda)
  * for documentation.
  */
 @ActiveByDefault(since = "1.23.0")

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/Wrapping.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/Wrapping.kt
@@ -13,7 +13,7 @@ import io.gitlab.arturbosch.detekt.api.internal.Configuration
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#wrapping) for documentation.
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#wrapping) for documentation.
  */
 @ActiveByDefault(since = "1.20.0")
 @AutoCorrectable(since = "1.20.0")

--- a/detekt-generator/build.gradle.kts
+++ b/detekt-generator/build.gradle.kts
@@ -74,6 +74,8 @@ val generateDocumentation by tasks.registering(JavaExec::class) {
         configDir,
         "--cli-options",
         cliOptionsFile,
+        "--replace",
+        "<ktlintVersion/>=${libs.versions.ktlint.get()}"
     )
 }
 

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/Generator.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/Generator.kt
@@ -15,7 +15,7 @@ class Generator(
     private val arguments: GeneratorArgs,
     private val outPrinter: PrintStream = System.out
 ) {
-    private val collector = DetektCollector()
+    private val collector = DetektCollector(arguments.textReplacements)
     private val printer = DetektPrinter(arguments)
     private val cliOptionsPrinter = CliOptionsPrinter()
 
@@ -48,7 +48,7 @@ class Generator(
             arguments.inputPath
                 .map { parseAll(parser, it.resolve("src/main/kotlin/")) to it }
                 .forEach { (list: Collection<KtFile>, folder: Path) ->
-                    val collector = DetektCollector()
+                    val collector = DetektCollector(arguments.textReplacements)
                     list.forEach { file ->
                         collector.visit(file)
                     }

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/GeneratorArgs.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/GeneratorArgs.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.generator
 
+import com.beust.jcommander.DynamicParameter
 import com.beust.jcommander.Parameter
 import java.nio.file.Path
 import kotlin.io.path.Path
@@ -49,6 +50,15 @@ class GeneratorArgs {
             "Path to user rules can be specified with --input option"
     )
     var generateCustomRuleConfig: Boolean = false
+
+    @DynamicParameter(
+        names = ["--replace", "-r"],
+        required = false,
+        description = "Any number of key and value pairs that are used to replace placeholders " +
+            "during data collection and output generation. Key and value are separated by '='. " +
+            "The property may be used multiple times."
+    )
+    var textReplacements: Map<String, String> = mutableMapOf()
 
     val inputPath: List<Path> by lazy {
         checkNotNull(input) { "Input parameter was not initialized by jcommander!" }

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/DetektCollector.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/DetektCollector.kt
@@ -3,10 +3,10 @@ package io.gitlab.arturbosch.detekt.generator.collection
 import io.gitlab.arturbosch.detekt.generator.collection.exception.InvalidDocumentationException
 import org.jetbrains.kotlin.psi.KtFile
 
-class DetektCollector : Collector<RuleSetPage> {
+class DetektCollector(textReplacements: Map<String, String>) : Collector<RuleSetPage> {
 
     private val ruleSetProviderCollector = RuleSetProviderCollector()
-    private val ruleCollector = RuleCollector()
+    private val ruleCollector = RuleCollector(textReplacements)
     private val multiRuleCollector = MultiRuleCollector()
 
     private val collectors = listOf(

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/DocumentationCollector.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/DocumentationCollector.kt
@@ -3,11 +3,16 @@ package io.gitlab.arturbosch.detekt.generator.collection
 import io.gitlab.arturbosch.detekt.generator.collection.exception.InvalidCodeExampleDocumentationException
 import org.jetbrains.kotlin.psi.KtClassOrObject
 
-class DocumentationCollector {
+class DocumentationCollector(private val textReplacements: Map<String, String>) {
 
     private var name: String = ""
     var description: String = ""
-        private set
+        private set(newValue) {
+            field = textReplacements.toList()
+                .fold(newValue) { acc, replacement ->
+                    acc.replace(replacement.first, replacement.second)
+                }
+        }
     var compliant: String = ""
         private set
     var nonCompliant: String = ""
@@ -30,9 +35,11 @@ class DocumentationCollector {
                 extractNonCompliantDocumentation(comment, nonCompliantIndex)
                 extractCompliantDocumentation(comment, compliantIndex)
             }
+
             compliantIndex != -1 -> throw InvalidCodeExampleDocumentationException(
                 "Rule $name contains a compliant without a noncompliant code definition"
             )
+
             else -> description = comment
         }
     }

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleCollector.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleCollector.kt
@@ -2,11 +2,11 @@ package io.gitlab.arturbosch.detekt.generator.collection
 
 import org.jetbrains.kotlin.psi.KtFile
 
-class RuleCollector : Collector<Rule> {
+class RuleCollector(private val textReplacements: Map<String, String>) : Collector<Rule> {
     override val items = mutableListOf<Rule>()
 
     override fun visit(file: KtFile) {
-        val visitor = RuleVisitor()
+        val visitor = RuleVisitor(textReplacements)
         file.accept(visitor)
 
         if (visitor.containsRule) {

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleVisitor.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleVisitor.kt
@@ -18,12 +18,12 @@ import org.jetbrains.kotlin.psi.psiUtil.containingClass
 import org.jetbrains.kotlin.psi.psiUtil.getSuperNames
 import java.lang.reflect.Modifier
 
-internal class RuleVisitor : DetektVisitor() {
+internal class RuleVisitor(textReplacements: Map<String, String>) : DetektVisitor() {
 
     val containsRule
         get() = classesMap.any { it.value }
     private var name = ""
-    private val documentationCollector = DocumentationCollector()
+    private val documentationCollector = DocumentationCollector(textReplacements)
     private var defaultActivationStatus: DefaultActivationStatus = Inactive
     private var autoCorrect = false
     private var requiresTypeResolution = false

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/GeneratorArgsSpec.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/GeneratorArgsSpec.kt
@@ -1,0 +1,61 @@
+package io.gitlab.arturbosch.detekt.generator
+
+import com.beust.jcommander.JCommander
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class GeneratorArgsSpec {
+    @Nested
+    inner class TextReplacements {
+
+        private fun parse(vararg args: String): GeneratorArgs {
+            val options = GeneratorArgs()
+            val parser = JCommander(options)
+            parser.parse("-i", ".", *args)
+            return options
+        }
+
+        @Test
+        fun noReplacements() {
+            val options = parse()
+
+            assertThat(options.textReplacements).isEmpty()
+        }
+
+        @Test
+        fun simpleReplacement() {
+            val options = parse("--replace", "foo=bar")
+
+            val expected = mapOf("foo" to "bar")
+            assertThat(options.textReplacements).containsExactlyEntriesOf(expected)
+        }
+
+        @Test
+        fun simpleReplacementShortcut() {
+            val options = parse("-r", "foo=bar")
+
+            val expected = mapOf("foo" to "bar")
+            assertThat(options.textReplacements).containsExactlyEntriesOf(expected)
+        }
+
+        @Test
+        fun emptyReplacementValue() {
+            val options = parse("--replace", "foo=")
+
+            val expected = mapOf("foo" to "")
+            assertThat(options.textReplacements).containsExactlyEntriesOf(expected)
+        }
+
+        @Test
+        fun multipleReplacements() {
+            val options = parse("--replace", "foo=bar", "--replace", "faz=baz")
+
+            val expected = mapOf(
+                "foo" to "bar",
+                "faz" to "baz"
+            )
+            assertThat(options.textReplacements).containsExactlyEntriesOf(expected)
+        }
+    }
+}

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleCollectorSpec.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleCollectorSpec.kt
@@ -20,7 +20,7 @@ class RuleCollectorSpec {
 
     @BeforeEach
     fun createSubject() {
-        subject = RuleCollector()
+        subject = RuleCollector(emptyMap())
     }
 
     @Test
@@ -70,6 +70,18 @@ class RuleCollectorSpec {
         """.trimIndent()
         val items = subject.run(code)
         assertThat(items[0].description).isEqualTo(description)
+    }
+
+    @Test
+    fun `replaces text in the rule description`() {
+        val code = """
+            /**
+             * some <foo/> description with more <foo/>. 
+             */
+            class SomeRandomClass : Rule
+        """.trimIndent()
+        val items = RuleCollector(mapOf("<foo/>" to "bar")).run(code)
+        assertThat(items[0].description).isEqualTo("some bar description with more bar.")
     }
 
     @Test

--- a/website/versioned_docs/version-1.21.0/rules/formatting.md
+++ b/website/versioned_docs/version-1.21.0/rules/formatting.md
@@ -130,7 +130,8 @@ See [ktlint-readme](https://github.com/pinterest/ktlint#experimental-rules) for 
 
 See [ktlint-readme](https://github.com/pinterest/ktlint#standard-rules) for documentation.
 
-For defining import layout patterns see the [KtLint Source Code](https://github.com/pinterest/ktlint/blob/a6ca5b2edf95cc70a138a9470cfb6c4fd5d9d3ce/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/ImportOrderingRule.kt)
+For defining import layout patterns see
+the [KtLint Source Code](https://github.com/pinterest/ktlint/blob/0.50.0/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ImportOrderingRule.kt)
 
 **Active by default**: Yes - Since v1.19.0
 

--- a/website/versioned_docs/version-1.22.0/rules/formatting.md
+++ b/website/versioned_docs/version-1.22.0/rules/formatting.md
@@ -17,19 +17,19 @@ in the command line interface.
 
 ### AnnotationOnSeparateLine
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#annotation-formatting) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#annotation-formatting) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### AnnotationSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#annotation-spacing) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#annotation-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### ArgumentListWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#argument-list-wrapping) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#argument-list-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
@@ -45,26 +45,27 @@ See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#argument-li
 
 ### BlockCommentInitialStarAlignment
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#block-comment-initial-star-alignment) for
+See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/experimental/#block-comment-initial-star-alignment)
+for
 documentation.
 
 **Active by default**: No
 
 ### ChainWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#chain-wrapping) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#chain-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### CommentSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#comment-spacing) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#comment-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### CommentWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#comment-wrapping) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/experimental/#comment-wrapping) for documentation.
 
 **Active by default**: No
 
@@ -76,20 +77,20 @@ See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#comment
 
 ### DiscouragedCommentLocation
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#discouraged-comment-location) for
+See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/experimental/#discouraged-comment-location) for
 documentation.
 
 **Active by default**: No
 
 ### EnumEntryNameCase
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#enum-entry) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#enum-entry) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### Filename
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#file-name) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#file-name) for documentation.
 
 This rules overlaps with [naming&gt;MatchingDeclarationName](https://detekt.dev/naming.html#matchingdeclarationname)
 from the standard rules, make sure to enable just one.
@@ -98,7 +99,7 @@ from the standard rules, make sure to enable just one.
 
 ### FinalNewline
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#final-newline) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#final-newline) for documentation.
 
 This rules overlaps with [style&gt;NewLineAtEndOfFile](https://detekt.dev/style.html#newlineatendoffile)
 from the standard rules, make sure to enable just one. The pro of this rule is that it can auto-correct the issue.
@@ -113,20 +114,20 @@ from the standard rules, make sure to enable just one. The pro of this rule is t
 
 ### FunKeywordSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#fun-keyword-spacing) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/experimental/#fun-keyword-spacing) for documentation.
 
 **Active by default**: No
 
 ### FunctionReturnTypeSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#function-return-type-spacing) for
+See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/experimental/#function-return-type-spacing) for
 documentation.
 
 **Active by default**: No
 
 ### FunctionSignature
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#function-signature) for
+See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/experimental/#function-signature) for
 documentation.
 
 **Active by default**: No
@@ -151,21 +152,21 @@ documentation.
 
 ### FunctionStartOfBodySpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#function-start-of-body-spacing) for
+See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/experimental/#function-start-of-body-spacing) for
 documentation.
 
 **Active by default**: No
 
 ### FunctionTypeReferenceSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#function-type-reference-spacing) for
+See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/experimental/#function-type-reference-spacing) for
 documentation.
 
 **Active by default**: No
 
 ### ImportOrdering
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#import-ordering) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#import-ordering) for documentation.
 
 For defining import layout patterns see the [KtLint Source Code](https://github.com/pinterest/ktlint/blob/a6ca5b2edf95cc70a138a9470cfb6c4fd5d9d3ce/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/ImportOrderingRule.kt)
 
@@ -179,7 +180,7 @@ For defining import layout patterns see the [KtLint Source Code](https://github.
 
 ### Indentation
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#indentation) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#indentation) for documentation.
 
 **Active by default**: Yes - Since v1.19.0
 
@@ -197,7 +198,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#indentation
 
 ### KdocWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#kdoc-wrapping) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/experimental/#kdoc-wrapping) for documentation.
 
 **Active by default**: No
 
@@ -209,7 +210,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#kdoc-wr
 
 ### MaximumLineLength
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#max-line-length) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#max-line-length) for documentation.
 
 This rules overlaps with [style&gt;MaxLineLength](https://detekt.dev/style.html#maxlinelength)
 from the standard rules, make sure to enable just one or keep them aligned. The pro of this rule is that it can
@@ -229,13 +230,14 @@ auto-correct the issue.
 
 ### ModifierListSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#modifier-list-spacing) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/experimental/#modifier-list-spacing) for
+documentation.
 
 **Active by default**: No
 
 ### ModifierOrdering
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#modifier-order) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#modifier-order) for documentation.
 
 This rules overlaps with [style&gt;ModifierOrder](https://detekt.dev/style.html#modifierorder)
 from the standard rules, make sure to enable just one. The pro of this rule is that it can auto-correct the issue.
@@ -244,88 +246,89 @@ from the standard rules, make sure to enable just one. The pro of this rule is t
 
 ### MultiLineIfElse
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#multiline-if-else) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#multiline-if-else) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### NoBlankLineBeforeRbrace
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#no-blank-lines-before) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#no-blank-lines-before) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoBlankLinesInChainedMethodCalls
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#no-blank-lines-in-chained-method-calls) for
+See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#no-blank-lines-in-chained-method-calls) for
 documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### NoConsecutiveBlankLines
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#no-consecutive-blank-lines) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#no-consecutive-blank-lines) for
+documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoEmptyClassBody
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#no-empty-class-bodies) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#no-empty-class-bodies) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoEmptyFirstLineInMethodBlock
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#no-leading-empty-lines-in-method-blocks) for
+See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#no-leading-empty-lines-in-method-blocks) for
 documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### NoLineBreakAfterElse
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#no-line-break-after-else) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#no-line-break-after-else) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoLineBreakBeforeAssignment
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#no-line-break-before-assignment) for
+See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#no-line-break-before-assignment) for
 documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoMultipleSpaces
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#no-multi-spaces) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#no-multi-spaces) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoSemicolons
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#no-semicolons) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#no-semicolons) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoTrailingSpaces
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#no-trailing-whitespaces) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#no-trailing-whitespaces) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoUnitReturn
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#no-unit-as-return-type) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#no-unit-as-return-type) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoUnusedImports
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#no-unused-imports) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#no-unused-imports) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoWildcardImports
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#no-wildcard-imports) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#no-wildcard-imports) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
@@ -337,28 +340,28 @@ See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#no-wildcard
 
 ### NullableTypeSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#nullable-type-spacing) for
+See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/experimental/#nullable-type-spacing) for
 documentation.
 
 **Active by default**: No
 
 ### PackageName
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#no-underscores-in-package-names) for
+See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#no-underscores-in-package-names) for
 documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### ParameterListSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#parameter-list-spacing) for
+See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/experimental/#parameter-list-spacing) for
 documentation.
 
 **Active by default**: No
 
 ### ParameterListWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#parameter-list-wrapping) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#parameter-list-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
@@ -376,100 +379,101 @@ See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#parameter-l
 
 ### SpacingAroundAngleBrackets
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#angle-bracket-spacing) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#angle-bracket-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingAroundColon
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#colon-spacing) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#colon-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundComma
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#comma-spacing) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#comma-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundCurly
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#curly-spacing) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#curly-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundDot
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#dot-spacing) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#dot-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundDoubleColon
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#double-colon-spacing) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#double-colon-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingAroundKeyword
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#keyword-spacing) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#keyword-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundOperators
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#operator-spacing) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#operator-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundParens
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#parenthesis-spacing) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#parenthesis-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundRangeOperator
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#range-spacing) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#range-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundUnaryOperator
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#unary-operator-spacing) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#unary-operator-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingBetweenDeclarationsWithAnnotations
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#blank-line-between-declarations-with-annotations)
+See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#blank-line-between-declarations-with-annotations)
 for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingBetweenDeclarationsWithComments
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#blank-line-between-declaration-with-comments)
+See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#blank-line-between-declaration-with-comments)
 for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingBetweenFunctionNameAndOpeningParenthesis
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#spacing-between-function-name-and-opening-parenthesis) for
+See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/experimental/#spacing-between-function-name-and-opening-parenthesis)
+for
 documentation.
 
 **Active by default**: No
 
 ### StringTemplate
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#string-template) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#string-template) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### TrailingCommaOnCallSite
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/) for documentation.
 
 The default config comes from ktlint and follows these conventions:
 - [Kotlin coding convention](https://kotlinlang.org/docs/coding-conventions.html#trailing-commas) recommends
@@ -488,7 +492,7 @@ trailing comma usage yet.
 
 ### TrailingCommaOnDeclarationSite
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/) for documentation.
 
 The default config comes from ktlint and follows these conventions:
 - [Kotlin coding convention](https://kotlinlang.org/docs/coding-conventions.html#trailing-commas) recommends
@@ -507,28 +511,28 @@ trailing comma usage yet.
 
 ### TypeArgumentListSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#type-argument-list-spacing) for
+See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/experimental/#type-argument-list-spacing) for
 documentation.
 
 **Active by default**: No
 
 ### TypeParameterListSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#type-parameter-list-spacing) for
+See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/experimental/#type-parameter-list-spacing) for
 documentation.
 
 **Active by default**: No
 
 ### UnnecessaryParenthesesBeforeTrailingLambda
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#unnecessary-parenthesis-before-trailing-lambda)
+See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/experimental/#unnecessary-parenthesis-before-trailing-lambda)
 for documentation.
 
 **Active by default**: No
 
 ### Wrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#wrapping) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.20.0
 

--- a/website/versioned_docs/version-1.22.0/rules/formatting.md
+++ b/website/versioned_docs/version-1.22.0/rules/formatting.md
@@ -168,7 +168,8 @@ documentation.
 
 See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#import-ordering) for documentation.
 
-For defining import layout patterns see the [KtLint Source Code](https://github.com/pinterest/ktlint/blob/a6ca5b2edf95cc70a138a9470cfb6c4fd5d9d3ce/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/ImportOrderingRule.kt)
+For defining import layout patterns see
+the [KtLint Source Code](https://github.com/pinterest/ktlint/blob/0.50.0/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ImportOrderingRule.kt)
 
 **Active by default**: Yes - Since v1.19.0
 
@@ -477,10 +478,10 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/) for
 
 The default config comes from ktlint and follows these conventions:
 - [Kotlin coding convention](https://kotlinlang.org/docs/coding-conventions.html#trailing-commas) recommends
-trailing comma encourage the use of trailing commas at the declaration site and
-leaves it at your discretion for the call site.
+  trailing comma encourage the use of trailing commas at the declaration site and
+  leaves it at your discretion for the call site.
 - [Android Kotlin style guide](https://developer.android.com/kotlin/style-guide) does not include
-trailing comma usage yet.
+  trailing comma usage yet.
 
 **Active by default**: No
 
@@ -496,10 +497,10 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/) for
 
 The default config comes from ktlint and follows these conventions:
 - [Kotlin coding convention](https://kotlinlang.org/docs/coding-conventions.html#trailing-commas) recommends
-trailing comma encourage the use of trailing commas at the declaration site and
-leaves it at your discretion for the call site.
+  trailing comma encourage the use of trailing commas at the declaration site and
+  leaves it at your discretion for the call site.
 - [Android Kotlin style guide](https://developer.android.com/kotlin/style-guide) does not include
-trailing comma usage yet.
+  trailing comma usage yet.
 
 **Active by default**: No
 

--- a/website/versioned_docs/version-1.23.0/rules/formatting.md
+++ b/website/versioned_docs/version-1.23.0/rules/formatting.md
@@ -18,7 +18,7 @@ Note: Issues reported by this rule set can only be suppressed on file level (`@f
 
 ### AnnotationOnSeparateLine
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#annotation-formatting) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#annotation-formatting) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
@@ -30,13 +30,13 @@ See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#annotation-
 
 ### AnnotationSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#annotation-spacing) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#annotation-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### ArgumentListWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#argument-list-wrapping) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#argument-list-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
@@ -52,14 +52,15 @@ See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#argument-li
 
 ### BlockCommentInitialStarAlignment
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#block-comment-initial-star-alignment) for
+See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#block-comment-initial-star-alignment)
+for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### ChainWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#chain-wrapping) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#chain-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
@@ -71,20 +72,20 @@ See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#chain-wrapp
 
 ### ClassName
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#classobject-naming) for
+See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#classobject-naming) for
 documentation.
 
 **Active by default**: No
 
 ### CommentSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#comment-spacing) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#comment-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### CommentWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#comment-wrapping) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#comment-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
@@ -96,7 +97,8 @@ See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#comment
 
 ### ContextReceiverMapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#content-receiver-wrapping) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/experimental/#content-receiver-wrapping) for
+documentation.
 
 **Active by default**: No
 
@@ -112,20 +114,20 @@ See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#content
 
 ### DiscouragedCommentLocation
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#discouraged-comment-location) for
+See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/experimental/#discouraged-comment-location) for
 documentation.
 
 **Active by default**: No
 
 ### EnumEntryNameCase
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#enum-entry) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#enum-entry) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### EnumWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#enum-wrapping) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/experimental/#enum-wrapping) for documentation.
 
 **Active by default**: No
 
@@ -137,7 +139,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#enum-wr
 
 ### Filename
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#file-name) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#file-name) for documentation.
 
 This rules overlaps with [naming>MatchingDeclarationName](https://detekt.dev/naming.html#matchingdeclarationname)
 from the standard rules, make sure to enable just one.
@@ -146,7 +148,7 @@ from the standard rules, make sure to enable just one.
 
 ### FinalNewline
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#final-newline) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#final-newline) for documentation.
 
 This rules overlaps with [style>NewLineAtEndOfFile](https://detekt.dev/style.html#newlineatendoffile)
 from the standard rules, make sure to enable just one. The pro of this rule is that it can auto-correct the issue.
@@ -161,20 +163,20 @@ from the standard rules, make sure to enable just one. The pro of this rule is t
 
 ### FunKeywordSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#fun-keyword-spacing) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#fun-keyword-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### FunctionName
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#function-naming) for
+See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/experimental/#function-naming) for
 documentation.
 
 **Active by default**: No
 
 ### FunctionReturnTypeSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#function-return-type-spacing) for
+See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#function-return-type-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
@@ -187,7 +189,7 @@ documentation.
 
 ### FunctionSignature
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#function-signature) for
+See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/experimental/#function-signature) for
 documentation.
 
 **Active by default**: No
@@ -212,21 +214,21 @@ documentation.
 
 ### FunctionStartOfBodySpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#function-start-of-body-spacing) for
+See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#function-start-of-body-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### FunctionTypeReferenceSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#function-type-reference-spacing) for
+See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#function-type-reference-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### IfElseBracing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#if-else-bracing) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/experimental/#if-else-bracing) for documentation.
 
 **Active by default**: No
 
@@ -238,7 +240,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#if-else
 
 ### IfElseWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#if-else-wrapping) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/experimental/#if-else-wrapping) for documentation.
 
 **Active by default**: No
 
@@ -250,9 +252,10 @@ See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#if-else
 
 ### ImportOrdering
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#import-ordering) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#import-ordering) for documentation.
 
-For defining import layout patterns see the [KtLint Source Code](https://github.com/pinterest/ktlint/blob/a6ca5b2edf95cc70a138a9470cfb6c4fd5d9d3ce/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/ImportOrderingRule.kt)
+For defining import layout patterns see
+the [KtLint Source Code](https://github.com/pinterest/ktlint/blob/0.49.1/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ImportOrderingRule.kt)
 
 **Active by default**: Yes - Since v1.19.0
 
@@ -264,7 +267,7 @@ For defining import layout patterns see the [KtLint Source Code](https://github.
 
 ### Indentation
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#indentation) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#indentation) for documentation.
 
 **Active by default**: Yes - Since v1.19.0
 
@@ -282,7 +285,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#indentation
 
 ### KdocWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#kdoc-wrapping) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#kdoc-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
@@ -294,7 +297,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#kdoc-wr
 
 ### MaximumLineLength
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#max-line-length) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#max-line-length) for documentation.
 
 This rules overlaps with [style>MaxLineLength](https://detekt.dev/style.html#maxlinelength)
 from the standard rules, make sure to enable just one or keep them aligned. The pro of this rule is that it can
@@ -314,13 +317,14 @@ auto-correct the issue.
 
 ### ModifierListSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#modifier-list-spacing) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#modifier-list-spacing) for
+documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### ModifierOrdering
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#modifier-order) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#modifier-order) for documentation.
 
 This rules overlaps with [style>ModifierOrder](https://detekt.dev/style.html#modifierorder)
 from the standard rules, make sure to enable just one. The pro of this rule is that it can auto-correct the issue.
@@ -329,7 +333,7 @@ from the standard rules, make sure to enable just one. The pro of this rule is t
 
 ### MultiLineIfElse
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#multiline-if-else) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#multiline-if-else) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
@@ -341,7 +345,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#multiline-i
 
 ### MultilineExpressionWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#multiline-expression-wrapping) for
+See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/experimental/#multiline-expression-wrapping) for
 documentation.
 
 **Active by default**: No
@@ -354,44 +358,47 @@ documentation.
 
 ### NoBlankLineBeforeRbrace
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#no-blank-lines-before) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#no-blank-lines-before) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoBlankLineInList
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#no-blank-lines-in-list) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/experimental/#no-blank-lines-in-list) for
+documentation.
 
 **Active by default**: No
 
 ### NoBlankLinesInChainedMethodCalls
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#no-blank-lines-in-chained-method-calls) for
+See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#no-blank-lines-in-chained-method-calls) for
 documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### NoConsecutiveBlankLines
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#no-consecutive-blank-lines) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#no-consecutive-blank-lines) for
+documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoConsecutiveComments
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#disallow-consecutive-comments) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/experimental/#disallow-consecutive-comments) for
+documentation.
 
 **Active by default**: No
 
 ### NoEmptyClassBody
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#no-empty-class-bodies) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#no-empty-class-bodies) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoEmptyFirstLineInClassBody
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#disallow-empty-lines-at-start-of-class-body)
+See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/experimental/#disallow-empty-lines-at-start-of-class-body)
 for documentation.
 
 **Active by default**: No
@@ -404,39 +411,40 @@ for documentation.
 
 ### NoEmptyFirstLineInMethodBlock
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#no-leading-empty-lines-in-method-blocks) for
+See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#no-leading-empty-lines-in-method-blocks) for
 documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### NoLineBreakAfterElse
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#no-line-break-after-else) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#no-line-break-after-else) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoLineBreakBeforeAssignment
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#no-line-break-before-assignment) for
+See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#no-line-break-before-assignment) for
 documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoMultipleSpaces
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#no-multi-spaces) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#no-multi-spaces) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoSemicolons
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#no-semicolons) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#no-semicolons) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoSingleLineBlockComment
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#no-single-line-block-comments) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/experimental/#no-single-line-block-comments) for
+documentation.
 
 **Active by default**: No
 
@@ -448,25 +456,25 @@ See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#no-sing
 
 ### NoTrailingSpaces
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#no-trailing-whitespaces) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#no-trailing-whitespaces) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoUnitReturn
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#no-unit-as-return-type) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#no-unit-as-return-type) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoUnusedImports
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#no-unused-imports) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#no-unused-imports) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoWildcardImports
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#no-wildcard-imports) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#no-wildcard-imports) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
@@ -478,28 +486,28 @@ See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#no-wildcard
 
 ### NullableTypeSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#nullable-type-spacing) for
+See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#nullable-type-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### PackageName
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#no-underscores-in-package-names) for
+See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#package-name) for
 documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### ParameterListSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#parameter-list-spacing) for
+See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/experimental/#parameter-list-spacing) for
 documentation.
 
 **Active by default**: No
 
 ### ParameterListWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#parameter-list-wrapping) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#parameter-list-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
@@ -515,7 +523,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#parameter-l
 
 ### ParameterWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#parameter-wrapping) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#parameter-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
@@ -531,14 +539,14 @@ See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#parameter-w
 
 ### PropertyName
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#property-naming) for
+See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/experimental/#property-naming) for
 documentation.
 
 **Active by default**: No
 
 ### PropertyWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#property-wrapping) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#property-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
@@ -554,100 +562,102 @@ See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#property-wr
 
 ### SpacingAroundAngleBrackets
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#angle-bracket-spacing) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#angle-bracket-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingAroundColon
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#colon-spacing) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#colon-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundComma
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#comma-spacing) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#comma-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundCurly
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#curly-spacing) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#curly-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundDot
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#dot-spacing) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#dot-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundDoubleColon
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#double-colon-spacing) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#double-colon-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingAroundKeyword
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#keyword-spacing) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#keyword-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundOperators
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#operator-spacing) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#operator-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundParens
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#parenthesis-spacing) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#parenthesis-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundRangeOperator
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#range-spacing) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#range-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundUnaryOperator
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#unary-operator-spacing) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#unary-operator-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingBetweenDeclarationsWithAnnotations
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#blank-line-between-declarations-with-annotations)
+See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#blank-line-between-declarations-with-annotations)
 for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingBetweenDeclarationsWithComments
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#blank-line-between-declaration-with-comments)
+See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#blank-line-between-declaration-with-comments)
 for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingBetweenFunctionNameAndOpeningParenthesis
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#spacing-between-function-name-and-opening-parenthesis) for
+See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#spacing-between-function-name-and-opening-parenthesis)
+for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### StringTemplate
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#string-template) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#string-template) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### StringTemplateIndent
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#string-template-indent) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/experimental/#string-template-indent) for
+documentation.
 
 **Active by default**: No
 
@@ -659,14 +669,15 @@ See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#string-
 
 ### TrailingCommaOnCallSite
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#trailing-comma-on-call-site) for
+documentation.
 
 The default config comes from ktlint and follows these conventions:
 - [Kotlin coding convention](https://kotlinlang.org/docs/coding-conventions.html#trailing-commas) recommends
-trailing comma encourage the use of trailing commas at the declaration site and
-leaves it at your discretion for the call site.
+  trailing comma encourage the use of trailing commas at the declaration site and
+  leaves it at your discretion for the call site.
 - [Android Kotlin style guide](https://developer.android.com/kotlin/style-guide) does not include
-trailing comma usage yet.
+  trailing comma usage yet.
 
 **Active by default**: No
 
@@ -678,14 +689,15 @@ trailing comma usage yet.
 
 ### TrailingCommaOnDeclarationSite
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#trailing-comma-on-declaration-site) for
+documentation.
 
 The default config comes from ktlint and follows these conventions:
 - [Kotlin coding convention](https://kotlinlang.org/docs/coding-conventions.html#trailing-commas) recommends
-trailing comma encourage the use of trailing commas at the declaration site and
-leaves it at your discretion for the call site.
+  trailing comma encourage the use of trailing commas at the declaration site and
+  leaves it at your discretion for the call site.
 - [Android Kotlin style guide](https://developer.android.com/kotlin/style-guide) does not include
-trailing comma usage yet.
+  trailing comma usage yet.
 
 **Active by default**: No
 
@@ -697,7 +709,7 @@ trailing comma usage yet.
 
 ### TryCatchFinallySpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#try-catch-finally-spacing) for
+See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/experimental/#try-catch-finally-spacing) for
 documentation.
 
 **Active by default**: No
@@ -710,7 +722,7 @@ documentation.
 
 ### TypeArgumentListSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#type-argument-list-spacing) for
+See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/experimental/#type-argument-list-spacing) for
 documentation.
 
 **Active by default**: No
@@ -723,7 +735,7 @@ documentation.
 
 ### TypeParameterListSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#type-parameter-list-spacing) for
+See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/experimental/#type-parameter-list-spacing) for
 documentation.
 
 **Active by default**: No
@@ -736,14 +748,14 @@ documentation.
 
 ### UnnecessaryParenthesesBeforeTrailingLambda
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/experimental/#unnecessary-parenthesis-before-trailing-lambda)
+See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#unnecessary-parenthesis-before-trailing-lambda)
 for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### Wrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/rules/standard/#wrapping) for documentation.
+See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.20.0
 


### PR DESCRIPTION
Fixes #6602 

This backports the automatic ktlint version replacement to the 1.x branch to (hopefully) fix the documentation generation for future 1.x releases. I also copied the versioned docs from the main branch.