### PR TITLE
Allow setting default autocorrect mode with Gradle property

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/DetektBasePlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/DetektBasePlugin.kt
@@ -39,7 +39,11 @@ class DetektBasePlugin : Plugin<Project> {
             allRules.convention(DEFAULT_ALL_RULES_VALUE)
             buildUponDefaultConfig.convention(DEFAULT_BUILD_UPON_DEFAULT_CONFIG_VALUE)
             disableDefaultRuleSets.convention(DEFAULT_DISABLE_RULESETS_VALUE)
-            autoCorrect.convention(DEFAULT_AUTO_CORRECT_VALUE)
+            autoCorrect.convention(
+                project.providers.gradleProperty(ENABLE_AUTOCORRECT)
+                    .map { it.toBoolean() }
+                    .orElse(DEFAULT_AUTO_CORRECT_VALUE)
+            )
             reportsDir.convention(
                 project.extensions.getByType(ReportingExtension::class.java).baseDirectory.dir("detekt")
             )
@@ -118,3 +122,4 @@ class DetektBasePlugin : Plugin<Project> {
 }
 
 internal const val CONFIGURATION_DETEKT_PLUGINS = "detektPlugins"
+internal const val ENABLE_AUTOCORRECT = "detekt.default.autocorrect"


### PR DESCRIPTION
This makes it possible to enable autocorrect when running tasks that depend on detekt tasks e.g.
`./gradlew check -Pdetekt.default.autocorrect=true`

Without this, the only way to enable autocorrect on CLI is by declaring every detekt task on the CLI and passing `--auto-correct` to every one.

Tests will be added once https://github.com/detekt/detekt/pull/6913 is merged as that provides some support to pass Gradle properties through to the CLI when setting up tests.