### PR TITLE
Fixes #6708

### DIFF
--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektReportMergeSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektReportMergeSpec.kt
@@ -55,13 +55,13 @@ class DetektReportMergeSpec {
             assertThat(result.output).containsIgnoringWhitespaces(
                 """
                     Execution failed for task ':child1:detekt'.
-                    > Analysis failed with 2 issues.
+                    > Analysis failed with 2 weighted issues.
                 """.trimIndent()
             )
             assertThat(result.output).containsIgnoringWhitespaces(
                 """
                     Execution failed for task ':child2:detekt'.
-                    > Analysis failed with 4 issues.
+                    > Analysis failed with 4 weighted issues.
                 """.trimIndent()
             )
             assertThat(projectFile("build/reports/detekt/detekt.sarif")).doesNotExist()
@@ -121,13 +121,13 @@ class DetektReportMergeSpec {
             assertThat(result.output).containsIgnoringWhitespaces(
                 """
                     Execution failed for task ':child1:detekt'.
-                    > Analysis failed with 2 issues.
+                    > Analysis failed with 2 weighted issues.
                 """.trimIndent()
             )
             assertThat(result.output).containsIgnoringWhitespaces(
                 """
                     Execution failed for task ':child2:detekt'.
-                    > Analysis failed with 4 issues.
+                    > Analysis failed with 4 weighted issues.
                 """.trimIndent()
             )
             assertThat(projectFile("build/reports/detekt/detekt.xml")).doesNotExist()

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektTaskSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektTaskSpec.kt
@@ -45,7 +45,7 @@ class DetektTaskSpec {
             .build()
 
         gradleRunner.runDetektTaskAndExpectFailure { result ->
-            assertThat(result.output).contains("Analysis failed with 15 issues.")
+            assertThat(result.output).contains("Analysis failed with 15 weighted issues.")
         }
     }
 }

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/JvmSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/JvmSpec.kt
@@ -14,7 +14,7 @@ class JvmSpec {
             .withArguments("detektMain")
             .buildAndFail()
 
-        assertThat(result.output).contains("failed with 3 issues.")
+        assertThat(result.output).contains("failed with 3 weighted issues.")
         assertThat(result.output).contains(
             "Do not directly exit the process outside the `main` function. Throw an exception(...)"
         )


### PR DESCRIPTION
This issue fixes multiple test failures that were caused by a change of wording in error messages. See #6708 for more details.
