### PR TITLE
Fail with meaningful error message if the list elements are not all strings

### DIFF
--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/BaseConfig.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/BaseConfig.kt
@@ -19,8 +19,20 @@ fun Config.valueOrDefaultInternal(
         if (result != null) {
             when {
                 result is String -> parser(result, default)
+                result is List<*> -> {
+                    if (default !is List<*>) {
+                        throw ClassCastException()
+                    }
+                    check(result.all { it is String }) {
+                        "Only lists of strings are supported. Value \"$result\" set " +
+                            "for config parameter \"${keySequence(key)}\" contains non-string values."
+                    }
+                    result.map { it as String }
+                }
+
                 default::class in PRIMITIVES &&
                     result::class != default::class -> throw ClassCastException()
+
                 else -> result
             }
         } else {
@@ -47,6 +59,7 @@ fun tryParseBasedOnDefault(result: String, defaultResult: Any): Any = when (defa
         } else {
             throw ClassCastException()
         }
+
     is Double -> result.toDouble()
     is String -> result
     else -> throw ClassCastException()

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/YamlConfigSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/YamlConfigSpec.kt
@@ -127,6 +127,16 @@ class YamlConfigSpec {
                     "Value \"[]\" set for config parameter \"RuleSet > Rule > active\" is not of required type Int."
                 )
         }
+
+        @Test
+        fun `prints meaningful message when list of ints is used instead of list of strings`() {
+            assertThatIllegalStateException().isThrownBy {
+                config.valueOrDefaultInternal(key = "key", result = listOf(1, 2), default = listOf("1", "2"))
+            }.withMessage(
+                "Only lists of strings are supported. " +
+                    "Value \"[1, 2]\" set for config parameter \"key\" contains non-string values."
+            )
+        }
     }
 
     @Nested

--- a/detekt-core/src/test/resources/wrong-property-type.yml
+++ b/detekt-core/src/test/resources/wrong-property-type.yml
@@ -2,5 +2,6 @@ RuleSet:
   Rule:
     active: []
     threshold: v5.7
+    strings: [ 0, 99 ]
 
 bool: fasle


### PR DESCRIPTION
fixes #6818

This makes sure that a configured list contains strings only or fails with a meaningful error message.
