### PR TITLE
Don't recreate sequence

### DIFF
--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Analyzer.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Analyzer.kt
@@ -112,13 +112,14 @@ internal class Analyzer(
             .filter { (_, ruleSetConfig) -> ruleSetConfig.isActive() }
             .map { (provider, ruleSetConfig) -> provider.instance(ruleSetConfig) to ruleSetConfig }
             .filter { (_, ruleSetConfig) -> ruleSetConfig.shouldAnalyzeFile(file) }
+            .toList()
 
         val ruleIdsToRuleSetIds = associateRuleIdsToRuleSetIds(
             activeRuleSetsToRuleSetConfigs.map { (ruleSet, _) -> ruleSet }
         )
 
         val (correctableRules, otherRules) = activeRuleSetsToRuleSetConfigs
-            .flatMap { (ruleSet, _) -> ruleSet.rules.asSequence() }
+            .flatMap { (ruleSet, _) -> ruleSet.rules }
             .filter { rule ->
                 bindingContext != BindingContext.EMPTY || !rule::class.hasAnnotation<RequiresTypeResolution>()
             }
@@ -150,7 +151,7 @@ internal class Analyzer(
             .map { it to config.subConfig(it.ruleSetId) }
             .filter { (_, ruleSetConfig) -> ruleSetConfig.isActive() }
             .map { (provider, ruleSetConfig) -> provider.instance(ruleSetConfig) to ruleSetConfig }
-            .flatMap { (ruleSet, _) -> ruleSet.rules.asSequence() }
+            .flatMap { (ruleSet, _) -> ruleSet.rules }
             .filter { rule -> (rule as? Rule)?.active == true }
             .filter { rule -> rule::class.hasAnnotation<RequiresTypeResolution>() }
             .forEach { rule ->

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/rules/RuleSets.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/rules/RuleSets.kt
@@ -31,7 +31,7 @@ fun RuleSet.visitFile(
         it.findings
     }
 
-fun associateRuleIdsToRuleSetIds(ruleSets: Sequence<RuleSet>): Map<RuleId, RuleSetId> {
+fun associateRuleIdsToRuleSetIds(ruleSets: List<RuleSet>): Map<RuleId, RuleSetId> {
     fun extractIds(rule: BaseRule) = sequenceOf(rule.ruleId)
     return ruleSets.flatMap { ruleSet ->
         ruleSet.rules

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/rules/RuleSets.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/rules/RuleSets.kt
@@ -2,7 +2,6 @@ package io.gitlab.arturbosch.detekt.core.rules
 
 import io.github.detekt.psi.absolutePath
 import io.github.detekt.tooling.api.spec.RulesSpec
-import io.gitlab.arturbosch.detekt.api.BaseRule
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.api.RuleId
@@ -32,16 +31,11 @@ fun RuleSet.visitFile(
     }
 
 fun associateRuleIdsToRuleSetIds(ruleSets: List<RuleSet>): Map<RuleId, RuleSetId> {
-    fun extractIds(rule: BaseRule) = sequenceOf(rule.ruleId)
-    return ruleSets.flatMap { ruleSet ->
-        ruleSet.rules
-            .asSequence()
-            .flatMap { rule ->
-                extractIds(rule).map { ruleId ->
-                    ruleId to ruleSet.id
-                }
-            }
-    }.toMap()
+    return ruleSets
+        .flatMap { ruleSet ->
+            ruleSet.rules.map { rule -> rule.ruleId to ruleSet.id }
+        }
+        .toMap()
 }
 
 fun ProcessingSettings.createRuleProviders(): List<RuleSetProvider> = when (val runPolicy = spec.rulesSpec.runPolicy) {


### PR DESCRIPTION
The `Sequence` are great but if we need to iterate them twice we should first convert them to a List to avoid generate its items twice.

This PR also cleans some redundant `asSquence` and simplifies a bit the code around those changes.