### PR TITLE
Less verbose tests

### DIFF
--- a/detekt-compiler-plugin/src/test/kotlin/io/github/detekt/compiler/plugin/util/CompilerAssertions.kt
+++ b/detekt-compiler-plugin/src/test/kotlin/io/github/detekt/compiler/plugin/util/CompilerAssertions.kt
@@ -24,7 +24,8 @@ class CompilationAssert(private val result: JvmCompilationResult) :
             failWithActualExpectedAndMessage(
                 result.exitCode,
                 expectedErrorCode,
-                "Expected compilation to finish with code $expectedErrorCode but was ${result.exitCode}"
+                "Expected compilation to finish with code $expectedErrorCode but was ${actual.exitCode}.\n" +
+                    actual.messages,
             )
         }
     }
@@ -42,7 +43,8 @@ class CompilationAssert(private val result: JvmCompilationResult) :
             failWithActualExpectedAndMessage(
                 status,
                 expectedStatus,
-                "Expected detekt to finish with success status: $expectedStatus but was $status",
+                "Expected detekt to finish with success status: $expectedStatus but was $status.\n" +
+                    actual.messages,
             )
         }
     }
@@ -54,7 +56,8 @@ class CompilationAssert(private val result: JvmCompilationResult) :
             failWithActualExpectedAndMessage(
                 detektViolations.size,
                 expectedViolationNumber,
-                "Expected detekt violations to be $expectedViolationNumber but was ${detektViolations.size}",
+                "Expected detekt violations to be $expectedViolationNumber but was ${detektViolations.size}.\n" +
+                    actual.messages,
             )
         }
     }
@@ -63,7 +66,8 @@ class CompilationAssert(private val result: JvmCompilationResult) :
         if (expectedRuleName.any { it !in detektViolations }) {
             failWithMessage(
                 "Expected rules ${expectedRuleName.toList()} to raise a violation but not all were found. " +
-                    "Found violations are instead $detektViolations"
+                    "Found violations are instead $detektViolations.\n" +
+                    actual.messages,
             )
         }
     }

--- a/detekt-compiler-plugin/src/test/kotlin/io/github/detekt/compiler/plugin/util/CompilerTestUtils.kt
+++ b/detekt-compiler-plugin/src/test/kotlin/io/github/detekt/compiler/plugin/util/CompilerTestUtils.kt
@@ -5,6 +5,7 @@ import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.SourceFile
 import io.github.detekt.compiler.plugin.DetektCompilerPluginRegistrar
 import org.intellij.lang.annotations.Language
+import java.io.OutputStream
 
 object CompilerTestUtils {
 
@@ -14,6 +15,11 @@ object CompilerTestUtils {
         }
         return KotlinCompilation().apply {
             verbose = false
+            messageOutputStream = object : OutputStream() {
+                override fun write(b: Int) {
+                    // no-op
+                }
+            }
             sources = sourceFiles
             compilerPluginRegistrars = listOf(DetektCompilerPluginRegistrar())
         }.compile()

--- a/detekt-compiler-plugin/src/test/kotlin/io/github/detekt/compiler/plugin/util/CompilerTestUtils.kt
+++ b/detekt-compiler-plugin/src/test/kotlin/io/github/detekt/compiler/plugin/util/CompilerTestUtils.kt
@@ -14,7 +14,6 @@ object CompilerTestUtils {
             SourceFile.kotlin("KClass.kt", it, trimIndent = true)
         }
         return KotlinCompilation().apply {
-            verbose = false
             messageOutputStream = object : OutputStream() {
                 override fun write(b: Int) {
                     // no-op

--- a/detekt-compiler-plugin/src/test/kotlin/io/github/detekt/compiler/plugin/util/CompilerTestUtils.kt
+++ b/detekt-compiler-plugin/src/test/kotlin/io/github/detekt/compiler/plugin/util/CompilerTestUtils.kt
@@ -13,6 +13,7 @@ object CompilerTestUtils {
             SourceFile.kotlin("KClass.kt", it, trimIndent = true)
         }
         return KotlinCompilation().apply {
+            verbose = false
             sources = sourceFiles
             compilerPluginRegistrars = listOf(DetektCompilerPluginRegistrar())
         }.compile()


### PR DESCRIPTION
Make the compiler-plugin tests less verbose:

Previusly:

```
CompilerTest > with a source file that contains violations() STANDARD_OUT
    logging: Created temporary working directory at /var/folders/_9/ntvzf7jd6y30cr9rxs154vl996qbgx/T/Kotlin-Compilation8875387757232399014
    logging: No services were given. Not running kapt steps.
    v: Using Kotlin home directory <no_path>
    v: Using JDK home directory /Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home
    v: Exception on loading scripting plugin: java.lang.ClassNotFoundException: org.jetbrains.kotlin.scripting.compiler.plugin.ScriptingCompilerConfigurationComponentRegistrar
    v: Scripting plugin will not be loaded: not all required jars are present in the classpath (missing files: [./kotlin-scripting-compiler.jar, ./kotlin-scripting-compiler-impl.jar, ./kotlin-scripting-common.jar, ./kotlin-scripting-jvm.jar])
    v: Using JVM IR backend
    v: Configuring the compilation environment
    v: Loading modules: [java.se, jdk.accessibility, jdk.attach, jdk.compiler, jdk.dynalink, jdk.httpserver, jdk.incubator.foreign, jdk.incubator.vector, jdk.jartool, jdk.javadoc, jdk.jconsole, jdk.jdi, jdk.jfr, jdk.jshell, jdk.jsobject, jdk.management, jdk.management.jfr, jdk.net, jdk.nio.mapmode, jdk.sctp, jdk.security.auth, jdk.security.jgss, jdk.unsupported, jdk.unsupported.desktop, jdk.xml.dom, java.base, java.compiler, java.datatransfer, java.desktop, java.xml, java.instrument, java.logging, java.management, java.management.rmi, java.rmi, java.naming, java.net.http, java.prefs, java.scripting, java.security.jgss, java.security.sasl, java.sql, java.transaction.xa, java.sql.rowset, java.xml.crypto, jdk.internal.jvmstat, jdk.management.agent, jdk.jdwp.agent, jdk.internal.ed, jdk.internal.le, jdk.internal.opt]
    v: Output:
    /var/folders/_9/ntvzf7jd6y30cr9rxs154vl996qbgx/T/Kotlin-Compilation2522115982881707435/classes/KClass.class
    Sources:
    /var/folders/_9/ntvzf7jd6y30cr9rxs154vl996qbgx/T/Kotlin-Compilation2522115982881707435/sources/KClass.kt
    v: Output:
    /var/folders/_9/ntvzf7jd6y30cr9rxs154vl996qbgx/T/Kotlin-Compilation2522115982881707435/classes/META-INF/main.kotlin_module
    Sources:
    /var/folders/_9/ntvzf7jd6y30cr9rxs154vl996qbgx/T/Kotlin-Compilation2522115982881707435/sources/KClass.kt
    i: Running detekt on module '<main>'
    i: /var/folders/_9/ntvzf7jd6y30cr9rxs154vl996qbgx/T/Kotlin-Compilation2522115982881707435/sources/KClass.kt:6:2: The file KClass.kt is not ending with a new line. [NewLineAtEndOfFile]
    /var/folders/_9/ntvzf7jd6y30cr9rxs154vl996qbgx/T/Kotlin-Compilation2522115982881707435/sources/KClass.kt:3:17: This expression contains a magic number. Consider defining it to a well named constant. [MagicNumber]
    i:
    i: 1 files analyzed
    i: style: 2 findings found.
    i: Success?: false
    w: Analysis failed with 2 issues.
    w: file:///var/folders/_9/ntvzf7jd6y30cr9rxs154vl996qbgx/T/Kotlin-Compilation2522115982881707435/sources/KClass.kt:6:2 NewLineAtEndOfFile: The file KClass.kt is not ending with a new line.
    w: file:///var/folders/_9/ntvzf7jd6y30cr9rxs154vl996qbgx/T/Kotlin-Compilation2522115982881707435/sources/KClass.kt:3:17 MagicNumber: This expression contains a magic number. Consider defining it to a well named constant.

CompilerTest > with a source file that contains local suppression() STANDARD_OUT
    logging: Created temporary working directory at /var/folders/_9/ntvzf7jd6y30cr9rxs154vl996qbgx/T/Kotlin-Compilation14666694828103075006
    logging: No services were given. Not running kapt steps.
    v: Using Kotlin home directory <no_path>
    v: Using JDK home directory /Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home
    v: Exception on loading scripting plugin: java.lang.ClassNotFoundException: org.jetbrains.kotlin.scripting.compiler.plugin.ScriptingCompilerConfigurationComponentRegistrar
    v: Scripting plugin will not be loaded: not all required jars are present in the classpath (missing files: [./kotlin-scripting-compiler.jar, ./kotlin-scripting-compiler-impl.jar, ./kotlin-scripting-common.jar, ./kotlin-scripting-jvm.jar])
    v: Using JVM IR backend
    v: Configuring the compilation environment
    v: Loading modules: [java.se, jdk.accessibility, jdk.attach, jdk.compiler, jdk.dynalink, jdk.httpserver, jdk.incubator.foreign, jdk.incubator.vector, jdk.jartool, jdk.javadoc, jdk.jconsole, jdk.jdi, jdk.jfr, jdk.jshell, jdk.jsobject, jdk.management, jdk.management.jfr, jdk.net, jdk.nio.mapmode, jdk.sctp, jdk.security.auth, jdk.security.jgss, jdk.unsupported, jdk.unsupported.desktop, jdk.xml.dom, java.base, java.compiler, java.datatransfer, java.desktop, java.xml, java.instrument, java.logging, java.management, java.management.rmi, java.rmi, java.naming, java.net.http, java.prefs, java.scripting, java.security.jgss, java.security.sasl, java.sql, java.transaction.xa, java.sql.rowset, java.xml.crypto, jdk.internal.jvmstat, jdk.management.agent, jdk.jdwp.agent, jdk.internal.ed, jdk.internal.le, jdk.internal.opt]
    v: Output:
    /var/folders/_9/ntvzf7jd6y30cr9rxs154vl996qbgx/T/Kotlin-Compilation14666694828103075006/classes/KClass.class
    Sources:
    /var/folders/_9/ntvzf7jd6y30cr9rxs154vl996qbgx/T/Kotlin-Compilation14666694828103075006/sources/KClass.kt
    v: Output:
    /var/folders/_9/ntvzf7jd6y30cr9rxs154vl996qbgx/T/Kotlin-Compilation14666694828103075006/classes/META-INF/main.kotlin_module
    Sources:
    /var/folders/_9/ntvzf7jd6y30cr9rxs154vl996qbgx/T/Kotlin-Compilation14666694828103075006/sources/KClass.kt
    i: Running detekt on module '<main>'
    i: 1 files analyzed
    i: Success?: true

CompilerTest > with a source file that does not contain violations() STANDARD_OUT
    logging: Created temporary working directory at /var/folders/_9/ntvzf7jd6y30cr9rxs154vl996qbgx/T/Kotlin-Compilation6392519861498146915
    logging: No services were given. Not running kapt steps.
    v: Using Kotlin home directory <no_path>
    v: Using JDK home directory /Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home
    v: Exception on loading scripting plugin: java.lang.ClassNotFoundException: org.jetbrains.kotlin.scripting.compiler.plugin.ScriptingCompilerConfigurationComponentRegistrar
    v: Scripting plugin will not be loaded: not all required jars are present in the classpath (missing files: [./kotlin-scripting-compiler.jar, ./kotlin-scripting-compiler-impl.jar, ./kotlin-scripting-common.jar, ./kotlin-scripting-jvm.jar])
    v: Using JVM IR backend
    v: Configuring the compilation environment
    v: Loading modules: [java.se, jdk.accessibility, jdk.attach, jdk.compiler, jdk.dynalink, jdk.httpserver, jdk.incubator.foreign, jdk.incubator.vector, jdk.jartool, jdk.javadoc, jdk.jconsole, jdk.jdi, jdk.jfr, jdk.jshell, jdk.jsobject, jdk.management, jdk.management.jfr, jdk.net, jdk.nio.mapmode, jdk.sctp, jdk.security.auth, jdk.security.jgss, jdk.unsupported, jdk.unsupported.desktop, jdk.xml.dom, java.base, java.compiler, java.datatransfer, java.desktop, java.xml, java.instrument, java.logging, java.management, java.management.rmi, java.rmi, java.naming, java.net.http, java.prefs, java.scripting, java.security.jgss, java.security.sasl, java.sql, java.transaction.xa, java.sql.rowset, java.xml.crypto, jdk.internal.jvmstat, jdk.management.agent, jdk.jdwp.agent, jdk.internal.ed, jdk.internal.le, jdk.internal.opt]
    v: Output:
    /var/folders/_9/ntvzf7jd6y30cr9rxs154vl996qbgx/T/Kotlin-Compilation6392519861498146915/classes/KClass.class
    Sources:
    /var/folders/_9/ntvzf7jd6y30cr9rxs154vl996qbgx/T/Kotlin-Compilation6392519861498146915/sources/KClass.kt
    v: Output:
    /var/folders/_9/ntvzf7jd6y30cr9rxs154vl996qbgx/T/Kotlin-Compilation6392519861498146915/classes/META-INF/main.kotlin_module
    Sources:
    /var/folders/_9/ntvzf7jd6y30cr9rxs154vl996qbgx/T/Kotlin-Compilation6392519861498146915/sources/KClass.kt
    i: Running detekt on module '<main>'
    i: 1 files analyzed
    i: Success?: true
```

Now: 
```
```