### PR TITLE
Properly handle nullable type

### DIFF
--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/FindingsAssertions.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/FindingsAssertions.kt
@@ -113,19 +113,19 @@ class FindingAssert(val actual: Finding?) : AbstractAssert<FindingAssert, Findin
 
     fun hasSourceLocation(line: Int, column: Int) = apply {
         val expectedLocation = SourceLocation(line, column)
-        val actualLocation = actual.location.source
+        val actualLocation = actual?.location?.source
         if (actualLocation != expectedLocation) {
             failWithMessage("Expected source location to be $expectedLocation but was $actualLocation")
         }
     }
 
     fun hasMessage(expectedMessage: String) = apply {
-        if (expectedMessage.isNotBlank() && actual.message.isBlank()) {
+        if (expectedMessage.isNotBlank() && actual?.message.isNullOrBlank()) {
             failWithMessage("Expected message <$expectedMessage> but finding has no message")
         }
 
-        if (!actual.message.trim().equals(expectedMessage.trim(), ignoreCase = true)) {
-            failWithMessage("Expected message <$expectedMessage> but actual message was <${actual.message}>")
+        if (!actual?.message?.trim().equals(expectedMessage.trim(), ignoreCase = true)) {
+            failWithMessage("Expected message <$expectedMessage> but actual message was <${actual?.message}>")
         }
     }
 }


### PR DESCRIPTION
`actual` is a nullable type but the K1 compiler ignores that when referencing `actual` in functions in the class. This is a compilation failure in K2. Backporting the fix as the new behaviour is correct.