### PR TITLE
Allow to easily add gradle arguments

### DIFF
--- a/detekt-gradle-plugin/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/testkit/DslGradleRunner.kt
+++ b/detekt-gradle-plugin/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/testkit/DslGradleRunner.kt
@@ -22,6 +22,7 @@ constructor(
     val gradleVersionOrNone: String? = null,
     val dryRun: Boolean = false,
     val jvmArgs: String = "-Xmx2g -XX:MaxMetaspaceSize=1g",
+    val gradleProperties: Map<String, String> = emptyMap(),
     val customPluginClasspath: List<File> = emptyList(),
     val projectScript: Project.() -> Unit = {}
 ) {
@@ -137,6 +138,7 @@ constructor(
             if (dryRun) {
                 add("-Pdetekt-dry-run=true")
             }
+            addAll(gradleProperties.toList().map { (key, value) -> "-P$key=$value" })
             addAll(tasks)
         }
 
@@ -175,7 +177,7 @@ constructor(
     }
 
     companion object {
-        const val SETTINGS_FILENAME = "settings.gradle"
+        private const val SETTINGS_FILENAME = "settings.gradle"
         private const val DETEKT_TASK = "detekt"
     }
 }


### PR DESCRIPTION
This code was created for #6913 and extracted from that PR. That PR will take long time to get merged (if it is merged at some point). But #7040 was waiting for this exactly change so I'm moving it to its own PR to unblock that.