### PR TITLE
Remove BaselineProvider.id()

### DIFF
--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineFormat.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineFormat.kt
@@ -2,9 +2,7 @@ package io.gitlab.arturbosch.detekt.core.baseline
 
 import io.github.detekt.tooling.api.Baseline
 import io.github.detekt.tooling.api.BaselineProvider
-import io.github.detekt.tooling.api.FindingId
 import io.github.detekt.tooling.api.FindingsIdList
-import io.gitlab.arturbosch.detekt.api.Finding
 import org.xml.sax.SAXParseException
 import java.nio.file.Path
 import javax.xml.XMLConstants
@@ -20,8 +18,6 @@ internal class BaselineFormat : BaselineProvider {
         get() = location.lineNumber to location.columnNumber
 
     class InvalidState(msg: String, error: Throwable) : IllegalStateException(msg, error)
-
-    override fun id(finding: Finding): FindingId = finding.baselineId
 
     override fun of(manuallySuppressedIssues: FindingsIdList, currentIssues: FindingsIdList): DefaultBaseline =
         DefaultBaseline(manuallySuppressedIssues, currentIssues)

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineFormatSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineFormatSpec.kt
@@ -3,7 +3,6 @@ package io.gitlab.arturbosch.detekt.core.baseline
 import io.github.detekt.test.utils.createTempFileForTest
 import io.github.detekt.test.utils.resourceAsPath
 import io.github.detekt.tooling.api.BaselineProvider
-import io.gitlab.arturbosch.detekt.test.createFinding
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatIllegalStateException
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -19,11 +18,6 @@ class BaselineFormatSpec {
         @Test
         fun `core implements provider`() {
             assertThat(BaselineProvider.load()).isInstanceOf(BaselineFormat::class.java)
-        }
-
-        @Test
-        fun `provider allows to query finding baseline ids`() {
-            assertThat(BaselineProvider.load().id(createFinding())).isEqualTo("TestSmell:TestEntitySignature")
         }
 
         @Test

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/DefaultBaselineKtTest.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/DefaultBaselineKtTest.kt
@@ -1,0 +1,12 @@
+package io.gitlab.arturbosch.detekt.core.baseline
+
+import io.gitlab.arturbosch.detekt.test.createFinding
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class DefaultBaselineKtTest {
+    @Test
+    fun `baselineId Extension`() {
+        assertThat(createFinding().baselineId).isEqualTo("TestSmell:TestEntitySignature")
+    }
+}

--- a/detekt-tooling/api/detekt-tooling.api
+++ b/detekt-tooling/api/detekt-tooling.api
@@ -15,7 +15,6 @@ public abstract interface class io/github/detekt/tooling/api/Baseline {
 
 public abstract interface class io/github/detekt/tooling/api/BaselineProvider {
 	public static final field Companion Lio/github/detekt/tooling/api/BaselineProvider$Companion;
-	public abstract fun id (Lio/gitlab/arturbosch/detekt/api/Finding;)Ljava/lang/String;
 	public abstract fun of (Ljava/util/Set;Ljava/util/Set;)Lio/github/detekt/tooling/api/Baseline;
 	public abstract fun read (Ljava/nio/file/Path;)Lio/github/detekt/tooling/api/Baseline;
 	public abstract fun write (Ljava/nio/file/Path;Lio/github/detekt/tooling/api/Baseline;)V

--- a/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/api/BaselineProvider.kt
+++ b/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/api/BaselineProvider.kt
@@ -1,12 +1,9 @@
 package io.github.detekt.tooling.api
 
-import io.gitlab.arturbosch.detekt.api.Finding
 import java.nio.file.Path
 import java.util.ServiceLoader
 
 interface BaselineProvider {
-
-    fun id(finding: Finding): FindingId
     fun of(manuallySuppressedIssues: FindingsIdList, currentIssues: FindingsIdList): Baseline
     fun read(sourcePath: Path): Baseline
     fun write(targetPath: Path, baseline: Baseline)


### PR DESCRIPTION
It is not needed/used in anyway afaik. And, if someone needs it, we could just make the extension function `public`.