### PR TITLE
Add `BigDecimal`'s double constructor to `ForbiddenMethodCall`'s default configuration

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -608,6 +608,8 @@ style:
         value: 'kotlin.io.print'
       - reason: 'println does not allow you to configure the output stream. Use a logger instead.'
         value: 'kotlin.io.println'
+      - reason: 'using `BigDecimal.<init>(kotlin.Double)` can result in unexpected float point precision behavior. Use `BigDecimal.valueOf(kotlin.Double)` or `BigDecimal.<init>(kotlin.String)` instead.'
+        value: 'java.math.BigDecimal.<init>(kotlin.Double)'
   ForbiddenSuppress:
     active: false
     rules: []

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCall.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCall.kt
@@ -68,6 +68,9 @@ class ForbiddenMethodCall(config: Config = Config.empty) : Rule(config) {
         valuesWithReason(
             "kotlin.io.print" to "print does not allow you to configure the output stream. Use a logger instead.",
             "kotlin.io.println" to "println does not allow you to configure the output stream. Use a logger instead.",
+            "java.math.BigDecimal.<init>(kotlin.Double)" to "using `BigDecimal.<init>(kotlin.Double)` can result in " +
+                "unexpected float point precision behavior. Use `BigDecimal.valueOf(kotlin.Double)` or " +
+                "`BigDecimal.<init>(kotlin.String)` instead.",
         )
     ) { list ->
         list.map { Forbidden(fromFunctionSignature(it.value), it.reason) }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCallSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCallSpec.kt
@@ -741,6 +741,39 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
                 ).compileAndLintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }
+
+            @Test
+            fun `should report BigDecimal double constructor usages by default`() {
+                val code = """
+                    import java.math.BigDecimal
+
+                    val x = BigDecimal(3.14)
+                """.trimIndent()
+                val findings = ForbiddenMethodCall(TestConfig()).compileAndLintWithContext(env, code)
+                assertThat(findings).hasSize(1)
+            }
+
+            @Test
+            fun `should report nothing when using BigDecimal string constructor`() {
+                val code = """
+                    import java.math.BigDecimal
+
+                    val x = BigDecimal("3.14")
+                """.trimIndent()
+                val findings = ForbiddenMethodCall(TestConfig()).compileAndLintWithContext(env, code)
+                assertThat(findings).isEmpty()
+            }
+
+            @Test
+            fun `should report nothing when using BigDecimal int constructor`() {
+                val code = """
+                    import java.math.BigDecimal
+
+                    val x = BigDecimal(3)
+                """.trimIndent()
+                val findings = ForbiddenMethodCall(TestConfig()).compileAndLintWithContext(env, code)
+                assertThat(findings).isEmpty()
+            }
         }
     }
 }


### PR DESCRIPTION

<!-- A similar PR may already be submitted! -->
<!-- Please search among the [Pull requests](https://github.com/detekt/detekt/pulls) before creating one. -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Link to relevant issues if possible. -->

<!-- For more information, see the [CONTRIBUTING guide](https://github.com/detekt/detekt/blob/main/.github/CONTRIBUTING.md). -->

This forbids usages of `BigDecimal` double constructor since it will almost never be the intended behavior of the user. Instead of calling `new BigDecimal(double)`, users should use `BigDecimal.valueOf(double)` or just `BigDecimal(string)`.
 
Resolves #6704
