### PR TITLE
Require a path to be passed to --generate-config

### DIFF
--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt
@@ -46,10 +46,10 @@ class CliArgs {
 
     @Parameter(
         names = ["--generate-config", "-gc"],
-        description = "Export default config. " +
-            "Path can be specified with --config option (default path: default-detekt-config.yml)"
+        description = "Export default config to the provided path.",
+        converter = PathConverter::class,
     )
-    var generateConfig: Boolean = false
+    var generateConfig: Path? = null
 
     @Parameter(
         names = ["--plugins", "-p"],

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliRunner.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliRunner.kt
@@ -19,7 +19,7 @@ class CliRunner : DetektCli {
 
         val specialRunner = when {
             arguments.showVersion -> VersionPrinter(outputChannel)
-            arguments.generateConfig -> ConfigExporter(arguments, outputChannel)
+            arguments.generateConfig != null -> ConfigExporter(arguments, outputChannel)
             else -> null
         }
 

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Main.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Main.kt
@@ -61,7 +61,7 @@ fun buildRunner(
     val arguments = parseArguments(args)
     return when {
         arguments.showVersion -> VersionPrinter(outputPrinter)
-        arguments.generateConfig -> ConfigExporter(arguments, outputPrinter)
+        arguments.generateConfig != null -> ConfigExporter(arguments, outputPrinter)
         else -> Runner(arguments, outputPrinter, errorPrinter)
     }
 }

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/ConfigExporter.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/ConfigExporter.kt
@@ -4,7 +4,6 @@ import io.github.detekt.tooling.api.DefaultConfigurationProvider
 import io.github.detekt.tooling.api.spec.ProcessingSpec
 import io.gitlab.arturbosch.detekt.cli.CliArgs
 import io.gitlab.arturbosch.detekt.cli.MultipleExistingPathConverter
-import kotlin.io.path.Path
 import kotlin.io.path.absolute
 
 class ConfigExporter(
@@ -13,7 +12,7 @@ class ConfigExporter(
 ) : Executable {
 
     override fun execute() {
-        val configPath = Path(arguments.config ?: "detekt.yml")
+        val configPath = arguments.generateConfig ?: error("Unexpected error generating config file")
         val spec = ProcessingSpec {
             extensions {
                 disableDefaultRuleSets = arguments.disableDefaultRuleSets

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/MainSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/MainSpec.kt
@@ -25,7 +25,7 @@ class MainSpec {
         @Suppress("UnusedPrivateMember")
         private fun runnerConfigs(): List<Arguments> {
             return listOf(
-                arguments(arrayOf("--generate-config"), ConfigExporter::class),
+                arguments(arrayOf("--generate-config", "detekt-test.yml"), ConfigExporter::class),
                 arguments(arrayOf("--run-rule", "RuleSet:Rule"), Runner::class),
                 arguments(arrayOf("--version"), VersionPrinter::class),
                 arguments(emptyArray<String>(), Runner::class),

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/ConfigExporterSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/ConfigExporterSpec.kt
@@ -13,7 +13,7 @@ class ConfigExporterSpec {
     @Test
     fun `should export the given config`() {
         val tmpConfig = createTempFileForTest("ConfigPrinterSpec", ".yml").also { it.deleteExisting() }
-        val cliArgs = parseArguments(arrayOf("--config", tmpConfig.toString()))
+        val cliArgs = parseArguments(arrayOf("--generate-config", tmpConfig.toString()))
 
         ConfigExporter(cliArgs, NullPrintStream()).execute()
 

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektGenerateConfigTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektGenerateConfigTask.kt
@@ -1,7 +1,6 @@
 package io.gitlab.arturbosch.detekt
 
 import io.gitlab.arturbosch.detekt.invoke.CliArgument
-import io.gitlab.arturbosch.detekt.invoke.ConfigArgument
 import io.gitlab.arturbosch.detekt.invoke.DetektInvoker
 import io.gitlab.arturbosch.detekt.invoke.DetektWorkAction
 import io.gitlab.arturbosch.detekt.invoke.GenerateConfigArgument
@@ -44,8 +43,7 @@ abstract class DetektGenerateConfigTask @Inject constructor(
     @get:Internal
     internal val arguments
         get() = listOf(
-            GenerateConfigArgument,
-            ConfigArgument(configFile.get())
+            GenerateConfigArgument(configFile.get())
         ).flatMap(CliArgument::toArgument)
 
     @TaskAction

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/CliArgument.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/CliArgument.kt
@@ -35,8 +35,8 @@ internal data object CreateBaselineArgument : CliArgument() {
     override fun toArgument() = listOf(CREATE_BASELINE_PARAMETER)
 }
 
-internal data object GenerateConfigArgument : CliArgument() {
-    override fun toArgument() = listOf(GENERATE_CONFIG_PARAMETER)
+internal data class GenerateConfigArgument(val file: RegularFile) : CliArgument() {
+    override fun toArgument() = listOf(GENERATE_CONFIG_PARAMETER, file.asFile.absolutePath)
 }
 
 internal data class InputArgument(val fileCollection: FileCollection) : CliArgument() {


### PR DESCRIPTION
I was attempting a refactor but got stuck because of `--generate-config` which motivated a rethink of how that parameter is used.

Currently when that flag is used it changes the meaning of `--config` - in normal usage, `--config` is a set of config paths that are read by detekt, but when `-gc` flag is passed, it means `--config` should contain a single file only which will be written or overwritten.

This PR changes the interface so `-gc` accepts a path directly. This makes detekt CLI easier to use. To generate a config now users can do `detekt -gc <path>` instead of `detekt -gc true -c <path>`.