### PR TITLE
Simplfy sarirf code

### DIFF
--- a/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/RuleDescriptors.kt
+++ b/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/RuleDescriptors.kt
@@ -6,7 +6,6 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.RuleSetId
 import io.gitlab.arturbosch.detekt.api.RuleSetProvider
-import java.util.Locale
 import java.util.ServiceLoader
 
 /**
@@ -30,8 +29,8 @@ internal fun toReportingDescriptors(): List<ReportingDescriptor> {
 }
 
 private fun Rule.toDescriptor(ruleSetId: RuleSetId): ReportingDescriptor {
-    val formattedRuleSetId = ruleSetId.lowercase(Locale.US)
-    val formattedRuleId = ruleId.lowercase(Locale.US)
+    val formattedRuleSetId = ruleSetId.lowercase()
+    val formattedRuleId = ruleId.lowercase()
 
     return ReportingDescriptor(
         id = "detekt.$ruleSetId.$ruleId",

--- a/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/RuleDescriptors.kt
+++ b/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/RuleDescriptors.kt
@@ -12,10 +12,9 @@ import java.util.ServiceLoader
 /**
  * Given the existing config, return a list of [ReportingDescriptor] for the rules.
  */
-internal fun toReportingDescriptors(config: Config): List<ReportingDescriptor> {
-    val sets =
-        ServiceLoader.load(RuleSetProvider::class.java, SarifOutputReport::class.java.classLoader)
-            .map { it.instance(config.subConfig(it.ruleSetId)) }
+internal fun toReportingDescriptors(): List<ReportingDescriptor> {
+    val sets = ServiceLoader.load(RuleSetProvider::class.java, SarifOutputReport::class.java.classLoader)
+        .map { it.instance(Config.empty) }
     val ruleSetIdAndRules = sets.flatMap { ruleSet ->
         ruleSet.rules.map { rule ->
             ruleSet.id to rule

--- a/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/SarifOutputReport.kt
+++ b/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/SarifOutputReport.kt
@@ -7,7 +7,6 @@ import io.github.detekt.sarif4k.SarifSerializer
 import io.github.detekt.sarif4k.Tool
 import io.github.detekt.sarif4k.ToolComponent
 import io.github.detekt.sarif4k.Version
-import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Detektion
 import io.gitlab.arturbosch.detekt.api.OutputReport
 import io.gitlab.arturbosch.detekt.api.SetupContext
@@ -28,12 +27,10 @@ class SarifOutputReport : BuiltInOutputReport, OutputReport() {
     override val ending: String = "sarif"
     override val id: String = "sarif"
 
-    private lateinit var config: Config
     private var basePath: String? = null
 
     @OptIn(UnstableApi::class)
     override fun init(context: SetupContext) {
-        this.config = context.config
         this.basePath = context.getOrNull<Path>(DETEKT_OUTPUT_REPORT_BASE_PATH_KEY)
             ?.absolute()
             ?.invariantSeparatorsPathString
@@ -57,7 +54,7 @@ class SarifOutputReport : BuiltInOutputReport, OutputReport() {
                             informationURI = "https://detekt.dev",
                             language = "en",
                             name = "detekt",
-                            rules = toReportingDescriptors(config),
+                            rules = toReportingDescriptors(),
                             organization = "detekt",
                             semanticVersion = version,
                             version = version


### PR DESCRIPTION
Some simplifications on the sarif code. We aren't using the real configuration to anything, we just need a configration to instantiate the RuleSet. For that reason I'm using `Config.empty`.