### PR TITLE
Add ignoreOperator option in TooManyFunctions rule

### DIFF
--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/TooManyFunctions.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/TooManyFunctions.kt
@@ -7,6 +7,7 @@ import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.config
 import io.gitlab.arturbosch.detekt.rules.hasAnnotation
+import io.gitlab.arturbosch.detekt.rules.isOperator
 import io.gitlab.arturbosch.detekt.rules.isOverride
 import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtClassOrObject
@@ -53,6 +54,9 @@ class TooManyFunctions(config: Config) : Rule(
 
     @Configuration("ignore overridden functions")
     private val ignoreOverridden: Boolean by config(false)
+
+    @Configuration("ignore operator functions")
+    private val ignoreOperator: Boolean by config(false)
 
     @Configuration("ignore functions annotated with these annotations")
     private val ignoreAnnotatedFunctions: List<String> by config(emptyList())
@@ -155,6 +159,7 @@ class TooManyFunctions(config: Config) : Rule(
         ignorePrivate && function.isPrivate() -> true
         ignoreOverridden && function.isOverride() -> true
         ignoreAnnotatedFunctions.any { function.hasAnnotation(it) } -> true
+        ignoreOperator && function.isOperator() -> true
         else -> false
     }
 

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/TooManyFunctionsSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/TooManyFunctionsSpec.kt
@@ -14,6 +14,7 @@ private const val ALLOWED_FUNCTIONS_PER_ENUM = "allowedFunctionsPerEnum"
 private const val IGNORE_DEPRECATED = "ignoreDeprecated"
 private const val IGNORE_PRIVATE = "ignorePrivate"
 private const val IGNORE_OVERRIDDEN = "ignoreOverridden"
+private const val IGNORE_OPERATOR = "ignoreOperator"
 private const val IGNORE_ANNOTATED_FUNCTIONS = "ignoreAnnotatedFunctions"
 
 class TooManyFunctionsSpec {
@@ -261,6 +262,46 @@ class TooManyFunctionsSpec {
                     ALLOWED_FUNCTIONS_PER_CLASS to "1",
                     ALLOWED_FUNCTIONS_PER_FILE to "1",
                     IGNORE_OVERRIDDEN to "false",
+                )
+            )
+            assertThat(configuredRule.compileAndLint(code)).hasSize(1)
+        }
+    }
+
+    @Nested
+    inner class `operator functions` {
+
+        val code = """
+            class Foo(val i : Int) {
+                operator fun plus(other: Foo): Foo {
+                    return Foo(i + other.i)
+                }
+            
+                operator fun times(other: Foo): Foo {
+                    return Foo(i * other.i)
+                }
+            }
+        """.trimIndent()
+
+        @Test
+        fun `should not report class with operator functions, if ignoreOperator is enabled`() {
+            val configuredRule = TooManyFunctions(
+                TestConfig(
+                    ALLOWED_FUNCTIONS_PER_CLASS to "1",
+                    ALLOWED_FUNCTIONS_PER_FILE to "1",
+                    IGNORE_OPERATOR to "true",
+                )
+            )
+            assertThat(configuredRule.compileAndLint(code)).isEmpty()
+        }
+
+        @Test
+        fun `should count operator functions, if ignoreOperator is disabled`() {
+            val configuredRule = TooManyFunctions(
+                TestConfig(
+                    ALLOWED_FUNCTIONS_PER_CLASS to "1",
+                    ALLOWED_FUNCTIONS_PER_FILE to "1",
+                    IGNORE_OPERATOR to "false",
                 )
             )
             assertThat(configuredRule.compileAndLint(code)).hasSize(1)


### PR DESCRIPTION
This PR adds an option to ignore operators from the `TooManyFunctions` rule. 

When writing a mathematical class, it's common to create Kotlin `operator fun` to allow using Operator overloading. Some operators can need a lot of implementation to deal with all numeric types accordingly (Double, Long, …), which can make the number of functions grow. 

Adding the `ignoreOperator` (which behave very similarly to `ignorePrivate` or `ignoreOverridden`) allow one to write math classes without raising warnings from Detekt.