### PR TITLE
Add missing overlapping info for NoEmptyClassBody

### DIFF
--- a/website/versioned_docs/version-1.23.5/rules/formatting.md
+++ b/website/versioned_docs/version-1.23.5/rules/formatting.md
@@ -387,6 +387,9 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#
 
 See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-empty-class-bodies) for documentation.
 
+This rules overlaps with [empty-blocks>EmptyClassBlock](https://detekt.dev/empty-blocks.html#emptyclassblock)
+from the standard rules, make sure to enable just one. The pro of this rule is that it can auto-correct the issue.
+
 **Active by default**: Yes - Since v1.0.0
 
 ### NoEmptyFirstLineInClassBody


### PR DESCRIPTION
Same thing I did [here](https://github.com/detekt/detekt/pull/5378) a while ago, but for some reason got lost at some point: [NoEmptyClassBody](https://detekt.dev/docs/rules/formatting/#noemptyclassbody) overlaps with [EmptyClassBlock](https://detekt.dev/docs/rules/empty-blocks/#emptyclassblock) and the docs don't mention it.