### PR TITLE
Use consistent JDK for Kotlin compilation

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
 }
 
 kotlin {
+    @Suppress("MagicNumber")
     jvmToolchain(8)
 }
 

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -16,6 +16,10 @@ dependencies {
     implementation(libs.plugins.dokka.asDependency())
 }
 
+kotlin {
+    jvmToolchain(8)
+}
+
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
     val isCiBuild = providers.environmentVariable("CI").isPresent
     if (isCiBuild) {

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -19,15 +19,16 @@ dependencies {
 kotlin {
     @Suppress("MagicNumber")
     jvmToolchain(8)
+
+    compilerOptions {
+        allWarningsAsErrors = providers.gradleProperty("warningsAsErrors").orNull.toBoolean()
+    }
 }
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
     val isCiBuild = providers.environmentVariable("CI").isPresent
     if (isCiBuild) {
         compilerExecutionStrategy = org.jetbrains.kotlin.gradle.tasks.KotlinCompilerExecutionStrategy.OUT_OF_PROCESS
-    }
-    compilerOptions {
-        allWarningsAsErrors = providers.gradleProperty("warningsAsErrors").orNull.toBoolean()
     }
 }
 

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -1,5 +1,9 @@
 rootProject.name = "build-logic"
 
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.7.0"
+}
+
 dependencyResolutionManagement {
     versionCatalogs {
         create("libs") {

--- a/build-logic/src/main/kotlin/module.gradle.kts
+++ b/build-logic/src/main/kotlin/module.gradle.kts
@@ -1,5 +1,6 @@
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
+import org.jetbrains.kotlin.gradle.tasks.UsesKotlinJavaToolchain
 
 plugins {
     id("packaging")
@@ -51,6 +52,14 @@ kotlin {
         progressiveMode = true
         allWarningsAsErrors = providers.gradleProperty("warningsAsErrors").orNull.toBoolean()
     }
+}
+
+val java8Launcher = javaToolchains.launcherFor {
+    languageVersion = JavaLanguageVersion.of(8)
+}
+
+project.tasks.withType<UsesKotlinJavaToolchain>().configureEach {
+    kotlinJavaToolchain.toolchain.use(java8Launcher)
 }
 
 testing {

--- a/detekt-gradle-plugin/settings.gradle.kts
+++ b/detekt-gradle-plugin/settings.gradle.kts
@@ -14,6 +14,7 @@ dependencyResolutionManagement {
 
 plugins {
     id("com.gradle.enterprise") version "3.16.1"
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.7.0"
 }
 
 val isCiBuild = providers.environmentVariable("CI").isPresent

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -47,6 +47,7 @@ enableFeaturePreview("STABLE_CONFIGURATION_CACHE")
 plugins {
     id("com.gradle.enterprise") version "3.16.1"
     id("com.gradle.common-custom-user-data-gradle-plugin") version "1.12.1"
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.7.0"
 }
 
 val isCiBuild = providers.environmentVariable("CI").isPresent


### PR DESCRIPTION
If toolchains are not used the version of Java that Gradle is running with is passed as an input to Kotlin compilation tasks. Using toolchains means compilation tasks have a consistent JDK version as the input. Builds can then run on any Java version and hit remote cache primed with builds run on different Java versions.