### PR TITLE
Fix duplicate class name error in test

### DIFF
--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ConstructorParameterNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ConstructorParameterNamingSpec.kt
@@ -25,7 +25,7 @@ class ConstructorParameterNamingSpec {
         val code = """
             class C(val PARAM: String, private val PRIVATE_PARAM: String)
             
-            class C {
+            class D {
                 constructor(PARAM: String) {}
                 constructor(PARAM: String, PRIVATE_PARAM: String) {}
             }


### PR DESCRIPTION
A test is triggering this error on CI since Kotlin 1.9.20 update:

```
ConstructorParameterNamingSpec > should find some violations() FAILED
    java.lang.IllegalStateException: ERROR Duplicate JVM class name 'Script_main$C' generated from: C, C (script.main.kts:1:1)
    ERROR Duplicate JVM class name 'Script_main$C' generated from: C, C (script.main.kts:3:1)
        at io.github.detekt.test.utils.KotlinScriptEngine.compile(KotlinScriptEngine.kt:39)
        at io.gitlab.arturbosch.detekt.test.RuleExtensionsKt.compileAndLint(RuleExtensions.kt:22)
        at io.gitlab.arturbosch.detekt.rules.naming.ConstructorParameterNamingSpec.should find some violations(ConstructorParameterNamingSpec.kt:33)
```