### PR TITLE
Move exitcode to cli

### DIFF
--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Main.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Main.kt
@@ -2,10 +2,10 @@
 
 package io.gitlab.arturbosch.detekt.cli
 
+import io.github.detekt.tooling.api.AnalysisResult
 import io.github.detekt.tooling.api.InvalidConfig
 import io.github.detekt.tooling.api.IssuesFound
 import io.github.detekt.tooling.api.UnexpectedError
-import io.github.detekt.tooling.api.exitCode
 import io.github.detekt.tooling.internal.NotApiButProbablyUsedByUsers
 import io.gitlab.arturbosch.detekt.api.internal.whichKotlin
 import io.gitlab.arturbosch.detekt.cli.runners.ConfigExporter
@@ -64,4 +64,12 @@ fun buildRunner(
         arguments.generateConfig != null -> ConfigExporter(arguments, outputPrinter)
         else -> Runner(arguments, outputPrinter, errorPrinter)
     }
+}
+
+@Suppress("detekt.MagicNumber")
+internal fun AnalysisResult.exitCode(): Int = when (error) {
+    is UnexpectedError -> 1
+    is IssuesFound -> 2
+    is InvalidConfig -> 3
+    null -> 0
 }

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/MainSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/MainSpec.kt
@@ -5,6 +5,11 @@ package io.gitlab.arturbosch.detekt.cli
 import io.github.detekt.test.utils.NullPrintStream
 import io.github.detekt.test.utils.StringPrintStream
 import io.github.detekt.test.utils.resourceAsPath
+import io.github.detekt.tooling.api.InvalidConfig
+import io.github.detekt.tooling.api.IssuesFound
+import io.github.detekt.tooling.api.UnexpectedError
+import io.github.detekt.tooling.internal.DefaultAnalysisResult
+import io.github.detekt.tooling.internal.EmptyContainer
 import io.gitlab.arturbosch.detekt.cli.runners.ConfigExporter
 import io.gitlab.arturbosch.detekt.cli.runners.Runner
 import io.gitlab.arturbosch.detekt.cli.runners.VersionPrinter
@@ -72,6 +77,31 @@ class MainSpec {
             buildRunner(args, out, err)
 
             assertThat(err.toString()).isEmpty()
+        }
+    }
+
+    @Nested
+    inner class `returns different exit codes based on error` {
+
+        @Test
+        fun `returns zero on no error`() {
+            assertThat(DefaultAnalysisResult(EmptyContainer, null).exitCode()).isEqualTo(0)
+        }
+
+        @Test
+        fun `returns one on any UnexpectedError`() {
+            val unexpectedError = UnexpectedError(IllegalArgumentException())
+            assertThat(DefaultAnalysisResult(null, unexpectedError).exitCode()).isEqualTo(1)
+        }
+
+        @Test
+        fun `returns two on MaxIssuesReached`() {
+            assertThat(DefaultAnalysisResult(null, IssuesFound("")).exitCode()).isEqualTo(2)
+        }
+
+        @Test
+        fun `returns three on InvalidConfig`() {
+            assertThat(DefaultAnalysisResult(null, InvalidConfig("")).exitCode()).isEqualTo(3)
         }
     }
 }

--- a/detekt-tooling/api/detekt-tooling.api
+++ b/detekt-tooling/api/detekt-tooling.api
@@ -3,10 +3,6 @@ public abstract interface class io/github/detekt/tooling/api/AnalysisResult {
 	public abstract fun getError ()Lio/github/detekt/tooling/api/DetektError;
 }
 
-public final class io/github/detekt/tooling/api/AnalysisResultKt {
-	public static final fun exitCode (Lio/github/detekt/tooling/api/AnalysisResult;)I
-}
-
 public abstract interface class io/github/detekt/tooling/api/Baseline {
 	public abstract fun contains (Ljava/lang/String;)Z
 	public abstract fun getCurrentIssues ()Ljava/util/Set;

--- a/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/api/AnalysisResult.kt
+++ b/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/api/AnalysisResult.kt
@@ -8,14 +8,3 @@ interface AnalysisResult {
 
     val container: Detektion?
 }
-
-/**
- * May be used to exit the JVM via [kotlin.system.exitProcess].
- */
-@Suppress("detekt.MagicNumber")
-fun AnalysisResult.exitCode(): Int = when (error) {
-    is UnexpectedError -> 1
-    is IssuesFound -> 2
-    is InvalidConfig -> 3
-    null -> 0
-}

--- a/detekt-tooling/src/test/kotlin/io/github/detekt/tooling/api/AnalysisResultSpec.kt
+++ b/detekt-tooling/src/test/kotlin/io/github/detekt/tooling/api/AnalysisResultSpec.kt
@@ -2,37 +2,10 @@ package io.github.detekt.tooling.api
 
 import io.github.detekt.tooling.internal.DefaultAnalysisResult
 import io.github.detekt.tooling.internal.EmptyContainer
-import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatCode
-import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 class AnalysisResultSpec {
-
-    @Nested
-    inner class `returns different exit codes based on error` {
-
-        @Test
-        fun `returns zero on no error`() {
-            assertThat(DefaultAnalysisResult(EmptyContainer, null).exitCode()).isEqualTo(0)
-        }
-
-        @Test
-        fun `returns one on any UnexpectedError`() {
-            val unexpectedError = UnexpectedError(IllegalArgumentException())
-            assertThat(DefaultAnalysisResult(null, unexpectedError).exitCode()).isEqualTo(1)
-        }
-
-        @Test
-        fun `returns two on MaxIssuesReached`() {
-            assertThat(DefaultAnalysisResult(null, IssuesFound("")).exitCode()).isEqualTo(2)
-        }
-
-        @Test
-        fun `returns three on InvalidConfig`() {
-            assertThat(DefaultAnalysisResult(null, InvalidConfig("")).exitCode()).isEqualTo(3)
-        }
-    }
 
     @Test
     fun `either container or error must be present`() {


### PR DESCRIPTION
No need to have this in `:detekt-tooling`. This is just an implementation detail of `cli`. There is not a good reason for other clients to use the same exit code convention.