### PR TITLE
Change how we decide if a rule should autocorrect or not

### DIFF
--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Rule.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Rule.kt
@@ -52,8 +52,10 @@ open class Rule(
     private val ruleSetId: RuleSet.Id? get() = config.parent?.parentPath?.let(RuleSet::Id)
 
     val autoCorrect: Boolean
-        get() = config.valueOrDefault(Config.AUTO_CORRECT_KEY, false) &&
-            (config.parent?.valueOrDefault(Config.AUTO_CORRECT_KEY, true) != false)
+        get() = config.valueOrDefault(
+            Config.AUTO_CORRECT_KEY,
+            (config.parent?.valueOrNull<Boolean>(Config.AUTO_CORRECT_KEY)) == true,
+        )
 
     private val findings: MutableList<Finding> = mutableListOf()
 

--- a/detekt-formatting/src/main/resources/config/config.yml
+++ b/detekt-formatting/src/main/resources/config/config.yml
@@ -36,6 +36,7 @@ formatting:
     indentSize: 4
   ClassName:
     active: false
+    autoCorrect: false
   ClassSignature:
     active: false
     autoCorrect: true
@@ -66,6 +67,7 @@ formatting:
     indentSize: 4
   Filename:
     active: true
+    autoCorrect: false
   FinalNewline:
     active: true
     autoCorrect: true
@@ -85,6 +87,7 @@ formatting:
     maxLineLength: 120
   FunctionName:
     active: false
+    autoCorrect: false
   FunctionReturnTypeSpacing:
     active: true
     autoCorrect: true
@@ -127,10 +130,12 @@ formatting:
     indentSize: 4
   MaximumLineLength:
     active: true
+    autoCorrect: false
     maxLineLength: 120
     ignoreBackTickedIdentifier: false
   MixedConditionOperators:
     active: false
+    autoCorrect: false
   ModifierListSpacing:
     active: true
     autoCorrect: true
@@ -163,11 +168,13 @@ formatting:
     autoCorrect: true
   NoConsecutiveComments:
     active: true
+    autoCorrect: false
   NoEmptyClassBody:
     active: true
     autoCorrect: true
   NoEmptyFile:
     active: true
+    autoCorrect: false
   NoEmptyFirstLineInClassBody:
     active: true
     autoCorrect: true
@@ -202,12 +209,14 @@ formatting:
     autoCorrect: true
   NoWildcardImports:
     active: true
+    autoCorrect: false
     packagesToUseImportOnDemandProperty: 'java.util.*,kotlinx.android.synthetic.**'
   NullableTypeSpacing:
     active: true
     autoCorrect: true
   PackageName:
     active: true
+    autoCorrect: false
   ParameterListSpacing:
     active: true
     autoCorrect: true
@@ -224,6 +233,7 @@ formatting:
     maxLineLength: 120
   PropertyName:
     active: true
+    autoCorrect: false
   PropertyWrapping:
     active: true
     autoCorrect: true
@@ -297,12 +307,14 @@ formatting:
     indentSize: 4
   TypeArgumentComment:
     active: true
+    autoCorrect: false
   TypeArgumentListSpacing:
     active: true
     autoCorrect: true
     indentSize: 4
   TypeParameterComment:
     active: true
+    autoCorrect: false
   TypeParameterListSpacing:
     active: true
     autoCorrect: true
@@ -312,8 +324,10 @@ formatting:
     autoCorrect: true
   ValueArgumentComment:
     active: true
+    autoCorrect: false
   ValueParameterComment:
     active: true
+    autoCorrect: false
   Wrapping:
     active: true
     autoCorrect: true

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/AutoCorrectLevelSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/AutoCorrectLevelSpec.kt
@@ -18,11 +18,11 @@ class AutoCorrectLevelSpec {
         "Undefined, Undefined, false",
         "Undefined, True,      true",
         "Undefined, False,     false",
-        "True,      Undefined, false",
+        "True,      Undefined, true",
         "True,      True,      true",
         "True,      False,     false",
         "False,     Undefined, false",
-        "False,     True,      false",
+        "False,     True,      true",
         "False,     False,     false",
     )
     fun autoCorrect(

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/defaultconfig/RuleSetConfigPrinter.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/defaultconfig/RuleSetConfigPrinter.kt
@@ -23,19 +23,24 @@ internal fun YamlNode.printRuleSet(ruleSet: RuleSetProvider, rules: List<Rule>) 
 
         ruleSet.configuration.forEach(::printConfiguration)
 
-        rules.forEach(::printRule)
+        val autoCorrectEnabled = ruleSet.configuration.any {
+            it.name == Config.AUTO_CORRECT_KEY && it.defaultValue.getPlainValue() == "true"
+        }
+        rules.forEach { printRule(it, autoCorrectEnabled) }
 
         emptyLine()
     }
 }
 
-internal fun YamlNode.printRule(rule: Rule) {
+internal fun YamlNode.printRule(rule: Rule, autoCorrectableRuleSet: Boolean) {
     if (rule.isDeprecated()) return
 
     node(rule.name) {
         keyValue { Config.ACTIVE_KEY to "${rule.defaultActivationStatus.active}" }
         if (rule.autoCorrect) {
             keyValue { Config.AUTO_CORRECT_KEY to "true" }
+        } else if (autoCorrectableRuleSet) {
+            keyValue { Config.AUTO_CORRECT_KEY to "false" }
         }
         val ruleExclusion = exclusions.singleOrNull { it.isExcluded(rule) }
         if (ruleExclusion != null) {

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/printer/defaultconfig/RuleSetConfigPrinterTest.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/printer/defaultconfig/RuleSetConfigPrinterTest.kt
@@ -81,7 +81,7 @@ internal class RuleSetConfigPrinterTest {
         @Test
         fun `starts with rule name`() {
             val rule = ruleTemplate.copy(name = "RuleA")
-            val actual = yaml { printRule(rule) }
+            val actual = yaml { printRule(rule, false) }
             assertThat(actual).startsWith("RuleA:\n")
         }
 
@@ -91,14 +91,14 @@ internal class RuleSetConfigPrinterTest {
             @Test
             fun `has active property`() {
                 val rule = ruleTemplate.copy(defaultActivationStatus = Active("1.0.0"))
-                val actual = yaml { printRule(rule) }
+                val actual = yaml { printRule(rule, false) }
                 assertThat(actual.lines()).contains("  active: true")
             }
 
             @Test
             fun `has active property if inactive`() {
                 val rule = ruleTemplate.copy(defaultActivationStatus = Inactive)
-                val actual = yaml { printRule(rule) }
+                val actual = yaml { printRule(rule, false) }
                 assertThat(actual.lines()).contains("  active: false")
             }
         }
@@ -109,14 +109,14 @@ internal class RuleSetConfigPrinterTest {
             @Test
             fun `has auto correct property`() {
                 val rule = ruleTemplate.copy(autoCorrect = true)
-                val actual = yaml { printRule(rule) }
+                val actual = yaml { printRule(rule, false) }
                 assertThat(actual.lines()).contains("  autoCorrect: true")
             }
 
             @Test
             fun `omits auto correct property if false`() {
                 val rule = ruleTemplate.copy(autoCorrect = false)
-                val actual = yaml { printRule(rule) }
+                val actual = yaml { printRule(rule, false) }
                 assertThat(actual).doesNotContain(Config.AUTO_CORRECT_KEY)
             }
         }
@@ -129,14 +129,14 @@ internal class RuleSetConfigPrinterTest {
                 val anExclusion = exclusions[0]
                 val anExcludedRuleName = anExclusion.rules.first()
                 val rule = ruleTemplate.copy(name = anExcludedRuleName)
-                val actual = yaml { printRule(rule) }
+                val actual = yaml { printRule(rule, false) }
                 assertThat(actual.lines()).contains("  excludes: ${anExclusion.pattern}")
             }
 
             @Test
             fun `omits excludes property if rule is not excluded in any exclusion`() {
                 val rule = ruleTemplate.copy(name = "ARuleNameThatIsNotExcluded")
-                val actual = yaml { printRule(rule) }
+                val actual = yaml { printRule(rule, false) }
                 assertThat(actual).doesNotContain(Config.EXCLUDES_KEY)
             }
         }


### PR DESCRIPTION
Fixes #1466

Implement what #1466 says has one side effect. The rulsets with rules autocorrectables and other no autocorrectables we should define in all of them if they are auto correctables or not. Otherwise all of them are autocorrectables.

This PR is the successor of #6914