### PR TITLE
Move APIs to a dedicated submenu and fix links

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -2,7 +2,7 @@
 // Note: type annotations allow type checking and IDEs autocompletion
 
 import { themes as prismThemes } from "prism-react-renderer";
-const detektVersionReplace = require('./src/remark/detektVersionReplace');
+const detektVersionReplace = require("./src/remark/detektVersionReplace");
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
@@ -123,14 +123,19 @@ const config = {
             position: "left",
           },
           {
-            href: "/kdoc/",
+            label: "APIs",
+            type: "dropdown",
             position: "left",
-            label: "API",
-          },
-          {
-            href: "/kdoc/detekt-gradle-plugin/",
-            position: "left",
-            label: "Gradle Plugin API",
+            items: [
+              {
+                href: "https://detekt.dev/kdoc/",
+                label: "Core APIs",
+              },
+              {
+                href: "https://detekt.dev/kdoc/detekt-gradle-plugin/",
+                label: "Gradle Plugin APIs",
+              },
+            ],
           },
           {
             to: "/marketplace",


### PR DESCRIPTION
Current behavior when clicking on the `API` or `Gradle Plugin API` the page shows a "Page Not found" screen. If the user refreshes the browser, it actually shows the KDoc correctly.

<img width="921" alt="Screenshot 2023-12-23 at 20 41 59" src="https://github.com/detekt/detekt/assets/3001957/4e676961-9ea7-4014-aa74-55be75f44670">

I've created an APIs dropdown menu, and fixed the KDoc links to open on a separate URL:
<img width="494" alt="Screenshot 2023-12-23 at 20 46 08" src="https://github.com/detekt/detekt/assets/3001957/8889b225-ee6b-4a10-be48-70cb6ba20edc">
