### PR TITLE
Disable the Gradle Daemon on Vercel

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -12,8 +12,8 @@
     "serve": "docusaurus serve",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
-    "generate": "../gradlew -p .. :detekt-generator:generateWebsite",
-    "generate-and-build": "../gradlew -p .. :detekt-generator:generateWebsite && docusaurus build"
+    "generate": "../gradlew -p .. :detekt-generator:generateWebsite --no-daemon",
+    "generate-and-build": "../gradlew -p .. :detekt-generator:generateWebsite --no-daemon && docusaurus build"
   },
   "dependencies": {
     "@docusaurus/core": "3.0.1",


### PR DESCRIPTION
The website deployment failed again on `main`. I'm unsure what's the cause as the memory config is passed correctly as I can see on the log:
```
The currently configured max heap space is '1 GiB' and the configured max metaspace is '512 MiB'.
```
Attempting to mitigate this by disabling the Gradle daemon on website builds.