### PR TITLE
Add failing test for worker API on Gradle 6.8.3

### DIFF
--- a/detekt-gradle-plugin/src/functionalTestMinSupportedGradle/kotlin/io/gitlab/arturbosch/detekt/GradleVersionSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTestMinSupportedGradle/kotlin/io/gitlab/arturbosch/detekt/GradleVersionSpec.kt
@@ -4,6 +4,7 @@ import io.gitlab.arturbosch.detekt.testkit.DslTestBuilder
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.TaskOutcome
 import org.gradle.testkit.runner.internal.PluginUnderTestMetadataReading
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.condition.EnabledForJreRange
@@ -26,6 +27,28 @@ class GradleVersionSpec {
             .withPluginClasspath(PluginUnderTestMetadataReading.readImplementationClasspath(metadataUrl))
             .build()
         gradleRunner.runDetektTaskAndCheckResult { result ->
+            assertThat(result.task(":detekt")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+        }
+    }
+
+    @Test
+    @DisplayName("Runs on version $GRADLE_VERSION with worker API enabled")
+    @EnabledForJreRange(max = JAVA_15, disabledReason = "Gradle $GRADLE_VERSION unsupported on this Java version")
+    @Disabled("https://github.com/detekt/detekt/issues/7058")
+    fun runsOnOldestSupportedGradleVersionWithWorkerApi() {
+        val builder = DslTestBuilder.kotlin()
+        val metadataUrl =
+            Paths.get("build/gradleMinVersionPluginUnderTestMetadata/plugin-under-test-metadata.properties")
+                .toUri()
+                .toURL()
+        val gradleRunner = builder
+            .withGradleVersion(GRADLE_VERSION)
+            .withPluginClasspath(PluginUnderTestMetadataReading.readImplementationClasspath(metadataUrl))
+            .build()
+        gradleRunner.runTasksAndCheckResult(
+            "detekt",
+            "-Pdetekt.use.worker.api=true",
+        ) { result ->
             assertThat(result.task(":detekt")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
         }
     }


### PR DESCRIPTION
See #7058 