### PR TITLE
Remove gradle versions plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,6 @@ import org.jetbrains.dokka.gradle.DokkaMultiModuleTask
 plugins {
     id("releasing")
     id("io.gitlab.arturbosch.detekt")
-    alias(libs.plugins.gradleVersions)
     alias(libs.plugins.dokka)
 }
 

--- a/detekt-compiler-plugin/build.gradle.kts
+++ b/detekt-compiler-plugin/build.gradle.kts
@@ -13,7 +13,6 @@ val detektPublication = "DetektPublication"
 
 plugins {
     id("module")
-    alias(libs.plugins.gradleVersions)
     alias(libs.plugins.shadow)
     alias(libs.plugins.download)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -49,7 +49,6 @@ kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 binaryCompatibilityValidator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version = "0.13.2" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 download = { id = "de.undercouch.download", version = "5.5.0" }
-gradleVersions = { id = "com.github.ben-manes.versions", version = "0.51.0" }
 pluginPublishing = { id = "com.gradle.plugin-publish", version = "1.2.1" }
 poko = { id = "dev.drewhamilton.poko", version.ref = "poko" }
 nexusPublish = { id = "io.github.gradle-nexus.publish-plugin", version = "1.3.0" }


### PR DESCRIPTION
We have renovate bot. We don't need this plugin any now.