### PR TITLE
Follow-up #6572: Re-order test classpath to load correct Logger as workaround for KT-60813

### DIFF
--- a/detekt-formatting/build.gradle.kts
+++ b/detekt-formatting/build.gradle.kts
@@ -4,7 +4,13 @@ plugins {
 
 val extraDepsToPackage: Configuration by configurations.creating
 val testRuntimeOnlyPriority: Configuration = configurations.resolvable("testRuntimeOnlyPriority").get()
-sourceSets.test.configure { runtimeClasspath = testRuntimeOnlyPriority + runtimeClasspath }
+sourceSets.test.configure {
+    val moduleSources = runtimeClasspath.filter { it.isDirectory }
+    val moduleDependencies = runtimeClasspath.filter { !it.isDirectory }
+    // Inject the priority dependencies between the compiled classes and the dependencies,
+    // so that KtTestCompiler.root resolves correctly.
+    runtimeClasspath = moduleSources + testRuntimeOnlyPriority + moduleDependencies
+}
 
 dependencies {
     compileOnly(projects.detektApi)

--- a/detekt-formatting/build.gradle.kts
+++ b/detekt-formatting/build.gradle.kts
@@ -59,8 +59,3 @@ tasks.test {
         jvmArgs("--add-opens=java.base/java.lang=ALL-UNNAMED")
     }
 }
-
-tasks.withType<Test>().configureEach {
-    // Required due to exclusion of kotlin-main-kts dependency above
-    systemProperty("compile-test-snippets", false)
-}

--- a/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/KtTestCompiler.kt
+++ b/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/KtTestCompiler.kt
@@ -31,7 +31,10 @@ internal object KtTestCompiler : KtCompiler() {
      * are JAR files, which leads to crashes. By initializing the root on demand, it's at least possible to
      * use String based input from Bazel.
      */
-    private val root by lazy { resourceAsPath("/") }
+    private val root: Path by lazy {
+        // STOPSHIP TestClass::class.java.protectionDomain.codeSource.location.toPath()
+        resourceAsPath("/META-INF/detekt-formatting_test.kotlin_module").parent.parent
+    }
 
     fun compile(path: Path) = compile(root, path)
 

--- a/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/KtTestCompiler.kt
+++ b/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/KtTestCompiler.kt
@@ -31,10 +31,7 @@ internal object KtTestCompiler : KtCompiler() {
      * are JAR files, which leads to crashes. By initializing the root on demand, it's at least possible to
      * use String based input from Bazel.
      */
-    private val root: Path by lazy {
-        // STOPSHIP TestClass::class.java.protectionDomain.codeSource.location.toPath()
-        resourceAsPath("/META-INF/detekt-formatting_test.kotlin_module").parent.parent
-    }
+    private val root: Path by lazy { resourceAsPath("/") }
 
     fun compile(path: Path) = compile(root, path)
 


### PR DESCRIPTION
 * Follow-up on https://github.com/detekt/detekt/pull/6572/files#r1386261829

This solution replaces the slf4j Logger with the correct one by classpath ordering: c4ef7372bd8bec71c20d864e2d0c170b2ab3c00d

I ran into #4140/#4170 not being implemented fully (current implementation is based on assumptions). The assumption is that the `/` resource on the classpath points to the current module's test sourceSet. By changing the order I changed this and now the slf4j.jar is on the classpath first, which triggers #4140. I was able to workaround this by looking for a specific file that's in the correct folder (ba150dbc3654f4392b06d065f2957a4674770448), but it's not scalable, so I instead changed the logic to insert the new dependency in the middle of the classpath: 68352ceeeb82b9d5c99637718ed9ef6b9797436f