### PR TITLE
Set detekt report default names based on task name when using KMP

### DIFF
--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektMultiplatformSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektMultiplatformSpec.kt
@@ -49,6 +49,7 @@ class DetektMultiplatformSpec {
         fun `configures detekt task without type resolution`() {
             gradleRunner.runTasksAndCheckResult(":shared:detektMetadataMain") {
                 assertThat(it.output).containsPattern("""--baseline \S*[/\\]detekt-baseline.xml """)
+                assertThat(it.output).containsPattern("""--report xml:\S*[/\\]metadataMain.xml""")
                 assertDetektWithoutClasspath(it)
             }
         }
@@ -135,6 +136,7 @@ class DetektMultiplatformSpec {
         fun `configures detekt task with type resolution backend`() {
             gradleRunner.runTasksAndCheckResult(":shared:detektJvmBackendMain") {
                 assertThat(it.output).containsPattern("""--baseline \S*[/\\]detekt-baseline-main.xml """)
+                assertThat(it.output).containsPattern("""--report xml:\S*[/\\]jvmBackendMain.xml""")
                 assertDetektWithClasspath(it)
             }
         }
@@ -143,6 +145,7 @@ class DetektMultiplatformSpec {
         fun `configures detekt task with type resolution embedded`() {
             gradleRunner.runTasksAndCheckResult(":shared:detektJvmEmbeddedMain") {
                 assertThat(it.output).containsPattern("""--baseline \S*[/\\]detekt-baseline-main.xml """)
+                assertThat(it.output).containsPattern("""--report xml:\S*[/\\]jvmEmbeddedMain.xml""")
                 assertDetektWithClasspath(it)
             }
         }
@@ -219,10 +222,12 @@ class DetektMultiplatformSpec {
         fun `configures detekt task with type resolution`() {
             gradleRunner.runTasksAndCheckResult(":shared:detektAndroidDebug") {
                 assertThat(it.output).containsPattern("""--baseline \S*[/\\]detekt-baseline-debug.xml """)
+                assertThat(it.output).containsPattern("""--report xml:\S*[/\\]debug.xml""")
                 assertDetektWithClasspath(it)
             }
             gradleRunner.runTasksAndCheckResult(":shared:detektAndroidRelease") {
                 assertThat(it.output).containsPattern("""--baseline \S*[/\\]detekt-baseline-release.xml """)
+                assertThat(it.output).containsPattern("""--report xml:\S*[/\\]release.xml""")
                 assertDetektWithClasspath(it)
             }
         }
@@ -267,10 +272,12 @@ class DetektMultiplatformSpec {
         fun `configures detekt task without type resolution`() {
             gradleRunner.runTasksAndCheckResult(":shared:detektJsMain") {
                 assertThat(it.output).containsPattern("""--baseline \S*[/\\]detekt-baseline.xml """)
+                assertThat(it.output).containsPattern("""--report xml:\S*[/\\]jsMain.xml""")
                 assertDetektWithoutClasspath(it)
             }
             gradleRunner.runTasksAndCheckResult(":shared:detektJsTest") {
                 assertThat(it.output).containsPattern("""--baseline \S*[/\\]detekt-baseline.xml """)
+                assertThat(it.output).containsPattern("""--report xml:\S*[/\\]jsTest.xml""")
                 assertDetektWithoutClasspath(it)
             }
         }
@@ -323,18 +330,22 @@ class DetektMultiplatformSpec {
         fun `configures detekt task without type resolution`() {
             gradleRunner.runTasksAndCheckResult(":shared:detektIosArm64Main") {
                 assertThat(it.output).containsPattern("""--baseline \S*[/\\]detekt-baseline.xml """)
+                assertThat(it.output).containsPattern("""--report xml:\S*[/\\]iosArm64Main.xml""")
                 assertDetektWithoutClasspath(it)
             }
             gradleRunner.runTasksAndCheckResult(":shared:detektIosArm64Test") {
                 assertThat(it.output).containsPattern("""--baseline \S*[/\\]detekt-baseline.xml """)
+                assertThat(it.output).containsPattern("""--report xml:\S*[/\\]iosArm64Test.xml""")
                 assertDetektWithoutClasspath(it)
             }
             gradleRunner.runTasksAndCheckResult(":shared:detektIosX64Main") {
                 assertThat(it.output).containsPattern("""--baseline \S*[/\\]detekt-baseline.xml """)
+                assertThat(it.output).containsPattern("""--report xml:\S*[/\\]iosX64Main.xml""")
                 assertDetektWithoutClasspath(it)
             }
             gradleRunner.runTasksAndCheckResult(":shared:detektIosX64Test") {
                 assertThat(it.output).containsPattern("""--baseline \S*[/\\]detekt-baseline.xml """)
+                assertThat(it.output).containsPattern("""--report xml:\S*[/\\]iosX64Test.xml""")
                 assertDetektWithoutClasspath(it)
             }
         }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektMultiplatform.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektMultiplatform.kt
@@ -106,7 +106,7 @@ internal class DetektMultiplatform(private val project: Project) {
             }?.let { baselineFile ->
                 baseline.convention(layout.file(provider { baselineFile }))
             }
-            setReportOutputConventions(reports, extension, compilation.name)
+            setReportOutputConventions(reports, extension, taskSuffix.decapitalize())
             description =
                 "Run detekt analysis for target ${target.name} and source set ${compilation.name}"
             if (runWithTypeResolution) {


### PR DESCRIPTION
This ensures uniqueness within a project and prevents tasks overwriting reports generated by other detekt tasks in the same project.

Fixes #4035 