### PR TITLE
Remove all the usages of mockk

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -208,6 +208,7 @@ style:
       - 'org.jetbrains.kotlin.diagnostics.DiagnosticUtils.getLineAndColumnInPsiFile'
   ForbiddenVoid:
     active: true
+    ignoreOverridden: true
   MagicNumber:
     excludes: ['**/test/**', '**/*Test.kt', '**/*Spec.kt']
     ignorePropertyDeclaration: true

--- a/detekt-core/build.gradle.kts
+++ b/detekt-core/build.gradle.kts
@@ -20,7 +20,6 @@ dependencies {
     testImplementation(projects.detektReportXml)
     testImplementation(projects.detektTest)
     testImplementation(testFixtures(projects.detektApi))
-    testImplementation(libs.mockk)
     testImplementation(libs.classgraph)
     testImplementation(libs.assertj)
     testRuntimeOnly(libs.slf4j.simple)

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/DetektMessageCollectorSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/DetektMessageCollectorSpec.kt
@@ -1,10 +1,5 @@
 package io.gitlab.arturbosch.detekt.core
 
-import io.mockk.Called
-import io.mockk.every
-import io.mockk.mockk
-import io.mockk.slot
-import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
 import org.junit.jupiter.api.BeforeEach
@@ -13,12 +8,12 @@ import org.junit.jupiter.api.Test
 
 class DetektMessageCollectorSpec {
 
-    private lateinit var debugPrinter: (() -> String) -> Unit
+    private var debugPrinter = FakePrinter()
     private lateinit var subject: DetektMessageCollector
 
     @BeforeEach
-    fun setupMocksAndSubject() {
-        debugPrinter = mockk { every { this@mockk.invoke(any()) } returns Unit }
+    fun setupFakesAndSubject() {
+        debugPrinter.messages.clear()
         subject = DetektMessageCollector(
             minSeverity = CompilerMessageSeverity.INFO,
             debugPrinter = debugPrinter,
@@ -34,9 +29,7 @@ class DetektMessageCollectorSpec {
 
         @Test
         fun `prints the message`() {
-            val slot = slot<() -> String>()
-            verify { debugPrinter.invoke(capture(slot)) }
-            assertThat(slot.captured()).isEqualTo("info: message")
+            assertThat(debugPrinter.messages).contains("info: message")
         }
     }
 
@@ -49,9 +42,7 @@ class DetektMessageCollectorSpec {
 
         @Test
         fun `prints the message`() {
-            val slot = slot<() -> String>()
-            verify { debugPrinter.invoke(capture(slot)) }
-            assertThat(slot.captured()).isEqualTo("warning: message")
+            assertThat(debugPrinter.messages).contains("warning: message")
         }
     }
 
@@ -64,7 +55,14 @@ class DetektMessageCollectorSpec {
 
         @Test
         fun `ignores the message`() {
-            verify { debugPrinter wasNot Called }
+            assertThat(debugPrinter.messages).isEmpty()
+        }
+    }
+
+    inner class FakePrinter : (() -> String) -> Unit {
+        val messages = mutableListOf<String>()
+        override fun invoke(param: () -> String) {
+            messages.add(param())
         }
     }
 }

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/DetektMessageCollectorSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/DetektMessageCollectorSpec.kt
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test
 
 class DetektMessageCollectorSpec {
 
-    private var debugPrinter = FakePrinter()
+    private val debugPrinter = FakePrinter()
     private lateinit var subject: DetektMessageCollector
 
     @BeforeEach
@@ -59,7 +59,7 @@ class DetektMessageCollectorSpec {
         }
     }
 
-    inner class FakePrinter : (() -> String) -> Unit {
+   class FakePrinter : (() -> String) -> Unit {
         val messages = mutableListOf<String>()
         override fun invoke(param: () -> String) {
             messages.add(param())

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/DetektMessageCollectorSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/DetektMessageCollectorSpec.kt
@@ -59,7 +59,7 @@ class DetektMessageCollectorSpec {
         }
     }
 
-   class FakePrinter : (() -> String) -> Unit {
+    class FakePrinter : (() -> String) -> Unit {
         val messages = mutableListOf<String>()
         override fun invoke(param: () -> String) {
             messages.add(param())

--- a/detekt-psi-utils/build.gradle.kts
+++ b/detekt-psi-utils/build.gradle.kts
@@ -7,8 +7,8 @@ dependencies {
     api(libs.kotlin.compilerEmbeddable)
 
     testImplementation(libs.assertj)
-    testImplementation(libs.mockk)
     testImplementation(projects.detektTest)
+    testImplementation(projects.detektTestUtils)
 }
 
 detekt {

--- a/detekt-psi-utils/src/test/kotlin/io/github/detekt/psi/KtFilesSpec.kt
+++ b/detekt-psi-utils/src/test/kotlin/io/github/detekt/psi/KtFilesSpec.kt
@@ -1,7 +1,6 @@
 package io.github.detekt.psi
 
-import io.mockk.every
-import io.mockk.mockk
+import io.github.detekt.test.utils.internal.FakePsiFile
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.com.intellij.psi.PsiFile
 import org.junit.jupiter.api.Nested
@@ -44,11 +43,7 @@ class KtFilesSpec {
         }
     }
 
-    private fun makeFile(filename: String): PsiFile {
-        return mockk {
-            every { name } returns filename
-        }
-    }
+    private fun makeFile(filename: String): PsiFile = FakePsiFile(name = filename)
 
     @Nested
     inner class FilePathSpec {

--- a/detekt-report-html/build.gradle.kts
+++ b/detekt-report-html/build.gradle.kts
@@ -12,6 +12,5 @@ dependencies {
     testImplementation(projects.detektMetrics)
     testImplementation(projects.detektTestUtils)
     testImplementation(testFixtures(projects.detektApi))
-    testImplementation(libs.mockk)
     testImplementation(libs.assertj)
 }

--- a/detekt-report-html/src/test/kotlin/io/github/detekt/report/html/HtmlOutputReportSpec.kt
+++ b/detekt-report-html/src/test/kotlin/io/github/detekt/report/html/HtmlOutputReportSpec.kt
@@ -7,6 +7,8 @@ import io.github.detekt.metrics.processors.linesKey
 import io.github.detekt.metrics.processors.logicalLinesKey
 import io.github.detekt.metrics.processors.sourceLinesKey
 import io.github.detekt.test.utils.createTempFileForTest
+import io.github.detekt.test.utils.internal.FakeKtElement
+import io.github.detekt.test.utils.internal.FakePsiFile
 import io.github.detekt.test.utils.resourceAsPath
 import io.gitlab.arturbosch.detekt.api.Detektion
 import io.gitlab.arturbosch.detekt.api.Finding
@@ -18,10 +20,7 @@ import io.gitlab.arturbosch.detekt.test.createEntity
 import io.gitlab.arturbosch.detekt.test.createFinding
 import io.gitlab.arturbosch.detekt.test.createIssue
 import io.gitlab.arturbosch.detekt.test.createLocation
-import io.mockk.every
-import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.kotlin.com.intellij.psi.PsiFile
 import org.jetbrains.kotlin.psi.KtElement
 import org.junit.jupiter.api.Test
 import java.nio.file.Path
@@ -197,18 +196,18 @@ class HtmlOutputReportSpec {
     }
 }
 
-private fun mockKtElement(): KtElement {
-    val ktElementMock = mockk<KtElement>()
-    val psiFileMock = mockk<PsiFile>()
-    every { psiFileMock.text } returns "\n\n\n\n\n\n\n\n\n\nabcdef\nhi\n"
-    every { ktElementMock.containingFile } returns psiFileMock
-    return ktElementMock
+private fun fakeKtElement(): KtElement {
+    val code = "\n\n\n\n\n\n\n\n\n\nabcdef\nhi\n"
+    val fakePsiFile = FakePsiFile(code)
+    val fakeKtElement = FakeKtElement(fakePsiFile)
+
+    return fakeKtElement
 }
 
 private fun createTestDetektionWithMultipleSmells(): Detektion {
     val entity1 = createEntity(
         location = createLocation("src/main/com/sample/Sample1.kt", position = 11 to 1, text = 10..14),
-        ktElement = mockKtElement()
+        ktElement = fakeKtElement()
     )
     val entity2 = createEntity(location = createLocation("src/main/com/sample/Sample2.kt", position = 22 to 2))
     val entity3 = createEntity(location = createLocation("src/main/com/sample/Sample3.kt", position = 33 to 3))
@@ -233,7 +232,7 @@ private fun createTestDetektionFromRelativePath(): Detektion {
             position = 11 to 1,
             text = 10..14,
         ),
-        ktElement = mockKtElement(),
+        ktElement = fakeKtElement(),
     )
     val entity2 = createEntity(
         location = createLocation(

--- a/detekt-report-md/build.gradle.kts
+++ b/detekt-report-md/build.gradle.kts
@@ -7,7 +7,7 @@ dependencies {
     implementation(projects.detektApi)
     implementation(projects.detektUtils)
 
+    testImplementation(projects.detektTestUtils)
     testImplementation(testFixtures(projects.detektApi))
-    testImplementation(libs.mockk)
     testImplementation(libs.assertj)
 }

--- a/detekt-report-md/src/test/kotlin/io/github/detekt/report/md/MdOutputReportSpec.kt
+++ b/detekt-report-md/src/test/kotlin/io/github/detekt/report/md/MdOutputReportSpec.kt
@@ -6,6 +6,8 @@ import io.github.detekt.metrics.processors.complexityKey
 import io.github.detekt.metrics.processors.linesKey
 import io.github.detekt.metrics.processors.logicalLinesKey
 import io.github.detekt.metrics.processors.sourceLinesKey
+import io.github.detekt.test.utils.internal.FakeKtElement
+import io.github.detekt.test.utils.internal.FakePsiFile
 import io.gitlab.arturbosch.detekt.api.Detektion
 import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.api.ProjectMetric
@@ -16,44 +18,15 @@ import io.gitlab.arturbosch.detekt.test.createEntity
 import io.gitlab.arturbosch.detekt.test.createFinding
 import io.gitlab.arturbosch.detekt.test.createIssue
 import io.gitlab.arturbosch.detekt.test.createLocation
-import io.mockk.clearStaticMockk
-import io.mockk.every
-import io.mockk.mockk
-import io.mockk.mockkStatic
 import org.assertj.core.api.Assertions.assertThat
 import org.intellij.lang.annotations.Language
-import org.jetbrains.kotlin.com.intellij.psi.PsiFile
 import org.jetbrains.kotlin.psi.KtElement
-import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import java.time.OffsetDateTime
-import java.time.ZoneOffset
 
 class MdOutputReportSpec {
     private val mdReport = MdOutputReport()
     private val detektion = createTestDetektionWithMultipleSmells()
     private val result = mdReport.render(detektion)
-
-    @BeforeEach
-    fun setup() {
-        mockkStatic(OffsetDateTime::class)
-        every { OffsetDateTime.now(ZoneOffset.UTC) } returns OffsetDateTime.of(
-            2000, // year
-            1, // month
-            1, // dayOfMonth
-            0, // hour
-            0, // minute
-            0, // second
-            0, // nanoOfSecond
-            ZoneOffset.UTC // offset
-        )
-    }
-
-    @AfterEach
-    fun teardown() {
-        clearStaticMockk(OffsetDateTime::class)
-    }
 
     @Test
     fun `renders Markdown structure correctly`() {
@@ -144,10 +117,7 @@ class MdOutputReportSpec {
     }
 }
 
-private fun mockKtElement(): KtElement {
-    val ktElementMock = mockk<KtElement>()
-    val psiFileMock = mockk<PsiFile>()
-
+private fun fakeKtElement(): KtElement {
     @Language("kotlin")
     val code = """
         package com.example.test
@@ -167,10 +137,10 @@ private fun mockKtElement(): KtElement {
             }
         }
     """.trimIndent()
+    val fakePsiFile = FakePsiFile(code)
+    val fakeKtElement = FakeKtElement(fakePsiFile)
 
-    every { psiFileMock.text } returns code
-    every { ktElementMock.containingFile } returns psiFileMock
-    return ktElementMock
+    return fakeKtElement
 }
 
 private fun createTestDetektionWithMultipleSmells(): Detektion {
@@ -181,7 +151,7 @@ private fun createTestDetektionWithMultipleSmells(): Detektion {
             position = 9 to 17,
             text = 17..20,
         ),
-        ktElement = mockKtElement(),
+        ktElement = fakeKtElement(),
     )
     val entity2 = createEntity(
         location = createLocation(
@@ -189,7 +159,7 @@ private fun createTestDetektionWithMultipleSmells(): Detektion {
             basePath = "/Users/tester/detekt/",
             position = 13 to 17,
         ),
-        ktElement = mockKtElement(),
+        ktElement = fakeKtElement(),
     )
     val entity3 = createEntity(
         location = createLocation(
@@ -197,7 +167,7 @@ private fun createTestDetektionWithMultipleSmells(): Detektion {
             basePath = "/Users/tester/detekt/",
             position = 14 to 16,
         ),
-        ktElement = mockKtElement(),
+        ktElement = fakeKtElement(),
     )
 
     val issueA = createIssue("id_a")

--- a/detekt-test-utils/build.gradle.kts
+++ b/detekt-test-utils/build.gradle.kts
@@ -12,3 +12,7 @@ dependencies {
 
     testImplementation(libs.assertj)
 }
+
+apiValidation {
+    ignoredPackages.add("io.github.detekt.test.utils.internal")
+}

--- a/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/internal/FakeKtElement.kt
+++ b/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/internal/FakeKtElement.kt
@@ -1,0 +1,244 @@
+package io.github.detekt.test.utils.internal
+
+import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+import org.jetbrains.kotlin.com.intellij.lang.Language
+import org.jetbrains.kotlin.com.intellij.navigation.ItemPresentation
+import org.jetbrains.kotlin.com.intellij.openapi.project.Project
+import org.jetbrains.kotlin.com.intellij.openapi.util.Key
+import org.jetbrains.kotlin.com.intellij.openapi.util.TextRange
+import org.jetbrains.kotlin.com.intellij.psi.PsiElement
+import org.jetbrains.kotlin.com.intellij.psi.PsiElementVisitor
+import org.jetbrains.kotlin.com.intellij.psi.PsiFile
+import org.jetbrains.kotlin.com.intellij.psi.PsiManager
+import org.jetbrains.kotlin.com.intellij.psi.PsiReference
+import org.jetbrains.kotlin.com.intellij.psi.ResolveState
+import org.jetbrains.kotlin.com.intellij.psi.scope.PsiScopeProcessor
+import org.jetbrains.kotlin.com.intellij.psi.search.GlobalSearchScope
+import org.jetbrains.kotlin.com.intellij.psi.search.SearchScope
+import org.jetbrains.kotlin.psi.KtElement
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtVisitor
+import javax.swing.Icon
+
+class FakeKtElement(val psiFile: PsiFile) : KtElement {
+
+    override fun <R, D> accept(visitor: KtVisitor<R, D>, data: D): R {
+        error("Fake not implemented yet")
+    }
+
+    override fun accept(p0: PsiElementVisitor) {
+        // no-op
+    }
+
+    override fun <D> acceptChildren(visitor: KtVisitor<Void, D>, data: D) {
+        // no-op
+    }
+
+    override fun acceptChildren(p0: PsiElementVisitor) {
+        // no-op
+    }
+
+    override fun add(p0: PsiElement): PsiElement {
+        error("Fake not implemented yet")
+    }
+
+    override fun addAfter(p0: PsiElement, p1: PsiElement?): PsiElement {
+        error("Fake not implemented yet")
+    }
+
+    override fun addBefore(p0: PsiElement, p1: PsiElement?): PsiElement {
+        error("Fake not implemented yet")
+    }
+
+    override fun addRange(p0: PsiElement?, p1: PsiElement?): PsiElement {
+        error("Fake not implemented yet")
+    }
+
+    override fun addRangeAfter(p0: PsiElement?, p1: PsiElement?, p2: PsiElement?): PsiElement {
+        error("Fake not implemented yet")
+    }
+
+    override fun addRangeBefore(p0: PsiElement, p1: PsiElement, p2: PsiElement?): PsiElement {
+        error("Fake not implemented yet")
+    }
+
+    override fun canNavigate(): Boolean = false
+
+    override fun canNavigateToSource(): Boolean = false
+
+    override fun checkAdd(p0: PsiElement) {
+        // no-op
+    }
+
+    override fun checkDelete() {
+        // no-op
+    }
+
+    override fun copy(): PsiElement {
+        error("Fake not implemented yet")
+    }
+
+    override fun delete() {
+        // no-op
+    }
+
+    override fun deleteChildRange(p0: PsiElement?, p1: PsiElement?) {
+        // no-op
+    }
+
+    override fun findElementAt(p0: Int): PsiElement? {
+        error("Fake not implemented yet")
+    }
+
+    override fun findReferenceAt(p0: Int): PsiReference? {
+        error("Fake not implemented yet")
+    }
+
+    override fun getChildren(): Array<PsiElement> {
+        error("Fake not implemented yet")
+    }
+
+    override fun getContainingFile(): PsiFile = psiFile
+
+    override fun getContainingKtFile(): KtFile {
+        error("Fake not implemented yet")
+    }
+
+    override fun getContext(): PsiElement? {
+        error("Fake not implemented yet")
+    }
+
+    override fun <T : Any?> getCopyableUserData(p0: Key<T>): T? {
+        error("Fake not implemented yet")
+    }
+
+    override fun getFirstChild(): PsiElement {
+        error("Fake not implemented yet")
+    }
+
+    override fun getIcon(p0: Int): Icon {
+        error("Fake not implemented yet")
+    }
+
+    override fun getLanguage(): Language {
+        error("Fake not implemented yet")
+    }
+
+    override fun getLastChild(): PsiElement {
+        error("Fake not implemented yet")
+    }
+
+    override fun getManager(): PsiManager {
+        error("Fake not implemented yet")
+    }
+
+    override fun getName(): String? = null
+
+    override fun getNavigationElement(): PsiElement {
+        error("Fake not implemented yet")
+    }
+
+    override fun getNextSibling(): PsiElement {
+        error("Fake not implemented yet")
+    }
+
+    override fun getNode(): ASTNode {
+        error("Fake not implemented yet")
+    }
+
+    override fun getOriginalElement(): PsiElement {
+        error("Fake not implemented yet")
+    }
+
+    override fun getParent(): PsiElement {
+        error("Fake not implemented yet")
+    }
+
+    override fun getPresentation(): ItemPresentation? {
+        error("Fake not implemented yet")
+    }
+
+    override fun getPrevSibling(): PsiElement {
+        error("Fake not implemented yet")
+    }
+
+    override fun getProject(): Project {
+        error("Fake not implemented yet")
+    }
+
+    override fun getPsiOrParent(): KtElement {
+        error("Fake not implemented yet")
+    }
+
+    @Deprecated("Don't use getReference() on KtElement for the choice is unpredictable")
+    override fun getReference(): PsiReference? {
+        error("Fake not implemented yet")
+    }
+
+    override fun getReferences(): Array<PsiReference> {
+        error("Fake not implemented yet")
+    }
+
+    override fun getResolveScope(): GlobalSearchScope {
+        error("Fake not implemented yet")
+    }
+
+    override fun getStartOffsetInParent(): Int = 0
+
+    override fun getText(): String = ""
+
+    override fun getTextLength(): Int = 0
+
+    override fun getTextOffset(): Int = 0
+
+    override fun getTextRange(): TextRange {
+        error("Fake not implemented yet")
+    }
+
+    override fun getUseScope(): SearchScope {
+        error("Fake not implemented yet")
+    }
+
+    override fun <T : Any?> getUserData(p0: Key<T>): T? {
+        error("Fake not implemented yet")
+    }
+
+    override fun isEquivalentTo(p0: PsiElement?): Boolean = false
+
+    override fun isPhysical(): Boolean = false
+
+    override fun isValid(): Boolean = false
+
+    override fun isWritable(): Boolean = false
+
+    override fun navigate(p0: Boolean) {
+        // no-op
+    }
+
+    override fun processDeclarations(
+        p0: PsiScopeProcessor,
+        p1: ResolveState,
+        p2: PsiElement?,
+        p3: PsiElement
+    ): Boolean = false
+
+    override fun <T : Any?> putCopyableUserData(p0: Key<T>, p1: T?) {
+        // no-op
+    }
+
+    override fun <T : Any?> putUserData(p0: Key<T>, p1: T?) {
+        // no-op
+    }
+
+    override fun replace(p0: PsiElement): PsiElement {
+        error("Fake not implemented yet")
+    }
+
+    override fun textContains(p0: Char): Boolean = false
+
+    override fun textMatches(p0: CharSequence): Boolean = false
+
+    override fun textMatches(p0: PsiElement): Boolean = false
+
+    override fun textToCharArray(): CharArray = "".toCharArray()
+}

--- a/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/internal/FakePsiFile.kt
+++ b/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/internal/FakePsiFile.kt
@@ -1,0 +1,261 @@
+package io.github.detekt.test.utils.internal
+
+import org.jetbrains.kotlin.com.intellij.lang.FileASTNode
+import org.jetbrains.kotlin.com.intellij.lang.Language
+import org.jetbrains.kotlin.com.intellij.navigation.ItemPresentation
+import org.jetbrains.kotlin.com.intellij.openapi.fileTypes.FileType
+import org.jetbrains.kotlin.com.intellij.openapi.project.Project
+import org.jetbrains.kotlin.com.intellij.openapi.util.Key
+import org.jetbrains.kotlin.com.intellij.openapi.util.TextRange
+import org.jetbrains.kotlin.com.intellij.openapi.vfs.VirtualFile
+import org.jetbrains.kotlin.com.intellij.psi.FileViewProvider
+import org.jetbrains.kotlin.com.intellij.psi.PsiDirectory
+import org.jetbrains.kotlin.com.intellij.psi.PsiElement
+import org.jetbrains.kotlin.com.intellij.psi.PsiElementVisitor
+import org.jetbrains.kotlin.com.intellij.psi.PsiFile
+import org.jetbrains.kotlin.com.intellij.psi.PsiFileSystemItem
+import org.jetbrains.kotlin.com.intellij.psi.PsiManager
+import org.jetbrains.kotlin.com.intellij.psi.PsiReference
+import org.jetbrains.kotlin.com.intellij.psi.ResolveState
+import org.jetbrains.kotlin.com.intellij.psi.scope.PsiScopeProcessor
+import org.jetbrains.kotlin.com.intellij.psi.search.GlobalSearchScope
+import org.jetbrains.kotlin.com.intellij.psi.search.PsiElementProcessor
+import org.jetbrains.kotlin.com.intellij.psi.search.SearchScope
+import javax.swing.Icon
+
+class FakePsiFile(private val text: String = "", private val name: String = "") : PsiFile {
+
+    override fun navigate(p0: Boolean) {
+        // no-op
+    }
+
+    override fun canNavigate(): Boolean = false
+
+    override fun canNavigateToSource(): Boolean = false
+
+    override fun getName(): String = name
+
+    override fun getPresentation(): ItemPresentation? = null
+
+    override fun getIcon(p0: Int): Icon {
+        error("Fake not implemented yet")
+    }
+
+    override fun <T : Any?> getUserData(p0: Key<T>): T? = null
+
+    override fun <T : Any?> putUserData(p0: Key<T>, p1: T?) {
+        // no-op
+    }
+
+    override fun getProject(): Project {
+        error("Fake not implemented yet")
+    }
+
+    override fun getLanguage(): Language {
+        error("Fake not implemented yet")
+    }
+
+    override fun getManager(): PsiManager {
+        error("Fake not implemented yet")
+    }
+
+    override fun getChildren(): Array<PsiElement> {
+        error("Fake not implemented yet")
+    }
+
+    override fun getParent(): PsiDirectory? = null
+
+    override fun getFirstChild(): PsiElement {
+        error("Fake not implemented yet")
+    }
+
+    override fun getLastChild(): PsiElement {
+        error("Fake not implemented yet")
+    }
+
+    override fun getNextSibling(): PsiElement {
+        error("Fake not implemented yet")
+    }
+
+    override fun getPrevSibling(): PsiElement {
+        error("Fake not implemented yet")
+    }
+
+    override fun getContainingFile(): PsiFile {
+        error("Fake not implemented yet")
+    }
+
+    override fun getTextRange(): TextRange {
+        error("Fake not implemented yet")
+    }
+
+    override fun getStartOffsetInParent(): Int = 0
+
+    override fun getTextLength(): Int = 0
+
+    override fun findElementAt(p0: Int): PsiElement? = null
+
+    override fun findReferenceAt(p0: Int): PsiReference? = null
+
+    override fun getTextOffset(): Int = 0
+
+    override fun getText(): String = text
+
+    override fun textToCharArray(): CharArray = "".toCharArray()
+
+    override fun getNavigationElement(): PsiElement {
+        error("Fake not implemented yet")
+    }
+
+    override fun getOriginalElement(): PsiElement {
+        error("Fake not implemented yet")
+    }
+
+    override fun textMatches(p0: CharSequence): Boolean = false
+
+    override fun textMatches(p0: PsiElement): Boolean = false
+
+    override fun textContains(p0: Char): Boolean = false
+
+    override fun accept(p0: PsiElementVisitor) {
+        // no-op
+    }
+
+    override fun acceptChildren(p0: PsiElementVisitor) {
+        // no-op
+    }
+
+    override fun copy(): PsiElement {
+        error("Fake not implemented yet")
+    }
+
+    override fun add(p0: PsiElement): PsiElement {
+        error("Fake not implemented yet")
+    }
+
+    override fun addBefore(p0: PsiElement, p1: PsiElement?): PsiElement {
+        error("Fake not implemented yet")
+    }
+
+    override fun addAfter(p0: PsiElement, p1: PsiElement?): PsiElement {
+        error("Fake not implemented yet")
+    }
+
+    @Deprecated("Deprecated in Java")
+    override fun checkAdd(p0: PsiElement) {
+        error("Fake not implemented yet")
+    }
+
+    override fun addRange(p0: PsiElement?, p1: PsiElement?): PsiElement {
+        error("Fake not implemented yet")
+    }
+
+    override fun addRangeBefore(p0: PsiElement, p1: PsiElement, p2: PsiElement?): PsiElement {
+        error("Fake not implemented yet")
+    }
+
+    override fun addRangeAfter(p0: PsiElement?, p1: PsiElement?, p2: PsiElement?): PsiElement {
+        error("Fake not implemented yet")
+    }
+
+    override fun delete() {
+        // no-op
+    }
+
+    @Deprecated("Deprecated in Java")
+    override fun checkDelete() {
+        // no-op
+    }
+
+    override fun deleteChildRange(p0: PsiElement?, p1: PsiElement?) {
+        // no-op
+    }
+
+    override fun replace(p0: PsiElement): PsiElement {
+        error("Fake not implemented yet")
+    }
+
+    override fun isValid(): Boolean = false
+
+    override fun isWritable(): Boolean = false
+
+    override fun getReference(): PsiReference? = null
+
+    override fun getReferences(): Array<PsiReference> {
+        error("Fake not implemented yet")
+    }
+
+    override fun <T : Any?> getCopyableUserData(p0: Key<T>): T? = null
+
+    override fun <T : Any?> putCopyableUserData(p0: Key<T>, p1: T?) {
+        // no-op
+    }
+
+    override fun processDeclarations(
+        p0: PsiScopeProcessor,
+        p1: ResolveState,
+        p2: PsiElement?,
+        p3: PsiElement
+    ): Boolean = false
+
+    override fun getContext(): PsiElement? = null
+
+    override fun isPhysical(): Boolean = false
+
+    override fun getResolveScope(): GlobalSearchScope {
+        error("Fake not implemented yet")
+    }
+
+    override fun getUseScope(): SearchScope {
+        error("Fake not implemented yet")
+    }
+
+    override fun getNode(): FileASTNode {
+        error("Fake not implemented yet")
+    }
+
+    override fun isEquivalentTo(p0: PsiElement?): Boolean = false
+
+    override fun setName(p0: String): PsiElement {
+        error("Fake not implemented yet")
+    }
+
+    override fun checkSetName(p0: String?) {
+        // no-op
+    }
+
+    override fun isDirectory(): Boolean = false
+
+    override fun getVirtualFile(): VirtualFile {
+        error("Fake not implemented yet")
+    }
+
+    override fun processChildren(p0: PsiElementProcessor<in PsiFileSystemItem>): Boolean = false
+
+    override fun getContainingDirectory(): PsiDirectory {
+        error("Fake not implemented yet")
+    }
+
+    override fun getModificationStamp(): Long = 0L
+
+    override fun getOriginalFile(): PsiFile {
+        error("Fake not implemented yet")
+    }
+
+    override fun getFileType(): FileType {
+        error("Fake not implemented yet")
+    }
+
+    @Deprecated("Deprecated in Java")
+    override fun getPsiRoots(): Array<PsiFile> {
+        error("Fake not implemented yet")
+    }
+
+    override fun getViewProvider(): FileViewProvider {
+        error("Fake not implemented yet")
+    }
+
+    override fun subtreeChanged() {
+        // no-op
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,7 +39,6 @@ junit-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "jun
 sarif4k = "io.github.detekt.sarif4k:sarif4k:0.5.0"
 assertj = "org.assertj:assertj-core:3.25.1"
 classgraph = "io.github.classgraph:classgraph:4.8.165"
-mockk = "io.mockk:mockk:1.13.9"
 snakeyaml = "org.snakeyaml:snakeyaml-engine:2.7"
 jcommander = "org.jcommander:jcommander:1.83"
 kotlinCompileTesting = { module = "dev.zacsweers.kctfork:core", version = "0.4.0" }


### PR DESCRIPTION
While going through the codebase, I realized that we do use mockk only for two external types, `KtElement` and `PsiFile`.

Here I'm cleaning up the tests to instead use Fake versions of those that I have created. The implementation is mostly stubbed, and we can tweak it to fit our needs.

Removing mockk means our tests will be faster + it's a dependency less to maintain.