### PR TITLE
We no longer have a trim indent by default so this is not needed any more

### DIFF
--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/NewLineAtEndOfFileSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/NewLineAtEndOfFileSpec.kt
@@ -12,7 +12,7 @@ class NewLineAtEndOfFileSpec {
 
     @Test
     fun `should not flag a kt file containing new line at the end`() {
-        val code = "class Test\n\n" // we need double '\n' because .lint() applies .trimIndent() which removes one
+        val code = "class Test\n"
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 


### PR DESCRIPTION
This was here because in the past we always applied a `trimIndent()` to all the code snippets. That's not the case anymore so we can remove the double `\n\n` and the comment.
