### PR TITLE
Make test pass on JVM 8

### DIFF
--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/CorrectableRulesFirstSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/CorrectableRulesFirstSpec.kt
@@ -17,22 +17,6 @@ class CorrectableRulesFirstSpec {
     @ParameterizedTest
     @ValueSource(booleans = [true, false])
     fun `runs the correctable rules first, the registration order doesn't matter`(reverse: Boolean) {
-        var actualLastRuleId = ""
-
-        class NonCorrectable(config: Config) : Rule(config) {
-            override val issue: Issue = Issue(javaClass.simpleName, "")
-            override fun visitClass(klass: KtClass) {
-                actualLastRuleId = issue.id
-            }
-        }
-
-        class Correctable(config: Config) : Rule(config) {
-            override val issue: Issue = Issue(javaClass.simpleName, "")
-            override fun visitClass(klass: KtClass) {
-                actualLastRuleId = issue.id
-            }
-        }
-
         val testFile = path.resolve("Test.kt")
         val settings = createProcessingSettings(
             testFile,
@@ -63,5 +47,21 @@ class CorrectableRulesFirstSpec {
         settings.use { detector.run(listOf(compileForTest(testFile))) }
 
         assertThat(actualLastRuleId).isEqualTo("NonCorrectable")
+    }
+}
+
+private var actualLastRuleId = ""
+
+private class NonCorrectable(config: Config) : Rule(config) {
+    override val issue: Issue = Issue(javaClass.simpleName, "")
+    override fun visitClass(klass: KtClass) {
+        actualLastRuleId = issue.id
+    }
+}
+
+private class Correctable(config: Config) : Rule(config) {
+    override val issue: Issue = Issue(javaClass.simpleName, "")
+    override fun visitClass(klass: KtClass) {
+        actualLastRuleId = issue.id
     }
 }


### PR DESCRIPTION
I'm not sure how this went through CI but it is there on `main`: https://github.com/detekt/detekt/commit/a03e3be950e29663f14bf036f1a1f77014dfe21b

On the JVM 8 the `simpleName` of a class contains the function name where it was declared. With this fix I move the rule declaration to the top level so the problem should be gone.