### PR TITLE
fix task 'config' property getting overwritten

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/SharedTasks.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/SharedTasks.kt
@@ -37,7 +37,7 @@ internal fun Project.registerDetektTask(
         it.autoCorrect.convention(extension.autoCorrect)
         it.ignoreFailures.convention(extension.ignoreFailures)
         it.failOnSeverity.convention(extension.failOnSeverity)
-        it.config.setFrom(provider { extension.config })
+        it.config.from(provider { extension.config })
         it.basePath.convention(extension.basePath.map { basePath -> basePath.asFile.absolutePath })
         it.allRules.convention(extension.allRules)
         configuration(it)
@@ -63,7 +63,7 @@ internal fun Project.registerCreateBaselineTask(
             )
         }
 
-        it.config.setFrom(project.provider { extension.config })
+        it.config.from(project.provider { extension.config })
         it.debug.convention(extension.debug)
         it.parallel.convention(extension.parallel)
         it.disableDefaultRuleSets.convention(extension.disableDefaultRuleSets)


### PR DESCRIPTION
`setFrom` overwrites whatever is there before. Changed to `from` which only adds, does not overwrite.

In practice, `setFrom` was causing an issue for me where trying to set the config file for a specific Detekt task was not working becuase it was being overwritten by what I put in the plugin extension `config`. The overwrite only occured for some Detekt tasks and not others, adding to the confusion. I suspect this is because the order of when gradle executed certain blocks of code mattered. My expectation is all configured files to be used, none should replace any other and especially not in a silent, confusing, unpredictable way.

With this change, order of when gradle executes different blocks of code no longer matters and all config files are used reliably both from the plugin extension and from task properties.