### PR TITLE
Exclude FirErrors class from JaCoCo instrumentation to avoid ASM MethodTooLargeException

### DIFF
--- a/build-logic/src/main/kotlin/module.gradle.kts
+++ b/build-logic/src/main/kotlin/module.gradle.kts
@@ -44,6 +44,10 @@ tasks.withType<Test>().configureEach {
         showCauses = true
         showStackTraces = true
     }
+
+    configure<JacocoTaskExtension> {
+        excludes = listOf("org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors")
+    }
 }
 
 kotlin {


### PR DESCRIPTION
This is required for code coverage to work correctly when building using K2 compiler.