### PR TITLE
gitignore .kotlin directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,9 @@ local.properties
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 
+### Kotlin ###
+.kotlin
+
 ### LaTeX ###
 *.acn
 *.acr


### PR DESCRIPTION
From Kotlin 2.0.0-Beta2 release notes:

> In Kotlin 1.8.20, the Kotlin Gradle plugin started to store its data in the Gradle project cache directory: <project-root-directory>/.gradle/kotlin. However, the .gradle directory is reserved for Gradle only, and as a result it's not future-proof. To solve this, in Kotlin 2.0.0-Beta2 we store Kotlin data in your <project-root-directory>/.kotlin by default. We will continue to store some data in .gradle/kotlin directory for backward compatibility.