### PR TITLE
Fix a problem in the sample that break task laziness

### DIFF
--- a/website/docs/introduction/reporting.md
+++ b/website/docs/introduction/reporting.md
@@ -95,7 +95,7 @@ run `./gradlew detekt reportMerge --continue` to execute detekt tasks and merge 
 
 ### Groovy DSL
 ```groovy
-tasks.register("reportMerge", io.gitlab.arturbosch.detekt.report.ReportMergeTask) {
+def reportMerge = tasks.create("reportMerge", io.gitlab.arturbosch.detekt.report.ReportMergeTask) {
   output = project.layout.buildDirectory.file("reports/detekt/merge.xml") // or "reports/detekt/merge.sarif"
 }
 
@@ -106,11 +106,8 @@ subprojects {
   }
 
   tasks.withType(io.gitlab.arturbosch.detekt.Detekt).configureEach {
+    reportMerge.input.from(xmlReportFile) // or sarifReportFile
     finalizedBy(reportMerge)
-  }
-
-  reportMerge.configure {
-    input.from(tasks.withType(io.gitlab.arturbosch.detekt.Detekt).collect { it.xmlReportFile }) // or sarifReportFile
   }
 }
 ```
@@ -118,7 +115,7 @@ subprojects {
 ### Kotlin DSL
 
 ```kotlin
-val reportMerge by tasks.registering(io.gitlab.arturbosch.detekt.report.ReportMergeTask::class) { 
+val reportMerge = tasks.create<io.gitlab.arturbosch.detekt.report.ReportMergeTask> { 
   output.set(rootProject.layout.buildDirectory.file("reports/detekt/merge.xml")) // or "reports/detekt/merge.sarif"
 }
 
@@ -129,11 +126,8 @@ subprojects {
   }
 
   tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
+    reportMerge.input.from(xmlReportFile) // or sarifReportFile
     finalizedBy(reportMerge)
-  }
-
-  reportMerge {
-    input.from(tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().map { it.xmlReportFile }) // or .sarifReportFile
   }
 }
 ```


### PR DESCRIPTION
Fixes #6691

So, basically the culprit the below line

```
input.from(tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().map { it.xmlReportFile })
```

Specifically here the function `map`. Gradle's `Provider` API has `map` and `flatmap` functions that helps keep laziness. This is why I thought this was fine. But actually this is only for `Provider`s. The return type of `tasks.withType()` function is `TaskCollection`. Calling `map` function on this type causes all of the tasks to be configured eagerly. 

## Solution

Another problem while thinking of solution is the fact that there is a cyclic dependency between this `reportMerge` task and the others. I'm not sure if there is any other way to keep 100% lazy.

`reportMerge` is a single task in the whole project. It is actually not so bad if a single task is always configured. That's why I am proposing the below. 

If anyone has any idea to keep everything 100% lazy, that would be aweseom.