### PR TITLE
Remove unnecessary functions from detekt-psi-utils

### DIFF
--- a/detekt-psi-utils/api/detekt-psi-utils.api
+++ b/detekt-psi-utils/api/detekt-psi-utils.api
@@ -142,8 +142,6 @@ public final class io/gitlab/arturbosch/detekt/rules/ThrowExtensionsKt {
 }
 
 public final class io/gitlab/arturbosch/detekt/rules/TraversingKt {
-	public static final fun getParentExpressionRemovingParenthesis (Lorg/jetbrains/kotlin/com/intellij/psi/PsiElement;Z)Lorg/jetbrains/kotlin/com/intellij/psi/PsiElement;
-	public static synthetic fun getParentExpressionRemovingParenthesis$default (Lorg/jetbrains/kotlin/com/intellij/psi/PsiElement;ZILjava/lang/Object;)Lorg/jetbrains/kotlin/com/intellij/psi/PsiElement;
 	public static final fun isPublicInherited (Lorg/jetbrains/kotlin/psi/KtNamedDeclaration;)Z
 	public static final fun isPublicInherited (Lorg/jetbrains/kotlin/psi/KtNamedDeclaration;Z)Z
 }

--- a/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/Traversing.kt
+++ b/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/Traversing.kt
@@ -3,9 +3,7 @@ package io.gitlab.arturbosch.detekt.rules
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.psi.KtNamedDeclaration
-import org.jetbrains.kotlin.psi.KtParenthesizedExpression
 import org.jetbrains.kotlin.psi.psiUtil.containingClassOrObject
-import org.jetbrains.kotlin.psi.psiUtil.getParentOfTypesAndPredicate
 import org.jetbrains.kotlin.psi.psiUtil.isPublic
 
 /**
@@ -21,12 +19,6 @@ inline fun <reified T : KtElement, reified S : KtElement> KtElement.parentsOfTyp
             current = current.parent
         }
     }
-
-fun PsiElement.getParentExpressionRemovingParenthesis(strict: Boolean = true): PsiElement? =
-    this.getParentOfTypesAndPredicate(
-        strict,
-        PsiElement::class.java,
-    ) { it !is KtParenthesizedExpression }
 
 fun KtNamedDeclaration.isPublicInherited(): Boolean = isPublicInherited(false)
 

--- a/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/Traversing.kt
+++ b/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/Traversing.kt
@@ -1,24 +1,8 @@
 package io.gitlab.arturbosch.detekt.rules
 
-import org.jetbrains.kotlin.com.intellij.psi.PsiElement
-import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.psi.KtNamedDeclaration
 import org.jetbrains.kotlin.psi.psiUtil.containingClassOrObject
 import org.jetbrains.kotlin.psi.psiUtil.isPublic
-
-/**
- * Returns a list of all parents of type [T] before first occurrence of [S].
- */
-inline fun <reified T : KtElement, reified S : KtElement> KtElement.parentsOfTypeUntil(strict: Boolean = true) =
-    sequence<T> {
-        var current: PsiElement? = if (strict) this@parentsOfTypeUntil.parent else this@parentsOfTypeUntil
-        while (current != null && current !is S) {
-            if (current is T) {
-                yield(current)
-            }
-            current = current.parent
-        }
-    }
 
 fun KtNamedDeclaration.isPublicInherited(): Boolean = isPublicInherited(false)
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitItLambdaParameter.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitItLambdaParameter.kt
@@ -7,9 +7,9 @@ import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.rules.IT_LITERAL
-import io.gitlab.arturbosch.detekt.rules.getParentExpressionRemovingParenthesis
 import org.jetbrains.kotlin.psi.KtCallableReferenceExpression
 import org.jetbrains.kotlin.psi.KtLambdaExpression
+import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
 
 /**
  * Lambda expressions are one of the core features of the language. They often include very small chunks of
@@ -51,7 +51,7 @@ class ExplicitItLambdaParameter(config: Config) : Rule(config) {
 
     override fun visitLambdaExpression(lambdaExpression: KtLambdaExpression) {
         super.visitLambdaExpression(lambdaExpression)
-        if (lambdaExpression.getParentExpressionRemovingParenthesis() is KtCallableReferenceExpression) return
+        if (lambdaExpression.getStrictParentOfType<KtCallableReferenceExpression>() != null) return
         val parameterNames = lambdaExpression.valueParameters.map { it.name }
         if (IT_LITERAL in parameterNames) {
             val message = if (parameterNames.size == 1) {

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCount.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCount.kt
@@ -9,7 +9,6 @@ import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.config
 import io.gitlab.arturbosch.detekt.api.simplePatternToRegex
-import io.gitlab.arturbosch.detekt.rules.parentsOfTypeUntil
 import io.gitlab.arturbosch.detekt.rules.yieldStatementsSkippingGuardClauses
 import org.jetbrains.kotlin.psi.KtLambdaExpression
 import org.jetbrains.kotlin.psi.KtNamedFunction
@@ -106,7 +105,7 @@ class ReturnCount(config: Config) : Rule(config) {
     private fun KtReturnExpression.isNamedReturnFromLambda(): Boolean {
         val label = this.labeledExpression
         if (label != null) {
-            return this.parentsOfTypeUntil<KtLambdaExpression, KtNamedFunction>().any()
+            return this.getParentOfType<KtLambdaExpression>(true, KtNamedFunction::class.java) != null
         }
         return false
     }


### PR DESCRIPTION
Remove two functions which had single usages that could be simplify replaced with functions available in `kotlin-compiler-embeddable`.