### PR TITLE
Import custom assertions together with AssertJ assertions

### DIFF
--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/AutoCorrectLevelSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/AutoCorrectLevelSpec.kt
@@ -6,9 +6,9 @@ import io.gitlab.arturbosch.detekt.api.RuleSet
 import io.gitlab.arturbosch.detekt.api.RuleSetProvider
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.yamlConfigFromContent
+import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.psi.KtFile
 import org.junit.jupiter.api.Test
-import org.assertj.core.api.Assertions.assertThat as assertJThat
 
 class AutoCorrectLevelSpec {
 
@@ -28,7 +28,7 @@ class AutoCorrectLevelSpec {
         val (file, findings) = runRule(config)
 
         assertThat(findings).isNotEmpty()
-        assertJThat(wasFormatted(file)).isTrue()
+        assertThat(wasFormatted(file)).isTrue()
     }
 
     @Test
@@ -47,7 +47,7 @@ class AutoCorrectLevelSpec {
         val (file, findings) = runRule(config)
 
         assertThat(findings).isNotEmpty()
-        assertJThat(wasFormatted(file)).isFalse()
+        assertThat(wasFormatted(file)).isFalse()
     }
 
     @Test
@@ -66,7 +66,7 @@ class AutoCorrectLevelSpec {
         val (file, findings) = runRule(config)
 
         assertThat(findings).isNotEmpty()
-        assertJThat(wasFormatted(file)).isFalse()
+        assertThat(wasFormatted(file)).isFalse()
     }
 }
 

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/ChainWrappingSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/ChainWrappingSpec.kt
@@ -3,8 +3,8 @@ package io.gitlab.arturbosch.detekt.formatting
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.formatting.wrappers.ChainWrapping
 import io.gitlab.arturbosch.detekt.test.assertThat
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import org.assertj.core.api.Assertions.assertThat as assertJThat
 
 class ChainWrappingSpec {
 
@@ -16,6 +16,6 @@ class ChainWrappingSpec {
         val findings = ChainWrapping(Config.empty).lint(subject.text)
 
         assertThat(findings).isNotEmpty()
-        assertJThat(subject.text).isEqualTo(expected)
+        assertThat(subject.text).isEqualTo(expected)
     }
 }

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/MaximumLineLengthSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/MaximumLineLengthSpec.kt
@@ -5,10 +5,10 @@ import io.gitlab.arturbosch.detekt.formatting.wrappers.MaximumLineLength
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLint
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.assertj.core.api.Assertions.assertThat as assertJThat
 
 class MaximumLineLengthSpec {
 
@@ -39,7 +39,7 @@ class MaximumLineLengthSpec {
                 "Test.kt"
             ).first()
 
-            assertJThat(finding.entity.signature).isEqualTo("Test.kt\$}")
+            assertThat(finding.entity.signature).isEqualTo("Test.kt\$}")
         }
 
         @Test

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicPropertySpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicPropertySpec.kt
@@ -2,8 +2,8 @@ package io.gitlab.arturbosch.detekt.rules.documentation
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
+import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLint
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
@@ -328,7 +328,7 @@ class UndocumentedPublicPropertySpec {
             """.trimIndent()
             val findings = subject.compileAndLint(code)
             assertThat(findings).hasSize(1)
-            io.gitlab.arturbosch.detekt.test.assertThat(findings[0]).hasSourceLocation(9, 13)
+            assertThat(findings[0]).hasSourceLocation(9, 13)
         }
 
         @Test
@@ -348,7 +348,7 @@ class UndocumentedPublicPropertySpec {
             """.trimIndent()
             val findings = subject.compileAndLint(code)
             assertThat(findings).hasSize(1)
-            io.gitlab.arturbosch.detekt.test.assertThat(findings[0]).hasSourceLocation(2, 9)
+            assertThat(findings[0]).hasSourceLocation(2, 9)
         }
 
         @Test

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/TopLevelPropertyNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/TopLevelPropertyNamingSpec.kt
@@ -2,9 +2,9 @@ package io.gitlab.arturbosch.detekt.rules.naming
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
+import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLint
 import io.gitlab.arturbosch.detekt.test.lint
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 


### PR DESCRIPTION
This allows assertThat to be used consistently regardless of which set of assertions is being used.