### PR TITLE
Add io.gitlab.arturbosch.detekt.generator.Main to the jar manifest

### DIFF
--- a/detekt-generator/build.gradle.kts
+++ b/detekt-generator/build.gradle.kts
@@ -1,6 +1,11 @@
 plugins {
     alias(libs.plugins.shadow)
     id("module")
+    application
+}
+
+application {
+    mainClass = "io.gitlab.arturbosch.detekt.generator.Main"
 }
 
 val generatedUsage by configurations.dependencyScope("generatedUsage")


### PR DESCRIPTION
Fixes #6600

We weren't adding declaring the Main class in the `detekt-generator-*-all.jar`. This will fix that.