### PR TITLE
Move CompilerResources from internal to public API

### DIFF
--- a/detekt-api/api/detekt-api.api
+++ b/detekt-api/api/detekt-api.api
@@ -58,15 +58,8 @@ public final class io/gitlab/arturbosch/detekt/api/Compactable$DefaultImpls {
 
 public final class io/gitlab/arturbosch/detekt/api/CompilerResources {
 	public fun <init> (Lorg/jetbrains/kotlin/config/LanguageVersionSettings;Lorg/jetbrains/kotlin/resolve/calls/smartcasts/DataFlowValueFactory;)V
-	public final fun component1 ()Lorg/jetbrains/kotlin/config/LanguageVersionSettings;
-	public final fun component2 ()Lorg/jetbrains/kotlin/resolve/calls/smartcasts/DataFlowValueFactory;
-	public final fun copy (Lorg/jetbrains/kotlin/config/LanguageVersionSettings;Lorg/jetbrains/kotlin/resolve/calls/smartcasts/DataFlowValueFactory;)Lio/gitlab/arturbosch/detekt/api/CompilerResources;
-	public static synthetic fun copy$default (Lio/gitlab/arturbosch/detekt/api/CompilerResources;Lorg/jetbrains/kotlin/config/LanguageVersionSettings;Lorg/jetbrains/kotlin/resolve/calls/smartcasts/DataFlowValueFactory;ILjava/lang/Object;)Lio/gitlab/arturbosch/detekt/api/CompilerResources;
-	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDataFlowValueFactory ()Lorg/jetbrains/kotlin/resolve/calls/smartcasts/DataFlowValueFactory;
 	public final fun getLanguageVersionSettings ()Lorg/jetbrains/kotlin/config/LanguageVersionSettings;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
 }
 
 public abstract interface class io/gitlab/arturbosch/detekt/api/Config {

--- a/detekt-api/api/detekt-api.api
+++ b/detekt-api/api/detekt-api.api
@@ -13,7 +13,7 @@ public abstract class io/gitlab/arturbosch/detekt/api/BaseRule : io/gitlab/artur
 	public synthetic fun <init> (Lio/gitlab/arturbosch/detekt/api/Context;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun clearFindings ()V
 	public final fun getBindingContext ()Lorg/jetbrains/kotlin/resolve/BindingContext;
-	public final fun getCompilerResources ()Lio/gitlab/arturbosch/detekt/api/internal/CompilerResources;
+	public final fun getCompilerResources ()Lio/gitlab/arturbosch/detekt/api/CompilerResources;
 	protected final fun getContext ()Lio/gitlab/arturbosch/detekt/api/Context;
 	public fun getFindings ()Ljava/util/List;
 	public fun getRuleId ()Ljava/lang/String;
@@ -21,11 +21,11 @@ public abstract class io/gitlab/arturbosch/detekt/api/BaseRule : io/gitlab/artur
 	protected fun preVisit (Lorg/jetbrains/kotlin/psi/KtFile;)V
 	public fun report (Lio/gitlab/arturbosch/detekt/api/Finding;Ljava/util/Set;Ljava/lang/String;)V
 	public final fun setBindingContext (Lorg/jetbrains/kotlin/resolve/BindingContext;)V
-	public final fun setCompilerResources (Lio/gitlab/arturbosch/detekt/api/internal/CompilerResources;)V
+	public final fun setCompilerResources (Lio/gitlab/arturbosch/detekt/api/CompilerResources;)V
 	public fun visit (Lorg/jetbrains/kotlin/psi/KtFile;)V
 	public abstract fun visitCondition (Lorg/jetbrains/kotlin/psi/KtFile;)Z
-	public final fun visitFile (Lorg/jetbrains/kotlin/psi/KtFile;Lorg/jetbrains/kotlin/resolve/BindingContext;Lio/gitlab/arturbosch/detekt/api/internal/CompilerResources;)V
-	public static synthetic fun visitFile$default (Lio/gitlab/arturbosch/detekt/api/BaseRule;Lorg/jetbrains/kotlin/psi/KtFile;Lorg/jetbrains/kotlin/resolve/BindingContext;Lio/gitlab/arturbosch/detekt/api/internal/CompilerResources;ILjava/lang/Object;)V
+	public final fun visitFile (Lorg/jetbrains/kotlin/psi/KtFile;Lorg/jetbrains/kotlin/resolve/BindingContext;Lio/gitlab/arturbosch/detekt/api/CompilerResources;)V
+	public static synthetic fun visitFile$default (Lio/gitlab/arturbosch/detekt/api/BaseRule;Lorg/jetbrains/kotlin/psi/KtFile;Lorg/jetbrains/kotlin/resolve/BindingContext;Lio/gitlab/arturbosch/detekt/api/CompilerResources;ILjava/lang/Object;)V
 }
 
 public class io/gitlab/arturbosch/detekt/api/CodeSmell : io/gitlab/arturbosch/detekt/api/Finding {
@@ -54,6 +54,19 @@ public abstract interface class io/gitlab/arturbosch/detekt/api/Compactable {
 
 public final class io/gitlab/arturbosch/detekt/api/Compactable$DefaultImpls {
 	public static fun compactWithSignature (Lio/gitlab/arturbosch/detekt/api/Compactable;)Ljava/lang/String;
+}
+
+public final class io/gitlab/arturbosch/detekt/api/CompilerResources {
+	public fun <init> (Lorg/jetbrains/kotlin/config/LanguageVersionSettings;Lorg/jetbrains/kotlin/resolve/calls/smartcasts/DataFlowValueFactory;)V
+	public final fun component1 ()Lorg/jetbrains/kotlin/config/LanguageVersionSettings;
+	public final fun component2 ()Lorg/jetbrains/kotlin/resolve/calls/smartcasts/DataFlowValueFactory;
+	public final fun copy (Lorg/jetbrains/kotlin/config/LanguageVersionSettings;Lorg/jetbrains/kotlin/resolve/calls/smartcasts/DataFlowValueFactory;)Lio/gitlab/arturbosch/detekt/api/CompilerResources;
+	public static synthetic fun copy$default (Lio/gitlab/arturbosch/detekt/api/CompilerResources;Lorg/jetbrains/kotlin/config/LanguageVersionSettings;Lorg/jetbrains/kotlin/resolve/calls/smartcasts/DataFlowValueFactory;ILjava/lang/Object;)Lio/gitlab/arturbosch/detekt/api/CompilerResources;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDataFlowValueFactory ()Lorg/jetbrains/kotlin/resolve/calls/smartcasts/DataFlowValueFactory;
+	public final fun getLanguageVersionSettings ()Lorg/jetbrains/kotlin/config/LanguageVersionSettings;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public abstract interface class io/gitlab/arturbosch/detekt/api/Config {

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/BaseRule.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/BaseRule.kt
@@ -1,6 +1,5 @@
 package io.gitlab.arturbosch.detekt.api
 
-import io.gitlab.arturbosch.detekt.api.internal.CompilerResources
 import io.gitlab.arturbosch.detekt.api.internal.DefaultContext
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.resolve.BindingContext

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/CompilerResources.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/CompilerResources.kt
@@ -6,7 +6,7 @@ import org.jetbrains.kotlin.resolve.calls.smartcasts.DataFlowValueFactory
 /**
  * Provides compiler resources.
  */
-data class CompilerResources(
+class CompilerResources(
     val languageVersionSettings: LanguageVersionSettings,
     val dataFlowValueFactory: DataFlowValueFactory
 )

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/CompilerResources.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/CompilerResources.kt
@@ -1,4 +1,4 @@
-package io.gitlab.arturbosch.detekt.api.internal
+package io.gitlab.arturbosch.detekt.api
 
 import org.jetbrains.kotlin.config.LanguageVersionSettings
 import org.jetbrains.kotlin.resolve.calls.smartcasts.DataFlowValueFactory

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Analyzer.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Analyzer.kt
@@ -3,13 +3,13 @@ package io.gitlab.arturbosch.detekt.core
 import io.github.detekt.psi.absolutePath
 import io.github.detekt.tooling.api.spec.ProcessingSpec
 import io.gitlab.arturbosch.detekt.api.BaseRule
+import io.gitlab.arturbosch.detekt.api.CompilerResources
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.FileProcessListener
 import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.RuleSetId
 import io.gitlab.arturbosch.detekt.api.RuleSetProvider
-import io.gitlab.arturbosch.detekt.api.internal.CompilerResources
 import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.internal.whichDetekt
 import io.gitlab.arturbosch.detekt.api.internal.whichJava

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantVisibilityModifierRuleSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantVisibilityModifierRuleSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.style
 
 import io.github.detekt.test.utils.compileContentForTest
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.internal.CompilerResources
+import io.gitlab.arturbosch.detekt.api.CompilerResources
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.jetbrains.kotlin.config.AnalysisFlag

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantVisibilityModifierRuleSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantVisibilityModifierRuleSpec.kt
@@ -1,8 +1,8 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
 import io.github.detekt.test.utils.compileContentForTest
-import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.CompilerResources
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.jetbrains.kotlin.config.AnalysisFlag

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/RuleExtensions.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/RuleExtensions.kt
@@ -4,8 +4,8 @@ import io.github.detekt.test.utils.KotlinScriptEngine
 import io.github.detekt.test.utils.compileContentForTest
 import io.github.detekt.test.utils.compileForTest
 import io.gitlab.arturbosch.detekt.api.BaseRule
+import io.gitlab.arturbosch.detekt.api.CompilerResources
 import io.gitlab.arturbosch.detekt.api.Finding
-import io.gitlab.arturbosch.detekt.api.internal.CompilerResources
 import org.intellij.lang.annotations.Language
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.jetbrains.kotlin.config.languageVersionSettings


### PR DESCRIPTION
This type is used in `BaseRule` so it should be part of the public API.