### PR TITLE
Fix cli tests

### DIFF
--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/RunnerSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/RunnerSpec.kt
@@ -71,14 +71,16 @@ class RunnerSpec {
         }
 
         @Nested
-        inner class `execute with default config with issues` {
+        inner class `execute with issues` {
 
             @BeforeEach
             fun setUp() {
                 val args = parseArguments(
                     arrayOf(
                         "--input",
-                        inputPath.toString()
+                        inputPath.toString(),
+                        "--config-resource",
+                        "/configs/valid-config.yml"
                     )
                 )
 
@@ -168,7 +170,9 @@ class RunnerSpec {
                     "--report",
                     "txt:$tmp",
                     "--run-rule",
-                    "test:test"
+                    "test:test",
+                    "--config-resource",
+                    "/configs/valid-config.yml"
                 )
             }.isExactlyInstanceOf(IssuesFound::class.java)
             assertThat(tmp.readLines()).hasSize(1)

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/TestRules.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/TestRules.kt
@@ -11,10 +11,10 @@ import org.jetbrains.kotlin.psi.KtClass
 
 class TestProvider : RuleSetProvider {
     override val ruleSetId: String = "test"
-    override fun instance(config: Config): RuleSet = RuleSet(ruleSetId, listOf(TestRule()))
+    override fun instance(config: Config): RuleSet = RuleSet(ruleSetId, listOf(TestRule(config)))
 }
 
-class TestRule : Rule() {
+class TestRule(config: Config) : Rule(config) {
     override val issue = Issue("test", "A failure")
     override fun visitClass(klass: KtClass) {
         if (klass.name == "Poko") {

--- a/detekt-cli/src/test/resources/configs/valid-config.yml
+++ b/detekt-cli/src/test/resources/configs/valid-config.yml
@@ -1,0 +1,3 @@
+test:
+  test:
+    active: true


### PR DESCRIPTION
These tests wasn't testing what we expected. They were passing because all the rules are enabled by default if you use `Config.empty` (the default value for `Rule`). But, in the real scenarios, we never use `Config.empty` so we weren't testing the expected behaviour.

This issue is related with #6734.