### PR TITLE
Improve logging configs

### DIFF
--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Config.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Config.kt
@@ -68,6 +68,10 @@ interface Config {
             override fun subConfigKeys(): Set<String> = emptySet()
 
             override fun <T : Any> valueOrNull(key: String): T? = null
+
+            override fun toString(): String {
+                return "Config.empty"
+            }
         }
 
         const val ACTIVE_KEY: String = "active"

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/AllRulesConfig.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/AllRulesConfig.kt
@@ -4,9 +4,10 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.core.config.validation.DeprecatedRule
 import io.gitlab.arturbosch.detekt.core.config.validation.ValidatableConfiguration
 import io.gitlab.arturbosch.detekt.core.config.validation.validateConfig
+import io.gitlab.arturbosch.detekt.core.util.indentCompat
 
 @Suppress("UNCHECKED_CAST")
-internal data class AllRulesConfig(
+internal class AllRulesConfig(
     private val originalConfig: Config,
     private val defaultConfig: Config,
     private val deprecatedRules: Set<DeprecatedRule> = emptySet(),
@@ -43,4 +44,13 @@ internal data class AllRulesConfig(
     private fun isDeprecated(): Boolean = deprecatedRules.any { parentPath == it.toPath() }
 
     private fun DeprecatedRule.toPath() = "$ruleSetId > $ruleId"
+
+    @Suppress("MagicNumber")
+    override fun toString() = """
+        AllRulesConfig(
+            originalConfig=${originalConfig.toString().indentCompat(12).trim()},
+            defaultConfig=${defaultConfig.toString().indentCompat(12).trim()},
+            deprecatedRules=$deprecatedRules,
+        )
+    """.trimIndent()
 }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/CompositeConfig.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/CompositeConfig.kt
@@ -4,6 +4,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Notification
 import io.gitlab.arturbosch.detekt.core.config.validation.ValidatableConfiguration
 import io.gitlab.arturbosch.detekt.core.config.validation.validateConfig
+import io.gitlab.arturbosch.detekt.core.util.indentCompat
 
 /**
  * Wraps two different configuration which should be considered when retrieving properties.
@@ -34,7 +35,13 @@ class CompositeConfig(
     override fun <T : Any> valueOrNull(key: String): T? =
         lookFirst.valueOrNull(key) ?: lookSecond.valueOrNull(key)
 
-    override fun toString(): String = "CompositeConfig(lookFirst=$lookFirst, lookSecond=$lookSecond)"
+    @Suppress("MagicNumber")
+    override fun toString() = """
+        CompositeConfig(
+            lookFirst=${lookFirst.toString().indentCompat(12).trim()},
+            lookSecond=${lookSecond.toString().indentCompat(12).trim()},
+        )
+    """.trimIndent()
 
     /**
      * Validates both sides of the composite config according to defined properties of the baseline config.

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/DisabledAutoCorrectConfig.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/DisabledAutoCorrectConfig.kt
@@ -4,6 +4,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Notification
 import io.gitlab.arturbosch.detekt.core.config.validation.ValidatableConfiguration
 import io.gitlab.arturbosch.detekt.core.config.validation.validateConfig
+import io.gitlab.arturbosch.detekt.core.util.indentCompat
 
 @Suppress("UNCHECKED_CAST")
 class DisabledAutoCorrectConfig(
@@ -32,4 +33,11 @@ class DisabledAutoCorrectConfig(
 
     override fun validate(baseline: Config, excludePatterns: Set<Regex>): List<Notification> =
         validateConfig(wrapped, baseline, excludePatterns)
+
+    @Suppress("MagicNumber")
+    override fun toString() = """
+        DisabledAutoCorrectConfig(
+            ${wrapped.toString().indentCompat(12).trim()},
+        )
+    """.trimIndent()
 }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/util/ConfigExtensions.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/util/ConfigExtensions.kt
@@ -31,3 +31,8 @@ private fun PathFilters.isIgnored(ktFile: KtFile): Boolean {
     }
     return isIgnored(ktFile.absolutePath())
 }
+
+internal fun String.indentCompat(indent: Int): String {
+    val spaces = " ".repeat(indent)
+    return this.lines().joinToString("\n") { spaces + it }
+}


### PR DESCRIPTION
Working on #7054 I had a bad time debugging the differences of two config files because their `toString` where not friendly.

This PR fixes that, an example, before:
```
io.gitlab.arturbosch.detekt.core.config.DisabledAutoCorrectConfig@3fb450d7
```

After:
```
DisabledAutoCorrectConfig(
    YamlConfig(
        {
            style={
                autoCorrect=true,
                MagicNumber={autoCorrect=true},
                MagicString={autoCorrect=false},
            },
            comments={
                autoCorrect=false,
                ClassDoc={autoCorrect=true},
                FunctionDoc={autoCorrect=false},
            },
        },
    ),
)
```
