### PR TITLE
Isolate detekt classpath from Gradle runtime on workers

### DIFF
--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -87,7 +87,6 @@ dependencies {
     implementation(libs.sarif4k)
     testFixturesCompileOnly("org.jetbrains:annotations:24.1.0")
     compileOnly("org.jetbrains:annotations:24.1.0")
-    compileOnly("io.gitlab.arturbosch.detekt:detekt-cli:1.23.5")
 
     testKitRuntimeOnly(libs.kotlin.gradle)
     testKitGradleMinVersionRuntimeOnly(libs.kotlin.gradle) {

--- a/detekt-gradle-plugin/src/functionalTestMinSupportedGradle/kotlin/io/gitlab/arturbosch/detekt/GradleVersionSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTestMinSupportedGradle/kotlin/io/gitlab/arturbosch/detekt/GradleVersionSpec.kt
@@ -4,7 +4,6 @@ import io.gitlab.arturbosch.detekt.testkit.DslTestBuilder
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.TaskOutcome
 import org.gradle.testkit.runner.internal.PluginUnderTestMetadataReading
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.condition.EnabledForJreRange
@@ -34,7 +33,6 @@ class GradleVersionSpec {
     @Test
     @DisplayName("Runs on version $GRADLE_VERSION with worker API enabled")
     @EnabledForJreRange(max = JAVA_15, disabledReason = "Gradle $GRADLE_VERSION unsupported on this Java version")
-    @Disabled("https://github.com/detekt/detekt/issues/7058")
     fun runsOnOldestSupportedGradleVersionWithWorkerApi() {
         val builder = DslTestBuilder.kotlin()
         val metadataUrl =

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -177,13 +177,11 @@ abstract class Detekt @Inject constructor(
     fun check() {
         if (providers.gradleProperty(USE_WORKER_API).getOrElse("false") == "true") {
             logger.info("Executing $name using Worker API")
-            val workQueue = workerExecutor.processIsolation { workerSpec ->
-                workerSpec.classpath.from(detektClasspath)
-                workerSpec.classpath.from(pluginClasspath)
-            }
+            val workQueue = workerExecutor.processIsolation()
 
             workQueue.submit(DetektWorkAction::class.java) { workParameters ->
                 workParameters.arguments.set(arguments)
+                workParameters.classpath.setFrom(detektClasspath, pluginClasspath)
                 workParameters.ignoreFailures.set(ignoreFailures)
                 workParameters.dryRun.set(isDryRun.orNull.toBoolean())
                 workParameters.taskName.set(name)

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
@@ -145,13 +145,11 @@ abstract class DetektCreateBaselineTask @Inject constructor(
     fun baseline() {
         if (providers.gradleProperty(USE_WORKER_API).getOrElse("false") == "true") {
             logger.info("Executing $name using Worker API")
-            val workQueue = workerExecutor.processIsolation { workerSpec ->
-                workerSpec.classpath.from(detektClasspath)
-                workerSpec.classpath.from(pluginClasspath)
-            }
+            val workQueue = workerExecutor.processIsolation()
 
             workQueue.submit(DetektWorkAction::class.java) { workParameters ->
                 workParameters.arguments.set(arguments)
+                workParameters.classpath.setFrom(detektClasspath, pluginClasspath)
                 workParameters.ignoreFailures.set(ignoreFailures)
                 workParameters.taskName.set(name)
             }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektGenerateConfigTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektGenerateConfigTask.kt
@@ -57,13 +57,11 @@ abstract class DetektGenerateConfigTask @Inject constructor(
 
         if (providers.gradleProperty(USE_WORKER_API).getOrElse("false") == "true") {
             logger.info("Executing $name using Worker API")
-            val workQueue = workerExecutor.processIsolation { workerSpec ->
-                workerSpec.classpath.from(detektClasspath)
-                workerSpec.classpath.from(pluginClasspath)
-            }
+            val workQueue = workerExecutor.processIsolation()
 
             workQueue.submit(DetektWorkAction::class.java) { workParameters ->
                 workParameters.arguments.set(arguments)
+                workParameters.classpath.setFrom(detektClasspath, pluginClasspath)
                 workParameters.taskName.set(name)
             }
         } else {

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/DetektInvoker.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/DetektInvoker.kt
@@ -55,17 +55,12 @@ internal abstract class DetektWorkAction : WorkAction<DetektWorkParameters> {
             return
         }
 
-        try {
-            @Suppress("DEPRECATION")
-            val runner = io.gitlab.arturbosch.detekt.cli.buildRunner(
-                parameters.arguments.get().toTypedArray(),
-                System.out,
-                System.err
-            )
-            runner.execute()
-        } catch (e: Exception) {
-            processResult(e.message, e, parameters.ignoreFailures.getOrElse(false))
-        }
+        DefaultCliInvoker().invokeCli(
+            parameters.arguments.get(),
+            parameters.classpath,
+            parameters.taskName.get(),
+            parameters.ignoreFailures.getOrElse(false)
+        )
     }
 }
 


### PR DESCRIPTION
Fixes #7058

I have not done any performance tests - this keeps the parallelism provided by the worker API, and does work across all Gradle versions now, so it's an improvement over what came before even if it's slower.

EDIT: Performance is likely to be terrible. Behaviour of worker daemons changed since Gradle 8. See:
* https://github.com/gradle/gradle/pull/21632
* https://github.com/gradle/gradle/issues/28479

They no longer create persistent daemons which can be reused across multiple builds.