### PR TITLE
Unblock snapshots by updating the base plugin id

### DIFF
--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -88,7 +88,7 @@ gradlePlugin {
     vcsUrl = "https://github.com/detekt/detekt"
     plugins {
         create("detektBasePlugin") {
-            id = "dev.detekt.gradle.base"
+            id = "io.github.detekt.gradle.base"
             implementationClass = "dev.detekt.gradle.plugin.DetektBasePlugin"
             displayName = "Static code analysis for Kotlin"
             description = "Static code analysis for Kotlin"


### PR DESCRIPTION
This change should unblock the -SNAPSHOT versions which are currently red. This is happening as the base plugin is attempting to publish to `dev.detekt.*`.

While we do have permission there, we would have to change the publishing host to be:
```
"https://s01.oss.sonatype.org/service/local/"
"https://s01.oss.sonatype.org/content/repositories/snapshots/"
```

That means that we'll end up having a more complex build setup as we'll have a mixture of `dev.detekt.*` which needs to go on `s01` and `io.gitlab...` which needs to go to the old host.

To keep things simple, let's just update the base Gradle plugin to hit the old nexus host and we'll update all of them once we're close to release 2.0.0