### PR TITLE
Create a value class for the id of a `Rule`

### DIFF
--- a/detekt-api/api/detekt-api.api
+++ b/detekt-api/api/detekt-api.api
@@ -213,7 +213,7 @@ public final class io/gitlab/arturbosch/detekt/api/HasEntity$DefaultImpls {
 public final class io/gitlab/arturbosch/detekt/api/Issue {
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getDescription ()Ljava/lang/String;
-	public final fun getId-2Rbgges ()Ljava/lang/String;
+	public final fun getId ()Ljava/lang/String;
 	public fun toString ()Ljava/lang/String;
 }
 

--- a/detekt-api/api/detekt-api.api
+++ b/detekt-api/api/detekt-api.api
@@ -211,9 +211,9 @@ public final class io/gitlab/arturbosch/detekt/api/HasEntity$DefaultImpls {
 }
 
 public final class io/gitlab/arturbosch/detekt/api/Issue {
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lio/gitlab/arturbosch/detekt/api/Rule$Id;Ljava/lang/String;)V
 	public final fun getDescription ()Ljava/lang/String;
-	public final fun getId ()Ljava/lang/String;
+	public final fun getId ()Lio/gitlab/arturbosch/detekt/api/Rule$Id;
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -310,7 +310,7 @@ public class io/gitlab/arturbosch/detekt/api/Rule : io/gitlab/arturbosch/detekt/
 	public fun getDefaultRuleIdAliases ()Ljava/util/Set;
 	public fun getFilters ()Lio/gitlab/arturbosch/detekt/api/internal/PathFilters;
 	public final fun getIssue ()Lio/gitlab/arturbosch/detekt/api/Issue;
-	public fun getRuleId-2Rbgges ()Ljava/lang/String;
+	public fun getRuleId ()Lio/gitlab/arturbosch/detekt/api/Rule$Id;
 	protected fun postVisit (Lorg/jetbrains/kotlin/psi/KtFile;)V
 	protected fun preVisit (Lorg/jetbrains/kotlin/psi/KtFile;)V
 	public final fun report (Lio/gitlab/arturbosch/detekt/api/Finding;)V
@@ -323,17 +323,11 @@ public class io/gitlab/arturbosch/detekt/api/Rule : io/gitlab/arturbosch/detekt/
 }
 
 public final class io/gitlab/arturbosch/detekt/api/Rule$Id {
-	public static final synthetic fun box-impl (Ljava/lang/String;)Lio/gitlab/arturbosch/detekt/api/Rule$Id;
-	public static fun constructor-impl (Ljava/lang/String;)Ljava/lang/String;
+	public fun <init> (Ljava/lang/String;)V
 	public fun equals (Ljava/lang/Object;)Z
-	public static fun equals-impl (Ljava/lang/String;Ljava/lang/Object;)Z
-	public static final fun equals-impl0 (Ljava/lang/String;Ljava/lang/String;)Z
 	public final fun getValue ()Ljava/lang/String;
 	public fun hashCode ()I
-	public static fun hashCode-impl (Ljava/lang/String;)I
 	public fun toString ()Ljava/lang/String;
-	public static fun toString-impl (Ljava/lang/String;)Ljava/lang/String;
-	public final synthetic fun unbox-impl ()Ljava/lang/String;
 }
 
 public final class io/gitlab/arturbosch/detekt/api/RuleSet {

--- a/detekt-api/api/detekt-api.api
+++ b/detekt-api/api/detekt-api.api
@@ -211,9 +211,9 @@ public final class io/gitlab/arturbosch/detekt/api/HasEntity$DefaultImpls {
 }
 
 public final class io/gitlab/arturbosch/detekt/api/Issue {
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getDescription ()Ljava/lang/String;
-	public final fun getId ()Ljava/lang/String;
+	public final fun getId-2Rbgges ()Ljava/lang/String;
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -310,7 +310,7 @@ public class io/gitlab/arturbosch/detekt/api/Rule : io/gitlab/arturbosch/detekt/
 	public fun getDefaultRuleIdAliases ()Ljava/util/Set;
 	public fun getFilters ()Lio/gitlab/arturbosch/detekt/api/internal/PathFilters;
 	public final fun getIssue ()Lio/gitlab/arturbosch/detekt/api/Issue;
-	public fun getRuleId ()Ljava/lang/String;
+	public fun getRuleId-2Rbgges ()Ljava/lang/String;
 	protected fun postVisit (Lorg/jetbrains/kotlin/psi/KtFile;)V
 	protected fun preVisit (Lorg/jetbrains/kotlin/psi/KtFile;)V
 	public final fun report (Lio/gitlab/arturbosch/detekt/api/Finding;)V
@@ -320,6 +320,20 @@ public class io/gitlab/arturbosch/detekt/api/Rule : io/gitlab/arturbosch/detekt/
 	public fun visitCondition (Lorg/jetbrains/kotlin/psi/KtFile;)Z
 	public final fun visitFile (Lorg/jetbrains/kotlin/psi/KtFile;Lorg/jetbrains/kotlin/resolve/BindingContext;Lio/gitlab/arturbosch/detekt/api/CompilerResources;)Ljava/util/List;
 	public static synthetic fun visitFile$default (Lio/gitlab/arturbosch/detekt/api/Rule;Lorg/jetbrains/kotlin/psi/KtFile;Lorg/jetbrains/kotlin/resolve/BindingContext;Lio/gitlab/arturbosch/detekt/api/CompilerResources;ILjava/lang/Object;)Ljava/util/List;
+}
+
+public final class io/gitlab/arturbosch/detekt/api/Rule$Id {
+	public static final synthetic fun box-impl (Ljava/lang/String;)Lio/gitlab/arturbosch/detekt/api/Rule$Id;
+	public static fun constructor-impl (Ljava/lang/String;)Ljava/lang/String;
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (Ljava/lang/String;Ljava/lang/Object;)Z
+	public static final fun equals-impl0 (Ljava/lang/String;Ljava/lang/String;)Z
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public static fun hashCode-impl (Ljava/lang/String;)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (Ljava/lang/String;)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()Ljava/lang/String;
 }
 
 public final class io/gitlab/arturbosch/detekt/api/RuleSet {

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Issue.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Issue.kt
@@ -4,7 +4,6 @@ package io.gitlab.arturbosch.detekt.api
  * An issue represents a problem in the codebase.
  */
 class Issue(
-    @get:JvmName("getId")
     val id: Rule.Id,
     val description: String,
 ) {

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Issue.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Issue.kt
@@ -1,18 +1,12 @@
 package io.gitlab.arturbosch.detekt.api
 
-import io.gitlab.arturbosch.detekt.api.internal.validateIdentifier
-
 /**
  * An issue represents a problem in the codebase.
  */
 class Issue(
-    val id: String,
+    val id: Rule.Id,
     val description: String,
 ) {
-
-    init {
-        validateIdentifier(id)
-    }
 
     override fun toString(): String {
         return "Issue(id='$id')"

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Issue.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Issue.kt
@@ -4,6 +4,7 @@ package io.gitlab.arturbosch.detekt.api
  * An issue represents a problem in the codebase.
  */
 class Issue(
+    @get:JvmName("getId")
     val id: Rule.Id,
     val description: String,
 ) {

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Rule.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Rule.kt
@@ -4,6 +4,7 @@ import io.gitlab.arturbosch.detekt.api.Config.Companion.SEVERITY_KEY
 import io.gitlab.arturbosch.detekt.api.internal.PathFilters
 import io.gitlab.arturbosch.detekt.api.internal.createPathFilters
 import io.gitlab.arturbosch.detekt.api.internal.isSuppressedBy
+import io.gitlab.arturbosch.detekt.api.internal.validateIdentifier
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.resolve.BindingContext
 
@@ -30,7 +31,7 @@ open class Rule(
      * An id this rule is identified with.
      * Conventionally the rule id is derived from the issue id as these two classes have a coexistence.
      */
-    open val ruleId: RuleId = javaClass.simpleName
+    open val ruleId: Id by lazy(LazyThreadSafetyMode.NONE) { Id(javaClass.simpleName) }
 
     /**
      * List of rule ids which can optionally be used in suppress annotations to refer to this rule.
@@ -154,9 +155,15 @@ open class Rule(
             findings.add(finding)
         }
     }
-}
 
-/**
- * The type to use when referring to rule ids giving it more context then a String would.
- */
-typealias RuleId = String
+    @JvmInline
+    value class Id(val value: String) {
+        init {
+            validateIdentifier(value)
+        }
+
+        override fun toString(): String {
+            return value
+        }
+    }
+}

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Rule.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Rule.kt
@@ -156,14 +156,26 @@ open class Rule(
         }
     }
 
-    @JvmInline
-    value class Id(val value: String) {
+    class Id(val value: String) {
         init {
             validateIdentifier(value)
         }
 
         override fun toString(): String {
             return value
+        }
+
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (javaClass != other?.javaClass) return false
+
+            other as Id
+
+            return value == other.value
+        }
+
+        override fun hashCode(): Int {
+            return value.hashCode()
         }
     }
 }

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Rule.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Rule.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.api
 
+import dev.drewhamilton.poko.Poko
 import io.gitlab.arturbosch.detekt.api.Config.Companion.SEVERITY_KEY
 import io.gitlab.arturbosch.detekt.api.internal.PathFilters
 import io.gitlab.arturbosch.detekt.api.internal.createPathFilters
@@ -156,6 +157,7 @@ open class Rule(
         }
     }
 
+    @Poko
     class Id(val value: String) {
         init {
             validateIdentifier(value)
@@ -163,19 +165,6 @@ open class Rule(
 
         override fun toString(): String {
             return value
-        }
-
-        override fun equals(other: Any?): Boolean {
-            if (this === other) return true
-            if (javaClass != other?.javaClass) return false
-
-            other as Id
-
-            return value == other.value
-        }
-
-        override fun hashCode(): Int {
-            return value.hashCode()
         }
     }
 }

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/RuleSet.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/RuleSet.kt
@@ -5,7 +5,7 @@ import io.gitlab.arturbosch.detekt.api.internal.validateIdentifier
 /**
  * A rule set is a collection of rules and must be defined within a rule set provider implementation.
  */
-class RuleSet(val id: Id, val rules: Map<String, (Config) -> Rule>) {
+class RuleSet(val id: Id, val rules: Map<Rule.Id, (Config) -> Rule>) {
     companion object {
         operator fun invoke(id: Id, rules: List<(Config) -> Rule>): RuleSet {
             return RuleSet(id, rules.associateBy { it(Config.empty).ruleId })

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/Suppressions.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/Suppressions.kt
@@ -1,6 +1,6 @@
 package io.gitlab.arturbosch.detekt.api.internal
 
-import io.gitlab.arturbosch.detekt.api.RuleId
+import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.RuleSet
 import org.jetbrains.kotlin.psi.KtAnnotated
 import org.jetbrains.kotlin.psi.KtElement
@@ -11,13 +11,13 @@ import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
  * Checks if this psi element is suppressed by @Suppress or @SuppressWarnings annotations.
  * If this element cannot have annotations, the first annotative parent is searched.
  */
-fun KtElement.isSuppressedBy(id: String, aliases: Set<String>, ruleSetId: RuleSet.Id? = null): Boolean =
+fun KtElement.isSuppressedBy(id: Rule.Id, aliases: Set<String>, ruleSetId: RuleSet.Id? = null): Boolean =
     this is KtAnnotated &&
         this.isSuppressedBy(id, aliases, ruleSetId) ||
         findAnnotatedSuppressedParent(id, aliases, ruleSetId)
 
 private fun KtElement.findAnnotatedSuppressedParent(
-    id: String,
+    id: Rule.Id,
     aliases: Set<String>,
     ruleSetId: RuleSet.Id? = null
 ): Boolean {
@@ -42,8 +42,8 @@ private val suppressionAnnotations = setOf("Suppress", "SuppressWarnings")
 /**
  * Checks if this kt element is suppressed by @Suppress or @SuppressWarnings annotations.
  */
-fun KtAnnotated.isSuppressedBy(id: RuleId, aliases: Set<String>, ruleSetId: RuleSet.Id? = null): Boolean {
-    val acceptedSuppressionIds = mutableSetOf(id, "ALL", "all", "All")
+fun KtAnnotated.isSuppressedBy(id: Rule.Id, aliases: Set<String>, ruleSetId: RuleSet.Id? = null): Boolean {
+    val acceptedSuppressionIds = mutableSetOf(id.value, "ALL", "all", "All")
     if (ruleSetId != null) {
         acceptedSuppressionIds.addAll(listOf(ruleSetId.value, "$ruleSetId.$id", "$ruleSetId:$id"))
     }

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/ConfigPropertySpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/ConfigPropertySpec.kt
@@ -522,5 +522,5 @@ class ConfigPropertySpec {
 }
 
 open class TestRule(vararg data: Pair<String, Any>) : Rule(TestConfig(*data), "description") {
-    final override val ruleId: RuleId = "TestRule"
+    final override val ruleId: Id = Id("TestRule")
 }

--- a/detekt-api/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/test/TestDetektion.kt
+++ b/detekt-api/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/test/TestDetektion.kt
@@ -11,7 +11,7 @@ import org.jetbrains.kotlin.com.intellij.openapi.util.UserDataHolderBase
 open class TestDetektion(vararg findings: Finding) : Detektion, UserDataHolderBase() {
 
     override val findings: Map<RuleSet.Id, List<Finding>> = findings
-        .groupBy { RuleSet.Id(it.issue.id) } // FIXME this is not correct
+        .groupBy { RuleSet.Id(it.issue.id.value) } // FIXME this is not correct
     override val metrics: Collection<ProjectMetric> get() = _metrics
     override val notifications: List<Notification> get() = _notifications
 

--- a/detekt-api/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/test/TestFactory.kt
+++ b/detekt-api/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/test/TestFactory.kt
@@ -6,6 +6,7 @@ import io.gitlab.arturbosch.detekt.api.CorrectableCodeSmell
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Location
+import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.api.TextLocation
@@ -67,7 +68,7 @@ fun createFindingForRelativePath(
 )
 
 fun createIssue(id: String) = Issue(
-    id = id,
+    id = Rule.Id(id),
     description = "Description $id",
 )
 

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Spec.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Spec.kt
@@ -2,6 +2,7 @@ package io.gitlab.arturbosch.detekt.cli
 
 import io.github.detekt.tooling.api.spec.ProcessingSpec
 import io.github.detekt.tooling.api.spec.RulesSpec
+import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.RuleSet
 import io.gitlab.arturbosch.detekt.api.commaSeparatedPattern
 
@@ -75,5 +76,5 @@ private fun asPatterns(rawValue: String?): List<String> =
 private fun CliArgs.toRunPolicy(): RulesSpec.RunPolicy {
     val parts = runRule?.split(":") ?: return RulesSpec.RunPolicy.NoRestrictions
     require(parts.size == 2) { "Pattern 'RuleSetId:RuleId' expected." }
-    return RulesSpec.RunPolicy.RestrictToSingleRule(RuleSet.Id(parts[0]), parts[1])
+    return RulesSpec.RunPolicy.RestrictToSingleRule(RuleSet.Id(parts[0]), Rule.Id(parts[1]))
 }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Analyzer.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Analyzer.kt
@@ -115,7 +115,7 @@ internal class Analyzer(
             .flatMap { (ruleSet, ruleSetConfig) ->
                 ruleSet.rules
                     .asSequence()
-                    .map { (ruleId, ruleProvider) -> ruleProvider to ruleSetConfig.subConfig(ruleId) }
+                    .map { (ruleId, ruleProvider) -> ruleProvider to ruleSetConfig.subConfig(ruleId.value) }
                     .filter { (_, config) -> config.isActiveOrDefault(false) }
                     .map { (ruleProvider, config) -> ruleProvider(config) }
             }
@@ -153,7 +153,7 @@ internal class Analyzer(
             .flatMap { (ruleSet, ruleSetConfig) ->
                 ruleSet.rules
                     .asSequence()
-                    .map { (ruleId, ruleProvider) -> ruleProvider to ruleSetConfig.subConfig(ruleId) }
+                    .map { (ruleId, ruleProvider) -> ruleProvider to ruleSetConfig.subConfig(ruleId.value) }
                     .filter { (_, config) -> config.isActiveOrDefault(false) }
                     .map { (ruleProvider, config) -> ruleProvider(config) }
             }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/DefaultBaseline.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/DefaultBaseline.kt
@@ -35,4 +35,4 @@ internal const val CURRENT_ISSUES = "CurrentIssues"
 internal const val ID = "ID"
 
 internal val Finding.baselineId: String
-    get() = issue.id + ":" + this.signature
+    get() = "${issue.id}:${this.signature}"

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/rules/RuleSets.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/rules/RuleSets.kt
@@ -3,7 +3,7 @@ package io.gitlab.arturbosch.detekt.core.rules
 import io.github.detekt.psi.absolutePath
 import io.github.detekt.tooling.api.spec.RulesSpec
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.RuleId
+import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.RuleSet
 import io.gitlab.arturbosch.detekt.api.RuleSetProvider
 import io.gitlab.arturbosch.detekt.api.internal.createPathFilters
@@ -15,7 +15,7 @@ fun Config.shouldAnalyzeFile(file: KtFile): Boolean {
     return filters == null || !filters.isIgnored(file.absolutePath())
 }
 
-fun associateRuleIdsToRuleSetIds(ruleSets: List<RuleSet>): Map<RuleId, RuleSet.Id> {
+fun associateRuleIdsToRuleSetIds(ruleSets: List<RuleSet>): Map<Rule.Id, RuleSet.Id> {
     return ruleSets
         .flatMap { ruleSet ->
             ruleSet.rules.map { (ruleId, _) -> ruleId to ruleSet.id }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/rules/SingleRuleProvider.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/rules/SingleRuleProvider.kt
@@ -2,12 +2,11 @@ package io.gitlab.arturbosch.detekt.core.rules
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Rule
-import io.gitlab.arturbosch.detekt.api.RuleId
 import io.gitlab.arturbosch.detekt.api.RuleSet
 import io.gitlab.arturbosch.detekt.api.RuleSetProvider
 
 internal class SingleRuleProvider(
-    private val ruleId: RuleId,
+    private val ruleId: Rule.Id,
     private val wrapped: RuleSetProvider
 ) : RuleSetProvider {
 

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/CorrectableRulesFirstSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/CorrectableRulesFirstSpec.kt
@@ -53,12 +53,12 @@ private var actualLastRuleId = ""
 
 private class NonCorrectable(config: Config) : Rule(config, "") {
     override fun visitClass(klass: KtClass) {
-        actualLastRuleId = issue.id
+        actualLastRuleId = issue.id.value
     }
 }
 
 private class Correctable(config: Config) : Rule(config, "") {
     override fun visitClass(klass: KtClass) {
-        actualLastRuleId = issue.id
+        actualLastRuleId = issue.id.value
     }
 }

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/SuppressionSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/SuppressionSpec.kt
@@ -293,7 +293,7 @@ private fun isSuppressedBy(annotation: String, argument: String): Boolean {
     """.trimIndent()
     val file = compileContentForTest(annotated)
     val annotatedClass = file.children.first { it is KtClass } as KtAnnotated
-    return annotatedClass.isSuppressedBy("Test", setOf("alias"))
+    return annotatedClass.isSuppressedBy(Rule.Id("Test"), setOf("alias"))
 }
 
 private class TestRule(config: Config = Config.empty) : Rule(config, "") {

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/Builders.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/Builders.kt
@@ -4,17 +4,17 @@ import io.github.detekt.psi.FilePath
 import io.gitlab.arturbosch.detekt.api.CodeSmell
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Finding
-import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Location
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.api.TextLocation
 import io.gitlab.arturbosch.detekt.test.TestConfig
+import io.gitlab.arturbosch.detekt.test.createIssue
 import org.jetbrains.kotlin.psi.KtElement
 import kotlin.io.path.Path
 
 internal fun buildFinding(element: KtElement?): Finding = CodeSmell(
-    issue = Issue("RuleName", ""),
+    issue = createIssue("RuleName"),
     entity = element?.let { Entity.from(element) } ?: buildEmptyEntity(),
     message = "TestMessage",
 )

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/AutoCorrectLevelSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/AutoCorrectLevelSpec.kt
@@ -74,7 +74,7 @@ private fun runRule(config: Config): Pair<KtFile, List<Finding>> {
     val testFile = loadFile("configTests/fixed.kt")
     val ruleSet = loadRuleSet<FormattingProvider>()
     val rules = ruleSet.rules
-        .map { (ruleId, provider) -> provider(config.subConfig(ruleSet.id.value).subConfig(ruleId)) }
+        .map { (ruleId, provider) -> provider(config.subConfig(ruleSet.id.value).subConfig(ruleId.value)) }
         .filter { it.config.valueOrDefault("active", false) }
     return testFile to rules.flatMap { it.visitFile(testFile) }
 }

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/config/ConfigAssert.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/config/ConfigAssert.kt
@@ -54,7 +54,7 @@ class ConfigAssert(
         val clazz = rule::class.java
         assertThat(rule.ruleId)
             .withFailMessage { "rule $clazz declares the rule id ${rule.ruleId} instead of ${clazz.simpleName}" }
-            .isEqualTo(clazz.simpleName)
+            .isEqualTo(Rule.Id(clazz.simpleName))
     }
 
     private fun getYmlRuleConfig() = config.subConfig(name) as? YamlConfig

--- a/detekt-report-html/src/main/kotlin/io/github/detekt/report/html/HtmlOutputReport.kt
+++ b/detekt-report-html/src/main/kotlin/io/github/detekt/report/html/HtmlOutputReport.kt
@@ -6,6 +6,7 @@ import io.gitlab.arturbosch.detekt.api.Detektion
 import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.api.OutputReport
 import io.gitlab.arturbosch.detekt.api.ProjectMetric
+import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.RuleSet
 import io.gitlab.arturbosch.detekt.api.TextLocation
 import io.gitlab.arturbosch.detekt.api.internal.BuiltInOutputReport
@@ -108,15 +109,15 @@ class HtmlOutputReport : BuiltInOutputReport, OutputReport() {
         findings
             .groupBy { it.issue.id }
             .toList()
-            .sortedBy { (rule, _) -> rule }
+            .sortedBy { (rule, _) -> rule.value }
             .forEach { (rule, ruleFindings) ->
                 renderRule(rule, group, ruleFindings)
             }
     }
 
-    private fun FlowContent.renderRule(rule: String, group: RuleSet.Id, findings: List<Finding>) {
+    private fun FlowContent.renderRule(rule: Rule.Id, group: RuleSet.Id, findings: List<Finding>) {
         details {
-            id = rule
+            id = rule.value
             open = true
 
             summary("rule-container") {
@@ -124,7 +125,7 @@ class HtmlOutputReport : BuiltInOutputReport, OutputReport() {
                 span("description") { text(findings.first().issue.description) }
             }
 
-            a("$DETEKT_WEBSITE_BASE_URL/docs/rules/${group.value.lowercase()}#${rule.lowercase()}") {
+            a("$DETEKT_WEBSITE_BASE_URL/docs/rules/${group.value.lowercase()}#${rule.value.lowercase()}") {
                 +"Documentation"
             }
 

--- a/detekt-report-html/src/main/kotlin/io/github/detekt/report/html/HtmlUtils.kt
+++ b/detekt-report-html/src/main/kotlin/io/github/detekt/report/html/HtmlUtils.kt
@@ -1,5 +1,6 @@
 package io.github.detekt.report.html
 
+import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.api.internal.whichDetekt
 import kotlinx.html.FlowContent
@@ -17,7 +18,12 @@ import java.util.Locale
 import kotlin.math.max
 import kotlin.math.min
 
-internal fun FlowContent.snippetCode(ruleName: String, lines: Sequence<String>, location: SourceLocation, length: Int) {
+internal fun FlowContent.snippetCode(
+    ruleName: Rule.Id,
+    lines: Sequence<String>,
+    location: SourceLocation,
+    length: Int,
+) {
     try {
         pre {
             code {
@@ -61,7 +67,7 @@ private fun FlowContent.writeErrorLine(line: String, errorStarts: Int, length: I
     return errorEnds - errorStarts
 }
 
-private fun FlowContent.showError(ruleName: String, throwable: Throwable) {
+private fun FlowContent.showError(ruleName: Rule.Id, throwable: Throwable) {
     div("exception") {
         h4 {
             text("Error showing the code snippet")
@@ -77,7 +83,7 @@ private fun FlowContent.showError(ruleName: String, throwable: Throwable) {
     }
 }
 
-private fun createReportUrl(ruleName: String, throwable: Throwable): String {
+private fun createReportUrl(ruleName: Rule.Id, throwable: Throwable): String {
     val title = URLEncoder.encode("HtmlReport error in rule: $ruleName", "UTF8")
     val stackTrace = throwable.printStackTraceString()
         .lineSequence()

--- a/detekt-report-html/src/test/kotlin/io/github/detekt/report/html/HtmlUtilsSpec.kt
+++ b/detekt-report-html/src/test/kotlin/io/github/detekt/report/html/HtmlUtilsSpec.kt
@@ -1,5 +1,6 @@
 package io.github.detekt.report.html
 
+import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.SourceLocation
 import kotlinx.html.div
 import kotlinx.html.stream.createHTML
@@ -30,7 +31,7 @@ class HtmlUtilsSpec {
     @Test
     fun `all line`() {
         val snippet = createHTML().div {
-            snippetCode("ruleName", code, SourceLocation(7, 1), 34)
+            snippetCode(Rule.Id("ruleName"), code, SourceLocation(7, 1), 34)
         }
 
         assertThat(snippet).isEqualTo(
@@ -53,7 +54,7 @@ class HtmlUtilsSpec {
     @Test
     fun `part of line`() {
         val snippet = createHTML().div {
-            snippetCode("ruleName", code, SourceLocation(7, 7), 26)
+            snippetCode(Rule.Id("ruleName"), code, SourceLocation(7, 7), 26)
         }
 
         assertThat(snippet).isEqualTo(
@@ -76,7 +77,7 @@ class HtmlUtilsSpec {
     @Test
     fun `more than one line`() {
         val snippet = createHTML().div {
-            snippetCode("ruleName", code, SourceLocation(7, 7), 66)
+            snippetCode(Rule.Id("ruleName"), code, SourceLocation(7, 7), 66)
         }
 
         assertThat(snippet).isEqualTo(
@@ -99,7 +100,7 @@ class HtmlUtilsSpec {
     @Test
     fun `first line`() {
         val snippet = createHTML().div {
-            snippetCode("ruleName", code, SourceLocation(1, 1), 1)
+            snippetCode(Rule.Id("ruleName"), code, SourceLocation(1, 1), 1)
         }
 
         assertThat(snippet).contains((1..4).map { "  $it " })
@@ -108,7 +109,7 @@ class HtmlUtilsSpec {
     @Test
     fun `second line`() {
         val snippet = createHTML().div {
-            snippetCode("ruleName", code, SourceLocation(2, 1), 1)
+            snippetCode(Rule.Id("ruleName"), code, SourceLocation(2, 1), 1)
         }
 
         assertThat(snippet).contains((1..5).map { "  $it " })
@@ -117,7 +118,7 @@ class HtmlUtilsSpec {
     @Test
     fun `penultimate line`() {
         val snippet = createHTML().div {
-            snippetCode("ruleName", code, SourceLocation(15, 1), 1)
+            snippetCode(Rule.Id("ruleName"), code, SourceLocation(15, 1), 1)
         }
 
         assertThat(snippet).contains((12..16).map { "  $it " })
@@ -126,7 +127,7 @@ class HtmlUtilsSpec {
     @Test
     fun `last line`() {
         val snippet = createHTML().div {
-            snippetCode("ruleName", code, SourceLocation(16, 1), 1)
+            snippetCode(Rule.Id("ruleName"), code, SourceLocation(16, 1), 1)
         }
 
         assertThat(snippet).contains((13..16).map { "  $it " })
@@ -135,7 +136,7 @@ class HtmlUtilsSpec {
     @Test
     fun `when we provide an invalid source location the exception div is shown`() {
         val snippet = createHTML().div {
-            snippetCode("ruleName", code, SourceLocation(7, 100), 1)
+            snippetCode(Rule.Id("ruleName"), code, SourceLocation(7, 100), 1)
         }
 
         assertThat(snippet).contains("""<div class="exception">""")

--- a/detekt-report-md/src/main/kotlin/io/github/detekt/report/md/MdOutputReport.kt
+++ b/detekt-report-md/src/main/kotlin/io/github/detekt/report/md/MdOutputReport.kt
@@ -15,6 +15,7 @@ import io.gitlab.arturbosch.detekt.api.Detektion
 import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.api.OutputReport
 import io.gitlab.arturbosch.detekt.api.ProjectMetric
+import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.RuleSet
 import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.api.internal.BuiltInOutputReport
@@ -86,20 +87,20 @@ private fun MarkdownContent.renderGroup(group: RuleSet.Id, findings: List<Findin
     findings
         .groupBy { it.issue.id }
         .toList()
-        .sortedBy { (rule, _) -> rule }
+        .sortedBy { (rule, _) -> rule.value }
         .forEach { (rule, ruleFindings) ->
             renderRule(rule, group, ruleFindings)
         }
 }
 
-private fun MarkdownContent.renderRule(rule: String, group: RuleSet.Id, findings: List<Finding>) {
+private fun MarkdownContent.renderRule(rule: Rule.Id, group: RuleSet.Id, findings: List<Finding>) {
     h3 { "$group, $rule (%,d)".format(Locale.ROOT, findings.size) }
     paragraph { (findings.first().issue.description) }
 
     paragraph {
         link(
             "Documentation",
-            "$DETEKT_WEBSITE_BASE_URL/docs/rules/${group.value.lowercase()}#${rule.lowercase()}"
+            "$DETEKT_WEBSITE_BASE_URL/docs/rules/${group.value.lowercase()}#${rule.value.lowercase()}"
         )
     }
 

--- a/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/RuleDescriptors.kt
+++ b/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/RuleDescriptors.kt
@@ -28,11 +28,11 @@ internal fun toReportingDescriptors(): List<ReportingDescriptor> {
 
 private fun Rule.toDescriptor(ruleSetId: RuleSet.Id): ReportingDescriptor {
     val formattedRuleSetId = ruleSetId.value.lowercase()
-    val formattedRuleId = ruleId.lowercase()
+    val formattedRuleId = ruleId.value.lowercase()
 
     return ReportingDescriptor(
         id = "detekt.$ruleSetId.$ruleId",
-        name = ruleId,
+        name = ruleId.value,
         shortDescription = MultiformatMessageString(text = issue.description),
         helpURI = "https://detekt.dev/$formattedRuleSetId.html#$formattedRuleId"
     )

--- a/detekt-report-xml/src/main/kotlin/io/github/detekt/report/xml/XmlOutputReport.kt
+++ b/detekt-report-xml/src/main/kotlin/io/github/detekt/report/xml/XmlOutputReport.kt
@@ -35,7 +35,7 @@ class XmlOutputReport : BuiltInOutputReport, OutputReport() {
                         "column=\"${it.location.source.column.toXmlString()}\"",
                         "severity=\"${it.severityLabel.toXmlString()}\"",
                         "message=\"${it.message.toXmlString()}\"",
-                        "source=\"${"detekt.${it.issue.id.toXmlString()}"}\" />"
+                        "source=\"${"detekt.${it.issue.id.value.toXmlString()}"}\" />"
                     ).joinToString(separator = " ")
                 }
                 lines += "</file>"

--- a/detekt-report-xml/src/test/kotlin/io/github/detekt/report/xml/XmlOutputFormatSpec.kt
+++ b/detekt-report-xml/src/test/kotlin/io/github/detekt/report/xml/XmlOutputFormatSpec.kt
@@ -3,13 +3,13 @@ package io.github.detekt.report.xml
 import io.github.detekt.psi.FilePath
 import io.gitlab.arturbosch.detekt.api.CodeSmell
 import io.gitlab.arturbosch.detekt.api.Entity
-import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Location
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.api.TextLocation
 import io.gitlab.arturbosch.detekt.test.TestDetektion
 import io.gitlab.arturbosch.detekt.test.createFindingForRelativePath
+import io.gitlab.arturbosch.detekt.test.createIssue
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -57,7 +57,7 @@ class XmlOutputFormatSpec {
 
     @Test
     fun `renders one reported issue in single file`() {
-        val smell = CodeSmell(Issue("id_a", ""), entity1, message = "TestMessage")
+        val smell = CodeSmell(createIssue("id_a"), entity1, message = "TestMessage")
 
         val result = outputFormat.render(TestDetektion(smell))
 
@@ -75,8 +75,8 @@ class XmlOutputFormatSpec {
 
     @Test
     fun `renders two reported issues in single file`() {
-        val smell1 = CodeSmell(Issue("id_a", ""), entity1, message = "TestMessage")
-        val smell2 = CodeSmell(Issue("id_b", ""), entity1, message = "TestMessage")
+        val smell1 = CodeSmell(createIssue("id_a"), entity1, message = "TestMessage")
+        val smell2 = CodeSmell(createIssue("id_b"), entity1, message = "TestMessage")
 
         val result = outputFormat.render(TestDetektion(smell1, smell2))
 
@@ -95,8 +95,8 @@ class XmlOutputFormatSpec {
 
     @Test
     fun `renders one reported issue across multiple files`() {
-        val smell1 = CodeSmell(Issue("id_a", ""), entity1, message = "TestMessage")
-        val smell2 = CodeSmell(Issue("id_a", ""), entity2, message = "TestMessage")
+        val smell1 = CodeSmell(createIssue("id_a"), entity1, message = "TestMessage")
+        val smell2 = CodeSmell(createIssue("id_a"), entity2, message = "TestMessage")
 
         val result = outputFormat.render(TestDetektion(smell1, smell2))
 
@@ -147,10 +147,10 @@ class XmlOutputFormatSpec {
 
     @Test
     fun `renders two reported issues across multiple files`() {
-        val smell1 = CodeSmell(Issue("id_a", ""), entity1, message = "TestMessage")
-        val smell2 = CodeSmell(Issue("id_b", ""), entity1, message = "TestMessage")
-        val smell3 = CodeSmell(Issue("id_a", ""), entity2, message = "TestMessage")
-        val smell4 = CodeSmell(Issue("id_b", ""), entity2, message = "TestMessage")
+        val smell1 = CodeSmell(createIssue("id_a"), entity1, message = "TestMessage")
+        val smell2 = CodeSmell(createIssue("id_b"), entity1, message = "TestMessage")
+        val smell3 = CodeSmell(createIssue("id_a"), entity2, message = "TestMessage")
+        val smell4 = CodeSmell(createIssue("id_b"), entity2, message = "TestMessage")
 
         val result = outputFormat.render(
             TestDetektion(
@@ -186,7 +186,7 @@ class XmlOutputFormatSpec {
         fun `renders detektion with severity as XML with severity`(severity: Severity) {
             val xmlSeverity = severity.name.lowercase(Locale.US)
             val finding = object : CodeSmell(
-                issue = Issue("issue_id", "issue description"),
+                issue = createIssue("issue_id"),
                 entity = entity1,
                 message = "message"
             ) {

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingWhenCaseSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingWhenCaseSpec.kt
@@ -39,7 +39,6 @@ class MissingWhenCaseSpec(private val env: KotlinCoreEnvironment) {
                 """.trimIndent()
                 val actual = subject.lintWithContext(env, code)
                 assertThat(actual).hasSize(1)
-                assertThat(actual.first().issue.id).isEqualTo("MissingWhenCase")
                 assertThat(actual.first().message).isEqualTo(
                     "When expression is missing cases: RED. Either add missing cases or a default `else` case."
                 )
@@ -63,7 +62,6 @@ class MissingWhenCaseSpec(private val env: KotlinCoreEnvironment) {
                 """.trimIndent()
                 val actual = subject.lintWithContext(env, code)
                 assertThat(actual).hasSize(1)
-                assertThat(actual.first().issue.id).isEqualTo("MissingWhenCase")
                 assertThat(actual.first().message).isEqualTo(
                     "When expression is missing cases: RED, null. Either add missing cases or a default `else` case."
                 )
@@ -88,7 +86,6 @@ class MissingWhenCaseSpec(private val env: KotlinCoreEnvironment) {
                 """.trimIndent()
                 val actual = subject.lintWithContext(env, code)
                 assertThat(actual).hasSize(1)
-                assertThat(actual.first().issue.id).isEqualTo("MissingWhenCase")
                 assertThat(actual.first().message).isEqualTo(
                     "When expression is missing cases: null. Either add missing cases or a default `else` case."
                 )
@@ -163,7 +160,6 @@ class MissingWhenCaseSpec(private val env: KotlinCoreEnvironment) {
                 """.trimIndent()
                 val actual = subject.lintWithContext(env, code)
                 assertThat(actual).hasSize(1)
-                assertThat(actual.first().issue.id).isEqualTo("MissingWhenCase")
                 assertThat(actual.first().message).isEqualTo(
                     "When expression is missing cases: VariantC. Either add missing cases or a default `else` case."
                 )
@@ -188,7 +184,6 @@ class MissingWhenCaseSpec(private val env: KotlinCoreEnvironment) {
                 """.trimIndent()
                 val actual = subject.lintWithContext(env, code)
                 assertThat(actual).hasSize(1)
-                assertThat(actual.first().issue.id).isEqualTo("MissingWhenCase")
                 assertThat(actual.first().message).isEqualTo(
                     "When expression is missing cases: null. Either add missing cases or a default `else` case."
                 )
@@ -212,7 +207,6 @@ class MissingWhenCaseSpec(private val env: KotlinCoreEnvironment) {
                 """.trimIndent()
                 val actual = subject.lintWithContext(env, code)
                 assertThat(actual).hasSize(1)
-                assertThat(actual.first().issue.id).isEqualTo("MissingWhenCase")
                 assertThat(actual.first().message).isEqualTo(
                     "When expression is missing cases: VariantC, null. Either add missing cases or a default `else` case."
                 )
@@ -337,7 +331,6 @@ class MissingWhenCaseSpec(private val env: KotlinCoreEnvironment) {
                 """.trimIndent()
                 val actual = subject.compileAndLintWithContext(env, code)
                 assertThat(actual).hasSize(1)
-                assertThat(actual.first().issue.id).isEqualTo("MissingWhenCase")
                 assertThat(actual.first().message).isEqualTo("When expression is missing cases: RED.")
             }
 
@@ -361,7 +354,6 @@ class MissingWhenCaseSpec(private val env: KotlinCoreEnvironment) {
                 """.trimIndent()
                 val actual = subject.compileAndLintWithContext(env, code)
                 assertThat(actual).hasSize(1)
-                assertThat(actual.first().issue.id).isEqualTo("MissingWhenCase")
                 assertThat(actual.first().message).isEqualTo("When expression is missing cases: null.")
             }
 
@@ -408,7 +400,6 @@ class MissingWhenCaseSpec(private val env: KotlinCoreEnvironment) {
                 """.trimIndent()
                 val actual = subject.compileAndLintWithContext(env, code)
                 assertThat(actual).hasSize(1)
-                assertThat(actual.first().issue.id).isEqualTo("MissingWhenCase")
                 assertThat(actual.first().message).isEqualTo("When expression is missing cases: VariantC.")
             }
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ModifierOrder.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ModifierOrder.kt
@@ -4,7 +4,6 @@ import io.gitlab.arturbosch.detekt.api.ActiveByDefault
 import io.gitlab.arturbosch.detekt.api.CodeSmell
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Entity
-import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import org.jetbrains.kotlin.lexer.KtModifierKeywordToken
 import org.jetbrains.kotlin.lexer.KtTokens.ABSTRACT_KEYWORD
@@ -88,16 +87,7 @@ class ModifierOrder(config: Config) : Rule(
         if (modifiers != sortedModifiers) {
             val modifierString = sortedModifiers.joinToString(" ") { it.value }
 
-            report(
-                CodeSmell(
-                    Issue(
-                        javaClass.simpleName,
-                        "Modifier order should be: $modifierString",
-                    ),
-                    Entity.from(list),
-                    "Modifier order should be: $modifierString"
-                )
-            )
+            report(CodeSmell(issue, Entity.from(list), "Modifier order should be: $modifierString"))
         }
     }
 }

--- a/detekt-tooling/api/detekt-tooling.api
+++ b/detekt-tooling/api/detekt-tooling.api
@@ -224,7 +224,7 @@ public final class io/github/detekt/tooling/api/spec/RulesSpec$RunPolicy$NoRestr
 
 public final class io/github/detekt/tooling/api/spec/RulesSpec$RunPolicy$RestrictToSingleRule : io/github/detekt/tooling/api/spec/RulesSpec$RunPolicy {
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun getRuleId ()Ljava/lang/String;
+	public final fun getRuleId-2Rbgges ()Ljava/lang/String;
 	public final fun getRuleSetId-7o6PJhY ()Ljava/lang/String;
 }
 

--- a/detekt-tooling/api/detekt-tooling.api
+++ b/detekt-tooling/api/detekt-tooling.api
@@ -223,8 +223,8 @@ public final class io/github/detekt/tooling/api/spec/RulesSpec$RunPolicy$NoRestr
 }
 
 public final class io/github/detekt/tooling/api/spec/RulesSpec$RunPolicy$RestrictToSingleRule : io/github/detekt/tooling/api/spec/RulesSpec$RunPolicy {
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun getRuleId-2Rbgges ()Ljava/lang/String;
+	public synthetic fun <init> (Ljava/lang/String;Lio/gitlab/arturbosch/detekt/api/Rule$Id;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getRuleId ()Lio/gitlab/arturbosch/detekt/api/Rule$Id;
 	public final fun getRuleSetId-7o6PJhY ()Ljava/lang/String;
 }
 

--- a/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/api/spec/RulesSpec.kt
+++ b/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/api/spec/RulesSpec.kt
@@ -1,6 +1,6 @@
 package io.github.detekt.tooling.api.spec
 
-import io.gitlab.arturbosch.detekt.api.RuleId
+import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.RuleSet
 import io.gitlab.arturbosch.detekt.api.Severity
 
@@ -62,6 +62,6 @@ interface RulesSpec {
         /**
          * Run a single rule.
          */
-        class RestrictToSingleRule(val ruleSetId: RuleSet.Id, val ruleId: RuleId) : RunPolicy()
+        class RestrictToSingleRule(val ruleSetId: RuleSet.Id, val ruleId: Rule.Id) : RunPolicy()
     }
 }


### PR DESCRIPTION
A continuation of #6849. Add a little of type safety to all the ids that we have in the project so we don't mess up. Now the `id` of a `Rule` has it's own type. It is a `value class` to avoid the Boxing problem.