### PR TITLE
Remove redundant notCompatibleWithConfigurationCache calls for Dokka tasks

### DIFF
--- a/build-logic/src/main/kotlin/public-api.gradle.kts
+++ b/build-logic/src/main/kotlin/public-api.gradle.kts
@@ -1,5 +1,4 @@
 import org.jetbrains.dokka.gradle.DokkaTask
-import org.jetbrains.dokka.gradle.DokkaTaskPartial
 
 plugins {
     id("org.jetbrains.kotlinx.binary-compatibility-validator")
@@ -8,8 +7,4 @@ plugins {
 
 tasks.withType<DokkaTask>().configureEach {
     failOnWarning = true
-}
-
-tasks.withType<DokkaTaskPartial>().configureEach {
-    notCompatibleWithConfigurationCache("https://github.com/Kotlin/dokka/issues/1217")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,6 @@ plugins {
 }
 
 tasks.withType<DokkaMultiModuleTask>().configureEach {
-    notCompatibleWithConfigurationCache("https://github.com/Kotlin/dokka/issues/1217")
     outputDirectory = layout.projectDirectory.dir("website/static/kdoc")
 }
 

--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -156,7 +156,6 @@ tasks {
         suppressInheritedMembers = true
         failOnWarning = true
         outputDirectory = layout.projectDirectory.dir("../website/static/kdoc/detekt-gradle-plugin")
-        notCompatibleWithConfigurationCache("https://github.com/Kotlin/dokka/issues/1217")
 
         dokkaSourceSets.configureEach {
             apiVersion = "1.4"


### PR DESCRIPTION
Configuration cache is still not supported but the Dokka plugin takes care of declaring the incompatibility since v1.9.10.

https://github.com/Kotlin/dokka/releases/tag/v1.9.10