### PR TITLE
Remove PRIMITIVES from public API

### DIFF
--- a/detekt-api/api/detekt-api.api
+++ b/detekt-api/api/detekt-api.api
@@ -74,7 +74,6 @@ public final class io/gitlab/arturbosch/detekt/api/Config$Companion {
 	public static final field INCLUDES_KEY Ljava/lang/String;
 	public static final field SEVERITY_KEY Ljava/lang/String;
 	public final fun getEmpty ()Lio/gitlab/arturbosch/detekt/api/Config;
-	public final fun getPRIMITIVES ()Ljava/util/Set;
 }
 
 public final class io/gitlab/arturbosch/detekt/api/Config$DefaultImpls {

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Config.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Config.kt
@@ -1,7 +1,6 @@
 package io.gitlab.arturbosch.detekt.api
 
 import io.gitlab.arturbosch.detekt.api.internal.EmptyConfig
-import kotlin.reflect.KClass
 
 /**
  * A configuration holds information about how to configure specific rules.
@@ -59,16 +58,5 @@ interface Config {
         const val EXCLUDES_KEY: String = "excludes"
         const val INCLUDES_KEY: String = "includes"
         const val CONFIG_SEPARATOR: String = ">"
-
-        val PRIMITIVES: Set<KClass<out Any>> = setOf(
-            Int::class,
-            Boolean::class,
-            Float::class,
-            Double::class,
-            String::class,
-            Short::class,
-            Char::class,
-            Long::class
-        )
     }
 }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/BaseConfig.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/BaseConfig.kt
@@ -3,6 +3,7 @@ package io.gitlab.arturbosch.detekt.core.config
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Config.Companion.CONFIG_SEPARATOR
 import io.gitlab.arturbosch.detekt.api.commaSeparatedPattern
+import kotlin.reflect.KClass
 
 private val ALLOWED_BOOL_VALUES = setOf("true", "false")
 
@@ -19,7 +20,7 @@ fun Config.valueOrDefaultInternal(
         if (result != null) {
             when {
                 result is String -> parser(result, default)
-                default::class in Config.PRIMITIVES &&
+                default::class in PRIMITIVES &&
                     result::class != default::class -> throw ClassCastException()
                 else -> result
             }
@@ -52,3 +53,14 @@ fun tryParseBasedOnDefault(result: String, defaultResult: Any): Any = when (defa
     is List<*> -> result.commaSeparatedPattern().toList()
     else -> throw ClassCastException()
 }
+
+private val PRIMITIVES: Set<KClass<out Any>> = setOf(
+    Int::class,
+    Boolean::class,
+    Float::class,
+    Double::class,
+    String::class,
+    Short::class,
+    Char::class,
+    Long::class
+)


### PR DESCRIPTION
This is very unlikely to have been used in any third party code so I don't think this needs to be tagged as a breaking change.