### PR TITLE
Fix test snippets for K2

### DIFF
--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicClassSpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicClassSpec.kt
@@ -252,7 +252,11 @@ class UndocumentedPublicClassSpec {
     @Test
     fun `does not report protected class by default`() {
         val code = """
-            protected class Test {
+            /**
+             * Sample KDoc for parent class.
+             */
+            class Test {
+                protected class ProtectedClass
             }
         """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
@@ -261,7 +265,11 @@ class UndocumentedPublicClassSpec {
     @Test
     fun `reports protected class if configured`() {
         val code = """
-            protected class Test {
+            /**
+             * Sample KDoc for parent class.
+             */
+            class Test {
+                protected class ProtectedClass
             }
         """.trimIndent()
         val subject = UndocumentedPublicClass(TestConfig(SEARCH_IN_PROTECTED_CLASS to "true"))


### PR DESCRIPTION
In language version 2.0 it is not permitted to use `protected` on a class that is in a file. As test snippets are compiled as KTS scripts this will otherwise cause these tests to fail.