### PR TITLE
Define default values only at the DetektExtension level

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -150,17 +150,17 @@ abstract class Detekt @Inject constructor(
             DefaultReportArgument(reports.txt),
             DefaultReportArgument(reports.sarif),
             DefaultReportArgument(reports.md),
-            DebugArgument(debug.getOrElse(false)),
-            ParallelArgument(parallel.getOrElse(false)),
-            BuildUponDefaultConfigArgument(buildUponDefaultConfig.getOrElse(false)),
-            AllRulesArgument(allRules.getOrElse(false)),
-            AutoCorrectArgument(autoCorrect.getOrElse(false)),
+            DebugArgument(debug.get()),
+            ParallelArgument(parallel.get()),
+            BuildUponDefaultConfigArgument(buildUponDefaultConfig.get()),
+            AllRulesArgument(allRules.get()),
+            AutoCorrectArgument(autoCorrect.get()),
             FailOnSeverityArgument(
-                ignoreFailures = ignoreFailures.getOrElse(false),
+                ignoreFailures = ignoreFailures.get(),
                 minSeverity = failOnSeverity.get()
             ),
             BasePathArgument(basePath.orNull),
-            DisableDefaultRuleSetArgument(disableDefaultRuleSets.getOrElse(false))
+            DisableDefaultRuleSetArgument(disableDefaultRuleSets.get())
         ).plus(convertCustomReportsToArguments()).flatMap(CliArgument::toArgument)
 
     @InputFiles

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
@@ -126,13 +126,13 @@ abstract class DetektCreateBaselineTask @Inject constructor(
             BaselineArgument(baseline.get()),
             InputArgument(source),
             ConfigArgument(config),
-            DebugArgument(debug.getOrElse(false)),
-            ParallelArgument(parallel.getOrElse(false)),
-            BuildUponDefaultConfigArgument(buildUponDefaultConfig.getOrElse(false)),
-            AutoCorrectArgument(autoCorrect.getOrElse(false)),
-            AllRulesArgument(allRules.getOrElse(false)),
+            DebugArgument(debug.get()),
+            ParallelArgument(parallel.get()),
+            BuildUponDefaultConfigArgument(buildUponDefaultConfig.get()),
+            AutoCorrectArgument(autoCorrect.get()),
+            AllRulesArgument(allRules.get()),
             BasePathArgument(basePath.orNull),
-            DisableDefaultRuleSetArgument(disableDefaultRuleSets.getOrElse(false))
+            DisableDefaultRuleSetArgument(disableDefaultRuleSets.get())
         ).flatMap(CliArgument::toArgument)
 
     @InputFiles
@@ -157,7 +157,7 @@ abstract class DetektCreateBaselineTask @Inject constructor(
             logger.info("Executing $name using DetektInvoker")
             DetektInvoker.create().invokeCli(
                 arguments = arguments,
-                ignoreFailures = ignoreFailures.getOrElse(false),
+                ignoreFailures = ignoreFailures.get(),
                 classpath = detektClasspath.plus(pluginClasspath).files,
                 taskName = name
             )

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/SharedTasks.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/SharedTasks.kt
@@ -69,6 +69,7 @@ internal fun Project.registerCreateBaselineTask(
         it.disableDefaultRuleSets.convention(extension.disableDefaultRuleSets)
         it.buildUponDefaultConfig.convention(extension.buildUponDefaultConfig)
         it.autoCorrect.convention(extension.autoCorrect)
+        it.ignoreFailures.convention(extension.ignoreFailures)
         it.basePath.convention(extension.basePath.map { basePath -> basePath.asFile.absolutePath })
         it.allRules.convention(extension.allRules)
         configuration(it)

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/DetektInvoker.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/DetektInvoker.kt
@@ -50,7 +50,7 @@ internal abstract class DetektWorkAction : WorkAction<DetektWorkParameters> {
                 parameters.arguments.get(),
                 parameters.classpath.files,
                 parameters.taskName.get(),
-                parameters.ignoreFailures.getOrElse(false)
+                parameters.ignoreFailures.get()
             )
             return
         }
@@ -59,7 +59,7 @@ internal abstract class DetektWorkAction : WorkAction<DetektWorkParameters> {
             parameters.arguments.get(),
             parameters.classpath.files,
             parameters.taskName.get(),
-            parameters.ignoreFailures.getOrElse(false)
+            parameters.ignoreFailures.get()
         )
     }
 }


### PR DESCRIPTION
While working on #7054 I realized that changing the default values in the `DetektTask` and `BaselineDetektTask` did nothing. The `DetektExtesion` is the one that defines these default values. For that reason I'm removing this useless values.

I think that this is a breaking change for the user that only uses our task without the plugin but this change goes to 2.0.0 so I imagine that's not a big deal.

I see other options to fix this:
- Move the conventions to the tasks.
- Use the same constants in the tasks that the ones that are used when setting the conventions on the extension.

But I think that is better to don't have default values on the tasks.