### PR TITLE
Improve error messages for failing assertions

### DIFF
--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/KtTreeCompilerSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/KtTreeCompilerSpec.kt
@@ -15,9 +15,9 @@ class KtTreeCompilerSpec {
     @Test
     fun `should compile all files`() {
         val (ktFiles, _) = fixture { compile(path) }
-        assertThat(ktFiles.size)
+        assertThat(ktFiles)
             .describedAs("It should compile at least three files, but did ${ktFiles.size}")
-            .isGreaterThanOrEqualTo(3)
+            .hasSizeGreaterThanOrEqualTo(3)
     }
 
     @Test
@@ -45,9 +45,9 @@ class KtTreeCompilerSpec {
     @ValueSource(strings = ["**/ignored/**", "**/ignored", "**/cases/i*"])
     fun `skips entire subtrees`(filter: String) {
         val (ktFiles, output) = fixture(filter, loggingDebug = true) { compile(path) }
-        assertThat(ktFiles.size)
+        assertThat(ktFiles)
             .describedAs("It should compile at least three files, but did ${ktFiles.size}")
-            .isGreaterThanOrEqualTo(3)
+            .hasSizeGreaterThanOrEqualTo(3)
         assertThat(output)
             .describedAs("File should not be ignored as entire subtree should be skipped")
             .doesNotContainPattern("""Ignoring file.*Something\.kt""")
@@ -58,7 +58,7 @@ class KtTreeCompilerSpec {
     @Test
     fun `should also compile regular files`() {
         val (ktFiles, _) = fixture { compile(path.resolve("Default.kt")) }
-        assertThat(ktFiles.size).isEqualTo(1)
+        assertThat(ktFiles).hasSize(1)
     }
 
     @Test

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/SuppressionSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/SuppressionSpec.kt
@@ -142,7 +142,7 @@ class SuppressionSpec {
                 it.visitFile(ktFile)
                 it.findings
             }
-            assertThat(findings.size).isZero()
+            assertThat(findings).isEmpty()
         }
 
         @Test

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/MethodOverloadingSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/MethodOverloadingSpec.kt
@@ -49,7 +49,7 @@ class MethodOverloadingSpec {
                     }
                 """.trimIndent()
             )
-            assertThat(subject.findings.size).isZero()
+            assertThat(subject.findings).isEmpty()
         }
     }
 
@@ -65,7 +65,7 @@ class MethodOverloadingSpec {
                     fun Long.foo() {}
                 """.trimIndent()
             )
-            assertThat(subject.findings.size).isZero()
+            assertThat(subject.findings).isEmpty()
         }
 
         @Test
@@ -77,7 +77,7 @@ class MethodOverloadingSpec {
                     fun Int.foo(i: String) {}
                 """.trimIndent()
             )
-            assertThat(subject.findings.size).isEqualTo(1)
+            assertThat(subject.findings).hasSize(1)
         }
     }
 

--- a/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunSwallowedCancellationSpec.kt
+++ b/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunSwallowedCancellationSpec.kt
@@ -1274,7 +1274,7 @@ class SuspendFunSwallowedCancellationSpec(private val env: KotlinCoreEnvironment
         listOfEndLocation: List<SourceLocation>,
     ) {
         assertThat(listOfEndLocation).hasSameSizeAs(listOfStartLocation)
-        assertThatFindings(findings).hasSize(listOfStartLocation.size)
+        assertThatFindings(findings).hasSameSizeAs(listOfStartLocation)
         assertThatFindings(findings).hasStartSourceLocations(*listOfStartLocation.toTypedArray())
         assertThatFindings(findings).hasEndSourceLocations(*listOfEndLocation.toTypedArray())
     }

--- a/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunSwallowedCancellationSpec.kt
+++ b/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunSwallowedCancellationSpec.kt
@@ -4,11 +4,12 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
-import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import io.gitlab.arturbosch.detekt.test.assertThat as assertThatFindings
 
 @KotlinCoreEnvironmentTest
 class SuspendFunSwallowedCancellationSpec(private val env: KotlinCoreEnvironment) {
@@ -1272,9 +1273,9 @@ class SuspendFunSwallowedCancellationSpec(private val env: KotlinCoreEnvironment
         listOfStartLocation: List<SourceLocation>,
         listOfEndLocation: List<SourceLocation>,
     ) {
-        check(listOfEndLocation.size == listOfStartLocation.size)
-        assertThat(findings).hasSize(listOfStartLocation.size)
-        assertThat(findings).hasStartSourceLocations(*listOfStartLocation.toTypedArray())
-        assertThat(findings).hasEndSourceLocations(*listOfEndLocation.toTypedArray())
+        assertThat(listOfEndLocation).hasSameSizeAs(listOfStartLocation)
+        assertThatFindings(findings).hasSize(listOfStartLocation.size)
+        assertThatFindings(findings).hasStartSourceLocations(*listOfStartLocation.toTypedArray())
+        assertThatFindings(findings).hasEndSourceLocations(*listOfEndLocation.toTypedArray())
     }
 }

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionCaughtSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionCaughtSpec.kt
@@ -36,7 +36,7 @@ class TooGenericExceptionCaughtSpec {
             }
         """.trimIndent()
 
-        assertThat(rule.compileAndLint(code)).hasSize(TooGenericExceptionCaught.caughtExceptionDefaults.size)
+        assertThat(rule.compileAndLint(code)).hasSameSizeAs(TooGenericExceptionCaught.caughtExceptionDefaults)
     }
 
     @Nested

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/EqualsNullCallSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/EqualsNullCallSpec.kt
@@ -15,7 +15,7 @@ class EqualsNullCallSpec {
                 a.equals(null)
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code).size).isEqualTo(1)
+        assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 
     @Test
@@ -25,7 +25,7 @@ class EqualsNullCallSpec {
                 a.equals(b.equals(null))
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code).size).isEqualTo(1)
+        assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 
     @Test
@@ -35,6 +35,6 @@ class EqualsNullCallSpec {
                 a.equals(b)
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code).size).isEqualTo(0)
+        assertThat(subject.compileAndLint(code)).isEmpty()
     }
 }


### PR DESCRIPTION
AssertJ has a very rich set of features to verify expectations. It is both easy to write and also to read. While those tests are exactly that, it would still be harder than necessary to find the failure reason should they fail. Example:

Before
```
java.lang.AssertionError: [It should compile at least three files, but did 2] 
Expecting actual:
  2
to be greater than or equal to:
  3

	at app//io.gitlab.arturbosch.detekt.core.KtTreeCompilerSpec.should compile all files(KtTreeCompilerSpec.kt:20)
	at java.base@17.0.6/java.lang.reflect.Method.invoke(Method.java:568)
	at java.base@17.0.6/java.util.ArrayList.forEach(ArrayList.java:1511)
	at java.base@17.0.6/java.util.ArrayList.forEach(ArrayList.java:1511)
```

After this change
```
java.lang.AssertionError: [It should compile at least three files, but did 2] 
Expecting size of:
  [KtFile: KotlinScript.kts, KtFile: Test.kt]
to be greater than or equal to 3 but was 2
	at app//io.gitlab.arturbosch.detekt.core.KtTreeCompilerSpec.should compile all files(KtTreeCompilerSpec.kt:20)
	at java.base@17.0.6/java.lang.reflect.Method.invoke(Method.java:568)
	at java.base@17.0.6/java.util.ArrayList.forEach(ArrayList.java:1511)
	at java.base@17.0.6/java.util.ArrayList.forEach(ArrayList.java:1511)
```
