### PR TITLE
`ConfigAware` doesn't need to implement `Config`

### DIFF
--- a/detekt-api/api/detekt-api.api
+++ b/detekt-api/api/detekt-api.api
@@ -90,9 +90,10 @@ public final class io/gitlab/arturbosch/detekt/api/Config$InvalidConfigurationEr
 	public synthetic fun <init> (Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
-public abstract interface class io/gitlab/arturbosch/detekt/api/ConfigAware : io/gitlab/arturbosch/detekt/api/Config {
+public abstract interface class io/gitlab/arturbosch/detekt/api/ConfigAware {
 	public abstract fun getActive ()Z
 	public abstract fun getAutoCorrect ()Z
+	public abstract fun getRuleConfig ()Lio/gitlab/arturbosch/detekt/api/Config;
 	public abstract fun getRuleId ()Ljava/lang/String;
 	public abstract fun getRuleSetConfig ()Lio/gitlab/arturbosch/detekt/api/Config;
 	public abstract fun subConfig (Ljava/lang/String;)Lio/gitlab/arturbosch/detekt/api/Config;
@@ -103,7 +104,7 @@ public abstract interface class io/gitlab/arturbosch/detekt/api/ConfigAware : io
 public final class io/gitlab/arturbosch/detekt/api/ConfigAware$DefaultImpls {
 	public static fun getActive (Lio/gitlab/arturbosch/detekt/api/ConfigAware;)Z
 	public static fun getAutoCorrect (Lio/gitlab/arturbosch/detekt/api/ConfigAware;)Z
-	public static fun getParentPath (Lio/gitlab/arturbosch/detekt/api/ConfigAware;)Ljava/lang/String;
+	public static fun getRuleConfig (Lio/gitlab/arturbosch/detekt/api/ConfigAware;)Lio/gitlab/arturbosch/detekt/api/Config;
 	public static fun subConfig (Lio/gitlab/arturbosch/detekt/api/ConfigAware;Ljava/lang/String;)Lio/gitlab/arturbosch/detekt/api/Config;
 	public static fun valueOrDefault (Lio/gitlab/arturbosch/detekt/api/ConfigAware;Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun valueOrNull (Lio/gitlab/arturbosch/detekt/api/ConfigAware;Ljava/lang/String;)Ljava/lang/Object;
@@ -351,7 +352,7 @@ public abstract class io/gitlab/arturbosch/detekt/api/Rule : io/gitlab/arturbosc
 	public fun getDefaultRuleIdAliases ()Ljava/util/Set;
 	public fun getFilters ()Lio/gitlab/arturbosch/detekt/api/internal/PathFilters;
 	public abstract fun getIssue ()Lio/gitlab/arturbosch/detekt/api/Issue;
-	public fun getParentPath ()Ljava/lang/String;
+	public fun getRuleConfig ()Lio/gitlab/arturbosch/detekt/api/Config;
 	public final fun getRuleId ()Ljava/lang/String;
 	public fun getRuleSetConfig ()Lio/gitlab/arturbosch/detekt/api/Config;
 	public final fun report (Lio/gitlab/arturbosch/detekt/api/Finding;)V

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/ConfigAware.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/ConfigAware.kt
@@ -15,7 +15,7 @@ package io.gitlab.arturbosch.detekt.api
  * rule set and all rules upfront and letting them 'sub config' the rule set config would
  * be error-prone.
  */
-interface ConfigAware : Config {
+interface ConfigAware {
 
     /**
      * Id which is used to retrieve the sub config for the rule implementing this interface.
@@ -30,7 +30,7 @@ interface ConfigAware : Config {
      */
     val ruleSetConfig: Config
 
-    private val ruleConfig: Config
+    val ruleConfig: Config
         get() = ruleSetConfig.subConfig(ruleId)
 
     /**
@@ -47,12 +47,12 @@ interface ConfigAware : Config {
      */
     val active: Boolean get() = valueOrDefault(Config.ACTIVE_KEY, false)
 
-    override fun subConfig(key: String): Config =
+    fun subConfig(key: String): Config =
         ruleConfig.subConfig(key)
 
-    override fun <T : Any> valueOrDefault(key: String, default: T): T =
+    fun <T : Any> valueOrDefault(key: String, default: T): T =
         ruleConfig.valueOrDefault(key, default)
 
-    override fun <T : Any> valueOrNull(key: String): T? =
+    fun <T : Any> valueOrNull(key: String): T? =
         ruleConfig.valueOrNull(key)
 }

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/ConfigProperty.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/ConfigProperty.kt
@@ -127,7 +127,7 @@ private fun ConfigAware.getListOrDefault(propertyName: String, defaultValue: Lis
     return if (defaultValue.all { it is String }) {
         @Suppress("UNCHECKED_CAST")
         val defaultValueAsListOfStrings = defaultValue as List<String>
-        valueOrDefaultCommaSeparated(propertyName, defaultValueAsListOfStrings)
+        ruleConfig.valueOrDefaultCommaSeparated(propertyName, defaultValueAsListOfStrings)
     } else {
         error("Only lists of strings are supported. '$propertyName' is invalid. ")
     }

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Rule.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Rule.kt
@@ -54,7 +54,7 @@ abstract class Rule(
      * Rules are aware of the paths they should run on via configuration properties.
      */
     open val filters: PathFilters? by lazy(LazyThreadSafetyMode.NONE) {
-        createPathFilters()
+        ruleConfig.createPathFilters()
     }
 
     override fun visitCondition(root: KtFile): Boolean =

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenCommentSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenCommentSpec.kt
@@ -6,6 +6,7 @@ import io.gitlab.arturbosch.detekt.api.ValueWithReason
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.toConfig
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
@@ -250,8 +251,8 @@ class ForbiddenCommentSpec {
     @Nested
     inner class `custom message is not configured` {
         private val messageConfig = TestConfig(VALUES to "Comment")
-        private val messageConfigWithReason = ForbiddenComment(
-            ValueWithReason("Comment", "Comment is disallowed")
+        private val messageWithReasonConfig = TestConfig(
+            COMMENTS to listOf(ValueWithReason("Comment", "Comment is disallowed").toConfig())
         )
 
         @Test
@@ -266,7 +267,7 @@ class ForbiddenCommentSpec {
         @Test
         fun `should report a Finding with reason`() {
             val comment = "// Comment"
-            val findings = ForbiddenComment(messageConfigWithReason).compileAndLint(comment)
+            val findings = ForbiddenComment(messageWithReasonConfig).compileAndLint(comment)
             assertThat(findings).hasSize(1)
             assertThat(findings.first().message).isEqualTo("Comment is disallowed")
         }
@@ -1044,7 +1045,3 @@ class ForbiddenCommentSpec {
 @Suppress("TestFunctionName") // This is a factory function for ForbiddenComment
 private fun ForbiddenComment(vararg comments: String): ForbiddenComment =
     ForbiddenComment(TestConfig(COMMENTS to comments.toList()))
-
-@Suppress("TestFunctionName")
-private fun ForbiddenComment(vararg comments: ValueWithReason): ForbiddenComment =
-    ForbiddenComment(TestConfig(COMMENTS to comments.map { mapOf("value" to it.value, "reason" to it.reason) }))


### PR DESCRIPTION
`ConfigAware` impelments `Config` and `Rule` implements `ConfigAware` so, at the end a `Rule` is a `Config` class. That's really odd. We were even configuring a rule with another rule on our tests!! This PR changes that.