### PR TITLE
useDefaultConfig on tests

### DIFF
--- a/detekt-compiler-plugin/build.gradle.kts
+++ b/detekt-compiler-plugin/build.gradle.kts
@@ -85,7 +85,6 @@ val testPluginKotlinc by tasks.registering(Task::class) {
     outputs.dir(outputDir)
 
     val baseExecutablePath = "${unzipKotlinCompiler.get().destinationDir}/kotlinc/bin/kotlinc"
-    val pluginParameters = "plugin:detekt-compiler-plugin:debug=true"
 
     val kotlincExecution = providers.exec {
         workingDir = outputDir.get().asFile
@@ -95,14 +94,15 @@ val testPluginKotlinc by tasks.registering(Task::class) {
             sourceFile.path,
             "-Xplugin=${tasks.shadowJar.get().archiveFile.get().asFile.absolutePath}",
             "-P",
+            "plugin:detekt-compiler-plugin:debug=true".toArg(),
+            "-P",
+            "plugin:detekt-compiler-plugin:useDefaultConfig=true".toArg(),
         )
 
-        if (org.apache.tools.ant.taskdefs.condition.Os.isFamily("windows")) {
-            executable = "$baseExecutablePath.bat"
-            args("\"$pluginParameters\"")
+        executable = if (org.apache.tools.ant.taskdefs.condition.Os.isFamily("windows")) {
+            "$baseExecutablePath.bat"
         } else {
-            executable = baseExecutablePath
-            args(pluginParameters)
+            baseExecutablePath
         }
     }
 
@@ -117,6 +117,12 @@ val testPluginKotlinc by tasks.registering(Task::class) {
             )
         }
     }
+}
+
+private fun String.toArg() = if (org.apache.tools.ant.taskdefs.condition.Os.isFamily("windows")) {
+    "\"$this\""
+} else {
+    this
 }
 
 tasks.check {

--- a/detekt-compiler-plugin/src/test/kotlin/io/github/detekt/compiler/plugin/util/CompilerTestUtils.kt
+++ b/detekt-compiler-plugin/src/test/kotlin/io/github/detekt/compiler/plugin/util/CompilerTestUtils.kt
@@ -2,14 +2,19 @@ package io.github.detekt.compiler.plugin.util
 
 import com.tschuchort.compiletesting.JvmCompilationResult
 import com.tschuchort.compiletesting.KotlinCompilation
+import com.tschuchort.compiletesting.PluginOption
 import com.tschuchort.compiletesting.SourceFile
+import io.github.detekt.compiler.plugin.DetektCommandLineProcessor
 import io.github.detekt.compiler.plugin.DetektCompilerPluginRegistrar
 import org.intellij.lang.annotations.Language
 import java.io.OutputStream
 
 object CompilerTestUtils {
 
-    fun compile(@Language("kotlin") vararg kotlinSources: String): JvmCompilationResult {
+    fun compile(
+        @Language("kotlin") vararg kotlinSources: String,
+        useDefaultConfig: Boolean = true,
+    ): JvmCompilationResult {
         val sourceFiles = kotlinSources.map {
             SourceFile.kotlin("KClass.kt", it, trimIndent = true)
         }
@@ -21,6 +26,14 @@ object CompilerTestUtils {
             }
             sources = sourceFiles
             compilerPluginRegistrars = listOf(DetektCompilerPluginRegistrar())
+            commandLineProcessors = listOf(DetektCommandLineProcessor())
+            pluginOptions = listOf(
+                PluginOption(
+                    "detekt-compiler-plugin",
+                    "useDefaultConfig",
+                    useDefaultConfig.toString(),
+                )
+            )
         }.compile()
     }
 }


### PR DESCRIPTION
Right now the tests of `detekt-compiler-plugin` relies in an "undefined behavior" of the core. They don't define a configuration nor use `useDefaultConfig=true`, so no rule should be run. Every rule is disabled by default unless you define the configuration or have `useDefaultConfig=true`.

I want to refactor how the configuration is created on `detekt-core` and remove that "undefined behaviour". For that reason I need to fix these tests to pass `useDefaultConfig=true`.