### PR TITLE
Update to Kotlin 2.0.0

### DIFF
--- a/detekt-api/build.gradle.kts
+++ b/detekt-api/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     id("module")
     id("public-api")
     id("java-test-fixtures")
-    id("dev.drewhamilton.poko") version "0.15.3"
+    id("dev.drewhamilton.poko") version "0.16.0-beta01"
 }
 
 dependencies {

--- a/detekt-compiler-plugin/gradle.properties
+++ b/detekt-compiler-plugin/gradle.properties
@@ -1,4 +1,4 @@
-kotlinCompilerChecksum=eb7b68e01029fa67bc8d060ee54c12018f2c60ddc438cf21db14517229aa693b
+kotlinCompilerChecksum=ef578730976154fd2c5968d75af8c2703b3de84a78dffe913f670326e149da3b
 
 kotlin.code.style=official
 systemProp.sonar.host.url=http://localhost:9000

--- a/detekt-parser/src/main/kotlin/io/github/detekt/parser/BindingContextUtils.kt
+++ b/detekt-parser/src/main/kotlin/io/github/detekt/parser/BindingContextUtils.kt
@@ -36,7 +36,7 @@ fun generateBindingContext(
         TopDownAnalyzerFacadeForJVM.analyzeFilesWithJavaIntegration(
             environment.project,
             files,
-            NoScopeRecordCliBindingTrace(),
+            NoScopeRecordCliBindingTrace(environment.project),
             environment.configuration,
             environment::createPackagePartProvider
         )

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValue.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValue.kt
@@ -13,8 +13,8 @@ import io.gitlab.arturbosch.detekt.api.configWithFallback
 import io.gitlab.arturbosch.detekt.api.simplePatternToRegex
 import io.gitlab.arturbosch.detekt.rules.fqNameOrNull
 import io.gitlab.arturbosch.detekt.rules.isCalling
-import org.jetbrains.kotlin.backend.common.serialization.findPackage
 import org.jetbrains.kotlin.descriptors.annotations.AnnotationDescriptor
+import org.jetbrains.kotlin.descriptors.findPackage
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtExpression

--- a/detekt-test-utils/src/test/kotlin/io/github/detekt/test/utils/KotlinScriptEngineTest.kt
+++ b/detekt-test-utils/src/test/kotlin/io/github/detekt/test/utils/KotlinScriptEngineTest.kt
@@ -47,7 +47,7 @@ class KotlinScriptEngineTest {
 
         assertThatThrownBy { KotlinScriptEngine.compile(codeWithMissingImport) }
             .isInstanceOf(IllegalStateException::class.java)
-            .hasMessage("ERROR Unresolved reference: Random (script.main.kts:2:5)")
+            .hasMessage("ERROR Unresolved reference 'Random'. (script.main.kts:2:5)")
     }
 
     @RepeatedTest(10)

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/KotlinCoreEnvironmentExtensions.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/KotlinCoreEnvironmentExtensions.kt
@@ -10,7 +10,7 @@ fun KotlinCoreEnvironment.createBindingContext(files: List<KtFile>): BindingCont
     TopDownAnalyzerFacadeForJVM.analyzeFilesWithJavaIntegration(
         this.project,
         files,
-        NoScopeRecordCliBindingTrace(),
+        NoScopeRecordCliBindingTrace(this.project),
         this.configuration,
         this::createPackagePartProvider
     ).bindingContext

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -42,7 +42,7 @@ assertj = "org.assertj:assertj-core:3.25.3"
 classgraph = "io.github.classgraph:classgraph:4.8.172"
 snakeyaml = "org.snakeyaml:snakeyaml-engine:2.7"
 jcommander = "org.jcommander:jcommander:1.83"
-kotlinCompileTesting = { module = "dev.zacsweers.kctfork:core", version = "0.4.1" }
+kotlinCompileTesting = { module = "dev.zacsweers.kctfork:core", version = "0.5.0-alpha07" }
 jetbrains-annotations = "org.jetbrains:annotations:24.1.0"
 
 [plugins]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 dokka = "1.9.20"
 jacoco = "0.8.12"
-kotlin = "1.9.24"
+kotlin = "2.0.0"
 coroutines = "1.8.1"
 ktlint = "1.2.1"
 junit = "5.10.2"


### PR DESCRIPTION
Fixes #6715

This is safe to release with alpha/beta dependencies in my opinion. poko 0.16.0-beta01 is based on Kotlin 2.0.0-RC3 which is the same as 2.0.0. kctfork is only used in tests.