### PR TITLE
Remove `autoCorrect` from rule set level

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -67,7 +67,6 @@ exceptions:
 formatting:
   active: true
   android: false
-  autoCorrect: true
   BinaryExpressionWrapping:
     active: true
   BlankLineBeforeDeclaration:

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Rule.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Rule.kt
@@ -52,8 +52,7 @@ open class Rule(
     private val ruleSetId: RuleSet.Id? get() = config.parent?.parentPath?.let(RuleSet::Id)
 
     val autoCorrect: Boolean
-        get() = config.valueOrDefault(Config.AUTO_CORRECT_KEY, false) &&
-            (config.parent?.valueOrDefault(Config.AUTO_CORRECT_KEY, true) != false)
+        get() = config.valueOrDefault(Config.AUTO_CORRECT_KEY, false)
 
     private val findings: MutableList<Finding> = mutableListOf()
 

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/TopLevelAutoCorrectSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/TopLevelAutoCorrectSpec.kt
@@ -31,7 +31,7 @@ class TopLevelAutoCorrectSpec {
                 inputPaths = listOf(fileUnderTest)
             }
             config {
-                resources = listOf(resourceUrl("configs/rule-and-ruleset-autocorrect-true.yaml"))
+                resources = listOf(resourceUrl("configs/rule-autocorrect-true.yaml"))
             }
             rules {
                 autoCorrect = false // fixture

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/WorkaroundConfigurationKtSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/WorkaroundConfigurationKtSpec.kt
@@ -66,69 +66,50 @@ class WorkaroundConfigurationKtSpec {
     @Nested
     inner class `auto correct config` {
 
-        @Nested
-        inner class `when specified it respects all autoCorrect values of rules and rule sets` {
-            private val config = ProcessingSpec {
+        @Test
+        fun `when specified it respects all autoCorrect values of rules and rule sets`() {
+            val config = ProcessingSpec {
                 config { resources = listOf(resourceUrl("/configs/config-with-auto-correct.yml")) }
                 rules { autoCorrect = true }
             }.let { spec ->
                 spec.workaroundConfiguration(spec.loadConfiguration())
             }
+            val style = config.subConfig("style")
 
-            private val style = config.subConfig("style")
-            private val comments = config.subConfig("comments")
-
-            @Test
-            fun `is disabled for rules`() {
-                assertThat(style.subConfig("MagicNumber").valueOrNull<Boolean>("autoCorrect")).isTrue()
-                assertThat(style.subConfig("MagicString").valueOrNull<Boolean>("autoCorrect")).isFalse()
-                assertThat(comments.subConfig("ClassDoc").valueOrNull<Boolean>("autoCorrect")).isTrue()
-                assertThat(comments.subConfig("FunctionDoc").valueOrNull<Boolean>("autoCorrect")).isFalse()
-            }
+            assertThat(style.subConfig("MagicNumber").valueOrNull<Boolean>("autoCorrect")).isTrue()
+            assertThat(style.subConfig("MagicString").valueOrNull<Boolean>("autoCorrect")).isFalse()
         }
 
-        @Nested
-        inner class `when not specified all autoCorrect values are overridden to false` {
-            private val config = ProcessingSpec {
+        @Test
+        fun `when not specified all autoCorrect values are overridden to false`() {
+            val config = ProcessingSpec {
                 config { resources = listOf(resourceUrl("/configs/config-with-auto-correct.yml")) }
             }.let { spec ->
                 spec.workaroundConfiguration(spec.loadConfiguration())
             }
-            private val style = config.subConfig("style")
-            private val comments = config.subConfig("comments")
+            val style = config.subConfig("style")
 
-            @Test
-            fun `is disabled for rules`() {
-                assertThat(style.subConfig("MagicNumber").valueOrNull<Boolean>("autoCorrect")).isFalse()
-                assertThat(style.subConfig("MagicString").valueOrNull<Boolean>("autoCorrect")).isFalse()
-                assertThat(comments.subConfig("ClassDoc").valueOrNull<Boolean>("autoCorrect")).isFalse()
-                assertThat(comments.subConfig("FunctionDoc").valueOrNull<Boolean>("autoCorrect")).isFalse()
-            }
+            assertThat(style.subConfig("MagicNumber").valueOrNull<Boolean>("autoCorrect")).isFalse()
+            assertThat(style.subConfig("MagicString").valueOrNull<Boolean>("autoCorrect")).isFalse()
         }
 
-        @Nested
-        inner class `when specified as false, all autoCorrect values are overridden to false` {
-            private val config = ProcessingSpec {
+        @Test
+        fun `when specified as false, all autoCorrect values are overridden to false`() {
+            val config = ProcessingSpec {
                 config { resources = listOf(resourceUrl("/configs/config-with-auto-correct.yml")) }
                 rules { autoCorrect = false }
             }.let { spec ->
                 spec.workaroundConfiguration(spec.loadConfiguration())
             }
-            private val style = config.subConfig("style")
-            private val comments = config.subConfig("comments")
+            val style = config.subConfig("style")
 
-            @Test
-            fun `is disabled for rules`() {
-                assertThat(style.subConfig("MagicNumber").valueOrNull<Boolean>("autoCorrect")).isFalse()
-                assertThat(style.subConfig("MagicString").valueOrNull<Boolean>("autoCorrect")).isFalse()
-                assertThat(comments.subConfig("ClassDoc").valueOrNull<Boolean>("autoCorrect")).isFalse()
-                assertThat(comments.subConfig("FunctionDoc").valueOrNull<Boolean>("autoCorrect")).isFalse()
-            }
+            assertThat(style.subConfig("MagicNumber").valueOrNull<Boolean>("autoCorrect")).isFalse()
+            assertThat(style.subConfig("MagicString").valueOrNull<Boolean>("autoCorrect")).isFalse()
         }
 
-        @Nested
-        inner class `regardless of other cli options, autoCorrect values are overridden to false` {
-            private val config = ProcessingSpec {
+        @Test
+        fun `regardless of other cli options, autoCorrect values are overridden to false`() {
+            val config = ProcessingSpec {
                 config {
                     useDefaultConfig = true
                     resources = listOf(resourceUrl("/configs/config-with-auto-correct.yml"))
@@ -141,16 +122,10 @@ class WorkaroundConfigurationKtSpec {
                 spec.workaroundConfiguration(spec.loadConfiguration())
             }
 
-            private val style = config.subConfig("style")
-            private val comments = config.subConfig("comments")
+            val style = config.subConfig("style")
 
-            @Test
-            fun `is disabled for rules`() {
-                assertThat(style.subConfig("MagicNumber").valueOrNull<Boolean>("autoCorrect")).isFalse()
-                assertThat(style.subConfig("MagicString").valueOrNull<Boolean>("autoCorrect")).isFalse()
-                assertThat(comments.subConfig("ClassDoc").valueOrNull<Boolean>("autoCorrect")).isFalse()
-                assertThat(comments.subConfig("FunctionDoc").valueOrNull<Boolean>("autoCorrect")).isFalse()
-            }
+            assertThat(style.subConfig("MagicNumber").valueOrNull<Boolean>("autoCorrect")).isFalse()
+            assertThat(style.subConfig("MagicString").valueOrNull<Boolean>("autoCorrect")).isFalse()
         }
     }
 }

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/WorkaroundConfigurationKtSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/WorkaroundConfigurationKtSpec.kt
@@ -6,6 +6,8 @@ import io.gitlab.arturbosch.detekt.core.config.loadConfiguration
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
 
 class WorkaroundConfigurationKtSpec {
 
@@ -67,7 +69,7 @@ class WorkaroundConfigurationKtSpec {
     inner class `auto correct config` {
 
         @Test
-        fun `when specified it respects all autoCorrect values of rules and rule sets`() {
+        fun `when specified it respects all autoCorrect values of rules`() {
             val config = ProcessingSpec {
                 config { resources = listOf(resourceUrl("/configs/config-with-auto-correct.yml")) }
                 rules { autoCorrect = true }
@@ -80,43 +82,27 @@ class WorkaroundConfigurationKtSpec {
             assertThat(style.subConfig("MagicString").valueOrNull<Boolean>("autoCorrect")).isFalse()
         }
 
-        @Test
-        fun `when not specified all autoCorrect values are overridden to false`() {
-            val config = ProcessingSpec {
-                config { resources = listOf(resourceUrl("/configs/config-with-auto-correct.yml")) }
-            }.let { spec ->
-                spec.workaroundConfiguration(spec.loadConfiguration())
-            }
-            val style = config.subConfig("style")
-
-            assertThat(style.subConfig("MagicNumber").valueOrNull<Boolean>("autoCorrect")).isFalse()
-            assertThat(style.subConfig("MagicString").valueOrNull<Boolean>("autoCorrect")).isFalse()
-        }
-
-        @Test
-        fun `when specified as false, all autoCorrect values are overridden to false`() {
-            val config = ProcessingSpec {
-                config { resources = listOf(resourceUrl("/configs/config-with-auto-correct.yml")) }
-                rules { autoCorrect = false }
-            }.let { spec ->
-                spec.workaroundConfiguration(spec.loadConfiguration())
-            }
-            val style = config.subConfig("style")
-
-            assertThat(style.subConfig("MagicNumber").valueOrNull<Boolean>("autoCorrect")).isFalse()
-            assertThat(style.subConfig("MagicString").valueOrNull<Boolean>("autoCorrect")).isFalse()
-        }
-
-        @Test
-        fun `regardless of other cli options, autoCorrect values are overridden to false`() {
+        @ParameterizedTest
+        @CsvSource(
+            """
+                true, true
+                true, false
+                false, true
+                false, false
+            """
+        )
+        fun `regardless of other cli options, autoCorrect values are overridden to false`(
+            useDefaultConfig: Boolean,
+            activateAllRules: Boolean
+        ) {
             val config = ProcessingSpec {
                 config {
-                    useDefaultConfig = true
+                    this.useDefaultConfig = useDefaultConfig
                     resources = listOf(resourceUrl("/configs/config-with-auto-correct.yml"))
                 }
                 rules {
                     autoCorrect = false
-                    activateAllRules = true
+                    this.activateAllRules = activateAllRules
                 }
             }.let { spec ->
                 spec.workaroundConfiguration(spec.loadConfiguration())

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/WorkaroundConfigurationKtSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/WorkaroundConfigurationKtSpec.kt
@@ -68,7 +68,6 @@ class WorkaroundConfigurationKtSpec {
 
         @Nested
         inner class `when specified it respects all autoCorrect values of rules and rule sets` {
-
             private val config = ProcessingSpec {
                 config { resources = listOf(resourceUrl("/configs/config-with-auto-correct.yml")) }
                 rules { autoCorrect = true }
@@ -78,12 +77,6 @@ class WorkaroundConfigurationKtSpec {
 
             private val style = config.subConfig("style")
             private val comments = config.subConfig("comments")
-
-            @Test
-            fun `is disabled for rule sets`() {
-                assertThat(style.valueOrNull<Boolean>("autoCorrect")).isTrue()
-                assertThat(comments.valueOrNull<Boolean>("autoCorrect")).isFalse()
-            }
 
             @Test
             fun `is disabled for rules`() {
@@ -105,12 +98,6 @@ class WorkaroundConfigurationKtSpec {
             private val comments = config.subConfig("comments")
 
             @Test
-            fun `is disabled for rule sets`() {
-                assertThat(style.valueOrNull<Boolean>("autoCorrect")).isFalse()
-                assertThat(comments.valueOrNull<Boolean>("autoCorrect")).isFalse()
-            }
-
-            @Test
             fun `is disabled for rules`() {
                 assertThat(style.subConfig("MagicNumber").valueOrNull<Boolean>("autoCorrect")).isFalse()
                 assertThat(style.subConfig("MagicString").valueOrNull<Boolean>("autoCorrect")).isFalse()
@@ -129,12 +116,6 @@ class WorkaroundConfigurationKtSpec {
             }
             private val style = config.subConfig("style")
             private val comments = config.subConfig("comments")
-
-            @Test
-            fun `is disabled for rule sets`() {
-                assertThat(style.valueOrNull<Boolean>("autoCorrect")).isFalse()
-                assertThat(comments.valueOrNull<Boolean>("autoCorrect")).isFalse()
-            }
 
             @Test
             fun `is disabled for rules`() {
@@ -162,12 +143,6 @@ class WorkaroundConfigurationKtSpec {
 
             private val style = config.subConfig("style")
             private val comments = config.subConfig("comments")
-
-            @Test
-            fun `is disabled for rule sets`() {
-                assertThat(style.valueOrNull<Boolean>("autoCorrect")).isFalse()
-                assertThat(comments.valueOrNull<Boolean>("autoCorrect")).isFalse()
-            }
 
             @Test
             fun `is disabled for rules`() {

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/DisabledAutoCorrectConfigSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/DisabledAutoCorrectConfigSpec.kt
@@ -14,22 +14,6 @@ class DisabledAutoCorrectConfigSpec {
         """.trimIndent()
     )
 
-    private val configWithAutoCorrect = yamlConfigFromContent(
-        """
-            style:
-              MagicNumber:
-                autoCorrect: true
-              MagicString:
-                autoCorrect: false
-            
-            comments:
-              ClassDoc:
-                autoCorrect: true
-              FunctionDoc:
-                autoCorrect: false
-        """.trimIndent()
-    )
-
     @Test
     fun `subConfigs returns the expected number of sub configs`() {
         val subject = DisabledAutoCorrectConfig(configSingleRuleInStyle)
@@ -57,7 +41,7 @@ class DisabledAutoCorrectConfigSpec {
         val commentsConfig = DisabledAutoCorrectConfig(config.subConfig("comments"))
         commentsConfig.subConfig("ClassDoc").let { classDocConfig ->
             assertThat(classDocConfig.valueOrDefault("autoCorrect", true)).isFalse()
-            assert(classDocConfig.valueOrNull<Boolean>("autoCorrect") == false)
+            assertThat(classDocConfig.valueOrNull<Boolean>("autoCorrect")).isFalse()
         }
     }
 
@@ -77,27 +61,37 @@ class DisabledAutoCorrectConfigSpec {
 
         commentsConfig.subConfig("ClassDoc").let { classDocConfig ->
             assertThat(classDocConfig.valueOrDefault("test", true)).isTrue()
-            assert(classDocConfig.valueOrNull<Boolean>("test") == true)
+            assertThat(classDocConfig.valueOrNull<Boolean>("test")).isTrue()
         }
 
         commentsConfig.subConfig("FunctionDoc").let { functionDocConfig ->
             assertThat(functionDocConfig.valueOrDefault("test", true)).isTrue()
-            assert(functionDocConfig.valueOrNull<Boolean>("test") == true)
+            assertThat(functionDocConfig.valueOrNull<Boolean>("test")).isTrue()
         }
     }
 
     @Test
     fun `verify the autocorrect field always false`() {
-        val commentsConfig = DisabledAutoCorrectConfig(configWithAutoCorrect.subConfig("comments"))
+        val config = yamlConfigFromContent(
+            """
+                comments:
+                  ClassDoc:
+                    autoCorrect: true
+                  FunctionDoc:
+                    autoCorrect: false
+        """.trimIndent()
+        )
+
+        val commentsConfig = DisabledAutoCorrectConfig(config.subConfig("comments"))
 
         commentsConfig.subConfig("ClassDoc").let { classDocConfig ->
             assertThat(classDocConfig.valueOrDefault("autoCorrect", true)).isFalse()
-            assert(classDocConfig.valueOrNull<Boolean>("autoCorrect") == false)
+            assertThat(classDocConfig.valueOrNull<Boolean>("autoCorrect")).isFalse()
         }
 
         commentsConfig.subConfig("FunctionDoc").let { functionDocConfig ->
             assertThat(functionDocConfig.valueOrDefault("autoCorrect", true)).isFalse()
-            assert(functionDocConfig.valueOrNull<Boolean>("autoCorrect") == false)
+            assertThat(functionDocConfig.valueOrNull<Boolean>("autoCorrect")).isFalse()
         }
     }
 

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/DisabledAutoCorrectConfigSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/DisabledAutoCorrectConfigSpec.kt
@@ -17,14 +17,12 @@ class DisabledAutoCorrectConfigSpec {
     private val configWithAutoCorrect = yamlConfigFromContent(
         """
             style:
-              autoCorrect: true
               MagicNumber:
                 autoCorrect: true
               MagicString:
                 autoCorrect: false
             
             comments:
-              autoCorrect: false
               ClassDoc:
                 autoCorrect: true
               FunctionDoc:
@@ -51,7 +49,6 @@ class DisabledAutoCorrectConfigSpec {
         val config = yamlConfigFromContent(
             """
             comments:
-              autoCorrect: false
               ClassDoc:
                 test: true
             """.trimMargin()

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/DisabledAutoCorrectConfigSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/DisabledAutoCorrectConfigSpec.kt
@@ -32,9 +32,9 @@ class DisabledAutoCorrectConfigSpec {
     fun `verify the autocorrect field false in case the autoCorrect not present into yaml config`() {
         val config = yamlConfigFromContent(
             """
-            comments:
-              ClassDoc:
-                test: true
+                comments:
+                  ClassDoc:
+                    test: true
             """.trimMargin()
         )
 
@@ -49,11 +49,11 @@ class DisabledAutoCorrectConfigSpec {
     fun `verify the disable auto correct config return fields as normal`() {
         val config = yamlConfigFromContent(
             """
-            comments:
-              ClassDoc:
-                test: true
-              FunctionDoc:
-                test: true
+                comments:
+                  ClassDoc:
+                    test: true
+                  FunctionDoc:
+                    test: true
             """.trimMargin()
         )
 
@@ -79,7 +79,7 @@ class DisabledAutoCorrectConfigSpec {
                     autoCorrect: true
                   FunctionDoc:
                     autoCorrect: false
-        """.trimIndent()
+            """.trimIndent()
         )
 
         val commentsConfig = DisabledAutoCorrectConfig(config.subConfig("comments"))

--- a/detekt-core/src/test/resources/configs/config-with-auto-correct.yml
+++ b/detekt-core/src/test/resources/configs/config-with-auto-correct.yml
@@ -3,9 +3,3 @@ style:
     autoCorrect: true
   MagicString:
     autoCorrect: false
-
-comments:
-  ClassDoc:
-    autoCorrect: true
-  FunctionDoc:
-    autoCorrect: false

--- a/detekt-core/src/test/resources/configs/config-with-auto-correct.yml
+++ b/detekt-core/src/test/resources/configs/config-with-auto-correct.yml
@@ -1,12 +1,10 @@
 style:
-  autoCorrect: true
   MagicNumber:
     autoCorrect: true
   MagicString:
     autoCorrect: false
 
 comments:
-  autoCorrect: false
   ClassDoc:
     autoCorrect: true
   FunctionDoc:

--- a/detekt-core/src/test/resources/configs/rule-autocorrect-true.yaml
+++ b/detekt-core/src/test/resources/configs/rule-autocorrect-true.yaml
@@ -1,4 +1,3 @@
 test-rule-set:
-  autoCorrect: true
   DeleteAnnotationsRule:
     autoCorrect: true

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingProvider.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingProvider.kt
@@ -221,9 +221,6 @@ class FormattingProvider : RuleSetProvider {
     companion object {
         @Configuration("if android style guides should be preferred")
         val android by ruleSetConfig(false)
-
-        @Configuration("if rules should auto correct style violation")
-        val autoCorrect by ruleSetConfig(true)
     }
 }
 

--- a/detekt-formatting/src/main/resources/config/config.yml
+++ b/detekt-formatting/src/main/resources/config/config.yml
@@ -1,7 +1,6 @@
 formatting:
   active: true
   android: false
-  autoCorrect: true
   AnnotationOnSeparateLine:
     active: true
     autoCorrect: true

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/AutoCorrectLevelSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/AutoCorrectLevelSpec.kt
@@ -18,7 +18,6 @@ class AutoCorrectLevelSpec {
             """
                 formatting:
                   active: true
-                  autoCorrect: true
                   ChainWrapping:
                     active: true
                     autoCorrect: true
@@ -32,31 +31,11 @@ class AutoCorrectLevelSpec {
     }
 
     @Test
-    fun `autoCorrect_ false on ruleSet level should not reformat the test file`() {
-        val config = yamlConfigFromContent(
-            """
-                formatting:
-                  active: true
-                  autoCorrect: false
-                  ChainWrapping:
-                    active: true
-                    autoCorrect: true
-            """.trimIndent()
-        )
-
-        val (file, findings) = runRule(config)
-
-        assertThat(findings).isNotEmpty()
-        assertThat(wasFormatted(file)).isFalse()
-    }
-
-    @Test
     fun `autoCorrect_ false on rule level should not reformat the test file`() {
         val config = yamlConfigFromContent(
             """
                 formatting:
                   active: true
-                  autoCorrect: true
                   ChainWrapping:
                     active: true
                     autoCorrect: false


### PR DESCRIPTION
Fixes #1466

Based on the #1466 discussion we want that a rule with `autoCorrect: true` autocorrects even if its rule set says `autoCorrect: false`. Then there is no reason to keep `autoCorrect` at rule set level. If you want to autoCorrect you enable it at "detekt" level and the the rules decide if they should autoCorrect or not. If you don't want to autoCorrect you just not enable it at detekt level and that's it.

For that reason I'm removing this intermediate flag.