### PR TITLE
Move `@file:Suppress` handling from `Rule` to `core`

### DIFF
--- a/detekt-api/api/detekt-api.api
+++ b/detekt-api/api/detekt-api.api
@@ -327,7 +327,6 @@ public class io/gitlab/arturbosch/detekt/api/Rule : io/gitlab/arturbosch/detekt/
 	public final fun setBindingContext (Lorg/jetbrains/kotlin/resolve/BindingContext;)V
 	public final fun setCompilerResources (Lio/gitlab/arturbosch/detekt/api/CompilerResources;)V
 	public fun visit (Lorg/jetbrains/kotlin/psi/KtFile;)V
-	public fun visitCondition (Lorg/jetbrains/kotlin/psi/KtFile;)Z
 	public final fun visitFile (Lorg/jetbrains/kotlin/psi/KtFile;Lorg/jetbrains/kotlin/resolve/BindingContext;Lio/gitlab/arturbosch/detekt/api/CompilerResources;)Ljava/util/List;
 	public static synthetic fun visitFile$default (Lio/gitlab/arturbosch/detekt/api/Rule;Lorg/jetbrains/kotlin/psi/KtFile;Lorg/jetbrains/kotlin/resolve/BindingContext;Lio/gitlab/arturbosch/detekt/api/CompilerResources;ILjava/lang/Object;)Ljava/util/List;
 }

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Rule.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Rule.kt
@@ -34,7 +34,7 @@ open class Rule(
     /**
      * List of rule ids which can optionally be used in suppress annotations to refer to this rule.
      */
-    val aliases: Set<String> get() = config.valueOrDefault("aliases", defaultRuleIdAliases)
+    val aliases: Set<String> get() = config.valueOrDefault("aliases", defaultRuleIdAliases.toList()).toSet()
 
     var bindingContext: BindingContext = BindingContext.EMPTY
     var compilerResources: CompilerResources? = null

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Rule.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Rule.kt
@@ -73,11 +73,9 @@ open class Rule(
         findings.clear()
         this.bindingContext = bindingContext
         this.compilerResources = compilerResources
-        if (visitCondition(root)) {
-            preVisit(root)
-            visit(root)
-            postVisit(root)
-        }
+        preVisit(root)
+        visit(root)
+        postVisit(root)
         return findings
     }
 
@@ -104,13 +102,6 @@ open class Rule(
     protected open fun postVisit(root: KtFile) {
         // nothing to do by default
     }
-
-    /**
-     * Basic mechanism to decide if a rule should run or not.
-     *
-     * By default, any rule not suppressed by a [Suppress] annotation on file level should run.
-     */
-    open fun visitCondition(root: KtFile): Boolean = !root.isSuppressedBy(ruleId, aliases, ruleSetId)
 
     /**
      * Reports a single code smell finding.

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Analyzer.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Analyzer.kt
@@ -16,6 +16,7 @@ import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.RuleSet
 import io.gitlab.arturbosch.detekt.api.RuleSetProvider
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.internal.isSuppressedBy
 import io.gitlab.arturbosch.detekt.api.internal.whichDetekt
 import io.gitlab.arturbosch.detekt.api.internal.whichJava
 import io.gitlab.arturbosch.detekt.api.internal.whichOS
@@ -125,6 +126,7 @@ internal class Analyzer(
                     .filter { (_, config) -> config.isActiveOrDefault(false) }
                     .filter { (_, config) -> config.shouldAnalyzeFile(file) }
                     .map { (ruleProvider, config) -> ruleProvider(config) }
+                    .filter { rule -> !file.isSuppressedBy(rule.ruleId, rule.aliases, ruleSet.id) }
             }
             .filter { rule ->
                 bindingContext != BindingContext.EMPTY || !rule::class.hasAnnotation<RequiresTypeResolution>()

--- a/detekt-core/src/test/resources/suppression/SuppressedByAllObject.kt
+++ b/detekt-core/src/test/resources/suppression/SuppressedByAllObject.kt
@@ -1,8 +1,0 @@
-@file:SuppressWarnings("ALL")
-
-object SuppressedByAllObject {
-
-    fun stuff() {
-        println("FAILED TEST")
-    }
-}

--- a/detekt-core/src/test/resources/suppression/SuppressedObject.kt
+++ b/detekt-core/src/test/resources/suppression/SuppressedObject.kt
@@ -1,8 +1,0 @@
-@file:SuppressWarnings("TestRule")
-
-object SuppressedObject {
-
-    fun stuff() {
-        println("FAILED TEST")
-    }
-}

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingRuleSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingRuleSpec.kt
@@ -24,19 +24,6 @@ class FormattingRuleSpec {
     inner class `formatting rules can be suppressed` {
 
         @Test
-        fun `does support suppression on file level`() {
-            val findings = subject.compileAndLint(
-                """
-                    @file:Suppress("NoLineBreakBeforeAssignment")
-                    fun main()
-                    = Unit
-                """.trimIndent()
-            )
-
-            assertThat(findings).isEmpty()
-        }
-
-        @Test
         fun `support suppression on node level`() {
             val findings = subject.compileAndLint(
                 """

--- a/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/AbsentOrWrongFileLicense.kt
+++ b/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/AbsentOrWrongFileLicense.kt
@@ -29,11 +29,8 @@ class AbsentOrWrongFileLicense(config: Config) : Rule(
     @Configuration("whether or not the license header template is a regex template")
     private val licenseTemplateIsRegex: Boolean by config(DEFAULT_LICENSE_TEMPLATE_IS_REGEX)
 
-    override fun visitCondition(root: KtFile): Boolean =
-        super.visitCondition(root) && (root.hasLicenseHeader() || root.hasLicenseHeaderRegex())
-
     override fun visitKtFile(file: KtFile) {
-        if (!file.hasValidLicense()) {
+        if ((file.hasLicenseHeader() || file.hasLicenseHeaderRegex()) && !file.hasValidLicense()) {
             report(
                 CodeSmell(
                     issue,

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/InvalidPackageDeclarationSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/InvalidPackageDeclarationSpec.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lint
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import kotlin.io.path.Path
@@ -23,11 +24,9 @@ class InvalidPackageDeclarationSpec {
     }
 
     @Test
-    fun `should ignore the issue by alias suppression`() {
-        val ktFile = compileForTest(Path("src/test/resources/InvalidPackageDeclarationSpec/src/bar/suppressed.kt"))
-        val findings = InvalidPackageDeclaration(Config.empty).lint(ktFile)
-
-        assertThat(findings).isEmpty()
+    fun `has correct aliases`() {
+        assertThat(InvalidPackageDeclaration(Config.empty).aliases)
+            .containsExactlyInAnyOrder("PackageDirectoryMismatch")
     }
 
     @Test

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/PackageNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/PackageNamingSpec.kt
@@ -15,27 +15,9 @@ class PackageNamingSpec {
     }
 
     @Test
-    fun `should ignore the issue by alias suppression - PackageName`() {
-        assertThat(
-            PackageNaming(Config.empty).compileAndLint(
-                """
-                    @file:Suppress("PackageName")
-                    package FOO.BAR
-                """.trimIndent()
-            )
-        ).isEmpty()
-    }
-
-    @Test
     fun `should ignore the issue by alias suppression - PackageDirectoryMismatch`() {
-        assertThat(
-            PackageNaming(Config.empty).compileAndLint(
-                """
-                    @file:Suppress("PackageDirectoryMismatch")
-                    package FOO.BAR
-                """.trimIndent()
-            )
-        ).isEmpty()
+        assertThat(PackageNaming(Config.empty).aliases)
+            .containsExactlyInAnyOrder("PackageDirectoryMismatch", "PackageName")
     }
 
     @Test

--- a/detekt-rules-naming/src/test/resources/InvalidPackageDeclarationSpec/src/bar/suppressed.kt
+++ b/detekt-rules-naming/src/test/resources/InvalidPackageDeclarationSpec/src/bar/suppressed.kt
@@ -1,5 +1,0 @@
-@file:Suppress("PackageDirectoryMismatch")
-
-package foo
-
-class C

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenSuppressSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenSuppressSpec.kt
@@ -166,8 +166,10 @@ internal class ForbiddenSuppressSpec {
         @Test
         fun `does not catch self-suppression`() {
             val code = """
-                @file:Suppress("ForbiddenSuppress")
                 package config
+
+                @Suppress("ForbiddenSuppress")
+                class Foo
             """.trimIndent()
             val findings = subject.compileAndLint(code)
             assertThat(findings).hasSize(0)
@@ -176,8 +178,10 @@ internal class ForbiddenSuppressSpec {
         @Test
         fun `does not catch suppression of any forbidden rule when one of them`() {
             val code = """
-                @file:Suppress("ForbiddenSuppress", "ARule")
                 package config
+
+                @Suppress("ForbiddenSuppress", "ARule")
+                class Foo
             """.trimIndent()
             val findings = subject.compileAndLint(code)
             assertThat(findings).hasSize(0)

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedParameterSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedParameterSpec.kt
@@ -240,23 +240,6 @@ class UnusedParameterSpec(val env: KotlinCoreEnvironment) {
 
             assertThat(subject.lint(code)).isEmpty()
         }
-
-        @Test
-        fun `does not report parameters in annotated file`() {
-            val code = """
-                @file:Suppress("UNUSED_PARAMETER")
-                
-                class Test {
-                    fun foo(unused: String){}
-                
-                    class InnerTest {
-                        fun bar(unused: String){}
-                    }
-                }
-            """.trimIndent()
-
-            assertThat(subject.lint(code)).isEmpty()
-        }
     }
 
     @Nested

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMemberSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateMemberSpec.kt
@@ -347,24 +347,6 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
 
             assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
-
-        @Test
-        fun `does not report private functions in annotated file`() {
-            val code = """
-                @file:Suppress("unused")
-                
-                class Test {
-                    private fun foo(): String = ""
-                    private fun bar(): String = ""
-                
-                    class InnerTest {
-                        private fun baz(): String = ""
-                    }
-                }
-            """.trimIndent()
-
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
-        }
     }
 
     @Nested

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivatePropertySpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivatePropertySpec.kt
@@ -522,24 +522,6 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
         }
 
         @Test
-        fun `does not report private constructor properties in annotated file`() {
-            val code = """
-                @file:Suppress("unused")
-                
-                class Test(
-                    private val foo: String,
-                    private val bar: String
-                ) {
-                    class InnerTest(
-                        private val baz: String
-                    ) {}
-                }
-            """.trimIndent()
-
-            assertThat(subject.lint(code)).isEmpty()
-        }
-
-        @Test
         fun `does not report annotated private properties`() {
             val code = """
                 class Test {
@@ -582,24 +564,6 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
         fun `does not report private properties in class with annotated outer class`() {
             val code = """
                 @Suppress("unused")
-                class Test {
-                    private val foo: String
-                    private val bar: String
-                
-                    class InnerTest {
-                        private val baz: String
-                    }
-                }
-            """.trimIndent()
-
-            assertThat(subject.lint(code)).isEmpty()
-        }
-
-        @Test
-        fun `does not report private properties in annotated file`() {
-            val code = """
-                @file:Suppress("unused")
-                
                 class Test {
                     private val foo: String
                     private val bar: String

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/SuppressingSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/SuppressingSpec.kt
@@ -74,64 +74,6 @@ class SuppressingSpec {
     }
 
     @Test
-    fun `all findings are suppressed on file levels`() {
-        @Suppress("KotlinConstantConditions")
-        val code = """
-            @file:Suppress("LongMethod", "LongParameterList", "ComplexCondition")
-            
-            fun lpl2(a: Int, b: Int, c: Int, d: Int, e: Int, f: Int) = (a + b + c + d + e + f).apply {
-                assert(false) { "FAILED TEST" }
-            }
-            
-            class SuppressedElements2 {
-            
-                fun lpl(a: Int, b: Int, c: Int, d: Int, e: Int, f: Int) = (a + b + c + d + e + f).apply {
-                    assert(false) { "FAILED TEST" }
-                }
-            
-                fun cc() {
-                    if (this is SuppressedElements2 && this !is Any && this is Nothing && this is SuppressedElements2) {
-                        assert(false) { "FAIL" }
-                    }
-                }
-            
-                fun lm() {
-                    lpl(1, 2, 3, 4, 5, 6)
-                    lpl(1, 2, 3, 4, 5, 6)
-                    lpl(1, 2, 3, 4, 5, 6)
-                    lpl(1, 2, 3, 4, 5, 6)
-                    lpl(1, 2, 3, 4, 5, 6)
-                    lpl(1, 2, 3, 4, 5, 6)
-                    lpl(1, 2, 3, 4, 5, 6)
-                    lpl(1, 2, 3, 4, 5, 6)
-                    lpl(1, 2, 3, 4, 5, 6)
-                    lpl(1, 2, 3, 4, 5, 6)
-                    lpl(1, 2, 3, 4, 5, 6)
-                    lpl(1, 2, 3, 4, 5, 6)
-                    lpl(1, 2, 3, 4, 5, 6)
-                    lpl(1, 2, 3, 4, 5, 6)
-                    lpl(1, 2, 3, 4, 5, 6)
-                    lpl(1, 2, 3, 4, 5, 6)
-                    lpl(1, 2, 3, 4, 5, 6)
-                    lpl(1, 2, 3, 4, 5, 6)
-                    lpl(1, 2, 3, 4, 5, 6)
-                    lpl(1, 2, 3, 4, 5, 6)
-                    lpl(1, 2, 3, 4, 5, 6)
-                    assert(false) { "FAILED TEST" }
-                }
-            }
-        """.trimIndent()
-        val ktFile = compileContentForTest(code)
-        val findings = listOf(
-            LongMethod(Config.empty),
-            LongParameterList(Config.empty),
-            ComplexCondition(Config.empty),
-        ).flatMap { it.visitFile(ktFile) }
-
-        assertThat(findings).isEmpty()
-    }
-
-    @Test
     fun `all findings are suppressed on class levels`() {
         @Suppress("KotlinConstantConditions")
         val code = """


### PR DESCRIPTION
Right now our code treats different a `@Suppress` and `@file:Suppress`. This PR moves only the `@file:Suppress` handling. Also, we finally don't need `visitCondition` any more inside `Rule`. The rules doesn't decide any longer if they should execute or not. That's core job now 🎉.