### PR TITLE
Only call getNameAsSafeName on instances of KtNamedDeclaration

### DIFF
--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLet.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLet.kt
@@ -14,6 +14,7 @@ import org.jetbrains.kotlin.descriptors.impl.ValueParameterDescriptorImpl.WithDe
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtLambdaExpression
+import org.jetbrains.kotlin.psi.KtNamedDeclaration
 import org.jetbrains.kotlin.psi.KtQualifiedExpression
 import org.jetbrains.kotlin.psi.KtSafeQualifiedExpression
 import org.jetbrains.kotlin.psi.KtSimpleNameExpression
@@ -104,6 +105,7 @@ private fun canBeReplacedWithCall(lambdaExpr: KtLambdaExpression?): Boolean {
     } else {
         lambdaParameter.destructuringDeclaration?.entries.orEmpty()
             .plus(lambdaParameter)
+            .filterIsInstance<KtNamedDeclaration>()
             .map { it.nameAsSafeName.asString() }
     }
     return lambdaParameterNames.any { receiver.textMatches(it) }


### PR DESCRIPTION
Without this filter there is a failure when compiling with Kotlin 2.0.0-Beta2 which looks like correct compiler behaviour. I'm backporting the fix as it's more correct.