### PR TITLE
Use standard Gradle properties to manage built-in report outputs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,7 +51,6 @@ allprojects {
             md.required = true
         }
         basePath = rootDir.absolutePath
-        finalizedBy(detektReportMergeSarif)
     }
     detektReportMergeSarif {
         input.from(tasks.withType<Detekt>().map { it.reports.sarif.outputLocation })

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,7 +54,7 @@ allprojects {
         finalizedBy(detektReportMergeSarif)
     }
     detektReportMergeSarif {
-        input.from(tasks.withType<Detekt>().map { it.sarifReportFile })
+        input.from(tasks.withType<Detekt>().map { it.reports.sarif.outputLocation })
     }
     tasks.withType<DetektCreateBaselineTask>().configureEach {
         jvmTarget = "1.8"

--- a/detekt-gradle-plugin/api/detekt-gradle-plugin.api
+++ b/detekt-gradle-plugin/api/detekt-gradle-plugin.api
@@ -61,7 +61,6 @@ public abstract class io/gitlab/arturbosch/detekt/Detekt : org/gradle/api/tasks/
 	public abstract fun getParallel ()Lorg/gradle/api/provider/Property;
 	public abstract fun getPluginClasspath ()Lorg/gradle/api/file/ConfigurableFileCollection;
 	public fun getReports ()Lio/gitlab/arturbosch/detekt/extensions/DetektReports;
-	public abstract fun getReportsDir ()Lorg/gradle/api/file/DirectoryProperty;
 	public fun getSource ()Lorg/gradle/api/file/FileTree;
 	public final fun reports (Lorg/gradle/api/Action;)V
 }

--- a/detekt-gradle-plugin/api/detekt-gradle-plugin.api
+++ b/detekt-gradle-plugin/api/detekt-gradle-plugin.api
@@ -62,14 +62,13 @@ public abstract class io/gitlab/arturbosch/detekt/Detekt : org/gradle/api/tasks/
 	public final fun getMdReportFile ()Lorg/gradle/api/provider/Provider;
 	public abstract fun getParallel ()Lorg/gradle/api/provider/Property;
 	public abstract fun getPluginClasspath ()Lorg/gradle/api/file/ConfigurableFileCollection;
-	public final fun getReports ()Lio/gitlab/arturbosch/detekt/extensions/DetektReports;
+	public abstract fun getReports ()Lio/gitlab/arturbosch/detekt/extensions/DetektReports;
 	public abstract fun getReportsDir ()Lorg/gradle/api/file/DirectoryProperty;
 	public final fun getSarifReportFile ()Lorg/gradle/api/provider/Provider;
 	public fun getSource ()Lorg/gradle/api/file/FileTree;
 	public final fun getTxtReportFile ()Lorg/gradle/api/provider/Provider;
 	public final fun getXmlReportFile ()Lorg/gradle/api/provider/Provider;
 	public final fun reports (Lorg/gradle/api/Action;)V
-	public final fun setReports (Lio/gitlab/arturbosch/detekt/extensions/DetektReports;)V
 }
 
 public abstract class io/gitlab/arturbosch/detekt/DetektCreateBaselineTask : org/gradle/api/tasks/SourceTask {

--- a/detekt-gradle-plugin/api/detekt-gradle-plugin.api
+++ b/detekt-gradle-plugin/api/detekt-gradle-plugin.api
@@ -62,7 +62,7 @@ public abstract class io/gitlab/arturbosch/detekt/Detekt : org/gradle/api/tasks/
 	public final fun getMdReportFile ()Lorg/gradle/api/provider/Provider;
 	public abstract fun getParallel ()Lorg/gradle/api/provider/Property;
 	public abstract fun getPluginClasspath ()Lorg/gradle/api/file/ConfigurableFileCollection;
-	public abstract fun getReports ()Lio/gitlab/arturbosch/detekt/extensions/DetektReports;
+	public fun getReports ()Lio/gitlab/arturbosch/detekt/extensions/DetektReports;
 	public abstract fun getReportsDir ()Lorg/gradle/api/file/DirectoryProperty;
 	public final fun getSarifReportFile ()Lorg/gradle/api/provider/Provider;
 	public fun getSource ()Lorg/gradle/api/file/FileTree;
@@ -163,13 +163,13 @@ public final class io/gitlab/arturbosch/detekt/extensions/DetektReportType : jav
 public class io/gitlab/arturbosch/detekt/extensions/DetektReports {
 	public fun <init> (Lorg/gradle/api/model/ObjectFactory;)V
 	public final fun custom (Lorg/gradle/api/Action;)V
-	public final fun getCustom ()Ljava/util/List;
-	public final fun getHtml ()Lio/gitlab/arturbosch/detekt/extensions/DetektReport;
-	public final fun getMd ()Lio/gitlab/arturbosch/detekt/extensions/DetektReport;
+	public fun getCustom ()Ljava/util/List;
+	public fun getHtml ()Lio/gitlab/arturbosch/detekt/extensions/DetektReport;
+	public fun getMd ()Lio/gitlab/arturbosch/detekt/extensions/DetektReport;
 	public final fun getObjects ()Lorg/gradle/api/model/ObjectFactory;
-	public final fun getSarif ()Lio/gitlab/arturbosch/detekt/extensions/DetektReport;
-	public final fun getTxt ()Lio/gitlab/arturbosch/detekt/extensions/DetektReport;
-	public final fun getXml ()Lio/gitlab/arturbosch/detekt/extensions/DetektReport;
+	public fun getSarif ()Lio/gitlab/arturbosch/detekt/extensions/DetektReport;
+	public fun getTxt ()Lio/gitlab/arturbosch/detekt/extensions/DetektReport;
+	public fun getXml ()Lio/gitlab/arturbosch/detekt/extensions/DetektReport;
 	public final fun html (Lorg/gradle/api/Action;)V
 	public final fun md (Lorg/gradle/api/Action;)V
 	public final fun sarif (Lorg/gradle/api/Action;)V

--- a/detekt-gradle-plugin/api/detekt-gradle-plugin.api
+++ b/detekt-gradle-plugin/api/detekt-gradle-plugin.api
@@ -54,20 +54,15 @@ public abstract class io/gitlab/arturbosch/detekt/Detekt : org/gradle/api/tasks/
 	public abstract fun getDetektClasspath ()Lorg/gradle/api/file/ConfigurableFileCollection;
 	public abstract fun getDisableDefaultRuleSets ()Lorg/gradle/api/provider/Property;
 	public abstract fun getFailOnSeverity ()Lorg/gradle/api/provider/Property;
-	public final fun getHtmlReportFile ()Lorg/gradle/api/provider/Provider;
 	public abstract fun getIgnoreFailures ()Lorg/gradle/api/provider/Property;
 	public abstract fun getJdkHome ()Lorg/gradle/api/file/DirectoryProperty;
 	public abstract fun getJvmTarget ()Lorg/gradle/api/provider/Property;
 	public abstract fun getLanguageVersion ()Lorg/gradle/api/provider/Property;
-	public final fun getMdReportFile ()Lorg/gradle/api/provider/Provider;
 	public abstract fun getParallel ()Lorg/gradle/api/provider/Property;
 	public abstract fun getPluginClasspath ()Lorg/gradle/api/file/ConfigurableFileCollection;
 	public fun getReports ()Lio/gitlab/arturbosch/detekt/extensions/DetektReports;
 	public abstract fun getReportsDir ()Lorg/gradle/api/file/DirectoryProperty;
-	public final fun getSarifReportFile ()Lorg/gradle/api/provider/Provider;
 	public fun getSource ()Lorg/gradle/api/file/FileTree;
-	public final fun getTxtReportFile ()Lorg/gradle/api/provider/Provider;
-	public final fun getXmlReportFile ()Lorg/gradle/api/provider/Provider;
 	public final fun reports (Lorg/gradle/api/Action;)V
 }
 

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektReportMergeSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektReportMergeSpec.kt
@@ -30,7 +30,7 @@ class DetektReportMergeSpec {
                     finalizedBy(sarifReportMerge)
                 }
                 sarifReportMerge {
-                  input.from(tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().map { it.sarifReportFile })
+                  input.from(tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().map { it.reports.sarif.outputLocation })
                 }
             }
         """.trimIndent()
@@ -96,7 +96,7 @@ class DetektReportMergeSpec {
                     finalizedBy(xmlReportMerge)
                 }
                 xmlReportMerge {
-                    input.from(tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().map { it.xmlReportFile })
+                    input.from(tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().map { it.reports.xml.outputLocation })
                 }
             }
         """.trimIndent()

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektReportMergeSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektReportMergeSpec.kt
@@ -25,7 +25,7 @@ class DetektReportMergeSpec {
             
             subprojects {
                 ${builder.gradleSubprojectsApplyPlugins.reIndent(1)}
-
+            
                 sarifReportMerge {
                   input.from(tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().map { it.reports.sarif.outputLocation })
                 }

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektReportMergeSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektReportMergeSpec.kt
@@ -25,10 +25,7 @@ class DetektReportMergeSpec {
             
             subprojects {
                 ${builder.gradleSubprojectsApplyPlugins.reIndent(1)}
-            
-                tasks.withType(io.gitlab.arturbosch.detekt.Detekt::class).configureEach {
-                    finalizedBy(sarifReportMerge)
-                }
+
                 sarifReportMerge {
                   input.from(tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().map { it.reports.sarif.outputLocation })
                 }
@@ -92,9 +89,6 @@ class DetektReportMergeSpec {
             subprojects {
                 ${builder.gradleSubprojectsApplyPlugins.reIndent(1)}
             
-                tasks.withType(io.gitlab.arturbosch.detekt.Detekt::class).configureEach {
-                    finalizedBy(xmlReportMerge)
-                }
                 xmlReportMerge {
                     input.from(tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().map { it.reports.xml.outputLocation })
                 }

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektTaskDslSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektTaskDslSpec.kt
@@ -340,7 +340,7 @@ class DetektTaskDslSpec {
             fun `fails the build`() {
                 gradleRunner.runDetektTaskAndExpectFailure { result ->
                     assertThat(result.output)
-                        .contains("If a custom report is specified, the destination must be present")
+                        .contains("property 'reports.custom.\$0.outputLocation' doesn't have a configured value")
                 }
             }
         }

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektTaskGroovyDslSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektTaskGroovyDslSpec.kt
@@ -73,7 +73,6 @@ class DetektTaskGroovyDslSpec {
                         outputLocation.set(file("build/reports/mydetekt.sarif"))
                     }
                 }
-                reportsDir = file("config.yml")
             }
         """.trimIndent()
         val groovyBuilder = DslTestBuilder.groovy()

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/report/ReportMergeSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/report/ReportMergeSpec.kt
@@ -57,7 +57,6 @@ class ReportMergeSpec {
             
                 plugins.withType<io.gitlab.arturbosch.detekt.DetektPlugin> {
                     tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
-                        finalizedBy(reportMerge)
                         reportMerge.configure { input.from(reports.xml.outputLocation) }
                     }
                 }
@@ -168,7 +167,6 @@ class ReportMergeSpec {
             
                 plugins.withType<io.gitlab.arturbosch.detekt.DetektPlugin> {
                     tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
-                        finalizedBy(reportMerge)
                         reportMerge.configure { input.from(reports.xml.outputLocation) }
                     }
                 }

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/report/ReportMergeSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/report/ReportMergeSpec.kt
@@ -58,7 +58,7 @@ class ReportMergeSpec {
                 plugins.withType<io.gitlab.arturbosch.detekt.DetektPlugin> {
                     tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
                         finalizedBy(reportMerge)
-                        reportMerge.configure { input.from(xmlReportFile) }
+                        reportMerge.configure { input.from(reports.xml.outputLocation) }
                     }
                 }
             }
@@ -169,7 +169,7 @@ class ReportMergeSpec {
                 plugins.withType<io.gitlab.arturbosch.detekt.DetektPlugin> {
                     tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
                         finalizedBy(reportMerge)
-                        reportMerge.configure { input.from(xmlReportFile) }
+                        reportMerge.configure { input.from(reports.xml.outputLocation) }
                     }
                 }
             }
@@ -195,8 +195,7 @@ class ReportMergeSpec {
             projectLayout.submodules.forEach {
                 assertThat(projectFile("${it.name}/build/reports/detekt/debug.xml")).exists()
             }
-            // #4192 this should exist by default
-            assertThat(projectFile("build/reports/detekt/merge.xml")).doesNotExist()
+            assertThat(projectFile("build/reports/detekt/merge.xml")).exists()
         }
     }
 }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -129,7 +129,7 @@ abstract class Detekt @Inject constructor(
     abstract val basePath: Property<String>
 
     @get:Internal
-    var reports: DetektReports = objects.newInstance(DetektReports::class.java)
+    abstract val reports: DetektReports
 
     @get:Internal
     abstract val reportsDir: DirectoryProperty

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -130,9 +130,6 @@ abstract class Detekt @Inject constructor(
      */
     open val reports: DetektReports = objects.newInstance(DetektReports::class.java)
 
-    @get:Internal
-    abstract val reportsDir: DirectoryProperty
-
     internal val customReportFiles: ConfigurableFileCollection
         @OutputFiles
         @Optional

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -44,6 +44,7 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.OutputFiles
@@ -128,8 +129,12 @@ abstract class Detekt @Inject constructor(
     @get:Optional
     abstract val basePath: Property<String>
 
-    @get:Internal
-    abstract val reports: DetektReports
+    @get:Nested
+    /*
+    Property must be open (as do the @Nested properties in DetektReports), see
+    https://github.com/gradle/gradle/pull/12601 and https://github.com/gradle/gradle/issues/6619
+     */
+    open val reports: DetektReports = objects.newInstance(DetektReports::class.java)
 
     @get:Internal
     abstract val reportsDir: DirectoryProperty

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -1,6 +1,5 @@
 package io.gitlab.arturbosch.detekt
 
-import io.gitlab.arturbosch.detekt.extensions.DetektReport
 import io.gitlab.arturbosch.detekt.extensions.DetektReportType
 import io.gitlab.arturbosch.detekt.extensions.DetektReports
 import io.gitlab.arturbosch.detekt.extensions.FailOnSeverity
@@ -26,16 +25,12 @@ import io.gitlab.arturbosch.detekt.invoke.LanguageVersionArgument
 import io.gitlab.arturbosch.detekt.invoke.ParallelArgument
 import org.gradle.api.Action
 import org.gradle.api.file.ConfigurableFileCollection
-import org.gradle.api.file.Directory
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.FileTree
-import org.gradle.api.file.RegularFile
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
-import org.gradle.api.provider.Provider
 import org.gradle.api.provider.ProviderFactory
-import org.gradle.api.reporting.ReportingExtension
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.Console
@@ -46,7 +41,6 @@ import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.Optional
-import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.OutputFiles
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
@@ -139,39 +133,10 @@ abstract class Detekt @Inject constructor(
     @get:Internal
     abstract val reportsDir: DirectoryProperty
 
-    val xmlReportFile: Provider<RegularFile>
-        @OutputFile
-        @Optional
-        get() = getTargetFileProvider(reports.xml)
-
-    val htmlReportFile: Provider<RegularFile>
-        @OutputFile
-        @Optional
-        get() = getTargetFileProvider(reports.html)
-
-    val txtReportFile: Provider<RegularFile>
-        @OutputFile
-        @Optional
-        get() = getTargetFileProvider(reports.txt)
-
-    val sarifReportFile: Provider<RegularFile>
-        @OutputFile
-        @Optional
-        get() = getTargetFileProvider(reports.sarif)
-
-    val mdReportFile: Provider<RegularFile>
-        @OutputFile
-        @Optional
-        get() = getTargetFileProvider(reports.md)
-
     internal val customReportFiles: ConfigurableFileCollection
         @OutputFiles
         @Optional
         get() = objects.fileCollection().from(reports.custom.mapNotNull { it.outputLocation.asFile.orNull })
-
-    private val defaultReportsDir: Directory = project.layout.buildDirectory.get()
-        .dir(ReportingExtension.DEFAULT_REPORTS_DIR_NAME)
-        .dir("detekt")
 
     private val isDryRun = project.providers.gradleProperty(DRY_RUN_PROPERTY)
 
@@ -189,11 +154,11 @@ abstract class Detekt @Inject constructor(
             JdkHomeArgument(jdkHome),
             ConfigArgument(config),
             BaselineArgument(baseline.orNull),
-            DefaultReportArgument(DetektReportType.XML, xmlReportFile.orNull),
-            DefaultReportArgument(DetektReportType.HTML, htmlReportFile.orNull),
-            DefaultReportArgument(DetektReportType.TXT, txtReportFile.orNull),
-            DefaultReportArgument(DetektReportType.SARIF, sarifReportFile.orNull),
-            DefaultReportArgument(DetektReportType.MD, mdReportFile.orNull),
+            DefaultReportArgument(reports.xml),
+            DefaultReportArgument(reports.html),
+            DefaultReportArgument(reports.txt),
+            DefaultReportArgument(reports.sarif),
+            DefaultReportArgument(reports.md),
             DebugArgument(debug.getOrElse(false)),
             ParallelArgument(parallel.getOrElse(false)),
             BuildUponDefaultConfigArgument(buildUponDefaultConfig.getOrElse(false)),
@@ -255,19 +220,6 @@ abstract class Detekt @Inject constructor(
         check(!destination.isDirectory) { "If a custom report is specified, the destination must be not a directory" }
 
         CustomReportArgument(reportId, objects.fileProperty().getOrElse { destination })
-    }
-
-    private fun getTargetFileProvider(
-        report: DetektReport
-    ): RegularFileProperty {
-        val isEnabled = report.required.getOrElse(DetektPlugin.DEFAULT_REPORT_ENABLED_VALUE)
-        val provider = objects.fileProperty()
-        if (isEnabled) {
-            val destination = report.outputLocation.orNull ?: reportsDir.getOrElse(defaultReportsDir)
-                .file("${DetektReport.DEFAULT_FILENAME}.${report.type.extension}")
-            provider.set(destination)
-        }
-        return provider
     }
 }
 

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -41,7 +41,6 @@ import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.Optional
-import org.gradle.api.tasks.OutputFiles
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.SkipWhenEmpty
@@ -129,11 +128,6 @@ abstract class Detekt @Inject constructor(
     https://github.com/gradle/gradle/pull/12601 and https://github.com/gradle/gradle/issues/6619
      */
     open val reports: DetektReports = objects.newInstance(DetektReports::class.java)
-
-    internal val customReportFiles: ConfigurableFileCollection
-        @OutputFiles
-        @Optional
-        get() = objects.fileCollection().from(reports.custom.mapNotNull { it.outputLocation.asFile.orNull })
 
     private val isDryRun = project.providers.gradleProperty(DRY_RUN_PROPERTY)
 

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
@@ -5,6 +5,7 @@ import dev.detekt.gradle.plugin.DetektBasePlugin
 import dev.detekt.gradle.plugin.DetektBasePlugin.Companion.CONFIG_DIR_NAME
 import dev.detekt.gradle.plugin.DetektBasePlugin.Companion.CONFIG_FILE
 import io.gitlab.arturbosch.detekt.extensions.DetektExtension
+import io.gitlab.arturbosch.detekt.extensions.DetektReport
 import io.gitlab.arturbosch.detekt.internal.DetektAndroid
 import io.gitlab.arturbosch.detekt.internal.DetektJvm
 import io.gitlab.arturbosch.detekt.internal.DetektMultiplatform
@@ -23,7 +24,7 @@ class DetektPlugin : Plugin<Project> {
         val extension = project.extensions.getByType(DetektExtension::class.java)
 
         configurePluginDependencies(project, extension)
-        setTaskDefaults(project)
+        setTaskDefaults(project, extension)
 
         project.registerDetektPlainTask(extension)
         project.registerDetektJvmTasks(extension)
@@ -89,10 +90,30 @@ class DetektPlugin : Plugin<Project> {
         }
     }
 
-    private fun setTaskDefaults(project: Project) {
+    private fun setTaskDefaults(project: Project, extension: DetektExtension) {
         project.tasks.withType(Detekt::class.java).configureEach {
             it.detektClasspath.setFrom(project.configurations.getAt(CONFIGURATION_DETEKT))
             it.pluginClasspath.setFrom(project.configurations.getAt(CONFIGURATION_DETEKT_PLUGINS))
+            it.reports.html { report ->
+                report.required.convention(DEFAULT_REPORT_ENABLED_VALUE)
+                report.outputLocation.convention(extension.reportsDir.file("${DetektReport.DEFAULT_FILENAME}.html"))
+            }
+            it.reports.md { report ->
+                report.required.convention(DEFAULT_REPORT_ENABLED_VALUE)
+                report.outputLocation.convention(extension.reportsDir.file("${DetektReport.DEFAULT_FILENAME}.md"))
+            }
+            it.reports.sarif { report ->
+                report.required.convention(DEFAULT_REPORT_ENABLED_VALUE)
+                report.outputLocation.convention(extension.reportsDir.file("${DetektReport.DEFAULT_FILENAME}.sarif"))
+            }
+            it.reports.txt { report ->
+                report.required.convention(DEFAULT_REPORT_ENABLED_VALUE)
+                report.outputLocation.convention(extension.reportsDir.file("${DetektReport.DEFAULT_FILENAME}.txt"))
+            }
+            it.reports.xml { report ->
+                report.required.convention(DEFAULT_REPORT_ENABLED_VALUE)
+                report.outputLocation.convention(extension.reportsDir.file("${DetektReport.DEFAULT_FILENAME}.xml"))
+            }
         }
 
         project.tasks.withType(DetektCreateBaselineTask::class.java).configureEach {

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
@@ -5,7 +5,6 @@ import dev.detekt.gradle.plugin.DetektBasePlugin
 import dev.detekt.gradle.plugin.DetektBasePlugin.Companion.CONFIG_DIR_NAME
 import dev.detekt.gradle.plugin.DetektBasePlugin.Companion.CONFIG_FILE
 import io.gitlab.arturbosch.detekt.extensions.DetektExtension
-import io.gitlab.arturbosch.detekt.extensions.DetektReport
 import io.gitlab.arturbosch.detekt.internal.DetektAndroid
 import io.gitlab.arturbosch.detekt.internal.DetektJvm
 import io.gitlab.arturbosch.detekt.internal.DetektMultiplatform
@@ -96,23 +95,23 @@ class DetektPlugin : Plugin<Project> {
             it.pluginClasspath.setFrom(project.configurations.getAt(CONFIGURATION_DETEKT_PLUGINS))
             it.reports.html { report ->
                 report.required.convention(DEFAULT_REPORT_ENABLED_VALUE)
-                report.outputLocation.convention(extension.reportsDir.file("${DetektReport.DEFAULT_FILENAME}.html"))
+                report.outputLocation.convention(extension.reportsDir.file("${it.name}.html"))
             }
             it.reports.md { report ->
                 report.required.convention(DEFAULT_REPORT_ENABLED_VALUE)
-                report.outputLocation.convention(extension.reportsDir.file("${DetektReport.DEFAULT_FILENAME}.md"))
+                report.outputLocation.convention(extension.reportsDir.file("${it.name}.md"))
             }
             it.reports.sarif { report ->
                 report.required.convention(DEFAULT_REPORT_ENABLED_VALUE)
-                report.outputLocation.convention(extension.reportsDir.file("${DetektReport.DEFAULT_FILENAME}.sarif"))
+                report.outputLocation.convention(extension.reportsDir.file("${it.name}.sarif"))
             }
             it.reports.txt { report ->
                 report.required.convention(DEFAULT_REPORT_ENABLED_VALUE)
-                report.outputLocation.convention(extension.reportsDir.file("${DetektReport.DEFAULT_FILENAME}.txt"))
+                report.outputLocation.convention(extension.reportsDir.file("${it.name}.txt"))
             }
             it.reports.xml { report ->
                 report.required.convention(DEFAULT_REPORT_ENABLED_VALUE)
-                report.outputLocation.convention(extension.reportsDir.file("${DetektReport.DEFAULT_FILENAME}.xml"))
+                report.outputLocation.convention(extension.reportsDir.file("${it.name}.xml"))
             }
         }
 

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
@@ -90,28 +90,28 @@ class DetektPlugin : Plugin<Project> {
     }
 
     private fun setTaskDefaults(project: Project, extension: DetektExtension) {
-        project.tasks.withType(Detekt::class.java).configureEach {
-            it.detektClasspath.setFrom(project.configurations.getAt(CONFIGURATION_DETEKT))
-            it.pluginClasspath.setFrom(project.configurations.getAt(CONFIGURATION_DETEKT_PLUGINS))
-            it.reports.html { report ->
+        project.tasks.withType(Detekt::class.java).configureEach { task ->
+            task.detektClasspath.setFrom(project.configurations.getAt(CONFIGURATION_DETEKT))
+            task.pluginClasspath.setFrom(project.configurations.getAt(CONFIGURATION_DETEKT_PLUGINS))
+            task.reports.html { report ->
                 report.required.convention(DEFAULT_REPORT_ENABLED_VALUE)
-                report.outputLocation.convention(extension.reportsDir.file("${it.name}.html"))
+                report.outputLocation.convention(extension.reportsDir.file("${task.name}.html"))
             }
-            it.reports.md { report ->
+            task.reports.md { report ->
                 report.required.convention(DEFAULT_REPORT_ENABLED_VALUE)
-                report.outputLocation.convention(extension.reportsDir.file("${it.name}.md"))
+                report.outputLocation.convention(extension.reportsDir.file("${task.name}.md"))
             }
-            it.reports.sarif { report ->
+            task.reports.sarif { report ->
                 report.required.convention(DEFAULT_REPORT_ENABLED_VALUE)
-                report.outputLocation.convention(extension.reportsDir.file("${it.name}.sarif"))
+                report.outputLocation.convention(extension.reportsDir.file("${task.name}.sarif"))
             }
-            it.reports.txt { report ->
+            task.reports.txt { report ->
                 report.required.convention(DEFAULT_REPORT_ENABLED_VALUE)
-                report.outputLocation.convention(extension.reportsDir.file("${it.name}.txt"))
+                report.outputLocation.convention(extension.reportsDir.file("${task.name}.txt"))
             }
-            it.reports.xml { report ->
+            task.reports.xml { report ->
                 report.required.convention(DEFAULT_REPORT_ENABLED_VALUE)
-                report.outputLocation.convention(extension.reportsDir.file("${it.name}.xml"))
+                report.outputLocation.convention(extension.reportsDir.file("${task.name}.xml"))
             }
         }
 

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektReport.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektReport.kt
@@ -17,8 +17,4 @@ abstract class DetektReport @Inject constructor(@get:Internal val type: DetektRe
     override fun toString(): String {
         return "DetektReport(type='$type', required=$required, outputLocation=$outputLocation)"
     }
-
-    internal companion object {
-        internal const val DEFAULT_FILENAME = "detekt"
-    }
 }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektReport.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektReport.kt
@@ -3,10 +3,11 @@ package io.gitlab.arturbosch.detekt.extensions
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputFile
 import javax.inject.Inject
 
-abstract class DetektReport @Inject constructor(val type: DetektReportType) {
+abstract class DetektReport @Inject constructor(@get:Internal val type: DetektReportType) {
     @get:Input
     abstract val required: Property<Boolean>
 

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektReports.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektReports.kt
@@ -7,22 +7,30 @@ import io.gitlab.arturbosch.detekt.extensions.DetektReportType.TXT
 import io.gitlab.arturbosch.detekt.extensions.DetektReportType.XML
 import org.gradle.api.Action
 import org.gradle.api.model.ObjectFactory
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Nested
 import javax.inject.Inject
 
 @Suppress("TooManyFunctions")
-open class DetektReports @Inject constructor(val objects: ObjectFactory) {
+open class DetektReports @Inject constructor(@get:Internal val objects: ObjectFactory) {
 
-    val xml: DetektReport = objects.newInstance(DetektReport::class.java, XML)
+    @get:Nested
+    open val xml: DetektReport = objects.newInstance(DetektReport::class.java, XML)
 
-    val html: DetektReport = objects.newInstance(DetektReport::class.java, HTML)
+    @get:Nested
+    open val html: DetektReport = objects.newInstance(DetektReport::class.java, HTML)
 
-    val txt: DetektReport = objects.newInstance(DetektReport::class.java, TXT)
+    @get:Nested
+    open val txt: DetektReport = objects.newInstance(DetektReport::class.java, TXT)
 
-    val sarif: DetektReport = objects.newInstance(DetektReport::class.java, SARIF)
+    @get:Nested
+    open val sarif: DetektReport = objects.newInstance(DetektReport::class.java, SARIF)
 
-    val md: DetektReport = objects.newInstance(DetektReport::class.java, MD)
+    @get:Nested
+    open val md: DetektReport = objects.newInstance(DetektReport::class.java, MD)
 
-    val custom = mutableListOf<CustomDetektReport>()
+    @get:Nested
+    open val custom = mutableListOf<CustomDetektReport>()
 
     fun xml(action: Action<in DetektReport>): Unit = action.execute(xml)
 

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektPlain.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektPlain.kt
@@ -22,7 +22,6 @@ internal class DetektPlain(private val project: Project) {
             setSource(existingInputDirectoriesProvider(project, extension))
             setIncludes(DetektPlugin.defaultIncludes)
             setExcludes(DetektPlugin.defaultExcludes)
-            reportsDir.convention(extension.reportsDir)
         }
 
         tasks.matching { it.name == LifecycleBasePlugin.CHECK_TASK_NAME }.configureEach {

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/CliArgument.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/CliArgument.kt
@@ -1,6 +1,6 @@
 package io.gitlab.arturbosch.detekt.invoke
 
-import io.gitlab.arturbosch.detekt.extensions.DetektReportType
+import io.gitlab.arturbosch.detekt.extensions.DetektReport
 import io.gitlab.arturbosch.detekt.extensions.FailOnSeverity
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.FileCollection
@@ -70,9 +70,14 @@ internal data class BaselineArgument(val baseline: RegularFile?) : CliArgument()
     override fun toArgument() = baseline?.let { listOf(BASELINE_PARAMETER, it.asFile.absolutePath) }.orEmpty()
 }
 
-internal data class DefaultReportArgument(val type: DetektReportType, val file: RegularFile?) : CliArgument() {
-    override fun toArgument() =
-        file?.let { listOf(REPORT_PARAMETER, "${type.reportId}:${it.asFile.absoluteFile}") }.orEmpty()
+internal data class DefaultReportArgument(val report: DetektReport) : CliArgument() {
+    override fun toArgument(): List<String> {
+        return if (report.required.get()) {
+            listOf(REPORT_PARAMETER, "${report.type.reportId}:${report.outputLocation.get().asFile.absoluteFile}")
+        } else {
+            emptyList()
+        }
+    }
 }
 
 internal data class CustomReportArgument(val reportId: String, val file: RegularFile) : CliArgument() {

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/DetektInvoker.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/DetektInvoker.kt
@@ -7,6 +7,8 @@ import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.FileCollection
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.tasks.VerificationException
+import org.gradle.util.GradleVersion
 import org.gradle.workers.WorkAction
 import org.gradle.workers.WorkParameters
 import java.io.PrintStream
@@ -62,16 +64,9 @@ internal abstract class DetektWorkAction : WorkAction<DetektWorkParameters> {
             )
             runner.execute()
         } catch (e: Exception) {
-            if (isBuildFailure(e.message) && parameters.ignoreFailures.get()) {
-                return
-            } else {
-                throw GradleException(e.message ?: "There was a problem running detekt.")
-            }
+            processResult(e.message, e, parameters.ignoreFailures.getOrElse(false))
         }
     }
-
-    private fun isBuildFailure(msg: String?) =
-        msg != null && "Build failed with" in msg && "issues" in msg
 }
 
 internal class DefaultCliInvoker(
@@ -95,15 +90,25 @@ internal class DefaultCliInvoker(
             ).invoke(null, arguments.toTypedArray(), System.out, System.err)
             runner::class.java.getMethod("execute").invoke(runner)
         } catch (reflectionWrapper: InvocationTargetException) {
-            val message = reflectionWrapper.targetException.message
-            if (message != null && isAnalysisFailure(message) && ignoreFailures) {
-                return
-            }
-            throw GradleException(message ?: "There was a problem running detekt.", reflectionWrapper)
+            processResult(reflectionWrapper.targetException.message, reflectionWrapper, ignoreFailures)
         }
     }
+}
 
-    private fun isAnalysisFailure(msg: String) = "Analysis failed with" in msg && "issues" in msg
+private fun isAnalysisFailure(msg: String) = "Analysis failed with" in msg && "issues" in msg
+
+private fun processResult(message: String?, reflectionWrapper: Exception, ignoreFailures: Boolean) {
+    if (message != null && isAnalysisFailure(message)) {
+        when {
+            ignoreFailures -> return
+            GradleVersion.current() >= GradleVersion.version("8.2") ->
+                throw VerificationException(message, reflectionWrapper)
+            GradleVersion.current() >= GradleVersion.version("7.4") -> throw VerificationException(message)
+            else -> throw GradleException(message, reflectionWrapper)
+        }
+    } else {
+        throw GradleException(message ?: "There was a problem running detekt.", reflectionWrapper)
+    }
 }
 
 private class DryRunInvoker : DetektInvoker {

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/DetektInvoker.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/DetektInvoker.kt
@@ -97,6 +97,7 @@ internal class DefaultCliInvoker(
 
 private fun isAnalysisFailure(msg: String) = "Analysis failed with" in msg && "issues" in msg
 
+@Suppress("ThrowsCount")
 private fun processResult(message: String?, reflectionWrapper: Exception, ignoreFailures: Boolean) {
     if (message != null && isAnalysisFailure(message)) {
         when {

--- a/website/docs/introduction/reporting.md
+++ b/website/docs/introduction/reporting.md
@@ -93,10 +93,6 @@ subprojects {
     // reports.sarif.required.set(true)
   }
 
-  tasks.withType(io.gitlab.arturbosch.detekt.Detekt).configureEach {
-    finalizedBy(reportMerge)
-  }
-
   reportMerge.configure {
     input.from(tasks.withType(io.gitlab.arturbosch.detekt.Detekt).collect { it.reports.xml.outputLocation }) // or sarif.outputLocation
   }
@@ -114,10 +110,6 @@ subprojects {
   detekt {
     reports.xml.required.set(true)
     // reports.sarif.required.set(true)
-  }
-
-  tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
-    finalizedBy(reportMerge)
   }
 
   reportMerge {

--- a/website/docs/introduction/reporting.md
+++ b/website/docs/introduction/reporting.md
@@ -67,6 +67,13 @@ namely XML and SARIF.
 
 ## Merging reports
 
+:::caution Attention
+
+**Gradle 7.4 or higher is required**. Earlier Gradle prevent tasks running if they depend on a failing task, so merge
+tasks will not run if detekt finds issues.
+
+:::
+
 The machine-readable report formats support report merging.
 Detekt Gradle Plugin is not opinionated in how merging is set up and respects each project's build logic, especially 
 the merging makes most sense in a multi-module project. In this spirit, only Gradle tasks are provided.

--- a/website/docs/introduction/reporting.md
+++ b/website/docs/introduction/reporting.md
@@ -91,7 +91,7 @@ subprojects {
   }
 
   reportMerge.configure {
-    input.from(tasks.withType(io.gitlab.arturbosch.detekt.Detekt).collect { it.xmlReportFile }) // or sarifReportFile
+    input.from(tasks.withType(io.gitlab.arturbosch.detekt.Detekt).collect { it.reports.xml.outputLocation }) // or sarif.outputLocation
   }
 }
 ```
@@ -114,7 +114,7 @@ subprojects {
   }
 
   reportMerge {
-    input.from(tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().map { it.xmlReportFile }) // or .sarifReportFile
+    input.from(tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().map { it.reports.xml.outputLocation }) // or sarif.outputLocation
   }
 }
 ```


### PR DESCRIPTION
* Fixes #4192 
* Fixes #4856 
* Fixes #6963 

There's one issue I can see which is there's a problem with using `VerificationException` and the Worker API. We don't enable Worker API by default but this could be considered a blocker for doing that. See https://github.com/gradle/gradle/issues/28034.

