### PR TITLE
Add ruleSetId into `Finding2`

### DIFF
--- a/detekt-api/api/detekt-api.api
+++ b/detekt-api/api/detekt-api.api
@@ -191,6 +191,7 @@ public final class io/gitlab/arturbosch/detekt/api/Finding2$DefaultImpls {
 public abstract interface class io/gitlab/arturbosch/detekt/api/Finding2$RuleInfo {
 	public abstract fun getDescription ()Ljava/lang/String;
 	public abstract fun getId ()Lio/gitlab/arturbosch/detekt/api/Rule$Id;
+	public abstract fun getRuleSetId ()Lio/gitlab/arturbosch/detekt/api/RuleSet$Id;
 }
 
 public final class io/gitlab/arturbosch/detekt/api/Location : io/gitlab/arturbosch/detekt/api/Compactable {

--- a/detekt-api/api/detekt-api.api
+++ b/detekt-api/api/detekt-api.api
@@ -180,7 +180,7 @@ public abstract interface class io/gitlab/arturbosch/detekt/api/Finding2 {
 	public abstract fun getLocation ()Lio/gitlab/arturbosch/detekt/api/Location;
 	public abstract fun getMessage ()Ljava/lang/String;
 	public abstract fun getReferences ()Ljava/util/List;
-	public abstract fun getRule ()Lio/gitlab/arturbosch/detekt/api/Finding2$RuleInfo;
+	public abstract fun getRuleInfo ()Lio/gitlab/arturbosch/detekt/api/Finding2$RuleInfo;
 	public abstract fun getSeverity ()Lio/gitlab/arturbosch/detekt/api/Severity;
 }
 

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Finding2.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Finding2.kt
@@ -7,7 +7,7 @@ package io.gitlab.arturbosch.detekt.api
  * about the position. Entity references can also be considered for deeper characterization.
  */
 interface Finding2 {
-    val rule: RuleInfo
+    val ruleInfo: RuleInfo
     val entity: Entity
     val references: List<Entity>
     val message: String

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Finding2.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Finding2.kt
@@ -19,6 +19,7 @@ interface Finding2 {
 
     interface RuleInfo {
         val id: Rule.Id
+        val ruleSetId: RuleSet.Id
         val description: String
     }
 }

--- a/detekt-api/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/test/TestDetektion.kt
+++ b/detekt-api/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/test/TestDetektion.kt
@@ -11,7 +11,7 @@ import org.jetbrains.kotlin.com.intellij.openapi.util.UserDataHolderBase
 open class TestDetektion(vararg findings: Finding2) : Detektion, UserDataHolderBase() {
 
     override val findings: Map<RuleSet.Id, List<Finding2>> = findings
-        .groupBy { RuleSet.Id(it.rule.id.value) } // FIXME this is not correct
+        .groupBy { RuleSet.Id(it.ruleInfo.id.value) } // FIXME this is not correct
     override val metrics: Collection<ProjectMetric> get() = _metrics
     override val notifications: List<Notification> get() = _notifications
 

--- a/detekt-api/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/test/TestFactory.kt
+++ b/detekt-api/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/test/TestFactory.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Finding2
 import io.gitlab.arturbosch.detekt.api.Location
 import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.RuleSet
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.api.TextLocation
@@ -18,7 +19,7 @@ fun createFinding(
     severity: Severity = Severity.Error,
     autoCorrectEnabled: Boolean = false,
 ): Finding2 = Finding2Impl(
-    rule = Finding2Impl.RuleInfo(Rule.Id(ruleName), "Description $ruleName"),
+    rule = Finding2Impl.RuleInfo(Rule.Id(ruleName), RuleSet.Id("ruleSetId"), "Description $ruleName"),
     entity = entity,
     message = message,
     severity = severity,
@@ -31,7 +32,7 @@ fun createFindingForRelativePath(
     basePath: String = "/Users/tester/detekt/",
     relativePath: String = "TestFile.kt"
 ): Finding2 = Finding2Impl(
-    rule = Finding2Impl.RuleInfo(Rule.Id(ruleName), "Description $ruleName"),
+    rule = Finding2Impl.RuleInfo(Rule.Id(ruleName), RuleSet.Id("ruleSetId"), "Description $ruleName"),
     entity = Entity(
         name = "TestEntity",
         signature = "TestEntitySignature",
@@ -79,5 +80,9 @@ private data class Finding2Impl(
     override val autoCorrectEnabled: Boolean = false,
     override val references: List<Entity> = emptyList(),
 ) : Finding2 {
-    data class RuleInfo(override val id: Rule.Id, override val description: String) : Finding2.RuleInfo
+    data class RuleInfo(
+        override val id: Rule.Id,
+        override val ruleSetId: RuleSet.Id,
+        override val description: String,
+    ) : Finding2.RuleInfo
 }

--- a/detekt-api/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/test/TestFactory.kt
+++ b/detekt-api/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/test/TestFactory.kt
@@ -19,7 +19,7 @@ fun createFinding(
     severity: Severity = Severity.Error,
     autoCorrectEnabled: Boolean = false,
 ): Finding2 = Finding2Impl(
-    rule = Finding2Impl.RuleInfo(Rule.Id(ruleName), RuleSet.Id("ruleSetId"), "Description $ruleName"),
+    ruleInfo = Finding2Impl.RuleInfo(Rule.Id(ruleName), RuleSet.Id("ruleSetId"), "Description $ruleName"),
     entity = entity,
     message = message,
     severity = severity,
@@ -32,7 +32,7 @@ fun createFindingForRelativePath(
     basePath: String = "/Users/tester/detekt/",
     relativePath: String = "TestFile.kt"
 ): Finding2 = Finding2Impl(
-    rule = Finding2Impl.RuleInfo(Rule.Id(ruleName), RuleSet.Id("ruleSetId"), "Description $ruleName"),
+    ruleInfo = Finding2Impl.RuleInfo(Rule.Id(ruleName), RuleSet.Id("ruleSetId"), "Description $ruleName"),
     entity = Entity(
         name = "TestEntity",
         signature = "TestEntitySignature",
@@ -73,7 +73,7 @@ fun createLocation(
 )
 
 private data class Finding2Impl(
-    override val rule: RuleInfo,
+    override val ruleInfo: RuleInfo,
     override val entity: Entity,
     override val message: String,
     override val severity: Severity = Severity.Error,

--- a/detekt-compiler-plugin/src/main/kotlin/io/github/detekt/compiler/plugin/internal/MessageCollectorExtensions.kt
+++ b/detekt-compiler-plugin/src/main/kotlin/io/github/detekt/compiler/plugin/internal/MessageCollectorExtensions.kt
@@ -39,5 +39,5 @@ fun Finding2.renderAsCompilerWarningMessage(): Pair<String, CompilerMessageLocat
         )
     }
 
-    return "${rule.id}: $message" to sourceLocation
+    return "${ruleInfo.id}: $message" to sourceLocation
 }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Analyzer.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Analyzer.kt
@@ -206,7 +206,7 @@ private fun Rule.toRuleInfo(ruleSetId: RuleSet.Id): Finding2.RuleInfo {
 }
 
 private data class Finding2Impl(
-    override val rule: Finding2.RuleInfo,
+    override val ruleInfo: Finding2.RuleInfo,
     override val entity: Entity,
     override val message: String,
     override val references: List<Entity>,

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Analyzer.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Analyzer.kt
@@ -116,18 +116,18 @@ internal class Analyzer(
                     .map { (ruleId, ruleProvider) -> ruleProvider to ruleSetConfig.subConfig(ruleId.value) }
                     .filter { (_, config) -> config.isActiveOrDefault(false) }
                     .filter { (_, config) -> config.shouldAnalyzeFile(file) }
-                    .map { (ruleProvider, config) -> ruleProvider(config) }
-                    .filter { rule -> !file.isSuppressedBy(rule.ruleId, rule.aliases, ruleSet.id) }
+                    .map { (ruleProvider, config) -> ruleSet.id to ruleProvider(config) }
+                    .filter { (_, rule) -> !file.isSuppressedBy(rule.ruleId, rule.aliases, ruleSet.id) }
             }
-            .filter { rule ->
+            .filter { (_, rule) ->
                 bindingContext != BindingContext.EMPTY || !rule::class.hasAnnotation<RequiresTypeResolution>()
             }
-            .partition { rule -> rule.autoCorrect }
+            .partition { (_, rule) -> rule.autoCorrect }
 
         val result = HashMap<RuleSet.Id, MutableList<Finding2>>()
 
-        fun executeRules(rules: List<Rule>) {
-            for (rule in rules) {
+        fun executeRules(rules: List<Pair<RuleSet.Id, Rule>>) {
+            for ((ruleSetId, rule) in rules) {
                 val findings = rule.visitFile(file, bindingContext, compilerResources)
                     .filterSuppressedFindings(rule, bindingContext)
                 for (finding in findings) {
@@ -135,7 +135,7 @@ internal class Analyzer(
                         "Mapping for '${rule.ruleId}' expected."
                     }
                     result.computeIfAbsent(mappedRuleSet) { mutableListOf() }
-                        .add(finding.toFinding2(rule.toRuleInfo(), rule.computeSeverity()))
+                        .add(finding.toFinding2(rule.toRuleInfo(ruleSetId), rule.computeSeverity()))
                 }
             }
         }
@@ -201,8 +201,8 @@ private fun Finding.toFinding2(rule: Finding2.RuleInfo, severity: Severity): Fin
     }
 }
 
-private fun Rule.toRuleInfo(): Finding2.RuleInfo {
-    return Finding2Impl.RuleInfo(ruleId, description)
+private fun Rule.toRuleInfo(ruleSetId: RuleSet.Id): Finding2.RuleInfo {
+    return Finding2Impl.RuleInfo(ruleId, ruleSetId, description)
 }
 
 private data class Finding2Impl(
@@ -215,6 +215,7 @@ private data class Finding2Impl(
 ) : Finding2 {
     data class RuleInfo(
         override val id: Rule.Id,
+        override val ruleSetId: RuleSet.Id,
         override val description: String,
     ) : Finding2.RuleInfo
 }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/DefaultBaseline.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/DefaultBaseline.kt
@@ -35,4 +35,4 @@ internal const val CURRENT_ISSUES = "CurrentIssues"
 internal const val ID = "ID"
 
 internal val Finding2.baselineId: String
-    get() = "${rule.id}:${this.entity.signature}"
+    get() = "${ruleInfo.id}:${this.entity.signature}"

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/Reporting.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/Reporting.kt
@@ -62,4 +62,4 @@ private fun Finding2.truncatedMessage(): String {
     }
 }
 
-private fun Finding2.detailed(): String = "${rule.id} - [${truncatedMessage()}] at ${location.compact()}"
+private fun Finding2.detailed(): String = "${ruleInfo.id} - [${truncatedMessage()}] at ${location.compact()}"

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/LiteFindingsReport.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/LiteFindingsReport.kt
@@ -14,7 +14,7 @@ class LiteFindingsReport : AbstractFindingsReport() {
     override fun render(findings: Map<RuleSet.Id, List<Finding2>>): String {
         return buildString {
             findings.values.flatten().forEach { finding ->
-                append("${finding.location.compact()}: ${finding.message} [${finding.rule.id}]")
+                append("${finding.location.compact()}: ${finding.message} [${finding.ruleInfo.id}]")
                 appendLine()
             }
         }

--- a/detekt-report-html/src/main/kotlin/io/github/detekt/report/html/HtmlOutputReport.kt
+++ b/detekt-report-html/src/main/kotlin/io/github/detekt/report/html/HtmlOutputReport.kt
@@ -107,7 +107,7 @@ class HtmlOutputReport : BuiltInOutputReport, OutputReport() {
         h3 { text("$group: %,d".format(Locale.ROOT, findings.size)) }
 
         findings
-            .groupBy { it.rule.id }
+            .groupBy { it.ruleInfo.id }
             .toList()
             .sortedBy { (rule, _) -> rule.value }
             .forEach { (rule, ruleFindings) ->
@@ -122,7 +122,7 @@ class HtmlOutputReport : BuiltInOutputReport, OutputReport() {
 
             summary("rule-container") {
                 span("rule") { text("$rule: %,d ".format(Locale.ROOT, findings.size)) }
-                span("description") { text(findings.first().rule.description) }
+                span("description") { text(findings.first().ruleInfo.description) }
             }
 
             a("$DETEKT_WEBSITE_BASE_URL/docs/rules/${group.value.lowercase()}#${rule.value.lowercase()}") {
@@ -163,7 +163,7 @@ class HtmlOutputReport : BuiltInOutputReport, OutputReport() {
         val psiFile = finding.entity.ktElement?.containingFile
         if (psiFile != null) {
             val lineSequence = psiFile.text.splitToSequence('\n')
-            snippetCode(finding.rule.id, lineSequence, finding.location.source, finding.location.text.length())
+            snippetCode(finding.ruleInfo.id, lineSequence, finding.location.source, finding.location.text.length())
         }
     }
 

--- a/detekt-report-md/src/main/kotlin/io/github/detekt/report/md/MdOutputReport.kt
+++ b/detekt-report-md/src/main/kotlin/io/github/detekt/report/md/MdOutputReport.kt
@@ -85,7 +85,7 @@ private fun MarkdownContent.renderComplexity(complexityReport: List<String>) {
 
 private fun MarkdownContent.renderGroup(group: RuleSet.Id, findings: List<Finding2>) {
     findings
-        .groupBy { it.rule.id }
+        .groupBy { it.ruleInfo.id }
         .toList()
         .sortedBy { (rule, _) -> rule.value }
         .forEach { (rule, ruleFindings) ->
@@ -95,7 +95,7 @@ private fun MarkdownContent.renderGroup(group: RuleSet.Id, findings: List<Findin
 
 private fun MarkdownContent.renderRule(rule: Rule.Id, group: RuleSet.Id, findings: List<Finding2>) {
     h3 { "$group, $rule (%,d)".format(Locale.ROOT, findings.size) }
-    paragraph { (findings.first().rule.description) }
+    paragraph { (findings.first().ruleInfo.description) }
 
     paragraph {
         link(

--- a/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/Results.kt
+++ b/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/Results.kt
@@ -25,7 +25,7 @@ internal fun Severity.toResultLevel() = when (this) {
 
 private fun Finding2.toResult(ruleSetId: RuleSet.Id): io.github.detekt.sarif4k.Result {
     return io.github.detekt.sarif4k.Result(
-        ruleID = "detekt.$ruleSetId.${rule.id}",
+        ruleID = "detekt.$ruleSetId.${ruleInfo.id}",
         level = severity.toResultLevel(),
         locations = (listOf(location) + references.map { it.location }).map { it.toLocation() }.distinct(),
         message = Message(text = message)

--- a/detekt-report-txt/src/main/kotlin/io/github/detekt/report/txt/TxtOutputReport.kt
+++ b/detekt-report-txt/src/main/kotlin/io/github/detekt/report/txt/TxtOutputReport.kt
@@ -23,4 +23,4 @@ class TxtOutputReport : BuiltInOutputReport, OutputReport() {
 }
 
 private fun Finding2.compactWithSignature(): String =
-    "${rule.id} - ${entity.compact()} - Signature=${entity.signature}"
+    "${ruleInfo.id} - ${entity.compact()} - Signature=${entity.signature}"

--- a/detekt-report-xml/src/main/kotlin/io/github/detekt/report/xml/XmlOutputReport.kt
+++ b/detekt-report-xml/src/main/kotlin/io/github/detekt/report/xml/XmlOutputReport.kt
@@ -35,7 +35,7 @@ class XmlOutputReport : BuiltInOutputReport, OutputReport() {
                         "column=\"${it.location.source.column.toXmlString()}\"",
                         "severity=\"${it.severityLabel.toXmlString()}\"",
                         "message=\"${it.message.toXmlString()}\"",
-                        "source=\"${"detekt.${it.rule.id.value.toXmlString()}"}\" />"
+                        "source=\"${"detekt.${it.ruleInfo.id.value.toXmlString()}"}\" />"
                     ).joinToString(separator = " ")
                 }
                 lines += "</file>"

--- a/detekt-report-xml/src/test/kotlin/io/github/detekt/report/xml/XmlOutputFormatSpec.kt
+++ b/detekt-report-xml/src/test/kotlin/io/github/detekt/report/xml/XmlOutputFormatSpec.kt
@@ -189,7 +189,7 @@ class XmlOutputFormatSpec {
                 <?xml version="1.0" encoding="UTF-8"?>
                 <checkstyle version="4.3">
                 <file name="src/main/com/sample/Sample1.kt">
-                $TAB<error line="${finding.location.source.line}" column="${finding.location.source.column}" severity="$xmlSeverity" message="${finding.message}" source="detekt.${finding.rule.id}" />
+                $TAB<error line="${finding.location.source.line}" column="${finding.location.source.column}" severity="$xmlSeverity" message="${finding.message}" source="detekt.${finding.ruleInfo.id}" />
                 </file>
                 </checkstyle>
             """.trimIndent()


### PR DESCRIPTION
Add `RuleSet.Id` inside `Finding2`. This change by itself has little sense. But this unlocks a great simplification on the `Deteketion` implementations. This simplification is implemented in the draft #6884