### PR TITLE
Move `PathFilters` from detekt-api to detekt-utils

### DIFF
--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/internal/PathFiltersSpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/internal/PathFiltersSpec.kt
@@ -1,46 +1,42 @@
 package io.gitlab.arturbosch.detekt.api.internal
 
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import kotlin.io.path.Path
 
 class PathFiltersSpec {
 
-    @Nested
-    inner class `parsing with different nullability combinations of path filters` {
-        @Test
-        fun `returns an empty path filter when includes are empty and excludes are empty`() {
-            val pathFilter = PathFilters.of(emptyList(), emptyList())
-            assertThat(pathFilter).isNull()
-        }
+    @Test
+    fun `returns an empty path filter when includes are empty and excludes are empty`() {
+        val pathFilter = PathFilters.of(emptyList(), emptyList())
+        assertThat(pathFilter).isNull()
+    }
 
-        @Test
-        fun `parses includes correctly`() {
-            val pathFilter = PathFilters.of(listOf("**/one/**", "**/two/**"), emptyList())
-            assertThat(pathFilter).isNotNull
-            assertThat(pathFilter?.isIgnored(Path("/one/path"))).isFalse
-            assertThat(pathFilter?.isIgnored(Path("/two/path"))).isFalse
-            assertThat(pathFilter?.isIgnored(Path("/three/path"))).isTrue
-        }
+    @Test
+    fun `parses includes correctly`() {
+        val pathFilter = PathFilters.of(listOf("**/one/**", "**/two/**"), emptyList())
+        assertThat(pathFilter).isNotNull
+        assertThat(pathFilter?.isIgnored(Path("/one/path"))).isFalse
+        assertThat(pathFilter?.isIgnored(Path("/two/path"))).isFalse
+        assertThat(pathFilter?.isIgnored(Path("/three/path"))).isTrue
+    }
 
-        @Test
-        fun `parses excludes correctly`() {
-            val pathFilter = PathFilters.of(emptyList(), listOf("**/one/**", "**/two/**"))
-            assertThat(pathFilter).isNotNull
-            assertThat(pathFilter?.isIgnored(Path("/one/path"))).isTrue
-            assertThat(pathFilter?.isIgnored(Path("/two/path"))).isTrue
-            assertThat(pathFilter?.isIgnored(Path("/three/path"))).isFalse
-        }
+    @Test
+    fun `parses excludes correctly`() {
+        val pathFilter = PathFilters.of(emptyList(), listOf("**/one/**", "**/two/**"))
+        assertThat(pathFilter).isNotNull
+        assertThat(pathFilter?.isIgnored(Path("/one/path"))).isTrue
+        assertThat(pathFilter?.isIgnored(Path("/two/path"))).isTrue
+        assertThat(pathFilter?.isIgnored(Path("/three/path"))).isFalse
+    }
 
-        @Test
-        fun `parses both includes and excludes correctly`() {
-            val pathFilter = PathFilters.of(listOf("**/one/**"), listOf("**/two/**"))
-            assertThat(pathFilter).isNotNull
-            assertThat(pathFilter?.isIgnored(Path("/one/path"))).isFalse
-            assertThat(pathFilter?.isIgnored(Path("/two/path"))).isTrue
-            assertThat(pathFilter?.isIgnored(Path("/three/path"))).isTrue
-            assertThat(pathFilter?.isIgnored(Path("/one/two/three/path"))).isTrue
-        }
+    @Test
+    fun `parses both includes and excludes correctly`() {
+        val pathFilter = PathFilters.of(listOf("**/one/**"), listOf("**/two/**"))
+        assertThat(pathFilter).isNotNull
+        assertThat(pathFilter?.isIgnored(Path("/one/path"))).isFalse
+        assertThat(pathFilter?.isIgnored(Path("/two/path"))).isTrue
+        assertThat(pathFilter?.isIgnored(Path("/three/path"))).isTrue
+        assertThat(pathFilter?.isIgnored(Path("/one/two/three/path"))).isTrue
     }
 }

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/internal/PathFiltersSpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/internal/PathFiltersSpec.kt
@@ -1,6 +1,5 @@
-package io.gitlab.arturbosch.detekt.cli
+package io.gitlab.arturbosch.detekt.api.internal
 
-import io.gitlab.arturbosch.detekt.api.internal.PathFilters
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test

--- a/detekt-cli/build.gradle.kts
+++ b/detekt-cli/build.gradle.kts
@@ -22,6 +22,7 @@ val pluginsJarFiles by configurations.resolvable("pluginsJarFiles") {
 dependencies {
     implementation(libs.jcommander)
     implementation(projects.detektTooling)
+    implementation(projects.detektUtils)
     implementation(libs.kotlin.compilerEmbeddable) {
         version {
             strictly(libs.versions.kotlin.get())

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Spec.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Spec.kt
@@ -2,9 +2,9 @@ package io.gitlab.arturbosch.detekt.cli
 
 import io.github.detekt.tooling.api.spec.ProcessingSpec
 import io.github.detekt.tooling.api.spec.RulesSpec
+import io.github.detekt.utils.PathFilters
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.RuleSet
-import io.gitlab.arturbosch.detekt.api.internal.PathFilters
 import java.nio.file.Path
 import kotlin.io.path.ExperimentalPathApi
 import kotlin.io.path.absolute

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/util/ConfigExtensions.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/util/ConfigExtensions.kt
@@ -1,8 +1,8 @@
 package io.gitlab.arturbosch.detekt.core.util
 
 import io.github.detekt.psi.absolutePath
+import io.github.detekt.utils.PathFilters
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.internal.PathFilters
 import org.jetbrains.kotlin.psi.KtFile
 import java.nio.file.Path
 import kotlin.io.path.Path

--- a/detekt-utils/src/main/kotlin/io/github/detekt/utils/PathFilters.kt
+++ b/detekt-utils/src/main/kotlin/io/github/detekt/utils/PathFilters.kt
@@ -1,4 +1,4 @@
-package io.gitlab.arturbosch.detekt.api.internal
+package io.github.detekt.utils
 
 import java.nio.file.Path
 import java.nio.file.PathMatcher

--- a/detekt-utils/src/main/kotlin/io/github/detekt/utils/PathMatchers.kt
+++ b/detekt-utils/src/main/kotlin/io/github/detekt/utils/PathMatchers.kt
@@ -1,4 +1,4 @@
-package io.gitlab.arturbosch.detekt.api.internal
+package io.github.detekt.utils
 
 import java.nio.file.FileSystem
 import java.nio.file.FileSystems
@@ -9,7 +9,7 @@ import java.nio.file.PathMatcher
  * We only support the "glob:" syntax to stay os independently.
  * Internally a globbing pattern is transformed to a regex respecting the Windows file system.
  */
-fun pathMatcher(pattern: String): PathMatcher {
+internal fun pathMatcher(pattern: String): PathMatcher {
     val result = when (pattern.substringBefore(":")) {
         "glob" -> pattern
         "regex" -> throw IllegalArgumentException(USE_GLOB_MSG)

--- a/detekt-utils/src/test/kotlin/io/github/detekt/utils/PathFiltersSpec.kt
+++ b/detekt-utils/src/test/kotlin/io/github/detekt/utils/PathFiltersSpec.kt
@@ -1,4 +1,4 @@
-package io.gitlab.arturbosch.detekt.api.internal
+package io.github.detekt.utils
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test

--- a/detekt-utils/src/test/kotlin/io/github/detekt/utils/PathMatchersSpec.kt
+++ b/detekt-utils/src/test/kotlin/io/github/detekt/utils/PathMatchersSpec.kt
@@ -1,4 +1,4 @@
-package io.gitlab.arturbosch.detekt.api.internal
+package io.github.detekt.utils
 
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy


### PR DESCRIPTION
Also see #6814

~We had a little mess around this class. I splitted some tests and move them to the correct locations and then move `PathFilters` to `:detekt-tooling`.~

~We have far too much "utils" subprojects and I'm not 100% sure the responsability of which one, but this one seems the correct one. We don't want this at `:detekt-api` because it is only used by `:detekt-core` and by `:detekt-cli`. And it would be really nice to move it to `:detekt-core` but, as I said it is also used by `:detekt-cli`.~

~If someone create some documentation about which is the responsabilities of each subproject it would be great.~

Move `PathFilters` to `:detekt-utils`. This class is used on `detekt-cli` and `detekt-core` but we don't want it to be part of our public API so I'm moving it to `:detekt-utils`.

~Waiting for #7009~