### PR TITLE
Remove input and output file registration for generateDocumentation task

### DIFF
--- a/detekt-generator/build.gradle.kts
+++ b/detekt-generator/build.gradle.kts
@@ -66,17 +66,6 @@ val generateDocumentation by tasks.registering(JavaExec::class) {
         .filter { it.exists() }
         .toList()
 
-    inputs.files(ruleModules)
-
-    outputs.files(
-        fileTree(documentationDir),
-        file(defaultConfigFile),
-        file(formattingConfigFile),
-        file(librariesConfigFile),
-        file(ruleauthorsConfigFile),
-        file(deprecationFile),
-    )
-
     classpath(
         configurations.runtimeClasspath.get(),
         configurations.compileClasspath.get(),


### PR DESCRIPTION
This task has caching disabled. When enabling with outputs.cacheIf {true} there is an error about overlapping task outputs because the fileTree output location includes `_category_.json` file.

Using a filter like `include("**/*.md")` on the fileTree does not work due to https://github.com/gradle/gradle/issues/9131.

There's no way to enumerate the output file names and use file declarations instead as the output filename is based on the value of `ruleSetId` in the rule set provider.

Based on the above it is not currently feasible to cache this task's outputs, so it makes sense to remove the redundant input and output file registrations from the task declaration.