### PR TITLE
Demo false negative for `UnusedPrivateProperty`

### DIFF
--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivatePropertySpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivatePropertySpec.kt
@@ -724,7 +724,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                 class A(private val foo: Any) {
                     fun myFoo() = foo
                 }
-                class B(private val foo: Any) : ITest
+                class B(private val foo: Any)
             """.trimIndent()
             assertThat(subject.lint(code)).hasSize(1)
         }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivatePropertySpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivatePropertySpec.kt
@@ -719,6 +719,17 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
         }
 
         @Test
+        fun `reports unused private property if used in one class but not another`() {
+            val code = """
+                class A(private val foo: Any) {
+                    fun myFoo() = foo
+                }
+                class B(private val foo: Any) : ITest
+            """.trimIndent()
+            assertThat(subject.lint(code)).hasSize(1)
+        }
+
+        @Test
         fun `does not report public property`() {
             val code = """
                 class Test(val unused: Any)


### PR DESCRIPTION
```kt
class A(private val foo: Any) {
    fun myFoo() = foo
}
class B(private val foo: Any) // <-- foo should be reported here
```
