### PR TITLE
Make `findings` a `List<Finding2>` instead of a `Map<RuleSet.Id, List<Finding2>>`

### DIFF
--- a/detekt-api/api/detekt-api.api
+++ b/detekt-api/api/detekt-api.api
@@ -107,7 +107,7 @@ public class io/gitlab/arturbosch/detekt/api/DetektVisitor : org/jetbrains/kotli
 public abstract interface class io/gitlab/arturbosch/detekt/api/Detektion : org/jetbrains/kotlin/com/intellij/openapi/util/UserDataHolder {
 	public abstract fun add (Lio/gitlab/arturbosch/detekt/api/Notification;)V
 	public abstract fun add (Lio/gitlab/arturbosch/detekt/api/ProjectMetric;)V
-	public abstract fun getFindings ()Ljava/util/Map;
+	public abstract fun getFindings ()Ljava/util/List;
 	public abstract fun getMetrics ()Ljava/util/Collection;
 	public abstract fun getNotifications ()Ljava/util/Collection;
 }
@@ -149,7 +149,7 @@ public final class io/gitlab/arturbosch/detekt/api/Extension$DefaultImpls {
 public abstract interface class io/gitlab/arturbosch/detekt/api/FileProcessListener : io/gitlab/arturbosch/detekt/api/Extension {
 	public abstract fun onFinish (Ljava/util/List;Lio/gitlab/arturbosch/detekt/api/Detektion;Lorg/jetbrains/kotlin/resolve/BindingContext;)V
 	public abstract fun onProcess (Lorg/jetbrains/kotlin/psi/KtFile;Lorg/jetbrains/kotlin/resolve/BindingContext;)V
-	public abstract fun onProcessComplete (Lorg/jetbrains/kotlin/psi/KtFile;Ljava/util/Map;Lorg/jetbrains/kotlin/resolve/BindingContext;)V
+	public abstract fun onProcessComplete (Lorg/jetbrains/kotlin/psi/KtFile;Ljava/util/List;Lorg/jetbrains/kotlin/resolve/BindingContext;)V
 	public abstract fun onStart (Ljava/util/List;Lorg/jetbrains/kotlin/resolve/BindingContext;)V
 }
 
@@ -159,7 +159,7 @@ public final class io/gitlab/arturbosch/detekt/api/FileProcessListener$DefaultIm
 	public static fun init (Lio/gitlab/arturbosch/detekt/api/FileProcessListener;Lio/gitlab/arturbosch/detekt/api/SetupContext;)V
 	public static fun onFinish (Lio/gitlab/arturbosch/detekt/api/FileProcessListener;Ljava/util/List;Lio/gitlab/arturbosch/detekt/api/Detektion;Lorg/jetbrains/kotlin/resolve/BindingContext;)V
 	public static fun onProcess (Lio/gitlab/arturbosch/detekt/api/FileProcessListener;Lorg/jetbrains/kotlin/psi/KtFile;Lorg/jetbrains/kotlin/resolve/BindingContext;)V
-	public static fun onProcessComplete (Lio/gitlab/arturbosch/detekt/api/FileProcessListener;Lorg/jetbrains/kotlin/psi/KtFile;Ljava/util/Map;Lorg/jetbrains/kotlin/resolve/BindingContext;)V
+	public static fun onProcessComplete (Lio/gitlab/arturbosch/detekt/api/FileProcessListener;Lorg/jetbrains/kotlin/psi/KtFile;Ljava/util/List;Lorg/jetbrains/kotlin/resolve/BindingContext;)V
 	public static fun onStart (Lio/gitlab/arturbosch/detekt/api/FileProcessListener;Ljava/util/List;Lorg/jetbrains/kotlin/resolve/BindingContext;)V
 }
 
@@ -254,7 +254,7 @@ public abstract interface class io/gitlab/arturbosch/detekt/api/PropertiesAware 
 public abstract interface class io/gitlab/arturbosch/detekt/api/ReportingExtension : io/gitlab/arturbosch/detekt/api/Extension {
 	public abstract fun onFinalResult (Lio/gitlab/arturbosch/detekt/api/Detektion;)V
 	public abstract fun onRawResult (Lio/gitlab/arturbosch/detekt/api/Detektion;)V
-	public abstract fun transformFindings (Ljava/util/Map;)Ljava/util/Map;
+	public abstract fun transformFindings (Ljava/util/List;)Ljava/util/List;
 }
 
 public final class io/gitlab/arturbosch/detekt/api/ReportingExtension$DefaultImpls {
@@ -263,7 +263,7 @@ public final class io/gitlab/arturbosch/detekt/api/ReportingExtension$DefaultImp
 	public static fun init (Lio/gitlab/arturbosch/detekt/api/ReportingExtension;Lio/gitlab/arturbosch/detekt/api/SetupContext;)V
 	public static fun onFinalResult (Lio/gitlab/arturbosch/detekt/api/ReportingExtension;Lio/gitlab/arturbosch/detekt/api/Detektion;)V
 	public static fun onRawResult (Lio/gitlab/arturbosch/detekt/api/ReportingExtension;Lio/gitlab/arturbosch/detekt/api/Detektion;)V
-	public static fun transformFindings (Lio/gitlab/arturbosch/detekt/api/ReportingExtension;Ljava/util/Map;)Ljava/util/Map;
+	public static fun transformFindings (Lio/gitlab/arturbosch/detekt/api/ReportingExtension;Ljava/util/List;)Ljava/util/List;
 }
 
 public abstract interface annotation class io/gitlab/arturbosch/detekt/api/RequiresTypeResolution : java/lang/annotation/Annotation {

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Detektion.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Detektion.kt
@@ -7,7 +7,7 @@ import org.jetbrains.kotlin.com.intellij.openapi.util.UserDataHolder
  * which needs to be transferred from the detekt engine to the user.
  */
 interface Detektion : UserDataHolder {
-    val findings: Map<RuleSet.Id, List<Finding2>>
+    val findings: List<Finding2>
     val notifications: Collection<Notification>
     val metrics: Collection<ProjectMetric>
 

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/FileProcessListener.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/FileProcessListener.kt
@@ -28,7 +28,7 @@ interface FileProcessListener : Extension {
      * Called when processing of a file completes.
      * This method is called from a thread pool thread. Heavy computations allowed.
      */
-    fun onProcessComplete(file: KtFile, findings: Map<RuleSet.Id, List<Finding2>>, bindingContext: BindingContext) {}
+    fun onProcessComplete(file: KtFile, findings: List<Finding2>, bindingContext: BindingContext) {}
 
     /**
      * Mainly use this method to save computed metrics from KtFile's to the {@link Detektion} container.

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/ReportingExtension.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/ReportingExtension.kt
@@ -16,7 +16,7 @@ interface ReportingExtension : Extension {
     /**
      * Allows to transform the reported findings e.g. apply custom filtering.
      */
-    fun transformFindings(findings: Map<RuleSet.Id, List<Finding2>>): Map<RuleSet.Id, List<Finding2>> = findings
+    fun transformFindings(findings: List<Finding2>): List<Finding2> = findings
 
     /**
      * Is called after all extensions's [transformFindings] were called.

--- a/detekt-api/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/test/TestDetektion.kt
+++ b/detekt-api/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/test/TestDetektion.kt
@@ -4,7 +4,6 @@ import io.gitlab.arturbosch.detekt.api.Detektion
 import io.gitlab.arturbosch.detekt.api.Finding2
 import io.gitlab.arturbosch.detekt.api.Notification
 import io.gitlab.arturbosch.detekt.api.ProjectMetric
-import io.gitlab.arturbosch.detekt.api.RuleSet
 import org.jetbrains.kotlin.com.intellij.openapi.util.Key
 import org.jetbrains.kotlin.com.intellij.openapi.util.UserDataHolderBase
 
@@ -14,7 +13,7 @@ class TestDetektion(
     notifications: List<Notification> = emptyList(),
 ) : Detektion, UserDataHolderBase() {
 
-    override val findings: Map<RuleSet.Id, List<Finding2>> = findings.groupBy { it.ruleInfo.ruleSetId }
+    override val findings: List<Finding2> = findings.toList()
     override val metrics: Collection<ProjectMetric> get() = _metrics
     override val notifications: List<Notification> get() = _notifications
 

--- a/detekt-compiler-plugin/src/main/kotlin/io/github/detekt/compiler/plugin/internal/MessageCollectorExtensions.kt
+++ b/detekt-compiler-plugin/src/main/kotlin/io/github/detekt/compiler/plugin/internal/MessageCollectorExtensions.kt
@@ -21,7 +21,7 @@ fun MessageCollector.error(msg: String) {
 }
 
 fun MessageCollector.reportFindings(result: Detektion) {
-    for (finding in result.findings.values.flatten()) {
+    for (finding in result.findings) {
         val (message, location) = finding.renderAsCompilerWarningMessage()
         warn(message, location)
     }

--- a/detekt-compiler-plugin/src/main/kotlin/io/github/detekt/compiler/plugin/internal/MessageCollectorExtensions.kt
+++ b/detekt-compiler-plugin/src/main/kotlin/io/github/detekt/compiler/plugin/internal/MessageCollectorExtensions.kt
@@ -21,7 +21,7 @@ fun MessageCollector.error(msg: String) {
 }
 
 fun MessageCollector.reportFindings(result: Detektion) {
-    for (finding in result.findings) {
+    result.findings.forEach { finding ->
         val (message, location) = finding.renderAsCompilerWarningMessage()
         warn(message, location)
     }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Analyzer.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Analyzer.kt
@@ -43,15 +43,13 @@ internal class Analyzer(
 
         val dataFlowValueFactory = DataFlowValueFactoryImpl(languageVersionSettings)
         val compilerResources = CompilerResources(languageVersionSettings, dataFlowValueFactory)
-        val findingsPerFile: FindingsResult =
-            if (settings.spec.executionSpec.parallelAnalysis) {
-                runAsync(ktFiles, bindingContext, compilerResources)
-            } else {
-                runSync(ktFiles, bindingContext, compilerResources)
-            }
-
         if (bindingContext == BindingContext.EMPTY) {
             warnAboutEnabledRequiresTypeResolutionRules()
+        }
+        val findingsPerFile: FindingsResult = if (settings.spec.executionSpec.parallelAnalysis) {
+            runAsync(ktFiles, bindingContext, compilerResources)
+        } else {
+            runSync(ktFiles, bindingContext, compilerResources)
         }
 
         val findingsPerRuleSet = HashMap<RuleSet.Id, List<Finding2>>()

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/DelegatingResult.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/DelegatingResult.kt
@@ -2,9 +2,8 @@ package io.gitlab.arturbosch.detekt.core
 
 import io.gitlab.arturbosch.detekt.api.Detektion
 import io.gitlab.arturbosch.detekt.api.Finding2
-import io.gitlab.arturbosch.detekt.api.RuleSet
 
 class DelegatingResult(
     result: Detektion,
-    override val findings: Map<RuleSet.Id, List<Finding2>>
+    override val findings: List<Finding2>
 ) : Detektion by result

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/DetektResult.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/DetektResult.kt
@@ -4,11 +4,10 @@ import io.gitlab.arturbosch.detekt.api.Detektion
 import io.gitlab.arturbosch.detekt.api.Finding2
 import io.gitlab.arturbosch.detekt.api.Notification
 import io.gitlab.arturbosch.detekt.api.ProjectMetric
-import io.gitlab.arturbosch.detekt.api.RuleSet
 import org.jetbrains.kotlin.com.intellij.openapi.util.UserDataHolderBase
 
 @Suppress("DataClassShouldBeImmutable")
-data class DetektResult(override val findings: Map<RuleSet.Id, List<Finding2>>) : Detektion, UserDataHolderBase() {
+data class DetektResult(override val findings: List<Finding2>) : Detektion, UserDataHolderBase() {
 
     private val _notifications = ArrayList<Notification>()
     override val notifications: Collection<Notification> = _notifications

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineFilteredResult.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineFilteredResult.kt
@@ -3,13 +3,11 @@ package io.gitlab.arturbosch.detekt.core.baseline
 import io.github.detekt.tooling.api.Baseline
 import io.gitlab.arturbosch.detekt.api.Detektion
 import io.gitlab.arturbosch.detekt.api.Finding2
-import io.gitlab.arturbosch.detekt.api.RuleSet
 
 internal class BaselineFilteredResult(
     result: Detektion,
     private val baseline: Baseline,
 ) : Detektion by result {
 
-    override val findings: Map<RuleSet.Id, List<Finding2>> = result.findings
-        .mapValues { (_, findings) -> findings.filterNot { baseline.contains(it.baselineId) } }
+    override val findings: List<Finding2> = result.findings.filterNot { baseline.contains(it.baselineId) }
 }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineResultMapping.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineResultMapping.kt
@@ -2,7 +2,6 @@ package io.gitlab.arturbosch.detekt.core.baseline
 
 import io.gitlab.arturbosch.detekt.api.Finding2
 import io.gitlab.arturbosch.detekt.api.ReportingExtension
-import io.gitlab.arturbosch.detekt.api.RuleSet
 import io.gitlab.arturbosch.detekt.api.SetupContext
 import io.gitlab.arturbosch.detekt.api.getOrNull
 import io.gitlab.arturbosch.detekt.core.DetektResult
@@ -20,7 +19,7 @@ class BaselineResultMapping : ReportingExtension {
         createBaseline = context.getOrNull(DETEKT_BASELINE_CREATION_KEY) ?: false
     }
 
-    override fun transformFindings(findings: Map<RuleSet.Id, List<Finding2>>): Map<RuleSet.Id, List<Finding2>> {
+    override fun transformFindings(findings: List<Finding2>): List<Finding2> {
         val baselineFile = baselineFile
         require(!createBaseline || (createBaseline && baselineFile != null)) {
             "Invalid baseline options invariant."
@@ -29,14 +28,13 @@ class BaselineResultMapping : ReportingExtension {
         return baselineFile?.let { findings.transformWithBaseline(it) } ?: findings
     }
 
-    private fun Map<RuleSet.Id, List<Finding2>>.transformWithBaseline(
+    private fun List<Finding2>.transformWithBaseline(
         baselinePath: Path,
-    ): Map<RuleSet.Id, List<Finding2>> {
+    ): List<Finding2> {
         val facade = BaselineFacade()
-        val flatten = this.flatMap { it.value }
 
         if (createBaseline) {
-            facade.createOrUpdate(baselinePath, flatten)
+            facade.createOrUpdate(baselinePath, this)
         }
 
         return facade.transformResult(baselinePath, DetektResult(this)).findings

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/FailurePolicies.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/FailurePolicies.kt
@@ -23,7 +23,6 @@ private fun Detektion.checkForIssuesWithSeverity(config: Config, minSeverity: Se
 
 private fun Detektion.computeIssueCount(config: Config, minSeverity: Severity): Int =
     filterAutoCorrectedIssues(config)
-        .flatMap { it.value }
         .count { it.severity.isAtLeast(minSeverity) }
 
 private fun Severity.isAtLeast(severity: Severity): Boolean = this.ordinal <= severity.ordinal

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/Reporting.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/Reporting.kt
@@ -4,7 +4,6 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Detektion
 import io.gitlab.arturbosch.detekt.api.Finding2
 import io.gitlab.arturbosch.detekt.api.OutputReport
-import io.gitlab.arturbosch.detekt.api.RuleSet
 import io.gitlab.arturbosch.detekt.api.internal.BuiltInOutputReport
 
 internal fun defaultReportMapping(report: OutputReport) =
@@ -35,21 +34,16 @@ private val messageReplacementRegex = Regex("\\s+")
 
 fun Config.excludeCorrectable(): Boolean = subConfig(BUILD).valueOrDefault(EXCLUDE_CORRECTABLE, false)
 
-fun Detektion.filterEmptyIssues(config: Config): Map<RuleSet.Id, List<Finding2>> {
+fun Detektion.filterEmptyIssues(config: Config): List<Finding2> {
     return this
         .filterAutoCorrectedIssues(config)
-        .filter { it.value.isNotEmpty() }
 }
 
-fun Detektion.filterAutoCorrectedIssues(config: Config): Map<RuleSet.Id, List<Finding2>> {
+fun Detektion.filterAutoCorrectedIssues(config: Config): List<Finding2> {
     if (!config.excludeCorrectable()) {
         return findings
     }
-    val filteredFindings = HashMap<RuleSet.Id, List<Finding2>>()
-    findings.forEach { (ruleSetId, findingsList) ->
-        filteredFindings[ruleSetId] = findingsList.filter { finding -> !finding.autoCorrectEnabled }
-    }
-    return filteredFindings
+    return findings.filter { finding -> !finding.autoCorrectEnabled }
 }
 
 private fun Finding2.truncatedMessage(): String {

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/AbstractFindingsReport.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/AbstractFindingsReport.kt
@@ -4,7 +4,6 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.ConsoleReport
 import io.gitlab.arturbosch.detekt.api.Detektion
 import io.gitlab.arturbosch.detekt.api.Finding2
-import io.gitlab.arturbosch.detekt.api.RuleSet
 import io.gitlab.arturbosch.detekt.core.reporting.filterEmptyIssues
 
 abstract class AbstractFindingsReport : ConsoleReport() {
@@ -25,5 +24,5 @@ abstract class AbstractFindingsReport : ConsoleReport() {
         return render(findings)
     }
 
-    abstract fun render(findings: Map<RuleSet.Id, List<Finding2>>): String
+    abstract fun render(findings: List<Finding2>): String
 }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/FileBasedFindingsReport.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/FileBasedFindingsReport.kt
@@ -1,7 +1,6 @@
 package io.gitlab.arturbosch.detekt.core.reporting.console
 
 import io.gitlab.arturbosch.detekt.api.Finding2
-import io.gitlab.arturbosch.detekt.api.RuleSet
 import io.gitlab.arturbosch.detekt.core.reporting.printFindings
 
 /**
@@ -12,10 +11,8 @@ class FileBasedFindingsReport : AbstractFindingsReport() {
 
     override val id: String = "FileBasedFindingsReport"
 
-    override fun render(findings: Map<RuleSet.Id, List<Finding2>>): String {
-        val findingsPerFile = findings.values
-            .flatten()
-            .groupBy { it.entity.location.filePath.absolutePath.toString() }
+    override fun render(findings: List<Finding2>): String {
+        val findingsPerFile = findings.groupBy { it.entity.location.filePath.absolutePath.toString() }
         return printFindings(findingsPerFile)
     }
 }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/FindingsReport.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/FindingsReport.kt
@@ -1,7 +1,6 @@
 package io.gitlab.arturbosch.detekt.core.reporting.console
 
 import io.gitlab.arturbosch.detekt.api.Finding2
-import io.gitlab.arturbosch.detekt.api.RuleSet
 import io.gitlab.arturbosch.detekt.core.reporting.printFindings
 
 /**
@@ -12,7 +11,7 @@ class FindingsReport : AbstractFindingsReport() {
 
     override val id: String = "FindingsReport"
 
-    override fun render(findings: Map<RuleSet.Id, List<Finding2>>): String {
-        return printFindings(findings.mapKeys { (key, _) -> key.value })
+    override fun render(findings: List<Finding2>): String {
+        return printFindings(findings.groupBy { it.ruleInfo.ruleSetId }.mapKeys { (key, _) -> key.value })
     }
 }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/LiteFindingsReport.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/LiteFindingsReport.kt
@@ -1,7 +1,6 @@
 package io.gitlab.arturbosch.detekt.core.reporting.console
 
 import io.gitlab.arturbosch.detekt.api.Finding2
-import io.gitlab.arturbosch.detekt.api.RuleSet
 
 /**
  * A lightweight versions of the console report, where each line contains location, messages and issue id only.
@@ -11,9 +10,9 @@ class LiteFindingsReport : AbstractFindingsReport() {
 
     override val id: String = "LiteFindingsReport"
 
-    override fun render(findings: Map<RuleSet.Id, List<Finding2>>): String {
+    override fun render(findings: List<Finding2>): String {
         return buildString {
-            findings.values.flatten().forEach { finding ->
+            findings.forEach { finding ->
                 append("${finding.location.compact()}: ${finding.message} [${finding.ruleInfo.id}]")
                 appendLine()
             }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/rules/RuleSets.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/rules/RuleSets.kt
@@ -1,18 +1,8 @@
 package io.gitlab.arturbosch.detekt.core.rules
 
 import io.github.detekt.tooling.api.spec.RulesSpec
-import io.gitlab.arturbosch.detekt.api.Rule
-import io.gitlab.arturbosch.detekt.api.RuleSet
 import io.gitlab.arturbosch.detekt.api.RuleSetProvider
 import io.gitlab.arturbosch.detekt.core.ProcessingSettings
-
-fun associateRuleIdsToRuleSetIds(ruleSets: List<RuleSet>): Map<Rule.Id, RuleSet.Id> {
-    return ruleSets
-        .flatMap { ruleSet ->
-            ruleSet.rules.map { (ruleId, _) -> ruleId to ruleSet.id }
-        }
-        .toMap()
-}
 
 fun ProcessingSettings.createRuleProviders(): List<RuleSetProvider> = when (val runPolicy = spec.rulesSpec.runPolicy) {
     RulesSpec.RunPolicy.NoRestrictions -> RuleSetLocator(this).load()

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/tooling/Lifecycle.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/tooling/Lifecycle.kt
@@ -3,8 +3,6 @@ package io.gitlab.arturbosch.detekt.core.tooling
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Detektion
 import io.gitlab.arturbosch.detekt.api.FileProcessListener
-import io.gitlab.arturbosch.detekt.api.Finding2
-import io.gitlab.arturbosch.detekt.api.RuleSet
 import io.gitlab.arturbosch.detekt.api.RuleSetProvider
 import io.gitlab.arturbosch.detekt.core.Analyzer
 import io.gitlab.arturbosch.detekt.core.DetektResult
@@ -42,8 +40,8 @@ internal interface Lifecycle {
         val result = measure(Phase.Analyzer) {
             val analyzer = Analyzer(settings, ruleSets, processors)
             processors.forEach { it.onStart(filesToAnalyze, bindingContext) }
-            val findings: Map<RuleSet.Id, List<Finding2>> = analyzer.run(filesToAnalyze, bindingContext)
-            val result: Detektion = DetektResult(findings.toSortedMap { o1, o2 -> o1.value.compareTo(o2.value) })
+            val findings = analyzer.run(filesToAnalyze, bindingContext)
+            val result: Detektion = DetektResult(findings)
             processors.forEach { it.onFinish(filesToAnalyze, result, bindingContext) }
             result
         }

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/AnalyzerSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/AnalyzerSpec.kt
@@ -98,7 +98,7 @@ class AnalyzerSpec(val env: KotlinCoreEnvironment) {
             )
             val analyzer = Analyzer(settings, listOf(CustomRuleSetProvider()), emptyList())
 
-            assertThat(settings.use { analyzer.run(listOf(compileForTest(testFile))) }.values.flatten()).isEmpty()
+            assertThat(settings.use { analyzer.run(listOf(compileForTest(testFile))) }).isEmpty()
             assertThat(output.toString()).isEqualTo(
                 "The rule 'RequiresTypeResolutionMaxLineLength' requires type resolution but it was run without it.\n"
             )
@@ -125,7 +125,7 @@ class AnalyzerSpec(val env: KotlinCoreEnvironment) {
             )
             val analyzer = Analyzer(settings, listOf(CustomRuleSetProvider()), emptyList())
 
-            assertThat(settings.use { analyzer.run(listOf(compileForTest(testFile))) }.values.flatten()).hasSize(1)
+            assertThat(settings.use { analyzer.run(listOf(compileForTest(testFile))) }).hasSize(1)
             assertThat(output.toString()).isEqualTo(
                 "The rule 'RequiresTypeResolutionMaxLineLength' requires type resolution but it was run without it.\n"
             )
@@ -154,7 +154,7 @@ class AnalyzerSpec(val env: KotlinCoreEnvironment) {
             val ktFile = compileForTest(testFile)
             val bindingContext = env.getContextForPaths(listOf(ktFile))
 
-            assertThat(settings.use { analyzer.run(listOf(ktFile), bindingContext) }.values.flatten()).hasSize(2)
+            assertThat(settings.use { analyzer.run(listOf(ktFile), bindingContext) }).hasSize(2)
             assertThat(output.toString()).isEmpty()
         }
 
@@ -178,7 +178,7 @@ class AnalyzerSpec(val env: KotlinCoreEnvironment) {
             )
             val analyzer = Analyzer(settings, listOf(CustomRuleSetProvider()), emptyList())
 
-            assertThat(settings.use { analyzer.run(listOf(compileForTest(testFile))) }.values.flatten()).isEmpty()
+            assertThat(settings.use { analyzer.run(listOf(compileForTest(testFile))) }).isEmpty()
             assertThat(output.toString()).isEmpty()
         }
 
@@ -350,8 +350,6 @@ class AnalyzerSpec(val env: KotlinCoreEnvironment) {
                 .use { settings ->
                     Analyzer(settings, listOf(CustomRuleSetProvider()), emptyList())
                         .run(listOf(compileContentForTest("", root, Path(path))))
-                        .values
-                        .flatten()
                         .isNotEmpty()
                 }
         }

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/AnalyzerSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/AnalyzerSpec.kt
@@ -21,7 +21,6 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
-import java.util.concurrent.CompletionException
 import kotlin.io.path.Path
 
 @KotlinCoreEnvironmentTest
@@ -45,9 +44,8 @@ class AnalyzerSpec(val env: KotlinCoreEnvironment) {
             )
             val analyzer = Analyzer(settings, listOf(CustomRuleSetProvider()), emptyList())
 
-            assertThatThrownBy {
-                settings.use { analyzer.run(listOf(compileForTest(testFile))) }
-            }.isInstanceOf(IllegalStateException::class.java)
+            assertThatThrownBy { settings.use { analyzer.run(listOf(compileForTest(testFile))) } }
+                .isInstanceOf(IllegalStateException::class.java)
         }
 
         @Test
@@ -72,8 +70,7 @@ class AnalyzerSpec(val env: KotlinCoreEnvironment) {
             val analyzer = Analyzer(settings, listOf(CustomRuleSetProvider()), emptyList())
 
             assertThatThrownBy { settings.use { analyzer.run(listOf(compileForTest(testFile))) } }
-                .isInstanceOf(CompletionException::class.java)
-                .hasCauseInstanceOf(IllegalStateException::class.java)
+                .isInstanceOf(IllegalStateException::class.java)
         }
     }
 

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineFilteredResultSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineFilteredResultSpec.kt
@@ -12,18 +12,9 @@ class BaselineFilteredResultSpec {
     private val baselineFile = resourceAsPath("/baseline_feature/valid-baseline.xml")
 
     private val result = TestDetektion(
-        createFinding(
-            ruleName = "LongParameterList",
-            entity = createEntity(signature = "Signature"),
-        ),
-        createFinding(
-            ruleName = "LongMethod",
-            entity = createEntity(signature = "Signature"),
-        ),
-        createFinding(
-            ruleName = "FeatureEnvy",
-            entity = createEntity(signature = "Signature"),
-        ),
+        createFinding("LongParameterList", createEntity(signature = "Signature")),
+        createFinding("LongMethod", createEntity(signature = "Signature")),
+        createFinding("FeatureEnvy", createEntity(signature = "Signature")),
     )
 
     @Test
@@ -36,8 +27,6 @@ class BaselineFilteredResultSpec {
     fun `filters with an existing baseline file`() {
         val baseline = DefaultBaseline.load(baselineFile)
         val actual = BaselineFilteredResult(result, baseline)
-        // Note: Detektion works with Map<RuleSetId, List<Finding>
-        // but the TestDetektion maps the RuleId as RuleSetId
-        actual.findings.forEach { (_, value) -> assertThat(value).isEmpty() }
+        assertThat(actual.findings).isEmpty()
     }
 }

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineResultMappingSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineResultMappingSpec.kt
@@ -4,11 +4,10 @@ import io.github.detekt.test.utils.NullPrintStream
 import io.github.detekt.test.utils.createTempDirectoryForTest
 import io.github.detekt.test.utils.resourceAsPath
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.Finding2
-import io.gitlab.arturbosch.detekt.api.RuleSet
 import io.gitlab.arturbosch.detekt.api.SetupContext
 import io.gitlab.arturbosch.detekt.test.createEntity
 import io.gitlab.arturbosch.detekt.test.createFinding
+import io.gitlab.arturbosch.detekt.test.createRuleInfo
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
@@ -23,11 +22,12 @@ class BaselineResultMappingSpec {
     private val dir = createTempDirectoryForTest("baseline_format")
     private val baselineFile = dir.resolve("baseline.xml")
     private val existingBaselineFile = resourceAsPath("/baseline_feature/valid-baseline.xml")
-    private val finding: Finding2 = createFinding(
-        ruleName = "SomeIssueId",
-        entity = createEntity(signature = "SomeSignature"),
+    private val findings = listOf(
+        createFinding(
+            ruleInfo = createRuleInfo("SomeIssueId", "RuleSet"),
+            entity = createEntity(signature = "SomeSignature"),
+        )
     )
-    private val findings: Map<RuleSet.Id, List<Finding2>> = mapOf(RuleSet.Id("RuleSet") to listOf(finding))
 
     @AfterEach
     fun tearDown() {
@@ -41,7 +41,7 @@ class BaselineResultMappingSpec {
             createBaseline = true,
         )
 
-        mapping.transformFindings(emptyMap())
+        mapping.transformFindings(emptyList())
 
         assertThat(baselineFile).doesNotExist()
     }

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/OutputFacadeSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/OutputFacadeSpec.kt
@@ -7,11 +7,11 @@ import io.github.detekt.report.xml.XmlOutputReport
 import io.github.detekt.test.utils.StringPrintStream
 import io.github.detekt.test.utils.createTempFileForTest
 import io.github.detekt.test.utils.resourceAsPath
-import io.gitlab.arturbosch.detekt.api.RuleSet
 import io.gitlab.arturbosch.detekt.core.DetektResult
 import io.gitlab.arturbosch.detekt.core.createNullLoggingSpec
 import io.gitlab.arturbosch.detekt.core.tooling.withSettings
 import io.gitlab.arturbosch.detekt.test.createFinding
+import io.gitlab.arturbosch.detekt.test.createRuleInfo
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.nio.file.Path
@@ -22,7 +22,7 @@ class OutputFacadeSpec {
     fun `Running the output facade with multiple reports`() {
         val printStream = StringPrintStream()
         val inputPath: Path = resourceAsPath("/cases")
-        val defaultResult = DetektResult(mapOf(RuleSet.Id("Key") to listOf(createFinding())))
+        val defaultResult = DetektResult(listOf(createFinding(createRuleInfo(ruleSetId = "Key"))))
         val plainOutputPath = createTempFileForTest("detekt", ".txt")
         val htmlOutputPath = createTempFileForTest("detekt", ".html")
         val xmlOutputPath = createTempFileForTest("detekt", ".xml")

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/ComplexityReportSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/ComplexityReportSpec.kt
@@ -8,9 +8,9 @@ import io.github.detekt.metrics.processors.logicalLinesKey
 import io.github.detekt.metrics.processors.sourceLinesKey
 import io.github.detekt.test.utils.readResourceContent
 import io.gitlab.arturbosch.detekt.api.Detektion
-import io.gitlab.arturbosch.detekt.api.RuleSet
 import io.gitlab.arturbosch.detekt.core.DetektResult
 import io.gitlab.arturbosch.detekt.test.createFinding
+import io.gitlab.arturbosch.detekt.test.createRuleInfo
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -33,7 +33,7 @@ class ComplexityReportSpec {
     }
 }
 
-private fun createDetektion(): Detektion = DetektResult(mapOf(RuleSet.Id("Key") to listOf(createFinding())))
+private fun createDetektion(): Detektion = DetektResult(listOf(createFinding(createRuleInfo(ruleSetId = "Key"))))
 
 private fun addData(detektion: Detektion) {
     detektion.putUserData(complexityKey, 2)

--- a/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/ComplexityMetric.kt
+++ b/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/ComplexityMetric.kt
@@ -15,5 +15,5 @@ class ComplexityMetric(detektion: Detektion) {
     val sloc = detektion.getUserData(sourceLinesKey)
     val lloc = detektion.getUserData(logicalLinesKey)
     val cloc = detektion.getUserData(commentLinesKey)
-    val findings = detektion.findings.entries
+    val findingsCount = detektion.findings.values.sumOf { it.size }
 }

--- a/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/ComplexityMetric.kt
+++ b/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/ComplexityMetric.kt
@@ -15,5 +15,5 @@ class ComplexityMetric(detektion: Detektion) {
     val sloc = detektion.getUserData(sourceLinesKey)
     val lloc = detektion.getUserData(logicalLinesKey)
     val cloc = detektion.getUserData(commentLinesKey)
-    val findingsCount = detektion.findings.values.sumOf { it.size }
+    val findingsCount = detektion.findings.size
 }

--- a/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/ComplexityReportGenerator.kt
+++ b/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/ComplexityReportGenerator.kt
@@ -36,7 +36,7 @@ class ComplexityReportGenerator(private val complexityMetric: ComplexityMetric) 
             complexityMetric.lloc == null || complexityMetric.lloc == 0 -> true
             complexityMetric.sloc == null || complexityMetric.sloc == 0 -> true
             else -> {
-                numberOfSmells = complexityMetric.findings.sumOf { it.value.size }
+                numberOfSmells = complexityMetric.findingsCount
                 smellPerThousandLines = numberOfSmells * 1000 / complexityMetric.lloc
                 mccPerThousandLines = requireNotNull(complexityMetric.mcc) * 1000 / complexityMetric.lloc
                 commentSourceRatio = requireNotNull(complexityMetric.cloc) * 100 / complexityMetric.sloc

--- a/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/processors/MetricProcessorTester.kt
+++ b/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/processors/MetricProcessorTester.kt
@@ -4,7 +4,6 @@ import io.gitlab.arturbosch.detekt.api.Detektion
 import io.gitlab.arturbosch.detekt.api.Finding2
 import io.gitlab.arturbosch.detekt.api.Notification
 import io.gitlab.arturbosch.detekt.api.ProjectMetric
-import io.gitlab.arturbosch.detekt.api.RuleSet
 import org.jetbrains.kotlin.com.intellij.openapi.util.Key
 import org.jetbrains.kotlin.com.intellij.openapi.util.UserDataHolderBase
 import org.jetbrains.kotlin.psi.KtFile
@@ -19,7 +18,7 @@ class MetricProcessorTester(
         with(processor) {
             onStart(listOf(file), BindingContext.EMPTY)
             onProcess(file, BindingContext.EMPTY)
-            onProcessComplete(file, emptyMap(), BindingContext.EMPTY)
+            onProcessComplete(file, emptyList(), BindingContext.EMPTY)
             onFinish(listOf(file), result, BindingContext.EMPTY)
         }
         return checkNotNull(result.getUserData(key))
@@ -27,7 +26,7 @@ class MetricProcessorTester(
 }
 
 private class MetricResults : Detektion, UserDataHolderBase() {
-    override val findings: Map<RuleSet.Id, List<Finding2>>
+    override val findings: List<Finding2>
         get() = throw UnsupportedOperationException()
     override val notifications: Collection<Notification>
         get() = throw UnsupportedOperationException()

--- a/detekt-report-html/src/main/kotlin/io/github/detekt/report/html/HtmlOutputReport.kt
+++ b/detekt-report-html/src/main/kotlin/io/github/detekt/report/html/HtmlOutputReport.kt
@@ -85,16 +85,13 @@ class HtmlOutputReport : BuiltInOutputReport, OutputReport() {
         }
     }
 
-    private fun renderFindings(findings: Map<RuleSet.Id, List<Finding2>>) = createHTML().div {
-        val total = findings.values
-            .asSequence()
-            .map { it.size }
-            .fold(0) { a, b -> a + b }
+    private fun renderFindings(findings: List<Finding2>) = createHTML().div {
+        val total = findings.count()
 
         text("Total: %,d".format(Locale.ROOT, total))
 
         findings
-            .filter { it.value.isNotEmpty() }
+            .groupBy { it.ruleInfo.ruleSetId }
             .toList()
             .sortedBy { (group, _) -> group.value }
             .forEach { (group, groupFindings) ->

--- a/detekt-report-md/src/main/kotlin/io/github/detekt/report/md/MdOutputReport.kt
+++ b/detekt-report-md/src/main/kotlin/io/github/detekt/report/md/MdOutputReport.kt
@@ -15,7 +15,6 @@ import io.gitlab.arturbosch.detekt.api.Detektion
 import io.gitlab.arturbosch.detekt.api.Finding2
 import io.gitlab.arturbosch.detekt.api.OutputReport
 import io.gitlab.arturbosch.detekt.api.ProjectMetric
-import io.gitlab.arturbosch.detekt.api.RuleSet
 import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.api.internal.BuiltInOutputReport
 import io.gitlab.arturbosch.detekt.api.internal.whichDetekt
@@ -120,16 +119,13 @@ private fun MarkdownContent.renderRule(ruleInfo: Finding2.RuleInfo, findings: Li
     }
 }
 
-private fun MarkdownContent.renderFindings(findings: Map<RuleSet.Id, List<Finding2>>) {
-    val total = findings.values
-        .asSequence()
-        .map { it.size }
-        .fold(0) { a, b -> a + b }
+private fun MarkdownContent.renderFindings(findings: List<Finding2>) {
+    val total = findings.count()
 
     h2 { "Findings (%,d)".format(Locale.ROOT, total) }
 
     findings
-        .filter { it.value.isNotEmpty() }
+        .groupBy { it.ruleInfo.ruleSetId }
         .toList()
         .sortedBy { (group, _) -> group.value }
         .forEach { (_, groupFindings) ->

--- a/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/Results.kt
+++ b/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/Results.kt
@@ -8,14 +8,11 @@ import io.github.detekt.sarif4k.Region
 import io.gitlab.arturbosch.detekt.api.Detektion
 import io.gitlab.arturbosch.detekt.api.Finding2
 import io.gitlab.arturbosch.detekt.api.Location
-import io.gitlab.arturbosch.detekt.api.RuleSet
 import io.gitlab.arturbosch.detekt.api.Severity
 import kotlin.io.path.invariantSeparatorsPathString
 
 internal fun toResults(detektion: Detektion): List<io.github.detekt.sarif4k.Result> =
-    detektion.findings.flatMap { (ruleSetId, findings) ->
-        findings.map { it.toResult(ruleSetId) }
-    }
+    detektion.findings.map { it.toResult() }
 
 internal fun Severity.toResultLevel() = when (this) {
     Severity.Error -> Level.Error
@@ -23,9 +20,9 @@ internal fun Severity.toResultLevel() = when (this) {
     Severity.Info -> Level.Note
 }
 
-private fun Finding2.toResult(ruleSetId: RuleSet.Id): io.github.detekt.sarif4k.Result {
+private fun Finding2.toResult(): io.github.detekt.sarif4k.Result {
     return io.github.detekt.sarif4k.Result(
-        ruleID = "detekt.$ruleSetId.${ruleInfo.id}",
+        ruleID = "detekt.${ruleInfo.ruleSetId}.${ruleInfo.id}",
         level = severity.toResultLevel(),
         locations = (listOf(location) + references.map { it.location }).map { it.toLocation() }.distinct(),
         message = Message(text = message)

--- a/detekt-report-txt/src/main/kotlin/io/github/detekt/report/txt/TxtOutputReport.kt
+++ b/detekt-report-txt/src/main/kotlin/io/github/detekt/report/txt/TxtOutputReport.kt
@@ -16,7 +16,6 @@ class TxtOutputReport : BuiltInOutputReport, OutputReport() {
 
     override fun render(detektion: Detektion): String {
         return detektion.findings
-            .flatMap { it.value }
             .ifEmpty { return "" }
             .joinToString("\n", postfix = "\n") { it.compactWithSignature() }
     }

--- a/detekt-report-xml/src/main/kotlin/io/github/detekt/report/xml/XmlOutputReport.kt
+++ b/detekt-report-xml/src/main/kotlin/io/github/detekt/report/xml/XmlOutputReport.kt
@@ -20,13 +20,12 @@ class XmlOutputReport : BuiltInOutputReport, OutputReport() {
         get() = severity.name.lowercase(Locale.US)
 
     override fun render(detektion: Detektion): String {
-        val smells = detektion.findings.flatMap { it.value }
-
         val lines = ArrayList<String>()
         lines += "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
         lines += "<checkstyle version=\"4.3\">"
 
-        smells.groupBy { it.location.filePath.relativePath ?: it.location.filePath.absolutePath }
+        detektion.findings
+            .groupBy { it.location.filePath.relativePath ?: it.location.filePath.absolutePath }
             .forEach { (filePath, findings) ->
                 lines += "<file name=\"${filePath.invariantSeparatorsPathString.toXmlString()}\">"
                 findings.forEach {

--- a/detekt-sample-extensions/src/test/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/processors/QualifiedNameProcessorSpec.kt
+++ b/detekt-sample-extensions/src/test/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/processors/QualifiedNameProcessorSpec.kt
@@ -5,7 +5,6 @@ import io.gitlab.arturbosch.detekt.api.Detektion
 import io.gitlab.arturbosch.detekt.api.Finding2
 import io.gitlab.arturbosch.detekt.api.Notification
 import io.gitlab.arturbosch.detekt.api.ProjectMetric
-import io.gitlab.arturbosch.detekt.api.RuleSet
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.com.intellij.openapi.util.UserDataHolderBase
 import org.jetbrains.kotlin.resolve.BindingContext
@@ -31,7 +30,7 @@ class QualifiedNameProcessorSpec {
 
 private val result = object : Detektion, UserDataHolderBase() {
 
-    override val findings: Map<RuleSet.Id, List<Finding2>> = emptyMap()
+    override val findings: List<Finding2> = emptyList()
     override val notifications: Collection<Notification> = emptyList()
     override val metrics: Collection<ProjectMetric> = emptyList()
 

--- a/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/internal/EmptyContainer.kt
+++ b/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/internal/EmptyContainer.kt
@@ -4,12 +4,11 @@ import io.gitlab.arturbosch.detekt.api.Detektion
 import io.gitlab.arturbosch.detekt.api.Finding2
 import io.gitlab.arturbosch.detekt.api.Notification
 import io.gitlab.arturbosch.detekt.api.ProjectMetric
-import io.gitlab.arturbosch.detekt.api.RuleSet
 import org.jetbrains.kotlin.com.intellij.openapi.util.Key
 
 object EmptyContainer : Detektion {
 
-    override val findings: Map<RuleSet.Id, List<Finding2>> = emptyMap()
+    override val findings: List<Finding2> = emptyList()
     override val notifications: Collection<Notification> = emptyList()
     override val metrics: Collection<ProjectMetric> = emptyList()
 


### PR DESCRIPTION
This change simplifies a lot `Detektion` and all their related code. We were using `Map<RuleSet.Id, List<Finding2>>` as the only way to carry the `RuleSet.Id` of a finding. Now we have that information inside `Finding2` so we don't need this Map anymore.

You can see that a lot of reports were just flattening that map because they don't need it. And the ones that really need it now it is as simple as add a `findings.groupBy { it.rule.ruleSetId }`.

We should even check if we need to `sort` the findings at the `core` level. But I didn't want to touch that part right now.