### PR TITLE
Don't allow invalid Source Locations

### DIFF
--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Location.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Location.kt
@@ -72,7 +72,7 @@ class Location(
 class SourceLocation(val line: Int, val column: Int) {
     init {
         require(line > 0) { "The source location line must be greater than 0" }
-        require(column > 0) { "The source location column must should be greater than 0" }
+        require(column > 0) { "The source location column must be greater than 0" }
     }
 
     override fun toString(): String = "$line:$column"

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Location.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Location.kt
@@ -71,7 +71,7 @@ class Location(
 @Poko
 class SourceLocation(val line: Int, val column: Int) {
     init {
-        require(line > 0) { "The source location line must should be greater than 0" }
+        require(line > 0) { "The source location line must be greater than 0" }
         require(column > 0) { "The source location column must should be greater than 0" }
     }
 

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Location.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Location.kt
@@ -33,9 +33,9 @@ class Location(
          */
         fun from(element: PsiElement, offset: Int = 0): Location {
             val start = startLineAndColumn(element, offset)
-            val sourceLocation = SourceLocation(start.line, start.column)
+            val sourceLocation = SourceLocation(start.line.coerceAtLeast(1), start.column.coerceAtLeast(1))
             val end = endLineAndColumn(element, offset)
-            val endSourceLocation = SourceLocation(end.line, end.column)
+            val endSourceLocation = SourceLocation(end.line.coerceAtLeast(1), end.column.coerceAtLeast(1))
             val textLocation = TextLocation(element.startOffset + offset, element.endOffset + offset)
             return Location(sourceLocation, endSourceLocation, textLocation, element.containingFile.toFilePath())
         }
@@ -70,6 +70,11 @@ class Location(
  */
 @Poko
 class SourceLocation(val line: Int, val column: Int) {
+    init {
+        require(line > 0) { "The source location line must should be greater than 0" }
+        require(column > 0) { "The source location column must should be greater than 0" }
+    }
+
     override fun toString(): String = "$line:$column"
 }
 

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Location.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Location.kt
@@ -33,9 +33,9 @@ class Location(
          */
         fun from(element: PsiElement, offset: Int = 0): Location {
             val start = startLineAndColumn(element, offset)
-            val sourceLocation = SourceLocation(start.line.coerceAtLeast(1), start.column.coerceAtLeast(1))
+            val sourceLocation = SourceLocation(start.line, start.column)
             val end = endLineAndColumn(element, offset)
-            val endSourceLocation = SourceLocation(end.line.coerceAtLeast(1), end.column.coerceAtLeast(1))
+            val endSourceLocation = SourceLocation(end.line, end.column)
             val textLocation = TextLocation(element.startOffset + offset, element.endOffset + offset)
             return Location(sourceLocation, endSourceLocation, textLocation, element.containingFile.toFilePath())
         }
@@ -60,7 +60,7 @@ class Location(
 
         private fun lineAndColumn(element: PsiElement, range: TextRange): PsiDiagnosticUtils.LineAndColumn {
             return getLineAndColumnInPsiFile(element.containingFile, range)
-                ?: PsiDiagnosticUtils.LineAndColumn(-1, -1, null)
+                ?: PsiDiagnosticUtils.LineAndColumn(1, 1, null)
         }
     }
 }

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/Builders.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/Builders.kt
@@ -21,7 +21,7 @@ private fun buildEmptyEntity(): Entity = Entity(
     name = "",
     signature = "",
     location = Location(
-        source = SourceLocation(0, 0),
+        source = SourceLocation(1, 1),
         text = TextLocation(0, 0),
         filePath = FilePath.fromAbsolute(Path("/"))
     ),

--- a/detekt-psi-utils/src/main/kotlin/io/github/detekt/psi/KtFiles.kt
+++ b/detekt-psi-utils/src/main/kotlin/io/github/detekt/psi/KtFiles.kt
@@ -83,10 +83,14 @@ fun PsiFile.toFilePath(): FilePath {
 
 // #3317 If any rule mutates the PsiElement, searching the original PsiElement may throw an exception.
 fun getLineAndColumnInPsiFile(file: PsiFile, range: TextRange): PsiDiagnosticUtils.LineAndColumn? {
-    return runCatching {
-        @Suppress("ForbiddenMethodCall")
-        DiagnosticUtils.getLineAndColumnInPsiFile(file, range)
-    }.getOrNull()
+    return if (file.textLength == 0) {
+        null
+    } else {
+        runCatching {
+            @Suppress("ForbiddenMethodCall")
+            DiagnosticUtils.getLineAndColumnInPsiFile(file, range)
+        }.getOrNull()
+    }
 }
 
 private fun buildPlatformSpecificSuffixes(platforms: List<String>): List<String> =

--- a/detekt-rules-empty/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyKotlinFileSpec.kt
+++ b/detekt-rules-empty/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyKotlinFileSpec.kt
@@ -9,16 +9,6 @@ import org.junit.jupiter.api.Test
 class EmptyKotlinFileSpec {
     private val subject = EmptyKotlinFile(Config.empty)
 
-    private val codeWithPackageStatement = """
-            package my.packagee
-    """.trimIndent()
-
-    private val codeWithFunction = """
-            package my.packagee
-            
-            fun myFunction() {}
-    """.trimIndent()
-
     @Test
     fun `reports empty if file is blank`() {
         val code = ""
@@ -27,11 +17,19 @@ class EmptyKotlinFileSpec {
 
     @Test
     fun `does report file with package statement`() {
+        val codeWithPackageStatement = """
+            package my.packagee
+        """.trimIndent()
         assertThat(subject.compileAndLint(codeWithPackageStatement)).hasSize(1)
     }
 
     @Test
     fun `does not report file with code`() {
-        assertThat(subject.compileAndLint(codeWithFunction)).hasSize(0)
+        val code = """
+            package my.packagee
+
+            fun myFunction() {}
+        """.trimIndent()
+        assertThat(subject.compileAndLint(code)).isEmpty()
     }
 }

--- a/detekt-rules-empty/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyKotlinFileSpec.kt
+++ b/detekt-rules-empty/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyKotlinFileSpec.kt
@@ -12,7 +12,9 @@ class EmptyKotlinFileSpec {
     @Test
     fun `reports empty if file is blank`() {
         val code = ""
-        assertThat(subject.lint(code)).hasSize(1)
+        assertThat(subject.lint(code))
+            .singleElement()
+            .hasSourceLocation(1, 1)
     }
 
     @Test
@@ -20,7 +22,9 @@ class EmptyKotlinFileSpec {
         val codeWithPackageStatement = """
             package my.packagee
         """.trimIndent()
-        assertThat(subject.compileAndLint(codeWithPackageStatement)).hasSize(1)
+        assertThat(subject.compileAndLint(codeWithPackageStatement))
+            .singleElement()
+            .hasSourceLocation(1, 1)
     }
 
     @Test


### PR DESCRIPTION
Fix #7024

A line or column value less than 1 is not valid. Detekt didn't check this but sarif those so we were generating invalid sarif.

Other way to solve the issue is to move this code to the sarif serializer but I think that it's more correct to fix it in our own code and don't allow to point to a source location that doesn't exist.