### PR TITLE
Refactor DGP to compile against AGP API

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,7 +25,7 @@ kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-t
 
 # This represents the oldest AGP version that is supported by detekt.
 # This should only be updated when updating the minimum version supported by detekt's Gradle plugin.
-android-gradle-minSupported = "com.android.tools.build:gradle:7.0.0"
+android-gradle-minSupported = "com.android.tools.build:gradle-api:7.1.0"
 
 # This version of AGP is used for testing and should be updated when new AGP versions are released to ensure detekt's
 # Gradle plugin remains compatible.


### PR DESCRIPTION
Closes #3327

In AGP 7.1.0 `nestedComponents` was incubating, but it's part of the stable API now.

Requires AGP min version bump to 7.1.0, released in Jan 2022. Marking as a notable change for that reason.