### PR TITLE
Don't use explicit byte-buddy version

### DIFF
--- a/detekt-core/build.gradle.kts
+++ b/detekt-core/build.gradle.kts
@@ -20,7 +20,7 @@ dependencies {
     testImplementation(projects.detektReportXml)
     testImplementation(projects.detektTest)
     testImplementation(testFixtures(projects.detektApi))
-    testImplementation(libs.bundles.mocking)
+    testImplementation(libs.mockk)
     testImplementation(libs.classgraph)
     testImplementation(libs.assertj)
     testRuntimeOnly(libs.slf4j.simple)

--- a/detekt-psi-utils/build.gradle.kts
+++ b/detekt-psi-utils/build.gradle.kts
@@ -7,7 +7,7 @@ dependencies {
     api(libs.kotlin.compilerEmbeddable)
 
     testImplementation(libs.assertj)
-    testImplementation(libs.bundles.mocking)
+    testImplementation(libs.mockk)
     testImplementation(projects.detektTest)
 }
 

--- a/detekt-report-html/build.gradle.kts
+++ b/detekt-report-html/build.gradle.kts
@@ -12,6 +12,6 @@ dependencies {
     testImplementation(projects.detektMetrics)
     testImplementation(projects.detektTestUtils)
     testImplementation(testFixtures(projects.detektApi))
-    testImplementation(libs.bundles.mocking)
+    testImplementation(libs.mockk)
     testImplementation(libs.assertj)
 }

--- a/detekt-report-md/build.gradle.kts
+++ b/detekt-report-md/build.gradle.kts
@@ -8,6 +8,6 @@ dependencies {
     implementation(projects.detektUtils)
 
     testImplementation(testFixtures(projects.detektApi))
-    testImplementation(libs.bundles.mocking)
+    testImplementation(libs.mockk)
     testImplementation(libs.assertj)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -40,14 +40,10 @@ sarif4k = "io.github.detekt.sarif4k:sarif4k:0.5.0"
 assertj = "org.assertj:assertj-core:3.25.1"
 classgraph = "io.github.classgraph:classgraph:4.8.165"
 mockk = "io.mockk:mockk:1.13.9"
-byte-buddy = "net.bytebuddy:byte-buddy:1.14.11"
 snakeyaml = "org.snakeyaml:snakeyaml-engine:2.7"
 jcommander = "org.jcommander:jcommander:1.83"
 kotlinCompileTesting = { module = "dev.zacsweers.kctfork:core", version = "0.4.0" }
 poko-annotations = { module = "dev.drewhamilton.poko:poko-annotations", version.ref = "poko" }
-
-[bundles]
-mocking = ["mockk", "byte-buddy"]
 
 [plugins]
 kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }


### PR DESCRIPTION
This was only used in the past as mockk pulled an old version transitively which didn't support Java 21