### PR TITLE
Make the abi a bit cleaner

### DIFF
--- a/detekt-api/api/detekt-api.api
+++ b/detekt-api/api/detekt-api.api
@@ -325,12 +325,12 @@ public class io/gitlab/arturbosch/detekt/api/Rule : io/gitlab/arturbosch/detekt/
 public final class io/gitlab/arturbosch/detekt/api/RuleSet {
 	public static final field Companion Lio/gitlab/arturbosch/detekt/api/RuleSet$Companion;
 	public synthetic fun <init> (Ljava/lang/String;Ljava/util/Map;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun getId-7o6PJhY ()Ljava/lang/String;
+	public final fun getId ()Ljava/lang/String;
 	public final fun getRules ()Ljava/util/Map;
 }
 
 public final class io/gitlab/arturbosch/detekt/api/RuleSet$Companion {
-	public final fun invoke-wynkp2w (Ljava/lang/String;Ljava/util/List;)Lio/gitlab/arturbosch/detekt/api/RuleSet;
+	public final fun invoke (Ljava/lang/String;Ljava/util/List;)Lio/gitlab/arturbosch/detekt/api/RuleSet;
 }
 
 public final class io/gitlab/arturbosch/detekt/api/RuleSet$Id {

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/RuleSet.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/RuleSet.kt
@@ -5,8 +5,9 @@ import io.gitlab.arturbosch.detekt.api.internal.validateIdentifier
 /**
  * A rule set is a collection of rules and must be defined within a rule set provider implementation.
  */
-class RuleSet(val id: Id, val rules: Map<String, (Config) -> Rule>) {
+class RuleSet(@get:JvmName("getId") val id: Id, val rules: Map<String, (Config) -> Rule>) {
     companion object {
+        @JvmName("invoke")
         operator fun invoke(id: Id, rules: List<(Config) -> Rule>): RuleSet {
             return RuleSet(id, rules.associateBy { it(Config.empty).ruleId })
         }


### PR DESCRIPTION
#6849 introduced some hashes on our ABIs. This PR remove some of them.

I couldn't remove all of them because I can't add a `@JvmName` annotation inside an interface so I couldn't fix this one:

```
public abstract interface class io/gitlab/arturbosch/detekt/api/RuleSetProvider {
	public abstract fun getRuleSetId-7o6PJhY ()Ljava/lang/String;
	public abstract fun instance ()Lio/gitlab/arturbosch/detekt/api/RuleSet;
}
```

Any idea with that is more than welcome.