### PR TITLE
Report rule's default severity in sarif

### DIFF
--- a/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/Results.kt
+++ b/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/Results.kt
@@ -17,7 +17,7 @@ internal fun toResults(detektion: Detektion): List<io.github.detekt.sarif4k.Resu
         findings.map { it.toResult(ruleSetId) }
     }
 
-private fun Severity.toResultLevel() = when (this) {
+internal fun Severity.toResultLevel() = when (this) {
     Severity.Error -> Level.Error
     Severity.Warning -> Level.Warning
     Severity.Info -> Level.Note

--- a/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/RuleDescriptors.kt
+++ b/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/RuleDescriptors.kt
@@ -1,32 +1,37 @@
 package io.github.detekt.report.sarif
 
 import io.github.detekt.sarif4k.MultiformatMessageString
+import io.github.detekt.sarif4k.ReportingConfiguration
 import io.github.detekt.sarif4k.ReportingDescriptor
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.RuleSet
 import io.gitlab.arturbosch.detekt.api.RuleSetProvider
+import io.gitlab.arturbosch.detekt.api.Severity
 import java.util.ServiceLoader
 
 /**
  * Given the existing config, return a list of [ReportingDescriptor] for the rules.
  */
-internal fun toReportingDescriptors(): List<ReportingDescriptor> {
+internal fun toReportingDescriptors(config: Config): List<ReportingDescriptor> {
     val sets = ServiceLoader.load(RuleSetProvider::class.java, SarifOutputReport::class.java.classLoader)
         .map { it.instance() }
     val ruleSetIdAndRules = sets.flatMap { ruleSet ->
         ruleSet.rules.map { (_, provider) ->
-            ruleSet.id to provider(Config.empty).issue
+            val rule = provider(config)
+            val severity = rule.computeSeverity()
+            RuleInfo(ruleSet.id, rule.issue, severity)
         }
     }
     val descriptors = mutableListOf<ReportingDescriptor>()
-    ruleSetIdAndRules.forEach { (ruleSetId, issue) ->
-        descriptors.add(issue.toDescriptor(ruleSetId))
+    ruleSetIdAndRules.forEach { (ruleSetId, issue, severity) ->
+        descriptors.add(issue.toDescriptor(ruleSetId, severity))
     }
     return descriptors
 }
 
-private fun Issue.toDescriptor(ruleSetId: RuleSet.Id): ReportingDescriptor {
+private fun Issue.toDescriptor(ruleSetId: RuleSet.Id, severity: Severity): ReportingDescriptor {
     val formattedRuleSetId = ruleSetId.value.lowercase()
     val formattedRuleId = id.value.lowercase()
 
@@ -34,6 +39,28 @@ private fun Issue.toDescriptor(ruleSetId: RuleSet.Id): ReportingDescriptor {
         id = "detekt.$ruleSetId.$id",
         name = id.value,
         shortDescription = MultiformatMessageString(text = description),
-        helpURI = "https://detekt.dev/$formattedRuleSetId.html#$formattedRuleId"
+        helpURI = "https://detekt.dev/$formattedRuleSetId.html#$formattedRuleId",
+        defaultConfiguration = ReportingConfiguration(
+            level = severity.toResultLevel()
+        )
     )
+}
+
+private data class RuleInfo(
+    val id: RuleSet.Id,
+    val severity: Issue,
+    val issue: Severity
+)
+
+private fun Rule.computeSeverity(): Severity {
+    val configValue: String = config.valueOrNull(Config.SEVERITY_KEY)
+        ?: config.parent?.valueOrNull(Config.SEVERITY_KEY)
+        ?: return Severity.Error
+    return parseToSeverity(configValue)
+}
+
+internal fun parseToSeverity(severity: String): Severity {
+    val lowercase = severity.lowercase()
+    return Severity.entries.find { it.name.lowercase() == lowercase }
+        ?: error("$severity is not a valid Severity. Allowed values are ${Severity.entries}")
 }

--- a/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/RuleDescriptors.kt
+++ b/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/RuleDescriptors.kt
@@ -18,8 +18,9 @@ internal fun toReportingDescriptors(config: Config): List<ReportingDescriptor> {
     val sets = ServiceLoader.load(RuleSetProvider::class.java, SarifOutputReport::class.java.classLoader)
         .map { it.instance() }
     val ruleSetIdAndRules = sets.flatMap { ruleSet ->
-        ruleSet.rules.map { (_, provider) ->
-            val rule = provider(config)
+        val ruleSetConfig = config.subConfig(ruleSet.id.value)
+        ruleSet.rules.map { (id, provider) ->
+            val rule = provider(ruleSetConfig.subConfig(id.value))
             val severity = rule.computeSeverity()
             RuleInfo(ruleSet.id, rule.issue, severity)
         }

--- a/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/SarifOutputReport.kt
+++ b/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/SarifOutputReport.kt
@@ -38,7 +38,7 @@ class SarifOutputReport : BuiltInOutputReport, OutputReport() {
                 if (!it.endsWith("/")) "$it/" else it
             }
 
-        this.config = config
+        this.config = context.config
     }
 
     override fun render(detektion: Detektion): String {

--- a/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/SarifOutputReport.kt
+++ b/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/SarifOutputReport.kt
@@ -28,7 +28,7 @@ class SarifOutputReport : BuiltInOutputReport, OutputReport() {
     override val id: String = "sarif"
 
     private var basePath: String? = null
-    private var config: Config? = null
+    private lateinit var config: Config
 
     override fun init(context: SetupContext) {
         this.basePath = context.getOrNull<Path>(DETEKT_OUTPUT_REPORT_BASE_PATH_KEY)
@@ -42,8 +42,6 @@ class SarifOutputReport : BuiltInOutputReport, OutputReport() {
     }
 
     override fun render(detektion: Detektion): String {
-        val config = config ?: Config.empty
-
         val version = whichDetekt()
         val sarifSchema210 = SarifSchema210(
             schema = "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",

--- a/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/SarifOutputReport.kt
+++ b/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/SarifOutputReport.kt
@@ -7,6 +7,7 @@ import io.github.detekt.sarif4k.SarifSerializer
 import io.github.detekt.sarif4k.Tool
 import io.github.detekt.sarif4k.ToolComponent
 import io.github.detekt.sarif4k.Version
+import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Detektion
 import io.gitlab.arturbosch.detekt.api.OutputReport
 import io.gitlab.arturbosch.detekt.api.SetupContext
@@ -27,6 +28,7 @@ class SarifOutputReport : BuiltInOutputReport, OutputReport() {
     override val id: String = "sarif"
 
     private var basePath: String? = null
+    private var config: Config? = null
 
     override fun init(context: SetupContext) {
         this.basePath = context.getOrNull<Path>(DETEKT_OUTPUT_REPORT_BASE_PATH_KEY)
@@ -35,9 +37,13 @@ class SarifOutputReport : BuiltInOutputReport, OutputReport() {
             ?.let {
                 if (!it.endsWith("/")) "$it/" else it
             }
+
+        this.config = config
     }
 
     override fun render(detektion: Detektion): String {
+        val config = config ?: Config.empty
+
         val version = whichDetekt()
         val sarifSchema210 = SarifSchema210(
             schema = "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
@@ -52,7 +58,7 @@ class SarifOutputReport : BuiltInOutputReport, OutputReport() {
                             informationURI = "https://detekt.dev",
                             language = "en",
                             name = "detekt",
-                            rules = toReportingDescriptors(),
+                            rules = toReportingDescriptors(config),
                             organization = "detekt",
                             semanticVersion = version,
                             version = version

--- a/detekt-report-sarif/src/test/kotlin/io/github/detekt/report/sarif/SarifOutputReportSpec.kt
+++ b/detekt-report-sarif/src/test/kotlin/io/github/detekt/report/sarif/SarifOutputReportSpec.kt
@@ -6,6 +6,8 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Location
 import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.RuleSet
+import io.gitlab.arturbosch.detekt.api.RuleSetProvider
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.api.TextLocation
@@ -169,6 +171,11 @@ private fun constrainRegion(startLine: Int, startColumn: Int, endLine: Int, endC
       "startLine": $startLine
     }
 """.trimIndent()
+
+class TestProvider : RuleSetProvider {
+    override val ruleSetId = RuleSet.Id("test")
+    override fun instance(): RuleSet = RuleSet(ruleSetId, listOf(::TestRule))
+}
 
 class TestRule(config: Config = Config.empty) : Rule(config, "") {
     override fun visitClassOrObject(classOrObject: KtClassOrObject) {

--- a/detekt-report-sarif/src/test/resources/META-INF/services/io.gitlab.arturbosch.detekt.api.RuleSetProvider
+++ b/detekt-report-sarif/src/test/resources/META-INF/services/io.gitlab.arturbosch.detekt.api.RuleSetProvider
@@ -1,0 +1,1 @@
+io.github.detekt.report.sarif.TestProvider

--- a/detekt-report-sarif/src/test/resources/config_with_rule_set_to_warning.yml
+++ b/detekt-report-sarif/src/test/resources/config_with_rule_set_to_warning.yml
@@ -1,0 +1,3 @@
+test:
+  TestRule:
+    severity: 'warning'

--- a/detekt-report-sarif/src/test/resources/relative_path.sarif.json
+++ b/detekt-report-sarif/src/test/resources/relative_path.sarif.json
@@ -83,6 +83,17 @@
           "name": "detekt",
           "organization": "detekt",
           "rules": [
+            {
+              "defaultConfiguration": {
+                "level": "error"
+              },
+              "helpUri": "https://detekt.dev/test.html#testrule",
+              "id": "detekt.test.TestRule",
+              "name": "TestRule",
+              "shortDescription": {
+                "text": ""
+              }
+            }
           ],
           "semanticVersion": "1.16.0",
           "version": "1.16.0"

--- a/detekt-report-sarif/src/test/resources/rule_warning.sarif.json
+++ b/detekt-report-sarif/src/test/resources/rule_warning.sarif.json
@@ -1,0 +1,96 @@
+{
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "results": [
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "<PREFIX>TestFile.kt"
+                },
+                "region": {
+                  "startColumn": 1,
+                  "startLine": 1
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "TestMessage"
+          },
+          "ruleId": "detekt.TestSmellA.TestSmellA"
+        },
+        {
+          "level": "warning",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "<PREFIX>TestFile.kt"
+                },
+                "region": {
+                  "startColumn": 1,
+                  "startLine": 1
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "TestMessage"
+          },
+          "ruleId": "detekt.TestSmellB.TestSmellB"
+        },
+        {
+          "level": "note",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "<PREFIX>TestFile.kt"
+                },
+                "region": {
+                  "startColumn": 1,
+                  "startLine": 1
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "TestMessage"
+          },
+          "ruleId": "detekt.TestSmellC.TestSmellC"
+        }
+      ],
+      "tool": {
+        "driver": {
+          "downloadUri": "https://github.com/detekt/detekt/releases/download/v1.16.0/detekt",
+          "fullName": "detekt",
+          "guid": "022ca8c2-f6a2-4c95-b107-bb72c43263f3",
+          "informationUri": "https://detekt.dev",
+          "language": "en",
+          "name": "detekt",
+          "organization": "detekt",
+          "rules": [
+            {
+              "defaultConfiguration": {
+                "level": "warning"
+              },
+              "helpUri": "https://detekt.dev/test.html#testrule",
+              "id": "detekt.test.TestRule",
+              "name": "TestRule",
+              "shortDescription": {
+                "text": ""
+              }
+            }
+          ],
+          "semanticVersion": "1.16.0",
+          "version": "1.16.0"
+        }
+      }
+    }
+  ]
+}

--- a/detekt-report-sarif/src/test/resources/vanilla.sarif.json
+++ b/detekt-report-sarif/src/test/resources/vanilla.sarif.json
@@ -75,6 +75,17 @@
           "name": "detekt",
           "organization": "detekt",
           "rules": [
+            {
+              "defaultConfiguration": {
+                "level": "error"
+              },
+              "helpUri": "https://detekt.dev/test.html#testrule",
+              "id": "detekt.test.TestRule",
+              "name": "TestRule",
+              "shortDescription": {
+                "text": ""
+              }
+            }
           ],
           "semanticVersion": "1.16.0",
           "version": "1.16.0"


### PR DESCRIPTION
Some tools (such as [Github's sarif to markdown](https://github.com/security-alert/security-alert/blob/36dcb0cabe078e81f9b776e9a435b3fe1dfe2dbd/packages/sarif-to-markdown/src/sarif-to-markdown.ts#L204C31-L204C51)) seem to rely on `defaultConfiguration.level` being present on rules in sarif files.

This PR adds that field to detekt's sarif output.

I've copied `computeSeverity` method from [Analyzer.kt](https://github.com/detekt/detekt/blob/36e410b7347569ab8c1f71415e33e4fc2d5b0db6/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Analyzer.kt#L251). Since this method is in another module and it is fairly short, it seemed prudent to just create a copy. But I'm open to suggestions on how to reuse it.