### PR TITLE
Fix deprecations in Android KMP tests

### DIFF
--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektMultiplatformSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektMultiplatformSpec.kt
@@ -180,7 +180,7 @@ class DetektMultiplatformSpec {
                                 }
                             }
                             kotlin {
-                                android {
+                                androidTarget {
                                     compilations.all {
                                         kotlinOptions.jvmTarget = "1.8"
                                     }

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektMultiplatformSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektMultiplatformSpec.kt
@@ -190,9 +190,9 @@ class DetektMultiplatformSpec {
                         DETEKT_BLOCK,
                     ),
                     srcDirs = listOf(
-                        "src/debug/kotlin",
-                        "src/release/kotlin",
-                        "src/androidTest/kotlin",
+                        "src/androidDebug/kotlin",
+                        "src/androidRelease/kotlin",
+                        "src/androidUnitTest/kotlin",
                         "src/androidMain/kotlin",
                         "src/commonMain/kotlin",
                         "src/commonTest/kotlin"
@@ -374,8 +374,8 @@ private fun setupProject(projectLayoutAction: ProjectLayout.() -> Unit): DslGrad
 private fun setupAndroidProject(projectLayoutAction: ProjectLayout.() -> Unit): DslGradleRunner {
     val gradleRunner = setupProject { projectLayoutAction() }
     gradleRunner.writeProjectFile("shared/src/androidMain/AndroidManifest.xml", manifestContent)
-    gradleRunner.writeProjectFile("shared/src/debug/AndroidManifest.xml", manifestContent)
-    gradleRunner.writeProjectFile("shared/src/release/AndroidManifest.xml", manifestContent)
+    gradleRunner.writeProjectFile("shared/src/androidDebug/AndroidManifest.xml", manifestContent)
+    gradleRunner.writeProjectFile("shared/src/androidRelease/AndroidManifest.xml", manifestContent)
     return gradleRunner
 }
 

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/report/ReportMergeSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/report/ReportMergeSpec.kt
@@ -116,7 +116,7 @@ class ReportMergeSpec {
                         implementation(project(":lib"))
                     }
                 """.trimIndent(),
-                srcDirs = listOf("src/main/java", "src/debug/java", "src/test/java", "src/androidTest/java"),
+                srcDirs = listOf("src/main/java", "src/debug/java", "src/test/java", "src/androidUnitTest/java"),
             )
             addSubmodule(
                 name = "lib",
@@ -140,7 +140,7 @@ class ReportMergeSpec {
                         }
                     }
                 """.trimIndent(),
-                srcDirs = listOf("src/main/java", "src/debug/java", "src/test/java", "src/androidTest/java")
+                srcDirs = listOf("src/main/java", "src/debug/java", "src/test/java", "src/androidUnitTest/java")
             )
         }
         val mainBuildFileContent: String = """


### PR DESCRIPTION
* Replace android with androidTarget in KMP project test: https://kotlinlang.org/docs/multiplatform-compatibility-guide.html#rename-of-android-target-to-androidtarget
* Update Android source layout in KMP tests: https://kotlinlang.org/docs/multiplatform-android-layout.html