### PR TITLE
Set remote build cache to push only if authenticated

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -75,12 +75,18 @@ buildCache {
         isEnabled = true
     }
     remote<HttpBuildCache> {
-        isPush = isCiBuild
-        isEnabled = true
         url = uri("https://ge.detekt.dev/cache/")
+        isEnabled = true
+
+        val cacheUsername = providers.environmentVariable("GRADLE_CACHE_USERNAME").orNull
+        val cachePassword = providers.environmentVariable("GRADLE_CACHE_PASSWORD").orNull
+        val isAuthenticated = !cacheUsername.isNullOrEmpty() && !cachePassword.isNullOrEmpty()
+
+        // Check credentials presence to avoid build cache errors on PR builds when access key is not present
+        isPush = isCiBuild && isAuthenticated
         credentials {
-            username = providers.environmentVariable("GRADLE_CACHE_USERNAME").orNull
-            password = providers.environmentVariable("GRADLE_CACHE_PASSWORD").orNull
+            username = cacheUsername
+            password = cachePassword
         }
     }
 }


### PR DESCRIPTION
- Updated remote build cache config to only push when authenticated -> if an unauthenticated push is attempted remote build cache will get turned off for the rest of the build. This can happen (does) on forked PR builds which run in an unsecure environment.
