### PR TITLE
Add @Deprecated to overridden functions that are deprecated in interface

### DIFF
--- a/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/internal/FakeKtElement.kt
+++ b/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/internal/FakeKtElement.kt
@@ -66,10 +66,12 @@ class FakeKtElement(val psiFile: PsiFile) : KtElement {
 
     override fun canNavigateToSource(): Boolean = false
 
+    @Deprecated("Deprecated in PsiElement interface")
     override fun checkAdd(p0: PsiElement) {
         // no-op
     }
 
+    @Deprecated("Deprecated in PsiElement interface")
     override fun checkDelete() {
         // no-op
     }


### PR DESCRIPTION
This is an IDE warning when using Kotlin 1.9.22 and 2.0.0-Beta3, but for some reason does not trigger a compiler warning on compilation with Kotlin 1.9.22, but it does with 2.0.0-Beta3.

Long story short, this deprecation should be added.