### PR TITLE
Disable local build cache on CI

### DIFF
--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -16,7 +16,7 @@ val isCiBuild = providers.environmentVariable("CI").isPresent
 
 buildCache {
     local {
-        isEnabled = true
+        isEnabled = !isCiBuild
     }
     remote<HttpBuildCache> {
         isPush = isCiBuild

--- a/detekt-gradle-plugin/settings.gradle.kts
+++ b/detekt-gradle-plugin/settings.gradle.kts
@@ -21,7 +21,7 @@ val isCiBuild = providers.environmentVariable("CI").isPresent
 
 buildCache {
     local {
-        isEnabled = true
+        isEnabled = !isCiBuild
     }
     remote<HttpBuildCache> {
         isPush = isCiBuild

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -63,7 +63,7 @@ develocity {
 
 buildCache {
     local {
-        isEnabled = true
+        isEnabled = !isCiBuild
     }
     remote(develocity.buildCache) {
         isEnabled = true


### PR DESCRIPTION
From https://docs.gradle.org/8.5/userguide/build_cache.html#sec:build_cache_configure:
> Gradle tries to load build outputs from the local build cache first, and
> then tries the remote build cache if no build outputs are found. If
> outputs are found in the remote cache, they are also stored in the local
> cache, so next time they will be found locally.

Inversely this means that that when local cache is hit, the outputs will not be stored in the remote cache. This is not what we want on CI nodes. Forcing remote build cache only on CI means cache will be updated for every task that does not have outputs already stored in the remote cache. This ensures they're available for local dev builds.

This recent build result is from CI: https://ge.detekt.dev/s/55usta3jzxkya/timeline?toggled=WyI5Il0&view=by-type#9
The first two tasks listed are `:detekt-gradle-plugin:compileFunctionalTestKotlin` and `:detekt-gradle-plugin:compileTestKotlin`. They were both restored from (local) cache which was restored by gradle-build-action.

This result is from my machine hours later: https://ge.detekt.dev/s/cphvzlb5tnkti/timeline?toggled=WyIzOCJd&view=by-type#38
The same two tasks listed 2nd and 3rd were not restored from (remote) cache because they weren't stored there by the CI run.