### PR TITLE
Enable Kotlin metadata version check for script compilation

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,6 +5,7 @@ org.gradle.caching=true
 org.gradle.configuration-cache=true
 org.gradle.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8
 org.gradle.kotlin.dsl.allWarningsAsErrors=true
+org.gradle.kotlin.dsl.skipMetadataVersionCheck=false
 
 # Enable Predictive Test Selection by default: https://docs.gradle.com/enterprise/predictive-test-selection/
 enablePTS=true


### PR DESCRIPTION
This will be the default in Gradle 9.

https://docs.gradle.org/8.5/release-notes.html#kotlin-dsl