### PR TITLE
Remove ruleContext property from Rule constructor

### DIFF
--- a/detekt-api/api/detekt-api.api
+++ b/detekt-api/api/detekt-api.api
@@ -338,8 +338,7 @@ public final class io/gitlab/arturbosch/detekt/api/ReportingExtension$DefaultImp
 }
 
 public abstract class io/gitlab/arturbosch/detekt/api/Rule : io/gitlab/arturbosch/detekt/api/BaseRule, io/gitlab/arturbosch/detekt/api/ConfigAware {
-	public fun <init> (Lio/gitlab/arturbosch/detekt/api/Config;Lio/gitlab/arturbosch/detekt/api/Context;)V
-	public synthetic fun <init> (Lio/gitlab/arturbosch/detekt/api/Config;Lio/gitlab/arturbosch/detekt/api/Context;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lio/gitlab/arturbosch/detekt/api/Config;)V
 	public fun getActive ()Z
 	public final fun getAliases ()Ljava/util/Set;
 	public fun getAutoCorrect ()Z

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Rule.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Rule.kt
@@ -1,7 +1,6 @@
 package io.gitlab.arturbosch.detekt.api
 
 import io.gitlab.arturbosch.detekt.api.Config.Companion.SEVERITY_KEY
-import io.gitlab.arturbosch.detekt.api.internal.DefaultContext
 import io.gitlab.arturbosch.detekt.api.internal.PathFilters
 import io.gitlab.arturbosch.detekt.api.internal.createPathFilters
 import io.gitlab.arturbosch.detekt.api.internal.isSuppressedBy
@@ -18,8 +17,7 @@ import org.jetbrains.kotlin.psi.KtFile
  */
 abstract class Rule(
     override val ruleSetConfig: Config,
-    ruleContext: Context = DefaultContext()
-) : BaseRule(ruleContext), ConfigAware {
+) : BaseRule(), ConfigAware {
 
     /**
      * A rule is motivated to point out a specific issue in the code base.


### PR DESCRIPTION
This isn't used anywhere in detekt's codebase.