### PR TITLE
Require Gradle 7.4.2 before throwing VerificationException

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/DetektInvoker.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/DetektInvoker.kt
@@ -104,7 +104,7 @@ private fun processResult(message: String?, reflectionWrapper: Exception, ignore
             ignoreFailures -> return
             GradleVersion.current() >= GradleVersion.version("8.2") ->
                 throw VerificationException(message, reflectionWrapper)
-            GradleVersion.current() >= GradleVersion.version("7.4") -> throw VerificationException(message)
+            GradleVersion.current() >= GradleVersion.version("7.4.2") -> throw VerificationException(message)
             else -> throw GradleException(message, reflectionWrapper)
         }
     } else {


### PR DESCRIPTION
Avoids a NPE when configuration cache is enabled on Gradle 7.4 & 7.4.1.

See https://github.com/gradle/gradle/issues/20246