### PR TITLE
Ignore unresolved classes in UnreachableCatchBlock

### DIFF
--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnreachableCatchBlockSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnreachableCatchBlockSpec.kt
@@ -4,6 +4,7 @@ import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
 
@@ -72,6 +73,20 @@ class UnreachableCatchBlockSpec(private val env: KotlinCoreEnvironment) {
             }
         """.trimIndent()
         val findings = subject.compileAndLintWithContext(env, code)
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report unreachable catch block for unknown exceptions`() {
+        val code = """
+            fun test() {
+                try {
+                } catch (e: Foo) {
+                } catch (e: Bar) {
+                }
+            }
+        """.trimIndent()
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 }


### PR DESCRIPTION
Kotlin compiler uses ErrorClassDescriptor for classes that doesn't resolve correctly. They all are subclasses of each other causing the check in UnreachableCatchBlock to consider all them unreachable.

Ignore ErrorClassDescriptor's to not add most likely false warnings as we can't know if the classes are subclasses or not.

Fixes #6626

<!-- A similar PR may already be submitted! -->
<!-- Please search among the [Pull requests](https://github.com/detekt/detekt/pulls) before creating one. -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Link to relevant issues if possible. -->

<!-- For more information, see the [CONTRIBUTING guide](https://github.com/detekt/detekt/blob/main/.github/CONTRIBUTING.md). -->
