### PR TITLE
UnusedPrivateClass: don't report if private classes are used for type conversion

### DIFF
--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateClass.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateClass.kt
@@ -8,6 +8,7 @@ import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Rule
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.psi.KtAnnotationEntry
+import org.jetbrains.kotlin.psi.KtBinaryExpressionWithTypeRHS
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtCallableReferenceExpression
 import org.jetbrains.kotlin.psi.KtClass
@@ -17,6 +18,7 @@ import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtFunctionType
 import org.jetbrains.kotlin.psi.KtImportDirective
+import org.jetbrains.kotlin.psi.KtIsExpression
 import org.jetbrains.kotlin.psi.KtNameReferenceExpression
 import org.jetbrains.kotlin.psi.KtNamedDeclaration
 import org.jetbrains.kotlin.psi.KtNamedFunction
@@ -141,6 +143,16 @@ class UnusedPrivateClass(config: Config) : Rule(
         override fun visitProperty(property: KtProperty) {
             property.typeReference?.run { registerAccess(this) }
             super.visitProperty(property)
+        }
+
+        override fun visitBinaryWithTypeRHSExpression(expression: KtBinaryExpressionWithTypeRHS) {
+            expression.right?.run { registerAccess(this) }
+            super.visitBinaryWithTypeRHSExpression(expression)
+        }
+
+        override fun visitIsExpression(expression: KtIsExpression) {
+            expression.typeReference?.run { registerAccess(this) }
+            super.visitIsExpression(expression)
         }
 
         override fun visitCallExpression(expression: KtCallExpression) {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateClassSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateClassSpec.kt
@@ -307,6 +307,26 @@ class UnusedPrivateClassSpec {
 
             assertThat(findings).isEmpty()
         }
+
+        @Test
+        fun `should not report them if used for type conversion`() {
+            val code = """
+                private class Foo(val bar: String)
+                private fun f(a: Any) = a as Foo
+            """.trimIndent()
+            val findings = subject.compileAndLint(code)
+            assertThat(findings).isEmpty()
+        }
+
+        @Test
+        fun `should not report them if used for type checking`() {
+            val code = """
+                private class Foo(val bar: String)
+                private fun f(a: Any) = a is Foo
+            """.trimIndent()
+            val findings = subject.compileAndLint(code)
+            assertThat(findings).isEmpty()
+        }
     }
 
     @Nested


### PR DESCRIPTION
Fixes #6982