### PR TITLE
Enable gradle worker api by default on detekt tasks

### DIFF
--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektReportMergeSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektReportMergeSpec.kt
@@ -45,7 +45,13 @@ class DetektReportMergeSpec {
             )
         }
 
-        val gradleRunner = DslGradleRunner(projectLayout, builder.gradleBuildName, buildFileContent)
+        val gradleRunner = DslGradleRunner(
+            projectLayout,
+            builder.gradleBuildName,
+            buildFileContent,
+            // because of https://github.com/gradle/gradle/issues/28034
+            gradleProperties = mapOf("detekt.use.worker.api" to "false"),
+        )
         gradleRunner.setupProject()
         gradleRunner.runTasksAndExpectFailure("detekt", "sarifReportMerge", "--continue") { result ->
             assertThat(result.output).contains("FAILURE: Build completed with 2 failures.")
@@ -108,7 +114,13 @@ class DetektReportMergeSpec {
             )
         }
 
-        val gradleRunner = DslGradleRunner(projectLayout, builder.gradleBuildName, buildFileContent)
+        val gradleRunner = DslGradleRunner(
+            projectLayout,
+            builder.gradleBuildName,
+            buildFileContent,
+            // because of https://github.com/gradle/gradle/issues/28034
+            gradleProperties = mapOf("detekt.use.worker.api" to "false"),
+        )
         gradleRunner.setupProject()
         gradleRunner.runTasksAndExpectFailure("detekt", "xmlReportMerge", "--continue") { result ->
             assertThat(result.output).contains("FAILURE: Build completed with 2 failures.")

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -175,7 +175,7 @@ abstract class Detekt @Inject constructor(
 
     @TaskAction
     fun check() {
-        if (providers.gradleProperty(USE_WORKER_API).getOrElse("false") == "true") {
+        if (providers.isWorkerApiEnabled()) {
             logger.info("Executing $name using Worker API")
             val workQueue = workerExecutor.processIsolation { workerSpec ->
                 workerSpec.classpath.from(detektClasspath)

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
@@ -143,7 +143,7 @@ abstract class DetektCreateBaselineTask @Inject constructor(
 
     @TaskAction
     fun baseline() {
-        if (providers.gradleProperty(USE_WORKER_API).getOrElse("false") == "true") {
+        if (providers.isWorkerApiEnabled()) {
             logger.info("Executing $name using Worker API")
             val workQueue = workerExecutor.processIsolation { workerSpec ->
                 workerSpec.classpath.from(detektClasspath)

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektGenerateConfigTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektGenerateConfigTask.kt
@@ -55,7 +55,7 @@ abstract class DetektGenerateConfigTask @Inject constructor(
 
         Files.createDirectories(configFile.get().asFile.parentFile.toPath())
 
-        if (providers.gradleProperty(USE_WORKER_API).getOrElse("false") == "true") {
+        if (providers.isWorkerApiEnabled()) {
             logger.info("Executing $name using Worker API")
             val workQueue = workerExecutor.processIsolation { workerSpec ->
                 workerSpec.classpath.from(detektClasspath)

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
@@ -151,7 +151,8 @@ class DetektPlugin : Plugin<Project> {
 internal const val CONFIGURATION_DETEKT = "detekt"
 
 internal fun ProviderFactory.isWorkerApiEnabled(): Boolean {
-    return gradleProperty("detekt.use.worker.api").getOrElse("false") == "true"
+    val defaultValue = isGradleVersionAtLeast(major = 7, minor = 6).toString()
+    return gradleProperty("detekt.use.worker.api").getOrElse(defaultValue).toBoolean()
 }
 
 @Incubating

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
@@ -13,7 +13,6 @@ import org.gradle.api.Incubating
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.provider.ProviderFactory
-import org.jetbrains.kotlin.gradle.utils.isGradleVersionAtLeast
 import java.net.URL
 import java.util.jar.Manifest
 
@@ -151,8 +150,7 @@ class DetektPlugin : Plugin<Project> {
 internal const val CONFIGURATION_DETEKT = "detekt"
 
 internal fun ProviderFactory.isWorkerApiEnabled(): Boolean {
-    val defaultValue = isGradleVersionAtLeast(major = 7, minor = 6).toString()
-    return gradleProperty("detekt.use.worker.api").getOrElse(defaultValue).toBoolean()
+    return gradleProperty("detekt.use.worker.api").getOrElse("true").toBoolean()
 }
 
 @Incubating

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
@@ -12,6 +12,8 @@ import io.gitlab.arturbosch.detekt.internal.DetektPlain
 import org.gradle.api.Incubating
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.provider.ProviderFactory
+import org.jetbrains.kotlin.gradle.utils.isGradleVersionAtLeast
 import java.net.URL
 import java.util.jar.Manifest
 
@@ -147,7 +149,10 @@ class DetektPlugin : Plugin<Project> {
 }
 
 internal const val CONFIGURATION_DETEKT = "detekt"
-internal const val USE_WORKER_API = "detekt.use.worker.api"
+
+internal fun ProviderFactory.isWorkerApiEnabled(): Boolean {
+    return gradleProperty("detekt.use.worker.api").getOrElse("false") == "true"
+}
 
 @Incubating
 fun getSupportedKotlinVersion(): String {

--- a/detekt-gradle-plugin/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/testkit/DslGradleRunner.kt
+++ b/detekt-gradle-plugin/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/testkit/DslGradleRunner.kt
@@ -22,6 +22,7 @@ constructor(
     val gradleVersionOrNone: String? = null,
     val dryRun: Boolean = false,
     val jvmArgs: String = "-Xmx2g -XX:MaxMetaspaceSize=1g",
+    gradleProperties: Map<String, String> = emptyMap(),
     val customPluginClasspath: List<File> = emptyList(),
     val projectScript: Project.() -> Unit = {}
 ) {
@@ -34,6 +35,9 @@ constructor(
         rootProject.name = "rootDir-project"
         include(${projectLayout.submodules.joinToString(",") { "\"${it.name}\"" }})
     """.trimIndent()
+
+    private val propertiesContent = gradleProperties.toList()
+        .joinToString(separator = "\n") { (key, value) -> "$key=$value" }
 
     @Language("xml")
     private val baselineContent = """
@@ -66,6 +70,7 @@ constructor(
     fun setupProject() {
         writeProjectFile(buildFileName, mainBuildFileContent)
         writeProjectFile(SETTINGS_FILENAME, settingsContent)
+        writeProjectFile(PROPERTIES_FILENAME, propertiesContent)
         configFileOrNone?.let { writeProjectFile(it, configFileContent) }
         baselineFiles.forEach { file -> writeProjectFile(file, baselineContent) }
         projectLayout.srcDirs.forEachIndexed { srcDirIdx, sourceDir ->
@@ -175,7 +180,8 @@ constructor(
     }
 
     companion object {
-        const val SETTINGS_FILENAME = "settings.gradle"
+        private const val SETTINGS_FILENAME = "settings.gradle"
+        private const val PROPERTIES_FILENAME = "gradle.properties"
         private const val DETEKT_TASK = "detekt"
     }
 }

--- a/website/docs/gettingstarted/gradle.mdx
+++ b/website/docs/gettingstarted/gradle.mdx
@@ -310,7 +310,7 @@ detekt {
 ### <a name="gradle-properties">Options for detekt Gradle properties</a>
 
 ```groovy
-// If set to true, enables Gradle Worker API for Detekt tasks. `false` by default.
+// If set to true, enables Gradle Worker API for Detekt tasks. `true` by default.
 // See the doc for the Worker API at https://docs.gradle.org/8.1/userguide/worker_api.html
 detekt.use.worker.api = false
 ```

--- a/website/docs/introduction/reporting.md
+++ b/website/docs/introduction/reporting.md
@@ -74,6 +74,13 @@ tasks will not run if detekt finds issues.
 
 :::
 
+:::caution Attention
+
+Because of [gradle/gradle#28034](https://github.com/gradle/gradle/issues/28034) to make `reportMerge` to work you need
+to [disable the Worker API](https://detekt.dev/docs/gettingstarted/gradle#options-for-detekt-gradle-properties).
+
+:::
+
 The machine-readable report formats support report merging.
 Detekt Gradle Plugin is not opinionated in how merging is set up and respects each project's build logic, especially 
 the merging makes most sense in a multi-module project. In this spirit, only Gradle tasks are provided.


### PR DESCRIPTION
Closes #6887
Closes #2957

To get the reasoning behind this change read the related issue.