### PR TITLE
Bump compileSdk in Android test projects

### DIFF
--- a/detekt-gradle-plugin/src/functionalTest/kotlin/dev/detekt/gradle/plugin/DetektBasePluginSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/dev/detekt/gradle/plugin/DetektBasePluginSpec.kt
@@ -70,7 +70,7 @@ class DetektBasePluginSpec {
                 }
                 
                 android {
-                    compileSdk = 30
+                    compileSdk = 34
                     namespace = "dev.detekt.gradle.plugin.app"
                 }
             """.trimIndent(),
@@ -135,7 +135,7 @@ class DetektBasePluginSpec {
                 }
                 
                 android {
-                    compileSdk = 30
+                    compileSdk = 34
                     namespace = "dev.detekt.gradle.plugin.app"
                 }
             """.trimIndent(),

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektAndroidSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektAndroidSpec.kt
@@ -662,7 +662,7 @@ private val KOTLIN_ONLY_LIB_PLUGIN_BLOCK = """
 @Language("gradle.kts")
 private val ANDROID_BLOCK = """
     android {
-        compileSdk = 30
+        compileSdk = 34
         namespace = "io.gitlab.arturbosch.detekt.app"
         compileOptions {
             sourceCompatibility = JavaVersion.VERSION_1_8
@@ -677,7 +677,7 @@ private val ANDROID_BLOCK = """
 @Language("gradle.kts")
 private val ANDROID_BLOCK_WITH_FLAVOR = """
     android {
-        compileSdk = 30
+        compileSdk = 34
         namespace = "io.gitlab.arturbosch.detekt.app"
         flavorDimensions("age", "name")
         productFlavors {
@@ -704,7 +704,7 @@ private val ANDROID_BLOCK_WITH_FLAVOR = """
 @Language("gradle.kts")
 private val ANDROID_BLOCK_WITH_VIEW_BINDING = """
     android {
-        compileSdk = 30
+        compileSdk = 34
         namespace = "io.gitlab.arturbosch.detekt.app"
         defaultConfig {
             applicationId = "io.gitlab.arturbosch.detekt.app"

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektMultiplatformSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektMultiplatformSpec.kt
@@ -169,7 +169,7 @@ class DetektMultiplatformSpec {
                                 id("io.gitlab.arturbosch.detekt")
                             }
                             android {
-                                compileSdk = 30
+                                compileSdk = 34
                                 namespace = "io.gitlab.arturbosch.detekt.app"
                                 sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
                                 buildTypes {

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/report/ReportMergeSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/report/ReportMergeSpec.kt
@@ -100,7 +100,7 @@ class ReportMergeSpec {
                         id("io.gitlab.arturbosch.detekt")
                     }
                     android {
-                       compileSdk = 30
+                       compileSdk = 34
                        namespace = "io.github.detekt.app"
                        compileOptions {
                            sourceCompatibility = JavaVersion.VERSION_11
@@ -127,7 +127,7 @@ class ReportMergeSpec {
                         kotlin("android")
                     }
                     android {
-                        compileSdk = 30
+                        compileSdk = 34
                         namespace = "io.github.detekt.lib"
                         compileOptions {
                             sourceCompatibility = JavaVersion.VERSION_11


### PR DESCRIPTION
Version 30 isn't preinstalled on CI runners anymore and there were problems trying to install it when tests were run on a PR.