### PR TITLE
Simplify `MessageCollectorExtensions`

### DIFF
--- a/detekt-compiler-plugin/src/main/kotlin/io/github/detekt/compiler/plugin/internal/MessageCollectorExtensions.kt
+++ b/detekt-compiler-plugin/src/main/kotlin/io/github/detekt/compiler/plugin/internal/MessageCollectorExtensions.kt
@@ -21,14 +21,9 @@ fun MessageCollector.error(msg: String) {
 }
 
 fun MessageCollector.reportFindings(result: Detektion) {
-    for ((ruleSetId, findings) in result.findings.entries) {
-        if (findings.isNotEmpty()) {
-            info("$ruleSetId: ${findings.size} findings found.")
-            for (issue in findings) {
-                val (message, location) = issue.renderAsCompilerWarningMessage()
-                warn(message, location)
-            }
-        }
+    for (finding in result.findings.values.flatten()) {
+        val (message, location) = finding.renderAsCompilerWarningMessage()
+        warn(message, location)
     }
 }
 


### PR DESCRIPTION
There is not reason to group this issues by rulset. This code will be even more simplier once #6884 is merger. The `flatten` will not be needed.