### PR TITLE
Update broken link in SpreadOperator/ForEachOnRange

### DIFF
--- a/detekt-rules-performance/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/ForEachOnRange.kt
+++ b/detekt-rules-performance/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/ForEachOnRange.kt
@@ -18,7 +18,8 @@ import org.jetbrains.kotlin.psi2ir.deparenthesize
  *
  * Benchmarks have shown that using forEach on a range can have a huge performance cost in comparison to
  * simple for loops. Hence, in most contexts, a simple for loop should be used instead.
- * See more details here: https://sites.google.com/a/athaydes.com/renato-athaydes/posts/kotlinshiddencosts-benchmarks
+ * See more details here:
+ * https://web.archive.org/web/20230514162525/https://sites.google.com/a/athaydes.com/renato-athaydes/posts/kotlinshiddencosts-benchmarks
  * To solve this CodeSmell, the forEach usage should be replaced by a for loop.
  *
  * <noncompliant>

--- a/detekt-rules-performance/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/SpreadOperator.kt
+++ b/detekt-rules-performance/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/SpreadOperator.kt
@@ -18,7 +18,7 @@ import org.jetbrains.kotlin.resolve.calls.util.getResolvedCall
 /**
  * In most cases using a spread operator causes a full copy of the array to be created before calling a method.
  * This has a very high performance penalty. Benchmarks showing this performance penalty can be seen here:
- * https://sites.google.com/a/athaydes.com/renato-athaydes/posts/kotlinshiddencosts-benchmarks
+ * https://web.archive.org/web/20230514162525/https://sites.google.com/a/athaydes.com/renato-athaydes/posts/kotlinshiddencosts-benchmarks
  *
  * The Kotlin compiler since v1.1.60 has an optimization that skips the array copy when an array constructor
  * function is used to create the arguments that are passed to the vararg parameter. This case will not be flagged


### PR DESCRIPTION
Update broken link in SpreadOperator and ForEachOnRange to point to the web archive version of the "Kotlin's hidden costs" article since the original URL is now dead.

<!-- A similar PR may already be submitted! -->
<!-- Please search among the [Pull requests](https://github.com/detekt/detekt/pulls) before creating one. -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Link to relevant issues if possible. -->

<!-- For more information, see the [CONTRIBUTING guide](https://github.com/detekt/detekt/blob/main/.github/CONTRIBUTING.md). -->
