### PR TITLE
Remove unnecessary tests

### DIFF
--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ModifierOrderSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ModifierOrderSpec.kt
@@ -1,7 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import io.gitlab.arturbosch.detekt.test.lint
@@ -39,14 +38,6 @@ class ModifierOrderSpec {
             assertThat(subject.lint("private actual class Test(val test: String)")).isEmpty()
             assertThat(subject.lint("expect annotation class Test")).isEmpty()
             assertThat(subject.lint("private /* comment */ data class Test(val test: String)")).isEmpty()
-        }
-
-        @Test
-        fun `should not report issues if inactive`() {
-            val rule = ModifierOrder(TestConfig(Config.ACTIVE_KEY to "false"))
-            assertThat(rule.compileAndLint(bad1)).isEmpty()
-            assertThat(rule.lint(bad2)).isEmpty()
-            assertThat(rule.lint(bad3)).isEmpty()
         }
     }
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/WildcardImportSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/WildcardImportSpec.kt
@@ -1,6 +1,5 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
-import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import io.gitlab.arturbosch.detekt.test.lint
@@ -21,14 +20,6 @@ class WildcardImportSpec {
             class Test {
             }
         """.trimIndent()
-
-        @Test
-        fun `should not report anything when the rule is turned off`() {
-            val rule = WildcardImport(TestConfig(Config.ACTIVE_KEY to "false"))
-
-            val findings = rule.compileAndLint(code)
-            assertThat(findings).isEmpty()
-        }
 
         @Test
         fun `should report all wildcard imports`() {


### PR DESCRIPTION
We don't needs test on each rule to ensure that a non-active rule doesn't emit any `Finding`. That's handled in other part of detekt not related with the implementation of `ModifierOrder` nor `WildcardImport`.