### PR TITLE
Don't use Config.empty on rule initialisation

### DIFF
--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/CognitiveComplexMethod.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/CognitiveComplexMethod.kt
@@ -25,7 +25,7 @@ import org.jetbrains.kotlin.psi.KtNamedFunction
  * - __Nesting Level Increments__ - `if`, `when`, `for`, `while`, `do while`, `catch`, `nested function`
  * - __Additional Complexity Increments by Nesting Level__ - `if`, `when`, `for`, `while`, `do while`, `catch`
  */
-class CognitiveComplexMethod(config: Config = Config.empty) : Rule(config) {
+class CognitiveComplexMethod(config: Config) : Rule(config) {
 
     override val issue = Issue(
         "CognitiveComplexMethod",

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexCondition.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexCondition.kt
@@ -36,9 +36,7 @@ import org.jetbrains.kotlin.psi.psiUtil.collectDescendantsOfType
  * </compliant>
  */
 @ActiveByDefault(since = "1.0.0")
-class ComplexCondition(
-    config: Config = Config.empty
-) : Rule(config) {
+class ComplexCondition(config: Config) : Rule(config) {
 
     override val issue = Issue(
         "ComplexCondition",

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexInterface.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexInterface.kt
@@ -25,9 +25,7 @@ import org.jetbrains.kotlin.psi.psiUtil.isPrivate
  * Large interfaces should be split into smaller interfaces which have a clear responsibility and are easier
  * to understand and implement.
  */
-class ComplexInterface(
-    config: Config = Config.empty,
-) : Rule(config) {
+class ComplexInterface(config: Config) : Rule(config) {
 
     override val issue = Issue(
         javaClass.simpleName,

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/CyclomaticComplexMethod.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/CyclomaticComplexMethod.kt
@@ -34,7 +34,7 @@ import org.jetbrains.kotlin.psi.KtWhenExpression
  *  [Reference](https://kotlinlang.org/docs/scope-functions.html)
  */
 @ActiveByDefault(since = "1.0.0")
-class CyclomaticComplexMethod(config: Config = Config.empty) : Rule(config) {
+class CyclomaticComplexMethod(config: Config) : Rule(config) {
 
     override val issue = Issue(
         "CyclomaticComplexMethod",

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LabeledExpression.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LabeledExpression.kt
@@ -57,7 +57,7 @@ import org.jetbrains.kotlin.psi.psiUtil.isExtensionDeclaration
  * }
  * </compliant>
  */
-class LabeledExpression(config: Config = Config.empty) : Rule(config) {
+class LabeledExpression(config: Config) : Rule(config) {
 
     override val issue: Issue = Issue(
         "LabeledExpression",

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LargeClass.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LargeClass.kt
@@ -21,7 +21,7 @@ import java.util.IdentityHashMap
  * things.
  */
 @ActiveByDefault(since = "1.0.0")
-class LargeClass(config: Config = Config.empty) : Rule(config) {
+class LargeClass(config: Config) : Rule(config) {
 
     override val issue = Issue(
         "LargeClass",

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongMethod.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongMethod.kt
@@ -21,7 +21,7 @@ import java.util.IdentityHashMap
  * Extract parts of the functionality of long methods into separate, smaller methods.
  */
 @ActiveByDefault(since = "1.0.0")
-class LongMethod(config: Config = Config.empty) : Rule(config) {
+class LongMethod(config: Config) : Rule(config) {
 
     override val issue = Issue(
         "LongMethod",

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterList.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterList.kt
@@ -26,7 +26,7 @@ import org.jetbrains.kotlin.psi.KtSecondaryConstructor
  */
 @Suppress("ViolatesTypeResolutionRequirements")
 @ActiveByDefault(since = "1.0.0")
-class LongParameterList(config: Config = Config.empty) : Rule(config) {
+class LongParameterList(config: Config) : Rule(config) {
     override val issue = Issue(
         "LongParameterList",
         "The more parameters a function has the more complex it is. Long parameter lists are often " +

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/MethodOverloading.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/MethodOverloading.kt
@@ -22,7 +22,7 @@ import org.jetbrains.kotlin.psi.psiUtil.isExtensionDeclaration
  *
  * Refactor these methods and try to use optional parameters instead to prevent some of the overloading.
  */
-class MethodOverloading(config: Config = Config.empty) : Rule(config) {
+class MethodOverloading(config: Config) : Rule(config) {
 
     override val issue = Issue(
         "MethodOverloading",

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NamedArguments.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NamedArguments.kt
@@ -30,7 +30,7 @@ import org.jetbrains.kotlin.resolve.calls.util.getResolvedCall
  * </compliant>
  */
 @RequiresTypeResolution
-class NamedArguments(config: Config = Config.empty) : Rule(config) {
+class NamedArguments(config: Config) : Rule(config) {
 
     override val issue = Issue(
         "NamedArguments",

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedBlockDepth.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedBlockDepth.kt
@@ -25,7 +25,7 @@ import org.jetbrains.kotlin.psi.KtWhenExpression
  * Prefer extracting the nested code into well-named functions to make it easier to understand.
  */
 @ActiveByDefault(since = "1.0.0")
-class NestedBlockDepth(config: Config = Config.empty) : Rule(config) {
+class NestedBlockDepth(config: Config) : Rule(config) {
 
     override val issue = Issue(
         "NestedBlockDepth",

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedScopeFunctions.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedScopeFunctions.kt
@@ -40,7 +40,7 @@ import org.jetbrains.kotlin.resolve.calls.util.getResolvedCall
  * </compliant>
  */
 @RequiresTypeResolution
-class NestedScopeFunctions(config: Config = Config.empty) : Rule(config) {
+class NestedScopeFunctions(config: Config) : Rule(config) {
 
     override val issue = Issue(
         javaClass.simpleName,

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ReplaceSafeCallChainWithRun.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ReplaceSafeCallChainWithRun.kt
@@ -37,7 +37,7 @@ import org.jetbrains.kotlin.types.isNullable
  *
  */
 @RequiresTypeResolution
-class ReplaceSafeCallChainWithRun(config: Config = Config.empty) : Rule(config) {
+class ReplaceSafeCallChainWithRun(config: Config) : Rule(config) {
 
     override val issue = Issue(
         javaClass.simpleName,

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/StringLiteralDuplication.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/StringLiteralDuplication.kt
@@ -39,7 +39,7 @@ import org.jetbrains.kotlin.psi.psiUtil.plainContent
  * }
  * </compliant>
  */
-class StringLiteralDuplication(config: Config = Config.empty) : Rule(config) {
+class StringLiteralDuplication(config: Config) : Rule(config) {
 
     override val issue = Issue(
         javaClass.simpleName,

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/TooManyFunctions.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/TooManyFunctions.kt
@@ -24,7 +24,7 @@ import org.jetbrains.kotlin.psi.psiUtil.isPrivate
  * which clearly belongs together in separate parts of the code.
  */
 @ActiveByDefault(since = "1.0.0")
-class TooManyFunctions(config: Config = Config.empty) : Rule(config) {
+class TooManyFunctions(config: Config) : Rule(config) {
 
     override val issue = Issue(
         "TooManyFunctions",

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/CyclomaticComplexMethodSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/CyclomaticComplexMethodSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.complexity
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
@@ -298,7 +299,7 @@ class CyclomaticComplexMethodSpec {
 
         @Test
         fun `should not count these overridden functions to base functions complexity`() {
-            assertThat(CyclomaticComplexMethod().compileAndLint(code)).isEmpty()
+            assertThat(CyclomaticComplexMethod(Config.empty).compileAndLint(code)).isEmpty()
         }
     }
 }

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LabeledExpressionSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LabeledExpressionSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.complexity
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLint
@@ -7,7 +8,7 @@ import org.junit.jupiter.api.Test
 
 class LabeledExpressionSpec {
 
-    private val subject = LabeledExpression()
+    private val subject = LabeledExpression(Config.empty)
 
     @Test
     fun `reports break and continue labels`() {

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ReplaceSafeCallChainWithRunSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ReplaceSafeCallChainWithRunSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.complexity
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
 import org.assertj.core.api.Assertions.assertThat
@@ -9,7 +10,7 @@ import org.junit.jupiter.api.Test
 @KotlinCoreEnvironmentTest
 class ReplaceSafeCallChainWithRunSpec(val env: KotlinCoreEnvironment) {
 
-    val subject = ReplaceSafeCallChainWithRun()
+    val subject = ReplaceSafeCallChainWithRun(Config.empty)
 
     @Test
     fun `reports long chain of unnecessary safe qualified expressions`() {

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/StringLiteralDuplicationSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/StringLiteralDuplicationSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.complexity
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.assertj.core.api.Assertions.assertThat
@@ -187,7 +188,7 @@ class StringLiteralDuplicationSpec {
             }
         """.trimIndent()
 
-        assertThat(StringLiteralDuplication().compileAndLint(code)).isEmpty()
+        assertThat(StringLiteralDuplication(Config.empty).compileAndLint(code)).isEmpty()
     }
 }
 

--- a/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/GlobalCoroutineUsage.kt
+++ b/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/GlobalCoroutineUsage.kt
@@ -37,7 +37,7 @@ import org.jetbrains.kotlin.resolve.calls.util.getCalleeExpressionIfAny
  * }
  * </compliant>
  */
-class GlobalCoroutineUsage(config: Config = Config.empty) : Rule(config) {
+class GlobalCoroutineUsage(config: Config) : Rule(config) {
     override val issue = Issue(
         javaClass.simpleName,
         "The usage of the `GlobalScope` instance is highly discouraged.",

--- a/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SleepInsteadOfDelay.kt
+++ b/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SleepInsteadOfDelay.kt
@@ -46,7 +46,7 @@ import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameOrNull
  */
 @RequiresTypeResolution
 @ActiveByDefault(since = "1.21.0")
-class SleepInsteadOfDelay(config: Config = Config.empty) : Rule(config) {
+class SleepInsteadOfDelay(config: Config) : Rule(config) {
     override val issue = Issue(
         javaClass.simpleName,
         "Usage of `Thread.sleep()` in coroutines can potentially halt multiple coroutines at once.",

--- a/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/AbsentOrWrongFileLicense.kt
+++ b/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/AbsentOrWrongFileLicense.kt
@@ -17,7 +17,7 @@ import org.jetbrains.kotlin.psi.KtFile
  * a regular expression produced from the passed template license file (defined via `licenseTemplateFile` configuration
  * option).
  */
-class AbsentOrWrongFileLicense(config: Config = Config.empty) : Rule(config) {
+class AbsentOrWrongFileLicense(config: Config) : Rule(config) {
 
     override val issue = Issue(
         id = RULE_NAME,

--- a/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentOverPrivateFunction.kt
+++ b/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentOverPrivateFunction.kt
@@ -17,7 +17,7 @@ import org.jetbrains.kotlin.psi.KtNamedFunction
  * with better names if necessary. Giving the function a better, more descriptive name can also help in
  * solving this issue.
  */
-class CommentOverPrivateFunction(config: Config = Config.empty) : Rule(config) {
+class CommentOverPrivateFunction(config: Config) : Rule(config) {
 
     override val issue = Issue(
         "CommentOverPrivateFunction",

--- a/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentOverPrivateProperty.kt
+++ b/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentOverPrivateProperty.kt
@@ -17,7 +17,7 @@ import org.jetbrains.kotlin.psi.KtProperty
  * name. If this property is inside a bigger class, it makes sense to refactor and split up the class. This can
  * increase readability and make the documentation obsolete.
  */
-class CommentOverPrivateProperty(config: Config = Config.empty) : Rule(config) {
+class CommentOverPrivateProperty(config: Config) : Rule(config) {
 
     override val issue = Issue(
         "CommentOverPrivateProperty",

--- a/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/DeprecatedBlockTag.kt
+++ b/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/DeprecatedBlockTag.kt
@@ -36,7 +36,7 @@ import org.jetbrains.kotlin.psi.KtDeclaration
  * }
  * </compliant>
  */
-class DeprecatedBlockTag(config: Config = Config.empty) : Rule(config) {
+class DeprecatedBlockTag(config: Config) : Rule(config) {
     override val issue = Issue(
         "DeprecatedBlockTag",
         "Do not use the `@deprecated` block tag, which is not supported by KDoc. " +

--- a/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/EndOfSentenceFormat.kt
+++ b/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/EndOfSentenceFormat.kt
@@ -15,7 +15,7 @@ import org.jetbrains.kotlin.psi.KtDeclaration
  * It should end with proper punctuation or with a correct URL.
  */
 @Suppress("MemberNameEqualsClassName")
-class EndOfSentenceFormat(config: Config = Config.empty) : Rule(config) {
+class EndOfSentenceFormat(config: Config) : Rule(config) {
 
     override val issue = Issue(
         javaClass.simpleName,

--- a/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/KDocReferencesNonPublicProperty.kt
+++ b/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/KDocReferencesNonPublicProperty.kt
@@ -45,7 +45,7 @@ import org.jetbrains.kotlin.psi.psiUtil.isPublic
  * </compliant>
  *
  */
-class KDocReferencesNonPublicProperty(config: Config = Config.empty) : Rule(config) {
+class KDocReferencesNonPublicProperty(config: Config) : Rule(config) {
 
     override val issue = Issue(
         javaClass.simpleName,

--- a/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/OutdatedDocumentation.kt
+++ b/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/OutdatedDocumentation.kt
@@ -62,7 +62,7 @@ import org.jetbrains.kotlin.utils.addToStdlib.ifTrue
  * </compliant>
  */
 @Suppress("TooManyFunctions")
-class OutdatedDocumentation(config: Config = Config.empty) : Rule(config) {
+class OutdatedDocumentation(config: Config) : Rule(config) {
 
     override val issue = Issue(
         javaClass.simpleName,

--- a/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicClass.kt
+++ b/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicClass.kt
@@ -21,7 +21,7 @@ import org.jetbrains.kotlin.psi.KtObjectDeclaration
  * By default, this rule also searches for nested and inner classes and objects. This default behavior can be changed
  * with the configuration options of this rule.
  */
-class UndocumentedPublicClass(config: Config = Config.empty) : Rule(config) {
+class UndocumentedPublicClass(config: Config) : Rule(config) {
 
     override val issue = Issue(
         javaClass.simpleName,

--- a/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicFunction.kt
+++ b/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicFunction.kt
@@ -19,7 +19,7 @@ import org.jetbrains.kotlin.psi.psiUtil.parents
  * If the codebase should have documentation on all public functions enable this rule to enforce this.
  * Overridden functions are excluded by this rule.
  */
-class UndocumentedPublicFunction(config: Config = Config.empty) : Rule(config) {
+class UndocumentedPublicFunction(config: Config) : Rule(config) {
 
     override val issue = Issue(
         javaClass.simpleName,

--- a/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicProperty.kt
+++ b/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicProperty.kt
@@ -21,7 +21,7 @@ import org.jetbrains.kotlin.psi.psiUtil.isPublic
  * If the codebase should have documentation on all public properties enable this rule to enforce this.
  * Overridden properties are excluded by this rule.
  */
-class UndocumentedPublicProperty(config: Config = Config.empty) : Rule(config) {
+class UndocumentedPublicProperty(config: Config) : Rule(config) {
 
     override val issue = Issue(
         javaClass.simpleName,

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/AbsentOrWrongFileLicenseSpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/AbsentOrWrongFileLicenseSpec.kt
@@ -203,5 +203,5 @@ private fun checkLicence(@Language("kotlin") content: String, isRegexLicense: Bo
         onStart(listOf(file), BindingContext.EMPTY)
     }
 
-    return AbsentOrWrongFileLicense().lint(file)
+    return AbsentOrWrongFileLicense(Config.empty).lint(file)
 }

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentOverPrivateMethodSpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentOverPrivateMethodSpec.kt
@@ -1,11 +1,12 @@
 package io.gitlab.arturbosch.detekt.rules.documentation
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 class CommentOverPrivateMethodSpec {
-    val subject = CommentOverPrivateFunction()
+    val subject = CommentOverPrivateFunction(Config.empty)
 
     @Test
     fun `reports private method with a comment`() {

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentOverPrivatePropertiesSpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentOverPrivatePropertiesSpec.kt
@@ -1,11 +1,12 @@
 package io.gitlab.arturbosch.detekt.rules.documentation
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 class CommentOverPrivatePropertiesSpec {
-    private val subject = CommentOverPrivateProperty()
+    private val subject = CommentOverPrivateProperty(Config.empty)
 
     @Test
     fun `reports private property with a comment`() {

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/DeprecatedBlockTagSpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/DeprecatedBlockTagSpec.kt
@@ -1,12 +1,13 @@
 package io.gitlab.arturbosch.detekt.rules.documentation
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 class DeprecatedBlockTagSpec {
-    val subject = DeprecatedBlockTag()
+    val subject = DeprecatedBlockTag(Config.empty)
 
     @Test
     fun `does not report regular kdoc block`() {

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/EndOfSentenceFormatSpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/EndOfSentenceFormatSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.documentation
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.junit.jupiter.api.Nested
@@ -7,7 +8,7 @@ import org.junit.jupiter.api.Test
 
 class EndOfSentenceFormatSpec {
 
-    val subject = EndOfSentenceFormat()
+    val subject = EndOfSentenceFormat(Config.empty)
 
     @Test
     fun `reports invalid KDoc endings on classes`() {

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/KDocReferencesNonPublicPropertySpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/KDocReferencesNonPublicPropertySpec.kt
@@ -1,11 +1,12 @@
 package io.gitlab.arturbosch.detekt.rules.documentation
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.junit.jupiter.api.Test
 
 class KDocReferencesNonPublicPropertySpec {
-    val subject = KDocReferencesNonPublicProperty()
+    val subject = KDocReferencesNonPublicProperty(Config.empty)
 
     @Test
     fun `reports referenced non-public properties`() {

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/OutdatedDocumentationSpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/OutdatedDocumentationSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.documentation
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.assertj.core.api.Assertions.assertThat
@@ -7,7 +8,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 class OutdatedDocumentationSpec {
-    val subject = OutdatedDocumentation()
+    val subject = OutdatedDocumentation(Config.empty)
 
     @Nested
     inner class General {

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicClassSpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicClassSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.documentation
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.assertj.core.api.Assertions.assertThat
@@ -12,7 +13,7 @@ private const val SEARCH_IN_INNER_INTERFACE = "searchInInnerInterface"
 private const val SEARCH_IN_PROTECTED_CLASS = "searchInProtectedClass"
 
 class UndocumentedPublicClassSpec {
-    val subject = UndocumentedPublicClass()
+    val subject = UndocumentedPublicClass(Config.empty)
 
     val inner = """
         /** Some doc */

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicFunctionSpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicFunctionSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.documentation
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.assertj.core.api.Assertions.assertThat
@@ -9,7 +10,7 @@ import org.junit.jupiter.api.Test
 private const val SEARCH_PROTECTED_FUN = "searchProtectedFunction"
 
 class UndocumentedPublicFunctionSpec {
-    val subject = UndocumentedPublicFunction()
+    val subject = UndocumentedPublicFunction(Config.empty)
 
     @Test
     fun `reports undocumented public functions`() {

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicPropertySpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicPropertySpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.documentation
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.assertj.core.api.Assertions.assertThat
@@ -9,7 +10,7 @@ import org.junit.jupiter.api.Test
 private const val SEARCH_PROTECTED_PROPERTY = "searchProtectedProperty"
 
 class UndocumentedPublicPropertySpec {
-    val subject = UndocumentedPublicProperty()
+    val subject = UndocumentedPublicProperty(Config.empty)
 
     @Test
     fun `reports undocumented public property`() {

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/CastNullableToNonNullableType.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/CastNullableToNonNullableType.kt
@@ -39,7 +39,7 @@ import org.jetbrains.kotlin.utils.addToStdlib.ifTrue
  * </compliant>
  */
 @RequiresTypeResolution
-class CastNullableToNonNullableType(config: Config = Config.empty) : Rule(config) {
+class CastNullableToNonNullableType(config: Config) : Rule(config) {
     override val issue: Issue = Issue(
         javaClass.simpleName,
         "Nullable type to non-null type cast is found. Consider using two assertions, " +

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/CastToNullableType.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/CastToNullableType.kt
@@ -30,7 +30,7 @@ import org.jetbrains.kotlin.types.typeUtil.supertypes
  */
 
 @RequiresTypeResolution
-class CastToNullableType(config: Config = Config.empty) : Rule(config) {
+class CastToNullableType(config: Config) : Rule(config) {
     override val issue: Issue = Issue(
         javaClass.simpleName,
         "Use safe cast instead of unsafe cast to nullable types.",

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/CharArrayToStringCall.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/CharArrayToStringCall.kt
@@ -35,7 +35,7 @@ import org.jetbrains.kotlin.resolve.calls.util.getType
  * </compliant>
  */
 @RequiresTypeResolution
-class CharArrayToStringCall(config: Config = Config.empty) : Rule(config) {
+class CharArrayToStringCall(config: Config) : Rule(config) {
     override val issue = Issue(
         javaClass.simpleName,
         "`CharArray.toString()` call does not return expected result.",

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DoubleMutabilityForCollection.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DoubleMutabilityForCollection.kt
@@ -43,7 +43,7 @@ import org.jetbrains.kotlin.resolve.BindingContext
  */
 @RequiresTypeResolution
 @ActiveByDefault(since = "1.21.0")
-class DoubleMutabilityForCollection(config: Config = Config.empty) : Rule(config) {
+class DoubleMutabilityForCollection(config: Config) : Rule(config) {
 
     override val defaultRuleIdAliases: Set<String> = setOf("DoubleMutability")
 

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ElseCaseInsteadOfExhaustiveWhen.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ElseCaseInsteadOfExhaustiveWhen.kt
@@ -51,7 +51,7 @@ import org.jetbrains.kotlin.types.typeUtil.isBooleanOrNullableBoolean
  * </compliant>
  */
 @RequiresTypeResolution
-class ElseCaseInsteadOfExhaustiveWhen(config: Config = Config.empty) : Rule(config) {
+class ElseCaseInsteadOfExhaustiveWhen(config: Config) : Rule(config) {
 
     override val issue: Issue = Issue(
         "ElseCaseInsteadOfExhaustiveWhen",

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsAlwaysReturnsTrueOrFalse.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsAlwaysReturnsTrueOrFalse.kt
@@ -36,7 +36,7 @@ import org.jetbrains.kotlin.psi.psiUtil.collectDescendantsOfType
  * </compliant>
  */
 @ActiveByDefault(since = "1.2.0")
-class EqualsAlwaysReturnsTrueOrFalse(config: Config = Config.empty) : Rule(config) {
+class EqualsAlwaysReturnsTrueOrFalse(config: Config) : Rule(config) {
 
     override val issue = Issue(
         "EqualsAlwaysReturnsTrueOrFalse",

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsWithHashCodeExist.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsWithHashCodeExist.kt
@@ -43,7 +43,7 @@ import org.jetbrains.kotlin.psi.KtNamedFunction
  * </compliant>
  */
 @ActiveByDefault(since = "1.0.0")
-class EqualsWithHashCodeExist(config: Config = Config.empty) : Rule(config) {
+class EqualsWithHashCodeExist(config: Config) : Rule(config) {
 
     override val issue = Issue(
         "EqualsWithHashCodeExist",

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ExitOutsideMain.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ExitOutsideMain.kt
@@ -43,7 +43,7 @@ import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameOrNull
  *
  */
 @RequiresTypeResolution
-class ExitOutsideMain(config: Config = Config.empty) : Rule(config) {
+class ExitOutsideMain(config: Config) : Rule(config) {
 
     override val issue = Issue(
         javaClass.simpleName,

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValue.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValue.kt
@@ -52,7 +52,7 @@ import org.jetbrains.kotlin.types.typeUtil.isUnit
  */
 @RequiresTypeResolution
 @ActiveByDefault(since = "1.21.0")
-class IgnoredReturnValue(config: Config = Config.empty) : Rule(config) {
+class IgnoredReturnValue(config: Config) : Rule(config) {
 
     override val issue: Issue = Issue(
         "IgnoredReturnValue",

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ImplicitDefaultLocale.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ImplicitDefaultLocale.kt
@@ -38,7 +38,7 @@ import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
  */
 @ActiveByDefault(since = "1.16.0")
 @RequiresTypeResolution
-class ImplicitDefaultLocale(config: Config = Config.empty) : Rule(config) {
+class ImplicitDefaultLocale(config: Config) : Rule(config) {
 
     private val formatCalls = listOf(
         FqName("kotlin.text.format")

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/InvalidRange.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/InvalidRange.kt
@@ -31,7 +31,7 @@ import org.jetbrains.kotlin.psi.KtBinaryExpression
  * </compliant>
  */
 @ActiveByDefault(since = "1.2.0")
-class InvalidRange(config: Config = Config.empty) : Rule(config) {
+class InvalidRange(config: Config) : Rule(config) {
 
     override val issue = Issue(
         javaClass.simpleName,

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IteratorHasNextCallsNextMethod.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IteratorHasNextCallsNextMethod.kt
@@ -28,7 +28,7 @@ import org.jetbrains.kotlin.psi.psiUtil.getSuperNames
  * </noncompliant>
  */
 @ActiveByDefault(since = "1.2.0")
-class IteratorHasNextCallsNextMethod(config: Config = Config.empty) : Rule(config) {
+class IteratorHasNextCallsNextMethod(config: Config) : Rule(config) {
 
     override val issue = Issue(
         "IteratorHasNextCallsNextMethod",

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IteratorNotThrowingNoSuchElementException.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IteratorNotThrowingNoSuchElementException.kt
@@ -43,7 +43,7 @@ import org.jetbrains.kotlin.psi.psiUtil.getSuperNames
  * </compliant>
  */
 @ActiveByDefault(since = "1.2.0")
-class IteratorNotThrowingNoSuchElementException(config: Config = Config.empty) : Rule(config) {
+class IteratorNotThrowingNoSuchElementException(config: Config) : Rule(config) {
 
     override val issue = Issue(
         "IteratorNotThrowingNoSuchElementException",

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/LateinitUsage.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/LateinitUsage.kt
@@ -25,7 +25,7 @@ import org.jetbrains.kotlin.psi.psiUtil.containingClass
  * }
  * </noncompliant>
  */
-class LateinitUsage(config: Config = Config.empty) : Rule(config) {
+class LateinitUsage(config: Config) : Rule(config) {
 
     override val issue = Issue(
         javaClass.simpleName,

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingPackageDeclaration.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingPackageDeclaration.kt
@@ -11,7 +11,7 @@ import org.jetbrains.kotlin.psi.KtPackageDirective
 /**
  * Reports when the package declaration is missing.
  */
-class MissingPackageDeclaration(config: Config = Config.empty) : Rule(config) {
+class MissingPackageDeclaration(config: Config) : Rule(config) {
 
     override val issue = Issue(
         javaClass.simpleName,

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingWhenCase.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingWhenCase.kt
@@ -68,7 +68,7 @@ import org.jetbrains.kotlin.resolve.calls.util.getType
 @ActiveByDefault(since = "1.2.0")
 @RequiresTypeResolution
 @Deprecated("Rule deprecated as compiler performs this check by default")
-class MissingWhenCase(config: Config = Config.empty) : Rule(config) {
+class MissingWhenCase(config: Config) : Rule(config) {
 
     override val issue: Issue = Issue(
         "MissingWhenCase",

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/NullableToStringCall.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/NullableToStringCall.kt
@@ -39,7 +39,7 @@ import org.jetbrains.kotlin.psi.psiUtil.getQualifiedExpressionForSelector
  * </compliant>
  */
 @RequiresTypeResolution
-class NullableToStringCall(config: Config = Config.empty) : Rule(config) {
+class NullableToStringCall(config: Config) : Rule(config) {
     override val issue = Issue(
         javaClass.simpleName,
         "`toString()` on nullable receiver may return the string \"null\"",

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/PropertyUsedBeforeDeclaration.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/PropertyUsedBeforeDeclaration.kt
@@ -49,7 +49,7 @@ import org.jetbrains.kotlin.utils.addIfNotNull
  * </compliant>
  */
 @RequiresTypeResolution
-class PropertyUsedBeforeDeclaration(config: Config = Config.empty) : Rule(config) {
+class PropertyUsedBeforeDeclaration(config: Config) : Rule(config) {
     override val issue = Issue(
         javaClass.simpleName,
         "Properties before declaration should not be used.",

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/RedundantElseInWhen.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/RedundantElseInWhen.kt
@@ -58,7 +58,7 @@ import org.jetbrains.kotlin.psi.KtWhenExpression
 @RequiresTypeResolution
 @ActiveByDefault(since = "1.2.0")
 @Deprecated("Rule deprecated as compiler performs this check by default")
-class RedundantElseInWhen(config: Config = Config.empty) : Rule(config) {
+class RedundantElseInWhen(config: Config) : Rule(config) {
 
     override val issue: Issue = Issue(
         "RedundantElseInWhen",

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnconditionalJumpStatementInLoop.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnconditionalJumpStatementInLoop.kt
@@ -33,7 +33,7 @@ import org.jetbrains.kotlin.psi.psiUtil.siblings
  * }
  * </compliant>
  */
-class UnconditionalJumpStatementInLoop(config: Config = Config.empty) : Rule(config) {
+class UnconditionalJumpStatementInLoop(config: Config) : Rule(config) {
 
     override val issue = Issue(
         javaClass.simpleName,

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnamedParameterUse.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnamedParameterUse.kt
@@ -74,7 +74,7 @@ import org.jetbrains.kotlin.types.typeUtil.isSubtypeOf
  * </compliant>
  */
 @RequiresTypeResolution
-class UnnamedParameterUse(config: Config = Config.empty) : Rule(config) {
+class UnnamedParameterUse(config: Config) : Rule(config) {
 
     override val issue = Issue(
         javaClass.simpleName,

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessaryNotNullCheck.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessaryNotNullCheck.kt
@@ -26,7 +26,7 @@ import org.jetbrains.kotlin.types.isNullable
  * </compliant>
  */
 @RequiresTypeResolution
-class UnnecessaryNotNullCheck(config: Config = Config.empty) : Rule(config) {
+class UnnecessaryNotNullCheck(config: Config) : Rule(config) {
 
     override val issue = Issue(
         "UnnecessaryNotNullCheck",

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessaryNotNullOperator.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessaryNotNullOperator.kt
@@ -25,7 +25,7 @@ import org.jetbrains.kotlin.psi.KtUnaryExpression
  */
 @RequiresTypeResolution
 @ActiveByDefault(since = "1.16.0")
-class UnnecessaryNotNullOperator(config: Config = Config.empty) : Rule(config) {
+class UnnecessaryNotNullOperator(config: Config) : Rule(config) {
 
     override val issue: Issue = Issue(
         "UnnecessaryNotNullOperator",

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessarySafeCall.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessarySafeCall.kt
@@ -28,7 +28,7 @@ import org.jetbrains.kotlin.psi.psiUtil.getChildOfType
  */
 @RequiresTypeResolution
 @ActiveByDefault(since = "1.16.0")
-class UnnecessarySafeCall(config: Config = Config.empty) : Rule(config) {
+class UnnecessarySafeCall(config: Config) : Rule(config) {
 
     override val issue: Issue = Issue(
         "UnnecessarySafeCall",

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnreachableCatchBlock.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnreachableCatchBlock.kt
@@ -46,7 +46,7 @@ import org.jetbrains.kotlin.resolve.descriptorUtil.isSubclassOf
  */
 @RequiresTypeResolution
 @ActiveByDefault(since = "1.21.0")
-class UnreachableCatchBlock(config: Config = Config.empty) : Rule(config) {
+class UnreachableCatchBlock(config: Config) : Rule(config) {
     override val issue = Issue(
         javaClass.simpleName,
         "Unreachable catch block detected.",

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnreachableCode.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnreachableCode.kt
@@ -32,7 +32,7 @@ import org.jetbrains.kotlin.psi.KtExpression
  */
 @RequiresTypeResolution
 @ActiveByDefault(since = "1.0.0")
-class UnreachableCode(config: Config = Config.empty) : Rule(config) {
+class UnreachableCode(config: Config) : Rule(config) {
 
     override val issue = Issue(
         "UnreachableCode",

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCallOnNullableType.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCallOnNullableType.kt
@@ -32,7 +32,7 @@ import org.jetbrains.kotlin.types.typeUtil.nullability
  */
 @RequiresTypeResolution
 @ActiveByDefault(since = "1.2.0")
-class UnsafeCallOnNullableType(config: Config = Config.empty) : Rule(config) {
+class UnsafeCallOnNullableType(config: Config) : Rule(config) {
     override val issue: Issue = Issue(
         "UnsafeCallOnNullableType",
         "Unsafe calls on nullable types detected. These calls will throw a NullPointerException in case " +

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCast.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCast.kt
@@ -31,7 +31,7 @@ import org.jetbrains.kotlin.psi.KtBinaryExpressionWithTypeRHS
  */
 @RequiresTypeResolution
 @ActiveByDefault(since = "1.16.0")
-class UnsafeCast(config: Config = Config.empty) : Rule(config) {
+class UnsafeCast(config: Config) : Rule(config) {
 
     override val defaultRuleIdAliases: Set<String> = setOf("UNCHECKED_CAST")
 

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnusedUnaryOperator.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnusedUnaryOperator.kt
@@ -37,7 +37,7 @@ import org.jetbrains.kotlin.resolve.calls.util.getResolvedCall
  */
 @RequiresTypeResolution
 @ActiveByDefault(since = "1.21.0")
-class UnusedUnaryOperator(config: Config = Config.empty) : Rule(config) {
+class UnusedUnaryOperator(config: Config) : Rule(config) {
     override val issue = Issue(
         javaClass.simpleName,
         "This unary operator is unused.",

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UselessPostfixExpression.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UselessPostfixExpression.kt
@@ -53,7 +53,7 @@ import org.jetbrains.kotlin.psi.psiUtil.isPropertyParameter
  * </compliant>
  */
 @ActiveByDefault(since = "1.21.0")
-class UselessPostfixExpression(config: Config = Config.empty) : Rule(config) {
+class UselessPostfixExpression(config: Config) : Rule(config) {
 
     override val issue: Issue = Issue(
         "UselessPostfixExpression",

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/WrongEqualsTypeParameter.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/WrongEqualsTypeParameter.kt
@@ -34,7 +34,7 @@ import org.jetbrains.kotlin.psi.KtNamedFunction
  * </compliant>
  */
 @ActiveByDefault(since = "1.2.0")
-class WrongEqualsTypeParameter(config: Config = Config.empty) : Rule(config) {
+class WrongEqualsTypeParameter(config: Config) : Rule(config) {
 
     override val issue = Issue(
         "WrongEqualsTypeParameter",

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/CastNullableToNonNullableTypeSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/CastNullableToNonNullableTypeSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.bugs
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
@@ -9,7 +10,7 @@ import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
 class CastNullableToNonNullableTypeSpec(private val env: KotlinCoreEnvironment) {
-    private val subject = CastNullableToNonNullableType()
+    private val subject = CastNullableToNonNullableType(Config.empty)
 
     @Test
     fun `reports casting Nullable type to NonNullable type`() {

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/CastToNullableTypeSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/CastToNullableTypeSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.bugs
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
@@ -8,7 +9,7 @@ import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
 class CastToNullableTypeSpec(private val env: KotlinCoreEnvironment) {
-    private val subject = CastToNullableType()
+    private val subject = CastToNullableType(Config.empty)
 
     @Test
     fun `casting to nullable types`() {

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/CharArrayToStringCallSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/CharArrayToStringCallSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.bugs
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
@@ -8,7 +9,7 @@ import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
 class CharArrayToStringCallSpec(private val env: KotlinCoreEnvironment) {
-    private val subject = CharArrayToStringCall()
+    private val subject = CharArrayToStringCall(Config.empty)
 
     @Test
     fun `toString() calls`() {

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ElseCaseInsteadOfExhaustiveWhenSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ElseCaseInsteadOfExhaustiveWhenSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.bugs
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
@@ -11,7 +12,7 @@ import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
 class ElseCaseInsteadOfExhaustiveWhenSpec(private val env: KotlinCoreEnvironment) {
-    private val subject = ElseCaseInsteadOfExhaustiveWhen()
+    private val subject = ElseCaseInsteadOfExhaustiveWhen(Config.empty)
 
     @Nested
     inner class Enum {

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ExitOutsideMainSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ExitOutsideMainSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.bugs
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
 import org.assertj.core.api.Assertions.assertThat
@@ -8,7 +9,7 @@ import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
 class ExitOutsideMainSpec(private val env: KotlinCoreEnvironment) {
-    private val subject = ExitOutsideMain()
+    private val subject = ExitOutsideMain(Config.empty)
 
     @Test
     fun `reports exitProcess used outside main()`() {

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValueSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValueSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.bugs
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
@@ -14,7 +15,7 @@ class IgnoredReturnValueSpec {
     @Nested
     @KotlinCoreEnvironmentTest
     inner class `default config with non-annotated return values`(private val env: KotlinCoreEnvironment) {
-        private val subject = IgnoredReturnValue()
+        private val subject = IgnoredReturnValue(Config.empty)
 
         @Test
         fun `does not report when a function which returns a value is called and the return is ignored`() {
@@ -184,7 +185,7 @@ class IgnoredReturnValueSpec {
     @Nested
     @KotlinCoreEnvironmentTest
     inner class `default config with annotated return values`(private val env: KotlinCoreEnvironment) {
-        private val subject = IgnoredReturnValue()
+        private val subject = IgnoredReturnValue(Config.empty)
 
         @Test
         fun `reports when a function which returns a value is called and the return is ignored`() {
@@ -1000,7 +1001,7 @@ class IgnoredReturnValueSpec {
     @Nested
     @KotlinCoreEnvironmentTest
     inner class `return value types default config`(private val env: KotlinCoreEnvironment) {
-        private val subject = IgnoredReturnValue()
+        private val subject = IgnoredReturnValue(Config.empty)
 
         @Test
         fun `reports when result of function returning Flow is ignored`() {
@@ -1067,7 +1068,7 @@ class IgnoredReturnValueSpec {
     @Nested
     @KotlinCoreEnvironmentTest(additionalJavaSourcePaths = ["java"])
     inner class `Java sources`(val env: KotlinCoreEnvironment) {
-        private val subject = IgnoredReturnValue()
+        private val subject = IgnoredReturnValue(Config.empty)
 
         @Test
         fun `reports when annotation is on the method`() {

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IteratorHasNextCallsNextMethodSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IteratorHasNextCallsNextMethodSpec.kt
@@ -1,11 +1,12 @@
 package io.gitlab.arturbosch.detekt.rules.bugs
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 class IteratorHasNextCallsNextMethodSpec {
-    private val subject = IteratorHasNextCallsNextMethod()
+    private val subject = IteratorHasNextCallsNextMethod(Config.empty)
 
     @Test
     fun `reports wrong iterator implementation`() {

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IteratorNotThrowingNoSuchElementExceptionSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IteratorNotThrowingNoSuchElementExceptionSpec.kt
@@ -1,11 +1,12 @@
 package io.gitlab.arturbosch.detekt.rules.bugs
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 class IteratorNotThrowingNoSuchElementExceptionSpec {
-    private val subject = IteratorNotThrowingNoSuchElementException()
+    private val subject = IteratorNotThrowingNoSuchElementException(Config.empty)
 
     @Test
     fun `reports invalid next() implementations`() {

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/LateinitUsageSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/LateinitUsageSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.bugs
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.assertj.core.api.Assertions.assertThat
@@ -20,7 +21,7 @@ class LateinitUsageSpec {
 
     @Test
     fun `should report lateinit usages`() {
-        val findings = LateinitUsage().compileAndLint(code)
+        val findings = LateinitUsage(Config.empty).compileAndLint(code)
         assertThat(findings).hasSize(2)
     }
 

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingPackageDeclarationSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingPackageDeclarationSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.bugs
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.junit.jupiter.api.Test
@@ -13,7 +14,7 @@ internal class MissingPackageDeclarationSpec {
             
             class C
         """.trimIndent()
-        val findings = MissingPackageDeclaration().compileAndLint(code)
+        val findings = MissingPackageDeclaration(Config.empty).compileAndLint(code)
 
         assertThat(findings).isEmpty()
     }
@@ -22,7 +23,7 @@ internal class MissingPackageDeclarationSpec {
     fun `should report if package declaration is missing`() {
         val code = "class C"
 
-        val findings = MissingPackageDeclaration().compileAndLint(code)
+        val findings = MissingPackageDeclaration(Config.empty).compileAndLint(code)
 
         assertThat(findings).hasSize(1)
     }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingWhenCaseSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingWhenCaseSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.bugs
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
@@ -16,7 +17,7 @@ class MissingWhenCaseSpec(private val env: KotlinCoreEnvironment) {
     inner class `MissingWhenCase rule` {
 
         @Suppress("DEPRECATION")
-        private val subject = MissingWhenCase()
+        private val subject = MissingWhenCase(Config.empty)
 
         @Nested
         inner class Enum {

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/NullableToStringCallSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/NullableToStringCallSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.bugs
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
 import org.assertj.core.api.Assertions.assertThat
@@ -8,7 +9,7 @@ import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
 class NullableToStringCallSpec(private val env: KotlinCoreEnvironment) {
-    private val subject = NullableToStringCall()
+    private val subject = NullableToStringCall(Config.empty)
 
     @Test
     fun `reports when a nullable toString is explicitly called`() {

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/PropertyUsedBeforeDeclarationSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/PropertyUsedBeforeDeclarationSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.bugs
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
@@ -8,7 +9,7 @@ import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
 class PropertyUsedBeforeDeclarationSpec(private val env: KotlinCoreEnvironment) {
-    private val subject = PropertyUsedBeforeDeclaration()
+    private val subject = PropertyUsedBeforeDeclaration(Config.empty)
 
     @Test
     fun `used before declaration in getter`() {

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/RedundantElseInWhenSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/RedundantElseInWhenSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.bugs
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
 import io.gitlab.arturbosch.detekt.test.lintWithContext
@@ -12,7 +13,7 @@ import org.junit.jupiter.api.Test
 class RedundantElseInWhenSpec(private val env: KotlinCoreEnvironment) {
 
     @Suppress("DEPRECATION")
-    private val subject = RedundantElseInWhen()
+    private val subject = RedundantElseInWhen(Config.empty)
 
     @Nested
     inner class Enum {

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnconditionalJumpStatementInLoopSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnconditionalJumpStatementInLoopSpec.kt
@@ -1,11 +1,12 @@
 package io.gitlab.arturbosch.detekt.rules.bugs
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 class UnconditionalJumpStatementInLoopSpec {
-    private val subject = UnconditionalJumpStatementInLoop()
+    private val subject = UnconditionalJumpStatementInLoop(Config.empty)
 
     @Test
     fun `reports an unconditional return in for loop`() {

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnamedParameterUseSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnamedParameterUseSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.bugs
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
@@ -10,7 +11,7 @@ import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
 class UnnamedParameterUseSpec(private val env: KotlinCoreEnvironment) {
-    private val subject = UnnamedParameterUse()
+    private val subject = UnnamedParameterUse(Config.empty)
 
     @Test
     fun `does not report for no param function call`() {

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessaryNotNullCheckSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessaryNotNullCheckSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.bugs
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lintWithContext
@@ -9,7 +10,7 @@ import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
 class UnnecessaryNotNullCheckSpec(private val env: KotlinCoreEnvironment) {
-    private val subject = UnnecessaryNotNullCheck()
+    private val subject = UnnecessaryNotNullCheck(Config.empty)
 
     @Nested
     inner class `check unnecessary not null checks` {

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessaryNotNullOperatorSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessaryNotNullOperatorSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.bugs
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
@@ -9,7 +10,7 @@ import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
 class UnnecessaryNotNullOperatorSpec(private val env: KotlinCoreEnvironment) {
-    private val subject = UnnecessaryNotNullOperator()
+    private val subject = UnnecessaryNotNullOperator(Config.empty)
 
     @Nested
     inner class `check unnecessary not null operators` {

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessarySafeCallSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessarySafeCallSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.bugs
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
@@ -10,7 +11,7 @@ import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
 class UnnecessarySafeCallSpec(private val env: KotlinCoreEnvironment) {
-    private val subject = UnnecessarySafeCall()
+    private val subject = UnnecessarySafeCall(Config.empty)
 
     @Nested
     inner class `check unnecessary safe operators` {

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnreachableCatchBlockSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnreachableCatchBlockSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.bugs
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
@@ -9,7 +10,7 @@ import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
 class UnreachableCatchBlockSpec(private val env: KotlinCoreEnvironment) {
-    private val subject = UnreachableCatchBlock()
+    private val subject = UnreachableCatchBlock(Config.empty)
 
     @Test
     fun `reports a unreachable catch block that is after the super class catch block`() {

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCallOnNullableTypeSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCallOnNullableTypeSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.bugs
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
 import org.assertj.core.api.Assertions.assertThat
@@ -8,7 +9,7 @@ import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
 class UnsafeCallOnNullableTypeSpec(private val env: KotlinCoreEnvironment) {
-    private val subject = UnsafeCallOnNullableType()
+    private val subject = UnsafeCallOnNullableType(Config.empty)
 
     @Test
     fun `reports unsafe call on nullable type`() {

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCastSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCastSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.bugs
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
 import org.assertj.core.api.Assertions.assertThat
@@ -8,7 +9,7 @@ import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
 class UnsafeCastSpec(private val env: KotlinCoreEnvironment) {
-    private val subject = UnsafeCast()
+    private val subject = UnsafeCast(Config.empty)
 
     @Test
     fun `reports cast that cannot succeed`() {

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnusedUnaryOperatorSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnusedUnaryOperatorSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.bugs
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
@@ -8,7 +9,7 @@ import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
 class UnusedUnaryOperatorSpec(private val env: KotlinCoreEnvironment) {
-    private val subject = UnusedUnaryOperator()
+    private val subject = UnusedUnaryOperator(Config.empty)
 
     @Test
     fun `unused plus operator`() {

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UselessPostfixExpressionSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UselessPostfixExpressionSpec.kt
@@ -1,12 +1,13 @@
 package io.gitlab.arturbosch.detekt.rules.bugs
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 class UselessPostfixExpressionSpec {
-    private val subject = UselessPostfixExpression()
+    private val subject = UselessPostfixExpression(Config.empty)
 
     @Nested
     inner class `check several types of postfix increments` {

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ExceptionRaisedInUnexpectedLocation.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ExceptionRaisedInUnexpectedLocation.kt
@@ -29,7 +29,7 @@ import org.jetbrains.kotlin.psi.psiUtil.anyDescendantOfType
  * </noncompliant>
  */
 @ActiveByDefault(since = "1.16.0")
-class ExceptionRaisedInUnexpectedLocation(config: Config = Config.empty) : Rule(config) {
+class ExceptionRaisedInUnexpectedLocation(config: Config) : Rule(config) {
 
     override val issue = Issue(
         "ExceptionRaisedInUnexpectedLocation",

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/InstanceOfCheckForException.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/InstanceOfCheckForException.kt
@@ -45,7 +45,7 @@ import org.jetbrains.kotlin.types.typeUtil.isSubtypeOf
  */
 @RequiresTypeResolution
 @ActiveByDefault(since = "1.21.0")
-class InstanceOfCheckForException(config: Config = Config.empty) : Rule(config) {
+class InstanceOfCheckForException(config: Config) : Rule(config) {
 
     override val issue = Issue(
         "InstanceOfCheckForException",

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/NotImplementedDeclaration.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/NotImplementedDeclaration.kt
@@ -25,7 +25,7 @@ import org.jetbrains.kotlin.resolve.calls.util.getCalleeExpressionIfAny
  * }
  * </noncompliant>
  */
-class NotImplementedDeclaration(config: Config = Config.empty) : Rule(config) {
+class NotImplementedDeclaration(config: Config) : Rule(config) {
 
     override val issue = Issue(
         "NotImplementedDeclaration",

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ObjectExtendsThrowable.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ObjectExtendsThrowable.kt
@@ -38,7 +38,7 @@ import org.jetbrains.kotlin.types.typeUtil.supertypes
  *
  */
 @RequiresTypeResolution
-class ObjectExtendsThrowable(config: Config = Config.empty) : Rule(config) {
+class ObjectExtendsThrowable(config: Config) : Rule(config) {
     override val issue = Issue(
         id = "ObjectExtendsThrowable",
         description = "An `object` should not extend and type of Throwable. Throwables are " +

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/PrintStackTrace.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/PrintStackTrace.kt
@@ -44,7 +44,7 @@ import org.jetbrains.kotlin.psi.psiUtil.getReceiverExpression
  * </compliant>
  */
 @ActiveByDefault(since = "1.16.0")
-class PrintStackTrace(config: Config = Config.empty) : Rule(config) {
+class PrintStackTrace(config: Config) : Rule(config) {
 
     override val issue = Issue(
         "PrintStackTrace",

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/RethrowCaughtException.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/RethrowCaughtException.kt
@@ -58,7 +58,7 @@ import org.jetbrains.kotlin.psi.psiUtil.getChildrenOfType
  * </compliant>
  */
 @ActiveByDefault(since = "1.16.0")
-class RethrowCaughtException(config: Config = Config.empty) : Rule(config) {
+class RethrowCaughtException(config: Config) : Rule(config) {
 
     override val issue = Issue(
         "RethrowCaughtException",

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ReturnFromFinally.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ReturnFromFinally.kt
@@ -40,7 +40,7 @@ import org.jetbrains.kotlin.types.KotlinType
  */
 @RequiresTypeResolution
 @ActiveByDefault(since = "1.16.0")
-class ReturnFromFinally(config: Config = Config.empty) : Rule(config) {
+class ReturnFromFinally(config: Config) : Rule(config) {
 
     override val issue = Issue(
         "ReturnFromFinally",

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedException.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedException.kt
@@ -67,7 +67,7 @@ import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
  * </compliant>
  */
 @ActiveByDefault(since = "1.16.0")
-class SwallowedException(config: Config = Config.empty) : Rule(config) {
+class SwallowedException(config: Config) : Rule(config) {
 
     override val issue = Issue(
         "SwallowedException",

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionFromFinally.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionFromFinally.kt
@@ -25,7 +25,7 @@ import org.jetbrains.kotlin.psi.psiUtil.forEachDescendantOfType
  * </noncompliant>
  */
 @ActiveByDefault(since = "1.16.0")
-class ThrowingExceptionFromFinally(config: Config = Config.empty) : Rule(config) {
+class ThrowingExceptionFromFinally(config: Config) : Rule(config) {
 
     override val issue = Issue(
         "ThrowingExceptionFromFinally",

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionInMain.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionInMain.kt
@@ -21,7 +21,7 @@ import org.jetbrains.kotlin.psi.psiUtil.anyDescendantOfType
  * }
  * </noncompliant>
  */
-class ThrowingExceptionInMain(config: Config = Config.empty) : Rule(config) {
+class ThrowingExceptionInMain(config: Config) : Rule(config) {
 
     override val issue = Issue(
         "ThrowingExceptionInMain",

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionsWithoutMessageOrCause.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionsWithoutMessageOrCause.kt
@@ -35,7 +35,7 @@ import org.jetbrains.kotlin.psi.KtCallExpression
  * </compliant>
  */
 @ActiveByDefault(since = "1.16.0")
-class ThrowingExceptionsWithoutMessageOrCause(config: Config = Config.empty) : Rule(config) {
+class ThrowingExceptionsWithoutMessageOrCause(config: Config) : Rule(config) {
 
     override val issue = Issue(
         "ThrowingExceptionsWithoutMessageOrCause",

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingNewInstanceOfSameException.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingNewInstanceOfSameException.kt
@@ -37,7 +37,7 @@ import org.jetbrains.kotlin.psi.psiUtil.findDescendantOfType
  * </compliant>
  */
 @ActiveByDefault(since = "1.16.0")
-class ThrowingNewInstanceOfSameException(config: Config = Config.empty) : Rule(config) {
+class ThrowingNewInstanceOfSameException(config: Config) : Rule(config) {
 
     override val issue = Issue(
         "ThrowingNewInstanceOfSameException",

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ExceptionRaisedInUnexpectedLocationSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ExceptionRaisedInUnexpectedLocationSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.exceptions
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import io.gitlab.arturbosch.detekt.test.lint
@@ -7,7 +8,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 class ExceptionRaisedInUnexpectedLocationSpec {
-    val subject = ExceptionRaisedInUnexpectedLocation()
+    val subject = ExceptionRaisedInUnexpectedLocation(Config.empty)
 
     @Test
     fun `reports methods raising an unexpected exception`() {

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/InstanceOfCheckForExceptionSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/InstanceOfCheckForExceptionSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.exceptions
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
 import org.assertj.core.api.Assertions.assertThat
@@ -8,7 +9,7 @@ import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
 class InstanceOfCheckForExceptionSpec(private val env: KotlinCoreEnvironment) {
-    val subject = InstanceOfCheckForException()
+    val subject = InstanceOfCheckForException(Config.empty)
 
     @Test
     fun `has is and as checks`() {

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/NotImplementedDeclarationSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/NotImplementedDeclarationSpec.kt
@@ -1,11 +1,12 @@
 package io.gitlab.arturbosch.detekt.rules.exceptions
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 class NotImplementedDeclarationSpec {
-    val subject = NotImplementedDeclaration()
+    val subject = NotImplementedDeclaration(Config.empty)
 
     @Test
     fun `reports NotImplementedErrors`() {

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ObjectExtendsThrowableSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ObjectExtendsThrowableSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.exceptions
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
 import org.assertj.core.api.Assertions.assertThat
@@ -9,7 +10,7 @@ import org.junit.jupiter.api.Test
 @KotlinCoreEnvironmentTest
 class ObjectExtendsThrowableSpec(val env: KotlinCoreEnvironment) {
 
-    val subject = ObjectExtendsThrowable()
+    val subject = ObjectExtendsThrowable(Config.empty)
 
     @Test
     fun `reports top-level objects that extend Throwable`() {

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/PrintStackTraceSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/PrintStackTraceSpec.kt
@@ -1,12 +1,13 @@
 package io.gitlab.arturbosch.detekt.rules.exceptions
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 class PrintStackTraceSpec {
-    val subject = PrintStackTrace()
+    val subject = PrintStackTrace(Config.empty)
 
     @Nested
     inner class `catch clauses with printStacktrace methods` {

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/RethrowCaughtExceptionSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/RethrowCaughtExceptionSpec.kt
@@ -1,11 +1,12 @@
 package io.gitlab.arturbosch.detekt.rules.exceptions
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 class RethrowCaughtExceptionSpec {
-    val subject = RethrowCaughtException()
+    val subject = RethrowCaughtException(Config.empty)
 
     @Test
     fun `reports when the same exception is rethrown`() {

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ReturnFromFinallySpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ReturnFromFinallySpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.exceptions
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
@@ -11,7 +12,7 @@ import org.junit.jupiter.api.Test
 @KotlinCoreEnvironmentTest
 class ReturnFromFinallySpec(val env: KotlinCoreEnvironment) {
 
-    val subject = ReturnFromFinally()
+    val subject = ReturnFromFinally(Config.empty)
 
     inner class `a finally block with a return statement` {
         val code = """

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedExceptionSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedExceptionSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.exceptions
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.assertj.core.api.Assertions.assertThat
@@ -9,7 +10,7 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 
 class SwallowedExceptionSpec {
-    val subject = SwallowedException()
+    val subject = SwallowedException(Config.empty)
 
     @Test
     fun `reports a swallowed exception`() {

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionFromFinallySpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionFromFinallySpec.kt
@@ -1,11 +1,12 @@
 package io.gitlab.arturbosch.detekt.rules.exceptions
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 class ThrowingExceptionFromFinallySpec {
-    val subject = ThrowingExceptionFromFinally()
+    val subject = ThrowingExceptionFromFinally(Config.empty)
 
     @Test
     fun `should report a throw expression`() {

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionInMainSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionInMainSpec.kt
@@ -1,12 +1,13 @@
 package io.gitlab.arturbosch.detekt.rules.exceptions
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 class ThrowingExceptionInMainSpec {
-    val subject = ThrowingExceptionInMain()
+    val subject = ThrowingExceptionInMain(Config.empty)
 
     @Test
     fun `reports a runnable main function without args which throws an exception`() {

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingNewInstanceOfSameExceptionSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingNewInstanceOfSameExceptionSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.exceptions
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
@@ -7,7 +8,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 class ThrowingNewInstanceOfSameExceptionSpec {
-    val subject = ThrowingNewInstanceOfSameException()
+    val subject = ThrowingNewInstanceOfSameException(Config.empty)
 
     @Nested
     inner class `a catch block which rethrows a new instance of the caught exception` {

--- a/detekt-rules-libraries/src/main/kotlin/io/gitlab/arturbosch/detekt/libraries/ForbiddenPublicDataClass.kt
+++ b/detekt-rules-libraries/src/main/kotlin/io/gitlab/arturbosch/detekt/libraries/ForbiddenPublicDataClass.kt
@@ -29,7 +29,7 @@ import org.jetbrains.kotlin.psi.psiUtil.visibilityModifierTypeOrDefault
  * </compliant>
  */
 @ActiveByDefault(since = "1.16.0")
-class ForbiddenPublicDataClass(config: Config = Config.empty) : Rule(config) {
+class ForbiddenPublicDataClass(config: Config) : Rule(config) {
 
     override val issue = Issue(
         javaClass.simpleName,

--- a/detekt-rules-libraries/src/main/kotlin/io/gitlab/arturbosch/detekt/libraries/LibraryCodeMustSpecifyReturnType.kt
+++ b/detekt-rules-libraries/src/main/kotlin/io/gitlab/arturbosch/detekt/libraries/LibraryCodeMustSpecifyReturnType.kt
@@ -45,7 +45,7 @@ import org.jetbrains.kotlin.resolve.checkers.ExplicitApiDeclarationChecker
  */
 @RequiresTypeResolution
 @ActiveByDefault(since = "1.2.0")
-class LibraryCodeMustSpecifyReturnType(config: Config = Config.empty) : Rule(config) {
+class LibraryCodeMustSpecifyReturnType(config: Config) : Rule(config) {
 
     override val issue = Issue(
         this.javaClass.simpleName,

--- a/detekt-rules-libraries/src/main/kotlin/io/gitlab/arturbosch/detekt/libraries/LibraryEntitiesShouldNotBePublic.kt
+++ b/detekt-rules-libraries/src/main/kotlin/io/gitlab/arturbosch/detekt/libraries/LibraryEntitiesShouldNotBePublic.kt
@@ -25,7 +25,7 @@ import org.jetbrains.kotlin.psi.psiUtil.isPublic
  * </compliant>
  */
 @ActiveByDefault(since = "1.16.0")
-class LibraryEntitiesShouldNotBePublic(ruleSetConfig: Config = Config.empty) : Rule(ruleSetConfig) {
+class LibraryEntitiesShouldNotBePublic(ruleSetConfig: Config) : Rule(ruleSetConfig) {
 
     override val issue: Issue = Issue(
         javaClass.simpleName,

--- a/detekt-rules-libraries/src/test/kotlin/io/gitlab/arturbosch/detekt/libraries/ForbiddenPublicDataClassSpec.kt
+++ b/detekt-rules-libraries/src/test/kotlin/io/gitlab/arturbosch/detekt/libraries/ForbiddenPublicDataClassSpec.kt
@@ -7,7 +7,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 class ForbiddenPublicDataClassSpec {
-    val subject = ForbiddenPublicDataClass()
+    val subject = ForbiddenPublicDataClass(Config.empty)
 
     @Test
     fun `public data class should pass without explicit filters set`() {

--- a/detekt-rules-libraries/src/test/kotlin/io/gitlab/arturbosch/detekt/libraries/LibraryCodeMustSpecifyReturnTypeSpec.kt
+++ b/detekt-rules-libraries/src/test/kotlin/io/gitlab/arturbosch/detekt/libraries/LibraryCodeMustSpecifyReturnTypeSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.libraries
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
@@ -15,7 +16,7 @@ import org.junit.jupiter.params.provider.ValueSource
 class LibraryCodeMustSpecifyReturnTypeSpec(val env: KotlinCoreEnvironment) {
     @Nested
     inner class `positive cases` {
-        val subject = LibraryCodeMustSpecifyReturnType()
+        val subject = LibraryCodeMustSpecifyReturnType(Config.empty)
 
         @Test
         fun `should report a top level function`() {
@@ -99,7 +100,7 @@ class LibraryCodeMustSpecifyReturnTypeSpec(val env: KotlinCoreEnvironment) {
 
     @Nested
     inner class `negative cases with public scope` {
-        val subject = LibraryCodeMustSpecifyReturnType()
+        val subject = LibraryCodeMustSpecifyReturnType(Config.empty)
 
         @Test
         fun `should not report a top level function`() {
@@ -185,7 +186,7 @@ class LibraryCodeMustSpecifyReturnTypeSpec(val env: KotlinCoreEnvironment) {
 
     @Nested
     inner class `negative cases with no public scope` {
-        val subject = LibraryCodeMustSpecifyReturnType()
+        val subject = LibraryCodeMustSpecifyReturnType(Config.empty)
 
         @Test
         fun `should not report a private top level function`() {

--- a/detekt-rules-libraries/src/test/kotlin/io/gitlab/arturbosch/detekt/libraries/LibraryEntitiesShouldNotBePublicSpec.kt
+++ b/detekt-rules-libraries/src/test/kotlin/io/gitlab/arturbosch/detekt/libraries/LibraryEntitiesShouldNotBePublicSpec.kt
@@ -23,7 +23,7 @@ class LibraryEntitiesShouldNotBePublicSpec {
 
     @Nested
     inner class `positive cases` {
-        val subject = LibraryEntitiesShouldNotBePublic()
+        val subject = LibraryEntitiesShouldNotBePublic(Config.empty)
 
         @Test
         fun `should report a class`() {
@@ -88,7 +88,7 @@ class LibraryEntitiesShouldNotBePublicSpec {
 
     @Nested
     inner class `negative cases` {
-        val subject = LibraryEntitiesShouldNotBePublic()
+        val subject = LibraryEntitiesShouldNotBePublic(Config.empty)
 
         @Test
         fun `should not report a class`() {

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/BooleanPropertyNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/BooleanPropertyNaming.kt
@@ -29,7 +29,7 @@ import org.jetbrains.kotlin.resolve.typeBinding.createTypeBindingForReturnType
  * </compliant>
  */
 @RequiresTypeResolution
-class BooleanPropertyNaming(config: Config = Config.empty) : Rule(config) {
+class BooleanPropertyNaming(config: Config) : Rule(config) {
 
     @Configuration("naming pattern")
     private val allowedPattern: Regex by config("^(is|has|are)", String::toRegex)

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ClassNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ClassNaming.kt
@@ -15,7 +15,7 @@ import org.jetbrains.kotlin.psi.KtClassOrObject
  * Reports class or object names that do not follow the specified naming convention.
  */
 @ActiveByDefault(since = "1.0.0")
-class ClassNaming(config: Config = Config.empty) : Rule(config) {
+class ClassNaming(config: Config) : Rule(config) {
 
     override val defaultRuleIdAliases: Set<String> = setOf("ClassName")
 

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ConstructorParameterNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ConstructorParameterNaming.kt
@@ -18,7 +18,7 @@ import org.jetbrains.kotlin.psi.psiUtil.isPrivate
  * Reports constructor parameter names that do not follow the specified naming convention.
  */
 @ActiveByDefault(since = "1.0.0")
-class ConstructorParameterNaming(config: Config = Config.empty) : Rule(config) {
+class ConstructorParameterNaming(config: Config) : Rule(config) {
 
     override val issue = Issue(
         javaClass.simpleName,

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/EnumNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/EnumNaming.kt
@@ -15,7 +15,7 @@ import org.jetbrains.kotlin.psi.KtEnumEntry
  * Reports enum names that do not follow the specified naming convention.
  */
 @ActiveByDefault(since = "1.0.0")
-class EnumNaming(config: Config = Config.empty) : Rule(config) {
+class EnumNaming(config: Config) : Rule(config) {
 
     override val issue = Issue(
         javaClass.simpleName,

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ForbiddenClassName.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ForbiddenClassName.kt
@@ -13,7 +13,7 @@ import org.jetbrains.kotlin.psi.KtClassOrObject
  * Reports class names which are forbidden per configuration. By default, this rule does not report any classes.
  * Examples for forbidden names might be too generic class names like `...Manager`.
  */
-class ForbiddenClassName(config: Config = Config.empty) : Rule(config) {
+class ForbiddenClassName(config: Config) : Rule(config) {
 
     override val issue = Issue(
         javaClass.simpleName,

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNameMaxLength.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNameMaxLength.kt
@@ -15,7 +15,7 @@ import org.jetbrains.kotlin.psi.KtNamedFunction
 /**
  * Reports when very long function names are used.
  */
-class FunctionNameMaxLength(config: Config = Config.empty) : Rule(config) {
+class FunctionNameMaxLength(config: Config) : Rule(config) {
 
     override val issue = Issue(
         javaClass.simpleName,

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNameMinLength.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNameMinLength.kt
@@ -15,7 +15,7 @@ import org.jetbrains.kotlin.psi.KtNamedFunction
 /**
  * Reports when very short function names are used.
  */
-class FunctionNameMinLength(config: Config = Config.empty) : Rule(config) {
+class FunctionNameMinLength(config: Config) : Rule(config) {
 
     override val issue = Issue(
         javaClass.simpleName,

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNaming.kt
@@ -19,7 +19,7 @@ import org.jetbrains.kotlin.psi.KtUserType
  * These factory functions can have the same name as the class being created.
  */
 @ActiveByDefault(since = "1.0.0")
-class FunctionNaming(config: Config = Config.empty) : Rule(config) {
+class FunctionNaming(config: Config) : Rule(config) {
 
     override val defaultRuleIdAliases: Set<String> = setOf("FunctionName")
 

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionParameterNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionParameterNaming.kt
@@ -20,7 +20,7 @@ import org.jetbrains.kotlin.psi.KtParameter
  * Reports function parameter names that do not follow the specified naming convention.
  */
 @ActiveByDefault(since = "1.0.0")
-class FunctionParameterNaming(config: Config = Config.empty) : Rule(config) {
+class FunctionParameterNaming(config: Config) : Rule(config) {
 
     override val issue = Issue(
         javaClass.simpleName,

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/InvalidPackageDeclaration.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/InvalidPackageDeclaration.kt
@@ -17,7 +17,7 @@ import org.jetbrains.kotlin.psi.KtPackageDirective
  * Reports when the file location does not match the declared package.
  */
 @ActiveByDefault(since = "1.21.0")
-class InvalidPackageDeclaration(config: Config = Config.empty) : Rule(config) {
+class InvalidPackageDeclaration(config: Config) : Rule(config) {
 
     override val defaultRuleIdAliases: Set<String> = setOf("PackageDirectoryMismatch")
 

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/LambdaParameterNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/LambdaParameterNaming.kt
@@ -14,7 +14,7 @@ import org.jetbrains.kotlin.psi.KtParameter
 /**
  * Reports lambda parameter names that do not follow the specified naming convention.
  */
-class LambdaParameterNaming(config: Config = Config.empty) : Rule(config) {
+class LambdaParameterNaming(config: Config) : Rule(config) {
 
     override val issue = Issue(
         javaClass.simpleName,

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MatchingDeclarationName.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MatchingDeclarationName.kt
@@ -46,7 +46,7 @@ import org.jetbrains.kotlin.psi.psiUtil.isPrivate
  * </compliant>
  */
 @ActiveByDefault(since = "1.0.0")
-class MatchingDeclarationName(config: Config = Config.empty) : Rule(config) {
+class MatchingDeclarationName(config: Config) : Rule(config) {
 
     override val issue: Issue = Issue(
         javaClass.simpleName,

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MemberNameEqualsClassName.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MemberNameEqualsClassName.kt
@@ -53,7 +53,7 @@ import org.jetbrains.kotlin.resolve.BindingContext
  */
 @RequiresTypeResolution
 @ActiveByDefault(since = "1.2.0")
-class MemberNameEqualsClassName(config: Config = Config.empty) : Rule(config) {
+class MemberNameEqualsClassName(config: Config) : Rule(config) {
 
     override val issue = Issue(
         javaClass.simpleName,

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NoNameShadowing.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NoNameShadowing.kt
@@ -48,7 +48,7 @@ import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
  */
 @RequiresTypeResolution
 @ActiveByDefault(since = "1.21.0")
-class NoNameShadowing(config: Config = Config.empty) : Rule(config) {
+class NoNameShadowing(config: Config) : Rule(config) {
     override val issue = Issue(
         javaClass.simpleName,
         "Disallow shadowing variable declarations.",

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NonBooleanPropertyPrefixedWithIs.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NonBooleanPropertyPrefixedWithIs.kt
@@ -30,7 +30,7 @@ import org.jetbrains.kotlin.types.isError
  * </compliant>
  */
 @RequiresTypeResolution
-class NonBooleanPropertyPrefixedWithIs(config: Config = Config.empty) : Rule(config) {
+class NonBooleanPropertyPrefixedWithIs(config: Config) : Rule(config) {
 
     private val booleanTypes = listOf(
         "kotlin.Boolean",

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNaming.kt
@@ -20,7 +20,7 @@ import org.jetbrains.kotlin.psi.psiUtil.isPrivate
  * Reports property names inside objects that do not follow the specified naming convention.
  */
 @ActiveByDefault(since = "1.0.0")
-class ObjectPropertyNaming(config: Config = Config.empty) : Rule(config) {
+class ObjectPropertyNaming(config: Config) : Rule(config) {
 
     override val issue = Issue(
         javaClass.simpleName,

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/PackageNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/PackageNaming.kt
@@ -14,7 +14,7 @@ import org.jetbrains.kotlin.psi.KtPackageDirective
  * Reports package names that do not follow the specified naming convention.
  */
 @ActiveByDefault(since = "1.0.0")
-class PackageNaming(config: Config = Config.empty) : Rule(config) {
+class PackageNaming(config: Config) : Rule(config) {
 
     override val defaultRuleIdAliases: Set<String> = setOf("PackageName", "PackageDirectoryMismatch")
 

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/TopLevelPropertyNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/TopLevelPropertyNaming.kt
@@ -17,7 +17,7 @@ import org.jetbrains.kotlin.psi.psiUtil.isPrivate
  * Reports top level constant that which do not follow the specified naming convention.
  */
 @ActiveByDefault(since = "1.0.0")
-class TopLevelPropertyNaming(config: Config = Config.empty) : Rule(config) {
+class TopLevelPropertyNaming(config: Config) : Rule(config) {
 
     override val issue = Issue(
         javaClass.simpleName,

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableMaxLength.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableMaxLength.kt
@@ -14,7 +14,7 @@ import org.jetbrains.kotlin.psi.KtProperty
 /**
  * Reports when very long variable names are used.
  */
-class VariableMaxLength(config: Config = Config.empty) : Rule(config) {
+class VariableMaxLength(config: Config) : Rule(config) {
 
     override val issue = Issue(
         javaClass.simpleName,

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableMinLength.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableMinLength.kt
@@ -15,7 +15,7 @@ import org.jetbrains.kotlin.resolve.calls.util.isSingleUnderscore
 /**
  * Reports when very short variable names are used.
  */
-class VariableMinLength(config: Config = Config.empty) : Rule(config) {
+class VariableMinLength(config: Config) : Rule(config) {
 
     override val issue = Issue(
         javaClass.simpleName,

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableNaming.kt
@@ -21,7 +21,7 @@ import org.jetbrains.kotlin.resolve.calls.util.isSingleUnderscore
  * Reports variable names that do not follow the specified naming convention.
  */
 @ActiveByDefault(since = "1.0.0")
-class VariableNaming(config: Config = Config.empty) : Rule(config) {
+class VariableNaming(config: Config) : Rule(config) {
 
     override val issue = Issue(
         javaClass.simpleName,

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/BooleanPropertyNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/BooleanPropertyNamingSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.naming
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
@@ -11,7 +12,7 @@ import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
 class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
-    val subject = BooleanPropertyNaming()
+    val subject = BooleanPropertyNaming(Config.empty)
 
     @Nested
     inner class `argument declarations` {

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ClassNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ClassNamingSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.naming
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLint
@@ -18,7 +19,7 @@ class ClassNamingSpec {
             }
         """.trimIndent()
 
-        assertThat(ClassNaming().compileAndLint(code)).isEmpty()
+        assertThat(ClassNaming(Config.empty).compileAndLint(code)).isEmpty()
     }
 
     @Test
@@ -39,7 +40,7 @@ class ClassNamingSpec {
             class MyClassWithNumbers5
         """.trimIndent()
 
-        assertThat(ClassNaming().compileAndLint(code)).isEmpty()
+        assertThat(ClassNaming(Config.empty).compileAndLint(code)).isEmpty()
     }
 
     @Test
@@ -49,7 +50,7 @@ class ClassNamingSpec {
             }
         """.trimIndent()
 
-        assertThat(ClassNaming().compileAndLint(code)).isEmpty()
+        assertThat(ClassNaming(Config.empty).compileAndLint(code)).isEmpty()
     }
 
     @Test
@@ -58,7 +59,7 @@ class ClassNamingSpec {
             class `NamingConventions`
         """.trimIndent()
 
-        assertThat(ClassNaming().compileAndLint(code)).isEmpty()
+        assertThat(ClassNaming(Config.empty).compileAndLint(code)).isEmpty()
     }
 
     @Test
@@ -67,7 +68,7 @@ class ClassNamingSpec {
             class _NamingConventions
         """.trimIndent()
 
-        assertThat(ClassNaming().compileAndLint(code))
+        assertThat(ClassNaming(Config.empty).compileAndLint(code))
             .hasSize(1)
             .hasTextLocations(6 to 24)
     }
@@ -78,7 +79,7 @@ class ClassNamingSpec {
             class namingConventions {}
         """.trimIndent()
 
-        assertThat(ClassNaming().compileAndLint(code))
+        assertThat(ClassNaming(Config.empty).compileAndLint(code))
             .hasSize(1)
             .hasTextLocations(6 to 23)
     }
@@ -89,7 +90,7 @@ class ClassNamingSpec {
             @Suppress("ClassName")
             class namingConventions {}
         """.trimIndent()
-        assertThat(ClassNaming().compileAndLint(code)).isEmpty()
+        assertThat(ClassNaming(Config.empty).compileAndLint(code)).isEmpty()
     }
 
     @Test
@@ -101,6 +102,6 @@ class ClassNamingSpec {
             }
         """.trimIndent()
 
-        assertThat(ClassNaming().compileAndLint(code)).isEmpty()
+        assertThat(ClassNaming(Config.empty).compileAndLint(code)).isEmpty()
     }
 }

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ConstructorParameterNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ConstructorParameterNamingSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.naming
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.junit.jupiter.api.Nested
@@ -17,7 +18,7 @@ class ConstructorParameterNamingSpec {
                 constructor(param: String, privateParam: String) {}
             }
         """.trimIndent()
-        assertThat(ConstructorParameterNaming().compileAndLint(code)).isEmpty()
+        assertThat(ConstructorParameterNaming(Config.empty).compileAndLint(code)).isEmpty()
     }
 
     @Test
@@ -30,7 +31,7 @@ class ConstructorParameterNamingSpec {
                 constructor(PARAM: String, PRIVATE_PARAM: String) {}
             }
         """.trimIndent()
-        assertThat(ConstructorParameterNaming().compileAndLint(code)).hasSize(5)
+        assertThat(ConstructorParameterNaming(Config.empty).compileAndLint(code)).hasSize(5)
     }
 
     @Test
@@ -38,7 +39,7 @@ class ConstructorParameterNamingSpec {
         val code = """
             class C(val PARAM: String)
         """.trimIndent()
-        assertThat(ConstructorParameterNaming().compileAndLint(code)).hasTextLocations(8 to 25)
+        assertThat(ConstructorParameterNaming(Config.empty).compileAndLint(code)).hasTextLocations(8 to 25)
     }
 
     @Test
@@ -48,7 +49,7 @@ class ConstructorParameterNamingSpec {
             
             interface I { val PARAM: String }
         """.trimIndent()
-        assertThat(ConstructorParameterNaming().compileAndLint(code)).isEmpty()
+        assertThat(ConstructorParameterNaming(Config.empty).compileAndLint(code)).isEmpty()
     }
 
     @Nested
@@ -58,7 +59,7 @@ class ConstructorParameterNamingSpec {
             val code = """
                 class Foo(val `is`: Boolean)
             """.trimIndent()
-            assertThat(ConstructorParameterNaming().compileAndLint(code)).isEmpty()
+            assertThat(ConstructorParameterNaming(Config.empty).compileAndLint(code)).isEmpty()
         }
 
         @Test
@@ -66,7 +67,7 @@ class ConstructorParameterNamingSpec {
             val code = """
                 class Foo(private val `is`: Boolean)
             """.trimIndent()
-            assertThat(ConstructorParameterNaming().compileAndLint(code)).isEmpty()
+            assertThat(ConstructorParameterNaming(Config.empty).compileAndLint(code)).isEmpty()
         }
 
         @Test
@@ -74,7 +75,7 @@ class ConstructorParameterNamingSpec {
             val code = """
                 class Foo(private val `PARAM_NAME`: Boolean)
             """.trimIndent()
-            assertThat(ConstructorParameterNaming().compileAndLint(code))
+            assertThat(ConstructorParameterNaming(Config.empty).compileAndLint(code))
                 .hasSize(1)
                 .hasStartSourceLocation(1, 11)
         }
@@ -87,7 +88,7 @@ class ConstructorParameterNamingSpec {
                     constructor(`is`: Boolean, `when`: Boolean): this(`is`)
                 }
             """.trimIndent()
-            assertThat(ConstructorParameterNaming().compileAndLint(code)).isEmpty()
+            assertThat(ConstructorParameterNaming(Config.empty).compileAndLint(code)).isEmpty()
         }
     }
 }

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/EnumNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/EnumNamingSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.naming
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLint
@@ -23,7 +24,7 @@ class EnumNamingSpec {
 
     @Test
     fun `should detect no violation`() {
-        val findings = EnumNaming().compileAndLint(
+        val findings = EnumNaming(Config.empty).compileAndLint(
             """
                 enum class WorkFlow {
                     ACTIVE, NOT_ACTIVE, Unknown, Number1
@@ -40,7 +41,7 @@ class EnumNamingSpec {
                 default
             }
         """.trimIndent()
-        assertThat(EnumNaming().compileAndLint(code)).hasSize(1)
+        assertThat(EnumNaming(Config.empty).compileAndLint(code)).hasSize(1)
     }
 
     @Test
@@ -50,7 +51,7 @@ class EnumNamingSpec {
                 _Default
             }
         """.trimIndent()
-        assertThat(EnumNaming().compileAndLint(code)).hasSize(1)
+        assertThat(EnumNaming(Config.empty).compileAndLint(code)).hasSize(1)
     }
 
     @Test
@@ -60,7 +61,7 @@ class EnumNamingSpec {
                 @Suppress("EnumNaming") _Default
             }
         """.trimIndent()
-        assertThat(EnumNaming().compileAndLint(code)).isEmpty()
+        assertThat(EnumNaming(Config.empty).compileAndLint(code)).isEmpty()
     }
 
     @Test
@@ -70,7 +71,7 @@ class EnumNamingSpec {
                 _Default,
             }
         """.trimIndent()
-        val findings = EnumNaming().compileAndLint(code)
+        val findings = EnumNaming(Config.empty).compileAndLint(code)
         assertThat(findings).hasTextLocations(26 to 34)
     }
 }

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionMinNameLengthSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionMinNameLengthSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.naming
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.assertj.core.api.Assertions.assertThat
@@ -10,7 +11,7 @@ class FunctionMinNameLengthSpec {
     @Test
     fun `should report a function name that is too short`() {
         val code = "fun a() = 3"
-        assertThat(FunctionNameMinLength().compileAndLint(code)).hasSize(1)
+        assertThat(FunctionNameMinLength(Config.empty).compileAndLint(code)).hasSize(1)
     }
 
     @Test
@@ -25,7 +26,7 @@ class FunctionMinNameLengthSpec {
     @Test
     fun `should not report a function name that is okay`() {
         val code = "fun three() = 3"
-        assertThat(FunctionNameMinLength().compileAndLint(code)).isEmpty()
+        assertThat(FunctionNameMinLength(Config.empty).compileAndLint(code)).isEmpty()
     }
 
     @Test

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNameMaxLengthSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNameMaxLengthSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.naming
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLint
@@ -31,13 +32,13 @@ class FunctionNameMaxLengthSpec {
     @Test
     fun `should report a function name that is too long`() {
         val code = "fun thisFunctionIsDefinitelyWayTooLongAndShouldBeMuchShorter() = 3"
-        assertThat(FunctionNameMaxLength().compileAndLint(code)).hasSize(1)
+        assertThat(FunctionNameMaxLength(Config.empty).compileAndLint(code)).hasSize(1)
     }
 
     @Test
     fun `should not report a function name that is okay`() {
         val code = "fun three() = 3"
-        assertThat(FunctionNameMaxLength().compileAndLint(code)).isEmpty()
+        assertThat(FunctionNameMaxLength(Config.empty).compileAndLint(code)).isEmpty()
     }
 
     @Test

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNamingSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.naming
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
@@ -17,7 +18,7 @@ class FunctionNamingSpec {
             @Suppress("FunctionName")
             fun MY_FUN() {}
         """.trimIndent()
-        assertThat(FunctionNaming().compileAndLint(code)).isEmpty()
+        assertThat(FunctionNaming(Config.empty).compileAndLint(code)).isEmpty()
     }
 
     @Test
@@ -27,7 +28,7 @@ class FunctionNamingSpec {
                 return i + i
             }
         """.trimIndent()
-        assertThat(FunctionNaming().compileAndLint(code)).isEmpty()
+        assertThat(FunctionNaming(Config.empty).compileAndLint(code)).isEmpty()
     }
 
     @Test
@@ -51,7 +52,7 @@ class FunctionNamingSpec {
             }
             interface I { fun shouldNotBeFlagged() }
         """.trimIndent()
-        assertThat(FunctionNaming().compileAndLint(code)).hasStartSourceLocation(3, 13)
+        assertThat(FunctionNaming(Config.empty).compileAndLint(code)).hasStartSourceLocation(3, 13)
     }
 
     @Test
@@ -62,7 +63,7 @@ class FunctionNamingSpec {
             }
             interface I { @Suppress("FunctionNaming") fun SHOULD_NOT_BE_FLAGGED() }
         """.trimIndent()
-        assertThat(FunctionNaming().compileAndLint(code)).isEmpty()
+        assertThat(FunctionNaming(Config.empty).compileAndLint(code)).isEmpty()
     }
 
     @Test
@@ -73,7 +74,7 @@ class FunctionNamingSpec {
             
             fun Foo(): Foo = FooImpl()
         """.trimIndent()
-        assertThat(FunctionNaming().compileAndLint(code)).isEmpty()
+        assertThat(FunctionNaming(Config.empty).compileAndLint(code)).isEmpty()
     }
 
     @Test
@@ -82,7 +83,7 @@ class FunctionNamingSpec {
             interface Foo<T>
             fun <T> Foo(): Foo<T> = object : Foo<T> {}
         """.trimIndent()
-        assertThat(FunctionNaming().compileAndLint(code)).isEmpty()
+        assertThat(FunctionNaming(Config.empty).compileAndLint(code)).isEmpty()
     }
 
     @Test
@@ -95,7 +96,7 @@ class FunctionNamingSpec {
             }
             interface I { @Suppress("FunctionNaming") fun SHOULD_BE_FLAGGED() }
         """.trimIndent()
-        assertThat(FunctionNaming().compileAndLint(code)).hasStartSourceLocation(3, 13)
+        assertThat(FunctionNaming(Config.empty).compileAndLint(code)).hasStartSourceLocation(3, 13)
     }
 
     @Test
@@ -103,7 +104,7 @@ class FunctionNamingSpec {
         val code = """
             fun `7his is a function name _`() = Unit
         """.trimIndent()
-        assertThat(FunctionNaming().compileAndLint(code)).hasStartSourceLocations(SourceLocation(1, 5))
+        assertThat(FunctionNaming(Config.empty).compileAndLint(code)).hasStartSourceLocations(SourceLocation(1, 5))
     }
 
     @Test
@@ -135,7 +136,7 @@ class FunctionNamingSpec {
 
     @Test
     fun `should report a function name that begins with a backtick, capitals, and spaces`() {
-        val subject = FunctionNaming()
+        val subject = FunctionNaming(Config.empty)
         val code = "fun `Hi bye`() = 3"
         subject.compileAndLint(code)
         assertThat(subject.findings).hasSize(1)
@@ -179,6 +180,6 @@ class FunctionNamingSpec {
                 val (_, HOLY_GRAIL) = D(5, 4)
             }
         """.trimIndent()
-        assertThat(FunctionNaming().compileAndLint(code)).isEmpty()
+        assertThat(FunctionNaming(Config.empty).compileAndLint(code)).isEmpty()
     }
 }

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionParameterNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionParameterNamingSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.naming
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLint
@@ -20,7 +21,7 @@ class FunctionParameterNamingSpec {
                     fun someStuff(param: String) {}
                 }
             """.trimIndent()
-            assertThat(FunctionParameterNaming().compileAndLint(code)).isEmpty()
+            assertThat(FunctionParameterNaming(Config.empty).compileAndLint(code)).isEmpty()
         }
 
         @Test
@@ -31,7 +32,7 @@ class FunctionParameterNamingSpec {
                 }
                 interface I { fun someStuff(@Suppress("FunctionParameterNaming") `object`: String) }
             """.trimIndent()
-            assertThat(FunctionParameterNaming().compileAndLint(code)).isEmpty()
+            assertThat(FunctionParameterNaming(Config.empty).compileAndLint(code)).isEmpty()
         }
 
         @Test
@@ -41,7 +42,7 @@ class FunctionParameterNamingSpec {
                     fun someStuff(PARAM: String) {}
                 }
             """.trimIndent()
-            assertThat(FunctionParameterNaming().compileAndLint(code)).hasSize(1)
+            assertThat(FunctionParameterNaming(Config.empty).compileAndLint(code)).hasSize(1)
         }
     }
 

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/InvalidPackageDeclarationSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/InvalidPackageDeclarationSpec.kt
@@ -1,6 +1,7 @@
 package io.gitlab.arturbosch.detekt.rules.naming
 
 import io.github.detekt.test.utils.compileForTest
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lint
@@ -16,7 +17,7 @@ class InvalidPackageDeclarationSpec {
     @Test
     fun `should pass if package declaration is correct`() {
         val ktFile = compileForTest(Path("src/test/resources/InvalidPackageDeclarationSpec/src/foo/bar/correct.kt"))
-        val findings = InvalidPackageDeclaration().lint(ktFile)
+        val findings = InvalidPackageDeclaration(Config.empty).lint(ktFile)
 
         assertThat(findings).isEmpty()
     }
@@ -24,7 +25,7 @@ class InvalidPackageDeclarationSpec {
     @Test
     fun `should ignore the issue by alias suppression`() {
         val ktFile = compileForTest(Path("src/test/resources/InvalidPackageDeclarationSpec/src/bar/suppressed.kt"))
-        val findings = InvalidPackageDeclaration().lint(ktFile)
+        val findings = InvalidPackageDeclaration(Config.empty).lint(ktFile)
 
         assertThat(findings).isEmpty()
     }
@@ -32,7 +33,7 @@ class InvalidPackageDeclarationSpec {
     @Test
     fun `should report if package declaration does not match source location`() {
         val ktFile = compileForTest(Path("src/test/resources/InvalidPackageDeclarationSpec/src/bar/incorrect.kt"))
-        val findings = InvalidPackageDeclaration().lint(ktFile)
+        val findings = InvalidPackageDeclaration(Config.empty).lint(ktFile)
 
         assertThat(findings).hasSize(1)
         assertThat(findings).hasTextLocations(0 to 11)

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/LambdaParameterNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/LambdaParameterNamingSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.naming
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.junit.jupiter.api.Test
@@ -11,7 +12,7 @@ class LambdaParameterNamingSpec {
         val code = """
             val a: (String) -> Unit = { HELLO_THERE -> Unit }
         """.trimIndent()
-        assertThat(LambdaParameterNaming().compileAndLint(code))
+        assertThat(LambdaParameterNaming(Config.empty).compileAndLint(code))
             .hasSize(1)
             .hasTextLocations("HELLO_THERE")
     }
@@ -21,7 +22,7 @@ class LambdaParameterNamingSpec {
         val code = """
             val a: (String, Int) -> Unit = { HI, HELLO_THERE -> Unit }
         """.trimIndent()
-        assertThat(LambdaParameterNaming().compileAndLint(code))
+        assertThat(LambdaParameterNaming(Config.empty).compileAndLint(code))
             .hasSize(2)
             .hasTextLocations("HI", "HELLO_THERE")
     }
@@ -31,7 +32,7 @@ class LambdaParameterNamingSpec {
         val code = """
             val a: (String) -> Unit = { helloThere -> Unit }
         """.trimIndent()
-        assertThat(LambdaParameterNaming().compileAndLint(code))
+        assertThat(LambdaParameterNaming(Config.empty).compileAndLint(code))
             .isEmpty()
     }
 
@@ -40,7 +41,7 @@ class LambdaParameterNamingSpec {
         val code = """
             val a = { helloThere: String -> Unit }
         """.trimIndent()
-        assertThat(LambdaParameterNaming().compileAndLint(code))
+        assertThat(LambdaParameterNaming(Config.empty).compileAndLint(code))
             .isEmpty()
     }
 
@@ -49,7 +50,7 @@ class LambdaParameterNamingSpec {
         val code = """
             val a: (String) -> Unit = { _ -> Unit }
         """.trimIndent()
-        assertThat(LambdaParameterNaming().compileAndLint(code))
+        assertThat(LambdaParameterNaming(Config.empty).compileAndLint(code))
             .isEmpty()
     }
 
@@ -58,7 +59,7 @@ class LambdaParameterNamingSpec {
         val code = """
             val a: (String) -> Unit = { Unit }
         """.trimIndent()
-        assertThat(LambdaParameterNaming().compileAndLint(code))
+        assertThat(LambdaParameterNaming(Config.empty).compileAndLint(code))
             .isEmpty()
     }
 
@@ -67,7 +68,7 @@ class LambdaParameterNamingSpec {
         val code = """
             val a: () -> Unit = { Unit }
         """.trimIndent()
-        assertThat(LambdaParameterNaming().compileAndLint(code))
+        assertThat(LambdaParameterNaming(Config.empty).compileAndLint(code))
             .isEmpty()
     }
 
@@ -77,7 +78,7 @@ class LambdaParameterNamingSpec {
             data class Bar(val a: String)
             val a: (Bar) -> Unit = { (HELLO_THERE) -> Unit }
         """.trimIndent()
-        assertThat(LambdaParameterNaming().compileAndLint(code))
+        assertThat(LambdaParameterNaming(Config.empty).compileAndLint(code))
             .hasSize(1)
             .hasTextLocations("HELLO_THERE")
     }
@@ -88,7 +89,7 @@ class LambdaParameterNamingSpec {
             data class Bar(val a: String, val b: String)
             val a: (Bar) -> Unit = { (HI, HELLO_THERE) -> Unit }
         """.trimIndent()
-        assertThat(LambdaParameterNaming().compileAndLint(code))
+        assertThat(LambdaParameterNaming(Config.empty).compileAndLint(code))
             .hasSize(2)
             .hasTextLocations("HI", "HELLO_THERE")
     }
@@ -99,7 +100,7 @@ class LambdaParameterNamingSpec {
             data class Bar(val a: String, val b: String)
             val a: (Bar) -> Unit = { (a, b) -> Unit }
         """.trimIndent()
-        assertThat(LambdaParameterNaming().compileAndLint(code))
+        assertThat(LambdaParameterNaming(Config.empty).compileAndLint(code))
             .isEmpty()
     }
 
@@ -109,7 +110,7 @@ class LambdaParameterNamingSpec {
             data class Bar(val a: String, val b: String)
             val a: (Bar) -> Unit = { (a: String, b) -> Unit }
         """.trimIndent()
-        assertThat(LambdaParameterNaming().compileAndLint(code))
+        assertThat(LambdaParameterNaming(Config.empty).compileAndLint(code))
             .isEmpty()
     }
 
@@ -119,7 +120,7 @@ class LambdaParameterNamingSpec {
             data class Bar(val a: String, val b: String)
             val a: (Bar) -> Unit = { (_, b) -> Unit }
         """.trimIndent()
-        assertThat(LambdaParameterNaming().compileAndLint(code))
+        assertThat(LambdaParameterNaming(Config.empty).compileAndLint(code))
             .isEmpty()
     }
 
@@ -128,7 +129,7 @@ class LambdaParameterNamingSpec {
         val code = """
             data class C(val _invalid: String)
         """.trimIndent()
-        assertThat(LambdaParameterNaming().compileAndLint(code))
+        assertThat(LambdaParameterNaming(Config.empty).compileAndLint(code))
             .isEmpty()
     }
 
@@ -137,7 +138,7 @@ class LambdaParameterNamingSpec {
         val code = """
             fun f(_invalid: String) = Unit
         """.trimIndent()
-        assertThat(LambdaParameterNaming().compileAndLint(code))
+        assertThat(LambdaParameterNaming(Config.empty).compileAndLint(code))
             .isEmpty()
     }
 }

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MatchingDeclarationNameSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MatchingDeclarationNameSpec.kt
@@ -1,6 +1,7 @@
 package io.gitlab.arturbosch.detekt.rules.naming
 
 import io.github.detekt.test.utils.compileContentForTest
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lint
@@ -15,7 +16,7 @@ class MatchingDeclarationNameSpec {
         @Test
         fun `should pass for object declaration`() {
             val ktFile = compileContentForTest("object O", filename = "O.kt")
-            val findings = MatchingDeclarationName().lint(ktFile)
+            val findings = MatchingDeclarationName(Config.empty).lint(ktFile)
             assertThat(findings).isEmpty()
         }
 
@@ -29,21 +30,21 @@ class MatchingDeclarationNameSpec {
                 """.trimIndent(),
                 filename = "Objects.kt"
             )
-            val findings = MatchingDeclarationName().lint(ktFile)
+            val findings = MatchingDeclarationName(Config.empty).lint(ktFile)
             assertThat(findings).isEmpty()
         }
 
         @Test
         fun `should pass for class declaration`() {
             val ktFile = compileContentForTest("class C", filename = "C.kt")
-            val findings = MatchingDeclarationName().lint(ktFile)
+            val findings = MatchingDeclarationName(Config.empty).lint(ktFile)
             assertThat(findings).isEmpty()
         }
 
         @Test
         fun `should pass for interface declaration`() {
             val ktFile = compileContentForTest("interface I", filename = "I.kt")
-            val findings = MatchingDeclarationName().lint(ktFile)
+            val findings = MatchingDeclarationName(Config.empty).lint(ktFile)
             assertThat(findings).isEmpty()
         }
 
@@ -57,7 +58,7 @@ class MatchingDeclarationNameSpec {
                 """.trimIndent(),
                 filename = "E.kt"
             )
-            val findings = MatchingDeclarationName().lint(ktFile)
+            val findings = MatchingDeclarationName(Config.empty).lint(ktFile)
             assertThat(findings).isEmpty()
         }
 
@@ -71,7 +72,7 @@ class MatchingDeclarationNameSpec {
                 """.trimIndent(),
                 filename = "MultiDeclarations.kt"
             )
-            val findings = MatchingDeclarationName().lint(ktFile)
+            val findings = MatchingDeclarationName(Config.empty).lint(ktFile)
             assertThat(findings).isEmpty()
         }
 
@@ -85,7 +86,7 @@ class MatchingDeclarationNameSpec {
                 """.trimIndent(),
                 filename = "C.kt"
             )
-            val findings = MatchingDeclarationName().lint(ktFile)
+            val findings = MatchingDeclarationName(Config.empty).lint(ktFile)
             assertThat(findings).isEmpty()
         }
 
@@ -99,7 +100,7 @@ class MatchingDeclarationNameSpec {
                 """.trimIndent(),
                 filename = "Classes.kt"
             )
-            val findings = MatchingDeclarationName().lint(ktFile)
+            val findings = MatchingDeclarationName(Config.empty).lint(ktFile)
             assertThat(findings).isEmpty()
         }
 
@@ -112,7 +113,7 @@ class MatchingDeclarationNameSpec {
                 """.trimIndent(),
                 filename = "b.kt"
             )
-            val findings = MatchingDeclarationName().lint(ktFile)
+            val findings = MatchingDeclarationName(Config.empty).lint(ktFile)
             assertThat(findings).isEmpty()
         }
 
@@ -124,14 +125,14 @@ class MatchingDeclarationNameSpec {
                 class FooImpl {}
             """.trimIndent()
             val ktFile = compileContentForTest(code, filename = "Foo.kt")
-            val findings = MatchingDeclarationName().lint(ktFile)
+            val findings = MatchingDeclarationName(Config.empty).lint(ktFile)
             assertThat(findings).isEmpty()
         }
 
         @Test
         fun `should pass for class declaration and name with platform suffix`() {
             val ktFile = compileContentForTest("actual class C", filename = "C.android.kt")
-            val findings = MatchingDeclarationName().lint(ktFile)
+            val findings = MatchingDeclarationName(Config.empty).lint(ktFile)
             assertThat(findings).isEmpty()
         }
 
@@ -151,14 +152,14 @@ class MatchingDeclarationNameSpec {
         @Test
         fun `should not pass for object declaration`() {
             val ktFile = compileContentForTest("object O", filename = "Objects.kt")
-            val findings = MatchingDeclarationName().lint(ktFile)
+            val findings = MatchingDeclarationName(Config.empty).lint(ktFile)
             assertThat(findings).hasStartSourceLocation(1, 8)
         }
 
         @Test
         fun `should not pass for class declaration with name and unknown suffix`() {
             val ktFile = compileContentForTest("class C", filename = "Object.mySuffix.kt")
-            val findings = MatchingDeclarationName().lint(ktFile)
+            val findings = MatchingDeclarationName(Config.empty).lint(ktFile)
             assertThat(findings).hasStartSourceLocation(1, 7)
         }
 
@@ -168,14 +169,14 @@ class MatchingDeclarationNameSpec {
                 """@Suppress("MatchingDeclarationName") object O""",
                 filename = "Objects.kt"
             )
-            val findings = MatchingDeclarationName().lint(ktFile)
+            val findings = MatchingDeclarationName(Config.empty).lint(ktFile)
             assertThat(findings).hasStartSourceLocation(1, 45)
         }
 
         @Test
         fun `should not pass for class declaration`() {
             val ktFile = compileContentForTest("class C", filename = "Classes.kt")
-            val findings = MatchingDeclarationName().lint(ktFile)
+            val findings = MatchingDeclarationName(Config.empty).lint(ktFile)
             assertThat(findings).hasStartSourceLocation(1, 7)
         }
 
@@ -189,14 +190,14 @@ class MatchingDeclarationNameSpec {
                 """.trimIndent(),
                 filename = "ClassUtils.kt"
             )
-            val findings = MatchingDeclarationName().lint(ktFile)
+            val findings = MatchingDeclarationName(Config.empty).lint(ktFile)
             assertThat(findings).hasStartSourceLocation(1, 7)
         }
 
         @Test
         fun `should not pass for interface declaration`() {
             val ktFile = compileContentForTest("interface I", filename = "Not_I.kt")
-            val findings = MatchingDeclarationName().lint(ktFile)
+            val findings = MatchingDeclarationName(Config.empty).lint(ktFile)
             assertThat(findings).hasStartSourceLocation(1, 11)
         }
 
@@ -210,7 +211,7 @@ class MatchingDeclarationNameSpec {
                 """.trimIndent(),
                 filename = "E.kt"
             )
-            val findings = MatchingDeclarationName().lint(ktFile)
+            val findings = MatchingDeclarationName(Config.empty).lint(ktFile)
             assertThat(findings).hasStartSourceLocation(1, 12)
         }
 
@@ -221,7 +222,7 @@ class MatchingDeclarationNameSpec {
                 typealias Bar = FooImpl
             """.trimIndent()
             val ktFile = compileContentForTest(code, filename = "Foo.kt")
-            val findings = MatchingDeclarationName().lint(ktFile)
+            val findings = MatchingDeclarationName(Config.empty).lint(ktFile)
             assertThat(findings).hasSize(1)
         }
 
@@ -244,7 +245,7 @@ class MatchingDeclarationNameSpec {
         @Test
         fun `should not pass for class declaration and name with common suffix`() {
             val ktFile = compileContentForTest("class C", filename = "C.common.kt")
-            val findings = MatchingDeclarationName().lint(ktFile)
+            val findings = MatchingDeclarationName(Config.empty).lint(ktFile)
             assertThat(findings).hasStartSourceLocation(1, 7)
         }
 

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MemberNameEqualsClassNameSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MemberNameEqualsClassNameSpec.kt
@@ -67,7 +67,7 @@ class MemberNameEqualsClassNameSpec(val env: KotlinCoreEnvironment) {
                     fun methodNameEqualsClassName() {}
                 }
             """.trimIndent()
-            assertThat(MemberNameEqualsClassName().compileAndLint(code)).hasSize(1)
+            assertThat(MemberNameEqualsClassName(Config.empty).compileAndLint(code)).hasSize(1)
         }
 
         @Test
@@ -77,7 +77,7 @@ class MemberNameEqualsClassNameSpec(val env: KotlinCoreEnvironment) {
                     fun MethodNameEqualsObjectName() {}
                 }
             """.trimIndent()
-            assertThat(MemberNameEqualsClassName().compileAndLint(code)).hasSize(1)
+            assertThat(MemberNameEqualsClassName(Config.empty).compileAndLint(code)).hasSize(1)
         }
 
         @Test
@@ -87,7 +87,7 @@ class MemberNameEqualsClassNameSpec(val env: KotlinCoreEnvironment) {
                     val propertyNameEqualsClassName = 0
                 }
             """.trimIndent()
-            assertThat(MemberNameEqualsClassName().compileAndLint(code)).hasSize(1)
+            assertThat(MemberNameEqualsClassName(Config.empty).compileAndLint(code)).hasSize(1)
         }
 
         @Test
@@ -97,7 +97,7 @@ class MemberNameEqualsClassNameSpec(val env: KotlinCoreEnvironment) {
                     val propertyNameEqualsObjectName = 0
                 }
             """.trimIndent()
-            assertThat(MemberNameEqualsClassName().compileAndLint(code)).hasSize(1)
+            assertThat(MemberNameEqualsClassName(Config.empty).compileAndLint(code)).hasSize(1)
         }
 
         @Test
@@ -109,7 +109,7 @@ class MemberNameEqualsClassNameSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(MemberNameEqualsClassName().compileAndLint(code)).hasSize(1)
+            assertThat(MemberNameEqualsClassName(Config.empty).compileAndLint(code)).hasSize(1)
         }
 
         @Test
@@ -121,7 +121,7 @@ class MemberNameEqualsClassNameSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(MemberNameEqualsClassName().compileAndLint(code)).hasSize(1)
+            assertThat(MemberNameEqualsClassName(Config.empty).compileAndLint(code)).hasSize(1)
         }
 
         @Test
@@ -134,7 +134,7 @@ class MemberNameEqualsClassNameSpec(val env: KotlinCoreEnvironment) {
                     abstract fun AbstractMethodNameEqualsClassName()
                 }
             """.trimIndent()
-            assertThat(MemberNameEqualsClassName().compileAndLint(code)).isEmpty()
+            assertThat(MemberNameEqualsClassName(Config.empty).compileAndLint(code)).isEmpty()
         }
 
         @Test
@@ -144,7 +144,7 @@ class MemberNameEqualsClassNameSpec(val env: KotlinCoreEnvironment) {
                     fun MethodNameEqualsInterfaceName() {}
                 }
             """.trimIndent()
-            assertThat(MemberNameEqualsClassName().compileAndLint(code)).isEmpty()
+            assertThat(MemberNameEqualsClassName(Config.empty).compileAndLint(code)).isEmpty()
         }
 
         @Test
@@ -170,7 +170,7 @@ class MemberNameEqualsClassNameSpec(val env: KotlinCoreEnvironment) {
                     abstract val AbstractMethodNameEqualsClassName: String
                 }
             """.trimIndent()
-            assertThat(MemberNameEqualsClassName().compileAndLint(code)).isEmpty()
+            assertThat(MemberNameEqualsClassName(Config.empty).compileAndLint(code)).isEmpty()
         }
 
         @Test
@@ -200,7 +200,7 @@ class MemberNameEqualsClassNameSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(MemberNameEqualsClassName().compileAndLint(code)).hasSize(1)
+            assertThat(MemberNameEqualsClassName(Config.empty).compileAndLint(code)).hasSize(1)
         }
 
         @Test
@@ -215,7 +215,7 @@ class MemberNameEqualsClassNameSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(MemberNameEqualsClassName().compileAndLint(code)).hasSize(1)
+            assertThat(MemberNameEqualsClassName(Config.empty).compileAndLint(code)).hasSize(1)
         }
 
         @Test
@@ -228,7 +228,7 @@ class MemberNameEqualsClassNameSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(MemberNameEqualsClassName().compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(MemberNameEqualsClassName(Config.empty).compileAndLintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -246,7 +246,7 @@ class MemberNameEqualsClassNameSpec(val env: KotlinCoreEnvironment) {
                 
                 class C: A()
             """.trimIndent()
-            assertThat(MemberNameEqualsClassName().compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(MemberNameEqualsClassName(Config.empty).compileAndLintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -263,7 +263,7 @@ class MemberNameEqualsClassNameSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(MemberNameEqualsClassName().compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(MemberNameEqualsClassName(Config.empty).compileAndLintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -280,7 +280,7 @@ class MemberNameEqualsClassNameSpec(val env: KotlinCoreEnvironment) {
                 class C: A()
             """.trimIndent()
 
-            assertThat(MemberNameEqualsClassName().compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(MemberNameEqualsClassName(Config.empty).compileAndLintWithContext(env, code)).isEmpty()
         }
     }
 }

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NoNameShadowingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NoNameShadowingSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.naming
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
@@ -8,7 +9,7 @@ import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
 class NoNameShadowingSpec(val env: KotlinCoreEnvironment) {
-    val subject = NoNameShadowing()
+    val subject = NoNameShadowing(Config.empty)
 
     @Test
     fun `report shadowing variable`() {

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NonBooleanPropertyWithPrefixIsSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NonBooleanPropertyWithPrefixIsSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.naming
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
@@ -10,7 +11,7 @@ import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
 class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinCoreEnvironment) {
-    val subject = NonBooleanPropertyPrefixedWithIs()
+    val subject = NonBooleanPropertyPrefixedWithIs(Config.empty)
 
     @Nested
     inner class `argument declarations` {

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNamingSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.naming
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLint
@@ -15,7 +16,7 @@ class ObjectPropertyNamingSpec {
     @Nested
     inner class `constants in object declarations` {
 
-        val subject = ObjectPropertyNaming()
+        val subject = ObjectPropertyNaming(Config.empty)
 
         @Test
         fun `should not detect public constants complying to the naming rules`() {
@@ -71,7 +72,7 @@ class ObjectPropertyNamingSpec {
     @Nested
     inner class `constants in companion object` {
 
-        val subject = ObjectPropertyNaming()
+        val subject = ObjectPropertyNaming(Config.empty)
 
         @Test
         fun `should not detect public constants complying to the naming rules`() {
@@ -137,7 +138,7 @@ class ObjectPropertyNamingSpec {
     @Nested
     inner class `variables in objects` {
 
-        val subject = ObjectPropertyNaming()
+        val subject = ObjectPropertyNaming(Config.empty)
 
         @Test
         fun `should not detect public variables complying to the naming rules`() {
@@ -235,7 +236,7 @@ class ObjectPropertyNamingSpec {
     inner class `top level properties` {
         @Test
         fun `should not detect top level properties`() {
-            val subject = ObjectPropertyNaming()
+            val subject = ObjectPropertyNaming(Config.empty)
 
             val code = """
                 val _invalidNaming = 1
@@ -247,7 +248,7 @@ class ObjectPropertyNamingSpec {
 
     @Test
     fun `should not detect class properties`() {
-        val subject = ObjectPropertyNaming()
+        val subject = ObjectPropertyNaming(Config.empty)
         val code = """
             class O {
                 val _invalidNaming = 1
@@ -258,7 +259,7 @@ class ObjectPropertyNamingSpec {
 
     @Test
     fun `should not detect properties of class in object declaration`() {
-        val subject = ObjectPropertyNaming()
+        val subject = ObjectPropertyNaming(Config.empty)
         val code = """
             object A {
                 class O {

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/PackageNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/PackageNamingSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.naming
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.assertj.core.api.Assertions.assertThat
@@ -16,7 +17,7 @@ class PackageNamingSpec {
     @Test
     fun `should ignore the issue by alias suppression - PackageName`() {
         assertThat(
-            PackageNaming().compileAndLint(
+            PackageNaming(Config.empty).compileAndLint(
                 """
                     @file:Suppress("PackageName")
                     package FOO.BAR
@@ -28,7 +29,7 @@ class PackageNamingSpec {
     @Test
     fun `should ignore the issue by alias suppression - PackageDirectoryMismatch`() {
         assertThat(
-            PackageNaming().compileAndLint(
+            PackageNaming(Config.empty).compileAndLint(
                 """
                     @file:Suppress("PackageDirectoryMismatch")
                     package FOO.BAR
@@ -39,21 +40,21 @@ class PackageNamingSpec {
 
     @Test
     fun `should find a uppercase package name`() {
-        assertThat(PackageNaming().compileAndLint("package FOO.BAR")).hasSize(1)
+        assertThat(PackageNaming(Config.empty).compileAndLint("package FOO.BAR")).hasSize(1)
     }
 
     @Test
     fun `should find a upper camel case package name`() {
-        assertThat(PackageNaming().compileAndLint("package Foo.Bar")).hasSize(1)
+        assertThat(PackageNaming(Config.empty).compileAndLint("package Foo.Bar")).hasSize(1)
     }
 
     @Test
     fun `should find a camel case package name`() {
-        assertThat(PackageNaming().compileAndLint("package fOO.bAR")).hasSize(1)
+        assertThat(PackageNaming(Config.empty).compileAndLint("package fOO.bAR")).hasSize(1)
     }
 
     @Test
     fun `should check an valid package name`() {
-        assertThat(PackageNaming().compileAndLint("package foo.bar")).isEmpty()
+        assertThat(PackageNaming(Config.empty).compileAndLint("package foo.bar")).isEmpty()
     }
 }

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/TopLevelPropertyNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/TopLevelPropertyNamingSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.naming
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import io.gitlab.arturbosch.detekt.test.lint
@@ -9,7 +10,7 @@ import org.junit.jupiter.api.Test
 
 class TopLevelPropertyNamingSpec {
 
-    val subject = TopLevelPropertyNaming()
+    val subject = TopLevelPropertyNaming(Config.empty)
 
     @Test
     fun `should use custom name top level properties`() {

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableMaxLengthSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableMaxLengthSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.naming
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLint
@@ -15,13 +16,13 @@ class VariableMaxLengthSpec {
                 val (_, status) = getResult()
             }
         """.trimIndent()
-        assertThat(VariableMaxLength().compileAndLint(code)).isEmpty()
+        assertThat(VariableMaxLength(Config.empty).compileAndLint(code)).isEmpty()
     }
 
     @Test
     fun `should not report a variable with 64 letters`() {
         val code = "private val varThatIsExactly64LettersLongWhichYouMightNotWantToBelieveInLolz = 3"
-        assertThat(VariableMaxLength().compileAndLint(code)).isEmpty()
+        assertThat(VariableMaxLength(Config.empty).compileAndLint(code)).isEmpty()
     }
 
     @Test
@@ -45,6 +46,6 @@ class VariableMaxLengthSpec {
     @Test
     fun `should report a variable name that is too long`() {
         val code = "private val thisVariableIsDefinitelyWayTooLongLongerThanEverythingAndShouldBeMuchShorter = 3"
-        assertThat(VariableMaxLength().compileAndLint(code)).hasSize(1)
+        assertThat(VariableMaxLength(Config.empty).compileAndLint(code)).hasSize(1)
     }
 }

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableMinLengthSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableMinLengthSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.naming
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.assertj.core.api.Assertions.assertThat
@@ -34,13 +35,13 @@ class VariableMinLengthSpec {
     @Test
     fun `should not report a variable name that is okay`() {
         val code = "private val thisOneIsCool = 3"
-        assertThat(VariableMinLength().compileAndLint(code)).isEmpty()
+        assertThat(VariableMinLength(Config.empty).compileAndLint(code)).isEmpty()
     }
 
     @Test
     fun `should not report a variable with single letter name`() {
         val code = "private val a = 3"
-        assertThat(VariableMinLength().compileAndLint(code)).isEmpty()
+        assertThat(VariableMinLength(Config.empty).compileAndLint(code)).isEmpty()
     }
 
     @Test
@@ -51,7 +52,7 @@ class VariableMinLengthSpec {
                 val (_, status) = getResult()
             }
         """.trimIndent()
-        assertThat(VariableMinLength().compileAndLint(code)).isEmpty()
+        assertThat(VariableMinLength(Config.empty).compileAndLint(code)).isEmpty()
     }
 
     @Test

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableNamingSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.naming
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
@@ -66,7 +67,7 @@ class VariableNamingSpec {
                 val camel_Case_Property = 5
             }
         """.trimIndent()
-        assertThat(VariableNaming().compileAndLint(code))
+        assertThat(VariableNaming(Config.empty).compileAndLint(code))
             .hasStartSourceLocations(
                 SourceLocation(2, 17),
                 SourceLocation(3, 9),
@@ -83,7 +84,7 @@ class VariableNamingSpec {
                 val camelCaseProperty = 5
             }
         """.trimIndent()
-        assertThat(VariableNaming().compileAndLint(code)).isEmpty()
+        assertThat(VariableNaming(Config.empty).compileAndLint(code)).isEmpty()
     }
 
     @Test
@@ -99,7 +100,7 @@ class VariableNamingSpec {
                 @Suppress("VariableNaming") val SHOULD_NOT_BE_FLAGGED: String
             }
         """.trimIndent()
-        assertThat(VariableNaming().compileAndLint(code)).isEmpty()
+        assertThat(VariableNaming(Config.empty).compileAndLint(code)).isEmpty()
     }
 
     @Test
@@ -112,7 +113,7 @@ class VariableNamingSpec {
                 listOf<Pair<Int, Int>>().flatMap { (right, _) -> listOf(right) }
             }
         """.trimIndent()
-        assertThat(VariableNaming().compileAndLint(code)).isEmpty()
+        assertThat(VariableNaming(Config.empty).compileAndLint(code)).isEmpty()
     }
 
     @Test
@@ -123,6 +124,6 @@ class VariableNamingSpec {
                 val (_, HOLY_GRAIL) = D(5, 4)
             }
         """.trimIndent()
-        assertThat(VariableNaming().compileAndLint(code)).isEmpty()
+        assertThat(VariableNaming(Config.empty).compileAndLint(code)).isEmpty()
     }
 }

--- a/detekt-rules-performance/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/ArrayPrimitive.kt
+++ b/detekt-rules-performance/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/ArrayPrimitive.kt
@@ -40,7 +40,7 @@ import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameOrNull
  */
 @RequiresTypeResolution
 @ActiveByDefault(since = "1.2.0")
-class ArrayPrimitive(config: Config = Config.empty) : Rule(config) {
+class ArrayPrimitive(config: Config) : Rule(config) {
     override val issue = Issue(
         "ArrayPrimitive",
         "Using `Array<Primitive>` leads to implicit boxing and a performance hit.",

--- a/detekt-rules-performance/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/CouldBeSequence.kt
+++ b/detekt-rules-performance/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/CouldBeSequence.kt
@@ -30,7 +30,7 @@ import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameOrNull
  * </compliant>
  */
 @RequiresTypeResolution
-class CouldBeSequence(config: Config = Config.empty) : Rule(config) {
+class CouldBeSequence(config: Config) : Rule(config) {
 
     override val issue: Issue = Issue(
         "CouldBeSequence",

--- a/detekt-rules-performance/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/ForEachOnRange.kt
+++ b/detekt-rules-performance/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/ForEachOnRange.kt
@@ -41,7 +41,7 @@ import org.jetbrains.kotlin.psi2ir.deparenthesize
  * </compliant>
  */
 @ActiveByDefault(since = "1.0.0")
-class ForEachOnRange(config: Config = Config.empty) : Rule(config) {
+class ForEachOnRange(config: Config) : Rule(config) {
 
     override val issue = Issue(
         "ForEachOnRange",

--- a/detekt-rules-performance/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/SpreadOperator.kt
+++ b/detekt-rules-performance/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/SpreadOperator.kt
@@ -48,7 +48,7 @@ import org.jetbrains.kotlin.resolve.calls.util.getResolvedCall
  */
 @RequiresTypeResolution
 @ActiveByDefault(since = "1.0.0")
-class SpreadOperator(config: Config = Config.empty) : Rule(config) {
+class SpreadOperator(config: Config) : Rule(config) {
 
     override val issue: Issue = Issue(
         "SpreadOperator",

--- a/detekt-rules-performance/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/UnnecessaryPartOfBinaryExpression.kt
+++ b/detekt-rules-performance/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/UnnecessaryPartOfBinaryExpression.kt
@@ -32,7 +32,7 @@ import org.jetbrains.kotlin.utils.addIfNotNull
  * </compliant>
  *
  */
-class UnnecessaryPartOfBinaryExpression(config: Config = Config.empty) : Rule(config) {
+class UnnecessaryPartOfBinaryExpression(config: Config) : Rule(config) {
 
     override val issue: Issue = Issue(
         "UnnecessaryPartOfBinaryExpression",

--- a/detekt-rules-performance/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/UnnecessaryTemporaryInstantiation.kt
+++ b/detekt-rules-performance/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/UnnecessaryTemporaryInstantiation.kt
@@ -23,7 +23,7 @@ import org.jetbrains.kotlin.psi.KtExpression
  * </compliant>
  */
 @ActiveByDefault(since = "1.0.0")
-class UnnecessaryTemporaryInstantiation(config: Config = Config.empty) : Rule(config) {
+class UnnecessaryTemporaryInstantiation(config: Config) : Rule(config) {
 
     override val issue: Issue = Issue(
         "UnnecessaryTemporaryInstantiation",

--- a/detekt-rules-performance/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/ArrayPrimitiveSpec.kt
+++ b/detekt-rules-performance/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/ArrayPrimitiveSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.performance
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
 import org.assertj.core.api.Assertions.assertThat
@@ -11,7 +12,7 @@ import org.junit.jupiter.api.Test
 @KotlinCoreEnvironmentTest
 class ArrayPrimitiveSpec(val env: KotlinCoreEnvironment) {
 
-    val subject = ArrayPrimitive()
+    val subject = ArrayPrimitive(Config.empty)
 
     @Nested
     inner class `one function parameter` {

--- a/detekt-rules-performance/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/ForEachOnRangeSpec.kt
+++ b/detekt-rules-performance/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/ForEachOnRangeSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.performance
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
@@ -7,7 +8,7 @@ import org.junit.jupiter.api.Test
 
 class ForEachOnRangeSpec {
 
-    val subject = ForEachOnRange()
+    val subject = ForEachOnRange(Config.empty)
 
     @Nested
     inner class `using a forEach on a range` {

--- a/detekt-rules-performance/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/SpreadOperatorSpec.kt
+++ b/detekt-rules-performance/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/SpreadOperatorSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.performance
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
 import org.assertj.core.api.Assertions.assertThat
@@ -9,7 +10,7 @@ import org.junit.jupiter.api.Test
 @KotlinCoreEnvironmentTest
 class SpreadOperatorSpec(val env: KotlinCoreEnvironment) {
 
-    private val subject = SpreadOperator()
+    private val subject = SpreadOperator(Config.empty)
 
     private val errorMessage = "Used in this way a spread operator causes a full copy of the array to" +
         " be created before calling a method. This may result in a performance penalty."

--- a/detekt-rules-performance/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/UnnecessaryPartOfBinaryExpressionSpec.kt
+++ b/detekt-rules-performance/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/UnnecessaryPartOfBinaryExpressionSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.performance
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.junit.jupiter.api.Test
@@ -18,7 +19,7 @@ class UnnecessaryPartOfBinaryExpressionSpec {
             }
         """.trimIndent()
 
-        val findings = UnnecessaryPartOfBinaryExpression().compileAndLint(code)
+        val findings = UnnecessaryPartOfBinaryExpression(Config.empty).compileAndLint(code)
         assertThat(findings).hasSize(1)
     }
 
@@ -37,7 +38,7 @@ class UnnecessaryPartOfBinaryExpressionSpec {
             }
         """.trimIndent()
 
-        val findings = UnnecessaryPartOfBinaryExpression().compileAndLint(code)
+        val findings = UnnecessaryPartOfBinaryExpression(Config.empty).compileAndLint(code)
         assertThat(findings).hasSize(0)
     }
 
@@ -56,7 +57,7 @@ class UnnecessaryPartOfBinaryExpressionSpec {
             }
         """.trimIndent()
 
-        val findings = UnnecessaryPartOfBinaryExpression().compileAndLint(code)
+        val findings = UnnecessaryPartOfBinaryExpression(Config.empty).compileAndLint(code)
         assertThat(findings).hasSize(1)
     }
 
@@ -72,7 +73,7 @@ class UnnecessaryPartOfBinaryExpressionSpec {
             }
         """.trimIndent()
 
-        val findings = UnnecessaryPartOfBinaryExpression().compileAndLint(code)
+        val findings = UnnecessaryPartOfBinaryExpression(Config.empty).compileAndLint(code)
         assertThat(findings).hasSize(0)
     }
 
@@ -88,7 +89,7 @@ class UnnecessaryPartOfBinaryExpressionSpec {
             }
         """.trimIndent()
 
-        val findings = UnnecessaryPartOfBinaryExpression().compileAndLint(code)
+        val findings = UnnecessaryPartOfBinaryExpression(Config.empty).compileAndLint(code)
         assertThat(findings).hasSize(0)
     }
 
@@ -104,7 +105,7 @@ class UnnecessaryPartOfBinaryExpressionSpec {
             }
         """.trimIndent()
 
-        val findings = UnnecessaryPartOfBinaryExpression().compileAndLint(code)
+        val findings = UnnecessaryPartOfBinaryExpression(Config.empty).compileAndLint(code)
         assertThat(findings).hasSize(1).hasTextLocations("baz && baz")
     }
 
@@ -119,7 +120,7 @@ class UnnecessaryPartOfBinaryExpressionSpec {
             }
         """.trimIndent()
 
-        val findings = UnnecessaryPartOfBinaryExpression().compileAndLint(code)
+        val findings = UnnecessaryPartOfBinaryExpression(Config.empty).compileAndLint(code)
         assertThat(findings).hasSize(1)
     }
 
@@ -136,7 +137,7 @@ class UnnecessaryPartOfBinaryExpressionSpec {
             }
         """.trimIndent()
 
-        val findings = UnnecessaryPartOfBinaryExpression().compileAndLint(code)
+        val findings = UnnecessaryPartOfBinaryExpression(Config.empty).compileAndLint(code)
         assertThat(findings).hasSize(1)
     }
 
@@ -153,7 +154,7 @@ class UnnecessaryPartOfBinaryExpressionSpec {
             }
         """.trimIndent()
 
-        val findings = UnnecessaryPartOfBinaryExpression().compileAndLint(code)
+        val findings = UnnecessaryPartOfBinaryExpression(Config.empty).compileAndLint(code)
         assertThat(findings).hasSize(1)
     }
 
@@ -168,7 +169,7 @@ class UnnecessaryPartOfBinaryExpressionSpec {
             }
         """.trimIndent()
 
-        val findings = UnnecessaryPartOfBinaryExpression().compileAndLint(code)
+        val findings = UnnecessaryPartOfBinaryExpression(Config.empty).compileAndLint(code)
         assertThat(findings).hasSize(1)
     }
 
@@ -183,7 +184,7 @@ class UnnecessaryPartOfBinaryExpressionSpec {
             }
         """.trimIndent()
 
-        val findings = UnnecessaryPartOfBinaryExpression().compileAndLint(code)
+        val findings = UnnecessaryPartOfBinaryExpression(Config.empty).compileAndLint(code)
         assertThat(findings).hasSize(1)
     }
 
@@ -201,7 +202,7 @@ class UnnecessaryPartOfBinaryExpressionSpec {
             }
         """.trimIndent()
 
-        val findings = UnnecessaryPartOfBinaryExpression().compileAndLint(code)
+        val findings = UnnecessaryPartOfBinaryExpression(Config.empty).compileAndLint(code)
         assertThat(findings).hasSize(1)
     }
 
@@ -216,7 +217,7 @@ class UnnecessaryPartOfBinaryExpressionSpec {
             }
         """.trimIndent()
 
-        val findings = UnnecessaryPartOfBinaryExpression().compileAndLint(code)
+        val findings = UnnecessaryPartOfBinaryExpression(Config.empty).compileAndLint(code)
         assertThat(findings).hasSize(0)
     }
 
@@ -232,7 +233,7 @@ class UnnecessaryPartOfBinaryExpressionSpec {
             }
         """.trimIndent()
 
-        val findings = UnnecessaryPartOfBinaryExpression().compileAndLint(code)
+        val findings = UnnecessaryPartOfBinaryExpression(Config.empty).compileAndLint(code)
         assertThat(findings).hasSize(0)
     }
 
@@ -246,7 +247,7 @@ class UnnecessaryPartOfBinaryExpressionSpec {
             }
         """.trimIndent()
 
-        val findings = UnnecessaryPartOfBinaryExpression().compileAndLint(code)
+        val findings = UnnecessaryPartOfBinaryExpression(Config.empty).compileAndLint(code)
         assertThat(findings).hasSize(1)
     }
 
@@ -262,7 +263,7 @@ class UnnecessaryPartOfBinaryExpressionSpec {
             }
         """.trimIndent()
 
-        val findings = UnnecessaryPartOfBinaryExpression().compileAndLint(code)
+        val findings = UnnecessaryPartOfBinaryExpression(Config.empty).compileAndLint(code)
         assertThat(findings).hasSize(1)
     }
 
@@ -279,7 +280,7 @@ class UnnecessaryPartOfBinaryExpressionSpec {
             }
         """.trimIndent()
 
-        val findings = UnnecessaryPartOfBinaryExpression().compileAndLint(code)
+        val findings = UnnecessaryPartOfBinaryExpression(Config.empty).compileAndLint(code)
         assertThat(findings).hasSize(1)
     }
 
@@ -291,7 +292,7 @@ class UnnecessaryPartOfBinaryExpressionSpec {
             }
         """.trimIndent()
 
-        val findings = UnnecessaryPartOfBinaryExpression().compileAndLint(code)
+        val findings = UnnecessaryPartOfBinaryExpression(Config.empty).compileAndLint(code)
         assertThat(findings).hasSize(0)
     }
 }

--- a/detekt-rules-performance/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/UnnecessaryTemporaryInstantiationSpec.kt
+++ b/detekt-rules-performance/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/UnnecessaryTemporaryInstantiationSpec.kt
@@ -1,11 +1,12 @@
 package io.gitlab.arturbosch.detekt.rules.performance
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 class UnnecessaryTemporaryInstantiationSpec {
-    val subject = UnnecessaryTemporaryInstantiation()
+    val subject = UnnecessaryTemporaryInstantiation(Config.empty)
 
     @Test
     fun `temporary instantiation for conversion`() {

--- a/detekt-rules-ruleauthors/src/main/kotlin/io/gitlab/arturbosch/detekt/authors/UseEntityAtName.kt
+++ b/detekt-rules-ruleauthors/src/main/kotlin/io/gitlab/arturbosch/detekt/authors/UseEntityAtName.kt
@@ -21,7 +21,7 @@ import org.jetbrains.kotlin.psi.psiUtil.getReceiverExpression
  * then it can be replaced with [Entity.atName] for more semantic code and better baseline support.
  */
 @ActiveByDefault("1.22.0")
-class UseEntityAtName(config: Config = Config.empty) : Rule(config) {
+class UseEntityAtName(config: Config) : Rule(config) {
 
     override val issue = Issue(
         "UseEntityAtName",

--- a/detekt-rules-ruleauthors/src/main/kotlin/io/gitlab/arturbosch/detekt/authors/ViolatesTypeResolutionRequirements.kt
+++ b/detekt-rules-ruleauthors/src/main/kotlin/io/gitlab/arturbosch/detekt/authors/ViolatesTypeResolutionRequirements.kt
@@ -24,7 +24,7 @@ import kotlin.reflect.KClass
  */
 @ActiveByDefault("1.22.0")
 @RequiresTypeResolution
-class ViolatesTypeResolutionRequirements(config: Config = Config.empty) : Rule(config) {
+class ViolatesTypeResolutionRequirements(config: Config) : Rule(config) {
     override val issue = Issue(
         javaClass.simpleName,
         "`@RequiresTypeResolution` should be used if and only if the property `bindingContext` is used.",

--- a/detekt-rules-ruleauthors/src/test/kotlin/io/gitlab/arturbosch/detekt/authors/UseEntityAtNameSpec.kt
+++ b/detekt-rules-ruleauthors/src/test/kotlin/io/gitlab/arturbosch/detekt/authors/UseEntityAtNameSpec.kt
@@ -1,12 +1,13 @@
 package io.gitlab.arturbosch.detekt.authors
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.junit.jupiter.api.Test
 
 internal class UseEntityAtNameSpec {
 
-    private val rule = UseEntityAtName()
+    private val rule = UseEntityAtName(Config.empty)
 
     @Test
     fun `should not report calls when there's no name involved`() {

--- a/detekt-rules-ruleauthors/src/test/kotlin/io/gitlab/arturbosch/detekt/authors/ViolatesTypeResolutionRequirementsSpec.kt
+++ b/detekt-rules-ruleauthors/src/test/kotlin/io/gitlab/arturbosch/detekt/authors/ViolatesTypeResolutionRequirementsSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.authors
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
 import org.assertj.core.api.Assertions.assertThat
@@ -9,7 +10,7 @@ import org.junit.jupiter.api.Test
 @KotlinCoreEnvironmentTest
 internal class ViolatesTypeResolutionRequirementsSpec(private val env: KotlinCoreEnvironment) {
 
-    private val rule = ViolatesTypeResolutionRequirements()
+    private val rule = ViolatesTypeResolutionRequirements(Config.empty)
 
     @Test
     fun `should not report classes that don't extend from BaseRule`() {

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/AbstractClassCanBeConcreteClass.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/AbstractClassCanBeConcreteClass.kt
@@ -48,7 +48,7 @@ import org.jetbrains.kotlin.types.typeUtil.isInterface
  */
 @ActiveByDefault(since = "1.2.0")
 @RequiresTypeResolution
-class AbstractClassCanBeConcreteClass(config: Config = Config.empty) : Rule(config) {
+class AbstractClassCanBeConcreteClass(config: Config) : Rule(config) {
 
     private val noAbstractMember = "An abstract class without an abstract member can be refactored to a concrete class."
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/AbstractClassCanBeInterface.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/AbstractClassCanBeInterface.kt
@@ -47,7 +47,7 @@ import org.jetbrains.kotlin.types.typeUtil.isInterface
  */
 @ActiveByDefault(since = "1.23.0")
 @RequiresTypeResolution
-class AbstractClassCanBeInterface(config: Config = Config.empty) : Rule(config) {
+class AbstractClassCanBeInterface(config: Config) : Rule(config) {
 
     private val noConcreteMember = "An abstract class without a concrete member can be refactored to an interface."
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/AlsoCouldBeApply.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/AlsoCouldBeApply.kt
@@ -35,7 +35,7 @@ import org.jetbrains.kotlin.psi.KtQualifiedExpression
  * }
  * </compliant>
  */
-class AlsoCouldBeApply(config: Config = Config.empty) : Rule(config) {
+class AlsoCouldBeApply(config: Config) : Rule(config) {
 
     override val issue = Issue(
         "AlsoCouldBeApply",

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/BracesOnIfStatements.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/BracesOnIfStatements.kt
@@ -143,7 +143,7 @@ import org.jetbrains.kotlin.psi.KtIfExpression
  *    f
  * </compliant>
  */
-class BracesOnIfStatements(config: Config = Config.empty) : Rule(config) {
+class BracesOnIfStatements(config: Config) : Rule(config) {
 
     override val issue = Issue(
         javaClass.simpleName,

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/BracesOnWhenStatements.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/BracesOnWhenStatements.kt
@@ -155,7 +155,7 @@ import org.jetbrains.kotlin.psi.psiUtil.siblings
  *
  *  </compliant>
  */
-class BracesOnWhenStatements(config: Config = Config.empty) : Rule(config) {
+class BracesOnWhenStatements(config: Config) : Rule(config) {
     override val issue = Issue(
         javaClass.simpleName,
         "Braces do not comply with the specified policy",

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/CanBeNonNullable.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/CanBeNonNullable.kt
@@ -128,7 +128,7 @@ import org.jetbrains.kotlin.types.isNullable
  * </compliant>
  */
 @RequiresTypeResolution
-class CanBeNonNullable(config: Config = Config.empty) : Rule(config) {
+class CanBeNonNullable(config: Config) : Rule(config) {
     override val issue = Issue(
         javaClass.simpleName,
         "Variable can be changed to non-nullable, as it is never set to null.",

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/CascadingCallWrapping.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/CascadingCallWrapping.kt
@@ -34,7 +34,7 @@ import org.jetbrains.kotlin.psi.psiUtil.startOffset
  *   .baz()
  * </compliant>
  */
-class CascadingCallWrapping(config: Config = Config.empty) : Rule(config) {
+class CascadingCallWrapping(config: Config) : Rule(config) {
     override val issue = Issue(
         id = javaClass.simpleName,
         description = "If a chained call is wrapped to a new line, subsequent chained calls should be as well.",

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ClassOrdering.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ClassOrdering.kt
@@ -51,7 +51,7 @@ private typealias DeclarationToSectionPair = Pair<KtDeclaration, Section>
  * }
  * </compliant>
  */
-class ClassOrdering(config: Config = Config.empty) : Rule(config) {
+class ClassOrdering(config: Config) : Rule(config) {
 
     override val issue = Issue(
         javaClass.simpleName,

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/CollapsibleIfStatements.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/CollapsibleIfStatements.kt
@@ -32,7 +32,7 @@ import org.jetbrains.kotlin.psi.psiUtil.getChildrenOfType
  * }
  * </compliant>
  */
-class CollapsibleIfStatements(config: Config = Config.empty) : Rule(config) {
+class CollapsibleIfStatements(config: Config) : Rule(config) {
 
     override val issue = Issue(
         "CollapsibleIfStatements",

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/DataClassContainsFunctions.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/DataClassContainsFunctions.kt
@@ -25,7 +25,7 @@ import org.jetbrains.kotlin.psi.KtNamedFunction
  * }
  * </noncompliant>
  */
-class DataClassContainsFunctions(config: Config = Config.empty) : Rule(config) {
+class DataClassContainsFunctions(config: Config) : Rule(config) {
 
     override val issue: Issue = Issue(
         "DataClassContainsFunctions",

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/DataClassShouldBeImmutable.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/DataClassShouldBeImmutable.kt
@@ -27,7 +27,7 @@ import org.jetbrains.kotlin.psi.KtClass
  * )
  * </compliant>
  */
-class DataClassShouldBeImmutable(config: Config = Config.empty) : Rule(config) {
+class DataClassShouldBeImmutable(config: Config) : Rule(config) {
 
     override val issue: Issue = Issue(
         "DataClassShouldBeImmutable",

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/DestructuringDeclarationWithTooManyEntries.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/DestructuringDeclarationWithTooManyEntries.kt
@@ -26,7 +26,7 @@ import org.jetbrains.kotlin.psi.KtDestructuringDeclaration
  * </compliant>
  */
 @ActiveByDefault(since = "1.21.0")
-class DestructuringDeclarationWithTooManyEntries(config: Config = Config.empty) : Rule(config) {
+class DestructuringDeclarationWithTooManyEntries(config: Config) : Rule(config) {
     override val issue = Issue(
         javaClass.simpleName,
         "Too many entries in a destructuring declaration make the code hard to understand.",

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/DoubleNegativeLambda.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/DoubleNegativeLambda.kt
@@ -27,7 +27,7 @@ import org.jetbrains.kotlin.psi.psiUtil.collectDescendantsOfType
  * fun Int.evenOrNull() = takeIf { it % 2 == 0 }
  * </compliant>
  */
-class DoubleNegativeLambda(config: Config = Config.empty) : Rule(config) {
+class DoubleNegativeLambda(config: Config) : Rule(config) {
 
     override val issue = Issue(
         "DoubleNegativeLambda",

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/EqualsNullCall.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/EqualsNullCall.kt
@@ -21,7 +21,7 @@ import org.jetbrains.kotlin.psi.KtCallExpression
  * </compliant>
  */
 @ActiveByDefault(since = "1.2.0")
-class EqualsNullCall(config: Config = Config.empty) : Rule(config) {
+class EqualsNullCall(config: Config) : Rule(config) {
 
     override val issue = Issue(
         "EqualsNullCall",

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/EqualsOnSignatureLine.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/EqualsOnSignatureLine.kt
@@ -31,7 +31,7 @@ import org.jetbrains.kotlin.psi.psiUtil.siblings
  * fun <V> foo(): Int where V : Int = 5
  * </compliant>
  */
-class EqualsOnSignatureLine(config: Config = Config.empty) : Rule(config) {
+class EqualsOnSignatureLine(config: Config) : Rule(config) {
 
     override val issue = Issue(javaClass.simpleName, MESSAGE)
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitCollectionElementAccessMethod.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitCollectionElementAccessMethod.kt
@@ -37,7 +37,7 @@ import org.jetbrains.kotlin.types.typeUtil.supertypes
  * </compliant>
  */
 @RequiresTypeResolution
-class ExplicitCollectionElementAccessMethod(config: Config = Config.empty) : Rule(config) {
+class ExplicitCollectionElementAccessMethod(config: Config) : Rule(config) {
 
     override val issue: Issue =
         Issue(

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExpressionBodySyntax.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExpressionBodySyntax.kt
@@ -38,7 +38,7 @@ import org.jetbrains.kotlin.psi.psiUtil.anyDescendantOfType
  * }
  * </compliant>
  */
-class ExpressionBodySyntax(config: Config = Config.empty) : Rule(config) {
+class ExpressionBodySyntax(config: Config) : Rule(config) {
 
     override val issue = Issue(
         javaClass.simpleName,

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenAnnotation.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenAnnotation.kt
@@ -37,7 +37,7 @@ import org.jetbrains.kotlin.types.KotlinType
  * </compliant>
  */
 @RequiresTypeResolution
-class ForbiddenAnnotation(config: Config = Config.empty) : Rule(config) {
+class ForbiddenAnnotation(config: Config) : Rule(config) {
 
     override val issue = Issue(
         javaClass.simpleName,

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenComment.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenComment.kt
@@ -87,7 +87,7 @@ import java.util.Locale
  * </noncompliant>
  */
 @ActiveByDefault(since = "1.0.0")
-class ForbiddenComment(config: Config = Config.empty) : Rule(config) {
+class ForbiddenComment(config: Config) : Rule(config) {
 
     override val issue = Issue(
         javaClass.simpleName,

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenImport.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenImport.kt
@@ -22,7 +22,7 @@ import org.jetbrains.kotlin.psi.KtImportDirective
  * import kotlin.SinceKotlin
  * </noncompliant>
  */
-class ForbiddenImport(config: Config = Config.empty) : Rule(config) {
+class ForbiddenImport(config: Config) : Rule(config) {
 
     override val issue = Issue(
         javaClass.simpleName,

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCall.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCall.kt
@@ -43,7 +43,7 @@ import org.jetbrains.kotlin.resolve.descriptorUtil.overriddenTreeUniqueAsSequenc
  *
  */
 @RequiresTypeResolution
-class ForbiddenMethodCall(config: Config = Config.empty) : Rule(config) {
+class ForbiddenMethodCall(config: Config) : Rule(config) {
 
     override val issue = Issue(
         javaClass.simpleName,

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenSuppress.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenSuppress.kt
@@ -37,7 +37,7 @@ import org.jetbrains.kotlin.psi.psiUtil.findDescendantOfType
  * class Bar
  * </compliant>
  */
-class ForbiddenSuppress(config: Config = Config.empty) : Rule(config) {
+class ForbiddenSuppress(config: Config) : Rule(config) {
 
     override val issue = Issue(
         javaClass.simpleName,

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenVoid.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenVoid.kt
@@ -37,7 +37,7 @@ import org.jetbrains.kotlin.resolve.bindingContextUtil.getAbbreviatedTypeOrType
  */
 @RequiresTypeResolution
 @ActiveByDefault(since = "1.21.0")
-class ForbiddenVoid(config: Config = Config.empty) : Rule(config) {
+class ForbiddenVoid(config: Config) : Rule(config) {
 
     override val issue = Issue(
         javaClass.simpleName,

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/FunctionOnlyReturningConstant.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/FunctionOnlyReturningConstant.kt
@@ -32,7 +32,7 @@ import org.jetbrains.kotlin.psi.psiUtil.containingClass
  * </compliant>
  */
 @ActiveByDefault(since = "1.2.0")
-class FunctionOnlyReturningConstant(config: Config = Config.empty) : Rule(config) {
+class FunctionOnlyReturningConstant(config: Config) : Rule(config) {
 
     override val issue = Issue(
         javaClass.simpleName,

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/LoopWithTooManyJumpStatements.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/LoopWithTooManyJumpStatements.kt
@@ -37,7 +37,7 @@ import org.jetbrains.kotlin.psi.KtWhileExpression
  * </noncompliant>
  */
 @ActiveByDefault(since = "1.2.0")
-class LoopWithTooManyJumpStatements(config: Config = Config.empty) : Rule(config) {
+class LoopWithTooManyJumpStatements(config: Config) : Rule(config) {
 
     override val issue = Issue(
         javaClass.simpleName,

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumber.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumber.kt
@@ -68,7 +68,7 @@ import java.util.Locale
  */
 @Suppress("TooManyFunctions")
 @ActiveByDefault(since = "1.0.0")
-class MagicNumber(config: Config = Config.empty) : Rule(config) {
+class MagicNumber(config: Config) : Rule(config) {
 
     override val issue = Issue(
         javaClass.simpleName,

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxChainedCallsOnSameLine.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxChainedCallsOnSameLine.kt
@@ -35,7 +35,7 @@ import org.jetbrains.kotlin.resolve.BindingContext
  * </compliant>
  */
 @RequiresTypeResolution
-class MaxChainedCallsOnSameLine(config: Config = Config.empty) : Rule(config) {
+class MaxChainedCallsOnSameLine(config: Config) : Rule(config) {
     override val issue = Issue(
         id = javaClass.simpleName,
         description = "Chained calls beyond the maximum should be wrapped to a new line.",

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLength.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLength.kt
@@ -26,7 +26,7 @@ import org.jetbrains.kotlin.psi.psiUtil.getParentOfType
  * in the codebase will help make the code more uniform.
  */
 @ActiveByDefault(since = "1.0.0")
-class MaxLineLength(config: Config = Config.empty) : Rule(config) {
+class MaxLineLength(config: Config) : Rule(config) {
 
     override val issue = Issue(
         javaClass.simpleName,

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MayBeConstant.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MayBeConstant.kt
@@ -34,7 +34,7 @@ import org.jetbrains.kotlin.psi.psiUtil.containingClassOrObject
  * </compliant>
  */
 @ActiveByDefault(since = "1.2.0")
-class MayBeConstant(config: Config = Config.empty) : Rule(config) {
+class MayBeConstant(config: Config) : Rule(config) {
 
     override val issue = Issue(
         javaClass.simpleName,

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ModifierOrder.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ModifierOrder.kt
@@ -50,7 +50,7 @@ import org.jetbrains.kotlin.psi.psiUtil.allChildren
  * </compliant>
  */
 @ActiveByDefault(since = "1.0.0")
-class ModifierOrder(config: Config = Config.empty) : Rule(config) {
+class ModifierOrder(config: Config) : Rule(config) {
 
     override val issue = Issue(
         javaClass.simpleName,

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/NestedClassesVisibility.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/NestedClassesVisibility.kt
@@ -35,7 +35,7 @@ import org.jetbrains.kotlin.psi.KtEnumEntry
  * </compliant>
  */
 @ActiveByDefault(since = "1.16.0")
-class NestedClassesVisibility(config: Config = Config.empty) : Rule(config) {
+class NestedClassesVisibility(config: Config) : Rule(config) {
 
     override val issue: Issue = Issue(
         "NestedClassesVisibility",

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/NewLineAtEndOfFile.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/NewLineAtEndOfFile.kt
@@ -19,7 +19,7 @@ import org.jetbrains.kotlin.psi.psiUtil.endOffset
  * This rule reports files which do not end with a line separator.
  */
 @ActiveByDefault(since = "1.0.0")
-class NewLineAtEndOfFile(config: Config = Config.empty) : Rule(config) {
+class NewLineAtEndOfFile(config: Config) : Rule(config) {
 
     override val issue = Issue(
         javaClass.simpleName,

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/NoTabs.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/NoTabs.kt
@@ -17,7 +17,7 @@ import org.jetbrains.kotlin.psi.KtStringTemplateEntryWithExpression
  * the only whitespace chars that are allowed in a source file are the line terminator sequence
  * and the ASCII horizontal space character (0x20). Strings containing tabs are allowed.
  */
-class NoTabs(config: Config = Config.empty) : Rule(config) {
+class NoTabs(config: Config) : Rule(config) {
 
     override val issue = Issue(
         javaClass.simpleName,

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/NullableBooleanCheck.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/NullableBooleanCheck.kt
@@ -31,7 +31,7 @@ import org.jetbrains.kotlin.types.typeUtil.isBooleanOrNullableBoolean
  * </compliant>
  */
 @RequiresTypeResolution
-class NullableBooleanCheck(config: Config = Config.empty) : Rule(config) {
+class NullableBooleanCheck(config: Config) : Rule(config) {
     override val issue = Issue(
         javaClass.simpleName,
         "Nullable boolean check should use `==` rather than `?:`",

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ObjectLiteralToLambda.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ObjectLiteralToLambda.kt
@@ -43,7 +43,7 @@ import org.jetbrains.kotlin.types.KotlinType
  */
 @RequiresTypeResolution
 @ActiveByDefault(since = "1.21.0")
-class ObjectLiteralToLambda(config: Config = Config.empty) : Rule(config) {
+class ObjectLiteralToLambda(config: Config) : Rule(config) {
     override val issue = Issue(
         javaClass.simpleName,
         "Report object literals that can be changed to lambdas.",

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/OptionalAbstractKeyword.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/OptionalAbstractKeyword.kt
@@ -32,7 +32,7 @@ import org.jetbrains.kotlin.psi.psiUtil.getChildrenOfType
  * </compliant>
  */
 @ActiveByDefault(since = "1.0.0")
-class OptionalAbstractKeyword(config: Config = Config.empty) : Rule(config) {
+class OptionalAbstractKeyword(config: Config) : Rule(config) {
 
     override val issue: Issue = Issue(
         javaClass.simpleName,

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ProtectedMemberInFinalClass.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ProtectedMemberInFinalClass.kt
@@ -33,7 +33,7 @@ import org.jetbrains.kotlin.psi.psiUtil.isProtected
  * </compliant>
  */
 @ActiveByDefault(since = "1.2.0")
-class ProtectedMemberInFinalClass(config: Config = Config.empty) : Rule(config) {
+class ProtectedMemberInFinalClass(config: Config) : Rule(config) {
 
     override val issue = Issue(
         javaClass.simpleName,

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/RangeUntilInsteadOfRangeTo.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/RangeUntilInsteadOfRangeTo.kt
@@ -27,7 +27,7 @@ import org.jetbrains.kotlin.psi.KtExpression
  * val range = 0..<10
  * </compliant>
  */
-class RangeUntilInsteadOfRangeTo(config: Config = Config.empty) : Rule(config) {
+class RangeUntilInsteadOfRangeTo(config: Config) : Rule(config) {
 
     override val issue = Issue(
         javaClass.simpleName,

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantConstructorKeyword.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantConstructorKeyword.kt
@@ -27,7 +27,7 @@ import org.jetbrains.kotlin.psi.psiUtil.siblings
  * }
  * </compliant>
  */
-class RedundantConstructorKeyword(config: Config = Config.empty) : Rule(config) {
+class RedundantConstructorKeyword(config: Config) : Rule(config) {
     override val issue = Issue(
         javaClass.simpleName,
         "Redundant `constructor` modifier can be removed.",

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantHigherOrderMapUsage.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantHigherOrderMapUsage.kt
@@ -72,7 +72,7 @@ import org.jetbrains.kotlin.types.typeUtil.immediateSupertypes
  */
 @RequiresTypeResolution
 @ActiveByDefault(since = "1.21.0")
-class RedundantHigherOrderMapUsage(config: Config = Config.empty) : Rule(config) {
+class RedundantHigherOrderMapUsage(config: Config) : Rule(config) {
     override val issue: Issue = Issue(
         javaClass.simpleName,
         "Checks for redundant 'map' calls, which can be removed.",

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantVisibilityModifierRule.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantVisibilityModifierRule.kt
@@ -41,7 +41,7 @@ import org.jetbrains.kotlin.psi.psiUtil.isPrivate
  * }
  * </compliant>
  */
-class RedundantVisibilityModifierRule(config: Config = Config.empty) : Rule(config) {
+class RedundantVisibilityModifierRule(config: Config) : Rule(config) {
 
     override val defaultRuleIdAliases: Set<String> = setOf("RedundantVisibilityModifier")
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCount.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCount.kt
@@ -44,7 +44,7 @@ import org.jetbrains.kotlin.psi.psiUtil.getParentOfType
  * </compliant>
  */
 @ActiveByDefault(since = "1.0.0")
-class ReturnCount(config: Config = Config.empty) : Rule(config) {
+class ReturnCount(config: Config) : Rule(config) {
 
     override val issue = Issue(
         javaClass.simpleName,

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/SafeCast.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/SafeCast.kt
@@ -32,7 +32,7 @@ import org.jetbrains.kotlin.psi.KtNameReferenceExpression
  * </compliant>
  */
 @ActiveByDefault(since = "1.0.0")
-class SafeCast(config: Config = Config.empty) : Rule(config) {
+class SafeCast(config: Config) : Rule(config) {
 
     override val issue = Issue(
         javaClass.simpleName,

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/SerialVersionUIDInSerializableClass.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/SerialVersionUIDInSerializableClass.kt
@@ -42,7 +42,7 @@ import org.jetbrains.kotlin.psi.psiUtil.isPrivate
  * </compliant>
  */
 @ActiveByDefault(since = "1.16.0")
-class SerialVersionUIDInSerializableClass(config: Config = Config.empty) : Rule(config) {
+class SerialVersionUIDInSerializableClass(config: Config) : Rule(config) {
 
     override val issue = Issue(
         javaClass.simpleName,

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/SpacingAfterPackageDeclaration.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/SpacingAfterPackageDeclaration.kt
@@ -33,7 +33,7 @@ import org.jetbrains.kotlin.psi.psiUtil.siblings
  * class Bar { }
  * </compliant>
  */
-class SpacingAfterPackageDeclaration(config: Config = Config.empty) : Rule(config) {
+class SpacingAfterPackageDeclaration(config: Config) : Rule(config) {
 
     override val issue = Issue(
         javaClass.simpleName,

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ThrowsCount.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ThrowsCount.kt
@@ -37,7 +37,7 @@ import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
  * </compliant>
  */
 @ActiveByDefault(since = "1.0.0")
-class ThrowsCount(config: Config = Config.empty) : Rule(config) {
+class ThrowsCount(config: Config) : Rule(config) {
 
     override val issue = Issue(
         javaClass.simpleName,

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/TrailingWhitespace.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/TrailingWhitespace.kt
@@ -20,7 +20,7 @@ import org.jetbrains.kotlin.psi.KtFile
  * nor [in KTIJ](https://youtrack.jetbrains.com/issue/KTIJ-6702/KDoc-Dokka-allow-for-newlines-line-breaks-inside-paragraphs)),
  * which means Markdown line-breaks in KDoc are really only trailing whitespace for now.
  */
-class TrailingWhitespace(config: Config = Config.empty) : Rule(config) {
+class TrailingWhitespace(config: Config) : Rule(config) {
 
     override val issue = Issue(
         javaClass.simpleName,

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiterals.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiterals.kt
@@ -29,7 +29,7 @@ import java.util.Locale
  * const val DEFAULT_AMOUNT = 1_000_000
  * </compliant>
  */
-class UnderscoresInNumericLiterals(config: Config = Config.empty) : Rule(config) {
+class UnderscoresInNumericLiterals(config: Config) : Rule(config) {
 
     override val issue = Issue(
         javaClass.simpleName,

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAnnotationUseSiteTarget.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAnnotationUseSiteTarget.kt
@@ -27,7 +27,7 @@ import org.jetbrains.kotlin.psi.KtProperty
  * class Module(@Inject private val foo: String)
  * </compliant>
  */
-class UnnecessaryAnnotationUseSiteTarget(config: Config = Config.empty) : Rule(config) {
+class UnnecessaryAnnotationUseSiteTarget(config: Config) : Rule(config) {
 
     override val issue = Issue(
         javaClass.simpleName,

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAny.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAny.kt
@@ -44,7 +44,7 @@ import org.jetbrains.kotlin.types.typeUtil.isSubtypeOf
  * </compliant>
  */
 @RequiresTypeResolution
-class UnnecessaryAny(config: Config = Config.empty) : Rule(config) {
+class UnnecessaryAny(config: Config) : Rule(config) {
     override val issue: Issue = Issue(
         javaClass.simpleName,
         "The `any {  }` usage is unnecessary.",

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryBackticks.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryBackticks.kt
@@ -25,7 +25,7 @@ import org.jetbrains.kotlin.psi.psiUtil.isIdentifier
  * class HelloWorld
  * </compliant>
  */
-class UnnecessaryBackticks(config: Config = Config.empty) : Rule(config) {
+class UnnecessaryBackticks(config: Config) : Rule(config) {
     override val issue: Issue = Issue(
         javaClass.simpleName,
         "Backticks are unnecessary.",

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryFilter.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryFilter.kt
@@ -49,7 +49,7 @@ import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameOrNull
  */
 @RequiresTypeResolution
 @ActiveByDefault(since = "1.21.0")
-class UnnecessaryFilter(config: Config = Config.empty) : Rule(config) {
+class UnnecessaryFilter(config: Config) : Rule(config) {
 
     override val issue: Issue = Issue(
         "UnnecessaryFilter",

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryInheritance.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryInheritance.kt
@@ -18,7 +18,7 @@ import org.jetbrains.kotlin.psi.KtClassOrObject
  * </noncompliant>
  */
 @ActiveByDefault(since = "1.2.0")
-class UnnecessaryInheritance(config: Config = Config.empty) : Rule(config) {
+class UnnecessaryInheritance(config: Config) : Rule(config) {
 
     override val issue: Issue = Issue(
         javaClass.simpleName,

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryInnerClass.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryInnerClass.kt
@@ -38,7 +38,7 @@ import org.jetbrains.kotlin.resolve.descriptorUtil.classId
  */
 @Suppress("TooManyFunctions")
 @RequiresTypeResolution
-class UnnecessaryInnerClass(config: Config = Config.empty) : Rule(config) {
+class UnnecessaryInnerClass(config: Config) : Rule(config) {
 
     private val candidateClassToParentClasses = mutableMapOf<KtClass, List<KtClass>>()
     private val classChain = ArrayDeque<KtClass>()

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryParentheses.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryParentheses.kt
@@ -48,7 +48,7 @@ import org.jetbrains.kotlin.psi.KtPsiUtil
  * }
  * </compliant>
  */
-class UnnecessaryParentheses(config: Config = Config.empty) : Rule(config) {
+class UnnecessaryParentheses(config: Config) : Rule(config) {
 
     override val issue = Issue(
         "UnnecessaryParentheses",

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedParameter.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedParameter.kt
@@ -43,7 +43,7 @@ import org.jetbrains.kotlin.psi.psiUtil.isProtected
  * </compliant>
  */
 @ActiveByDefault(since = "1.23.0")
-class UnusedParameter(config: Config = Config.empty) : Rule(config) {
+class UnusedParameter(config: Config) : Rule(config) {
     override val defaultRuleIdAliases: Set<String> =
         setOf("UNUSED_VARIABLE", "UNUSED_PARAMETER", "unused", "UnusedPrivateMember")
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateClass.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateClass.kt
@@ -36,7 +36,7 @@ import org.jetbrains.kotlin.utils.addIfNotNull
  * can lead to confusion and potential bugs.
  */
 @ActiveByDefault(since = "1.2.0")
-class UnusedPrivateClass(config: Config = Config.empty) : Rule(config) {
+class UnusedPrivateClass(config: Config) : Rule(config) {
 
     override val defaultRuleIdAliases: Set<String> = setOf("unused")
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMember.kt
@@ -46,7 +46,7 @@ private const val ARRAY_GET_METHOD_NAME = "get"
  */
 @RequiresTypeResolution
 @ActiveByDefault(since = "1.16.0")
-class UnusedPrivateMember(config: Config = Config.empty) : Rule(config) {
+class UnusedPrivateMember(config: Config) : Rule(config) {
 
     override val defaultRuleIdAliases: Set<String> = setOf("UNUSED_VARIABLE", "UNUSED_PARAMETER", "unused")
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateProperty.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateProperty.kt
@@ -48,7 +48,7 @@ import org.jetbrains.kotlin.psi.psiUtil.isPrivate
  * </compliant>
  */
 @ActiveByDefault(since = "1.23.0")
-class UnusedPrivateProperty(config: Config = Config.empty) : Rule(config) {
+class UnusedPrivateProperty(config: Config) : Rule(config) {
     override val defaultRuleIdAliases: Set<String> =
         setOf("UNUSED_VARIABLE", "UNUSED_PARAMETER", "unused", "UnusedPrivateMember")
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseAnyOrNoneInsteadOfFind.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseAnyOrNoneInsteadOfFind.kt
@@ -31,7 +31,7 @@ import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
  */
 @RequiresTypeResolution
 @ActiveByDefault(since = "1.21.0")
-class UseAnyOrNoneInsteadOfFind(config: Config = Config.empty) : Rule(config) {
+class UseAnyOrNoneInsteadOfFind(config: Config) : Rule(config) {
     override val issue: Issue = Issue(
         "UseAnyOrNoneInsteadOfFind",
         "Use `any` or `none` instead of `find` and `null` checks.",

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseArrayLiteralsInAnnotations.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseArrayLiteralsInAnnotations.kt
@@ -25,7 +25,7 @@ import org.jetbrains.kotlin.psi.psiUtil.containingClass
  * </compliant>
  */
 @ActiveByDefault(since = "1.21.0")
-class UseArrayLiteralsInAnnotations(config: Config = Config.empty) : Rule(config) {
+class UseArrayLiteralsInAnnotations(config: Config) : Rule(config) {
 
     override val issue = Issue(
         javaClass.simpleName,

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseCheckNotNull.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseCheckNotNull.kt
@@ -24,7 +24,7 @@ import org.jetbrains.kotlin.psi.KtCallExpression
  */
 @RequiresTypeResolution
 @ActiveByDefault(since = "1.21.0")
-class UseCheckNotNull(config: Config = Config.empty) : Rule(config) {
+class UseCheckNotNull(config: Config) : Rule(config) {
     override val issue = Issue(
         "UseCheckNotNull",
         "Use checkNotNull() instead of check() for checking not-null.",

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseCheckOrError.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseCheckOrError.kt
@@ -38,7 +38,7 @@ import org.jetbrains.kotlin.psi.KtThrowExpression
  */
 @RequiresTypeResolution
 @ActiveByDefault(since = "1.21.0")
-class UseCheckOrError(config: Config = Config.empty) : Rule(config) {
+class UseCheckOrError(config: Config) : Rule(config) {
 
     override val issue = Issue(
         "UseCheckOrError",

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseDataClass.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseDataClass.kt
@@ -45,7 +45,7 @@ import org.jetbrains.kotlin.types.KotlinType
  * </compliant>
  */
 @RequiresTypeResolution
-class UseDataClass(config: Config = Config.empty) : Rule(config) {
+class UseDataClass(config: Config) : Rule(config) {
 
     override val issue: Issue = Issue(
         "UseDataClass",

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIfEmptyOrIfBlank.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIfEmptyOrIfBlank.kt
@@ -46,7 +46,7 @@ import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameOrNull
  */
 @RequiresTypeResolution
 @Suppress("ComplexMethod")
-class UseIfEmptyOrIfBlank(config: Config = Config.empty) : Rule(config) {
+class UseIfEmptyOrIfBlank(config: Config) : Rule(config) {
     override val issue: Issue = Issue(
         "UseIfEmptyOrIfBlank",
         "Use `ifEmpty` or `ifBlank` instead of `isEmpty` or `isBlank` to assign a default value.",

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIfInsteadOfWhen.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIfInsteadOfWhen.kt
@@ -26,7 +26,7 @@ import org.jetbrains.kotlin.psi.KtWhenExpression
  * if (x == null) true else false
  * </compliant>
  */
-class UseIfInsteadOfWhen(config: Config = Config.empty) : Rule(config) {
+class UseIfInsteadOfWhen(config: Config) : Rule(config) {
 
     override val issue: Issue = Issue(
         "UseIfInsteadOfWhen",

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIsNullOrEmpty.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIsNullOrEmpty.kt
@@ -45,7 +45,7 @@ import org.jetbrains.kotlin.types.isNullable
 @Suppress("TooManyFunctions")
 @RequiresTypeResolution
 @ActiveByDefault(since = "1.21.0")
-class UseIsNullOrEmpty(config: Config = Config.empty) : Rule(config) {
+class UseIsNullOrEmpty(config: Config) : Rule(config) {
     override val issue: Issue = Issue(
         "UseIsNullOrEmpty",
         "Use `isNullOrEmpty()` call instead of `x == null || x.isEmpty()`.",

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseLet.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseLet.kt
@@ -28,9 +28,7 @@ import org.jetbrains.kotlin.psi.KtPsiUtil
  * x?.let { y }
  * </compliant>
  */
-class UseLet(
-    config: Config = Config.empty
-) : Rule(config) {
+class UseLet(config: Config) : Rule(config) {
     override val issue = Issue(
         javaClass.simpleName,
         "Use `?.let {}` instead of if/else with a null block when checking for nullable values",

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseOrEmpty.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseOrEmpty.kt
@@ -43,7 +43,7 @@ import org.jetbrains.kotlin.types.typeUtil.makeNotNullable
  */
 @RequiresTypeResolution
 @ActiveByDefault(since = "1.21.0")
-class UseOrEmpty(config: Config = Config.empty) : Rule(config) {
+class UseOrEmpty(config: Config) : Rule(config) {
     override val issue: Issue = Issue(
         "UseOrEmpty",
         "Use `orEmpty()` call instead of `?:` with empty collection factory methods",

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseRequire.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseRequire.kt
@@ -30,7 +30,7 @@ import org.jetbrains.kotlin.psi.KtThrowExpression
  */
 @RequiresTypeResolution
 @ActiveByDefault(since = "1.21.0")
-class UseRequire(config: Config = Config.empty) : Rule(config) {
+class UseRequire(config: Config) : Rule(config) {
 
     override val issue = Issue(
         "UseRequire",

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseRequireNotNull.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseRequireNotNull.kt
@@ -24,7 +24,7 @@ import org.jetbrains.kotlin.psi.KtCallExpression
  */
 @RequiresTypeResolution
 @ActiveByDefault(since = "1.21.0")
-class UseRequireNotNull(config: Config = Config.empty) : Rule(config) {
+class UseRequireNotNull(config: Config) : Rule(config) {
     override val issue = Issue(
         "UseRequireNotNull",
         "Use requireNotNull() instead of require() for checking not-null.",

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseSumOfInsteadOfFlatMapSize.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseSumOfInsteadOfFlatMapSize.kt
@@ -37,7 +37,7 @@ import org.jetbrains.kotlin.resolve.descriptorUtil.isSubclassOf
  * </compliant>
  */
 @RequiresTypeResolution
-class UseSumOfInsteadOfFlatMapSize(config: Config = Config.empty) : Rule(config) {
+class UseSumOfInsteadOfFlatMapSize(config: Config) : Rule(config) {
     override val issue: Issue = Issue(
         javaClass.simpleName,
         "Use `sumOf` instead of `flatMap` and `size/count` calls",

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UselessCallOnNotNull.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UselessCallOnNotNull.kt
@@ -45,7 +45,7 @@ import org.jetbrains.kotlin.types.isNullable
  */
 @RequiresTypeResolution
 @ActiveByDefault(since = "1.2.0")
-class UselessCallOnNotNull(config: Config = Config.empty) : Rule(config) {
+class UselessCallOnNotNull(config: Config) : Rule(config) {
     override val issue: Issue = Issue(
         "UselessCallOnNotNull",
         "This call on a non-null reference may be reduced or removed. " +

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UtilityClassWithPublicConstructor.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UtilityClassWithPublicConstructor.kt
@@ -56,7 +56,7 @@ import org.jetbrains.kotlin.psi.psiUtil.isPublic
  * </compliant>
  */
 @ActiveByDefault(since = "1.2.0")
-class UtilityClassWithPublicConstructor(config: Config = Config.empty) : Rule(config) {
+class UtilityClassWithPublicConstructor(config: Config) : Rule(config) {
 
     override val issue: Issue = Issue(
         javaClass.simpleName,

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/VarCouldBeVal.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/VarCouldBeVal.kt
@@ -58,7 +58,7 @@ import org.jetbrains.kotlin.util.containingNonLocalDeclaration
  */
 @ActiveByDefault(since = "1.16.0")
 @RequiresTypeResolution
-class VarCouldBeVal(config: Config = Config.empty) : Rule(config) {
+class VarCouldBeVal(config: Config) : Rule(config) {
 
     override val defaultRuleIdAliases: Set<String> = setOf("CanBeVal")
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/WildcardImport.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/WildcardImport.kt
@@ -39,7 +39,7 @@ import org.jetbrains.kotlin.psi.KtImportDirective
  * </compliant>
  */
 @ActiveByDefault(since = "1.0.0")
-class WildcardImport(config: Config = Config.empty) : Rule(config) {
+class WildcardImport(config: Config) : Rule(config) {
 
     override val issue = Issue(
         javaClass.simpleName,

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/movelambdaout/UnnecessaryBracesAroundTrailingLambda.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/movelambdaout/UnnecessaryBracesAroundTrailingLambda.kt
@@ -32,7 +32,7 @@ import org.jetbrains.kotlin.psi.KtNameReferenceExpression
  * </compliant>
  */
 @RequiresTypeResolution
-class UnnecessaryBracesAroundTrailingLambda(config: Config = Config.empty) : Rule(config) {
+class UnnecessaryBracesAroundTrailingLambda(config: Config) : Rule(config) {
     override val issue: Issue = Issue(
         javaClass.simpleName,
         "Braces around trailing lambda is unnecessary.",

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/MandatoryBracesLoops.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/MandatoryBracesLoops.kt
@@ -50,7 +50,7 @@ import org.jetbrains.kotlin.psi.psiUtil.siblings
  * do println("Hello, world") while (true)
  * </compliant>
  */
-class MandatoryBracesLoops(config: Config = Config.empty) : Rule(config) {
+class MandatoryBracesLoops(config: Config) : Rule(config) {
     override val issue = Issue(
         "MandatoryBracesLoops",
         "A multi-line loop was found that does not have braces. " +

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/OptionalUnit.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/OptionalUnit.kt
@@ -49,7 +49,7 @@ import org.jetbrains.kotlin.utils.addToStdlib.firstIsInstanceOrNull
  * </compliant>
  */
 @RequiresTypeResolution
-class OptionalUnit(config: Config = Config.empty) : Rule(config) {
+class OptionalUnit(config: Config) : Rule(config) {
 
     override val issue = Issue(
         javaClass.simpleName,

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/PreferToOverPairSyntax.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/PreferToOverPairSyntax.kt
@@ -27,7 +27,7 @@ import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameOrNull
  *
  */
 @RequiresTypeResolution
-class PreferToOverPairSyntax(config: Config = Config.empty) : Rule(config) {
+class PreferToOverPairSyntax(config: Config) : Rule(config) {
     override val issue = Issue(
         "PreferToOverPairSyntax",
         "Pair was created using the Pair constructor, using the to syntax is preferred.",

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/AbstractClassCanBeInterfaceSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/AbstractClassCanBeInterfaceSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
@@ -10,7 +11,7 @@ import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
 class AbstractClassCanBeInterfaceSpec(val env: KotlinCoreEnvironment) {
-    val subject = AbstractClassCanBeInterface()
+    val subject = AbstractClassCanBeInterface(Config.empty)
 
     @Nested
     inner class `abstract classes with no concrete members` {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/BracesOnIfStatementsSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/BracesOnIfStatementsSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.TextLocation
 import io.gitlab.arturbosch.detekt.rules.style.BracesOnIfStatements.BracePolicy
 import io.gitlab.arturbosch.detekt.rules.style.BracesOnIfStatementsSpec.Companion.NOT_RELEVANT
@@ -2129,7 +2130,7 @@ class BracesOnIfStatementsSpec {
             val codeLocation = locations.map { it(code) }.toTypedArray()
             // Separately compile the code because otherwise all the combinations would compile them again and again.
             val compileTest = dynamicTest("Compiles: $code") {
-                BracesOnIfStatements().compileAndLint(code)
+                BracesOnIfStatements(Config.empty).compileAndLint(code)
             }
             val validationTests = createBraceTests(singleLine, multiLine) { rule ->
                 rule.test(code, *codeLocation)

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/BracesOnWhenStatementsSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/BracesOnWhenStatementsSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.TextLocation
 import io.gitlab.arturbosch.detekt.rules.style.BracesOnWhenStatements.BracePolicy
 import io.gitlab.arturbosch.detekt.rules.style.BracesOnWhenStatementsSpec.Companion.NOT_RELEVANT
@@ -1215,7 +1216,7 @@ class BracesOnWhenStatementsSpec {
             val codeLocation = locations.map { it(code) }.toTypedArray()
             // Separately compile the code because otherwise all the combinations would compile them again and again.
             val compileTest = dynamicTest("Compiles: $code") {
-                BracesOnWhenStatements().compileAndLint(code)
+                BracesOnWhenStatements(Config.empty).compileAndLint(code)
             }
             val validationTests = createBraceTests(singleLine, multiLine) { rule ->
                 rule.test(code, *codeLocation)

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/DataClassContainsFunctionsSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/DataClassContainsFunctionsSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.assertj.core.api.Assertions.assertThat
@@ -10,7 +11,7 @@ private const val CONVERSION_FUNCTION_PREFIX = "conversionFunctionPrefix"
 private const val ALLOW_OPERATORS = "allowOperators"
 
 class DataClassContainsFunctionsSpec {
-    val subject = DataClassContainsFunctions()
+    val subject = DataClassContainsFunctions(Config.empty)
 
     @Nested
     inner class `flagged functions in data class` {
@@ -54,7 +55,7 @@ class DataClassContainsFunctionsSpec {
 
         @Test
         fun `reports operators if not allowed by default`() {
-            val rule = DataClassContainsFunctions()
+            val rule = DataClassContainsFunctions(Config.empty)
             assertThat(rule.compileAndLint(code)).hasSize(1)
         }
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/DataClassShouldBeImmutableSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/DataClassShouldBeImmutableSpec.kt
@@ -1,11 +1,12 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 class DataClassShouldBeImmutableSpec {
-    val subject = DataClassShouldBeImmutable()
+    val subject = DataClassShouldBeImmutable(Config.empty)
 
     @Test
     fun `reports mutable variable in primary constructor`() {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/DestructuringDeclarationWithTooManyEntriesSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/DestructuringDeclarationWithTooManyEntriesSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.assertj.core.api.Assertions.assertThat
@@ -9,7 +10,7 @@ import org.junit.jupiter.api.Test
 private const val MAX_DESTRUCTURING_ENTRIES = "maxDestructuringEntries"
 
 class DestructuringDeclarationWithTooManyEntriesSpec {
-    val subject = DestructuringDeclarationWithTooManyEntries()
+    val subject = DestructuringDeclarationWithTooManyEntries(Config.empty)
 
     @Nested
     inner class `default configuration` {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenAnnotationSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenAnnotationSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
@@ -19,7 +20,7 @@ class ForbiddenAnnotationSpec(val env: KotlinCoreEnvironment) {
             @SuppressWarnings("unused")
             fun main() {}
         """.trimIndent()
-        val findings = ForbiddenAnnotation().compileAndLintWithContext(env, code)
+        val findings = ForbiddenAnnotation(Config.empty).compileAndLintWithContext(env, code)
 
         assertThat(findings)
             .hasSize(1)
@@ -52,7 +53,7 @@ class ForbiddenAnnotationSpec(val env: KotlinCoreEnvironment) {
             @Inherited
             annotation class SomeClass(val value: Array<SomeClass>)
         """.trimIndent()
-        val findings = ForbiddenAnnotation().compileAndLintWithContext(env, code)
+        val findings = ForbiddenAnnotation(Config.empty).compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(6)
             .hasTextLocations(
                 "@Deprecated",
@@ -220,7 +221,7 @@ class ForbiddenAnnotationSpec(val env: KotlinCoreEnvironment) {
             @Dep
             fun f() = Unit
         """.trimIndent()
-        val findings = ForbiddenAnnotation().compileAndLintWithContext(env, code)
+        val findings = ForbiddenAnnotation(Config.empty).compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(1)
             .hasTextLocations("@Dep")
     }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenCommentSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenCommentSpec.kt
@@ -2,6 +2,7 @@
 
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.ValueWithReason
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
@@ -28,34 +29,34 @@ class ForbiddenCommentSpec {
         @Test
         @DisplayName("should report TODO: usages")
         fun reportTodoColon() {
-            val findings = ForbiddenComment().compileAndLint("// TODO: I need to fix this.")
+            val findings = ForbiddenComment(Config.empty).compileAndLint("// TODO: I need to fix this.")
             assertThat(findings).hasSize(1)
             assertThat(findings[0]).hasMessage("Forbidden TODO todo marker in comment, please do the changes.")
         }
 
         @Test
         fun `should not report TODO usages`() {
-            val findings = ForbiddenComment().compileAndLint("// TODO I need to fix this.")
+            val findings = ForbiddenComment(Config.empty).compileAndLint("// TODO I need to fix this.")
             assertThat(findings).isEmpty()
         }
 
         @Test
         @DisplayName("should report FIXME: usages")
         fun reportFixMe() {
-            val findings = ForbiddenComment().compileAndLint("// FIXME: I need to fix this.")
+            val findings = ForbiddenComment(Config.empty).compileAndLint("// FIXME: I need to fix this.")
             assertThat(findings).hasSize(1)
         }
 
         @Test
         fun `should not report FIXME usages`() {
-            val findings = ForbiddenComment().compileAndLint("// FIXME I need to fix this.")
+            val findings = ForbiddenComment(Config.empty).compileAndLint("// FIXME I need to fix this.")
             assertThat(findings).isEmpty()
         }
 
         @Test
         @DisplayName("should report STOPSHIP: usages")
         fun reportStopShipColon() {
-            val findings = ForbiddenComment().compileAndLint("// STOPSHIP: I need to fix this.")
+            val findings = ForbiddenComment(Config.empty).compileAndLint("// STOPSHIP: I need to fix this.")
             assertThat(findings).hasSize(1)
             assertThat(findings[0]).hasMessage(
                 "Forbidden STOPSHIP todo marker in comment, please address the problem before shipping the code."
@@ -64,7 +65,7 @@ class ForbiddenCommentSpec {
 
         @Test
         fun `should not report STOPSHIP usages`() {
-            val findings = ForbiddenComment().compileAndLint("// STOPSHIP I need to fix this.")
+            val findings = ForbiddenComment(Config.empty).compileAndLint("// STOPSHIP I need to fix this.")
             assertThat(findings).isEmpty()
         }
 
@@ -75,7 +76,7 @@ class ForbiddenCommentSpec {
                  TODO: I need to fix this.
                  */
             """.trimIndent()
-            val findings = ForbiddenComment().compileAndLint(code)
+            val findings = ForbiddenComment(Config.empty).compileAndLint(code)
             assertThat(findings).hasSize(1)
         }
 
@@ -84,7 +85,7 @@ class ForbiddenCommentSpec {
             val code = """
                 /*TODO: I need to fix this.*/
             """.trimIndent()
-            val findings = ForbiddenComment().compileAndLint(code)
+            val findings = ForbiddenComment(Config.empty).compileAndLint(code)
             assertThat(findings).hasSize(1)
         }
 
@@ -100,7 +101,7 @@ class ForbiddenCommentSpec {
                      */
                 }
             """.trimIndent()
-            val findings = ForbiddenComment().compileAndLint(code)
+            val findings = ForbiddenComment(Config.empty).compileAndLint(code)
             assertThat(findings).hasSize(2)
         }
 
@@ -112,7 +113,7 @@ class ForbiddenCommentSpec {
                  */
                 class A
             """.trimIndent()
-            val findings = ForbiddenComment().compileAndLint(code)
+            val findings = ForbiddenComment(Config.empty).compileAndLint(code)
             assertThat(findings).hasSize(1)
         }
     }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenImportSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenImportSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.ValueWithReason
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.lint
@@ -25,7 +26,7 @@ class ForbiddenImportSpec {
 
     @Test
     fun `should report nothing by default`() {
-        val findings = ForbiddenImport().lint(code)
+        val findings = ForbiddenImport(Config.empty).lint(code)
         assertThat(findings).isEmpty()
     }
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/FunctionOnlyReturningConstantSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/FunctionOnlyReturningConstantSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import io.gitlab.arturbosch.detekt.test.lint
@@ -12,7 +13,7 @@ private const val IGNORE_ACTUAL_FUNCTION = "ignoreActualFunction"
 private const val EXCLUDED_FUNCTIONS = "excludedFunctions"
 
 class FunctionOnlyReturningConstantSpec {
-    val subject = FunctionOnlyReturningConstant()
+    val subject = FunctionOnlyReturningConstant(Config.empty)
 
     @Nested
     inner class `FunctionOnlyReturningConstant rule - positive cases` {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/LoopWithTooManyJumpStatementsSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/LoopWithTooManyJumpStatementsSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLint
@@ -22,7 +23,7 @@ class LoopWithTooManyJumpStatementsSpec {
                 }
             }
         """.trimIndent()
-        assertThat(LoopWithTooManyJumpStatements().compileAndLint(code)).hasTextLocations(20 to 23)
+        assertThat(LoopWithTooManyJumpStatements(Config.empty).compileAndLint(code)).hasTextLocations(20 to 23)
     }
 
     @Test
@@ -34,7 +35,7 @@ class LoopWithTooManyJumpStatementsSpec {
                 }
             }
         """.trimIndent()
-        assertThat(LoopWithTooManyJumpStatements().compileAndLint(code)).hasTextLocations(20 to 25)
+        assertThat(LoopWithTooManyJumpStatements(Config.empty).compileAndLint(code)).hasTextLocations(20 to 25)
     }
 
     @Test
@@ -46,7 +47,7 @@ class LoopWithTooManyJumpStatementsSpec {
                 } while (i < 1)
             }
         """.trimIndent()
-        assertThat(LoopWithTooManyJumpStatements().compileAndLint(code)).hasTextLocations(20 to 22)
+        assertThat(LoopWithTooManyJumpStatements(Config.empty).compileAndLint(code)).hasTextLocations(20 to 22)
     }
 
     @Test
@@ -101,7 +102,7 @@ class LoopWithTooManyJumpStatementsSpec {
                 }
             }
         """.trimIndent()
-        val findings = LoopWithTooManyJumpStatements().compileAndLint(code)
+        val findings = LoopWithTooManyJumpStatements(Config.empty).compileAndLint(code)
         assertThat(findings).isEmpty()
     }
 
@@ -118,7 +119,7 @@ class LoopWithTooManyJumpStatementsSpec {
                 }
             }
         """.trimIndent()
-        val findings = LoopWithTooManyJumpStatements().compileAndLint(code)
+        val findings = LoopWithTooManyJumpStatements(Config.empty).compileAndLint(code)
         assertThat(findings).isEmpty()
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumberSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumberSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
@@ -32,7 +33,7 @@ class MagicNumberSpec {
 
         @Test
         fun `should not be reported by default`() {
-            val findings = MagicNumber().lint(code)
+            val findings = MagicNumber(Config.empty).lint(code)
             assertThat(findings).isEmpty()
         }
 
@@ -49,7 +50,7 @@ class MagicNumberSpec {
 
         @Test
         fun `should not be reported by default`() {
-            val findings = MagicNumber().lint(code)
+            val findings = MagicNumber(Config.empty).lint(code)
             assertThat(findings).isEmpty()
         }
 
@@ -66,7 +67,7 @@ class MagicNumberSpec {
 
         @Test
         fun `should not be reported by default`() {
-            val findings = MagicNumber().lint(code)
+            val findings = MagicNumber(Config.empty).lint(code)
             assertThat(findings).isEmpty()
         }
 
@@ -83,7 +84,7 @@ class MagicNumberSpec {
 
         @Test
         fun `should not be reported by default`() {
-            val findings = MagicNumber().lint(code)
+            val findings = MagicNumber(Config.empty).lint(code)
             assertThat(findings).isEmpty()
         }
 
@@ -100,7 +101,7 @@ class MagicNumberSpec {
 
         @Test
         fun `should not be reported by default`() {
-            val findings = MagicNumber().lint(code)
+            val findings = MagicNumber(Config.empty).lint(code)
             assertThat(findings).isEmpty()
         }
 
@@ -117,7 +118,7 @@ class MagicNumberSpec {
 
         @Test
         fun `should not be reported by default`() {
-            val findings = MagicNumber().lint(code)
+            val findings = MagicNumber(Config.empty).lint(code)
             assertThat(findings).isEmpty()
         }
 
@@ -134,7 +135,7 @@ class MagicNumberSpec {
 
         @Test
         fun `should be reported by default`() {
-            val findings = MagicNumber().lint(code)
+            val findings = MagicNumber(Config.empty).lint(code)
             assertThat(findings).hasStartSourceLocation(1, 15)
         }
 
@@ -171,7 +172,7 @@ class MagicNumberSpec {
 
         @Test
         fun `should not be reported by default`() {
-            val findings = MagicNumber().lint(code)
+            val findings = MagicNumber(Config.empty).lint(code)
             assertThat(findings).isEmpty()
         }
 
@@ -188,7 +189,7 @@ class MagicNumberSpec {
 
         @Test
         fun `should not be reported by default`() {
-            val findings = MagicNumber().lint(code)
+            val findings = MagicNumber(Config.empty).lint(code)
             assertThat(findings).isEmpty()
         }
 
@@ -205,7 +206,7 @@ class MagicNumberSpec {
 
         @Test
         fun `should not be reported by default`() {
-            val findings = MagicNumber().lint(code)
+            val findings = MagicNumber(Config.empty).lint(code)
             assertThat(findings).isEmpty()
         }
 
@@ -222,7 +223,7 @@ class MagicNumberSpec {
 
         @Test
         fun `should not be reported by default`() {
-            val findings = MagicNumber().lint(code)
+            val findings = MagicNumber(Config.empty).lint(code)
             assertThat(findings).isEmpty()
         }
 
@@ -239,7 +240,7 @@ class MagicNumberSpec {
 
         @Test
         fun `should not be reported by default`() {
-            val findings = MagicNumber().lint(code)
+            val findings = MagicNumber(Config.empty).lint(code)
             assertThat(findings).isEmpty()
         }
 
@@ -273,7 +274,7 @@ class MagicNumberSpec {
 
         @Test
         fun `should not be reported`() {
-            val findings = MagicNumber().lint(code)
+            val findings = MagicNumber(Config.empty).lint(code)
             assertThat(findings).hasSize(1)
         }
 
@@ -290,7 +291,7 @@ class MagicNumberSpec {
 
         @Test
         fun `should be reported by default`() {
-            val findings = MagicNumber().lint(code)
+            val findings = MagicNumber(Config.empty).lint(code)
             assertThat(findings).hasStartSourceLocation(1, 13)
         }
 
@@ -319,7 +320,7 @@ class MagicNumberSpec {
 
         @Test
         fun `should be reported`() {
-            val findings = MagicNumber().lint(code)
+            val findings = MagicNumber(Config.empty).lint(code)
             assertThat(findings)
                 .hasStartSourceLocations(
                     SourceLocation(1, 17),
@@ -344,7 +345,7 @@ class MagicNumberSpec {
 
         @Test
         fun `should be reported`() {
-            val findings = MagicNumber().lint(code)
+            val findings = MagicNumber(Config.empty).lint(code)
             assertThat(findings).hasStartSourceLocations(
                 SourceLocation(3, 9),
                 SourceLocation(3, 21),
@@ -366,7 +367,7 @@ class MagicNumberSpec {
 
         @Test
         fun `should be reported`() {
-            val findings = MagicNumber().lint(code)
+            val findings = MagicNumber(Config.empty).lint(code)
             assertThat(findings).hasSize(1)
         }
     }
@@ -381,7 +382,7 @@ class MagicNumberSpec {
 
         @Test
         fun `should not be reported`() {
-            val findings = MagicNumber().lint(code)
+            val findings = MagicNumber(Config.empty).lint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -392,7 +393,7 @@ class MagicNumberSpec {
 
         @Test
         fun `should not be reported`() {
-            val findings = MagicNumber().lint(code)
+            val findings = MagicNumber(Config.empty).lint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -404,7 +405,7 @@ class MagicNumberSpec {
 
         @Test
         fun `should be reported by default`() {
-            val findings = MagicNumber().lint(code)
+            val findings = MagicNumber(Config.empty).lint(code)
             assertThat(findings).hasStartSourceLocation(1, 12)
         }
 
@@ -421,7 +422,7 @@ class MagicNumberSpec {
         @Test
         fun `should report`() {
             val code = "val file = Array<String?>(42) { null }"
-            val findings = MagicNumber().compileAndLint(code)
+            val findings = MagicNumber(Config.empty).compileAndLint(code)
             assertThat(findings).hasSize(1)
         }
     }
@@ -526,7 +527,7 @@ class MagicNumberSpec {
 
         @Test
         fun `should not report any issues by default`() {
-            val findings = MagicNumber().lint(code)
+            val findings = MagicNumber(Config.empty).lint(code)
             assertThat(findings).isEmpty()
         }
 
@@ -613,7 +614,7 @@ class MagicNumberSpec {
 
         @Test
         fun `should not lead to a crash #276`() {
-            val findings = MagicNumber().lint(code)
+            val findings = MagicNumber(Config.empty).lint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -657,12 +658,12 @@ class MagicNumberSpec {
 
             @Test
             fun `should ignore numbers by default`() {
-                assertThat(MagicNumber().lint(code("53"))).isEmpty()
+                assertThat(MagicNumber(Config.empty).lint(code("53"))).isEmpty()
             }
 
             @Test
             fun `should ignore negative numbers by default`() {
-                assertThat(MagicNumber().lint(code("-53"))).isEmpty()
+                assertThat(MagicNumber(Config.empty).lint(code("-53"))).isEmpty()
             }
 
             @Test
@@ -672,14 +673,14 @@ class MagicNumberSpec {
                     
                     object B : A(n = 5)
                 """.trimIndent()
-                assertThat(MagicNumber().compileAndLint(code)).isEmpty()
+                assertThat(MagicNumber(Config.empty).compileAndLint(code)).isEmpty()
             }
 
             @Test
             fun `should ignore named arguments in parameter annotations - #1115`() {
                 val code =
                     "@JvmStatic fun setCustomDimension(@IntRange(from = 0, to = 19) index: Int, value: String?) {}"
-                assertThat(MagicNumber().lint(code)).isEmpty()
+                assertThat(MagicNumber(Config.empty).lint(code)).isEmpty()
             }
         }
 
@@ -697,7 +698,7 @@ class MagicNumberSpec {
 
             @Test
             fun `should detect the argument by default`() {
-                assertThat(MagicNumber().lint(code("53"))).hasSize(1)
+                assertThat(MagicNumber(Config.empty).lint(code("53"))).hasSize(1)
             }
         }
 
@@ -711,22 +712,22 @@ class MagicNumberSpec {
 
             @Test
             fun `should ignore int by default`() {
-                assertThat(MagicNumber().lint(code(53))).isEmpty()
+                assertThat(MagicNumber(Config.empty).lint(code(53))).isEmpty()
             }
 
             @Test
             fun `should ignore float by default`() {
-                assertThat(MagicNumber().lint(code(53f))).isEmpty()
+                assertThat(MagicNumber(Config.empty).lint(code(53f))).isEmpty()
             }
 
             @Test
             fun `should ignore binary by default`() {
-                assertThat(MagicNumber().lint(code(0b01001))).isEmpty()
+                assertThat(MagicNumber(Config.empty).lint(code(0b01001))).isEmpty()
             }
 
             @Test
             fun `should ignore integer with underscores`() {
-                assertThat(MagicNumber().lint(code(101_000))).isEmpty()
+                assertThat(MagicNumber(Config.empty).lint(code(101_000))).isEmpty()
             }
         }
 
@@ -741,7 +742,7 @@ class MagicNumberSpec {
 
             @Test
             fun `should be reported by default`() {
-                assertThat(MagicNumber().lint(code)).hasSize(1)
+                assertThat(MagicNumber(Config.empty).lint(code)).hasSize(1)
             }
 
             @Test
@@ -801,7 +802,7 @@ class MagicNumberSpec {
                 fun x() = 9
                 fun y(): Int { return 9 }
             """.trimIndent()
-            assertThat(MagicNumber().compileAndLint(code)).isEmpty()
+            assertThat(MagicNumber(Config.empty).compileAndLint(code)).isEmpty()
         }
 
         @Test
@@ -810,7 +811,7 @@ class MagicNumberSpec {
                 fun x() = 9 + 1
                 fun y(): Int { return 9 + 1 }
             """.trimIndent()
-            assertThat(MagicNumber().compileAndLint(code)).hasSize(2)
+            assertThat(MagicNumber(Config.empty).compileAndLint(code)).hasSize(2)
         }
     }
 
@@ -820,20 +821,20 @@ class MagicNumberSpec {
         @Test
         fun `reports no finding`() {
             val code = "class SomeClassWithDefault(val defaultValue: Int = 10)"
-            assertThat(MagicNumber().lint(code)).isEmpty()
+            assertThat(MagicNumber(Config.empty).lint(code)).isEmpty()
         }
 
         @Test
         fun `reports no finding for an explicit declaration`() {
             val code = "class SomeClassWithDefault constructor(val defaultValue: Int = 10)"
-            assertThat(MagicNumber().lint(code)).isEmpty()
+            assertThat(MagicNumber(Config.empty).lint(code)).isEmpty()
         }
 
         @Test
         fun `reports no finding for a function expression`() {
             val code =
                 "class SomeClassWithDefault constructor(val defaultValue: Duration = 10.toDuration(DurationUnit.MILLISECONDS))"
-            assertThat(MagicNumber().lint(code)).isEmpty()
+            assertThat(MagicNumber(Config.empty).lint(code)).isEmpty()
         }
     }
 
@@ -847,7 +848,7 @@ class MagicNumberSpec {
                     constructor(val defaultValue: Int = 10) { }
                 }
             """.trimIndent()
-            assertThat(MagicNumber().lint(code)).isEmpty()
+            assertThat(MagicNumber(Config.empty).lint(code)).isEmpty()
         }
 
         @Test
@@ -857,7 +858,7 @@ class MagicNumberSpec {
                     constructor(val defaultValue: Duration = 10.toDuration(DurationUnit.MILLISECONDS)) { }
                 }
             """.trimIndent()
-            assertThat(MagicNumber().lint(code)).isEmpty()
+            assertThat(MagicNumber(Config.empty).lint(code)).isEmpty()
         }
     }
 
@@ -867,13 +868,13 @@ class MagicNumberSpec {
         @Test
         fun `reports no finding`() {
             val code = "fun f(p: Int = 100)"
-            assertThat(MagicNumber().lint(code)).isEmpty()
+            assertThat(MagicNumber(Config.empty).lint(code)).isEmpty()
         }
 
         @Test
         fun `reports no finding for a function expression`() {
             val code = "fun f(p: Duration = 10.toDuration(DurationUnit.MILLISECONDS))"
-            assertThat(MagicNumber().lint(code)).isEmpty()
+            assertThat(MagicNumber(Config.empty).lint(code)).isEmpty()
         }
     }
 
@@ -894,7 +895,7 @@ class MagicNumberSpec {
         @ParameterizedTest
         @MethodSource("cases")
         fun `reports a code smell by default`(code: String) {
-            assertThat(MagicNumber().lint(code)).hasSize(1)
+            assertThat(MagicNumber(Config.empty).lint(code)).hasSize(1)
         }
 
         @ParameterizedTest

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLengthSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLengthSpec.kt
@@ -1,6 +1,7 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
 import io.github.detekt.test.utils.compileContentForTest
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
@@ -89,7 +90,7 @@ class MaxLineLengthSpec {
 
         @Test
         fun `should report all errors with default maxLineLength`() {
-            val rule = MaxLineLength()
+            val rule = MaxLineLength(Config.empty)
 
             rule.visitKtFile(file)
             assertThat(rule.findings).hasSize(3)
@@ -109,7 +110,7 @@ class MaxLineLengthSpec {
 
         @Test
         fun `should report meaningful signature for all violations`() {
-            val rule = MaxLineLength()
+            val rule = MaxLineLength(Config.empty)
 
             rule.visitKtFile(file)
             val locations = rule.findings.map { it.signature.substringAfterLast('$') }
@@ -192,7 +193,7 @@ class MaxLineLengthSpec {
 
         @Test
         fun `should not report as lines are suppressed`() {
-            val rule = MaxLineLength()
+            val rule = MaxLineLength(Config.empty)
 
             rule.visitKtFile(file)
             assertThat(rule.findings).isEmpty()

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MayBeConstantSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MayBeConstantSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLint
@@ -9,7 +10,7 @@ import org.junit.jupiter.api.Test
 
 class MayBeConstantSpec {
 
-    val subject = MayBeConstant()
+    val subject = MayBeConstant(Config.empty)
 
     @Nested
     inner class `some valid constants` {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/NestedClassesVisibilitySpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/NestedClassesVisibilitySpec.kt
@@ -1,11 +1,12 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 class NestedClassesVisibilitySpec {
-    val subject = NestedClassesVisibility()
+    val subject = NestedClassesVisibility(Config.empty)
 
     @Test
     fun `reports explicit public visibility in nested objects, classes and interfaces`() {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/NewLineAtEndOfFileSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/NewLineAtEndOfFileSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import io.gitlab.arturbosch.detekt.test.lint
@@ -7,7 +8,7 @@ import org.junit.jupiter.api.Test
 
 class NewLineAtEndOfFileSpec {
 
-    val subject = NewLineAtEndOfFile()
+    val subject = NewLineAtEndOfFile(Config.empty)
 
     @Test
     fun `should not flag a kt file containing new line at the end`() {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/NoTabsSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/NoTabsSpec.kt
@@ -1,11 +1,12 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
 import io.github.detekt.test.utils.compileContentForTest
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.assertThat
 import org.junit.jupiter.api.Test
 
 class NoTabsSpec {
-    private val subject = NoTabs()
+    private val subject = NoTabs(Config.empty)
 
     @Test
     fun `should flag a line that contains a tab`() {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ObjectLiteralToLambdaSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ObjectLiteralToLambdaSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assert
@@ -11,7 +12,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 class ObjectLiteralToLambdaSpec {
-    val subject = ObjectLiteralToLambda()
+    val subject = ObjectLiteralToLambda(Config.empty)
 
     @Nested
     @KotlinCoreEnvironmentTest

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/OptionalAbstractKeywordSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/OptionalAbstractKeywordSpec.kt
@@ -1,11 +1,12 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.junit.jupiter.api.Test
 
 class OptionalAbstractKeywordSpec {
-    val subject = OptionalAbstractKeyword()
+    val subject = OptionalAbstractKeyword(Config.empty)
 
     @Test
     fun `does not report abstract keywords on an interface`() {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantConstructorKeywordSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantConstructorKeywordSpec.kt
@@ -1,11 +1,12 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 class RedundantConstructorKeywordSpec {
-    val subject = RedundantConstructorKeyword()
+    val subject = RedundantConstructorKeyword(Config.empty)
 
     @Test fun `report on data class with redundant constructor keyword`() {
         val code = """

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantHigherOrderMapUsageSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantHigherOrderMapUsageSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
@@ -9,7 +10,7 @@ import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
 class RedundantHigherOrderMapUsageSpec(val env: KotlinCoreEnvironment) {
-    val subject = RedundantHigherOrderMapUsage()
+    val subject = RedundantHigherOrderMapUsage(Config.empty)
 
     @Nested
     inner class `report RedundantHigherOrderMapUsage rule` {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantVisibilityModifierRuleSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantVisibilityModifierRuleSpec.kt
@@ -1,6 +1,7 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
 import io.github.detekt.test.utils.compileContentForTest
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.internal.CompilerResources
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLint
@@ -14,7 +15,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 class RedundantVisibilityModifierRuleSpec {
-    val subject = RedundantVisibilityModifierRule()
+    val subject = RedundantVisibilityModifierRule(Config.empty)
 
     @Test
     fun `does not report overridden function of abstract class with public modifier`() {
@@ -188,7 +189,7 @@ class RedundantVisibilityModifierRuleSpec {
             """.trimIndent()
         )
 
-        val rule = RedundantVisibilityModifierRule()
+        val rule = RedundantVisibilityModifierRule(Config.empty)
 
         private fun mockCompilerResources(mode: ExplicitApiMode): CompilerResources {
             val languageVersionSettings = mockk<LanguageVersionSettings>()

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCountSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCountSpec.kt
@@ -355,7 +355,7 @@ class ReturnCountSpec {
 
         @Test
         fun `should get flagged by default`() {
-            val findings = ReturnCount().compileAndLint(code)
+            val findings = ReturnCount(Config.empty).compileAndLint(code)
             assertThat(findings).hasSize(1)
         }
 
@@ -386,7 +386,7 @@ class ReturnCountSpec {
 
         @Test
         fun `should not get flagged by default`() {
-            val findings = ReturnCount().compileAndLint(code)
+            val findings = ReturnCount(Config.empty).compileAndLint(code)
             assertThat(findings).isEmpty()
         }
 
@@ -600,7 +600,7 @@ class ReturnCountSpec {
 
         @Test
         fun `should not count labeled returns from lambda by default`() {
-            val findings = ReturnCount().lint(code)
+            val findings = ReturnCount(Config.empty).lint(code)
             assertThat(findings).isEmpty()
         }
 
@@ -644,7 +644,7 @@ class ReturnCountSpec {
 
         @Test
         fun `should not count labeled return of lambda with explicit label when deactivated by default`() {
-            val findings = ReturnCount().compileAndLint(code)
+            val findings = ReturnCount(Config.empty).compileAndLint(code)
             assertThat(findings).isEmpty()
         }
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/SafeCastSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/SafeCastSpec.kt
@@ -1,11 +1,12 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.junit.jupiter.api.Test
 
 class SafeCastSpec {
-    val subject = SafeCast()
+    val subject = SafeCast(Config.empty)
 
     @Test
     fun `reports negated expression`() {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/TrailingWhitespaceSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/TrailingWhitespaceSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.junit.jupiter.api.Nested
@@ -7,7 +8,7 @@ import org.junit.jupiter.api.Test
 
 class TrailingWhitespaceSpec {
 
-    private val subject = TrailingWhitespace()
+    private val subject = TrailingWhitespace(Config.empty)
 
     @Nested
     inner class `positive cases` {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiteralsSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiteralsSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLint
@@ -20,7 +21,7 @@ class UnderscoresInNumericLiteralsSpec {
 
         @Test
         fun `should not be reported by default`() {
-            val findings = UnderscoresInNumericLiterals().compileAndLint(code)
+            val findings = UnderscoresInNumericLiterals(Config.empty).compileAndLint(code)
             assertThat(findings).isEmpty()
         }
 
@@ -47,7 +48,7 @@ class UnderscoresInNumericLiteralsSpec {
 
         @Test
         fun `should not be reported`() {
-            val findings = UnderscoresInNumericLiterals().compileAndLint(code)
+            val findings = UnderscoresInNumericLiterals(Config.empty).compileAndLint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -58,7 +59,7 @@ class UnderscoresInNumericLiteralsSpec {
 
         @Test
         fun `should be reported by default`() {
-            val findings = UnderscoresInNumericLiterals().compileAndLint(code)
+            val findings = UnderscoresInNumericLiterals(Config.empty).compileAndLint(code)
             assertThat(findings).isNotEmpty
         }
 
@@ -77,7 +78,7 @@ class UnderscoresInNumericLiteralsSpec {
 
         @Test
         fun `should not be reported by default`() {
-            val findings = UnderscoresInNumericLiterals().compileAndLint(code)
+            val findings = UnderscoresInNumericLiterals(Config.empty).compileAndLint(code)
             assertThat(findings).isEmpty()
         }
 
@@ -96,7 +97,7 @@ class UnderscoresInNumericLiteralsSpec {
 
         @Test
         fun `should not be reported by default`() {
-            val findings = UnderscoresInNumericLiterals().compileAndLint(code)
+            val findings = UnderscoresInNumericLiterals(Config.empty).compileAndLint(code)
             assertThat(findings).isEmpty()
         }
 
@@ -115,7 +116,7 @@ class UnderscoresInNumericLiteralsSpec {
 
         @Test
         fun `should not be reported`() {
-            val findings = UnderscoresInNumericLiterals().compileAndLint(code)
+            val findings = UnderscoresInNumericLiterals(Config.empty).compileAndLint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -126,7 +127,7 @@ class UnderscoresInNumericLiteralsSpec {
 
         @Test
         fun `should be reported by default`() {
-            val findings = UnderscoresInNumericLiterals().compileAndLint(code)
+            val findings = UnderscoresInNumericLiterals(Config.empty).compileAndLint(code)
             assertThat(findings).isNotEmpty
         }
 
@@ -146,7 +147,7 @@ class UnderscoresInNumericLiteralsSpec {
 
         @Test
         fun `should not be reported`() {
-            val findings = UnderscoresInNumericLiterals().compileAndLint(code)
+            val findings = UnderscoresInNumericLiterals(Config.empty).compileAndLint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -157,7 +158,7 @@ class UnderscoresInNumericLiteralsSpec {
 
         @Test
         fun `should not be reported by default`() {
-            val findings = UnderscoresInNumericLiterals().compileAndLint(code)
+            val findings = UnderscoresInNumericLiterals(Config.empty).compileAndLint(code)
             assertThat(findings).isEmpty()
         }
 
@@ -176,7 +177,7 @@ class UnderscoresInNumericLiteralsSpec {
 
         @Test
         fun `should not be reported`() {
-            val findings = UnderscoresInNumericLiterals().lint(code)
+            val findings = UnderscoresInNumericLiterals(Config.empty).lint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -187,7 +188,7 @@ class UnderscoresInNumericLiteralsSpec {
 
         @Test
         fun `should be reported by default`() {
-            val findings = UnderscoresInNumericLiterals().lint(code)
+            val findings = UnderscoresInNumericLiterals(Config.empty).lint(code)
             assertThat(findings).isNotEmpty
         }
     }
@@ -198,7 +199,7 @@ class UnderscoresInNumericLiteralsSpec {
 
         @Test
         fun `should be reported by default`() {
-            val findings = UnderscoresInNumericLiterals().compileAndLint(code)
+            val findings = UnderscoresInNumericLiterals(Config.empty).compileAndLint(code)
             assertThat(findings).isNotEmpty
         }
 
@@ -225,7 +226,7 @@ class UnderscoresInNumericLiteralsSpec {
 
         @Test
         fun `should not be reported`() {
-            val findings = UnderscoresInNumericLiterals().compileAndLint(code)
+            val findings = UnderscoresInNumericLiterals(Config.empty).compileAndLint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -236,7 +237,7 @@ class UnderscoresInNumericLiteralsSpec {
 
         @Test
         fun `should not be reported`() {
-            val findings = UnderscoresInNumericLiterals().compileAndLint(code)
+            val findings = UnderscoresInNumericLiterals(Config.empty).compileAndLint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -247,7 +248,7 @@ class UnderscoresInNumericLiteralsSpec {
 
         @Test
         fun `should not be reported`() {
-            val findings = UnderscoresInNumericLiterals().compileAndLint(code)
+            val findings = UnderscoresInNumericLiterals(Config.empty).compileAndLint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -264,7 +265,7 @@ class UnderscoresInNumericLiteralsSpec {
 
         @Test
         fun `should not be reported`() {
-            val findings = UnderscoresInNumericLiterals().compileAndLint(code)
+            val findings = UnderscoresInNumericLiterals(Config.empty).compileAndLint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -279,7 +280,7 @@ class UnderscoresInNumericLiteralsSpec {
 
         @Test
         fun `should be reported by default`() {
-            val findings = UnderscoresInNumericLiterals().compileAndLint(code)
+            val findings = UnderscoresInNumericLiterals(Config.empty).compileAndLint(code)
             assertThat(findings).isNotEmpty
         }
     }
@@ -294,7 +295,7 @@ class UnderscoresInNumericLiteralsSpec {
 
         @Test
         fun `should not be reported`() {
-            val findings = UnderscoresInNumericLiterals().compileAndLint(code)
+            val findings = UnderscoresInNumericLiterals(Config.empty).compileAndLint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -313,7 +314,7 @@ class UnderscoresInNumericLiteralsSpec {
                     }
                 }
             """.trimIndent()
-            val findings = UnderscoresInNumericLiterals().compileAndLint(code)
+            val findings = UnderscoresInNumericLiterals(Config.empty).compileAndLint(code)
             assertThat(findings).hasSize(0)
         }
 
@@ -328,7 +329,7 @@ class UnderscoresInNumericLiteralsSpec {
                     }
                 }
             """.trimIndent()
-            val findings = UnderscoresInNumericLiterals().compileAndLint(code)
+            val findings = UnderscoresInNumericLiterals(Config.empty).compileAndLint(code)
             assertThat(findings).hasSize(0)
         }
     }
@@ -345,7 +346,7 @@ class UnderscoresInNumericLiteralsSpec {
                     private val serialVersionUID = -43857148126114372L
                 }
             """.trimIndent()
-            val findings = UnderscoresInNumericLiterals().compileAndLint(code)
+            val findings = UnderscoresInNumericLiterals(Config.empty).compileAndLint(code)
             assertThat(findings).hasSize(0)
         }
 
@@ -358,7 +359,7 @@ class UnderscoresInNumericLiteralsSpec {
                     private val serialVersionUID = 43857148126114372L
                 }
             """.trimIndent()
-            val findings = UnderscoresInNumericLiterals().compileAndLint(code)
+            val findings = UnderscoresInNumericLiterals(Config.empty).compileAndLint(code)
             assertThat(findings).hasSize(0)
         }
     }
@@ -369,7 +370,7 @@ class UnderscoresInNumericLiteralsSpec {
 
         @Test
         fun `should be reported by default`() {
-            val findings = UnderscoresInNumericLiterals().compileAndLint(code)
+            val findings = UnderscoresInNumericLiterals(Config.empty).compileAndLint(code)
             assertThat(findings).isNotEmpty
         }
 
@@ -389,7 +390,7 @@ class UnderscoresInNumericLiteralsSpec {
 
         @Test
         fun `should not be reported`() {
-            val findings = UnderscoresInNumericLiterals().compileAndLint(code)
+            val findings = UnderscoresInNumericLiterals(Config.empty).compileAndLint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -401,7 +402,7 @@ class UnderscoresInNumericLiteralsSpec {
 
         @Test
         fun `should not be reported`() {
-            val findings = UnderscoresInNumericLiterals().compileAndLint(code)
+            val findings = UnderscoresInNumericLiterals(Config.empty).compileAndLint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -427,7 +428,7 @@ class UnderscoresInNumericLiteralsSpec {
 
         @Test
         fun `should be reported by default`() {
-            val findings = UnderscoresInNumericLiterals().compileAndLint(code)
+            val findings = UnderscoresInNumericLiterals(Config.empty).compileAndLint(code)
             assertThat(findings).isNotEmpty
         }
 
@@ -447,7 +448,7 @@ class UnderscoresInNumericLiteralsSpec {
 
         @Test
         fun `should not be reported by default`() {
-            val findings = UnderscoresInNumericLiterals().compileAndLint(code)
+            val findings = UnderscoresInNumericLiterals(Config.empty).compileAndLint(code)
             assertThat(findings).isEmpty()
         }
     }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAnnotationUseSiteTargetSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAnnotationUseSiteTargetSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.junit.jupiter.api.DisplayName
@@ -15,7 +16,7 @@ class UnnecessaryAnnotationUseSiteTargetSpec {
             
             annotation class Asdf
         """.trimIndent()
-        assertThat(UnnecessaryAnnotationUseSiteTarget().compileAndLint(code)).hasTextLocations("param:")
+        assertThat(UnnecessaryAnnotationUseSiteTarget(Config.empty).compileAndLint(code)).hasTextLocations("param:")
     }
 
     @Test
@@ -26,7 +27,7 @@ class UnnecessaryAnnotationUseSiteTargetSpec {
             
             annotation class Asdf
         """.trimIndent()
-        assertThat(UnnecessaryAnnotationUseSiteTarget().compileAndLint(code)).hasTextLocations("param:")
+        assertThat(UnnecessaryAnnotationUseSiteTarget(Config.empty).compileAndLint(code)).hasTextLocations("param:")
     }
 
     @Test
@@ -37,7 +38,7 @@ class UnnecessaryAnnotationUseSiteTargetSpec {
             
             annotation class Asdf
         """.trimIndent()
-        assertThat(UnnecessaryAnnotationUseSiteTarget().compileAndLint(code)).isEmpty()
+        assertThat(UnnecessaryAnnotationUseSiteTarget(Config.empty).compileAndLint(code)).isEmpty()
     }
 
     @Test
@@ -48,7 +49,7 @@ class UnnecessaryAnnotationUseSiteTargetSpec {
             
             annotation class Asdf
         """.trimIndent()
-        assertThat(UnnecessaryAnnotationUseSiteTarget().compileAndLint(code)).isEmpty()
+        assertThat(UnnecessaryAnnotationUseSiteTarget(Config.empty).compileAndLint(code)).isEmpty()
     }
 
     @Test
@@ -61,7 +62,7 @@ class UnnecessaryAnnotationUseSiteTargetSpec {
             
             annotation class Asdf
         """.trimIndent()
-        assertThat(UnnecessaryAnnotationUseSiteTarget().compileAndLint(code)).hasTextLocations("property:")
+        assertThat(UnnecessaryAnnotationUseSiteTarget(Config.empty).compileAndLint(code)).hasTextLocations("property:")
     }
 
     @Test
@@ -72,6 +73,6 @@ class UnnecessaryAnnotationUseSiteTargetSpec {
             
             annotation class Asdf
         """.trimIndent()
-        assertThat(UnnecessaryAnnotationUseSiteTarget().compileAndLint(code)).hasTextLocations("property:")
+        assertThat(UnnecessaryAnnotationUseSiteTarget(Config.empty).compileAndLint(code)).hasTextLocations("property:")
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAnySpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAnySpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
 import org.assertj.core.api.Assertions.assertThat
@@ -9,7 +10,7 @@ import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
 class UnnecessaryAnySpec(val env: KotlinCoreEnvironment) {
-    val subject = UnnecessaryAny()
+    val subject = UnnecessaryAny(Config.empty)
 
     @Test
     fun `reports any which is used for checking presence of a element`() {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryFilterSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryFilterSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
@@ -10,7 +11,7 @@ import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
 class UnnecessaryFilterSpec(val env: KotlinCoreEnvironment) {
-    val subject = UnnecessaryFilter()
+    val subject = UnnecessaryFilter(Config.empty)
 
     @Nested
     inner class UnnecessaryFilterTest {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedParameterSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedParameterSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
@@ -11,7 +12,7 @@ import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
 class UnusedParameterSpec(val env: KotlinCoreEnvironment) {
-    val subject = UnusedParameter()
+    val subject = UnusedParameter(Config.empty)
 
     @Nested
     inner class `function parameters` {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateClassSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateClassSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import io.gitlab.arturbosch.detekt.test.lint
@@ -9,7 +10,7 @@ import org.junit.jupiter.api.Test
 
 class UnusedPrivateClassSpec {
 
-    val subject = UnusedPrivateClass()
+    val subject = UnusedPrivateClass(Config.empty)
 
     @Nested
     inner class `top level interfaces` {
@@ -320,7 +321,7 @@ class UnusedPrivateClassSpec {
                 fun bar(clazz: KClass<*>) = Unit
             """.trimIndent()
 
-            val findings = UnusedPrivateClass().compileAndLint(code)
+            val findings = UnusedPrivateClass(Config.empty).compileAndLint(code)
 
             assertThat(findings).hasSize(1)
         }
@@ -340,7 +341,7 @@ class UnusedPrivateClassSpec {
                 }
             """.trimIndent()
 
-            val findings = UnusedPrivateClass().compileAndLint(code)
+            val findings = UnusedPrivateClass(Config.empty).compileAndLint(code)
 
             assertThat(findings).isEmpty()
         }
@@ -365,7 +366,7 @@ class UnusedPrivateClassSpec {
                 }
             """.trimIndent()
 
-            val findings = UnusedPrivateClass().compileAndLint(code)
+            val findings = UnusedPrivateClass(Config.empty).compileAndLint(code)
 
             assertThat(findings).isEmpty()
         }
@@ -384,7 +385,7 @@ class UnusedPrivateClassSpec {
                 }
             """.trimIndent()
 
-            val findings = UnusedPrivateClass().compileAndLint(code)
+            val findings = UnusedPrivateClass(Config.empty).compileAndLint(code)
 
             assertThat(findings).isEmpty()
         }
@@ -408,7 +409,7 @@ class UnusedPrivateClassSpec {
                     }
                 }
             """.trimIndent()
-            val findings = UnusedPrivateClass().lint(code)
+            val findings = UnusedPrivateClass(Config.empty).lint(code)
             assertThat(findings).isEmpty()
         }
 
@@ -433,7 +434,7 @@ class UnusedPrivateClassSpec {
                     }
                 }
             """.trimIndent()
-            val findings = UnusedPrivateClass().lint(code)
+            val findings = UnusedPrivateClass(Config.empty).lint(code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasStartSourceLocation(10, 5)
         }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMemberSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMemberSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
@@ -12,7 +13,7 @@ import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
 class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
-    val subject = UnusedPrivateMember()
+    val subject = UnusedPrivateMember(Config.empty)
 
     @Nested
     inner class `interface functions` {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivatePropertySpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivatePropertySpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
@@ -16,7 +17,7 @@ private const val ALLOWED_NAMES_PATTERN = "allowedNames"
 
 @KotlinCoreEnvironmentTest
 class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
-    val subject = UnusedPrivateProperty()
+    val subject = UnusedPrivateProperty(Config.empty)
 
     val regexTestingCode = """
         class Test {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseAnyOrNoneInsteadOfFindSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseAnyOrNoneInsteadOfFindSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
 import org.assertj.core.api.Assertions.assertThat
@@ -9,7 +10,7 @@ import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
 class UseAnyOrNoneInsteadOfFindSpec(val env: KotlinCoreEnvironment) {
-    val subject = UseAnyOrNoneInsteadOfFind()
+    val subject = UseAnyOrNoneInsteadOfFind(Config.empty)
 
     @Test
     @DisplayName("Reports collections.find != null")

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseArrayLiteralsInAnnotationsSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseArrayLiteralsInAnnotationsSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.junit.jupiter.api.DisplayName
@@ -7,7 +8,7 @@ import org.junit.jupiter.api.Test
 
 class UseArrayLiteralsInAnnotationsSpec {
 
-    val subject = UseArrayLiteralsInAnnotations()
+    val subject = UseArrayLiteralsInAnnotations(Config.empty)
 
     @Test
     fun `finds an arrayOf usage`() {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseCheckNotNullSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseCheckNotNullSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
 import org.assertj.core.api.Assertions.assertThat
@@ -8,7 +9,7 @@ import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
 class UseCheckNotNullSpec(val env: KotlinCoreEnvironment) {
-    val subject = UseCheckNotNull()
+    val subject = UseCheckNotNull(Config.empty)
 
     @Test
     fun `reports 'check' calls with a non-null check`() {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIfEmptyOrIfBlankSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIfEmptyOrIfBlankSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
@@ -10,7 +11,7 @@ import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
 class UseIfEmptyOrIfBlankSpec(val env: KotlinCoreEnvironment) {
-    val subject = UseIfEmptyOrIfBlank()
+    val subject = UseIfEmptyOrIfBlank(Config.empty)
 
     @Nested
     inner class `report UseIfEmptyOrIfBlank rule` {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIfInsteadOfWhenSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIfInsteadOfWhenSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.assertj.core.api.Assertions.assertThat
@@ -7,7 +8,7 @@ import org.junit.jupiter.api.Test
 
 class UseIfInsteadOfWhenSpec {
 
-    val subject = UseIfInsteadOfWhen()
+    val subject = UseIfInsteadOfWhen(Config.empty)
 
     @Test
     fun `reports when using two branches`() {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIsNullOrEmptySpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIsNullOrEmptySpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
@@ -9,7 +10,7 @@ import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
 class UseIsNullOrEmptySpec(val env: KotlinCoreEnvironment) {
-    val subject = UseIsNullOrEmpty()
+    val subject = UseIsNullOrEmpty(Config.empty)
 
     @Nested
     inner class `report UseIsNullOrEmpty rule` {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseLetSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseLetSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.junit.jupiter.api.DynamicTest
@@ -8,7 +9,7 @@ import org.junit.jupiter.api.TestFactory
 
 class UseLetSpec {
 
-    val subject = UseLet()
+    val subject = UseLet(Config.empty)
 
     @TestFactory
     fun `it forbids all != null else null combinations`(): Iterable<DynamicTest> {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseOrEmptySpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseOrEmptySpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
@@ -9,7 +10,7 @@ import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
 class UseOrEmptySpec(val env: KotlinCoreEnvironment) {
-    val subject = UseOrEmpty()
+    val subject = UseOrEmpty(Config.empty)
 
     @Nested
     inner class `report UseOrEmptySpec rule` {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseRequireNotNullSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseRequireNotNullSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
 import org.assertj.core.api.Assertions.assertThat
@@ -8,7 +9,7 @@ import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
 class UseRequireNotNullSpec(val env: KotlinCoreEnvironment) {
-    val subject = UseRequireNotNull()
+    val subject = UseRequireNotNull(Config.empty)
 
     @Test
     fun `reports 'require' calls with a non-null check`() {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseSumOfInsteadOfFlatMapSizeSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseSumOfInsteadOfFlatMapSizeSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
 import org.assertj.core.api.Assertions.assertThat
@@ -8,7 +9,7 @@ import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
 class UseSumOfInsteadOfFlatMapSizeSpec(val env: KotlinCoreEnvironment) {
-    val subject = UseSumOfInsteadOfFlatMapSize()
+    val subject = UseSumOfInsteadOfFlatMapSize(Config.empty)
 
     @Test
     fun `reports flatMap and size`() {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UselessCallOnNotNullSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UselessCallOnNotNullSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
 import io.gitlab.arturbosch.detekt.test.lintWithContext
@@ -9,7 +10,7 @@ import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
 class UselessCallOnNotNullSpec(val env: KotlinCoreEnvironment) {
-    val subject = UselessCallOnNotNull()
+    val subject = UselessCallOnNotNull(Config.empty)
 
     @Test
     fun `reports when calling orEmpty on a list`() {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/VarCouldBeValSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/VarCouldBeValSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.compileAndLint
@@ -12,7 +13,7 @@ import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
 class VarCouldBeValSpec(val env: KotlinCoreEnvironment) {
-    val subject = VarCouldBeVal()
+    val subject = VarCouldBeVal(Config.empty)
 
     @Nested
     inner class `file-level declarations` {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/WildcardImportSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/WildcardImportSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import io.gitlab.arturbosch.detekt.test.lint
@@ -23,7 +24,7 @@ class WildcardImportSpec {
 
         @Test
         fun `should report all wildcard imports`() {
-            val rule = WildcardImport()
+            val rule = WildcardImport(Config.empty)
 
             val findings = rule.compileAndLint(code)
             assertThat(findings).hasSize(2)
@@ -75,7 +76,7 @@ class WildcardImportSpec {
                 import java.util.*
             """.trimIndent()
 
-            val findings = WildcardImport().lint(code2)
+            val findings = WildcardImport(Config.empty).lint(code2)
             assertThat(findings).isEmpty()
         }
     }
@@ -93,7 +94,7 @@ class WildcardImportSpec {
 
         @Test
         fun `should not report any issues`() {
-            val findings = WildcardImport().compileAndLint(code)
+            val findings = WildcardImport(Config.empty).compileAndLint(code)
             assertThat(findings).isEmpty()
         }
     }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/movelambdaout/UnnecessaryBracesAroundTrailingLambdaSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/movelambdaout/UnnecessaryBracesAroundTrailingLambdaSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.style.movelambdaout
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
@@ -10,7 +11,7 @@ import org.junit.jupiter.api.Test
 // Source https://github.com/JetBrains/intellij-community/tree/master/plugins/kotlin/idea/tests/testData/inspectionsLocal/moveLambdaOutsideParentheses
 @KotlinCoreEnvironmentTest
 class UnnecessaryBracesAroundTrailingLambdaSpec(val env: KotlinCoreEnvironment) {
-    private val subject = UnnecessaryBracesAroundTrailingLambda()
+    private val subject = UnnecessaryBracesAroundTrailingLambda(Config.empty)
 
     @Test
     fun `does report when trailing lambda had braces`() {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/MandatoryBracesLoopsSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/MandatoryBracesLoopsSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.style.optional
 
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.assertj.core.api.Assertions.assertThat
@@ -7,7 +8,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 class MandatoryBracesLoopsSpec {
-    val subject = MandatoryBracesLoops()
+    val subject = MandatoryBracesLoops(Config.empty)
 
     @Nested
     inner class `MandatoryBracesLoops rule for 'for' loops` {

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/SuppressingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/SuppressingSpec.kt
@@ -1,6 +1,7 @@
 package io.gitlab.arturbosch.detekt.rules
 
 import io.github.detekt.test.utils.compileContentForTest
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.complexity.ComplexCondition
 import io.gitlab.arturbosch.detekt.rules.complexity.LongMethod
 import io.gitlab.arturbosch.detekt.rules.complexity.LongParameterList
@@ -10,6 +11,7 @@ import org.junit.jupiter.api.Test
 class SuppressingSpec {
 
     @Test
+    @Suppress("LongMethod")
     fun `all findings are suppressed on element levels`() {
         @Suppress("KotlinConstantConditions")
         val code = """
@@ -62,7 +64,11 @@ class SuppressingSpec {
         """.trimIndent()
         val ktFile = compileContentForTest(code)
 
-        val findings = listOf(LongMethod(), LongParameterList(), ComplexCondition()).flatMap {
+        val findings = listOf(
+            LongMethod(Config.empty),
+            LongParameterList(Config.empty),
+            ComplexCondition(Config.empty),
+        ).flatMap {
             it.visitFile(ktFile)
             it.findings
         }
@@ -119,7 +125,11 @@ class SuppressingSpec {
             }
         """.trimIndent()
         val ktFile = compileContentForTest(code)
-        val findings = listOf(LongMethod(), LongParameterList(), ComplexCondition()).flatMap {
+        val findings = listOf(
+            LongMethod(Config.empty),
+            LongParameterList(Config.empty),
+            ComplexCondition(Config.empty),
+        ).flatMap {
             it.visitFile(ktFile)
             it.findings
         }
@@ -173,7 +183,11 @@ class SuppressingSpec {
 
         val ktFile = compileContentForTest(code)
 
-        val findings = listOf(LongMethod(), LongParameterList(), ComplexCondition()).flatMap {
+        val findings = listOf(
+            LongMethod(Config.empty),
+            LongParameterList(Config.empty),
+            ComplexCondition(Config.empty),
+        ).flatMap {
             it.visitFile(ktFile)
             it.findings
         }


### PR DESCRIPTION
Comment on `Config.empty` says "This config should only be used in test cases". Unfortunately it's been added over time to many other places in detekt, particularly as a default value in rule constructors.

This PR does the bulk of the work to remove those usages in production code (by removing the default value from the rule constructors) leaving only a handful of other instances which can hopefully be removed later. I'd like to move the empty config code to detekt-api test fixtures.