### PR TITLE
Align how we declare `Issue` inside the `Rule`s

### DIFF
--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/internal/InclusionExclusionPatternsSpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/internal/InclusionExclusionPatternsSpec.kt
@@ -119,7 +119,7 @@ private fun Path.runWith(rule: DummyRule): DummyRule {
 
 private class OnlyLibraryTrackingRule(config: Config) : Rule(config) {
 
-    override val issue: Issue = Issue("test", "")
+    override val issue = Issue("test", "")
     private var libraryFileVisited = false
     private var counter = 0
 

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/internal/InclusionExclusionPatternsSpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/internal/InclusionExclusionPatternsSpec.kt
@@ -119,7 +119,7 @@ private fun Path.runWith(rule: DummyRule): DummyRule {
 
 private class OnlyLibraryTrackingRule(config: Config) : Rule(config) {
 
-    override val issue = Issue("test", "")
+    override val issue = Issue(javaClass.simpleName, "")
     private var libraryFileVisited = false
     private var counter = 0
 
@@ -142,7 +142,7 @@ private class OnlyLibraryTrackingRule(config: Config) : Rule(config) {
 
 private class DummyRule(config: Config = Config.empty) : Rule(config) {
 
-    override val issue = Issue("test", "")
+    override val issue = Issue(javaClass.simpleName, "")
     private var isDirty: Boolean = false
 
     override fun visitKtFile(file: KtFile) {

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/RunnerSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/RunnerSpec.kt
@@ -90,7 +90,7 @@ class RunnerSpec {
 
             @Test
             fun `writes output to output printer`() {
-                assertThat(outPrintStream.toString()).contains("A failure [test]")
+                assertThat(outPrintStream.toString()).contains("A failure [TestRule]")
             }
 
             @Test
@@ -170,7 +170,7 @@ class RunnerSpec {
                     "--report",
                     "txt:$tmp",
                     "--run-rule",
-                    "test:test",
+                    "test:TestRule",
                     "--config-resource",
                     "/configs/valid-config.yml"
                 )
@@ -186,7 +186,7 @@ class RunnerSpec {
 
         @Test
         fun `should throw on non existing rule set`() {
-            assertThatThrownBy { executeDetekt("--run-rule", "non_existing:test") }
+            assertThatThrownBy { executeDetekt("--run-rule", "non_existing:TestRule") }
                 .isExactlyInstanceOf(IllegalArgumentException::class.java)
         }
 

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/TestRules.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/TestRules.kt
@@ -15,7 +15,7 @@ class TestProvider : RuleSetProvider {
 }
 
 class TestRule(config: Config) : Rule(config) {
-    override val issue = Issue("test", "A failure")
+    override val issue = Issue(javaClass.simpleName, "A failure")
     override fun visitClass(klass: KtClass) {
         if (klass.name == "Poko") {
             report(CodeSmell(issue, Entity.from(klass), issue.description))

--- a/detekt-cli/src/test/resources/configs/valid-config.yml
+++ b/detekt-cli/src/test/resources/configs/valid-config.yml
@@ -1,3 +1,3 @@
 test:
-  test:
+  TestRule:
     active: true

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/CorrectableRulesFirstSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/CorrectableRulesFirstSpec.kt
@@ -53,14 +53,14 @@ class CorrectableRulesFirstSpec {
 private var actualLastRuleId = ""
 
 private class NonCorrectable(config: Config) : Rule(config) {
-    override val issue: Issue = Issue(javaClass.simpleName, "")
+    override val issue = Issue(javaClass.simpleName, "")
     override fun visitClass(klass: KtClass) {
         actualLastRuleId = issue.id
     }
 }
 
 private class Correctable(config: Config) : Rule(config) {
-    override val issue: Issue = Issue(javaClass.simpleName, "")
+    override val issue = Issue(javaClass.simpleName, "")
     override fun visitClass(klass: KtClass) {
         actualLastRuleId = issue.id
     }

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/KT.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/KT.kt
@@ -26,7 +26,7 @@ class TestProvider2(override val ruleSetId: String = "Test2") : RuleSetProvider 
 }
 
 class FindName(config: Config) : Rule(config) {
-    override val issue: Issue = Issue(javaClass.simpleName, "")
+    override val issue = Issue(javaClass.simpleName, "")
     override fun visitClassOrObject(classOrObject: KtClassOrObject) {
         report(CodeSmell(issue, Entity.atName(classOrObject), message = "TestMessage"))
     }

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/SuppressionSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/SuppressionSpec.kt
@@ -260,17 +260,17 @@ class SuppressionSpec {
 
         @Test
         fun `suppresses by rule id`() {
-            assertCodeIsSuppressed("""@Suppress("LongParameterList")$code""", config)
+            assertCodeIsSuppressed("""@Suppress("TestLPL")$code""", config)
         }
 
         @Test
         fun `suppresses by combination of rule set and rule id`() {
-            assertCodeIsSuppressed("""@Suppress("complexity.LongParameterList")$code""", config)
+            assertCodeIsSuppressed("""@Suppress("complexity.TestLPL")$code""", config)
         }
 
         @Test
         fun `suppresses by combination of detekt prefix, rule set and rule id`() {
-            assertCodeIsSuppressed("""@Suppress("detekt:complexity:LongParameterList")$code""", config)
+            assertCodeIsSuppressed("""@Suppress("detekt:complexity:TestLPL")$code""", config)
         }
     }
 }
@@ -291,7 +291,7 @@ private fun isSuppressedBy(annotation: String, argument: String): Boolean {
 }
 
 private class TestRule(config: Config = Config.empty) : Rule(config) {
-    override val issue = Issue("Test", "")
+    override val issue = Issue(javaClass.simpleName, "")
     var expected: String? = "Test"
     override fun visitClassOrObject(classOrObject: KtClassOrObject) {
         expected = null
@@ -299,7 +299,7 @@ private class TestRule(config: Config = Config.empty) : Rule(config) {
 }
 
 private class TestLM(config: Config = Config.empty) : Rule(config) {
-    override val issue = Issue("LongMethod", "")
+    override val issue = Issue(javaClass.simpleName, "")
     override fun visitNamedFunction(function: KtNamedFunction) {
         val start = Location.startLineAndColumn(function.funKeyword!!).line
         val end = Location.startLineAndColumn(function.lastBlockStatementOrThis()).line
@@ -309,7 +309,7 @@ private class TestLM(config: Config = Config.empty) : Rule(config) {
 }
 
 private class TestLPL(config: Config = Config.empty) : Rule(config) {
-    override val issue = Issue("LongParameterList", "")
+    override val issue = Issue(javaClass.simpleName, "")
     override fun visitNamedFunction(function: KtNamedFunction) {
         val size = function.valueParameters.size
         if (size > 5) report(CodeSmell(issue, Entity.from(function), message = "TestMessage"))

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/TopLevelAutoCorrectSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/TopLevelAutoCorrectSpec.kt
@@ -67,7 +67,7 @@ class TopLevelAutoCorrectSpec {
 }
 
 private class DeleteAnnotationsRule(config: Config) : Rule(config) {
-    override val issue = Issue("test-rule", "")
+    override val issue = Issue(javaClass.simpleName, "")
     override fun visitAnnotation(annotation: KtAnnotation) {
         annotation.delete()
     }

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/rules/SingleRuleProviderSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/rules/SingleRuleProviderSpec.kt
@@ -16,6 +16,7 @@ class SingleRuleProviderSpec {
         "MagicNumber",
         object : RuleSetProvider {
             override val ruleSetId: String = "style"
+
             override fun instance(): RuleSet = RuleSet(ruleSetId, listOf(::MagicNumber))
         }
     )
@@ -39,5 +40,5 @@ private fun produceRule(provider: RuleSetProvider, config: Config): Rule =
     provider.instance().rules.map { (_, provider) -> provider(config.subConfig("style")) }.single() as Rule
 
 private class MagicNumber(config: Config) : Rule(config) {
-    override val issue = Issue("MagicNumber", "")
+    override val issue = Issue(javaClass.simpleName, "")
 }

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/SuppressorsSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/SuppressorsSpec.kt
@@ -55,5 +55,5 @@ class SuppressorsSpec {
 }
 
 private class ARule(config: Config = Config.empty) : Rule(config) {
-    override val issue = Issue("IssueId", "")
+    override val issue = Issue(javaClass.simpleName, "")
 }

--- a/detekt-core/src/test/resources/configs/rule-and-ruleset-autocorrect-true.yaml
+++ b/detekt-core/src/test/resources/configs/rule-and-ruleset-autocorrect-true.yaml
@@ -1,4 +1,4 @@
 test-rule-set:
   autoCorrect: true
-  test-rule:
+  DeleteAnnotationsRule:
     autoCorrect: true

--- a/detekt-core/src/test/resources/suppression/SuppressedElements.kt
+++ b/detekt-core/src/test/resources/suppression/SuppressedElements.kt
@@ -1,9 +1,9 @@
-@SuppressWarnings("LongParameterList")
+@SuppressWarnings("TestLPL")
 fun lpl(a: Int, b: Int, c: Int, d: Int, e: Int, f: Int) = (a + b + c + d + e + f).apply {
     assert(false) { "FAILED TEST" }
 }
 
-@SuppressWarnings("LongMethod")
+@SuppressWarnings("TestLM")
 fun lm() {
     lpl(1, 2, 3, 4, 5, 6)
     lpl(1, 2, 3, 4, 5, 6)

--- a/detekt-core/src/test/resources/suppression/SuppressedObject.kt
+++ b/detekt-core/src/test/resources/suppression/SuppressedObject.kt
@@ -1,4 +1,4 @@
-@file:SuppressWarnings("Test")
+@file:SuppressWarnings("TestRule")
 
 object SuppressedObject {
 

--- a/detekt-core/src/test/resources/suppression/ruleset-suppression.yml
+++ b/detekt-core/src/test/resources/suppression/ruleset-suppression.yml
@@ -1,4 +1,4 @@
 complexity:
-  LongParameterList:
+  TestLPL:
     active: true
     threshold: 5

--- a/detekt-generator/src/test/resources/ruleset1/src/main/kotlin/CognitiveComplexMethod.kt
+++ b/detekt-generator/src/test/resources/ruleset1/src/main/kotlin/CognitiveComplexMethod.kt
@@ -13,7 +13,7 @@ import org.jetbrains.kotlin.psi.KtNamedFunction
 class CognitiveComplexMethod(config: Config = Config.empty) : Rule(config) {
 
     override val issue = Issue(
-        "CognitiveComplexMethod",
+        javaClass.simpleName,
         "Prefer splitting up complex methods into smaller, easier to understand methods.",
     )
 

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/CognitiveComplexMethod.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/CognitiveComplexMethod.kt
@@ -28,7 +28,7 @@ import org.jetbrains.kotlin.psi.KtNamedFunction
 class CognitiveComplexMethod(config: Config) : Rule(config) {
 
     override val issue = Issue(
-        "CognitiveComplexMethod",
+        javaClass.simpleName,
         "Prefer splitting up complex methods into smaller, easier to understand methods.",
     )
 

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexCondition.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexCondition.kt
@@ -39,7 +39,7 @@ import org.jetbrains.kotlin.psi.psiUtil.collectDescendantsOfType
 class ComplexCondition(config: Config) : Rule(config) {
 
     override val issue = Issue(
-        "ComplexCondition",
+        javaClass.simpleName,
         "Complex conditions should be simplified and extracted into well-named methods if necessary.",
     )
 

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/CyclomaticComplexMethod.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/CyclomaticComplexMethod.kt
@@ -37,7 +37,7 @@ import org.jetbrains.kotlin.psi.KtWhenExpression
 class CyclomaticComplexMethod(config: Config) : Rule(config) {
 
     override val issue = Issue(
-        "CyclomaticComplexMethod",
+        javaClass.simpleName,
         "Prefer splitting up complex methods into smaller, easier to test methods.",
     )
 

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LabeledExpression.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LabeledExpression.kt
@@ -59,7 +59,7 @@ import org.jetbrains.kotlin.psi.psiUtil.isExtensionDeclaration
  */
 class LabeledExpression(config: Config) : Rule(config) {
 
-    override val issue: Issue = Issue(
+    override val issue = Issue(
         "LabeledExpression",
         "Expression with labels increase complexity and affect maintainability.",
     )

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LabeledExpression.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LabeledExpression.kt
@@ -60,7 +60,7 @@ import org.jetbrains.kotlin.psi.psiUtil.isExtensionDeclaration
 class LabeledExpression(config: Config) : Rule(config) {
 
     override val issue = Issue(
-        "LabeledExpression",
+        javaClass.simpleName,
         "Expression with labels increase complexity and affect maintainability.",
     )
 

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LargeClass.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LargeClass.kt
@@ -24,7 +24,7 @@ import java.util.IdentityHashMap
 class LargeClass(config: Config) : Rule(config) {
 
     override val issue = Issue(
-        "LargeClass",
+        javaClass.simpleName,
         "One class should have one responsibility. Large classes tend to handle many things at once. " +
             "Split up large classes into smaller classes that are easier to understand.",
     )

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongMethod.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongMethod.kt
@@ -24,7 +24,7 @@ import java.util.IdentityHashMap
 class LongMethod(config: Config) : Rule(config) {
 
     override val issue = Issue(
-        "LongMethod",
+        javaClass.simpleName,
         "One method should have one responsibility. Long methods tend to handle many things at once. " +
             "Prefer smaller methods to make them easier to understand.",
     )

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterList.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterList.kt
@@ -27,7 +27,7 @@ import org.jetbrains.kotlin.psi.KtSecondaryConstructor
 @ActiveByDefault(since = "1.0.0")
 class LongParameterList(config: Config) : Rule(config) {
     override val issue = Issue(
-        "LongParameterList",
+        javaClass.simpleName,
         "The more parameters a function has the more complex it is. Long parameter lists are often " +
             "used to control complex algorithms and violate the Single Responsibility Principle. " +
             "Prefer functions with short parameter lists.",

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/MethodOverloading.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/MethodOverloading.kt
@@ -25,7 +25,7 @@ import org.jetbrains.kotlin.psi.psiUtil.isExtensionDeclaration
 class MethodOverloading(config: Config) : Rule(config) {
 
     override val issue = Issue(
-        "MethodOverloading",
+        javaClass.simpleName,
         "Methods which are overloaded often might be harder to maintain. " +
             "Furthermore, these methods are tightly coupled. " +
             "Refactor these methods and try to use optional parameters.",

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NamedArguments.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NamedArguments.kt
@@ -33,7 +33,7 @@ import org.jetbrains.kotlin.resolve.calls.util.getResolvedCall
 class NamedArguments(config: Config) : Rule(config) {
 
     override val issue = Issue(
-        "NamedArguments",
+        javaClass.simpleName,
         "Named arguments are required for function calls with many arguments.",
     )
 

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedBlockDepth.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedBlockDepth.kt
@@ -28,7 +28,7 @@ import org.jetbrains.kotlin.psi.KtWhenExpression
 class NestedBlockDepth(config: Config) : Rule(config) {
 
     override val issue = Issue(
-        "NestedBlockDepth",
+        javaClass.simpleName,
         "Excessive nesting leads to hidden complexity. " +
             "Prefer extracting code to make it easier to understand.",
     )

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/TooManyFunctions.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/TooManyFunctions.kt
@@ -27,7 +27,7 @@ import org.jetbrains.kotlin.psi.psiUtil.isPrivate
 class TooManyFunctions(config: Config) : Rule(config) {
 
     override val issue = Issue(
-        "TooManyFunctions",
+        javaClass.simpleName,
         "Too many functions inside a/an file/class/object/interface always indicate a violation of " +
             "the single responsibility principle. Maybe the file/class/object/interface wants to manage too " +
             "many things at once. Extract functionality which clearly belongs together.",

--- a/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/InjectDispatcher.kt
+++ b/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/InjectDispatcher.kt
@@ -45,7 +45,7 @@ class InjectDispatcher(config: Config) : Rule(config) {
     private val dispatcherNames: Set<String> by config(listOf("IO", "Default", "Unconfined")) { it.toSet() }
 
     override val issue = Issue(
-        "InjectDispatcher",
+        javaClass.simpleName,
         "Don't hardcode dispatchers when creating new coroutines or calling `withContext`. " +
             "Use dependency injection for dispatchers to make testing easier.",
     )

--- a/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/RedundantSuspendModifier.kt
+++ b/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/RedundantSuspendModifier.kt
@@ -58,7 +58,7 @@ import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
 class RedundantSuspendModifier(config: Config) : Rule(config) {
 
     override val issue = Issue(
-        "RedundantSuspendModifier",
+        javaClass.simpleName,
         "The `suspend` modifier is only needed for functions that contain suspending calls.",
     )
 

--- a/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunSwallowedCancellation.kt
+++ b/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunSwallowedCancellation.kt
@@ -92,9 +92,8 @@ import org.jetbrains.kotlin.utils.addToStdlib.ifTrue
 @RequiresTypeResolution
 class SuspendFunSwallowedCancellation(config: Config) : Rule(config) {
     override val issue = Issue(
-        id = javaClass.simpleName,
-        description = "`runCatching` does not propagate `CancellationException`, don't use it with `suspend` lambda " +
-            "blocks.",
+        javaClass.simpleName,
+        "`runCatching` does not propagate `CancellationException`, don't use it with `suspend` lambda blocks.",
     )
 
     override fun visitCallExpression(expression: KtCallExpression) {

--- a/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunWithCoroutineScopeReceiver.kt
+++ b/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunWithCoroutineScopeReceiver.kt
@@ -49,10 +49,9 @@ import org.jetbrains.kotlin.types.typeUtil.supertypes
 class SuspendFunWithCoroutineScopeReceiver(config: Config) : Rule(config) {
 
     override val issue = Issue(
-        id = javaClass.simpleName,
-        description = "The `suspend` modifier should not be used for functions that use a " +
-            "CoroutinesScope as receiver. You should use suspend functions without the receiver or use plain " +
-            "functions and use coroutineScope { } instead.",
+        javaClass.simpleName,
+        "The `suspend` modifier should not be used for functions that use a CoroutinesScope as receiver. You should " +
+            "use suspend functions without the receiver or use plain functions and use coroutineScope { } instead.",
     )
 
     override val defaultRuleIdAliases = setOf("SuspendFunctionOnCoroutineScope")

--- a/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunWithCoroutineScopeReceiver.kt
+++ b/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunWithCoroutineScopeReceiver.kt
@@ -49,7 +49,7 @@ import org.jetbrains.kotlin.types.typeUtil.supertypes
 class SuspendFunWithCoroutineScopeReceiver(config: Config) : Rule(config) {
 
     override val issue = Issue(
-        id = "SuspendFunWithCoroutineScopeReceiver",
+        id = javaClass.simpleName,
         description = "The `suspend` modifier should not be used for functions that use a " +
             "CoroutinesScope as receiver. You should use suspend functions without the receiver or use plain " +
             "functions and use coroutineScope { } instead.",

--- a/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunWithFlowReturnType.kt
+++ b/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunWithFlowReturnType.kt
@@ -62,10 +62,9 @@ import org.jetbrains.kotlin.types.typeUtil.supertypes
 class SuspendFunWithFlowReturnType(config: Config) : Rule(config) {
 
     override val issue = Issue(
-        id = javaClass.simpleName,
-        description = "The `suspend` modifier should not be used for functions that return a " +
-            "Coroutines Flow type. Flows are cold streams and invoking a function that returns " +
-            "one should not produce any side effects.",
+        javaClass.simpleName,
+        "The `suspend` modifier should not be used for functions that return a Coroutines Flow type. Flows are cold " +
+            "streams and invoking a function that returns one should not produce any side effects.",
     )
 
     override fun visitNamedFunction(function: KtNamedFunction) {

--- a/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunWithFlowReturnType.kt
+++ b/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunWithFlowReturnType.kt
@@ -62,7 +62,7 @@ import org.jetbrains.kotlin.types.typeUtil.supertypes
 class SuspendFunWithFlowReturnType(config: Config) : Rule(config) {
 
     override val issue = Issue(
-        id = "SuspendFunWithFlowReturnType",
+        id = javaClass.simpleName,
         description = "The `suspend` modifier should not be used for functions that return a " +
             "Coroutines Flow type. Flows are cold streams and invoking a function that returns " +
             "one should not produce any side effects.",

--- a/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/AbsentOrWrongFileLicense.kt
+++ b/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/AbsentOrWrongFileLicense.kt
@@ -20,8 +20,8 @@ import org.jetbrains.kotlin.psi.KtFile
 class AbsentOrWrongFileLicense(config: Config) : Rule(config) {
 
     override val issue = Issue(
-        id = javaClass.simpleName,
-        description = "License text is absent or incorrect.",
+        javaClass.simpleName,
+        "License text is absent or incorrect.",
     )
 
     @Suppress("unused")

--- a/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/AbsentOrWrongFileLicense.kt
+++ b/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/AbsentOrWrongFileLicense.kt
@@ -20,7 +20,7 @@ import org.jetbrains.kotlin.psi.KtFile
 class AbsentOrWrongFileLicense(config: Config) : Rule(config) {
 
     override val issue = Issue(
-        id = RULE_NAME,
+        id = javaClass.simpleName,
         description = "License text is absent or incorrect.",
     )
 

--- a/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentOverPrivateFunction.kt
+++ b/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentOverPrivateFunction.kt
@@ -20,7 +20,7 @@ import org.jetbrains.kotlin.psi.KtNamedFunction
 class CommentOverPrivateFunction(config: Config) : Rule(config) {
 
     override val issue = Issue(
-        "CommentOverPrivateFunction",
+        javaClass.simpleName,
         "Comments for private functions should be avoided. " +
             "Prefer giving the function an expressive name. " +
             "Split it up in smaller, self-explaining functions if necessary.",

--- a/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentOverPrivateProperty.kt
+++ b/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentOverPrivateProperty.kt
@@ -20,7 +20,7 @@ import org.jetbrains.kotlin.psi.KtProperty
 class CommentOverPrivateProperty(config: Config) : Rule(config) {
 
     override val issue = Issue(
-        "CommentOverPrivateProperty",
+        javaClass.simpleName,
         "Private properties should be named in a self-explanatory manner without the need for a  comment.",
     )
 

--- a/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/DeprecatedBlockTag.kt
+++ b/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/DeprecatedBlockTag.kt
@@ -38,7 +38,7 @@ import org.jetbrains.kotlin.psi.KtDeclaration
  */
 class DeprecatedBlockTag(config: Config) : Rule(config) {
     override val issue = Issue(
-        "DeprecatedBlockTag",
+        javaClass.simpleName,
         "Do not use the `@deprecated` block tag, which is not supported by KDoc. " +
             "Use the `@Deprecated` annotation instead.",
     )

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/AvoidReferentialEquality.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/AvoidReferentialEquality.kt
@@ -36,7 +36,7 @@ import org.jetbrains.kotlin.resolve.calls.util.getType
 class AvoidReferentialEquality(config: Config) : Rule(config) {
 
     override val issue = Issue(
-        "AvoidReferentialEquality",
+        javaClass.simpleName,
         "Avoid using referential equality and prefer to use referential equality checks instead.",
     )
 

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/CastNullableToNonNullableType.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/CastNullableToNonNullableType.kt
@@ -40,7 +40,7 @@ import org.jetbrains.kotlin.utils.addToStdlib.ifTrue
  */
 @RequiresTypeResolution
 class CastNullableToNonNullableType(config: Config) : Rule(config) {
-    override val issue: Issue = Issue(
+    override val issue = Issue(
         javaClass.simpleName,
         "Nullable type to non-null type cast is found. Consider using two assertions, " +
             "`null` assertions and type cast",

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/CastToNullableType.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/CastToNullableType.kt
@@ -31,7 +31,7 @@ import org.jetbrains.kotlin.types.typeUtil.supertypes
 
 @RequiresTypeResolution
 class CastToNullableType(config: Config) : Rule(config) {
-    override val issue: Issue = Issue(
+    override val issue = Issue(
         javaClass.simpleName,
         "Use safe cast instead of unsafe cast to nullable types.",
     )

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/Deprecation.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/Deprecation.kt
@@ -18,7 +18,7 @@ import org.jetbrains.kotlin.psi.KtNamedDeclaration
 class Deprecation(config: Config) : Rule(config) {
 
     override val issue = Issue(
-        "Deprecation",
+        javaClass.simpleName,
         "Deprecated elements should not be used.",
     )
 

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DontDowncastCollectionTypes.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DontDowncastCollectionTypes.kt
@@ -38,7 +38,7 @@ import org.jetbrains.kotlin.resolve.calls.util.getType
 class DontDowncastCollectionTypes(config: Config) : Rule(config) {
 
     override val issue = Issue(
-        "DontDowncastCollectionTypes",
+        javaClass.simpleName,
         "Down-casting immutable collection types is breaking the collection contract.",
     )
 

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DoubleMutabilityForCollection.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DoubleMutabilityForCollection.kt
@@ -47,7 +47,7 @@ class DoubleMutabilityForCollection(config: Config) : Rule(config) {
 
     override val defaultRuleIdAliases: Set<String> = setOf("DoubleMutability")
 
-    override val issue: Issue = Issue(
+    override val issue = Issue(
         "DoubleMutabilityForCollection",
         "Using var with mutable collections or values leads to double mutability. " +
             "Consider using val or immutable collection or value types.",

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DoubleMutabilityForCollection.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DoubleMutabilityForCollection.kt
@@ -48,7 +48,7 @@ class DoubleMutabilityForCollection(config: Config) : Rule(config) {
     override val defaultRuleIdAliases: Set<String> = setOf("DoubleMutability")
 
     override val issue = Issue(
-        "DoubleMutabilityForCollection",
+        javaClass.simpleName,
         "Using var with mutable collections or values leads to double mutability. " +
             "Consider using val or immutable collection or value types.",
     )

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DuplicateCaseInWhenExpression.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DuplicateCaseInWhenExpression.kt
@@ -34,7 +34,7 @@ import org.jetbrains.kotlin.psi.KtWhenExpression
 class DuplicateCaseInWhenExpression(config: Config) : Rule(config) {
 
     override val issue = Issue(
-        "DuplicateCaseInWhenExpression",
+        javaClass.simpleName,
         "Duplicated `case` statements in a `when` expression detected. Both cases should be merged.",
     )
 

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ElseCaseInsteadOfExhaustiveWhen.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ElseCaseInsteadOfExhaustiveWhen.kt
@@ -53,7 +53,7 @@ import org.jetbrains.kotlin.types.typeUtil.isBooleanOrNullableBoolean
 @RequiresTypeResolution
 class ElseCaseInsteadOfExhaustiveWhen(config: Config) : Rule(config) {
 
-    override val issue: Issue = Issue(
+    override val issue = Issue(
         "ElseCaseInsteadOfExhaustiveWhen",
         "A `when` expression that has an exhaustive set of cases should not contain an `else` case.",
     )

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ElseCaseInsteadOfExhaustiveWhen.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ElseCaseInsteadOfExhaustiveWhen.kt
@@ -54,7 +54,7 @@ import org.jetbrains.kotlin.types.typeUtil.isBooleanOrNullableBoolean
 class ElseCaseInsteadOfExhaustiveWhen(config: Config) : Rule(config) {
 
     override val issue = Issue(
-        "ElseCaseInsteadOfExhaustiveWhen",
+        javaClass.simpleName,
         "A `when` expression that has an exhaustive set of cases should not contain an `else` case.",
     )
 

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsAlwaysReturnsTrueOrFalse.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsAlwaysReturnsTrueOrFalse.kt
@@ -39,7 +39,7 @@ import org.jetbrains.kotlin.psi.psiUtil.collectDescendantsOfType
 class EqualsAlwaysReturnsTrueOrFalse(config: Config) : Rule(config) {
 
     override val issue = Issue(
-        "EqualsAlwaysReturnsTrueOrFalse",
+        javaClass.simpleName,
         "Having an `equals()` method that always returns true or false is not a good idea. " +
             "It does not follow the contract of this method. " +
             "Consider a good default implementation (e.g. `this == other`).",

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsWithHashCodeExist.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsWithHashCodeExist.kt
@@ -46,7 +46,7 @@ import org.jetbrains.kotlin.psi.KtNamedFunction
 class EqualsWithHashCodeExist(config: Config) : Rule(config) {
 
     override val issue = Issue(
-        "EqualsWithHashCodeExist",
+        javaClass.simpleName,
         "Always override hashCode when you override equals. " +
             "All hash-based collections depend on objects meeting the equals-contract. " +
             "Two equal objects must produce the same hashcode. When inheriting equals or hashcode, " +

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ExplicitGarbageCollectionCall.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ExplicitGarbageCollectionCall.kt
@@ -26,7 +26,7 @@ import org.jetbrains.kotlin.psi.psiUtil.getReceiverExpression
 class ExplicitGarbageCollectionCall(config: Config) : Rule(config) {
 
     override val issue = Issue(
-        "ExplicitGarbageCollectionCall",
+        javaClass.simpleName,
         "Don't try to be smarter than the JVM. Your code should work independently whether the garbage " +
             "collector is disabled or not. If you face memory issues, " +
             "try tuning the JVM options instead of relying on code itself.",

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/HasPlatformType.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/HasPlatformType.kt
@@ -42,7 +42,7 @@ import org.jetbrains.kotlin.types.isFlexible
 class HasPlatformType(config: Config) : Rule(config) {
 
     override val issue = Issue(
-        "HasPlatformType",
+        javaClass.simpleName,
         "Platform types must be declared explicitly in public APIs.",
     )
 

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValue.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValue.kt
@@ -53,7 +53,7 @@ import org.jetbrains.kotlin.types.typeUtil.isUnit
 @ActiveByDefault(since = "1.21.0")
 class IgnoredReturnValue(config: Config) : Rule(config) {
 
-    override val issue: Issue = Issue(
+    override val issue = Issue(
         "IgnoredReturnValue",
         "This call returns a value which is ignored",
     )

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValue.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValue.kt
@@ -54,7 +54,7 @@ import org.jetbrains.kotlin.types.typeUtil.isUnit
 class IgnoredReturnValue(config: Config) : Rule(config) {
 
     override val issue = Issue(
-        "IgnoredReturnValue",
+        javaClass.simpleName,
         "This call returns a value which is ignored",
     )
 

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ImplicitDefaultLocale.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ImplicitDefaultLocale.kt
@@ -45,7 +45,7 @@ class ImplicitDefaultLocale(config: Config) : Rule(config) {
     )
 
     override val issue = Issue(
-        "ImplicitDefaultLocale",
+        javaClass.simpleName,
         "Implicit default locale used for string processing. Consider using explicit locale.",
     )
 

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IteratorHasNextCallsNextMethod.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IteratorHasNextCallsNextMethod.kt
@@ -31,7 +31,7 @@ import org.jetbrains.kotlin.psi.psiUtil.getSuperNames
 class IteratorHasNextCallsNextMethod(config: Config) : Rule(config) {
 
     override val issue = Issue(
-        "IteratorHasNextCallsNextMethod",
+        javaClass.simpleName,
         "The `hasNext()` method of an Iterator implementation should not call the `next()` method. " +
             "The state of the iterator should not be changed inside the `hasNext()` method. " +
             "The `hasNext()` method is not supposed to have any side effects.",

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IteratorNotThrowingNoSuchElementException.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IteratorNotThrowingNoSuchElementException.kt
@@ -46,7 +46,7 @@ import org.jetbrains.kotlin.psi.psiUtil.getSuperNames
 class IteratorNotThrowingNoSuchElementException(config: Config) : Rule(config) {
 
     override val issue = Issue(
-        "IteratorNotThrowingNoSuchElementException",
+        javaClass.simpleName,
         "The `next()` method of an `Iterator` implementation should throw a `NoSuchElementException` " +
             "when there are no more elements to return.",
     )

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MapGetWithNotNullAssertionOperator.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MapGetWithNotNullAssertionOperator.kt
@@ -47,7 +47,7 @@ import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
 class MapGetWithNotNullAssertionOperator(config: Config) : Rule(config) {
 
     override val issue = Issue(
-        "MapGetWithNotNullAssertionOperator",
+        javaClass.simpleName,
         "map.get() with not-null assertion operator (!!) can result in a NullPointerException. " +
             "Consider usage of map.getValue(), map.getOrDefault() or map.getOrElse() instead.",
     )

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MapGetWithNotNullAssertionOperator.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MapGetWithNotNullAssertionOperator.kt
@@ -46,12 +46,11 @@ import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
 @ActiveByDefault(since = "1.21.0")
 class MapGetWithNotNullAssertionOperator(config: Config) : Rule(config) {
 
-    override val issue: Issue =
-        Issue(
-            "MapGetWithNotNullAssertionOperator",
-            "map.get() with not-null assertion operator (!!) can result in a NullPointerException. " +
-                "Consider usage of map.getValue(), map.getOrDefault() or map.getOrElse() instead.",
-        )
+    override val issue = Issue(
+        "MapGetWithNotNullAssertionOperator",
+        "map.get() with not-null assertion operator (!!) can result in a NullPointerException. " +
+            "Consider usage of map.getValue(), map.getOrDefault() or map.getOrElse() instead.",
+    )
 
     override fun visitPostfixExpression(expression: KtPostfixExpression) {
         if (expression.operationToken == KtTokens.EXCLEXCL && expression.isMapGet()) {

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingWhenCase.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingWhenCase.kt
@@ -70,7 +70,7 @@ import org.jetbrains.kotlin.resolve.calls.util.getType
 @Deprecated("Rule deprecated as compiler performs this check by default")
 class MissingWhenCase(config: Config) : Rule(config) {
 
-    override val issue: Issue = Issue(
+    override val issue = Issue(
         "MissingWhenCase",
         "Check usage of `when` used as a statement and don't compare all enum or sealed class cases.",
     )

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingWhenCase.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingWhenCase.kt
@@ -71,7 +71,7 @@ import org.jetbrains.kotlin.resolve.calls.util.getType
 class MissingWhenCase(config: Config) : Rule(config) {
 
     override val issue = Issue(
-        "MissingWhenCase",
+        javaClass.simpleName,
         "Check usage of `when` used as a statement and don't compare all enum or sealed class cases.",
     )
 

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/RedundantElseInWhen.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/RedundantElseInWhen.kt
@@ -60,7 +60,7 @@ import org.jetbrains.kotlin.psi.KtWhenExpression
 @Deprecated("Rule deprecated as compiler performs this check by default")
 class RedundantElseInWhen(config: Config) : Rule(config) {
 
-    override val issue: Issue = Issue(
+    override val issue = Issue(
         "RedundantElseInWhen",
         "Check for redundant `else` case in `when` expression when used as statement.",
     )

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/RedundantElseInWhen.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/RedundantElseInWhen.kt
@@ -61,7 +61,7 @@ import org.jetbrains.kotlin.psi.KtWhenExpression
 class RedundantElseInWhen(config: Config) : Rule(config) {
 
     override val issue = Issue(
-        "RedundantElseInWhen",
+        javaClass.simpleName,
         "Check for redundant `else` case in `when` expression when used as statement.",
     )
 

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessaryNotNullCheck.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessaryNotNullCheck.kt
@@ -29,7 +29,7 @@ import org.jetbrains.kotlin.types.isNullable
 class UnnecessaryNotNullCheck(config: Config) : Rule(config) {
 
     override val issue = Issue(
-        "UnnecessaryNotNullCheck",
+        javaClass.simpleName,
         "Remove unnecessary not-null checks on non-null types.",
     )
 

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessaryNotNullOperator.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessaryNotNullOperator.kt
@@ -28,7 +28,7 @@ import org.jetbrains.kotlin.psi.KtUnaryExpression
 class UnnecessaryNotNullOperator(config: Config) : Rule(config) {
 
     override val issue = Issue(
-        "UnnecessaryNotNullOperator",
+        javaClass.simpleName,
         "Unnecessary not-null unary operator (!!) detected.",
     )
 

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessaryNotNullOperator.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessaryNotNullOperator.kt
@@ -27,7 +27,7 @@ import org.jetbrains.kotlin.psi.KtUnaryExpression
 @ActiveByDefault(since = "1.16.0")
 class UnnecessaryNotNullOperator(config: Config) : Rule(config) {
 
-    override val issue: Issue = Issue(
+    override val issue = Issue(
         "UnnecessaryNotNullOperator",
         "Unnecessary not-null unary operator (!!) detected.",
     )

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessarySafeCall.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessarySafeCall.kt
@@ -31,7 +31,7 @@ import org.jetbrains.kotlin.psi.psiUtil.getChildOfType
 class UnnecessarySafeCall(config: Config) : Rule(config) {
 
     override val issue = Issue(
-        "UnnecessarySafeCall",
+        javaClass.simpleName,
         "Unnecessary safe call operator detected.",
     )
 

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessarySafeCall.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessarySafeCall.kt
@@ -30,7 +30,7 @@ import org.jetbrains.kotlin.psi.psiUtil.getChildOfType
 @ActiveByDefault(since = "1.16.0")
 class UnnecessarySafeCall(config: Config) : Rule(config) {
 
-    override val issue: Issue = Issue(
+    override val issue = Issue(
         "UnnecessarySafeCall",
         "Unnecessary safe call operator detected.",
     )

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnreachableCode.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnreachableCode.kt
@@ -35,7 +35,7 @@ import org.jetbrains.kotlin.psi.KtExpression
 class UnreachableCode(config: Config) : Rule(config) {
 
     override val issue = Issue(
-        "UnreachableCode",
+        javaClass.simpleName,
         "Unreachable code detected. This code should be removed.",
     )
 

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCallOnNullableType.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCallOnNullableType.kt
@@ -34,7 +34,7 @@ import org.jetbrains.kotlin.types.typeUtil.nullability
 @ActiveByDefault(since = "1.2.0")
 class UnsafeCallOnNullableType(config: Config) : Rule(config) {
     override val issue = Issue(
-        "UnsafeCallOnNullableType",
+        javaClass.simpleName,
         "Unsafe calls on nullable types detected. These calls will throw a NullPointerException in case " +
             "the nullable value is null.",
     )

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCallOnNullableType.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCallOnNullableType.kt
@@ -33,7 +33,7 @@ import org.jetbrains.kotlin.types.typeUtil.nullability
 @RequiresTypeResolution
 @ActiveByDefault(since = "1.2.0")
 class UnsafeCallOnNullableType(config: Config) : Rule(config) {
-    override val issue: Issue = Issue(
+    override val issue = Issue(
         "UnsafeCallOnNullableType",
         "Unsafe calls on nullable types detected. These calls will throw a NullPointerException in case " +
             "the nullable value is null.",

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCast.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCast.kt
@@ -35,7 +35,7 @@ class UnsafeCast(config: Config) : Rule(config) {
 
     override val defaultRuleIdAliases: Set<String> = setOf("UNCHECKED_CAST")
 
-    override val issue: Issue = Issue(
+    override val issue = Issue(
         "UnsafeCast",
         "Cast operator throws an exception if the cast is not possible.",
     )

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCast.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCast.kt
@@ -36,7 +36,7 @@ class UnsafeCast(config: Config) : Rule(config) {
     override val defaultRuleIdAliases: Set<String> = setOf("UNCHECKED_CAST")
 
     override val issue = Issue(
-        "UnsafeCast",
+        javaClass.simpleName,
         "Cast operator throws an exception if the cast is not possible.",
     )
 

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UselessPostfixExpression.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UselessPostfixExpression.kt
@@ -55,7 +55,7 @@ import org.jetbrains.kotlin.psi.psiUtil.isPropertyParameter
 @ActiveByDefault(since = "1.21.0")
 class UselessPostfixExpression(config: Config) : Rule(config) {
 
-    override val issue: Issue = Issue(
+    override val issue = Issue(
         "UselessPostfixExpression",
         "The incremented or decremented value is unused. This value is replaced with the original value.",
     )

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UselessPostfixExpression.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UselessPostfixExpression.kt
@@ -56,7 +56,7 @@ import org.jetbrains.kotlin.psi.psiUtil.isPropertyParameter
 class UselessPostfixExpression(config: Config) : Rule(config) {
 
     override val issue = Issue(
-        "UselessPostfixExpression",
+        javaClass.simpleName,
         "The incremented or decremented value is unused. This value is replaced with the original value.",
     )
 

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/WrongEqualsTypeParameter.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/WrongEqualsTypeParameter.kt
@@ -37,7 +37,7 @@ import org.jetbrains.kotlin.psi.KtNamedFunction
 class WrongEqualsTypeParameter(config: Config) : Rule(config) {
 
     override val issue = Issue(
-        "WrongEqualsTypeParameter",
+        javaClass.simpleName,
         "Wrong parameter type for `equals()` method found. " +
             "To correctly override the `equals()` method use `Any?`.",
     )

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ExceptionRaisedInUnexpectedLocation.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ExceptionRaisedInUnexpectedLocation.kt
@@ -32,7 +32,7 @@ import org.jetbrains.kotlin.psi.psiUtil.anyDescendantOfType
 class ExceptionRaisedInUnexpectedLocation(config: Config) : Rule(config) {
 
     override val issue = Issue(
-        "ExceptionRaisedInUnexpectedLocation",
+        javaClass.simpleName,
         "This method is not expected to throw exceptions. This can cause weird behavior.",
     )
 

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/InstanceOfCheckForException.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/InstanceOfCheckForException.kt
@@ -48,7 +48,7 @@ import org.jetbrains.kotlin.types.typeUtil.isSubtypeOf
 class InstanceOfCheckForException(config: Config) : Rule(config) {
 
     override val issue = Issue(
-        "InstanceOfCheckForException",
+        javaClass.simpleName,
         "Instead of catching for a general exception type and checking for a specific exception type, " +
             "use multiple catch blocks.",
     )

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/NotImplementedDeclaration.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/NotImplementedDeclaration.kt
@@ -28,7 +28,7 @@ import org.jetbrains.kotlin.resolve.calls.util.getCalleeExpressionIfAny
 class NotImplementedDeclaration(config: Config) : Rule(config) {
 
     override val issue = Issue(
-        "NotImplementedDeclaration",
+        javaClass.simpleName,
         "The NotImplementedDeclaration should only be used when a method stub is necessary. " +
             "This defers the development of the functionality of this function. " +
             "Hence, the `NotImplementedDeclaration` should only serve as a temporary declaration. " +

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ObjectExtendsThrowable.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ObjectExtendsThrowable.kt
@@ -40,13 +40,11 @@ import org.jetbrains.kotlin.types.typeUtil.supertypes
 @RequiresTypeResolution
 class ObjectExtendsThrowable(config: Config) : Rule(config) {
     override val issue = Issue(
-        id = javaClass.simpleName,
-        description = "An `object` should not extend and type of Throwable. Throwables are " +
-            "stateful and should be instantiated only when needed for when a specific error " +
-            "occurs. An `object`, being a singleton, that extends any type of Throwable " +
-            "consequently introduces a global singleton exception whose instance may be " +
-            "inadvertently reused from multiple places, thus introducing shared mutable " +
-            "state.",
+        javaClass.simpleName,
+        "An `object` should not extend and type of Throwable. Throwables are stateful and should be instantiated " +
+            "only when needed for when a specific error occurs. An `object`, being a singleton, that extends any " +
+            "type of Throwable consequently introduces a global singleton exception whose instance may be " +
+            "inadvertently reused from multiple places, thus introducing shared mutable state.",
     )
 
     override fun visitObjectDeclaration(declaration: KtObjectDeclaration) {

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ObjectExtendsThrowable.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ObjectExtendsThrowable.kt
@@ -40,7 +40,7 @@ import org.jetbrains.kotlin.types.typeUtil.supertypes
 @RequiresTypeResolution
 class ObjectExtendsThrowable(config: Config) : Rule(config) {
     override val issue = Issue(
-        id = "ObjectExtendsThrowable",
+        id = javaClass.simpleName,
         description = "An `object` should not extend and type of Throwable. Throwables are " +
             "stateful and should be instantiated only when needed for when a specific error " +
             "occurs. An `object`, being a singleton, that extends any type of Throwable " +

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/PrintStackTrace.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/PrintStackTrace.kt
@@ -47,7 +47,7 @@ import org.jetbrains.kotlin.psi.psiUtil.getReceiverExpression
 class PrintStackTrace(config: Config) : Rule(config) {
 
     override val issue = Issue(
-        "PrintStackTrace",
+        javaClass.simpleName,
         "Do not print a stack trace. " +
             "These debug statements should be removed or replaced with a logger.",
     )

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/RethrowCaughtException.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/RethrowCaughtException.kt
@@ -61,7 +61,7 @@ import org.jetbrains.kotlin.psi.psiUtil.getChildrenOfType
 class RethrowCaughtException(config: Config) : Rule(config) {
 
     override val issue = Issue(
-        "RethrowCaughtException",
+        javaClass.simpleName,
         "Do not rethrow a caught exception of the same type.",
     )
 

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ReturnFromFinally.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ReturnFromFinally.kt
@@ -43,7 +43,7 @@ import org.jetbrains.kotlin.types.KotlinType
 class ReturnFromFinally(config: Config) : Rule(config) {
 
     override val issue = Issue(
-        "ReturnFromFinally",
+        javaClass.simpleName,
         "Do not return within a finally statement. This can discard exceptions.",
     )
 

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedException.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedException.kt
@@ -70,7 +70,7 @@ import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
 class SwallowedException(config: Config) : Rule(config) {
 
     override val issue = Issue(
-        "SwallowedException",
+        javaClass.simpleName,
         "The caught exception is swallowed. The original exception could be lost.",
     )
 

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionFromFinally.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionFromFinally.kt
@@ -28,7 +28,7 @@ import org.jetbrains.kotlin.psi.psiUtil.forEachDescendantOfType
 class ThrowingExceptionFromFinally(config: Config) : Rule(config) {
 
     override val issue = Issue(
-        "ThrowingExceptionFromFinally",
+        javaClass.simpleName,
         "Do not throw an exception within a finally statement. This can discard exceptions and is confusing.",
     )
 

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionInMain.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionInMain.kt
@@ -24,7 +24,7 @@ import org.jetbrains.kotlin.psi.psiUtil.anyDescendantOfType
 class ThrowingExceptionInMain(config: Config) : Rule(config) {
 
     override val issue = Issue(
-        "ThrowingExceptionInMain",
+        javaClass.simpleName,
         "The main method should not throw an exception.",
     )
 

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionsWithoutMessageOrCause.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionsWithoutMessageOrCause.kt
@@ -38,7 +38,7 @@ import org.jetbrains.kotlin.psi.KtCallExpression
 class ThrowingExceptionsWithoutMessageOrCause(config: Config) : Rule(config) {
 
     override val issue = Issue(
-        "ThrowingExceptionsWithoutMessageOrCause",
+        javaClass.simpleName,
         "A call to the default constructor of an exception was detected. " +
             "Instead one of the constructor overloads should be called. " +
             "This allows to provide more meaningful exceptions.",

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingNewInstanceOfSameException.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingNewInstanceOfSameException.kt
@@ -40,7 +40,7 @@ import org.jetbrains.kotlin.psi.psiUtil.findDescendantOfType
 class ThrowingNewInstanceOfSameException(config: Config) : Rule(config) {
 
     override val issue = Issue(
-        "ThrowingNewInstanceOfSameException",
+        javaClass.simpleName,
         "Avoid catch blocks that rethrow a caught exception wrapped inside a new instance of the same exception.",
     )
 

--- a/detekt-rules-libraries/src/main/kotlin/io/gitlab/arturbosch/detekt/libraries/LibraryCodeMustSpecifyReturnType.kt
+++ b/detekt-rules-libraries/src/main/kotlin/io/gitlab/arturbosch/detekt/libraries/LibraryCodeMustSpecifyReturnType.kt
@@ -48,7 +48,7 @@ import org.jetbrains.kotlin.resolve.checkers.ExplicitApiDeclarationChecker
 class LibraryCodeMustSpecifyReturnType(config: Config) : Rule(config) {
 
     override val issue = Issue(
-        this.javaClass.simpleName,
+        javaClass.simpleName,
         "Library functions/properties should have an explicit return type. " +
             "Inferred return types can easily be changed by mistake which may lead to breaking changes.",
     )

--- a/detekt-rules-libraries/src/main/kotlin/io/gitlab/arturbosch/detekt/libraries/LibraryEntitiesShouldNotBePublic.kt
+++ b/detekt-rules-libraries/src/main/kotlin/io/gitlab/arturbosch/detekt/libraries/LibraryEntitiesShouldNotBePublic.kt
@@ -25,9 +25,9 @@ import org.jetbrains.kotlin.psi.psiUtil.isPublic
  * </compliant>
  */
 @ActiveByDefault(since = "1.16.0")
-class LibraryEntitiesShouldNotBePublic(ruleSetConfig: Config) : Rule(ruleSetConfig) {
+class LibraryEntitiesShouldNotBePublic(config: Config) : Rule(config) {
 
-    override val issue: Issue = Issue(
+    override val issue = Issue(
         javaClass.simpleName,
         "Library classes should not be public.",
     )

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MatchingDeclarationName.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MatchingDeclarationName.kt
@@ -48,7 +48,7 @@ import org.jetbrains.kotlin.psi.psiUtil.isPrivate
 @ActiveByDefault(since = "1.0.0")
 class MatchingDeclarationName(config: Config) : Rule(config) {
 
-    override val issue: Issue = Issue(
+    override val issue = Issue(
         javaClass.simpleName,
         "If a source file contains only a single non-private top-level class or object, " +
             "the file name should reflect the case-sensitive name plus the .kt extension.",

--- a/detekt-rules-performance/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/ArrayPrimitive.kt
+++ b/detekt-rules-performance/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/ArrayPrimitive.kt
@@ -42,7 +42,7 @@ import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameOrNull
 @ActiveByDefault(since = "1.2.0")
 class ArrayPrimitive(config: Config) : Rule(config) {
     override val issue = Issue(
-        "ArrayPrimitive",
+        javaClass.simpleName,
         "Using `Array<Primitive>` leads to implicit boxing and a performance hit.",
     )
 

--- a/detekt-rules-performance/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/CouldBeSequence.kt
+++ b/detekt-rules-performance/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/CouldBeSequence.kt
@@ -32,7 +32,7 @@ import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameOrNull
 @RequiresTypeResolution
 class CouldBeSequence(config: Config) : Rule(config) {
 
-    override val issue: Issue = Issue(
+    override val issue = Issue(
         "CouldBeSequence",
         "Several chained collection operations that should be a sequence.",
     )

--- a/detekt-rules-performance/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/CouldBeSequence.kt
+++ b/detekt-rules-performance/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/CouldBeSequence.kt
@@ -33,7 +33,7 @@ import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameOrNull
 class CouldBeSequence(config: Config) : Rule(config) {
 
     override val issue = Issue(
-        "CouldBeSequence",
+        javaClass.simpleName,
         "Several chained collection operations that should be a sequence.",
     )
 

--- a/detekt-rules-performance/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/ForEachOnRange.kt
+++ b/detekt-rules-performance/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/ForEachOnRange.kt
@@ -44,7 +44,7 @@ import org.jetbrains.kotlin.psi2ir.deparenthesize
 class ForEachOnRange(config: Config) : Rule(config) {
 
     override val issue = Issue(
-        "ForEachOnRange",
+        javaClass.simpleName,
         "Using the forEach method on ranges has a heavy performance cost. Prefer using simple for loops.",
     )
 

--- a/detekt-rules-performance/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/SpreadOperator.kt
+++ b/detekt-rules-performance/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/SpreadOperator.kt
@@ -51,7 +51,7 @@ import org.jetbrains.kotlin.resolve.calls.util.getResolvedCall
 class SpreadOperator(config: Config) : Rule(config) {
 
     override val issue = Issue(
-        "SpreadOperator",
+        javaClass.simpleName,
         "In most cases using a spread operator causes a full copy of the array to be created before calling a " +
             "method. This may result in a performance penalty.",
     )

--- a/detekt-rules-performance/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/SpreadOperator.kt
+++ b/detekt-rules-performance/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/SpreadOperator.kt
@@ -50,7 +50,7 @@ import org.jetbrains.kotlin.resolve.calls.util.getResolvedCall
 @ActiveByDefault(since = "1.0.0")
 class SpreadOperator(config: Config) : Rule(config) {
 
-    override val issue: Issue = Issue(
+    override val issue = Issue(
         "SpreadOperator",
         "In most cases using a spread operator causes a full copy of the array to be created before calling a " +
             "method. This may result in a performance penalty.",

--- a/detekt-rules-performance/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/UnnecessaryPartOfBinaryExpression.kt
+++ b/detekt-rules-performance/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/UnnecessaryPartOfBinaryExpression.kt
@@ -34,7 +34,7 @@ import org.jetbrains.kotlin.utils.addIfNotNull
  */
 class UnnecessaryPartOfBinaryExpression(config: Config) : Rule(config) {
 
-    override val issue: Issue = Issue(
+    override val issue = Issue(
         "UnnecessaryPartOfBinaryExpression",
         "Detects duplicate condition into binary expression and recommends to remove unnecessary checks",
     )

--- a/detekt-rules-performance/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/UnnecessaryPartOfBinaryExpression.kt
+++ b/detekt-rules-performance/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/UnnecessaryPartOfBinaryExpression.kt
@@ -35,7 +35,7 @@ import org.jetbrains.kotlin.utils.addIfNotNull
 class UnnecessaryPartOfBinaryExpression(config: Config) : Rule(config) {
 
     override val issue = Issue(
-        "UnnecessaryPartOfBinaryExpression",
+        javaClass.simpleName,
         "Detects duplicate condition into binary expression and recommends to remove unnecessary checks",
     )
 

--- a/detekt-rules-performance/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/UnnecessaryTemporaryInstantiation.kt
+++ b/detekt-rules-performance/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/UnnecessaryTemporaryInstantiation.kt
@@ -25,7 +25,7 @@ import org.jetbrains.kotlin.psi.KtExpression
 @ActiveByDefault(since = "1.0.0")
 class UnnecessaryTemporaryInstantiation(config: Config) : Rule(config) {
 
-    override val issue: Issue = Issue(
+    override val issue = Issue(
         "UnnecessaryTemporaryInstantiation",
         "Avoid temporary objects when converting primitive types to `String`.",
     )

--- a/detekt-rules-performance/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/UnnecessaryTemporaryInstantiation.kt
+++ b/detekt-rules-performance/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/UnnecessaryTemporaryInstantiation.kt
@@ -26,7 +26,7 @@ import org.jetbrains.kotlin.psi.KtExpression
 class UnnecessaryTemporaryInstantiation(config: Config) : Rule(config) {
 
     override val issue = Issue(
-        "UnnecessaryTemporaryInstantiation",
+        javaClass.simpleName,
         "Avoid temporary objects when converting primitive types to `String`.",
     )
 

--- a/detekt-rules-ruleauthors/src/main/kotlin/io/gitlab/arturbosch/detekt/authors/UseEntityAtName.kt
+++ b/detekt-rules-ruleauthors/src/main/kotlin/io/gitlab/arturbosch/detekt/authors/UseEntityAtName.kt
@@ -24,7 +24,7 @@ import org.jetbrains.kotlin.psi.psiUtil.getReceiverExpression
 class UseEntityAtName(config: Config) : Rule(config) {
 
     override val issue = Issue(
-        "UseEntityAtName",
+        javaClass.simpleName,
         "Prefer Entity.atName to Entity.from(....nameIdentifier).",
     )
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/AbstractClassCanBeConcreteClass.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/AbstractClassCanBeConcreteClass.kt
@@ -52,11 +52,10 @@ class AbstractClassCanBeConcreteClass(config: Config) : Rule(config) {
 
     private val noAbstractMember = "An abstract class without an abstract member can be refactored to a concrete class."
 
-    override val issue =
-        Issue(
-            "AbstractClassCanBeConcreteClass",
-            "An abstract class is unnecessary. May be refactored to a concrete class.",
-        )
+    override val issue = Issue(
+        "AbstractClassCanBeConcreteClass",
+        "An abstract class is unnecessary. May be refactored to a concrete class.",
+    )
 
     @Configuration("Allows you to provide a list of annotations that disable this check.")
     @Deprecated("Use `ignoreAnnotated` instead")

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/AbstractClassCanBeConcreteClass.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/AbstractClassCanBeConcreteClass.kt
@@ -53,7 +53,7 @@ class AbstractClassCanBeConcreteClass(config: Config) : Rule(config) {
     private val noAbstractMember = "An abstract class without an abstract member can be refactored to a concrete class."
 
     override val issue = Issue(
-        "AbstractClassCanBeConcreteClass",
+        javaClass.simpleName,
         "An abstract class is unnecessary. May be refactored to a concrete class.",
     )
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/AbstractClassCanBeInterface.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/AbstractClassCanBeInterface.kt
@@ -51,11 +51,10 @@ class AbstractClassCanBeInterface(config: Config) : Rule(config) {
 
     private val noConcreteMember = "An abstract class without a concrete member can be refactored to an interface."
 
-    override val issue =
-        Issue(
-            "AbstractClassCanBeInterface",
-            "An abstract class is unnecessary. May be refactored to an interface.",
-        )
+    override val issue = Issue(
+        "AbstractClassCanBeInterface",
+        "An abstract class is unnecessary. May be refactored to an interface.",
+    )
 
     override fun visitClass(klass: KtClass) {
         klass.check()

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/AbstractClassCanBeInterface.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/AbstractClassCanBeInterface.kt
@@ -52,7 +52,7 @@ class AbstractClassCanBeInterface(config: Config) : Rule(config) {
     private val noConcreteMember = "An abstract class without a concrete member can be refactored to an interface."
 
     override val issue = Issue(
-        "AbstractClassCanBeInterface",
+        javaClass.simpleName,
         "An abstract class is unnecessary. May be refactored to an interface.",
     )
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/AlsoCouldBeApply.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/AlsoCouldBeApply.kt
@@ -38,7 +38,7 @@ import org.jetbrains.kotlin.psi.KtQualifiedExpression
 class AlsoCouldBeApply(config: Config) : Rule(config) {
 
     override val issue = Issue(
-        "AlsoCouldBeApply",
+        javaClass.simpleName,
         "When an `also` block contains only `it`-started expressions, simplify it to the `apply` block.",
     )
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/CascadingCallWrapping.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/CascadingCallWrapping.kt
@@ -36,8 +36,8 @@ import org.jetbrains.kotlin.psi.psiUtil.startOffset
  */
 class CascadingCallWrapping(config: Config) : Rule(config) {
     override val issue = Issue(
-        id = javaClass.simpleName,
-        description = "If a chained call is wrapped to a new line, subsequent chained calls should be as well.",
+        javaClass.simpleName,
+        "If a chained call is wrapped to a new line, subsequent chained calls should be as well.",
     )
 
     @Configuration("require trailing elvis expressions to be wrapped on a new line")

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/CollapsibleIfStatements.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/CollapsibleIfStatements.kt
@@ -35,7 +35,7 @@ import org.jetbrains.kotlin.psi.psiUtil.getChildrenOfType
 class CollapsibleIfStatements(config: Config) : Rule(config) {
 
     override val issue = Issue(
-        "CollapsibleIfStatements",
+        javaClass.simpleName,
         "Two if statements which could be collapsed were detected. " +
             "These statements can be merged to improve readability.",
     )

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/DataClassContainsFunctions.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/DataClassContainsFunctions.kt
@@ -28,7 +28,7 @@ import org.jetbrains.kotlin.psi.KtNamedFunction
 class DataClassContainsFunctions(config: Config) : Rule(config) {
 
     override val issue = Issue(
-        "DataClassContainsFunctions",
+        javaClass.simpleName,
         "Data classes should mainly be used to store data and should not have any extra functions " +
             "(Compiler will automatically generate equals, toString and hashCode functions).",
     )

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/DataClassContainsFunctions.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/DataClassContainsFunctions.kt
@@ -27,7 +27,7 @@ import org.jetbrains.kotlin.psi.KtNamedFunction
  */
 class DataClassContainsFunctions(config: Config) : Rule(config) {
 
-    override val issue: Issue = Issue(
+    override val issue = Issue(
         "DataClassContainsFunctions",
         "Data classes should mainly be used to store data and should not have any extra functions " +
             "(Compiler will automatically generate equals, toString and hashCode functions).",

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/DataClassShouldBeImmutable.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/DataClassShouldBeImmutable.kt
@@ -30,7 +30,7 @@ import org.jetbrains.kotlin.psi.KtClass
 class DataClassShouldBeImmutable(config: Config) : Rule(config) {
 
     override val issue = Issue(
-        "DataClassShouldBeImmutable",
+        javaClass.simpleName,
         "Data classes should mainly be immutable and should not have any side effects " +
             "(To copy an object altering some of its properties use the copy function).",
     )

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/DataClassShouldBeImmutable.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/DataClassShouldBeImmutable.kt
@@ -29,7 +29,7 @@ import org.jetbrains.kotlin.psi.KtClass
  */
 class DataClassShouldBeImmutable(config: Config) : Rule(config) {
 
-    override val issue: Issue = Issue(
+    override val issue = Issue(
         "DataClassShouldBeImmutable",
         "Data classes should mainly be immutable and should not have any side effects " +
             "(To copy an object altering some of its properties use the copy function).",

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/DoubleNegativeLambda.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/DoubleNegativeLambda.kt
@@ -30,7 +30,7 @@ import org.jetbrains.kotlin.psi.psiUtil.collectDescendantsOfType
 class DoubleNegativeLambda(config: Config) : Rule(config) {
 
     override val issue = Issue(
-        "DoubleNegativeLambda",
+        javaClass.simpleName,
         "Double negative from a function name expressed in the negative (like `takeUnless`) with a lambda block " +
             "that also contains negation. This is more readable when rewritten using a positive form of the function " +
             "(like `takeIf`).",

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/EqualsNullCall.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/EqualsNullCall.kt
@@ -24,7 +24,7 @@ import org.jetbrains.kotlin.psi.KtCallExpression
 class EqualsNullCall(config: Config) : Rule(config) {
 
     override val issue = Issue(
-        "EqualsNullCall",
+        javaClass.simpleName,
         "Equals() method is called with null as parameter. Consider using == to compare to null.",
     )
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitCollectionElementAccessMethod.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitCollectionElementAccessMethod.kt
@@ -40,7 +40,7 @@ import org.jetbrains.kotlin.types.typeUtil.supertypes
 class ExplicitCollectionElementAccessMethod(config: Config) : Rule(config) {
 
     override val issue = Issue(
-        "ExplicitCollectionElementAccessMethod",
+        javaClass.simpleName,
         "Prefer usage of the indexed access operator [] for map element access or insert methods.",
     )
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitCollectionElementAccessMethod.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitCollectionElementAccessMethod.kt
@@ -39,11 +39,10 @@ import org.jetbrains.kotlin.types.typeUtil.supertypes
 @RequiresTypeResolution
 class ExplicitCollectionElementAccessMethod(config: Config) : Rule(config) {
 
-    override val issue: Issue =
-        Issue(
-            "ExplicitCollectionElementAccessMethod",
-            "Prefer usage of the indexed access operator [] for map element access or insert methods.",
-        )
+    override val issue = Issue(
+        "ExplicitCollectionElementAccessMethod",
+        "Prefer usage of the indexed access operator [] for map element access or insert methods.",
+    )
 
     override fun visitDotQualifiedExpression(expression: KtDotQualifiedExpression) {
         super.visitDotQualifiedExpression(expression)

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxChainedCallsOnSameLine.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxChainedCallsOnSameLine.kt
@@ -37,8 +37,8 @@ import org.jetbrains.kotlin.resolve.BindingContext
 @RequiresTypeResolution
 class MaxChainedCallsOnSameLine(config: Config) : Rule(config) {
     override val issue = Issue(
-        id = javaClass.simpleName,
-        description = "Chained calls beyond the maximum should be wrapped to a new line.",
+        javaClass.simpleName,
+        "Chained calls beyond the maximum should be wrapped to a new line.",
     )
 
     @Configuration("maximum chained calls allowed on a single line")

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/NestedClassesVisibility.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/NestedClassesVisibility.kt
@@ -37,7 +37,7 @@ import org.jetbrains.kotlin.psi.KtEnumEntry
 @ActiveByDefault(since = "1.16.0")
 class NestedClassesVisibility(config: Config) : Rule(config) {
 
-    override val issue: Issue = Issue(
+    override val issue = Issue(
         "NestedClassesVisibility",
         "The explicit public modifier still results in an internal nested class.",
     )

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/NestedClassesVisibility.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/NestedClassesVisibility.kt
@@ -38,7 +38,7 @@ import org.jetbrains.kotlin.psi.KtEnumEntry
 class NestedClassesVisibility(config: Config) : Rule(config) {
 
     override val issue = Issue(
-        "NestedClassesVisibility",
+        javaClass.simpleName,
         "The explicit public modifier still results in an internal nested class.",
     )
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/OptionalAbstractKeyword.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/OptionalAbstractKeyword.kt
@@ -34,7 +34,7 @@ import org.jetbrains.kotlin.psi.psiUtil.getChildrenOfType
 @ActiveByDefault(since = "1.0.0")
 class OptionalAbstractKeyword(config: Config) : Rule(config) {
 
-    override val issue: Issue = Issue(
+    override val issue = Issue(
         javaClass.simpleName,
         "Unnecessary abstract modifier in interface detected. " +
             "This abstract modifier is unnecessary and thus can be removed.",

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantExplicitType.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantExplicitType.kt
@@ -47,7 +47,7 @@ import org.jetbrains.kotlin.types.typeUtil.isLong
 class RedundantExplicitType(config: Config) : Rule(config) {
 
     override val issue = Issue(
-        "RedundantExplicitType",
+        javaClass.simpleName,
         "Type does not need to be stated explicitly and can be removed.",
     )
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantHigherOrderMapUsage.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantHigherOrderMapUsage.kt
@@ -73,7 +73,7 @@ import org.jetbrains.kotlin.types.typeUtil.immediateSupertypes
 @RequiresTypeResolution
 @ActiveByDefault(since = "1.21.0")
 class RedundantHigherOrderMapUsage(config: Config) : Rule(config) {
-    override val issue: Issue = Issue(
+    override val issue = Issue(
         javaClass.simpleName,
         "Checks for redundant 'map' calls, which can be removed.",
     )

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantVisibilityModifierRule.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantVisibilityModifierRule.kt
@@ -46,7 +46,7 @@ class RedundantVisibilityModifierRule(config: Config) : Rule(config) {
     override val defaultRuleIdAliases: Set<String> = setOf("RedundantVisibilityModifier")
 
     override val issue = Issue(
-        "RedundantVisibilityModifierRule",
+        javaClass.simpleName,
         "Redundant visibility modifiers detected, which can be safely removed.",
     )
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantVisibilityModifierRule.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantVisibilityModifierRule.kt
@@ -45,7 +45,7 @@ class RedundantVisibilityModifierRule(config: Config) : Rule(config) {
 
     override val defaultRuleIdAliases: Set<String> = setOf("RedundantVisibilityModifier")
 
-    override val issue: Issue = Issue(
+    override val issue = Issue(
         "RedundantVisibilityModifierRule",
         "Redundant visibility modifiers detected, which can be safely removed.",
     )

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAny.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAny.kt
@@ -45,7 +45,7 @@ import org.jetbrains.kotlin.types.typeUtil.isSubtypeOf
  */
 @RequiresTypeResolution
 class UnnecessaryAny(config: Config) : Rule(config) {
-    override val issue: Issue = Issue(
+    override val issue = Issue(
         javaClass.simpleName,
         "The `any {  }` usage is unnecessary.",
     )

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryBackticks.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryBackticks.kt
@@ -26,7 +26,7 @@ import org.jetbrains.kotlin.psi.psiUtil.isIdentifier
  * </compliant>
  */
 class UnnecessaryBackticks(config: Config) : Rule(config) {
-    override val issue: Issue = Issue(
+    override val issue = Issue(
         javaClass.simpleName,
         "Backticks are unnecessary.",
     )

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryFilter.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryFilter.kt
@@ -52,7 +52,7 @@ import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameOrNull
 class UnnecessaryFilter(config: Config) : Rule(config) {
 
     override val issue = Issue(
-        "UnnecessaryFilter",
+        javaClass.simpleName,
         "`filter()` with other collection operations may be simplified.",
     )
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryFilter.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryFilter.kt
@@ -51,7 +51,7 @@ import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameOrNull
 @ActiveByDefault(since = "1.21.0")
 class UnnecessaryFilter(config: Config) : Rule(config) {
 
-    override val issue: Issue = Issue(
+    override val issue = Issue(
         "UnnecessaryFilter",
         "`filter()` with other collection operations may be simplified.",
     )

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryInheritance.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryInheritance.kt
@@ -20,7 +20,7 @@ import org.jetbrains.kotlin.psi.KtClassOrObject
 @ActiveByDefault(since = "1.2.0")
 class UnnecessaryInheritance(config: Config) : Rule(config) {
 
-    override val issue: Issue = Issue(
+    override val issue = Issue(
         javaClass.simpleName,
         "The extended super type is unnecessary.",
     )

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryInnerClass.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryInnerClass.kt
@@ -43,7 +43,7 @@ class UnnecessaryInnerClass(config: Config) : Rule(config) {
     private val candidateClassToParentClasses = mutableMapOf<KtClass, List<KtClass>>()
     private val classChain = ArrayDeque<KtClass>()
 
-    override val issue: Issue = Issue(
+    override val issue = Issue(
         javaClass.simpleName,
         "The 'inner' qualifier is unnecessary.",
     )

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryParentheses.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryParentheses.kt
@@ -51,7 +51,7 @@ import org.jetbrains.kotlin.psi.KtPsiUtil
 class UnnecessaryParentheses(config: Config) : Rule(config) {
 
     override val issue = Issue(
-        "UnnecessaryParentheses",
+        javaClass.simpleName,
         "Unnecessary parentheses don't add any value to the code and should be removed.",
     )
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedParameter.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedParameter.kt
@@ -47,7 +47,7 @@ class UnusedParameter(config: Config) : Rule(config) {
     override val defaultRuleIdAliases: Set<String> =
         setOf("UNUSED_VARIABLE", "UNUSED_PARAMETER", "unused", "UnusedPrivateMember")
 
-    override val issue: Issue = Issue(
+    override val issue = Issue(
         "UnusedParameter",
         "Function parameter is unused and should be removed.",
     )

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedParameter.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedParameter.kt
@@ -48,7 +48,7 @@ class UnusedParameter(config: Config) : Rule(config) {
         setOf("UNUSED_VARIABLE", "UNUSED_PARAMETER", "unused", "UnusedPrivateMember")
 
     override val issue = Issue(
-        "UnusedParameter",
+        javaClass.simpleName,
         "Function parameter is unused and should be removed.",
     )
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateClass.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateClass.kt
@@ -40,7 +40,7 @@ class UnusedPrivateClass(config: Config) : Rule(config) {
 
     override val defaultRuleIdAliases: Set<String> = setOf("unused")
 
-    override val issue: Issue = Issue(
+    override val issue = Issue(
         "UnusedPrivateClass",
         "Private class is unused and should be removed.",
     )

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateClass.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateClass.kt
@@ -41,7 +41,7 @@ class UnusedPrivateClass(config: Config) : Rule(config) {
     override val defaultRuleIdAliases: Set<String> = setOf("unused")
 
     override val issue = Issue(
-        "UnusedPrivateClass",
+        javaClass.simpleName,
         "Private class is unused and should be removed.",
     )
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
@@ -51,7 +51,7 @@ class UnusedPrivateMember(config: Config) : Rule(config) {
     override val defaultRuleIdAliases: Set<String> = setOf("UNUSED_VARIABLE", "UNUSED_PARAMETER", "unused")
 
     override val issue = Issue(
-        "UnusedPrivateMember",
+        javaClass.simpleName,
         "Private function is unused and should be removed.",
     )
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
@@ -50,7 +50,7 @@ class UnusedPrivateMember(config: Config) : Rule(config) {
 
     override val defaultRuleIdAliases: Set<String> = setOf("UNUSED_VARIABLE", "UNUSED_PARAMETER", "unused")
 
-    override val issue: Issue = Issue(
+    override val issue = Issue(
         "UnusedPrivateMember",
         "Private function is unused and should be removed.",
     )

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateProperty.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateProperty.kt
@@ -53,7 +53,7 @@ class UnusedPrivateProperty(config: Config) : Rule(config) {
         setOf("UNUSED_VARIABLE", "UNUSED_PARAMETER", "unused", "UnusedPrivateMember")
 
     override val issue = Issue(
-        "UnusedPrivateProperty",
+        javaClass.simpleName,
         "Property is unused and should be removed.",
     )
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateProperty.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateProperty.kt
@@ -52,7 +52,7 @@ class UnusedPrivateProperty(config: Config) : Rule(config) {
     override val defaultRuleIdAliases: Set<String> =
         setOf("UNUSED_VARIABLE", "UNUSED_PARAMETER", "unused", "UnusedPrivateMember")
 
-    override val issue: Issue = Issue(
+    override val issue = Issue(
         "UnusedPrivateProperty",
         "Property is unused and should be removed.",
     )

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseAnyOrNoneInsteadOfFind.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseAnyOrNoneInsteadOfFind.kt
@@ -32,7 +32,7 @@ import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
 @RequiresTypeResolution
 @ActiveByDefault(since = "1.21.0")
 class UseAnyOrNoneInsteadOfFind(config: Config) : Rule(config) {
-    override val issue: Issue = Issue(
+    override val issue = Issue(
         "UseAnyOrNoneInsteadOfFind",
         "Use `any` or `none` instead of `find` and `null` checks.",
     )

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseAnyOrNoneInsteadOfFind.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseAnyOrNoneInsteadOfFind.kt
@@ -33,7 +33,7 @@ import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
 @ActiveByDefault(since = "1.21.0")
 class UseAnyOrNoneInsteadOfFind(config: Config) : Rule(config) {
     override val issue = Issue(
-        "UseAnyOrNoneInsteadOfFind",
+        javaClass.simpleName,
         "Use `any` or `none` instead of `find` and `null` checks.",
     )
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseCheckNotNull.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseCheckNotNull.kt
@@ -26,7 +26,7 @@ import org.jetbrains.kotlin.psi.KtCallExpression
 @ActiveByDefault(since = "1.21.0")
 class UseCheckNotNull(config: Config) : Rule(config) {
     override val issue = Issue(
-        "UseCheckNotNull",
+        javaClass.simpleName,
         "Use checkNotNull() instead of check() for checking not-null.",
     )
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseCheckOrError.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseCheckOrError.kt
@@ -41,7 +41,7 @@ import org.jetbrains.kotlin.psi.KtThrowExpression
 class UseCheckOrError(config: Config) : Rule(config) {
 
     override val issue = Issue(
-        "UseCheckOrError",
+        javaClass.simpleName,
         "Use check() or error() instead of throwing an IllegalStateException.",
     )
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseDataClass.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseDataClass.kt
@@ -47,7 +47,7 @@ import org.jetbrains.kotlin.types.KotlinType
 @RequiresTypeResolution
 class UseDataClass(config: Config) : Rule(config) {
 
-    override val issue: Issue = Issue(
+    override val issue = Issue(
         "UseDataClass",
         "Classes that do nothing but hold data should be replaced with a data class.",
     )

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseDataClass.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseDataClass.kt
@@ -48,7 +48,7 @@ import org.jetbrains.kotlin.types.KotlinType
 class UseDataClass(config: Config) : Rule(config) {
 
     override val issue = Issue(
-        "UseDataClass",
+        javaClass.simpleName,
         "Classes that do nothing but hold data should be replaced with a data class.",
     )
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIfEmptyOrIfBlank.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIfEmptyOrIfBlank.kt
@@ -47,7 +47,7 @@ import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameOrNull
 @RequiresTypeResolution
 @Suppress("ComplexMethod")
 class UseIfEmptyOrIfBlank(config: Config) : Rule(config) {
-    override val issue: Issue = Issue(
+    override val issue = Issue(
         "UseIfEmptyOrIfBlank",
         "Use `ifEmpty` or `ifBlank` instead of `isEmpty` or `isBlank` to assign a default value.",
     )

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIfEmptyOrIfBlank.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIfEmptyOrIfBlank.kt
@@ -48,7 +48,7 @@ import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameOrNull
 @Suppress("ComplexMethod")
 class UseIfEmptyOrIfBlank(config: Config) : Rule(config) {
     override val issue = Issue(
-        "UseIfEmptyOrIfBlank",
+        javaClass.simpleName,
         "Use `ifEmpty` or `ifBlank` instead of `isEmpty` or `isBlank` to assign a default value.",
     )
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIfInsteadOfWhen.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIfInsteadOfWhen.kt
@@ -29,7 +29,7 @@ import org.jetbrains.kotlin.psi.KtWhenExpression
 class UseIfInsteadOfWhen(config: Config) : Rule(config) {
 
     override val issue = Issue(
-        "UseIfInsteadOfWhen",
+        javaClass.simpleName,
         "Binary expressions are better expressed using an `if` expression than a `when` expression.",
     )
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIfInsteadOfWhen.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIfInsteadOfWhen.kt
@@ -28,7 +28,7 @@ import org.jetbrains.kotlin.psi.KtWhenExpression
  */
 class UseIfInsteadOfWhen(config: Config) : Rule(config) {
 
-    override val issue: Issue = Issue(
+    override val issue = Issue(
         "UseIfInsteadOfWhen",
         "Binary expressions are better expressed using an `if` expression than a `when` expression.",
     )

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIsNullOrEmpty.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIsNullOrEmpty.kt
@@ -46,7 +46,7 @@ import org.jetbrains.kotlin.types.isNullable
 @RequiresTypeResolution
 @ActiveByDefault(since = "1.21.0")
 class UseIsNullOrEmpty(config: Config) : Rule(config) {
-    override val issue: Issue = Issue(
+    override val issue = Issue(
         "UseIsNullOrEmpty",
         "Use `isNullOrEmpty()` call instead of `x == null || x.isEmpty()`.",
     )

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIsNullOrEmpty.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIsNullOrEmpty.kt
@@ -47,7 +47,7 @@ import org.jetbrains.kotlin.types.isNullable
 @ActiveByDefault(since = "1.21.0")
 class UseIsNullOrEmpty(config: Config) : Rule(config) {
     override val issue = Issue(
-        "UseIsNullOrEmpty",
+        javaClass.simpleName,
         "Use `isNullOrEmpty()` call instead of `x == null || x.isEmpty()`.",
     )
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseOrEmpty.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseOrEmpty.kt
@@ -45,7 +45,7 @@ import org.jetbrains.kotlin.types.typeUtil.makeNotNullable
 @ActiveByDefault(since = "1.21.0")
 class UseOrEmpty(config: Config) : Rule(config) {
     override val issue = Issue(
-        "UseOrEmpty",
+        javaClass.simpleName,
         "Use `orEmpty()` call instead of `?:` with empty collection factory methods",
     )
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseOrEmpty.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseOrEmpty.kt
@@ -44,7 +44,7 @@ import org.jetbrains.kotlin.types.typeUtil.makeNotNullable
 @RequiresTypeResolution
 @ActiveByDefault(since = "1.21.0")
 class UseOrEmpty(config: Config) : Rule(config) {
-    override val issue: Issue = Issue(
+    override val issue = Issue(
         "UseOrEmpty",
         "Use `orEmpty()` call instead of `?:` with empty collection factory methods",
     )

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseRequire.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseRequire.kt
@@ -33,7 +33,7 @@ import org.jetbrains.kotlin.psi.KtThrowExpression
 class UseRequire(config: Config) : Rule(config) {
 
     override val issue = Issue(
-        "UseRequire",
+        javaClass.simpleName,
         "Use require() instead of throwing an IllegalArgumentException.",
     )
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseRequireNotNull.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseRequireNotNull.kt
@@ -26,7 +26,7 @@ import org.jetbrains.kotlin.psi.KtCallExpression
 @ActiveByDefault(since = "1.21.0")
 class UseRequireNotNull(config: Config) : Rule(config) {
     override val issue = Issue(
-        "UseRequireNotNull",
+        javaClass.simpleName,
         "Use requireNotNull() instead of require() for checking not-null.",
     )
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseSumOfInsteadOfFlatMapSize.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseSumOfInsteadOfFlatMapSize.kt
@@ -38,7 +38,7 @@ import org.jetbrains.kotlin.resolve.descriptorUtil.isSubclassOf
  */
 @RequiresTypeResolution
 class UseSumOfInsteadOfFlatMapSize(config: Config) : Rule(config) {
-    override val issue: Issue = Issue(
+    override val issue = Issue(
         javaClass.simpleName,
         "Use `sumOf` instead of `flatMap` and `size/count` calls",
     )

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UselessCallOnNotNull.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UselessCallOnNotNull.kt
@@ -46,7 +46,7 @@ import org.jetbrains.kotlin.types.isNullable
 @RequiresTypeResolution
 @ActiveByDefault(since = "1.2.0")
 class UselessCallOnNotNull(config: Config) : Rule(config) {
-    override val issue: Issue = Issue(
+    override val issue = Issue(
         "UselessCallOnNotNull",
         "This call on a non-null reference may be reduced or removed. " +
             "Some calls are intended to be called on nullable collection or text types (e.g. `String?`)." +

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UselessCallOnNotNull.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UselessCallOnNotNull.kt
@@ -47,7 +47,7 @@ import org.jetbrains.kotlin.types.isNullable
 @ActiveByDefault(since = "1.2.0")
 class UselessCallOnNotNull(config: Config) : Rule(config) {
     override val issue = Issue(
-        "UselessCallOnNotNull",
+        javaClass.simpleName,
         "This call on a non-null reference may be reduced or removed. " +
             "Some calls are intended to be called on nullable collection or text types (e.g. `String?`)." +
             "When this call is used on a reference to a non-null type " +

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UtilityClassWithPublicConstructor.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UtilityClassWithPublicConstructor.kt
@@ -58,7 +58,7 @@ import org.jetbrains.kotlin.psi.psiUtil.isPublic
 @ActiveByDefault(since = "1.2.0")
 class UtilityClassWithPublicConstructor(config: Config) : Rule(config) {
 
-    override val issue: Issue = Issue(
+    override val issue = Issue(
         javaClass.simpleName,
         "The class declaration is unnecessary because it only contains utility functions. " +
             "An object declaration should be used instead.",

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/VarCouldBeVal.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/VarCouldBeVal.kt
@@ -63,7 +63,7 @@ class VarCouldBeVal(config: Config) : Rule(config) {
     override val defaultRuleIdAliases: Set<String> = setOf("CanBeVal")
 
     override val issue = Issue(
-        "VarCouldBeVal",
+        javaClass.simpleName,
         "Var declaration could be val.",
     )
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/VarCouldBeVal.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/VarCouldBeVal.kt
@@ -62,7 +62,7 @@ class VarCouldBeVal(config: Config) : Rule(config) {
 
     override val defaultRuleIdAliases: Set<String> = setOf("CanBeVal")
 
-    override val issue: Issue = Issue(
+    override val issue = Issue(
         "VarCouldBeVal",
         "Var declaration could be val.",
     )

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/movelambdaout/UnnecessaryBracesAroundTrailingLambda.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/movelambdaout/UnnecessaryBracesAroundTrailingLambda.kt
@@ -33,7 +33,7 @@ import org.jetbrains.kotlin.psi.KtNameReferenceExpression
  */
 @RequiresTypeResolution
 class UnnecessaryBracesAroundTrailingLambda(config: Config) : Rule(config) {
-    override val issue: Issue = Issue(
+    override val issue = Issue(
         javaClass.simpleName,
         "Braces around trailing lambda is unnecessary.",
     )

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/MandatoryBracesLoops.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/MandatoryBracesLoops.kt
@@ -52,7 +52,7 @@ import org.jetbrains.kotlin.psi.psiUtil.siblings
  */
 class MandatoryBracesLoops(config: Config) : Rule(config) {
     override val issue = Issue(
-        "MandatoryBracesLoops",
+        javaClass.simpleName,
         "A multi-line loop was found that does not have braces. " +
             "These should be added to improve readability.",
     )

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/PreferToOverPairSyntax.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/PreferToOverPairSyntax.kt
@@ -29,7 +29,7 @@ import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameOrNull
 @RequiresTypeResolution
 class PreferToOverPairSyntax(config: Config) : Rule(config) {
     override val issue = Issue(
-        "PreferToOverPairSyntax",
+        javaClass.simpleName,
         "Pair was created using the Pair constructor, using the to syntax is preferred.",
     )
 


### PR DESCRIPTION
This is a cleanup around `Rule.issue`. In the future the `Issue` will have two different ids so this will help to make that change easier. The main idea is that on `id` we should always use `javaClass.simpleName`. In future PRs this will be simplified so you wouldn't need to even set it.