### PR TITLE
Remove UnstableApi annotation

### DIFF
--- a/detekt-api/api/detekt-api.api
+++ b/detekt-api/api/detekt-api.api
@@ -407,10 +407,6 @@ public final class io/gitlab/arturbosch/detekt/api/TextLocation {
 	public fun toString ()Ljava/lang/String;
 }
 
-public abstract interface annotation class io/gitlab/arturbosch/detekt/api/UnstableApi : java/lang/annotation/Annotation {
-	public abstract fun reason ()Ljava/lang/String;
-}
-
 public final class io/gitlab/arturbosch/detekt/api/ValueWithReason {
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/ConfigProperty.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/ConfigProperty.kt
@@ -44,7 +44,6 @@ fun <T : Any, U : Any> config(
  * @param defaultValue the value that the property evaluates to when there is no key with the name of the property in
  * the config. Although [T] is defined as [Any], only [String], [Int], [Boolean] and [List<String>] are supported.
  */
-@UnstableApi("fallback property handling is still under discussion")
 fun <T : Any> configWithFallback(
     fallbackProperty: KProperty0<T>,
     defaultValue: T
@@ -66,7 +65,6 @@ fun <T : Any> configWithFallback(
  * @param transformer a function that transforms the value from the configuration (or the default) into its final
  * value.
  */
-@UnstableApi("fallback property handling is still under discussion")
 fun <T : Any, U : Any> configWithFallback(
     fallbackProperty: KProperty0<U>,
     defaultValue: T,

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Extension.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Extension.kt
@@ -32,7 +32,6 @@ interface Extension {
     /**
      * Setup extension by querying common paths and config options.
      */
-    @OptIn(UnstableApi::class)
     fun init(context: SetupContext) {
         // implement for setup code
     }

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/PropertiesAware.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/PropertiesAware.kt
@@ -3,7 +3,6 @@ package io.gitlab.arturbosch.detekt.api
 /**
  * Properties holder. Allows to store and retrieve any data.
  */
-@UnstableApi
 interface PropertiesAware {
 
     /**
@@ -20,7 +19,6 @@ interface PropertiesAware {
 /**
  * Allows to retrieve stored properties in a type safe way.
  */
-@UnstableApi
 inline fun <reified T : Any> PropertiesAware.getOrNull(key: String): T? {
     val value = properties[key]
     if (value != null) {

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/ReportingExtension.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/ReportingExtension.kt
@@ -4,7 +4,6 @@ package io.gitlab.arturbosch.detekt.api
  * Allows to intercept detekt's result container by listening to the initial and final state
  * and manipulate the reported findings.
  */
-@UnstableApi
 interface ReportingExtension : Extension {
 
     /**

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/SetupContext.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/SetupContext.kt
@@ -5,7 +5,6 @@ import java.net.URI
 /**
  * Context providing useful processing settings to initialize extensions.
  */
-@UnstableApi
 interface SetupContext : PropertiesAware {
     /**
      * All config locations which where used to create [config].

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/UnstableApi.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/UnstableApi.kt
@@ -1,7 +1,0 @@
-package io.gitlab.arturbosch.detekt.api
-
-/**
- * Experimental detekt api which may change on minor or patch versions.
- */
-@RequiresOptIn
-annotation class UnstableApi(val reason: String = "")

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/ConfigPropertySpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/ConfigPropertySpec.kt
@@ -451,7 +451,6 @@ class ConfigPropertySpec {
         }
     }
 
-    @OptIn(UnstableApi::class)
     @Nested
     inner class ConfigWithFallback {
         @Nested

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/PropertiesAwareSpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/PropertiesAwareSpec.kt
@@ -5,7 +5,6 @@ import org.assertj.core.api.Assertions.assertThatCode
 import org.junit.jupiter.api.Test
 import kotlin.random.Random
 
-@OptIn(UnstableApi::class)
 class PropertiesAwareSpec {
 
     private val hash = Random(1).nextInt()

--- a/detekt-api/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/test/EmptySetupContext.kt
+++ b/detekt-api/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/test/EmptySetupContext.kt
@@ -2,10 +2,8 @@ package io.gitlab.arturbosch.detekt.test
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.SetupContext
-import io.gitlab.arturbosch.detekt.api.UnstableApi
 import java.net.URI
 
-@OptIn(UnstableApi::class)
 class EmptySetupContext : SetupContext {
     override val configUris: Collection<URI> = emptyList()
     override val config: Config = Config.empty

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/DetektProgressListener.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/DetektProgressListener.kt
@@ -3,7 +3,6 @@ package io.gitlab.arturbosch.detekt.cli
 import io.gitlab.arturbosch.detekt.api.Detektion
 import io.gitlab.arturbosch.detekt.api.FileProcessListener
 import io.gitlab.arturbosch.detekt.api.SetupContext
-import io.gitlab.arturbosch.detekt.api.UnstableApi
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.resolve.BindingContext
 
@@ -13,7 +12,6 @@ class DetektProgressListener : FileProcessListener {
 
     override val id: String = "DetektProgressListener"
 
-    @OptIn(UnstableApi::class)
     override fun init(context: SetupContext) {
         this.outPrinter = context.outputChannel
     }

--- a/detekt-compiler-plugin/src/main/kotlin/io/github/detekt/compiler/plugin/internal/DetektService.kt
+++ b/detekt-compiler-plugin/src/main/kotlin/io/github/detekt/compiler/plugin/internal/DetektService.kt
@@ -5,7 +5,6 @@ import io.github.detekt.tooling.api.InvalidConfig
 import io.github.detekt.tooling.api.IssuesFound
 import io.github.detekt.tooling.api.UnexpectedError
 import io.github.detekt.tooling.api.spec.ProcessingSpec
-import io.gitlab.arturbosch.detekt.api.UnstableApi
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.resolve.BindingContext
@@ -15,7 +14,6 @@ internal class DetektService(
     private val spec: ProcessingSpec
 ) {
 
-    @OptIn(UnstableApi::class)
     @Suppress("ForbiddenComment")
     fun analyze(files: Collection<KtFile>, context: BindingContext) {
         val detekt = DetektProvider.load().get(spec)

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/ProcessingSettings.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/ProcessingSettings.kt
@@ -4,7 +4,6 @@ import io.github.detekt.tooling.api.spec.ProcessingSpec
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.PropertiesAware
 import io.gitlab.arturbosch.detekt.api.SetupContext
-import io.gitlab.arturbosch.detekt.api.UnstableApi
 import io.gitlab.arturbosch.detekt.core.config.extractUris
 import io.gitlab.arturbosch.detekt.core.settings.ClassloaderAware
 import io.gitlab.arturbosch.detekt.core.settings.EnvironmentAware
@@ -24,7 +23,6 @@ import java.net.URI
  * Always close the settings as dispose the Kotlin compiler and detekt class loader.
  * If using a custom executor service be aware that detekt won't shut it down after use!
  */
-@OptIn(UnstableApi::class)
 class ProcessingSettings(
     val spec: ProcessingSpec,
     override val config: Config

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineResultMapping.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineResultMapping.kt
@@ -4,12 +4,10 @@ import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.api.ReportingExtension
 import io.gitlab.arturbosch.detekt.api.RuleSetId
 import io.gitlab.arturbosch.detekt.api.SetupContext
-import io.gitlab.arturbosch.detekt.api.UnstableApi
 import io.gitlab.arturbosch.detekt.api.getOrNull
 import io.gitlab.arturbosch.detekt.core.DetektResult
 import java.nio.file.Path
 
-@OptIn(UnstableApi::class)
 class BaselineResultMapping : ReportingExtension {
 
     private var baselineFile: Path? = null

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/extensions/Loading.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/extensions/Loading.kt
@@ -1,14 +1,12 @@
 package io.gitlab.arturbosch.detekt.core.extensions
 
 import io.gitlab.arturbosch.detekt.api.Extension
-import io.gitlab.arturbosch.detekt.api.UnstableApi
 import io.gitlab.arturbosch.detekt.core.NL
 import io.gitlab.arturbosch.detekt.core.ProcessingSettings
 import java.util.ServiceLoader
 
 val LIST_ITEM_SPACING = "$NL    "
 
-@OptIn(UnstableApi::class)
 inline fun <reified T : Extension> loadExtensions(
     settings: ProcessingSettings,
     predicate: (T) -> Boolean = { true }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/extensions/Reporting.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/extensions/Reporting.kt
@@ -2,11 +2,9 @@ package io.gitlab.arturbosch.detekt.core.extensions
 
 import io.gitlab.arturbosch.detekt.api.Detektion
 import io.gitlab.arturbosch.detekt.api.ReportingExtension
-import io.gitlab.arturbosch.detekt.api.UnstableApi
 import io.gitlab.arturbosch.detekt.core.DelegatingResult
 import io.gitlab.arturbosch.detekt.core.ProcessingSettings
 
-@OptIn(UnstableApi::class)
 fun handleReportingExtensions(settings: ProcessingSettings, initialResult: Detektion): Detektion {
     val extensions = loadExtensions<ReportingExtension>(settings)
     extensions.forEach { it.onRawResult(initialResult) }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/OutputFacade.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/OutputFacade.kt
@@ -2,12 +2,10 @@ package io.gitlab.arturbosch.detekt.core.reporting
 
 import io.github.detekt.tooling.api.spec.ReportsSpec
 import io.gitlab.arturbosch.detekt.api.Detektion
-import io.gitlab.arturbosch.detekt.api.UnstableApi
 import io.gitlab.arturbosch.detekt.api.getOrNull
 import io.gitlab.arturbosch.detekt.core.ProcessingSettings
 import io.gitlab.arturbosch.detekt.core.util.SimpleNotification
 
-@OptIn(UnstableApi::class)
 class OutputFacade(
     private val settings: ProcessingSettings
 ) {

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/settings/PropertiesFacade.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/settings/PropertiesFacade.kt
@@ -1,10 +1,8 @@
 package io.gitlab.arturbosch.detekt.core.settings
 
 import io.gitlab.arturbosch.detekt.api.PropertiesAware
-import io.gitlab.arturbosch.detekt.api.UnstableApi
 import java.util.concurrent.ConcurrentHashMap
 
-@OptIn(UnstableApi::class)
 internal class PropertiesFacade : PropertiesAware {
 
     private val _properties: MutableMap<String, Any?> = ConcurrentHashMap()

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/tooling/Lifecycle.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/tooling/Lifecycle.kt
@@ -6,7 +6,6 @@ import io.gitlab.arturbosch.detekt.api.FileProcessListener
 import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.api.RuleSetId
 import io.gitlab.arturbosch.detekt.api.RuleSetProvider
-import io.gitlab.arturbosch.detekt.api.UnstableApi
 import io.gitlab.arturbosch.detekt.core.Analyzer
 import io.gitlab.arturbosch.detekt.core.DetektResult
 import io.gitlab.arturbosch.detekt.core.FileProcessorLocator
@@ -30,7 +29,6 @@ internal interface Lifecycle {
     val processorsProvider: () -> List<FileProcessListener>
     val ruleSetsProvider: () -> List<RuleSetProvider>
 
-    @OptIn(UnstableApi::class)
     private fun <R> measure(phase: Phase, block: () -> R): R = settings.getOrCreateMonitor().measure(phase, block)
 
     fun analyze(): Detektion {

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/util/PerformanceMonitor.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/util/PerformanceMonitor.kt
@@ -1,7 +1,6 @@
 package io.gitlab.arturbosch.detekt.core.util
 
 import io.gitlab.arturbosch.detekt.api.PropertiesAware
-import io.gitlab.arturbosch.detekt.api.UnstableApi
 import io.gitlab.arturbosch.detekt.api.getOrNull
 import kotlin.time.Duration
 import kotlin.time.measureTimedValue
@@ -34,6 +33,5 @@ class PerformanceMonitor {
 
 internal const val MONITOR_PROPERTY_KEY = "detekt.core.monitor"
 
-@OptIn(UnstableApi::class)
 internal fun PropertiesAware.getOrCreateMonitor() =
     getOrNull(MONITOR_PROPERTY_KEY) ?: PerformanceMonitor().also { register(MONITOR_PROPERTY_KEY, it) }

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineResultMappingSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineResultMappingSpec.kt
@@ -6,7 +6,6 @@ import io.github.detekt.test.utils.resourceAsPath
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.api.SetupContext
-import io.gitlab.arturbosch.detekt.api.UnstableApi
 import io.gitlab.arturbosch.detekt.test.createEntity
 import io.gitlab.arturbosch.detekt.test.createFinding
 import org.assertj.core.api.Assertions.assertThat
@@ -114,7 +113,6 @@ class BaselineResultMappingSpec {
     }
 }
 
-@OptIn(UnstableApi::class)
 private fun resultMapping(baselineFile: Path?, createBaseline: Boolean?) =
     BaselineResultMapping().apply {
         init(object : SetupContext {

--- a/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/SarifOutputReport.kt
+++ b/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/SarifOutputReport.kt
@@ -10,7 +10,6 @@ import io.github.detekt.sarif4k.Version
 import io.gitlab.arturbosch.detekt.api.Detektion
 import io.gitlab.arturbosch.detekt.api.OutputReport
 import io.gitlab.arturbosch.detekt.api.SetupContext
-import io.gitlab.arturbosch.detekt.api.UnstableApi
 import io.gitlab.arturbosch.detekt.api.getOrNull
 import io.gitlab.arturbosch.detekt.api.internal.BuiltInOutputReport
 import io.gitlab.arturbosch.detekt.api.internal.whichDetekt
@@ -29,7 +28,6 @@ class SarifOutputReport : BuiltInOutputReport, OutputReport() {
 
     private var basePath: String? = null
 
-    @OptIn(UnstableApi::class)
     override fun init(context: SetupContext) {
         this.basePath = context.getOrNull<Path>(DETEKT_OUTPUT_REPORT_BASE_PATH_KEY)
             ?.absolute()

--- a/detekt-report-sarif/src/test/kotlin/io/github/detekt/report/sarif/SarifOutputReportSpec.kt
+++ b/detekt-report-sarif/src/test/kotlin/io/github/detekt/report/sarif/SarifOutputReportSpec.kt
@@ -10,7 +10,6 @@ import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.api.TextLocation
-import io.gitlab.arturbosch.detekt.api.UnstableApi
 import io.gitlab.arturbosch.detekt.api.internal.whichOS
 import io.gitlab.arturbosch.detekt.test.EmptySetupContext
 import io.gitlab.arturbosch.detekt.test.TestDetektion
@@ -23,7 +22,6 @@ import org.junit.jupiter.api.Test
 import kotlin.io.path.Path
 import kotlin.io.path.absolutePathString
 
-@OptIn(UnstableApi::class)
 class SarifOutputReportSpec {
 
     @Test

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterList.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterList.kt
@@ -5,7 +5,6 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
-import io.gitlab.arturbosch.detekt.api.UnstableApi
 import io.gitlab.arturbosch.detekt.api.config
 import io.gitlab.arturbosch.detekt.api.configWithFallback
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
@@ -39,12 +38,10 @@ class LongParameterList(config: Config = Config.empty) : Rule(config) {
     private val threshold: Int by config(DEFAULT_ALLOWED_FUNCTION_PARAMETERS)
 
     @Suppress("DEPRECATION")
-    @OptIn(UnstableApi::class)
     @Configuration("number of function parameters required to trigger the rule")
     private val allowedFunctionParameters: Int by configWithFallback(::threshold, DEFAULT_ALLOWED_FUNCTION_PARAMETERS)
 
     @Suppress("DEPRECATION")
-    @OptIn(UnstableApi::class)
     @Configuration("number of constructor parameters required to trigger the rule")
     private val allowedConstructorParameters: Int
         by configWithFallback(::threshold, DEFAULT_ALLOWED_CONSTRUCTOR_PARAMETERS)

--- a/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/LicenceHeaderLoaderExtension.kt
+++ b/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/LicenceHeaderLoaderExtension.kt
@@ -3,7 +3,6 @@ package io.gitlab.arturbosch.detekt.rules.documentation
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.FileProcessListener
 import io.gitlab.arturbosch.detekt.api.SetupContext
-import io.gitlab.arturbosch.detekt.api.UnstableApi
 import io.gitlab.arturbosch.detekt.rules.documentation.AbsentOrWrongFileLicense.Companion.DEFAULT_LICENSE_TEMPLATE_FILE
 import io.gitlab.arturbosch.detekt.rules.documentation.AbsentOrWrongFileLicense.Companion.DEFAULT_LICENSE_TEMPLATE_IS_REGEX
 import io.gitlab.arturbosch.detekt.rules.documentation.AbsentOrWrongFileLicense.Companion.PARAM_LICENSE_TEMPLATE_FILE
@@ -19,7 +18,6 @@ import kotlin.io.path.exists
 import kotlin.io.path.readText
 import kotlin.io.path.toPath
 
-@OptIn(UnstableApi::class)
 class LicenceHeaderLoaderExtension : FileProcessListener {
 
     private lateinit var config: Config

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/AbsentOrWrongFileLicenseSpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/AbsentOrWrongFileLicenseSpec.kt
@@ -6,7 +6,6 @@ import io.github.detekt.test.utils.resourceAsPath
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.api.SetupContext
-import io.gitlab.arturbosch.detekt.api.UnstableApi
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lint
 import io.gitlab.arturbosch.detekt.test.yamlConfig
@@ -181,7 +180,6 @@ class AbsentOrWrongFileLicenseSpec {
     }
 }
 
-@OptIn(UnstableApi::class)
 private fun checkLicence(@Language("kotlin") content: String, isRegexLicense: Boolean = false): List<Finding> {
     val file = compileContentForTest(content.trimIndent())
 

--- a/detekt-rules-empty/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyFunctionBlock.kt
+++ b/detekt-rules-empty/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyFunctionBlock.kt
@@ -1,7 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.empty
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.UnstableApi
 import io.gitlab.arturbosch.detekt.api.config
 import io.gitlab.arturbosch.detekt.api.configWithFallback
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
@@ -28,7 +27,6 @@ class EmptyFunctionBlock(config: Config) : EmptyRule(config) {
     private val ignoreOverriddenFunctions: Boolean by config(false)
 
     @Suppress("DEPRECATION")
-    @OptIn(UnstableApi::class)
     @Configuration("Excludes all the overridden functions")
     private val ignoreOverridden: Boolean by configWithFallback(::ignoreOverriddenFunctions, false)
 

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValue.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValue.kt
@@ -6,7 +6,6 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
-import io.gitlab.arturbosch.detekt.api.UnstableApi
 import io.gitlab.arturbosch.detekt.api.config
 import io.gitlab.arturbosch.detekt.api.configWithFallback
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
@@ -64,7 +63,6 @@ class IgnoredReturnValue(config: Config = Config.empty) : Rule(config) {
     private val restrictToAnnotatedMethods: Boolean by config(defaultValue = true)
 
     @Suppress("DEPRECATION")
-    @OptIn(UnstableApi::class)
     @Configuration("If the rule should check only methods matching to configuration, or all methods")
     private val restrictToConfig: Boolean by configWithFallback(::restrictToAnnotatedMethods, defaultValue = true)
 

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionParameterNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionParameterNaming.kt
@@ -5,7 +5,6 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
-import io.gitlab.arturbosch.detekt.api.UnstableApi
 import io.gitlab.arturbosch.detekt.api.config
 import io.gitlab.arturbosch.detekt.api.configWithFallback
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
@@ -40,7 +39,6 @@ class FunctionParameterNaming(config: Config = Config.empty) : Rule(config) {
     @Configuration("ignores overridden functions with parameters not matching the pattern")
     @Deprecated("This configuration is ignored and will be removed in the future")
     @Suppress("DEPRECATION", "UnusedPrivateMember")
-    @OptIn(UnstableApi::class)
     private val ignoreOverridden: Boolean by configWithFallback(::ignoreOverriddenFunctions, true)
 
     override fun visitParameter(parameter: KtParameter) {

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MemberNameEqualsClassName.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MemberNameEqualsClassName.kt
@@ -5,7 +5,6 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
-import io.gitlab.arturbosch.detekt.api.UnstableApi
 import io.gitlab.arturbosch.detekt.api.config
 import io.gitlab.arturbosch.detekt.api.configWithFallback
 import io.gitlab.arturbosch.detekt.api.internal.ActiveByDefault
@@ -70,7 +69,6 @@ class MemberNameEqualsClassName(config: Config = Config.empty) : Rule(config) {
     private val ignoreOverriddenFunction: Boolean by config(true)
 
     @Suppress("DEPRECATION")
-    @OptIn(UnstableApi::class)
     @Configuration("if overridden functions and properties should be ignored")
     private val ignoreOverridden: Boolean by configWithFallback(::ignoreOverriddenFunction, true)
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiterals.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiterals.kt
@@ -5,7 +5,6 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
-import io.gitlab.arturbosch.detekt.api.UnstableApi
 import io.gitlab.arturbosch.detekt.api.config
 import io.gitlab.arturbosch.detekt.api.configWithFallback
 import io.gitlab.arturbosch.detekt.api.internal.Configuration
@@ -42,7 +41,6 @@ class UnderscoresInNumericLiterals(config: Config = Config.empty) : Rule(config)
     private val acceptableDecimalLength: Int by config(5) { it - 1 }
 
     @Suppress("DEPRECATION")
-    @OptIn(UnstableApi::class)
     @Configuration("Maximum number of consecutive digits that a numeric literal can have without using an underscore")
     private val acceptableLength: Int by configWithFallback(::acceptableDecimalLength, 4)
 

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/LicenceHeaderLoaderExtensionSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/LicenceHeaderLoaderExtensionSpec.kt
@@ -4,13 +4,11 @@ import io.github.detekt.test.utils.NullPrintStream
 import io.github.detekt.test.utils.resource
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.SetupContext
-import io.gitlab.arturbosch.detekt.api.UnstableApi
 import org.assertj.core.api.Assertions.assertThatCode
 import org.junit.jupiter.api.Test
 import java.io.PrintStream
 import java.net.URI
 
-@OptIn(UnstableApi::class)
 class LicenceHeaderLoaderExtensionSpec {
 
     @Test

--- a/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/api/AnalysisResult.kt
+++ b/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/api/AnalysisResult.kt
@@ -1,13 +1,11 @@
 package io.github.detekt.tooling.api
 
 import io.gitlab.arturbosch.detekt.api.Detektion
-import io.gitlab.arturbosch.detekt.api.UnstableApi
 
 interface AnalysisResult {
 
     val error: DetektError?
 
-    @UnstableApi(reason = "Name and result type might change in the future.")
     val container: Detektion?
 }
 

--- a/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/internal/DefaultAnalysisResult.kt
+++ b/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/internal/DefaultAnalysisResult.kt
@@ -3,9 +3,7 @@ package io.github.detekt.tooling.internal
 import io.github.detekt.tooling.api.AnalysisResult
 import io.github.detekt.tooling.api.DetektError
 import io.gitlab.arturbosch.detekt.api.Detektion
-import io.gitlab.arturbosch.detekt.api.UnstableApi
 
-@OptIn(UnstableApi::class)
 class DefaultAnalysisResult(
     override val container: Detektion?,
     override val error: DetektError? = null


### PR DESCRIPTION
In 2.0 final we should not have any unstable APIs. See first commit for the elements which were declared unstable API in the past which can now be considered stable.

~~Tagged breaking change as a public annotation was removed from detekt-api but that might be unnecessary to feature in release notes.~~

Edit: changed my mind and untagged as breaking change - nobody would be using this in their own code.