### PR TITLE
Improve UnnamedParameterUse message (change CALL_EXPRESSION to actual function name)

### DIFF
--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnamedParameterUse.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnamedParameterUse.kt
@@ -75,6 +75,7 @@ import org.jetbrains.kotlin.types.typeUtil.isSubtypeOf
  */
 @RequiresTypeResolution
 class UnnamedParameterUse(config: Config = Config.empty) : Rule(config) {
+
     override val issue = Issue(
         javaClass.simpleName,
         "Passing no named parameters can cause issue when parameters order change",
@@ -125,8 +126,7 @@ class UnnamedParameterUse(config: Config = Config.empty) : Rule(config) {
                 CodeSmell(
                     issue,
                     Entity.from(expression),
-                    "$expression uses unnamed parameters. Consider using named parameters as they make usage " +
-                        "of function more safe"
+                    "Consider using named parameters in ${expression} as they make usage of function more safe."
                 )
             )
         }

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnamedParameterUse.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnamedParameterUse.kt
@@ -125,7 +125,7 @@ class UnnamedParameterUse(config: Config = Config.empty) : Rule(config) {
             report(
                 CodeSmell(
                     issue,
-                    Entity.from(expression),
+                    Entity.from(expression.calleeExpression ?: expression),
                     "Consider using named parameters in ${expression} as they make usage of function more safe."
                 )
             )

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnamedParameterUse.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnamedParameterUse.kt
@@ -126,7 +126,7 @@ class UnnamedParameterUse(config: Config = Config.empty) : Rule(config) {
                 CodeSmell(
                     issue,
                     Entity.from(expression.calleeExpression ?: expression),
-                    "Consider using named parameters in ${expression} as they make usage of function more safe."
+                    "Consider using named parameters in ${expression.calleeExpression?.text} as they make usage of the function more safe."
                 )
             )
         }

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnamedParameterUse.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnamedParameterUse.kt
@@ -122,11 +122,12 @@ class UnnamedParameterUse(config: Config = Config.empty) : Rule(config) {
         }
 
         if (namedArgumentList.any { it.first.not() }) {
+            val target = expression.calleeExpression ?: expression
             report(
                 CodeSmell(
                     issue,
-                    Entity.from(expression.calleeExpression ?: expression),
-                    "Consider using named parameters in ${expression.calleeExpression?.text} as they make usage of the function more safe."
+                    Entity.from(target),
+                    "Consider using named parameters in ${target.text} as they make usage of the function more safe."
                 )
             )
         }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnamedParameterUseSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnamedParameterUseSpec.kt
@@ -101,7 +101,7 @@ class UnnamedParameterUseSpec(private val env: KotlinCoreEnvironment) {
             }
         """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code))
-            .hasTextLocations(102 to 116)
+            .hasTextLocations(102 to 103)
             .singleElement()
             .hasMessage("Consider using named parameters in CALL_EXPRESSION as they make usage of function more safe.")
     }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnamedParameterUseSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnamedParameterUseSpec.kt
@@ -90,6 +90,23 @@ class UnnamedParameterUseSpec(private val env: KotlinCoreEnvironment) {
     }
 
     @Test
+    fun `report uses the function name as location and message`() {
+        val code = """
+            fun f(enabled: Boolean, shouldLog: Boolean) {
+                if (shouldLog) println(enabled)
+            }
+
+            fun test() {
+                f(false, true)
+            }
+        """.trimIndent()
+        assertThat(subject.compileAndLintWithContext(env, code))
+            .hasTextLocations(102 to 116)
+            .singleElement()
+            .hasMessage("Consider using named parameters in CALL_EXPRESSION as they make usage of function more safe.")
+    }
+
+    @Test
     fun `does not report two unnamed param when both are same`() {
         val code = """
             fun f(enabled: Boolean, shouldLog: Boolean) {

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnamedParameterUseSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnamedParameterUseSpec.kt
@@ -103,7 +103,7 @@ class UnnamedParameterUseSpec(private val env: KotlinCoreEnvironment) {
         assertThat(subject.compileAndLintWithContext(env, code))
             .hasTextLocations(102 to 103)
             .singleElement()
-            .hasMessage("Consider using named parameters in CALL_EXPRESSION as they make usage of function more safe.")
+            .hasMessage("Consider using named parameters in f as they make usage of the function more safe.")
     }
 
     @Test


### PR DESCRIPTION
I got some reports from this rule while testing detekt 2 upgrade:
```
....kt:49:9: CALL_EXPRESSION uses unnamed parameters. Consider using named parameters as they make usage of function more safe [UnnamedParameterUse]
....kt:54:12: CALL_EXPRESSION uses unnamed parameters. Consider using named parameters as they make usage of function more safe [UnnamedParameterUse]
....kt:59:9: CALL_EXPRESSION uses unnamed parameters. Consider using named parameters as they make usage of function more safe [UnnamedParameterUse]
```

to find the reported element I have to resort to lines and offsets. I'm guessing that the original intent was to put the text of the expression there instead of `CALL_EXPRESSION`.

While changing this behavior I also focused the report on the function name itself rather the the whole expression to prevent the usual large yellow blow in IDE (see https://github.com/detekt/detekt/issues/5316 for example).

Rule was added in https://github.com/detekt/detekt/pull/6055 cc @atulgpt (can't add you as reviewer for some reason)