### PR TITLE
Use more specific assertions

### DIFF
--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/ConfigPropertySpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/ConfigPropertySpec.kt
@@ -446,7 +446,7 @@ class ConfigPropertySpec {
                 repeat(5) {
                     assertThat(subject.useProperty()).isEqualTo("something with 1")
                 }
-                assertThat(subject.counter.get()).isEqualTo(1)
+                assertThat(subject.counter).hasValue(1)
             }
         }
     }

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/PropertiesAwareSpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/PropertiesAwareSpec.kt
@@ -38,7 +38,7 @@ class PropertiesAwareSpec {
 
     @Test
     fun `returns null on absent values`() {
-        assertThat(store.getOrNull<Boolean>("absent")).isEqualTo(null)
+        assertThat(store.getOrNull<Boolean>("absent")).isNull()
     }
 
     @Test

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleCollectorSpec.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleCollectorSpec.kt
@@ -214,7 +214,7 @@ class RuleCollectorSpec {
                 defaultAndroidValue = null,
                 deprecated = null
             )
-            assertThat(items[0].configurations[0]).isEqualTo(expectedConfiguration)
+            assertThat(items[0].configurations).singleElement().isEqualTo(expectedConfiguration)
         }
 
         @Test
@@ -531,7 +531,7 @@ class RuleCollectorSpec {
                     }
                 """.trimIndent()
                 val items = subject.run(code)
-                assertThat(items[0].configurations[0]).isEqualTo(
+                assertThat(items[0].configurations).singleElement().isEqualTo(
                     Configuration(
                         name = "maxLineLength",
                         description = "description",
@@ -555,7 +555,7 @@ class RuleCollectorSpec {
                     }
                 """.trimIndent()
                 val items = subject.run(code)
-                assertThat(items[0].configurations[0]).isEqualTo(
+                assertThat(items[0].configurations).singleElement().isEqualTo(
                     Configuration(
                         name = "maxLineLength",
                         description = "description",

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleSetProviderCollectorSpec.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleSetProviderCollectorSpec.kt
@@ -130,8 +130,7 @@ class RuleSetProviderCollectorSpec {
         fun `has one rule`() {
             val items = subject.run(code)
             val provider = items[0]
-            assertThat(provider.rules).hasSize(1)
-            assertThat(provider.rules[0]).isEqualTo(ruleName)
+            assertThat(provider.rules).singleElement().isEqualTo(ruleName)
         }
 
         @Test

--- a/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/processors/PackageCountVisitorSpec.kt
+++ b/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/processors/PackageCountVisitorSpec.kt
@@ -13,11 +13,10 @@ class PackageCountVisitorSpec {
             compileContentForTest(default),
             compileContentForTest(emptyEnum)
         )
-        val count = files
+        val distinctFiles = files
             .map { getData(it) }
             .distinct()
-            .count()
-        assertThat(count).isEqualTo(2)
+        assertThat(distinctFiles).hasSize(2)
     }
 }
 

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexConditionSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexConditionSpec.kt
@@ -22,8 +22,9 @@ class ComplexConditionSpec {
 
         val actual = ComplexCondition(testConfig).compileAndLint(code)
 
-        assertThat(actual).hasSize(1)
-        assertThat(actual.first()).isThresholded().withValue(5)
+        assertThat(actual).singleElement()
+            .isThresholded()
+            .withValue(5)
     }
 
     @Test

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongMethodSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongMethodSpec.kt
@@ -76,8 +76,9 @@ class LongMethodSpec {
 
         val findings = subject.compileAndLint(code)
 
-        assertThat(findings).hasSize(1)
-        assertThat(findings[0]).isThresholded().hasValue(6)
+        assertThat(findings).singleElement()
+            .isThresholded()
+            .hasValue(6)
     }
 
     @Test
@@ -100,8 +101,9 @@ class LongMethodSpec {
 
         val findings = subject.compileAndLint(code)
 
-        assertThat(findings).hasSize(1)
-        assertThat(findings[0]).isThresholded().hasValue(8)
+        assertThat(findings).singleElement()
+            .isThresholded()
+            .hasValue(8)
     }
 
     @Test
@@ -155,8 +157,9 @@ class LongMethodSpec {
 
         val findings = subject.compileAndLint(code)
 
-        assertThat(findings).hasSize(1)
+        assertThat(findings).singleElement()
+            .isThresholded()
+            .hasValue(6)
         assertThat(findings).hasTextLocations("nestedLongMethod")
-        assertThat(findings[0]).isThresholded().hasValue(6)
     }
 }

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NamedArgumentsSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NamedArgumentsSpec.kt
@@ -39,7 +39,7 @@ class NamedArgumentsSpec(val env: KotlinCoreEnvironment) {
             }
         """.trimIndent()
         val findings = subject.compileAndLintWithContext(env, code)
-        assertThat(findings).hasSize(0)
+        assertThat(findings).isEmpty()
     }
 
     @Test
@@ -67,7 +67,7 @@ class NamedArgumentsSpec(val env: KotlinCoreEnvironment) {
             }
         """.trimIndent()
         val findings = subject.compileAndLintWithContext(env, code)
-        assertThat(findings).hasSize(0)
+        assertThat(findings).isEmpty()
     }
 
     @Test
@@ -81,7 +81,7 @@ class NamedArgumentsSpec(val env: KotlinCoreEnvironment) {
             }
         """.trimIndent()
         val findings = subject.compileAndLintWithContext(env, code)
-        assertThat(findings).hasSize(0)
+        assertThat(findings).isEmpty()
     }
 
     @Test
@@ -103,7 +103,7 @@ class NamedArgumentsSpec(val env: KotlinCoreEnvironment) {
             val obj = C(a = 1, b = 2, c= 3)
         """.trimIndent()
         val findings = subject.compileAndLintWithContext(env, code)
-        assertThat(findings).hasSize(0)
+        assertThat(findings).isEmpty()
     }
 
     @Test
@@ -114,7 +114,7 @@ class NamedArgumentsSpec(val env: KotlinCoreEnvironment) {
             val obj = C(1, 2)
         """.trimIndent()
         val findings = subject.compileAndLintWithContext(env, code)
-        assertThat(findings).hasSize(0)
+        assertThat(findings).isEmpty()
     }
 
     @Test
@@ -127,7 +127,7 @@ class NamedArgumentsSpec(val env: KotlinCoreEnvironment) {
             }
         """.trimIndent()
         val findings = subject.compileAndLintWithContext(env, code)
-        assertThat(findings).hasSize(0)
+        assertThat(findings).isEmpty()
     }
 
     @Test
@@ -141,7 +141,7 @@ class NamedArgumentsSpec(val env: KotlinCoreEnvironment) {
             }
         """.trimIndent()
         val findings = subject.compileAndLintWithContext(env, code)
-        assertThat(findings).hasSize(0)
+        assertThat(findings).isEmpty()
     }
 
     @Test
@@ -181,7 +181,7 @@ class NamedArgumentsSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
-            assertThat(findings).hasSize(0)
+            assertThat(findings).isEmpty()
         }
 
         @Test
@@ -206,7 +206,7 @@ class NamedArgumentsSpec(val env: KotlinCoreEnvironment) {
             """.trimIndent()
             val subject = NamedArguments(TestConfig("threshold" to 1))
             val findings = subject.compileAndLintWithContext(env, code)
-            assertThat(findings).hasSize(0)
+            assertThat(findings).isEmpty()
         }
     }
 
@@ -226,7 +226,7 @@ class NamedArgumentsSpec(val env: KotlinCoreEnvironment) {
                     }
                 """.trimIndent()
                 val findings = subject.compileAndLintWithContext(env, code)
-                assertThat(findings).hasSize(0)
+                assertThat(findings).isEmpty()
             }
 
             @Test

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedBlockDepthSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedBlockDepthSpec.kt
@@ -55,8 +55,9 @@ class NestedBlockDepthSpec {
             }
         """.trimIndent()
         val findings = subject.lint(code)
-        assertThat(findings).hasSize(1)
-        assertThat(findings[0]).isThresholded().hasValue(5)
+        assertThat(findings).singleElement()
+            .isThresholded()
+            .hasValue(5)
     }
 
     @Test

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedScopeFunctionsSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedScopeFunctionsSpec.kt
@@ -114,7 +114,7 @@ class NestedScopeFunctionsSpec(private val env: KotlinCoreEnvironment) {
     private fun expectFunctionInMsg(scopeFunction: String) {
         val expected = "The scope function '$scopeFunction' is nested too deeply ('2'). " +
             "The maximum allowed depth is set to '1'."
-        assertThat(actual[0]).hasMessage(expected)
+        assertThat(actual).singleElement().hasMessage(expected)
     }
 
     private fun expectNoFindings() {

--- a/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SleepInsteadOfDelaySpec.kt
+++ b/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SleepInsteadOfDelaySpec.kt
@@ -23,7 +23,7 @@ class SleepInsteadOfDelaySpec(private val env: KotlinCoreEnvironment) {
                 delay(1000L)
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(0)
+        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 
     @Test

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/DeprecatedBlockTagSpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/DeprecatedBlockTagSpec.kt
@@ -19,7 +19,7 @@ class DeprecatedBlockTagSpec {
              */
             val v = 2
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(0)
+        assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
     @Nested

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/DeprecatedBlockTagSpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/DeprecatedBlockTagSpec.kt
@@ -34,13 +34,8 @@ class DeprecatedBlockTagSpec {
         """.trimIndent()
 
         @Test
-        fun `has found something`() {
-            assertThat(subject.compileAndLint(code)).hasSize(1)
-        }
-
-        @Test
         fun `correct message`() {
-            assertThat(subject.compileAndLint(code)[0]).hasMessage(
+            assertThat(subject.compileAndLint(code)).singleElement().hasMessage(
                 "@deprecated tag block does not properly report " +
                     "deprecation in Kotlin, use @Deprecated annotation instead"
             )

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicPropertySpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicPropertySpec.kt
@@ -327,8 +327,9 @@ class UndocumentedPublicPropertySpec {
                 }
             """.trimIndent()
             val findings = subject.compileAndLint(code)
-            assertThat(findings).hasSize(1)
-            assertThat(findings[0]).hasSourceLocation(9, 13)
+            assertThat(findings)
+                .singleElement()
+                .hasSourceLocation(9, 13)
         }
 
         @Test
@@ -347,8 +348,9 @@ class UndocumentedPublicPropertySpec {
                 }
             """.trimIndent()
             val findings = subject.compileAndLint(code)
-            assertThat(findings).hasSize(1)
-            assertThat(findings[0]).hasSourceLocation(2, 9)
+            assertThat(findings)
+                .singleElement()
+                .hasSourceLocation(2, 9)
         }
 
         @Test

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/CastNullableToNonNullableTypeSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/CastNullableToNonNullableTypeSpec.kt
@@ -20,12 +20,11 @@ class CastNullableToNonNullableTypeSpec(private val env: KotlinCoreEnvironment) 
             }
         """.trimIndent()
         val findings = subject.compileAndLintWithContext(env, code)
-        assertThat(findings).hasSize(1)
-        assertThat(findings).hasStartSourceLocation(2, 17)
-        assertThat(findings[0]).hasMessage(
+        assertThat(findings).singleElement().hasMessage(
             "Use separate `null` assertion and type cast like " +
                 "('(bar ?: error(\"null assertion message\")) as String') instead of 'bar as String'."
         )
+        assertThat(findings).hasStartSourceLocation(2, 17)
     }
 
     @Test
@@ -40,12 +39,11 @@ class CastNullableToNonNullableTypeSpec(private val env: KotlinCoreEnvironment) 
             }
         """.trimIndent()
         val findings = subject.compileAndLintWithContext(env, code)
-        assertThat(findings).hasSize(1)
-        assertThat(findings).hasStartSourceLocation(2, 11)
-        assertThat(findings[0]).hasMessage(
+        assertThat(findings).singleElement().hasMessage(
             "Use separate `null` assertion and type cast like " +
                 "('(bar() ?: error(\"null assertion message\")) as Int') instead of 'bar() as Int'."
         )
+        assertThat(findings).hasStartSourceLocation(2, 11)
     }
 
     @Test
@@ -205,8 +203,7 @@ class CastNullableToNonNullableTypeSpec(private val env: KotlinCoreEnvironment) 
             }
         """.trimIndent()
         val findings = subject.compileAndLintWithContext(env, code)
-        assertThat(findings).hasSize(1)
-        assertThat(findings[0]).hasMessage(
+        assertThat(findings).singleElement().hasMessage(
             "Use separate `null` assertion and type cast like " +
                 "('(array[0] ?: error(\"null assertion message\")) as T') instead of 'array[0] as T'."
         )

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/CastToNullableTypeSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/CastToNullableTypeSpec.kt
@@ -19,9 +19,8 @@ class CastToNullableTypeSpec(private val env: KotlinCoreEnvironment) {
             }
         """.trimIndent()
         val findings = subject.compileAndLintWithContext(env, code)
-        assertThat(findings).hasSize(1)
+        assertThat(findings).singleElement().hasMessage("Use the safe cast ('as? String') instead of 'as String?'.")
         assertThat(findings).hasStartSourceLocation(2, 24)
-        assertThat(findings[0]).hasMessage("Use the safe cast ('as? String') instead of 'as String?'.")
     }
 
     @Test

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValueSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValueSpec.kt
@@ -207,9 +207,9 @@ class IgnoredReturnValueSpec {
             """.trimIndent()
 
             val findings = subject.lintWithContext(env, code, annotationClass)
-            assertThat(findings).hasSize(1)
+            assertThat(findings).singleElement()
+                .hasMessage("The call listOfChecked is returning a value that is ignored.")
             assertThat(findings).hasStartSourceLocation(7, 5)
-            assertThat(findings[0]).hasMessage("The call listOfChecked is returning a value that is ignored.")
         }
 
         @Test
@@ -228,9 +228,9 @@ class IgnoredReturnValueSpec {
                 }
             """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
-            assertThat(findings).hasSize(1)
+            assertThat(findings).singleElement()
+                .hasMessage("The call listOfChecked is returning a value that is ignored.")
             assertThat(findings).hasStartSourceLocation(9, 5)
-            assertThat(findings[0]).hasMessage("The call listOfChecked is returning a value that is ignored.")
         }
 
         @Test
@@ -295,9 +295,9 @@ class IgnoredReturnValueSpec {
                 }
             """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
-            assertThat(findings).hasSize(1)
+            assertThat(findings).singleElement()
+                .hasMessage("The call listOfChecked is returning a value that is ignored.")
             assertThat(findings).hasStartSourceLocation(12, 10)
-            assertThat(findings[0]).hasMessage("The call listOfChecked is returning a value that is ignored.")
         }
 
         @Test
@@ -315,9 +315,9 @@ class IgnoredReturnValueSpec {
                 }
             """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
-            assertThat(findings).hasSize(1)
+            assertThat(findings).singleElement()
+                .hasMessage("The call listOfChecked is returning a value that is ignored.")
             assertThat(findings).hasStartSourceLocation(9, 5)
-            assertThat(findings[0]).hasMessage("The call listOfChecked is returning a value that is ignored.")
         }
 
         @Test
@@ -336,9 +336,9 @@ class IgnoredReturnValueSpec {
                 }
             """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
-            assertThat(findings).hasSize(1)
+            assertThat(findings).singleElement()
+                .hasMessage("The call listOfChecked is returning a value that is ignored.")
             assertThat(findings).hasStartSourceLocation(9, 20)
-            assertThat(findings[0]).hasMessage("The call listOfChecked is returning a value that is ignored.")
         }
 
         @Test
@@ -357,9 +357,9 @@ class IgnoredReturnValueSpec {
                 }
             """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
-            assertThat(findings).hasSize(1)
+            assertThat(findings).singleElement()
+                .hasMessage("The call listOfChecked is returning a value that is ignored.")
             assertThat(findings).hasStartSourceLocation(9, 14)
-            assertThat(findings[0]).hasMessage("The call listOfChecked is returning a value that is ignored.")
         }
 
         @Test
@@ -377,9 +377,9 @@ class IgnoredReturnValueSpec {
                 }
             """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
-            assertThat(findings).hasSize(1)
+            assertThat(findings).singleElement()
+                .hasMessage("The call isTheAnswer is returning a value that is ignored.")
             assertThat(findings).hasStartSourceLocation(8, 11)
-            assertThat(findings[0]).hasMessage("The call isTheAnswer is returning a value that is ignored.")
         }
 
         @Test
@@ -814,9 +814,9 @@ class IgnoredReturnValueSpec {
                 }
             """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
-            assertThat(findings).hasSize(1)
+            assertThat(findings).singleElement()
+                .hasMessage("The call listOfChecked is returning a value that is ignored.")
             assertThat(findings).hasStartSourceLocation(8, 5)
-            assertThat(findings[0]).hasMessage("The call listOfChecked is returning a value that is ignored.")
         }
 
         @Test
@@ -876,9 +876,9 @@ class IgnoredReturnValueSpec {
                 }
             """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
-            assertThat(findings).hasSize(1)
+            assertThat(findings).singleElement()
+                .hasMessage("The call listOfChecked is returning a value that is ignored.")
             assertThat(findings).hasStartSourceLocation(9, 5)
-            assertThat(findings[0]).hasMessage("The call listOfChecked is returning a value that is ignored.")
         }
 
         @Test
@@ -892,9 +892,9 @@ class IgnoredReturnValueSpec {
                 }
             """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
-            assertThat(findings).hasSize(1)
+            assertThat(findings).singleElement()
+                .hasMessage("The call listOfChecked is returning a value that is ignored.")
             assertThat(findings).hasStartSourceLocation(4, 5)
-            assertThat(findings[0]).hasMessage("The call listOfChecked is returning a value that is ignored.")
         }
 
         @Test
@@ -907,9 +907,9 @@ class IgnoredReturnValueSpec {
                 fun ignoredReturn(): String = "asd"
             """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
-            assertThat(findings).hasSize(1)
+            assertThat(findings).singleElement()
+                .hasMessage("The call ignoredReturn is returning a value that is ignored.")
             assertThat(findings).hasStartSourceLocation(2, 5)
-            assertThat(findings[0]).hasMessage("The call ignoredReturn is returning a value that is ignored.")
         }
 
         @Test

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnusedUnaryOperatorSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnusedUnaryOperatorSpec.kt
@@ -20,9 +20,9 @@ class UnusedUnaryOperatorSpec(private val env: KotlinCoreEnvironment) {
             }
         """.trimIndent()
         val findings = subject.compileAndLintWithContext(env, code)
-        assertThat(findings).hasSize(1)
+        assertThat(findings).singleElement()
+            .hasMessage("This '+ 3' is not used")
         assertThat(findings).hasStartSourceLocation(3, 9)
-        assertThat(findings[0]).hasMessage("This '+ 3' is not used")
     }
 
     @Test
@@ -34,9 +34,9 @@ class UnusedUnaryOperatorSpec(private val env: KotlinCoreEnvironment) {
             }
         """.trimIndent()
         val findings = subject.compileAndLintWithContext(env, code)
-        assertThat(findings).hasSize(1)
+        assertThat(findings).singleElement()
+            .hasMessage("This '- 3' is not used")
         assertThat(findings).hasStartSourceLocation(3, 9)
-        assertThat(findings[0]).hasMessage("This '- 3' is not used")
     }
 
     @Test
@@ -48,8 +48,8 @@ class UnusedUnaryOperatorSpec(private val env: KotlinCoreEnvironment) {
             }
         """.trimIndent()
         val findings = subject.compileAndLintWithContext(env, code)
-        assertThat(findings).hasSize(1)
-        assertThat(findings[0]).hasMessage("This '+ 3 + 4 + 5' is not used")
+        assertThat(findings).singleElement()
+            .hasMessage("This '+ 3 + 4 + 5' is not used")
     }
 
     @Test

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ReturnFromFinallySpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ReturnFromFinallySpec.kt
@@ -192,7 +192,7 @@ class ReturnFromFinallySpec(val env: KotlinCoreEnvironment) {
 
             val finding = subject.compileAndLintWithContext(env, code)
 
-            assertThat(finding).hasSize(0)
+            assertThat(finding).isEmpty()
         }
     }
 
@@ -211,7 +211,7 @@ class ReturnFromFinallySpec(val env: KotlinCoreEnvironment) {
 
             val finding = subject.compileAndLintWithContext(env, code)
 
-            assertThat(finding).hasSize(0)
+            assertThat(finding).isEmpty()
         }
     }
 
@@ -233,7 +233,7 @@ class ReturnFromFinallySpec(val env: KotlinCoreEnvironment) {
 
             val finding = subject.compileAndLintWithContext(env, code)
 
-            assertThat(finding).hasSize(0)
+            assertThat(finding).isEmpty()
         }
     }
 
@@ -253,7 +253,7 @@ class ReturnFromFinallySpec(val env: KotlinCoreEnvironment) {
 
             val finding = subject.compileAndLintWithContext(env, code)
 
-            assertThat(finding).hasSize(0)
+            assertThat(finding).isEmpty()
         }
     }
 

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/BooleanPropertyNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/BooleanPropertyNamingSpec.kt
@@ -194,7 +194,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
             """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
 
-            assertThat(findings).hasSize(0)
+            assertThat(findings).isEmpty()
         }
 
         @Test

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NoNameShadowingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NoNameShadowingSpec.kt
@@ -19,9 +19,8 @@ class NoNameShadowingSpec(val env: KotlinCoreEnvironment) {
             }
         """.trimIndent()
         val findings = subject.compileAndLintWithContext(env, code)
-        assertThat(findings).hasSize(1)
+        assertThat(findings).singleElement().hasMessage("Name shadowed: i")
         assertThat(findings).hasStartSourceLocation(2, 9)
-        assertThat(findings[0]).hasMessage("Name shadowed: i")
     }
 
     @Test
@@ -32,8 +31,7 @@ class NoNameShadowingSpec(val env: KotlinCoreEnvironment) {
             }
         """.trimIndent()
         val findings = subject.compileAndLintWithContext(env, code)
-        assertThat(findings).hasSize(1)
-        assertThat(findings[0]).hasMessage("Name shadowed: j")
+        assertThat(findings).singleElement().hasMessage("Name shadowed: j")
     }
 
     @Test
@@ -45,8 +43,7 @@ class NoNameShadowingSpec(val env: KotlinCoreEnvironment) {
             }
         """.trimIndent()
         val findings = subject.compileAndLintWithContext(env, code)
-        assertThat(findings).hasSize(1)
-        assertThat(findings[0]).hasMessage("Name shadowed: k")
+        assertThat(findings).singleElement().hasMessage("Name shadowed: k")
     }
 
     @Test
@@ -60,8 +57,7 @@ class NoNameShadowingSpec(val env: KotlinCoreEnvironment) {
             }
         """.trimIndent()
         val findings = subject.compileAndLintWithContext(env, code)
-        assertThat(findings).hasSize(1)
-        assertThat(findings[0]).hasMessage("Name shadowed: it")
+        assertThat(findings).singleElement().hasMessage("Name shadowed: it")
     }
 
     @Test

--- a/detekt-rules-performance/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/UnnecessaryPartOfBinaryExpressionSpec.kt
+++ b/detekt-rules-performance/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/UnnecessaryPartOfBinaryExpressionSpec.kt
@@ -39,7 +39,7 @@ class UnnecessaryPartOfBinaryExpressionSpec {
         """.trimIndent()
 
         val findings = UnnecessaryPartOfBinaryExpression(Config.empty).compileAndLint(code)
-        assertThat(findings).hasSize(0)
+        assertThat(findings).isEmpty()
     }
 
     @Test
@@ -74,7 +74,7 @@ class UnnecessaryPartOfBinaryExpressionSpec {
         """.trimIndent()
 
         val findings = UnnecessaryPartOfBinaryExpression(Config.empty).compileAndLint(code)
-        assertThat(findings).hasSize(0)
+        assertThat(findings).isEmpty()
     }
 
     @Test
@@ -90,7 +90,7 @@ class UnnecessaryPartOfBinaryExpressionSpec {
         """.trimIndent()
 
         val findings = UnnecessaryPartOfBinaryExpression(Config.empty).compileAndLint(code)
-        assertThat(findings).hasSize(0)
+        assertThat(findings).isEmpty()
     }
 
     @Test
@@ -218,7 +218,7 @@ class UnnecessaryPartOfBinaryExpressionSpec {
         """.trimIndent()
 
         val findings = UnnecessaryPartOfBinaryExpression(Config.empty).compileAndLint(code)
-        assertThat(findings).hasSize(0)
+        assertThat(findings).isEmpty()
     }
 
     @Test
@@ -234,7 +234,7 @@ class UnnecessaryPartOfBinaryExpressionSpec {
         """.trimIndent()
 
         val findings = UnnecessaryPartOfBinaryExpression(Config.empty).compileAndLint(code)
-        assertThat(findings).hasSize(0)
+        assertThat(findings).isEmpty()
     }
 
     @Test
@@ -293,6 +293,6 @@ class UnnecessaryPartOfBinaryExpressionSpec {
         """.trimIndent()
 
         val findings = UnnecessaryPartOfBinaryExpression(Config.empty).compileAndLint(code)
-        assertThat(findings).hasSize(0)
+        assertThat(findings).isEmpty()
     }
 }

--- a/detekt-rules-ruleauthors/src/test/kotlin/io/gitlab/arturbosch/detekt/authors/UseEntityAtNameSpec.kt
+++ b/detekt-rules-ruleauthors/src/test/kotlin/io/gitlab/arturbosch/detekt/authors/UseEntityAtNameSpec.kt
@@ -54,8 +54,8 @@ internal class UseEntityAtNameSpec {
             }
         """.trimIndent()
         val findings = rule.compileAndLint(code)
-        assertThat(findings).hasSize(1).hasTextLocations("from")
-        assertThat(findings.single()).hasMessage("Recommended to use Entity.atName(element) instead.")
+        assertThat(findings).singleElement().hasMessage("Recommended to use Entity.atName(element) instead.")
+        assertThat(findings).hasTextLocations("from")
     }
 
     @Test
@@ -71,8 +71,8 @@ internal class UseEntityAtNameSpec {
             }
         """.trimIndent()
         val findings = rule.compileAndLint(code)
-        assertThat(findings).hasSize(1).hasTextLocations("from")
-        assertThat(findings.single()).hasMessage("Recommended to use Entity.atName(element) instead.")
+        assertThat(findings).singleElement().hasMessage("Recommended to use Entity.atName(element) instead.")
+        assertThat(findings).hasTextLocations("from")
     }
 
     @Test
@@ -88,8 +88,8 @@ internal class UseEntityAtNameSpec {
             }
         """.trimIndent()
         val findings = rule.compileAndLint(code)
-        assertThat(findings).hasSize(1).hasTextLocations("from")
-        assertThat(findings.single()).hasMessage("Recommended to use Entity.atName(element) instead.")
+        assertThat(findings).singleElement().hasMessage("Recommended to use Entity.atName(element) instead.")
+        assertThat(findings).hasTextLocations("from")
     }
 
     @Test
@@ -108,9 +108,9 @@ internal class UseEntityAtNameSpec {
             }
         """.trimIndent()
         val findings = rule.compileAndLint(code)
-        assertThat(findings).hasSize(1).hasTextLocations("from")
-        assertThat(findings.single())
+        assertThat(findings).singleElement()
             .hasMessage("Recommended to use Entity.atName(element.getStrictParentOfType<KtClass>()) instead.")
+        assertThat(findings).hasTextLocations("from")
     }
 
     @Test
@@ -127,8 +127,8 @@ internal class UseEntityAtNameSpec {
             }
         """.trimIndent()
         val findings = rule.compileAndLint(code)
-        assertThat(findings).hasSize(1).hasTextLocations("from")
-        assertThat(findings.single()).hasMessage("Recommended to use Entity.atName(element) instead.")
+        assertThat(findings).singleElement().hasMessage("Recommended to use Entity.atName(element) instead.")
+        assertThat(findings).hasTextLocations("from")
     }
 
     @Test

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/CanBeNonNullableSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/CanBeNonNullableSpec.kt
@@ -1408,7 +1408,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                         println(a)
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).hasSize(0)
+                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
             }
 
             @Test
@@ -1420,7 +1420,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                         return a
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).hasSize(0)
+                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
             }
 
             @Test

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ClassOrderingSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ClassOrderingSpec.kt
@@ -212,7 +212,7 @@ class ClassOrderingSpec {
             }
         """.trimIndent()
 
-        assertThat(subject.compileAndLint(code)).hasSize(0)
+        assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
     @Test
@@ -235,7 +235,7 @@ class ClassOrderingSpec {
             }
         """.trimIndent()
 
-        assertThat(subject.compileAndLint(code)).hasSize(0)
+        assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
     @Test

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/DoubleNegativeLambdaSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/DoubleNegativeLambdaSpec.kt
@@ -217,12 +217,11 @@ class DoubleNegativeLambdaSpec {
         """.trimIndent()
 
         val findings = subject.compileAndLint(code)
-        assertThat(findings).hasSize(1)
-        assertThat(findings).hasStartSourceLocation(3, 37)
-        assertThat(findings).hasEndSourceLocation(3, 74)
-        assertThat(findings[0]).hasMessage(
+        assertThat(findings).singleElement().hasMessage(
             "Double negative through using `!in`, `!=` inside a `takeUnless` lambda. Use `takeIf` instead."
         )
+        assertThat(findings).hasStartSourceLocation(3, 37)
+        assertThat(findings).hasEndSourceLocation(3, 74)
     }
 
     @Test
@@ -240,7 +239,7 @@ class DoubleNegativeLambdaSpec {
         """.trimIndent()
 
         val findings = DoubleNegativeLambda(config).compileAndLint(code)
-        assertThat(findings[0]).hasMessage(
+        assertThat(findings).singleElement().hasMessage(
             "Double negative through using `!=` inside a `never` lambda. Rewrite in the positive."
         )
     }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitCollectionElementAccessMethodSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitCollectionElementAccessMethodSpec.kt
@@ -161,7 +161,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                         with(map) { get("a") }
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).hasSize(0)
+                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
             }
         }
 
@@ -220,7 +220,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                         val value = with(list) { get(0) }
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).hasSize(0)
+                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
             }
         }
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenCommentSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenCommentSpec.kt
@@ -31,8 +31,8 @@ class ForbiddenCommentSpec {
         @DisplayName("should report TODO: usages")
         fun reportTodoColon() {
             val findings = ForbiddenComment(Config.empty).compileAndLint("// TODO: I need to fix this.")
-            assertThat(findings).hasSize(1)
-            assertThat(findings[0]).hasMessage("Forbidden TODO todo marker in comment, please do the changes.")
+            assertThat(findings).singleElement()
+                .hasMessage("Forbidden TODO todo marker in comment, please do the changes.")
         }
 
         @Test
@@ -58,8 +58,7 @@ class ForbiddenCommentSpec {
         @DisplayName("should report STOPSHIP: usages")
         fun reportStopShipColon() {
             val findings = ForbiddenComment(Config.empty).compileAndLint("// STOPSHIP: I need to fix this.")
-            assertThat(findings).hasSize(1)
-            assertThat(findings[0]).hasMessage(
+            assertThat(findings).singleElement().hasMessage(
                 "Forbidden STOPSHIP todo marker in comment, please address the problem before shipping the code."
             )
         }
@@ -293,7 +292,7 @@ class ForbiddenCommentSpec {
             val comment = "// STOPSHIP to express in the preview that it's not a normal TextView."
             val findings = ForbiddenComment(messageConfig).compileAndLint(comment)
             assertThat(findings).hasSize(1)
-            assertThat(findings[0])
+            assertThat(findings).singleElement()
                 .hasMessage(
                     String.format(
                         Locale.ROOT,
@@ -308,7 +307,7 @@ class ForbiddenCommentSpec {
             val comment = "// REVIEW foo -> flag"
             val findings = ForbiddenComment(messageConfig).compileAndLint(comment)
             assertThat(findings).hasSize(1)
-            assertThat(findings[0])
+            assertThat(findings).singleElement()
                 .hasMessage(
                     String.format(
                         Locale.ROOT,
@@ -323,7 +322,7 @@ class ForbiddenCommentSpec {
             val comment = "//REVIEW foo -> flag"
             val findings = ForbiddenComment(messageConfig).compileAndLint(comment)
             assertThat(findings).hasSize(1)
-            assertThat(findings[0])
+            assertThat(findings).singleElement()
                 .hasMessage(
                     String.format(
                         Locale.ROOT,

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCallSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCallSpec.kt
@@ -188,7 +188,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
             TestConfig(METHODS to listOf("java.time.LocalDate.now()"))
         ).compileAndLintWithContext(env, code)
         assertThat(findings).hasStartSourceLocation(5, 26)
-        assertThat(findings[0])
+        assertThat(findings).singleElement()
             .hasMessage("The method `java.time.LocalDate.now()` has been forbidden in the detekt config.")
     }
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenSuppressSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenSuppressSpec.kt
@@ -115,7 +115,7 @@ internal class ForbiddenSuppressSpec {
                 fun foo() { }
             """.trimIndent()
             val findings = subject.compileAndLint(code)
-            assertThat(findings).hasSize(0)
+            assertThat(findings).isEmpty()
         }
     }
 
@@ -172,7 +172,7 @@ internal class ForbiddenSuppressSpec {
                 class Foo
             """.trimIndent()
             val findings = subject.compileAndLint(code)
-            assertThat(findings).hasSize(0)
+            assertThat(findings).isEmpty()
         }
 
         @Test
@@ -184,7 +184,7 @@ internal class ForbiddenSuppressSpec {
                 class Foo
             """.trimIndent()
             val findings = subject.compileAndLint(code)
-            assertThat(findings).hasSize(0)
+            assertThat(findings).isEmpty()
         }
     }
 
@@ -199,7 +199,7 @@ internal class ForbiddenSuppressSpec {
                 package config
             """.trimIndent()
             val findings = subject.compileAndLint(code)
-            assertThat(findings).hasSize(0)
+            assertThat(findings).isEmpty()
         }
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxChainedCallsOnSameLineSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxChainedCallsOnSameLineSpec.kt
@@ -55,7 +55,7 @@ class MaxChainedCallsOnSameLineSpec(private val env: KotlinCoreEnvironment) {
         val rule = MaxChainedCallsOnSameLine(TestConfig("maxChainedCalls" to 1))
         val findings = rule.compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(1)
-        assertThat(findings[0]).hasMessage(getTestMessage(2, 1))
+        assertThat(findings).singleElement().hasMessage(getTestMessage(2, 1))
     }
 
     @Test
@@ -71,8 +71,7 @@ class MaxChainedCallsOnSameLineSpec(private val env: KotlinCoreEnvironment) {
 
         val rule = MaxChainedCallsOnSameLine(TestConfig("maxChainedCalls" to 1))
         val findings = rule.compileAndLintWithContext(env, code)
-        assertThat(findings).hasSize(1)
-        assertThat(findings[0]).hasMessage(getTestMessage(2, 1))
+        assertThat(findings).singleElement().hasMessage(getTestMessage(2, 1))
     }
 
     @Test
@@ -88,8 +87,7 @@ class MaxChainedCallsOnSameLineSpec(private val env: KotlinCoreEnvironment) {
 
         val rule = MaxChainedCallsOnSameLine(TestConfig("maxChainedCalls" to 1))
         val findings = rule.compileAndLintWithContext(env, code)
-        assertThat(findings).hasSize(1)
-        assertThat(findings[0]).hasMessage(getTestMessage(2, 1))
+        assertThat(findings).singleElement().hasMessage(getTestMessage(2, 1))
     }
 
     @Test
@@ -186,8 +184,7 @@ class MaxChainedCallsOnSameLineSpec(private val env: KotlinCoreEnvironment) {
             val x = kotlin.math.floor(1.0).plus(1).plus(1).plus(1)
         """.trimIndent()
         val findings = rule.compileAndLintWithContext(env, code)
-        assertThat(findings).hasSize(1)
-        assertThat(findings[0]).hasMessage(getTestMessage(4, 3))
+        assertThat(findings).singleElement().hasMessage(getTestMessage(4, 3))
     }
 
     @Test
@@ -205,8 +202,7 @@ class MaxChainedCallsOnSameLineSpec(private val env: KotlinCoreEnvironment) {
             val x = kotlin.run { 1 }.plus(1).plus(1).plus(1)
         """.trimIndent()
         val findings = rule.compileAndLintWithContext(env, code)
-        assertThat(findings).hasSize(1)
-        assertThat(findings[0]).hasMessage(getTestMessage(4, 3))
+        assertThat(findings).singleElement().hasMessage(getTestMessage(4, 3))
     }
 
     @Test
@@ -227,8 +223,7 @@ class MaxChainedCallsOnSameLineSpec(private val env: KotlinCoreEnvironment) {
             val x = 1.0.ulp.ulp.ulp
         """.trimIndent()
         val findings = rule.compileAndLintWithContext(env, code)
-        assertThat(findings).hasSize(1)
-        assertThat(findings[0]).hasMessage(getTestMessage(4, 3))
+        assertThat(findings).singleElement().hasMessage(getTestMessage(4, 3))
     }
 
     @Test
@@ -269,8 +264,7 @@ class MaxChainedCallsOnSameLineSpec(private val env: KotlinCoreEnvironment) {
                 .plus(0)
         """.trimIndent()
         val findings = rule.compileAndLintWithContext(env, code)
-        assertThat(findings).hasSize(1)
-        assertThat(findings[0]).hasMessage(getTestMessage(4, 3))
+        assertThat(findings).singleElement().hasMessage(getTestMessage(4, 3))
     }
 
     @Nested
@@ -319,8 +313,7 @@ class MaxChainedCallsOnSameLineSpec(private val env: KotlinCoreEnvironment) {
             """.trimIndent()
             val rule = MaxChainedCallsOnSameLine(TestConfig("maxChainedCalls" to 1))
             val findings = rule.compileAndLintWithContext(env, code)
-            assertThat(findings).hasSize(1)
-            assertThat(findings[0]).hasMessage(getTestMessage(2, 1))
+            assertThat(findings).singleElement().hasMessage(getTestMessage(2, 1))
         }
 
         @Test
@@ -421,8 +414,7 @@ class MaxChainedCallsOnSameLineSpec(private val env: KotlinCoreEnvironment) {
                     )
             """.trimIndent()
             val findings = rule.compileAndLintWithContext(env, code)
-            assertThat(findings).hasSize(1)
-            assertThat(findings[0]).hasMessage(getTestMessage(4, 3))
+            assertThat(findings).singleElement().hasMessage(getTestMessage(4, 3))
         }
 
         @Test
@@ -440,8 +432,7 @@ class MaxChainedCallsOnSameLineSpec(private val env: KotlinCoreEnvironment) {
                     )
             """.trimIndent()
             val findings = rule.compileAndLintWithContext(env, code)
-            assertThat(findings).hasSize(1)
-            assertThat(findings[0]).hasMessage(getTestMessage(4, 3))
+            assertThat(findings).singleElement().hasMessage(getTestMessage(4, 3))
         }
 
         @Test
@@ -503,8 +494,7 @@ class MaxChainedCallsOnSameLineSpec(private val env: KotlinCoreEnvironment) {
                 ).ulp.ulp.ulp.ulp
             """.trimIndent()
             val findings = rule.compileAndLintWithContext(env, code)
-            assertThat(findings).hasSize(1)
-            assertThat(findings[0]).hasMessage(getTestMessage(4, 3))
+            assertThat(findings).singleElement().hasMessage(getTestMessage(4, 3))
         }
 
         @Nested
@@ -524,8 +514,7 @@ class MaxChainedCallsOnSameLineSpec(private val env: KotlinCoreEnvironment) {
                         )
                 """.trimIndent()
                 val findings = rule.compileAndLintWithContext(env, code)
-                assertThat(findings).hasSize(1)
-                assertThat(findings[0]).hasMessage(getTestMessage(4, 3))
+                assertThat(findings).singleElement().hasMessage(getTestMessage(4, 3))
             }
 
             @Test

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ModifierOrderSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ModifierOrderSpec.kt
@@ -19,16 +19,13 @@ class ModifierOrderSpec {
         @Test
         fun `should report incorrectly ordered modifiers`() {
             subject.compileAndLint(bad1).let {
-                assertThat(it).hasSize(1)
-                assertThat(it[0]).hasMessage("Modifier order should be: internal data")
+                assertThat(it).singleElement().hasMessage("Modifier order should be: internal data")
             }
             subject.lint(bad2).let {
-                assertThat(it).hasSize(1)
-                assertThat(it[0]).hasMessage("Modifier order should be: private actual")
+                assertThat(it).singleElement().hasMessage("Modifier order should be: private actual")
             }
             subject.lint(bad3).let {
-                assertThat(it).hasSize(1)
-                assertThat(it[0]).hasMessage("Modifier order should be: expect annotation")
+                assertThat(it).singleElement().hasMessage("Modifier order should be: expect annotation")
             }
         }
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MultilineRawStringIndentationSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MultilineRawStringIndentationSpec.kt
@@ -394,7 +394,7 @@ class MultilineRawStringIndentationSpec {
             """.trimIndent()
             val findings = subject.compileAndLint(code)
             assertThat(findings)
-                .hasSize(0)
+                .isEmpty()
         }
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/RangeUntilInsteadOfRangeToSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/RangeUntilInsteadOfRangeToSpec.kt
@@ -18,8 +18,7 @@ class RangeUntilInsteadOfRangeToSpec {
             }
         """.trimIndent()
         val findings = subject.lint(code)
-        assertThat(findings).hasSize(1)
-        assertThat(findings[0]).hasMessage("`..` call can be replaced with `..<`")
+        assertThat(findings).singleElement().hasMessage("`..` call can be replaced with `..<`")
     }
 
     @Test
@@ -70,7 +69,6 @@ class RangeUntilInsteadOfRangeToSpec {
     fun `reports for 'rangeTo'`() {
         val code = "val r = 0.rangeTo(10 - 1)"
         val findings = subject.lint(code)
-        assertThat(findings).hasSize(1)
-        assertThat(findings[0]).hasMessage("`rangeTo` call can be replaced with `..<`")
+        assertThat(findings).singleElement().hasMessage("`rangeTo` call can be replaced with `..<`")
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantHigherOrderMapUsageSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantHigherOrderMapUsageSpec.kt
@@ -24,9 +24,8 @@ class RedundantHigherOrderMapUsageSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
-            assertThat(findings).hasSize(1)
+            assertThat(findings).singleElement().hasMessage("This 'map' call can be removed.")
             assertThat(findings).hasStartSourceLocation(4, 10)
-            assertThat(findings[0]).hasMessage("This 'map' call can be removed.")
         }
 
         @Test
@@ -44,9 +43,9 @@ class RedundantHigherOrderMapUsageSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
-            assertThat(findings).hasSize(1)
+            assertThat(findings).singleElement()
+                .hasMessage("This 'map' call can be replaced with 'onEach' or 'forEach'.")
             assertThat(findings).hasStartSourceLocation(5, 10)
-            assertThat(findings[0]).hasMessage("This 'map' call can be replaced with 'onEach' or 'forEach'.")
         }
 
         @Test
@@ -171,8 +170,7 @@ class RedundantHigherOrderMapUsageSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
-            assertThat(findings).hasSize(1)
-            assertThat(findings[0]).hasMessage("This 'map' call can be replaced with 'toList'.")
+            assertThat(findings).singleElement().hasMessage("This 'map' call can be replaced with 'toList'.")
         }
     }
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/SerialVersionUIDInSerializableClassSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/SerialVersionUIDInSerializableClassSpec.kt
@@ -18,15 +18,14 @@ class SerialVersionUIDInSerializableClassSpec {
             class C : Serializable
         """.trimIndent()
         val findings = subject.compileAndLint(code)
-        assertThat(findings)
-            .hasSize(1)
-            .hasStartSourceLocation(3, 7)
-            .hasEndSourceLocation(3, 8)
-        assertThat(findings[0])
+        assertThat(findings).singleElement()
             .hasMessage(
                 "The class C implements the `Serializable` interface and should thus define " +
                     "a `serialVersionUID`."
             )
+        assertThat(findings)
+            .hasStartSourceLocation(3, 7)
+            .hasEndSourceLocation(3, 8)
     }
 
     @Test
@@ -41,13 +40,10 @@ class SerialVersionUIDInSerializableClassSpec {
             }
         """.trimIndent()
         val findings = subject.compileAndLint(code)
+        assertThat(findings).singleElement().hasMessage(WRONG_SERIAL_VERSION_UID_MESSAGE)
         assertThat(findings)
-            .hasSize(1)
             .hasStartSourceLocation(5, 27)
             .hasEndSourceLocation(5, 43)
-        assertThat(findings[0]).hasMessage(
-            WRONG_SERIAL_VERSION_UID_MESSAGE
-        )
     }
 
     @Test
@@ -62,12 +58,10 @@ class SerialVersionUIDInSerializableClassSpec {
             }
         """.trimIndent()
         val findings = subject.compileAndLint(code)
+        assertThat(findings).singleElement().hasMessage(WRONG_SERIAL_VERSION_UID_MESSAGE)
         assertThat(findings)
-            .hasSize(1)
             .hasStartSourceLocation(5, 27)
             .hasEndSourceLocation(5, 43)
-
-        assertThat(findings[0]).hasMessage(WRONG_SERIAL_VERSION_UID_MESSAGE)
     }
 
     @Test
@@ -82,12 +76,10 @@ class SerialVersionUIDInSerializableClassSpec {
             }
         """.trimIndent()
         val findings = subject.compileAndLint(code)
+        assertThat(findings).singleElement().hasMessage(WRONG_SERIAL_VERSION_UID_MESSAGE)
         assertThat(findings)
-            .hasSize(1)
             .hasStartSourceLocation(5, 19)
             .hasEndSourceLocation(5, 35)
-
-        assertThat(findings[0]).hasMessage(WRONG_SERIAL_VERSION_UID_MESSAGE)
     }
 
     @Test

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/StringShouldBeRawStringSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/StringShouldBeRawStringSpec.kt
@@ -394,8 +394,7 @@ class StringShouldBeRawStringSpec {
         """.trimIndent()
         val subject = StringShouldBeRawString(TestConfig(MAX_ESCAPED_CHARACTER_COUNT to 0))
         val findings = subject.compileAndLint(code)
-        assertThat(findings).hasSize(1)
-        assertThat(findings[0]).hasSourceLocation(5, 13)
+        assertThat(findings).singleElement().hasSourceLocation(5, 13)
     }
 
     @Test

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/StringShouldBeRawStringSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/StringShouldBeRawStringSpec.kt
@@ -322,7 +322,7 @@ class StringShouldBeRawStringSpec {
         """.trimIndent()
         val subject = StringShouldBeRawString(TestConfig(MAX_ESCAPED_CHARACTER_COUNT to 2))
         val findings = subject.compileAndLint(code)
-        assertThat(findings).hasSize(0)
+        assertThat(findings).isEmpty()
     }
 
     @Test
@@ -337,7 +337,7 @@ class StringShouldBeRawStringSpec {
         """.trimIndent()
         val subject = StringShouldBeRawString(TestConfig(MAX_ESCAPED_CHARACTER_COUNT to 2))
         val findings = subject.compileAndLint(code)
-        assertThat(findings).hasSize(0)
+        assertThat(findings).isEmpty()
     }
 
     @Test

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiteralsSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiteralsSpec.kt
@@ -315,7 +315,7 @@ class UnderscoresInNumericLiteralsSpec {
                 }
             """.trimIndent()
             val findings = UnderscoresInNumericLiterals(Config.empty).compileAndLint(code)
-            assertThat(findings).hasSize(0)
+            assertThat(findings).isEmpty()
         }
 
         @Test
@@ -330,7 +330,7 @@ class UnderscoresInNumericLiteralsSpec {
                 }
             """.trimIndent()
             val findings = UnderscoresInNumericLiterals(Config.empty).compileAndLint(code)
-            assertThat(findings).hasSize(0)
+            assertThat(findings).isEmpty()
         }
     }
 
@@ -347,7 +347,7 @@ class UnderscoresInNumericLiteralsSpec {
                 }
             """.trimIndent()
             val findings = UnderscoresInNumericLiterals(Config.empty).compileAndLint(code)
-            assertThat(findings).hasSize(0)
+            assertThat(findings).isEmpty()
         }
 
         @Test
@@ -360,7 +360,7 @@ class UnderscoresInNumericLiteralsSpec {
                 }
             """.trimIndent()
             val findings = UnderscoresInNumericLiterals(Config.empty).compileAndLint(code)
-            assertThat(findings).hasSize(0)
+            assertThat(findings).isEmpty()
         }
     }
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryBackticksSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryBackticksSpec.kt
@@ -73,7 +73,7 @@ class UnnecessaryBackticksSpec {
                 val x: `Foo Bar` = `Foo Bar`()
                 val y = ::`Foo Bar`
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).hasSize(0)
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         @Test
@@ -83,7 +83,7 @@ class UnnecessaryBackticksSpec {
                 val x = `foo bar`()
                 val y = ::`foo bar`
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).hasSize(0)
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         @Test
@@ -94,7 +94,7 @@ class UnnecessaryBackticksSpec {
                 val y = ::`foo bar`
                 val z = `foo bar`.length
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).hasSize(0)
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         @Test
@@ -122,7 +122,7 @@ class UnnecessaryBackticksSpec {
                 import test.`Foo Bar`
                 class `Foo Bar`
             """.trimIndent()
-            assertThat(subject.lint(code)).hasSize(0)
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
@@ -133,7 +133,7 @@ class UnnecessaryBackticksSpec {
                 val `bar baz` = ""
                 val y = "${'$'}`bar baz`"
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).hasSize(0)
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryFilterSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryFilterSpec.kt
@@ -24,8 +24,7 @@ class UnnecessaryFilterSpec(val env: KotlinCoreEnvironment) {
             """.trimIndent()
 
             val findings = subject.compileAndLintWithContext(env, code)
-            assertThat(findings).hasSize(1)
-            assertThat(findings[0]).hasMessage("'filter { it > 1 }' can be replaced by 'count { it > 1 }'")
+            assertThat(findings).singleElement().hasMessage("'filter { it > 1 }' can be replaced by 'count { it > 1 }'")
         }
 
         @Test
@@ -50,8 +49,7 @@ class UnnecessaryFilterSpec(val env: KotlinCoreEnvironment) {
             """.trimIndent()
 
             val findings = subject.compileAndLintWithContext(env, code)
-            assertThat(findings).hasSize(1)
-            assertThat(findings[0]).hasMessage("'filter { it > 2 }' can be replaced by 'count { it > 2 }'")
+            assertThat(findings).singleElement().hasMessage("'filter { it > 2 }' can be replaced by 'count { it > 2 }'")
         }
 
         @Test
@@ -65,8 +63,7 @@ class UnnecessaryFilterSpec(val env: KotlinCoreEnvironment) {
             """.trimIndent()
 
             val findings = subject.compileAndLintWithContext(env, code)
-            assertThat(findings).hasSize(1)
-            assertThat(findings[0]).hasMessage("'filter { it > 2 }' can be replaced by 'count { it > 2 }'")
+            assertThat(findings).singleElement().hasMessage("'filter { it > 2 }' can be replaced by 'count { it > 2 }'")
         }
 
         @Test

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLetSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLetSpec.kt
@@ -225,7 +225,7 @@ class UnnecessaryLetSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
         )
-        assertThat(findings).hasSize(0)
+        assertThat(findings).isEmpty()
     }
 
     @Test

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMemberSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMemberSpec.kt
@@ -664,7 +664,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(0)
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -714,7 +714,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(0)
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
     }
 
@@ -738,7 +738,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(0)
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -756,7 +756,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(0)
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -811,7 +811,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                         this.firstOrNull { it.s == s }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(0)
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -830,7 +830,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                         this.firstOrNull { it.s == b }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(0)
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -849,7 +849,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                         this.firstOrNull { it.s == s }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(0)
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -881,7 +881,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                 private operator fun List<StringWrapper>.get(s: String) =
                     this.firstOrNull { it.s == s }
             """.trimIndent()
-            assertThat(subject.lintWithContext(env, code)).hasSize(0)
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -900,7 +900,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
                 private operator fun List<StringWrapper>.get(s: String) =
                     this.firstOrNull { it.s == s }
             """.trimIndent()
-            assertThat(subject.lintWithContext(env, code)).hasSize(0)
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
     }
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivatePropertySpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivatePropertySpec.kt
@@ -205,7 +205,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                     println(o("$\{PC.Companion.OO.BLA.toString() + ""}"))
                 }
             """.trimIndent()
-            assertThat(subject.lint(code)).hasSize(0)
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIfEmptyOrIfBlankSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIfEmptyOrIfBlankSpec.kt
@@ -26,9 +26,8 @@ class UseIfEmptyOrIfBlankSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
-            assertThat(findings).hasSize(1)
+            assertThat(findings).singleElement().hasMessage("This 'isBlank' call can be replaced with 'ifBlank'")
             assertThat(findings).hasStartSourceLocation(4, 29)
-            assertThat(findings[0]).hasMessage("This 'isBlank' call can be replaced with 'ifBlank'")
         }
 
         @Test
@@ -45,9 +44,8 @@ class UseIfEmptyOrIfBlankSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
-            assertThat(findings).hasSize(1)
+            assertThat(findings).singleElement().hasMessage("This 'isNotBlank' call can be replaced with 'ifBlank'")
             assertThat(findings).hasStartSourceLocation(4, 29)
-            assertThat(findings[0]).hasMessage("This 'isNotBlank' call can be replaced with 'ifBlank'")
         }
 
         @Test
@@ -61,9 +59,8 @@ class UseIfEmptyOrIfBlankSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
-            assertThat(findings).hasSize(1)
+            assertThat(findings).singleElement().hasMessage("This 'isEmpty' call can be replaced with 'ifEmpty'")
             assertThat(findings).hasStartSourceLocation(4, 29)
-            assertThat(findings[0]).hasMessage("This 'isEmpty' call can be replaced with 'ifEmpty'")
         }
 
         @Test
@@ -80,9 +77,8 @@ class UseIfEmptyOrIfBlankSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
-            assertThat(findings).hasSize(1)
+            assertThat(findings).singleElement().hasMessage("This 'isNotEmpty' call can be replaced with 'ifEmpty'")
             assertThat(findings).hasStartSourceLocation(4, 29)
-            assertThat(findings[0]).hasMessage("This 'isNotEmpty' call can be replaced with 'ifEmpty'")
         }
 
         @Test
@@ -256,8 +252,7 @@ class UseIfEmptyOrIfBlankSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
-            assertThat(findings).hasSize(1)
-            assertThat(findings[0]).hasMessage("This 'isEmpty' call can be replaced with 'ifEmpty'")
+            assertThat(findings).singleElement().hasMessage("This 'isEmpty' call can be replaced with 'ifEmpty'")
         }
 
         @Test
@@ -272,8 +267,7 @@ class UseIfEmptyOrIfBlankSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
-            assertThat(findings).hasSize(1)
-            assertThat(findings[0]).hasMessage("This 'isNotEmpty' call can be replaced with 'ifEmpty'")
+            assertThat(findings).singleElement().hasMessage("This 'isNotEmpty' call can be replaced with 'ifEmpty'")
         }
     }
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIsNullOrEmptySpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIsNullOrEmptySpec.kt
@@ -24,11 +24,10 @@ class UseIsNullOrEmptySpec(val env: KotlinCoreEnvironment) {
                     }
                 """.trimIndent()
                 val findings = subject.compileAndLintWithContext(env, code)
-                assertThat(findings).hasSize(1)
-                assertThat(findings).hasStartSourceLocation(2, 9)
-                assertThat(findings[0]).hasMessage(
+                assertThat(findings).singleElement().hasMessage(
                     "This 'x == null || x.isEmpty()' can be replaced with 'isNullOrEmpty()' call"
                 )
+                assertThat(findings).hasStartSourceLocation(2, 9)
             }
 
             @Test

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseLetSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseLetSpec.kt
@@ -39,8 +39,7 @@ class UseLetSpec {
                         val shouldFail = (isNonNullCheck && rightIsNull) || (isNullCheck && leftIsNull)
                         val findings = subject.compileAndLint(expr)
                         if (shouldFail) {
-                            assertThat(findings).hasSize(1)
-                            assertThat(findings[0]).hasMessage(subject.description)
+                            assertThat(findings).singleElement().hasMessage(subject.description)
                         } else {
                             assertThat(findings).isEmpty()
                         }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseOrEmptySpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseOrEmptySpec.kt
@@ -22,9 +22,9 @@ class UseOrEmptySpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
             val findings = subject.compileAndLintWithContext(env, code)
-            assertThat(findings).hasSize(1)
+            assertThat(findings).singleElement()
+                .hasMessage("This '?: emptyList()' can be replaced with 'orEmpty()' call")
             assertThat(findings).hasStartSourceLocation(2, 13)
-            assertThat(findings[0]).hasMessage("This '?: emptyList()' can be replaced with 'orEmpty()' call")
         }
 
         @Test


### PR DESCRIPTION
Inspired by #6847 I looked for a few more opportunities to use better assertions, particularly by using [`singleElement`](https://assertj.github.io/doc/#assertj-core-group-navigation-singleElement) which first checks that a collection `hasSize(1)` and then "navigates" to that item so additional assertions can be made on the only item in the collection.