### PR TITLE
Add parent config property

### DIFF
--- a/detekt-api/api/detekt-api.api
+++ b/detekt-api/api/detekt-api.api
@@ -69,6 +69,7 @@ public abstract interface class io/gitlab/arturbosch/detekt/api/Config {
 	public static final field EXCLUDES_KEY Ljava/lang/String;
 	public static final field INCLUDES_KEY Ljava/lang/String;
 	public static final field SEVERITY_KEY Ljava/lang/String;
+	public abstract fun getParent ()Lio/gitlab/arturbosch/detekt/api/Config;
 	public abstract fun getParentPath ()Ljava/lang/String;
 	public abstract fun subConfig (Ljava/lang/String;)Lio/gitlab/arturbosch/detekt/api/Config;
 	public abstract fun valueOrDefault (Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/Object;

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Config.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Config.kt
@@ -13,6 +13,8 @@ interface Config {
      */
     val parentPath: String?
 
+    val parent: Config?
+
     /**
      * Tries to retrieve part of the configuration based on given key.
      */
@@ -49,6 +51,8 @@ interface Config {
          */
         val empty: Config = object : Config {
             override val parentPath: String? = null
+
+            override val parent: Config = this
 
             override fun subConfig(key: String): Config = this
 

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/AllRulesConfig.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/AllRulesConfig.kt
@@ -9,14 +9,15 @@ import io.gitlab.arturbosch.detekt.core.config.validation.validateConfig
 internal data class AllRulesConfig(
     private val originalConfig: Config,
     private val defaultConfig: Config,
-    private val deprecatedRules: Set<DeprecatedRule> = emptySet()
+    private val deprecatedRules: Set<DeprecatedRule> = emptySet(),
+    override val parent: Config? = null,
 ) : Config, ValidatableConfiguration {
 
     override val parentPath: String?
         get() = originalConfig.parentPath ?: defaultConfig.parentPath
 
     override fun subConfig(key: String) =
-        AllRulesConfig(originalConfig.subConfig(key), defaultConfig.subConfig(key), deprecatedRules)
+        AllRulesConfig(originalConfig.subConfig(key), defaultConfig.subConfig(key), deprecatedRules, this)
 
     override fun <T : Any> valueOrDefault(key: String, default: T): T {
         return when (key) {

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/CompositeConfig.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/CompositeConfig.kt
@@ -8,14 +8,17 @@ import io.gitlab.arturbosch.detekt.core.config.validation.validateConfig
 /**
  * Wraps two different configuration which should be considered when retrieving properties.
  */
-class CompositeConfig(private val lookFirst: Config, private val lookSecond: Config) :
-    Config, ValidatableConfiguration {
+class CompositeConfig(
+    private val lookFirst: Config,
+    private val lookSecond: Config,
+    override val parent: Config? = null,
+) : Config, ValidatableConfiguration {
 
     override val parentPath: String?
         get() = lookFirst.parentPath ?: lookSecond.parentPath
 
     override fun subConfig(key: String): Config =
-        CompositeConfig(lookFirst.subConfig(key), lookSecond.subConfig(key))
+        CompositeConfig(lookFirst.subConfig(key), lookSecond.subConfig(key), this)
 
     override fun <T : Any> valueOrDefault(key: String, default: T): T {
         if (lookFirst.valueOrNull<T>(key) != null) {

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/DisabledAutoCorrectConfig.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/DisabledAutoCorrectConfig.kt
@@ -6,12 +6,15 @@ import io.gitlab.arturbosch.detekt.core.config.validation.ValidatableConfigurati
 import io.gitlab.arturbosch.detekt.core.config.validation.validateConfig
 
 @Suppress("UNCHECKED_CAST")
-class DisabledAutoCorrectConfig(private val wrapped: Config) : Config, ValidatableConfiguration {
+class DisabledAutoCorrectConfig(
+    private val wrapped: Config,
+    override val parent: Config? = null,
+) : Config, ValidatableConfiguration {
 
     override val parentPath: String?
         get() = wrapped.parentPath
 
-    override fun subConfig(key: String): Config = DisabledAutoCorrectConfig(wrapped.subConfig(key))
+    override fun subConfig(key: String): Config = DisabledAutoCorrectConfig(wrapped.subConfig(key), this)
 
     override fun <T : Any> valueOrDefault(key: String, default: T): T = when (key) {
         Config.AUTO_CORRECT_KEY -> false as T

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/YamlConfig.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/YamlConfig.kt
@@ -20,7 +20,8 @@ import kotlin.io.path.reader
  */
 class YamlConfig internal constructor(
     val properties: Map<String, Any>,
-    override val parentPath: String? = null
+    override val parentPath: String?,
+    override val parent: Config?,
 ) : Config, ValidatableConfiguration {
 
     override fun subConfig(key: String): Config {
@@ -28,7 +29,8 @@ class YamlConfig internal constructor(
         val subProperties = properties.getOrElse(key) { emptyMap<String, Any>() } as Map<String, Any>
         return YamlConfig(
             subProperties,
-            if (parentPath == null) key else "$parentPath $CONFIG_SEPARATOR $key"
+            if (parentPath == null) key else "$parentPath $CONFIG_SEPARATOR $key",
+            this,
         )
     }
 
@@ -78,7 +80,7 @@ class YamlConfig internal constructor(
                 createYamlLoad().loadFromReader(bufferedReader) as Map<String, *>?
             }.getOrElse { throw Config.InvalidConfigurationError(it) }
             @Suppress("UNCHECKED_CAST")
-            YamlConfig(map.orEmpty() as Map<String, Any>)
+            YamlConfig(map.orEmpty() as Map<String, Any>, null, null)
         }
 
         private fun createYamlLoad() = Load(

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/AllRulesConfigSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/AllRulesConfigSpec.kt
@@ -38,6 +38,21 @@ class AllRulesConfigSpec {
     }
 
     @Nested
+    inner class Parent {
+        private val rulesetConfig = yamlConfig("/configs/single-rule-in-style-ruleset.yml")
+
+        @Test
+        fun `is the parent`() {
+            val subject = AllRulesConfig(
+                originalConfig = rulesetConfig,
+                defaultConfig = emptyYamlConfig,
+            )
+            val actual = subject.subConfig("style").parent
+            assertThat(actual).isEqualTo(subject)
+        }
+    }
+
+    @Nested
     inner class DeactivateDeprecatedRule {
 
         @Test

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/CompositeConfigSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/CompositeConfigSpec.kt
@@ -70,4 +70,11 @@ class CompositeConfigSpec {
             assertThat(actual).isEqualTo("code-smell")
         }
     }
+
+    @Test
+    fun `parent returns the parent instance`() {
+        val subject = compositeConfig
+        val actual = subject.subConfig("style").parent
+        assertThat(actual).isEqualTo(subject)
+    }
 }

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/DisabledAutoCorrectConfigSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/DisabledAutoCorrectConfigSpec.kt
@@ -6,12 +6,19 @@ import org.junit.jupiter.api.Test
 
 class DisabledAutoCorrectConfigSpec {
     private val rulesetId = "style"
-    private val rulesetConfig = yamlConfig("/configs/single-rule-in-style-ruleset.yml").subConfig(rulesetId)
+    private val config = yamlConfig("/configs/single-rule-in-style-ruleset.yml")
 
     @Test
     fun `parent path is derived from wrapped config`() {
-        val subject = DisabledAutoCorrectConfig(rulesetConfig)
+        val subject = DisabledAutoCorrectConfig(config.subConfig(rulesetId))
         val actual = subject.parentPath
         assertThat(actual).isEqualTo(rulesetId)
+    }
+
+    @Test
+    fun `parent returns the parent instance`() {
+        val subject = DisabledAutoCorrectConfig(config)
+        val actual = subject.subConfig(rulesetId).parent
+        assertThat(actual).isEqualTo(subject)
     }
 }

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/YamlConfigSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/YamlConfigSpec.kt
@@ -67,6 +67,14 @@ class YamlConfigSpec {
             val actual = subject.parentPath
             assertThat(actual).isEqualTo(rulesetId)
         }
+
+        @Test
+        fun `parent returns the original config`() {
+            val rulesetId = "style"
+            val subject = config.subConfig(rulesetId)
+            val actual = subject.parent
+            assertThat(actual).isEqualTo(config)
+        }
     }
 
     @Nested

--- a/detekt-test/api/detekt-test.api
+++ b/detekt-test/api/detekt-test.api
@@ -42,7 +42,9 @@ public final class io/gitlab/arturbosch/detekt/test/RuleExtensionsKt {
 }
 
 public final class io/gitlab/arturbosch/detekt/test/TestConfig : io/gitlab/arturbosch/detekt/api/Config {
+	public fun <init> (Lio/gitlab/arturbosch/detekt/api/Config;[Lkotlin/Pair;)V
 	public fun <init> ([Lkotlin/Pair;)V
+	public fun getParent ()Lio/gitlab/arturbosch/detekt/api/Config;
 	public fun getParentPath ()Ljava/lang/String;
 	public synthetic fun subConfig (Ljava/lang/String;)Lio/gitlab/arturbosch/detekt/api/Config;
 	public fun subConfig (Ljava/lang/String;)Lio/gitlab/arturbosch/detekt/test/TestConfig;

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/TestConfig.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/TestConfig.kt
@@ -6,13 +6,14 @@ import io.gitlab.arturbosch.detekt.core.config.tryParseBasedOnDefault
 import io.gitlab.arturbosch.detekt.core.config.valueOrDefaultInternal
 
 @Suppress("UNCHECKED_CAST")
-class TestConfig(vararg pairs: Pair<String, Any>) : Config {
-
+class TestConfig(override val parent: Config?, vararg pairs: Pair<String, Any>) : Config {
     private val values: Map<String, Any> = mapOf(*pairs)
 
     override val parentPath: String? = null
 
-    override fun subConfig(key: String) = this
+    constructor(vararg pairs: Pair<String, Any>) : this(Config.empty, *pairs)
+
+    override fun subConfig(key: String) = TestConfig(this, *values.map { (key, value) -> key to value }.toTypedArray())
 
     override fun <T : Any> valueOrDefault(key: String, default: T) =
         if (key == Config.ACTIVE_KEY) {


### PR DESCRIPTION
Blocked by #6736

Right now the rules get the configuration of its parent and then look for its configuration there because the rules need information of their configuration and their parent's configuration too. With this change we allow (next PRs) that the rule could receive its configuration and then, when needed, look at its parent configuration.