### PR TITLE
Add new rules from ktlint 1.2

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -89,6 +89,8 @@ formatting:
     active: true
   NoEmptyFirstLineInClassBody:
     active: false
+  SpacingAroundSquareBrackets:
+    active: true
   StringTemplateIndent:
     active: false
   ValueArgumentComment:

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -68,6 +68,8 @@ formatting:
   active: true
   android: false
   autoCorrect: true
+  BackingPropertyNaming:
+    active: true
   BinaryExpressionWrapping:
     active: true
   BlankLineBeforeDeclaration:

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -78,6 +78,9 @@ formatting:
     active: false
   FunctionSignature:
     active: false
+  Kdoc:
+    active: true
+    excludes: ['**/*.kts']
   MaximumLineLength:
     active: false
   MultilineExpressionWrapping:

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingProvider.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingProvider.kt
@@ -40,6 +40,7 @@ import io.gitlab.arturbosch.detekt.formatting.wrappers.IfElseBracing
 import io.gitlab.arturbosch.detekt.formatting.wrappers.IfElseWrapping
 import io.gitlab.arturbosch.detekt.formatting.wrappers.ImportOrdering
 import io.gitlab.arturbosch.detekt.formatting.wrappers.Indentation
+import io.gitlab.arturbosch.detekt.formatting.wrappers.Kdoc
 import io.gitlab.arturbosch.detekt.formatting.wrappers.KdocWrapping
 import io.gitlab.arturbosch.detekt.formatting.wrappers.MaximumLineLength
 import io.gitlab.arturbosch.detekt.formatting.wrappers.MixedConditionOperators
@@ -215,6 +216,7 @@ class FormattingProvider : RuleSetProvider {
             ::FunctionExpressionBody,
             ::FunctionLiteral,
             ::FunctionTypeModifierSpacing,
+            ::Kdoc,
             ::MixedConditionOperators,
             ::MultilineLoop,
         ).sorted()

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingProvider.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingProvider.kt
@@ -11,6 +11,7 @@ import io.gitlab.arturbosch.detekt.api.RuleSetProvider
 import io.gitlab.arturbosch.detekt.formatting.wrappers.AnnotationOnSeparateLine
 import io.gitlab.arturbosch.detekt.formatting.wrappers.AnnotationSpacing
 import io.gitlab.arturbosch.detekt.formatting.wrappers.ArgumentListWrapping
+import io.gitlab.arturbosch.detekt.formatting.wrappers.BackingPropertyNaming
 import io.gitlab.arturbosch.detekt.formatting.wrappers.BinaryExpressionWrapping
 import io.gitlab.arturbosch.detekt.formatting.wrappers.BlankLineBeforeDeclaration
 import io.gitlab.arturbosch.detekt.formatting.wrappers.BlankLineBetweenWhenConditions
@@ -209,6 +210,7 @@ class FormattingProvider : RuleSetProvider {
             ::ValueParameterComment,
             ::Wrapping,
             // Wrappers for experimental rules. Disabled by default.
+            ::BackingPropertyNaming,
             ::BinaryExpressionWrapping,
             ::BlankLineBetweenWhenConditions,
             ::ChainMethodContinuation,

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingProvider.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingProvider.kt
@@ -13,6 +13,7 @@ import io.gitlab.arturbosch.detekt.formatting.wrappers.AnnotationSpacing
 import io.gitlab.arturbosch.detekt.formatting.wrappers.ArgumentListWrapping
 import io.gitlab.arturbosch.detekt.formatting.wrappers.BinaryExpressionWrapping
 import io.gitlab.arturbosch.detekt.formatting.wrappers.BlankLineBeforeDeclaration
+import io.gitlab.arturbosch.detekt.formatting.wrappers.BlankLineBetweenWhenConditions
 import io.gitlab.arturbosch.detekt.formatting.wrappers.BlockCommentInitialStarAlignment
 import io.gitlab.arturbosch.detekt.formatting.wrappers.ChainMethodContinuation
 import io.gitlab.arturbosch.detekt.formatting.wrappers.ChainWrapping
@@ -207,6 +208,7 @@ class FormattingProvider : RuleSetProvider {
             ::Wrapping,
             // Wrappers for experimental rules. Disabled by default.
             ::BinaryExpressionWrapping,
+            ::BlankLineBetweenWhenConditions,
             ::ChainMethodContinuation,
             ::ClassSignature,
             ::ConditionWrapping,

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingProvider.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingProvider.kt
@@ -84,6 +84,7 @@ import io.gitlab.arturbosch.detekt.formatting.wrappers.SpacingAroundKeyword
 import io.gitlab.arturbosch.detekt.formatting.wrappers.SpacingAroundOperators
 import io.gitlab.arturbosch.detekt.formatting.wrappers.SpacingAroundParens
 import io.gitlab.arturbosch.detekt.formatting.wrappers.SpacingAroundRangeOperator
+import io.gitlab.arturbosch.detekt.formatting.wrappers.SpacingAroundSquareBrackets
 import io.gitlab.arturbosch.detekt.formatting.wrappers.SpacingAroundUnaryOperator
 import io.gitlab.arturbosch.detekt.formatting.wrappers.SpacingBetweenDeclarationsWithAnnotations
 import io.gitlab.arturbosch.detekt.formatting.wrappers.SpacingBetweenDeclarationsWithComments
@@ -219,6 +220,7 @@ class FormattingProvider : RuleSetProvider {
             ::Kdoc,
             ::MixedConditionOperators,
             ::MultilineLoop,
+            ::SpacingAroundSquareBrackets,
         ).sorted()
     )
 

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/BackingPropertyNaming.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/BackingPropertyNaming.kt
@@ -1,0 +1,16 @@
+package io.gitlab.arturbosch.detekt.formatting.wrappers
+
+import com.pinterest.ktlint.ruleset.standard.rules.BackingPropertyNamingRule
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.formatting.FormattingRule
+
+/**
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/experimental/#backing-property-naming)
+ * for documentation.
+ */
+class BackingPropertyNaming(config: Config) : FormattingRule(
+    config,
+    "Reports incorrect property name."
+) {
+    override val wrapping = BackingPropertyNamingRule()
+}

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/BlankLineBetweenWhenConditions.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/BlankLineBetweenWhenConditions.kt
@@ -1,0 +1,31 @@
+package io.gitlab.arturbosch.detekt.formatting.wrappers
+
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfigProperty
+import com.pinterest.ktlint.ruleset.standard.rules.BlankLineBetweenWhenConditions
+import com.pinterest.ktlint.ruleset.standard.rules.BlankLineBetweenWhenConditions.Companion.LINE_BREAK_AFTER_WHEN_CONDITION_PROPERTY
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Configuration
+import io.gitlab.arturbosch.detekt.api.config
+import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
+import io.gitlab.arturbosch.detekt.formatting.FormattingRule
+
+/**
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/experimental/#blank-lines-between-when-conditions)
+ * for documentation.
+ */
+@AutoCorrectable(since = "2.0.0")
+class BlankLineBetweenWhenConditions(config: Config) : FormattingRule(
+    config,
+    "Consistently add or remove blank lines between when-conditions in a when-statement"
+) {
+
+    override val wrapping = BlankLineBetweenWhenConditions()
+
+    @Configuration("require line breaks after multiline entries")
+    private val lineBreakAfterWhenEntries: Boolean by config(true)
+
+    override fun overrideEditorConfigProperties(): Map<EditorConfigProperty<*>, String> =
+        mapOf(
+            LINE_BREAK_AFTER_WHEN_CONDITION_PROPERTY to lineBreakAfterWhenEntries.toString()
+        )
+}

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/Kdoc.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/Kdoc.kt
@@ -1,0 +1,16 @@
+package io.gitlab.arturbosch.detekt.formatting.wrappers
+
+import com.pinterest.ktlint.ruleset.standard.rules.KdocRule
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.formatting.FormattingRule
+
+/**
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/experimental/#kdoc) for documentation.
+ */
+class Kdoc(config: Config) : FormattingRule(
+    config,
+    "Only allow KDoc when comments are in a location that can be converted to public documentation"
+) {
+
+    override val wrapping = KdocRule()
+}

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingAroundSquareBrackets.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/SpacingAroundSquareBrackets.kt
@@ -1,0 +1,19 @@
+package io.gitlab.arturbosch.detekt.formatting.wrappers
+
+import com.pinterest.ktlint.ruleset.standard.rules.SpacingAroundSquareBracketsRule
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
+import io.gitlab.arturbosch.detekt.formatting.FormattingRule
+
+/**
+ * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#square-brackets-spacing) for
+ * documentation.
+ */
+@AutoCorrectable(since = "2.0.0")
+class SpacingAroundSquareBrackets(config: Config) : FormattingRule(
+    config,
+    "Reports spaces around square brackets"
+) {
+
+    override val wrapping = SpacingAroundSquareBracketsRule()
+}

--- a/detekt-formatting/src/main/resources/config/config.yml
+++ b/detekt-formatting/src/main/resources/config/config.yml
@@ -23,6 +23,10 @@ formatting:
   BlankLineBeforeDeclaration:
     active: true
     autoCorrect: true
+  BlankLineBetweenWhenConditions:
+    active: false
+    autoCorrect: true
+    lineBreakAfterWhenEntries: true
   BlockCommentInitialStarAlignment:
     active: true
     autoCorrect: true

--- a/detekt-formatting/src/main/resources/config/config.yml
+++ b/detekt-formatting/src/main/resources/config/config.yml
@@ -15,6 +15,8 @@ formatting:
     indentSize: 4
     maxLineLength: 120
     ignoreRuleParameterThreshold: 8
+  BackingPropertyNaming:
+    active: false
   BinaryExpressionWrapping:
     active: false
     autoCorrect: true

--- a/detekt-formatting/src/main/resources/config/config.yml
+++ b/detekt-formatting/src/main/resources/config/config.yml
@@ -267,6 +267,9 @@ formatting:
   SpacingAroundRangeOperator:
     active: true
     autoCorrect: true
+  SpacingAroundSquareBrackets:
+    active: false
+    autoCorrect: true
   SpacingAroundUnaryOperator:
     active: true
     autoCorrect: true

--- a/detekt-formatting/src/main/resources/config/config.yml
+++ b/detekt-formatting/src/main/resources/config/config.yml
@@ -126,6 +126,8 @@ formatting:
     active: true
     autoCorrect: true
     indentSize: 4
+  Kdoc:
+    active: false
   KdocWrapping:
     active: true
     autoCorrect: true


### PR DESCRIPTION
New rules:
* BackingPropertyNaming
* BlankLineBetweenWhenConditions
* Kdoc
* SpacingAroundSquareBrackets