### PR TITLE
Remove severity from the Rule

### DIFF
--- a/detekt-api/api/detekt-api.api
+++ b/detekt-api/api/detekt-api.api
@@ -17,7 +17,6 @@ public class io/gitlab/arturbosch/detekt/api/CodeSmell : io/gitlab/arturbosch/de
 	public fun getLocation ()Lio/gitlab/arturbosch/detekt/api/Location;
 	public final fun getMessage ()Ljava/lang/String;
 	public final fun getReferences ()Ljava/util/List;
-	public fun getSeverity ()Lio/gitlab/arturbosch/detekt/api/Severity;
 	public fun getSignature ()Ljava/lang/String;
 	public fun getStartPosition ()Lio/gitlab/arturbosch/detekt/api/SourceLocation;
 	public fun toString ()Ljava/lang/String;
@@ -178,14 +177,12 @@ public abstract interface class io/gitlab/arturbosch/detekt/api/Finding : io/git
 	public abstract fun getIssue ()Lio/gitlab/arturbosch/detekt/api/Issue;
 	public abstract fun getMessage ()Ljava/lang/String;
 	public abstract fun getReferences ()Ljava/util/List;
-	public abstract fun getSeverity ()Lio/gitlab/arturbosch/detekt/api/Severity;
 }
 
 public final class io/gitlab/arturbosch/detekt/api/Finding$DefaultImpls {
 	public static fun getCharPosition (Lio/gitlab/arturbosch/detekt/api/Finding;)Lio/gitlab/arturbosch/detekt/api/TextLocation;
 	public static fun getFile (Lio/gitlab/arturbosch/detekt/api/Finding;)Ljava/lang/String;
 	public static fun getLocation (Lio/gitlab/arturbosch/detekt/api/Finding;)Lio/gitlab/arturbosch/detekt/api/Location;
-	public static fun getSeverity (Lio/gitlab/arturbosch/detekt/api/Finding;)Lio/gitlab/arturbosch/detekt/api/Severity;
 	public static fun getSignature (Lio/gitlab/arturbosch/detekt/api/Finding;)Ljava/lang/String;
 	public static fun getStartPosition (Lio/gitlab/arturbosch/detekt/api/Finding;)Lio/gitlab/arturbosch/detekt/api/SourceLocation;
 }

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/CodeSmell.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/CodeSmell.kt
@@ -17,16 +17,11 @@ open class CodeSmell(
         require(message.isNotBlank()) { "The message should not be empty" }
     }
 
-    internal var internalSeverity: Severity? = null
-    override val severity: Severity
-        get() = internalSeverity ?: super.severity
-
     override fun toString(): String {
         return "CodeSmell(issue=$issue, " +
             "entity=$entity, " +
             "message=$message, " +
-            "references=$references, " +
-            "severity=$severity)"
+            "references=$references)"
     }
 }
 
@@ -53,7 +48,6 @@ open class CorrectableCodeSmell(
             "issue=$issue, " +
             "entity=$entity, " +
             "message=$message, " +
-            "references=$references, " +
-            "severity=$severity)"
+            "references=$references)"
     }
 }

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Findings.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Findings.kt
@@ -10,8 +10,6 @@ interface Finding : HasEntity {
     val issue: Issue
     val references: List<Entity>
     val message: String
-    val severity: Severity
-        get() = Severity.DEFAULT
 }
 
 /**

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Rule.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Rule.kt
@@ -1,7 +1,6 @@
 package io.gitlab.arturbosch.detekt.api
 
 import dev.drewhamilton.poko.Poko
-import io.gitlab.arturbosch.detekt.api.Config.Companion.SEVERITY_KEY
 import io.gitlab.arturbosch.detekt.api.internal.isSuppressedBy
 import io.gitlab.arturbosch.detekt.api.internal.validateIdentifier
 import org.jetbrains.kotlin.psi.KtFile
@@ -113,23 +112,6 @@ open class Rule(
      */
     open fun visitCondition(root: KtFile): Boolean = !root.isSuppressedBy(ruleId, aliases, ruleSetId)
 
-    private fun Finding.updateWithComputedSeverity() {
-        (this as? CodeSmell)?.internalSeverity = computeSeverity()
-    }
-
-    /**
-     * Compute severity in the priority order:
-     * - Severity of the rule
-     * - Severity of the parent ruleset
-     * - Default severity
-     */
-    private fun computeSeverity(): Severity {
-        val configValue: String = config.valueOrNull(SEVERITY_KEY)
-            ?: config.parent?.valueOrNull(SEVERITY_KEY)
-            ?: Severity.DEFAULT.name
-        return Severity.fromString(configValue)
-    }
-
     /**
      * Reports a single code smell finding.
      *
@@ -137,7 +119,6 @@ open class Rule(
      * by @Suppress or @SuppressWarnings annotations.
      */
     fun report(finding: Finding) {
-        finding.updateWithComputedSeverity()
         val ktElement = finding.entity.ktElement
         if (ktElement == null || !ktElement.isSuppressedBy(finding.issue.id, aliases, ruleSetId)) {
             findings.add(finding)

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Severity.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Severity.kt
@@ -7,15 +7,5 @@ package io.gitlab.arturbosch.detekt.api
 enum class Severity {
     Error,
     Warning,
-    Info;
-
-    internal companion object {
-        val DEFAULT = Error
-
-        fun fromString(severity: String): Severity {
-            val lowercase = severity.lowercase()
-            return entries.find { it.name.lowercase() == lowercase }
-                ?: error("$severity is not a valid Severity. Allowed values are ${Severity.entries}")
-        }
-    }
+    Info,
 }

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/CodeSmellSpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/CodeSmellSpec.kt
@@ -32,7 +32,7 @@ class CodeSmellSpec {
                 "location=Location(source=1:1, endSource=1:1, text=0:0, " +
                 "filePath=FilePath(absolutePath=$basePath${File.separator}TestFile.kt, " +
                 "basePath=$basePath, relativePath=TestFile.kt)), ktElement=null), message=TestMessage, " +
-                "references=[], severity=Error)"
+                "references=[])"
         )
     }
 }

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/CorrectableCodeSmellSpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/CorrectableCodeSmellSpec.kt
@@ -15,17 +15,14 @@ class CorrectableCodeSmellSpec {
             entity = createEntity(location = createLocation("TestFile.kt")),
             message = "TestMessage",
             autoCorrectEnabled = true
-        ) {
-            override val severity: Severity
-                get() = Severity.Error
-        }
+        ) {}
 
         assertThat(codeSmell.toString()).isEqualTo(
             "CorrectableCodeSmell(autoCorrectEnabled=true, issue=Issue(id='TestSmell'), " +
                 "entity=Entity(name=TestEntity, signature=TestEntitySignature, " +
                 "location=Location(source=1:1, endSource=1:1, text=0:0, " +
                 "filePath=FilePath(absolutePath=TestFile.kt, basePath=null, relativePath=null)), " +
-                "ktElement=null), message=TestMessage, references=[], severity=Error)"
+                "ktElement=null), message=TestMessage, references=[])"
         )
     }
 }

--- a/detekt-api/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/test/TestFactory.kt
+++ b/detekt-api/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/test/TestFactory.kt
@@ -95,6 +95,6 @@ private data class Finding2Impl(
     override val entity: Entity,
     override val message: String,
     override val references: List<Entity> = emptyList(),
-    override val severity: Severity = Severity.DEFAULT,
+    override val severity: Severity = Severity.Error,
     override val autoCorrectEnabled: Boolean = false,
 ) : Finding2

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/SeveritySpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/SeveritySpec.kt
@@ -1,5 +1,6 @@
-package io.gitlab.arturbosch.detekt.api
+package io.gitlab.arturbosch.detekt.core
 
+import io.gitlab.arturbosch.detekt.api.Severity
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
@@ -10,7 +11,7 @@ class SeveritySpec {
     @ParameterizedTest
     @ValueSource(strings = ["warning", "WARNING", "wArNiNg"])
     fun `get warning severity from string ignoring case`(candidate: String) {
-        val actual = Severity.fromString(candidate)
+        val actual = parseToSeverity(candidate)
 
         assertThat(actual).isEqualTo(Severity.Warning)
     }
@@ -18,7 +19,7 @@ class SeveritySpec {
     @ParameterizedTest
     @EnumSource(Severity::class)
     fun `get all severities by lowercase`(severity: Severity) {
-        val actual = Severity.fromString(severity.name.lowercase())
+        val actual = parseToSeverity(severity.name.lowercase())
 
         assertThat(actual).isEqualTo(severity)
     }


### PR DESCRIPTION
The Rule doesn't need to know its `Severity`. That can be handled by the core.