### PR TITLE
Display dynamic --jvm-target values when using --help flag

### DIFF
--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/ArgumentConverters.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/ArgumentConverters.kt
@@ -2,6 +2,7 @@ package io.gitlab.arturbosch.detekt.cli
 
 import com.beust.jcommander.IStringConverter
 import com.beust.jcommander.ParameterException
+import org.jetbrains.kotlin.config.JvmTarget
 import org.jetbrains.kotlin.config.LanguageVersion
 import java.net.URL
 import java.nio.file.Path
@@ -47,6 +48,15 @@ class LanguageVersionConverter : IStringConverter<LanguageVersion> {
         val validValues by lazy { LanguageVersion.entries.joinToString { it.versionString } }
         return requireNotNull(LanguageVersion.fromFullVersionString(value)) {
             "\"$value\" passed to --language-version, expected one of [$validValues]"
+        }
+    }
+}
+
+class JvmTargetConverter : IStringConverter<JvmTarget> {
+    override fun convert(value: String): JvmTarget {
+        val validValues by lazy { JvmTarget.entries.joinToString { it.description } }
+        return checkNotNull(JvmTarget.fromString(value)) {
+            "Invalid value passed to --jvm-target, expected one of [$validValues]"
         }
     }
 }

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt
@@ -165,10 +165,11 @@ class CliArgs {
 
     @Parameter(
         names = ["--jvm-target"],
+        converter = JvmTargetConverter::class,
         description = "EXPERIMENTAL: Target version of the generated JVM bytecode that was generated during " +
-            "compilation and is now being used for type resolution (1.8, 9, 10, ..., 20)"
+            "compilation and is now being used for type resolution"
     )
-    var jvmTarget: String = JvmTarget.DEFAULT.description
+    var jvmTarget: JvmTarget = JvmTarget.DEFAULT
 
     @Parameter(
         names = ["--jdk-home"],

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Spec.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Spec.kt
@@ -57,7 +57,7 @@ internal fun CliArgs.createSpec(output: Appendable, error: Appendable): Processi
         }
 
         compiler {
-            jvmTarget = args.jvmTarget
+            jvmTarget = args.jvmTarget.toString()
             languageVersion = args.languageVersion?.versionString
             classpath = args.classpath?.trim()
             jdkHome = args.jdkHome


### PR DESCRIPTION
Copy-paste from #4694 below. That PR was reverted due to difficult to understand error messages caused by Kotlin compiler version mismatches due to incorrect Gradle dependencies. That's now resolved so this is safe to reintroduce.

---

This will now print values supported by the embedded Kotlin version and won't have to be updated manually anymore.

The required toString override was introduced in Kotlin 1.6.20 thanks to my first PR on jetbrains/kotlin :)

Before:
```
    --jvm-target
      EXPERIMENTAL: Target version of the generated JVM bytecode that was 
      generated during compilation and is now being used for type resolution 
      (1.6, 1.8, 9, 10, 11, 12, 13, 14, 15, 16 or 17)
      Default: 1.8
```
After:
```
    --jvm-target
      EXPERIMENTAL: Target version of the generated JVM bytecode that was 
      generated during compilation and is now being used for type resolution
      Default: 1.8
      Possible Values: [1.6, 1.8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18]
```