### PR TITLE
Move PathFilters from internal to public API

### DIFF
--- a/detekt-api/api/detekt-api.api
+++ b/detekt-api/api/detekt-api.api
@@ -306,6 +306,21 @@ public abstract class io/gitlab/arturbosch/detekt/api/OutputReport : io/gitlab/a
 	public final fun write (Ljava/nio/file/Path;Lio/gitlab/arturbosch/detekt/api/Detektion;)V
 }
 
+public final class io/gitlab/arturbosch/detekt/api/PathFilters {
+	public static final field Companion Lio/gitlab/arturbosch/detekt/api/PathFilters$Companion;
+	public final fun isIgnored (Ljava/nio/file/Path;)Z
+	public final fun isIgnored (Lorg/jetbrains/kotlin/psi/KtFile;)Z
+}
+
+public final class io/gitlab/arturbosch/detekt/api/PathFilters$Companion {
+	public final fun of (Ljava/util/List;Ljava/util/List;)Lio/gitlab/arturbosch/detekt/api/PathFilters;
+}
+
+public final class io/gitlab/arturbosch/detekt/api/PathFiltersKt {
+	public static final fun createPathFilters (Lio/gitlab/arturbosch/detekt/api/Config;)Lio/gitlab/arturbosch/detekt/api/PathFilters;
+	public static final fun valueOrDefaultCommaSeparated (Lio/gitlab/arturbosch/detekt/api/Config;Ljava/lang/String;Ljava/util/List;)Ljava/util/List;
+}
+
 public class io/gitlab/arturbosch/detekt/api/ProjectMetric {
 	public fun <init> (Ljava/lang/String;IIZI)V
 	public synthetic fun <init> (Ljava/lang/String;IIZIILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -344,7 +359,7 @@ public abstract class io/gitlab/arturbosch/detekt/api/Rule : io/gitlab/arturbosc
 	public final fun getAliases ()Ljava/util/Set;
 	public fun getAutoCorrect ()Z
 	public fun getDefaultRuleIdAliases ()Ljava/util/Set;
-	public fun getFilters ()Lio/gitlab/arturbosch/detekt/api/internal/PathFilters;
+	public fun getFilters ()Lio/gitlab/arturbosch/detekt/api/PathFilters;
 	public abstract fun getIssue ()Lio/gitlab/arturbosch/detekt/api/Issue;
 	public fun getParentPath ()Ljava/lang/String;
 	public final fun getRuleId ()Ljava/lang/String;

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/ConfigProperty.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/ConfigProperty.kt
@@ -1,6 +1,5 @@
 package io.gitlab.arturbosch.detekt.api
 
-import io.gitlab.arturbosch.detekt.api.internal.valueOrDefaultCommaSeparated
 import kotlin.properties.ReadOnlyProperty
 import kotlin.reflect.KProperty
 import kotlin.reflect.KProperty0

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/PathFilters.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/PathFilters.kt
@@ -1,9 +1,8 @@
-package io.gitlab.arturbosch.detekt.api.internal
+package io.gitlab.arturbosch.detekt.api
 
 import io.github.detekt.psi.absolutePath
 import io.github.detekt.psi.basePath
-import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.commaSeparatedPattern
+import io.gitlab.arturbosch.detekt.api.internal.pathMatcher
 import org.jetbrains.kotlin.psi.KtFile
 import java.nio.file.Path
 import java.nio.file.PathMatcher

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Rule.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Rule.kt
@@ -2,8 +2,6 @@ package io.gitlab.arturbosch.detekt.api
 
 import io.gitlab.arturbosch.detekt.api.Config.Companion.SEVERITY_KEY
 import io.gitlab.arturbosch.detekt.api.internal.DefaultContext
-import io.gitlab.arturbosch.detekt.api.internal.PathFilters
-import io.gitlab.arturbosch.detekt.api.internal.createPathFilters
 import io.gitlab.arturbosch.detekt.api.internal.isSuppressedBy
 import org.jetbrains.kotlin.psi.KtFile
 

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/PathFiltersSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/PathFiltersSpec.kt
@@ -1,7 +1,7 @@
 package io.gitlab.arturbosch.detekt.cli
 
 import io.github.detekt.test.utils.NullPrintStream
-import io.gitlab.arturbosch.detekt.api.internal.PathFilters
+import io.gitlab.arturbosch.detekt.api.PathFilters
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/KtTreeCompiler.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/KtTreeCompiler.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.core
 
 import io.github.detekt.parser.KtCompiler
 import io.github.detekt.tooling.api.spec.ProjectSpec
-import io.gitlab.arturbosch.detekt.api.internal.PathFilters
+import io.gitlab.arturbosch.detekt.api.PathFilters
 import org.jetbrains.kotlin.psi.KtFile
 import java.io.IOException
 import java.nio.file.FileVisitResult

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/rules/RuleSets.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/rules/RuleSets.kt
@@ -7,7 +7,7 @@ import io.gitlab.arturbosch.detekt.api.RuleId
 import io.gitlab.arturbosch.detekt.api.RuleSet
 import io.gitlab.arturbosch.detekt.api.RuleSetId
 import io.gitlab.arturbosch.detekt.api.RuleSetProvider
-import io.gitlab.arturbosch.detekt.api.internal.createPathFilters
+import io.gitlab.arturbosch.detekt.api.createPathFilters
 import io.gitlab.arturbosch.detekt.core.ProcessingSettings
 import org.jetbrains.kotlin.psi.KtFile
 

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/ValueOrDefaultCommaSeparatedSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/ValueOrDefaultCommaSeparatedSpec.kt
@@ -1,6 +1,6 @@
 package io.gitlab.arturbosch.detekt.core.config
 
-import io.gitlab.arturbosch.detekt.api.internal.valueOrDefaultCommaSeparated
+import io.gitlab.arturbosch.detekt.api.valueOrDefaultCommaSeparated
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested


### PR DESCRIPTION
This type is used in `Rule` so it should be part of the public API.