### PR TITLE
Mandatory config on Rule

### DIFF
--- a/detekt-api/api/detekt-api.api
+++ b/detekt-api/api/detekt-api.api
@@ -338,7 +338,6 @@ public final class io/gitlab/arturbosch/detekt/api/ReportingExtension$DefaultImp
 }
 
 public abstract class io/gitlab/arturbosch/detekt/api/Rule : io/gitlab/arturbosch/detekt/api/BaseRule, io/gitlab/arturbosch/detekt/api/ConfigAware {
-	public fun <init> ()V
 	public fun <init> (Lio/gitlab/arturbosch/detekt/api/Config;Lio/gitlab/arturbosch/detekt/api/Context;)V
 	public synthetic fun <init> (Lio/gitlab/arturbosch/detekt/api/Config;Lio/gitlab/arturbosch/detekt/api/Context;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun getActive ()Z

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Rule.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Rule.kt
@@ -17,7 +17,7 @@ import org.jetbrains.kotlin.psi.KtFile
  * two predefined (preVisit/postVisit) functions which can be overridden to setup/teardown additional data.
  */
 abstract class Rule(
-    override val ruleSetConfig: Config = Config.empty,
+    override val ruleSetConfig: Config,
     ruleContext: Context = DefaultContext()
 ) : BaseRule(ruleContext), ConfigAware {
 

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/KT.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/KT.kt
@@ -15,7 +15,7 @@ val path: Path = resourceAsPath("/cases")
 
 class TestProvider(override val ruleSetId: String = "Test") : RuleSetProvider {
     override fun instance(config: Config): RuleSet {
-        return RuleSet("Test", listOf(FindName()))
+        return RuleSet("Test", listOf(FindName(config)))
     }
 }
 
@@ -25,7 +25,7 @@ class TestProvider2(override val ruleSetId: String = "Test2") : RuleSetProvider 
     }
 }
 
-class FindName : Rule() {
+class FindName(config: Config) : Rule(config) {
     override val issue: Issue = Issue(javaClass.simpleName, "")
     override fun visitClassOrObject(classOrObject: KtClassOrObject) {
         report(CodeSmell(issue, Entity.atName(classOrObject), message = ""))

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/SuppressionSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/SuppressionSpec.kt
@@ -298,7 +298,7 @@ private class TestRule(config: Config = Config.empty) : Rule(config) {
     }
 }
 
-private class TestLM : Rule() {
+private class TestLM(config: Config = Config.empty) : Rule(config) {
     override val issue = Issue("LongMethod", "")
     override fun visitNamedFunction(function: KtNamedFunction) {
         val start = Location.startLineAndColumn(function.funKeyword!!).line

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/TopLevelAutoCorrectSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/TopLevelAutoCorrectSpec.kt
@@ -66,7 +66,7 @@ class TopLevelAutoCorrectSpec {
     }
 }
 
-private class DeleteAnnotationsRule : Rule() {
+private class DeleteAnnotationsRule(config: Config) : Rule(config) {
     override val issue = Issue("test-rule", "")
     override fun visitAnnotation(annotation: KtAnnotation) {
         annotation.delete()
@@ -75,5 +75,5 @@ private class DeleteAnnotationsRule : Rule() {
 
 private class TopLevelAutoCorrectProvider : RuleSetProvider {
     override val ruleSetId: String = "test-rule-set"
-    override fun instance(config: Config) = RuleSet(ruleSetId, listOf(DeleteAnnotationsRule()))
+    override fun instance(config: Config) = RuleSet(ruleSetId, listOf(DeleteAnnotationsRule(config)))
 }

--- a/detekt-report-sarif/src/test/kotlin/io/github/detekt/report/sarif/SarifOutputReportSpec.kt
+++ b/detekt-report-sarif/src/test/kotlin/io/github/detekt/report/sarif/SarifOutputReportSpec.kt
@@ -2,6 +2,7 @@ package io.github.detekt.report.sarif
 
 import io.github.detekt.test.utils.readResourceContent
 import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Location
@@ -172,7 +173,7 @@ private fun constrainRegion(startLine: Int, startColumn: Int, endLine: Int, endC
     }
 """.trimIndent()
 
-class TestRule : Rule() {
+class TestRule(config: Config = Config.empty) : Rule(config) {
     override val issue = Issue(javaClass.simpleName, "")
 
     override fun visitClassOrObject(classOrObject: KtClassOrObject) {

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitItLambdaParameter.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitItLambdaParameter.kt
@@ -43,7 +43,7 @@ import org.jetbrains.kotlin.psi.KtLambdaExpression
  * </compliant>
  */
 @ActiveByDefault(since = "1.21.0")
-class ExplicitItLambdaParameter(val config: Config) : Rule(config) {
+class ExplicitItLambdaParameter(config: Config) : Rule(config) {
     override val issue = Issue(
         javaClass.simpleName,
         "Declaring lambda parameters as `it` is redundant.",

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MultilineLambdaItParameter.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MultilineLambdaItParameter.kt
@@ -66,7 +66,7 @@ import org.jetbrains.kotlin.utils.ifEmpty
  *
  */
 @RequiresTypeResolution
-class MultilineLambdaItParameter(val config: Config) : Rule(config) {
+class MultilineLambdaItParameter(config: Config) : Rule(config) {
     override val issue = Issue(
         javaClass.simpleName,
         "Multiline lambdas should not use `it` as a parameter name.",

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/TrimMultilineRawString.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/TrimMultilineRawString.kt
@@ -45,7 +45,7 @@ import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
  * """Hello World! How are you?"""
  * </compliant>
  */
-class TrimMultilineRawString(val config: Config) : Rule(config) {
+class TrimMultilineRawString(config: Config) : Rule(config) {
     override val issue = Issue(
         javaClass.simpleName,
         "Multiline raw strings should be followed by `trimMargin()` or `trimIndent()`.",


### PR DESCRIPTION
If you don't pass a configuration to the rule your rule will not be able to be configured. It will seem that everything works but in reality it will not. If we force to pass a configuration it's less likely to have that problem.

There is only one place where this default value is used: in the tests. And we shouldn't have a default value on our production code just to make our tests a bit easier (you can see how few changes on tests this PR has).

TL;DR: api less error prone and the benefits to have it are minimal. 