### PR TITLE
Keep build cache configuration consistent in all builds

### DIFF
--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -7,3 +7,20 @@ dependencyResolutionManagement {
         }
     }
 }
+
+val isCiBuild = providers.environmentVariable("CI").isPresent
+
+buildCache {
+    local {
+        isEnabled = true
+    }
+    remote<HttpBuildCache> {
+        isPush = isCiBuild
+        isEnabled = true
+        url = uri("https://ge.detekt.dev/cache/")
+        credentials {
+            username = providers.environmentVariable("GRADLE_CACHE_USERNAME").orNull
+            password = providers.environmentVariable("GRADLE_CACHE_PASSWORD").orNull
+        }
+    }
+}

--- a/detekt-gradle-plugin/settings.gradle.kts
+++ b/detekt-gradle-plugin/settings.gradle.kts
@@ -15,3 +15,20 @@ dependencyResolutionManagement {
 plugins {
     id("com.gradle.enterprise") version "3.16"
 }
+
+val isCiBuild = providers.environmentVariable("CI").isPresent
+
+buildCache {
+    local {
+        isEnabled = true
+    }
+    remote<HttpBuildCache> {
+        isPush = isCiBuild
+        isEnabled = true
+        url = uri("https://ge.detekt.dev/cache/")
+        credentials {
+            username = providers.environmentVariable("GRADLE_CACHE_USERNAME").orNull
+            password = providers.environmentVariable("GRADLE_CACHE_PASSWORD").orNull
+        }
+    }
+}


### PR DESCRIPTION
It is recommended to keep the build cache configuration of the root build consistent with the build cache configuration of early evaluated included builds.

Included builds applied using `pluginManagement` do not inherit build cache configuration from the top-level build so were not saving task output to the remote cache.