### PR TITLE
Rename core/util/ConfigSpec.kt to core/util/ConfigExtensionsSpec.kt

### DIFF
--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/util/ConfigExtensionsSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/util/ConfigExtensionsSpec.kt
@@ -5,7 +5,7 @@ import io.gitlab.arturbosch.detekt.test.yamlConfigFromContent
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
-class ConfigSpec {
+class ConfigExtensionsSpec {
 
     @Test
     fun `use the provided value when defined`() {


### PR DESCRIPTION
This is a continuation of #6862 to keep the test file with the same name as the production file.