### PR TITLE
Make fakes more real

### DIFF
--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/LocationSpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/LocationSpec.kt
@@ -48,7 +48,7 @@ class LocationSpec {
 
         assertThat(location.toString()).isEqualTo(
             "Location(source=2:5, endSource=2:11, text=22:28, " +
-                "filePath=FilePath(absolutePath=${File.separator}Test.kt, basePath=null, relativePath=null))"
+                "filePath=FilePath(absolutePath=${File.separator}Test.kt, basePath=/, relativePath=Test.kt))"
         )
     }
 }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/tooling/ParsingStrategy.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/tooling/ParsingStrategy.kt
@@ -5,10 +5,12 @@ import io.gitlab.arturbosch.detekt.core.KtTreeCompiler
 import io.gitlab.arturbosch.detekt.core.ProcessingSettings
 import org.jetbrains.kotlin.psi.KtFile
 import java.nio.file.Path
+import kotlin.io.path.isRegularFile
 
 typealias ParsingStrategy = (settings: ProcessingSettings) -> List<KtFile>
 
 fun contentToKtFile(content: String, path: Path): ParsingStrategy = { settings ->
+    require(path.isRegularFile()) { "Given sub path ($path) should be a regular file!" }
     listOf(
         KtCompiler(settings.environment).createKtFile(content, settings.spec.projectSpec.basePath, path)
     )

--- a/detekt-parser/src/main/kotlin/io/github/detekt/parser/KtCompiler.kt
+++ b/detekt-parser/src/main/kotlin/io/github/detekt/parser/KtCompiler.kt
@@ -27,8 +27,6 @@ open class KtCompiler(
     }
 
     fun createKtFile(content: String, basePath: Path, path: Path): KtFile {
-        require(path.isRegularFile()) { "Given sub path ($path) should be a regular file!" }
-
         val normalizedAbsolutePath = path.absolute().normalize()
         val lineSeparator = content.determineLineSeparator()
 

--- a/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/CompileExtensions.kt
+++ b/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/CompileExtensions.kt
@@ -20,4 +20,4 @@ fun compileContentForTest(
 /**
  * Use this method if you test a kt file/class in the test resources.
  */
-fun compileForTest(path: Path) = KtTestCompiler.compile(path)
+fun compileForTest(path: Path) = KtTestCompiler.compile(resourceAsPath("/"), path)

--- a/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/CompileExtensions.kt
+++ b/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/CompileExtensions.kt
@@ -3,18 +3,19 @@ package io.github.detekt.test.utils
 import org.intellij.lang.annotations.Language
 import org.jetbrains.kotlin.psi.KtFile
 import java.nio.file.Path
+import kotlin.io.path.Path
 
 /**
  * Use this method if you define a kt file/class as a plain string in your test.
  */
 fun compileContentForTest(
     @Language("kotlin") content: String,
-    filename: String = TEST_FILENAME
+    filename: String = "Test.kt",
 ): KtFile {
     require('/' !in filename && '\\' !in filename) {
         "filename must be a file name only and not contain any path elements"
     }
-    return KtTestCompiler.compileFromContent(content, filename)
+    return KtTestCompiler.createKtFile(content, Path("/"), Path("/$filename"))
 }
 
 /**

--- a/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/KtTestCompiler.kt
+++ b/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/KtTestCompiler.kt
@@ -2,7 +2,6 @@ package io.github.detekt.test.utils
 
 import io.github.detekt.parser.KtCompiler
 import kotlinx.coroutines.CoroutineScope
-import org.intellij.lang.annotations.Language
 import org.jetbrains.kotlin.cli.common.CLIConfigurationKeys
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.cli.jvm.compiler.EnvironmentConfigFiles
@@ -13,27 +12,15 @@ import org.jetbrains.kotlin.cli.jvm.config.addJvmClasspathRoots
 import org.jetbrains.kotlin.cli.jvm.config.configureJdkClasspathRoots
 import org.jetbrains.kotlin.com.intellij.openapi.project.Project
 import org.jetbrains.kotlin.com.intellij.openapi.util.Disposer
-import org.jetbrains.kotlin.com.intellij.openapi.util.text.StringUtilRt
 import org.jetbrains.kotlin.config.CommonConfigurationKeys
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.config.JVMConfigurationKeys
-import org.jetbrains.kotlin.psi.KtFile
 import java.io.File
 
 /**
  * Test compiler extends kt compiler and adds ability to compile from text content.
  */
 internal object KtTestCompiler : KtCompiler() {
-
-    fun compileFromContent(@Language("kotlin") content: String, filename: String = TEST_FILENAME): KtFile {
-        require('/' !in filename && '\\' !in filename) {
-            "filename must be a file name only and not contain any path elements"
-        }
-        return psiFileFactory.createPhysicalFile(
-            filename,
-            StringUtilRt.convertLineSeparators(content)
-        )
-    }
 
     /**
      * Not sure why but this function only works from this context.
@@ -81,5 +68,3 @@ internal object KtTestCompiler : KtCompiler() {
         return File(CoroutineScope::class.java.protectionDomain.codeSource.location.path)
     }
 }
-
-internal const val TEST_FILENAME = "Test.kt"

--- a/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/KtTestCompiler.kt
+++ b/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/KtTestCompiler.kt
@@ -19,21 +19,11 @@ import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.config.JVMConfigurationKeys
 import org.jetbrains.kotlin.psi.KtFile
 import java.io.File
-import java.nio.file.Path
 
 /**
  * Test compiler extends kt compiler and adds ability to compile from text content.
  */
 internal object KtTestCompiler : KtCompiler() {
-
-    /*
-     * If tests are executed through Bazel, there is no File based resource path as all classpath elements
-     * are JAR files, which leads to crashes. By initializing the root on demand, it's at least possible to
-     * use String based input from Bazel.
-     */
-    private val root by lazy { resourceAsPath("/") }
-
-    fun compile(path: Path) = compile(root, path)
 
     fun compileFromContent(@Language("kotlin") content: String, filename: String = TEST_FILENAME): KtFile {
         require('/' !in filename && '\\' !in filename) {


### PR DESCRIPTION
We had some code to generate our Fake `KtFile` that just make them differ from the real ones without a good reason. This PR changes that. Now our tests are more similar to the real code that we executes.

The main reason to this change is that there was no way to have a `KtFile` with a `basePath` and a `Path`. The next PR (#6830) will use these changes to add missing tests on our code.