### PR TITLE
Add "excludes" to detekt extension

### DIFF
--- a/detekt-gradle-plugin/api/detekt-gradle-plugin.api
+++ b/detekt-gradle-plugin/api/detekt-gradle-plugin.api
@@ -123,6 +123,7 @@ public abstract interface class io/gitlab/arturbosch/detekt/extensions/DetektExt
 	public abstract fun getDebug ()Lorg/gradle/api/provider/Property;
 	public abstract fun getDisableDefaultRuleSets ()Lorg/gradle/api/provider/Property;
 	public abstract fun getEnableCompilerPlugin ()Lorg/gradle/api/provider/Property;
+	public abstract fun getExcludes ()Lorg/gradle/api/provider/ListProperty;
 	public abstract fun getIgnoreFailures ()Lorg/gradle/api/provider/Property;
 	public abstract fun getIgnoredBuildTypes ()Lorg/gradle/api/provider/ListProperty;
 	public abstract fun getIgnoredFlavors ()Lorg/gradle/api/provider/ListProperty;

--- a/detekt-gradle-plugin/src/main/kotlin/io/github/detekt/gradle/DetektKotlinCompilerPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/github/detekt/gradle/DetektKotlinCompilerPlugin.kt
@@ -2,7 +2,6 @@ package io.github.detekt.gradle
 
 import io.github.detekt.gradle.extensions.KotlinCompileTaskDetektExtension
 import io.gitlab.arturbosch.detekt.CONFIGURATION_DETEKT_PLUGINS
-import io.gitlab.arturbosch.detekt.DetektPlugin
 import io.gitlab.arturbosch.detekt.DetektPlugin.Companion.CONFIG_DIR_NAME
 import io.gitlab.arturbosch.detekt.DetektPlugin.Companion.CONFIG_FILE
 import io.gitlab.arturbosch.detekt.DetektPlugin.Companion.DETEKT_EXTENSION
@@ -62,7 +61,7 @@ class DetektKotlinCompilerPlugin : KotlinCompilerPluginSupportPlugin {
                 disableDefaultRuleSets.convention(extension.disableDefaultRuleSets)
                 parallel.convention(extension.parallel)
                 config.from(extension.config)
-                excludes.convention(DetektPlugin.defaultExcludes)
+                excludes.convention(extension.excludes)
             }
         }
     }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
@@ -33,6 +33,7 @@ class DetektPlugin : Plugin<Project> {
                 DEFAULT_SRC_DIR_KOTLIN,
                 DEFAULT_TEST_SRC_DIR_KOTLIN,
             )
+            excludes.convention(defaultExcludes)
             baseline.convention(project.layout.projectDirectory.file("detekt-baseline.xml"))
             enableCompilerPlugin.convention(DEFAULT_COMPILER_PLUGIN_ENABLED)
             debug.convention(DEFAULT_DEBUG_VALUE)

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
@@ -20,6 +20,11 @@ interface DetektExtension {
 
     val source: ConfigurableFileCollection
 
+    /**
+     * List of glob patterns for files and directories to be excluded from the analysis.
+     */
+    val excludes: ListProperty<String>
+
     val baseline: RegularFileProperty
 
     val basePath: DirectoryProperty

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektPlain.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektPlain.kt
@@ -21,7 +21,7 @@ internal class DetektPlain(private val project: Project) {
             }
             setSource(existingInputDirectoriesProvider(project, extension))
             setIncludes(DetektPlugin.defaultIncludes)
-            setExcludes(DetektPlugin.defaultExcludes)
+            setExcludes(extension.excludes.get())
             reportsDir.convention(extension.reportsDir)
         }
 

--- a/website/docs/gettingstarted/gradle.mdx
+++ b/website/docs/gettingstarted/gradle.mdx
@@ -196,6 +196,9 @@ detekt {
         "src/main/kotlin",
         "gensrc/main/kotlin"
     )
+
+    // List of glob patterns for files and directories to be excluded from the analysis.
+    excludes = ["**/generated-src/**"]
     
     // Builds the AST in parallel. Rules are always executed in parallel. 
     // Can lead to speedups in larger projects. `false` by default.
@@ -251,6 +254,9 @@ detekt {
     // The directories where detekt looks for source files. 
     // Defaults to `files("src/main/java", "src/test/java", "src/main/kotlin", "src/test/kotlin")`.
     source.setFrom("src/main/java", "src/main/kotlin")
+
+    // List of glob patterns for files and directories to be excluded from the analysis.
+    excludes = listOf("**/generated-src/**")
     
     // Builds the AST in parallel. Rules are always executed in parallel. 
     // Can lead to speedups in larger projects. `false` by default.


### PR DESCRIPTION
This PR adds the "excludes"-option to the DetektExtension and fixes the problem described here: https://github.com/detekt/detekt/discussions/6604

I tested it locally with the Kotlin compiler plugin.

Unfortunately, the compiler plugin cannot currently handle the "includes" flag, so I have left it out for now.
