### PR TITLE
Update NoEmptyClassBody.kt

### DIFF
--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/NoEmptyClassBody.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/NoEmptyClassBody.kt
@@ -8,6 +8,9 @@ import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 
 /**
  * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#no-empty-class-bodies) for documentation.
+ *
+ * This rules overlaps with [empty-blocks>EmptyClassBlock](https://detekt.dev/empty-blocks.html#emptyclassblock)
+ * from the standard rules, make sure to enable just one.
  */
 @ActiveByDefault(since = "1.0.0")
 @AutoCorrectable(since = "1.0.0")


### PR DESCRIPTION
Same thing I did [here](https://github.com/detekt/detekt/pull/5378) a while ago: [NoEmptyClassBody](https://detekt.dev/docs/rules/formatting/#noemptyclassbody) overlaps with [EmptyClassBlock](https://detekt.dev/docs/rules/empty-blocks/#emptyclassblock) and the current docs don't mention it.

Updating the KDoc this time so it's fixed permanently in future versions (thanks @3flex!).