### PR TITLE
Cli provides list of input files

### DIFF
--- a/config/detekt/argsfile
+++ b/config/detekt/argsfile
@@ -3,7 +3,7 @@
 -b
 ./config/detekt/baseline.xml
 -ex
-**/resources/**,**/detekt*/build/**,**/build-logic/build/**,**/build-logic/bin/**
+**/resources/**,detekt*/build/**,build-logic/build/**,build-logic/bin/**
 --build-upon-default-config
 -c
 ./config/detekt/detekt.yml

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgsSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgsSpec.kt
@@ -113,11 +113,21 @@ internal class CliArgsSpec {
 
             @Test
             fun `excludes in path normalized`() {
-                val spec = parseArguments(input + arrayOf("--excludes", "**/src/main/kotlin/**")).toSpec()
+                val spec = parseArguments(input + arrayOf("--excludes", "src/main/kotlin/**")).toSpec()
 
                 assertThat(spec.projectSpec.inputPaths).contains(pathBuildGradle)
                 assertThat(spec.projectSpec.inputPaths).doesNotContain(pathCliArgs)
                 assertThat(spec.projectSpec.inputPaths).doesNotContain(pathMain)
+                assertThat(spec.projectSpec.inputPaths).contains(pathAnalyzer)
+            }
+
+            @Test
+            fun `doesn't take into account absolute path`() {
+                val spec = parseArguments(input + arrayOf("--excludes", "/home/**,/Users/**")).toSpec()
+
+                assertThat(spec.projectSpec.inputPaths).contains(pathBuildGradle)
+                assertThat(spec.projectSpec.inputPaths).contains(pathCliArgs)
+                assertThat(spec.projectSpec.inputPaths).contains(pathMain)
                 assertThat(spec.projectSpec.inputPaths).contains(pathAnalyzer)
             }
 

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgsSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgsSpec.kt
@@ -1,11 +1,9 @@
 package io.gitlab.arturbosch.detekt.cli
 
-import io.github.detekt.test.utils.NullPrintStream
 import io.github.detekt.test.utils.resourceAsPath
 import io.github.detekt.tooling.api.spec.RulesSpec.FailurePolicy.FailOnSeverity
 import io.github.detekt.tooling.api.spec.RulesSpec.FailurePolicy.NeverFail
 import io.gitlab.arturbosch.detekt.api.Severity
-import io.gitlab.arturbosch.detekt.api.internal.PathFilters
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatCode
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
@@ -15,6 +13,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import org.junit.jupiter.params.provider.ValueSource
+import java.nio.file.Path
 import kotlin.io.path.Path
 import kotlin.io.path.absolute
 
@@ -22,24 +21,22 @@ internal class CliArgsSpec {
 
     @Nested
     inner class `Parsing the input path` {
-        private val projectPath = resourceAsPath("/").parent.parent.parent.parent
+        private val pathBuildGradle = Path("build.gradle.kts").absolute()
+        private val pathCliArgs = Path("src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt").absolute()
+        private val pathCliArgsSpec = Path("src/test/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgsSpec.kt").absolute()
+        private val pathAnalyzer =
+            Path("../detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/AnalyzerSpec.kt").absolute()
+                .normalize()
 
         @Test
         fun `the current working directory is used if parameter is not set`() {
             val spec = parseArguments(emptyArray()).toSpec()
-            assertThat(spec.projectSpec.inputPaths).containsExactly(Path("").absolute())
-        }
+            val workingDir = Path("").toAbsolutePath()
 
-        @Test
-        fun `a single value is converted to a path`() {
-            val spec = parseArguments(arrayOf("--input", "$projectPath")).toSpec()
-            assertThat(spec.projectSpec.inputPaths).containsExactly(projectPath)
-        }
-
-        @Test
-        fun `a single value is converted to a path absolute`() {
-            val spec = parseArguments(arrayOf("--input", "${projectPath.absolute()}")).toSpec()
-            assertThat(spec.projectSpec.inputPaths).containsExactly(projectPath.absolute())
+            assertThat(spec.projectSpec.inputPaths).allSatisfy { it.toAbsolutePath().startsWith(workingDir) }
+            assertThat(spec.projectSpec.inputPaths).contains(pathBuildGradle)
+            assertThat(spec.projectSpec.inputPaths).contains(pathCliArgs)
+            assertThat(spec.projectSpec.inputPaths).contains(pathCliArgsSpec)
         }
 
         @ParameterizedTest
@@ -52,11 +49,11 @@ internal class CliArgsSpec {
         )
         fun `when the input is defined it is passed to the spec`(param: String) {
             val spec = parseArguments(arrayOf("--input", param)).toSpec()
-            assertThat(spec.projectSpec.inputPaths).containsExactly(
-                Path("src/main"),
-                Path("../detekt-core/src/test"),
-                Path("build.gradle.kts"),
-            )
+
+            assertThat(spec.projectSpec.inputPaths).contains(pathBuildGradle)
+            assertThat(spec.projectSpec.inputPaths).contains(pathCliArgs)
+            assertThat(spec.projectSpec.inputPaths).doesNotContain(pathCliArgsSpec)
+            assertThat(spec.projectSpec.inputPaths).contains(pathAnalyzer)
         }
 
         @Test
@@ -66,6 +63,110 @@ internal class CliArgsSpec {
             assertThatExceptionOfType(HandledArgumentViolation::class.java)
                 .isThrownBy { parseArguments(params) }
                 .withMessage("Input path does not exist: 'nonExistent '")
+        }
+
+        @Nested
+        inner class FilterInput {
+            private val input = arrayOf("--input", "src/main/../main/,../detekt-core/src/test,build.gradle.kts")
+            private val pathMain = Path("src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Main.kt").absolute()
+
+            @Test
+            fun `no filters`() {
+                val spec = parseArguments(input).toSpec()
+
+                assertThat(spec.projectSpec.inputPaths).contains(pathBuildGradle)
+                assertThat(spec.projectSpec.inputPaths).contains(pathCliArgs)
+                assertThat(spec.projectSpec.inputPaths).contains(pathMain)
+                assertThat(spec.projectSpec.inputPaths).contains(pathAnalyzer)
+            }
+
+            @Test
+            fun `excludes in path`() {
+                val spec = parseArguments(input + arrayOf("--excludes", "**/test/**")).toSpec()
+
+                assertThat(spec.projectSpec.inputPaths).contains(pathBuildGradle)
+                assertThat(spec.projectSpec.inputPaths).contains(pathCliArgs)
+                assertThat(spec.projectSpec.inputPaths).contains(pathMain)
+                assertThat(spec.projectSpec.inputPaths).doesNotContain(pathAnalyzer)
+            }
+
+            @Test
+            fun `includes in path`() {
+                val spec = parseArguments(input + arrayOf("--includes", "**/test/**")).toSpec()
+
+                assertThat(spec.projectSpec.inputPaths).doesNotContain(pathBuildGradle)
+                assertThat(spec.projectSpec.inputPaths).doesNotContain(pathCliArgs)
+                assertThat(spec.projectSpec.inputPaths).doesNotContain(pathMain)
+                assertThat(spec.projectSpec.inputPaths).contains(pathAnalyzer)
+            }
+
+            @Test
+            fun `excludes and includes in path`() {
+                val spec = parseArguments(input + arrayOf("--excludes", "**/test/**", "--includes", "**/test/**"))
+                    .toSpec()
+
+                assertThat(spec.projectSpec.inputPaths).contains(pathBuildGradle)
+                assertThat(spec.projectSpec.inputPaths).contains(pathCliArgs)
+                assertThat(spec.projectSpec.inputPaths).contains(pathMain)
+                assertThat(spec.projectSpec.inputPaths).contains(pathAnalyzer)
+            }
+
+            @Test
+            fun `excludes in path normalized`() {
+                val spec = parseArguments(input + arrayOf("--excludes", "**/src/main/kotlin/**")).toSpec()
+
+                assertThat(spec.projectSpec.inputPaths).contains(pathBuildGradle)
+                assertThat(spec.projectSpec.inputPaths).doesNotContain(pathCliArgs)
+                assertThat(spec.projectSpec.inputPaths).doesNotContain(pathMain)
+                assertThat(spec.projectSpec.inputPaths).contains(pathAnalyzer)
+            }
+
+            @Test
+            fun `excludes main but includes one file`() {
+                val spec = parseArguments(input + arrayOf("--excludes", "**/main/**", "--includes", "**/CliArgs.kt"))
+                    .toSpec()
+
+                assertThat(spec.projectSpec.inputPaths).contains(pathBuildGradle)
+                assertThat(spec.projectSpec.inputPaths).contains(pathCliArgs)
+                assertThat(spec.projectSpec.inputPaths).doesNotContain(pathMain)
+                assertThat(spec.projectSpec.inputPaths).contains(pathAnalyzer)
+            }
+
+            @Test
+            fun `parse excludes correctly`() {
+                val paths: List<Collection<Path>> = listOf(
+                    "**/main/**,**/detekt-core/**,**/build.gradle.kts",
+                    "**/main/**;**/detekt-core/**;**/build.gradle.kts",
+                    "**/main/** ,**/detekt-core/**, **/build.gradle.kts",
+                    "**/main/** ;**/detekt-core/**; **/build.gradle.kts",
+                    "**/main/**,**/detekt-core/**;**/build.gradle.kts",
+                    "**/main/** ,**/detekt-core/**; **/build.gradle.kts",
+                    " ,,**/main/**,**/detekt-core/**,**/build.gradle.kts",
+                ).map {
+                    val spec = parseArguments(input + arrayOf("--excludes", it)).toSpec()
+                    spec.projectSpec.inputPaths
+                }
+
+                assertThat(paths.distinct()).hasSize(1)
+            }
+
+            @Test
+            fun `parse includes correctly`() {
+                val paths: List<Collection<Path>> = listOf(
+                    "**/main/**,**/detekt-core/**,**/build.gradle.kts",
+                    "**/main/**;**/detekt-core/**;**/build.gradle.kts",
+                    "**/main/** ,**/detekt-core/**, **/build.gradle.kts",
+                    "**/main/** ;**/detekt-core/**; **/build.gradle.kts",
+                    "**/main/**,**/detekt-core/**;**/build.gradle.kts",
+                    "**/main/** ,**/detekt-core/**; **/build.gradle.kts",
+                    " ,,**/main/**,**/detekt-core/**,**/build.gradle.kts",
+                ).map {
+                    val spec = parseArguments(input + arrayOf("--includes", it)).toSpec()
+                    spec.projectSpec.inputPaths
+                }
+
+                assertThat(paths.distinct()).hasSize(1)
+            }
         }
     }
 
@@ -127,47 +228,6 @@ internal class CliArgsSpec {
     fun `--all-rules lead to all rules being activated`() {
         val spec = parseArguments(arrayOf("--all-rules")).toSpec()
         assertThat(spec.rulesSpec.activateAllRules).isTrue()
-    }
-
-    @Test
-    fun `should load single filter`() {
-        val filters = CliArgs { excludes = "**/one/**" }.toSpecFilters()
-        assertThat(filters?.isIgnored(Path("/one/path"))).isTrue()
-        assertThat(filters?.isIgnored(Path("/two/path"))).isFalse()
-    }
-
-    @ParameterizedTest
-    @ValueSource(
-        strings = [
-            "**/one/**,**/two/**,**/three",
-            "**/one/**;**/two/**;**/three",
-            "**/one/** ,**/two/**, **/three",
-            "**/one/** ;**/two/**; **/three",
-            "**/one/**,**/two/**;**/three",
-            "**/one/** ,**/two/**; **/three",
-            " ,,**/one/**,**/two/**,**/three",
-        ]
-    )
-    fun parseExcludes(param: String) {
-        val spec = parseArguments(arrayOf("--excludes", param)).toSpec()
-        assertThat(spec.projectSpec.excludes).containsExactly("**/one/**", "**/two/**", "**/three")
-    }
-
-    @ParameterizedTest
-    @ValueSource(
-        strings = [
-            "**/one/**,**/two/**,**/three",
-            "**/one/**;**/two/**;**/three",
-            "**/one/** ,**/two/**, **/three",
-            "**/one/** ;**/two/**; **/three",
-            "**/one/**,**/two/**;**/three",
-            "**/one/** ,**/two/**; **/three",
-            " ,,**/one/**,**/two/**,**/three",
-        ]
-    )
-    fun parseIncludes(param: String) {
-        val spec = parseArguments(arrayOf("--includes", param)).toSpec()
-        assertThat(spec.projectSpec.includes).containsExactly("**/one/**", "**/two/**", "**/three")
     }
 
     @Nested
@@ -247,9 +307,4 @@ internal class CliArgsSpec {
             .isThrownBy { parseArguments(arrayOf("--jdk-home", "nonExistent")) }
             .withMessage("Value passed to --jdk-home must be a directory.")
     }
-}
-
-private fun CliArgs.toSpecFilters(): PathFilters? {
-    val spec = this.createSpec(NullPrintStream(), NullPrintStream()).projectSpec
-    return PathFilters.of(spec.includes.toList(), spec.excludes.toList())
 }


### PR DESCRIPTION
This is just the first step. Now the `cli` provides a list of files instead of directories and rules for include/exclude files.

After this change we can do things like #7009 where we can remove a lot of code from `:detekt-core` and simplify `:detekt-tooling`

Related with #6866