### PR TITLE
Remove `HasEntity`

### DIFF
--- a/detekt-api/api/detekt-api.api
+++ b/detekt-api/api/detekt-api.api
@@ -174,8 +174,10 @@ public abstract interface class io/gitlab/arturbosch/detekt/api/Finding {
 	public abstract fun getReferences ()Ljava/util/List;
 }
 
-public abstract interface class io/gitlab/arturbosch/detekt/api/Finding2 : io/gitlab/arturbosch/detekt/api/HasEntity {
+public abstract interface class io/gitlab/arturbosch/detekt/api/Finding2 {
 	public abstract fun getAutoCorrectEnabled ()Z
+	public abstract fun getEntity ()Lio/gitlab/arturbosch/detekt/api/Entity;
+	public abstract fun getLocation ()Lio/gitlab/arturbosch/detekt/api/Location;
 	public abstract fun getMessage ()Ljava/lang/String;
 	public abstract fun getReferences ()Ljava/util/List;
 	public abstract fun getRule ()Lio/gitlab/arturbosch/detekt/api/Finding2$RuleInfo;
@@ -189,15 +191,6 @@ public final class io/gitlab/arturbosch/detekt/api/Finding2$DefaultImpls {
 public abstract interface class io/gitlab/arturbosch/detekt/api/Finding2$RuleInfo {
 	public abstract fun getDescription ()Ljava/lang/String;
 	public abstract fun getId ()Lio/gitlab/arturbosch/detekt/api/Rule$Id;
-}
-
-public abstract interface class io/gitlab/arturbosch/detekt/api/HasEntity {
-	public abstract fun getEntity ()Lio/gitlab/arturbosch/detekt/api/Entity;
-	public abstract fun getLocation ()Lio/gitlab/arturbosch/detekt/api/Location;
-}
-
-public final class io/gitlab/arturbosch/detekt/api/HasEntity$DefaultImpls {
-	public static fun getLocation (Lio/gitlab/arturbosch/detekt/api/HasEntity;)Lio/gitlab/arturbosch/detekt/api/Location;
 }
 
 public final class io/gitlab/arturbosch/detekt/api/Location : io/gitlab/arturbosch/detekt/api/Compactable {

--- a/detekt-api/api/detekt-api.api
+++ b/detekt-api/api/detekt-api.api
@@ -10,14 +10,9 @@ public final class io/gitlab/arturbosch/detekt/api/AnnotationExcluder {
 public class io/gitlab/arturbosch/detekt/api/CodeSmell : io/gitlab/arturbosch/detekt/api/Finding {
 	public fun <init> (Lio/gitlab/arturbosch/detekt/api/Entity;Ljava/lang/String;Ljava/util/List;)V
 	public synthetic fun <init> (Lio/gitlab/arturbosch/detekt/api/Entity;Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun getCharPosition ()Lio/gitlab/arturbosch/detekt/api/TextLocation;
 	public final fun getEntity ()Lio/gitlab/arturbosch/detekt/api/Entity;
-	public fun getFile ()Ljava/lang/String;
-	public fun getLocation ()Lio/gitlab/arturbosch/detekt/api/Location;
 	public final fun getMessage ()Ljava/lang/String;
 	public final fun getReferences ()Ljava/util/List;
-	public fun getSignature ()Ljava/lang/String;
-	public fun getStartPosition ()Lio/gitlab/arturbosch/detekt/api/SourceLocation;
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -173,17 +168,10 @@ public final class io/gitlab/arturbosch/detekt/api/FileProcessListener$DefaultIm
 	public static fun onStart (Lio/gitlab/arturbosch/detekt/api/FileProcessListener;Ljava/util/List;Lorg/jetbrains/kotlin/resolve/BindingContext;)V
 }
 
-public abstract interface class io/gitlab/arturbosch/detekt/api/Finding : io/gitlab/arturbosch/detekt/api/HasEntity {
+public abstract interface class io/gitlab/arturbosch/detekt/api/Finding {
+	public abstract fun getEntity ()Lio/gitlab/arturbosch/detekt/api/Entity;
 	public abstract fun getMessage ()Ljava/lang/String;
 	public abstract fun getReferences ()Ljava/util/List;
-}
-
-public final class io/gitlab/arturbosch/detekt/api/Finding$DefaultImpls {
-	public static fun getCharPosition (Lio/gitlab/arturbosch/detekt/api/Finding;)Lio/gitlab/arturbosch/detekt/api/TextLocation;
-	public static fun getFile (Lio/gitlab/arturbosch/detekt/api/Finding;)Ljava/lang/String;
-	public static fun getLocation (Lio/gitlab/arturbosch/detekt/api/Finding;)Lio/gitlab/arturbosch/detekt/api/Location;
-	public static fun getSignature (Lio/gitlab/arturbosch/detekt/api/Finding;)Ljava/lang/String;
-	public static fun getStartPosition (Lio/gitlab/arturbosch/detekt/api/Finding;)Lio/gitlab/arturbosch/detekt/api/SourceLocation;
 }
 
 public abstract interface class io/gitlab/arturbosch/detekt/api/Finding2 : io/gitlab/arturbosch/detekt/api/HasEntity {

--- a/detekt-api/api/detekt-api.api
+++ b/detekt-api/api/detekt-api.api
@@ -183,11 +183,7 @@ public abstract interface class io/gitlab/arturbosch/detekt/api/Finding2 : io/gi
 }
 
 public final class io/gitlab/arturbosch/detekt/api/Finding2$DefaultImpls {
-	public static fun getCharPosition (Lio/gitlab/arturbosch/detekt/api/Finding2;)Lio/gitlab/arturbosch/detekt/api/TextLocation;
-	public static fun getFile (Lio/gitlab/arturbosch/detekt/api/Finding2;)Ljava/lang/String;
 	public static fun getLocation (Lio/gitlab/arturbosch/detekt/api/Finding2;)Lio/gitlab/arturbosch/detekt/api/Location;
-	public static fun getSignature (Lio/gitlab/arturbosch/detekt/api/Finding2;)Ljava/lang/String;
-	public static fun getStartPosition (Lio/gitlab/arturbosch/detekt/api/Finding2;)Lio/gitlab/arturbosch/detekt/api/SourceLocation;
 }
 
 public abstract interface class io/gitlab/arturbosch/detekt/api/Finding2$RuleInfo {
@@ -196,20 +192,12 @@ public abstract interface class io/gitlab/arturbosch/detekt/api/Finding2$RuleInf
 }
 
 public abstract interface class io/gitlab/arturbosch/detekt/api/HasEntity {
-	public abstract fun getCharPosition ()Lio/gitlab/arturbosch/detekt/api/TextLocation;
 	public abstract fun getEntity ()Lio/gitlab/arturbosch/detekt/api/Entity;
-	public abstract fun getFile ()Ljava/lang/String;
 	public abstract fun getLocation ()Lio/gitlab/arturbosch/detekt/api/Location;
-	public abstract fun getSignature ()Ljava/lang/String;
-	public abstract fun getStartPosition ()Lio/gitlab/arturbosch/detekt/api/SourceLocation;
 }
 
 public final class io/gitlab/arturbosch/detekt/api/HasEntity$DefaultImpls {
-	public static fun getCharPosition (Lio/gitlab/arturbosch/detekt/api/HasEntity;)Lio/gitlab/arturbosch/detekt/api/TextLocation;
-	public static fun getFile (Lio/gitlab/arturbosch/detekt/api/HasEntity;)Ljava/lang/String;
 	public static fun getLocation (Lio/gitlab/arturbosch/detekt/api/HasEntity;)Lio/gitlab/arturbosch/detekt/api/Location;
-	public static fun getSignature (Lio/gitlab/arturbosch/detekt/api/HasEntity;)Ljava/lang/String;
-	public static fun getStartPosition (Lio/gitlab/arturbosch/detekt/api/HasEntity;)Lio/gitlab/arturbosch/detekt/api/SourceLocation;
 }
 
 public final class io/gitlab/arturbosch/detekt/api/Location : io/gitlab/arturbosch/detekt/api/Compactable {

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Finding.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Finding.kt
@@ -3,7 +3,7 @@ package io.gitlab.arturbosch.detekt.api
 /**
  * Represents a problem in the source code detected by a rule.
  *
- * A finding has an issue (information about the rule that detected the problem), a severity and a source code position
+ * A finding has an issue (information about the rule that detected the problem), a severity and a source code position.
  * described as an entity. Entity references can also be considered for deeper characterization.
  */
 interface Finding {

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Finding.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Finding.kt
@@ -11,20 +11,3 @@ interface Finding {
     val references: List<Entity>
     val message: String
 }
-
-/**
- * Describes a source code position.
- */
-interface HasEntity {
-    val entity: Entity
-    val location: Location
-        get() = entity.location
-    val startPosition: SourceLocation
-        get() = location.source
-    val charPosition: TextLocation
-        get() = location.text
-    val file: String
-        get() = location.filePath.absolutePath.toString()
-    val signature: String
-        get() = entity.signature
-}

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Finding.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Finding.kt
@@ -6,7 +6,8 @@ package io.gitlab.arturbosch.detekt.api
  * A finding has an issue (information about the rule that detected the problem), a severity and a source code position
  * described as an entity. Entity references can also be considered for deeper characterization.
  */
-interface Finding : HasEntity {
+interface Finding {
+    val entity: Entity
     val references: List<Entity>
     val message: String
 }

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Finding.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Finding.kt
@@ -1,10 +1,10 @@
 package io.gitlab.arturbosch.detekt.api
 
 /**
- * Represents a problem in the source code detected by a rule.
+ * Represents a detected problem in the source code.
  *
- * A finding has an issue (information about the rule that detected the problem), a severity and a source code position.
- * described as an entity. Entity references can also be considered for deeper characterization.
+ * A finding has a source code position described as an entity and a message.
+ * Entity references can also be considered for deeper characterization.
  */
 interface Finding {
     val entity: Entity

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Finding.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Finding.kt
@@ -1,7 +1,7 @@
 package io.gitlab.arturbosch.detekt.api
 
 /**
- * Represents a problem detected by a rule on the source code
+ * Represents a problem in the source code detected by a rule.
  *
  * A finding has an issue (information about the rule that detected the problem), a severity and a source code position
  * described as an entity. Entity references can also be considered for deeper characterization.

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Finding2.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Finding2.kt
@@ -18,3 +18,20 @@ interface Finding2 : HasEntity {
         val description: String
     }
 }
+
+/**
+ * Describes a source code position.
+ */
+interface HasEntity {
+    val entity: Entity
+    val location: Location
+        get() = entity.location
+    val startPosition: SourceLocation
+        get() = location.source
+    val charPosition: TextLocation
+        get() = location.text
+    val file: String
+        get() = location.filePath.absolutePath.toString()
+    val signature: String
+        get() = entity.signature
+}

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Finding2.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Finding2.kt
@@ -26,12 +26,4 @@ interface HasEntity {
     val entity: Entity
     val location: Location
         get() = entity.location
-    val startPosition: SourceLocation
-        get() = location.source
-    val charPosition: TextLocation
-        get() = location.text
-    val file: String
-        get() = location.filePath.absolutePath.toString()
-    val signature: String
-        get() = entity.signature
 }

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Finding2.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Finding2.kt
@@ -6,24 +6,19 @@ package io.gitlab.arturbosch.detekt.api
  * A finding has information about the rule that detected the problem, a severity and an entity with information
  * about the position. Entity references can also be considered for deeper characterization.
  */
-interface Finding2 : HasEntity {
+interface Finding2 {
     val rule: RuleInfo
+    val entity: Entity
     val references: List<Entity>
     val message: String
     val severity: Severity
     val autoCorrectEnabled: Boolean
 
+    val location: Location
+        get() = entity.location
+
     interface RuleInfo {
         val id: Rule.Id
         val description: String
     }
-}
-
-/**
- * Describes a source code position.
- */
-interface HasEntity {
-    val entity: Entity
-    val location: Location
-        get() = entity.location
 }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/DefaultBaseline.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/DefaultBaseline.kt
@@ -35,4 +35,4 @@ internal const val CURRENT_ISSUES = "CurrentIssues"
 internal const val ID = "ID"
 
 internal val Finding2.baselineId: String
-    get() = "${rule.id}:${this.signature}"
+    get() = "${rule.id}:${this.entity.signature}"

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingRuleSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingRuleSpec.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.formatting.wrappers.ChainWrapping
 import io.gitlab.arturbosch.detekt.formatting.wrappers.NoLineBreakBeforeAssignment
 import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.location
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -49,7 +50,7 @@ class FormattingRuleSpec {
                 """.trimIndent()
             )
 
-            assertThat(findings.first().signature).isEqualTo("Test.kt\$=")
+            assertThat(findings.first().entity.signature).isEqualTo("Test.kt\$=")
         }
 
         @Test
@@ -62,7 +63,7 @@ class FormattingRuleSpec {
                 """.trimIndent()
             )
 
-            assertThat(findings.first().signature).isEqualTo("Test.kt\$=")
+            assertThat(findings.first().entity.signature).isEqualTo("Test.kt\$=")
         }
     }
 

--- a/detekt-report-html/src/main/kotlin/io/github/detekt/report/html/HtmlOutputReport.kt
+++ b/detekt-report-html/src/main/kotlin/io/github/detekt/report/html/HtmlOutputReport.kt
@@ -131,7 +131,13 @@ class HtmlOutputReport : BuiltInOutputReport, OutputReport() {
 
             ul {
                 findings
-                    .sortedWith(compareBy({ it.file }, { it.location.source.line }, { it.location.source.column }))
+                    .sortedWith(
+                        compareBy(
+                            { it.location.filePath.absolutePath.toString() },
+                            { it.location.source.line },
+                            { it.location.source.column },
+                        )
+                    )
                     .forEach {
                         li {
                             renderFinding(it)
@@ -157,7 +163,7 @@ class HtmlOutputReport : BuiltInOutputReport, OutputReport() {
         val psiFile = finding.entity.ktElement?.containingFile
         if (psiFile != null) {
             val lineSequence = psiFile.text.splitToSequence('\n')
-            snippetCode(finding.rule.id, lineSequence, finding.startPosition, finding.charPosition.length())
+            snippetCode(finding.rule.id, lineSequence, finding.location.source, finding.location.text.length())
         }
     }
 

--- a/detekt-report-md/src/main/kotlin/io/github/detekt/report/md/MdOutputReport.kt
+++ b/detekt-report-md/src/main/kotlin/io/github/detekt/report/md/MdOutputReport.kt
@@ -106,7 +106,13 @@ private fun MarkdownContent.renderRule(rule: Rule.Id, group: RuleSet.Id, finding
 
     list {
         findings
-            .sortedWith(compareBy({ it.file }, { it.location.source.line }, { it.location.source.column }))
+            .sortedWith(
+                compareBy(
+                    { it.location.filePath.absolutePath.toString() },
+                    { it.location.source.line },
+                    { it.location.source.column },
+                )
+            )
             .forEach {
                 item { renderFinding(it) }
             }
@@ -144,7 +150,7 @@ private fun MarkdownContent.renderFinding(finding: Finding2): String {
     val psiFile = finding.entity.ktElement?.containingFile
     val snippet = if (psiFile != null) {
         val lineSequence = psiFile.text.splitToSequence('\n')
-        snippetCode(lineSequence, finding.startPosition)
+        snippetCode(lineSequence, finding.location.source)
     } else {
         ""
     }

--- a/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/CoroutineLaunchedInTestWithoutRunTestSpec.kt
+++ b/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/CoroutineLaunchedInTestWithoutRunTestSpec.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
 import io.gitlab.arturbosch.detekt.test.getContextForPaths
+import io.gitlab.arturbosch.detekt.test.location
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.jetbrains.kotlin.psi.KtNamedFunction
@@ -300,8 +301,8 @@ class CoroutineLaunchedInTestWithoutRunTestSpec(private val env: KotlinCoreEnvir
 
         val findings = subject.compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(2)
-        assert(findings.any { it.startPosition.line == 9 })
-        assert(findings.any { it.startPosition.line == 14 })
+        assert(findings.any { it.location.source.line == 9 })
+        assert(findings.any { it.location.source.line == 14 })
     }
 
     @Test

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/RethrowCaughtExceptionSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/RethrowCaughtExceptionSpec.kt
@@ -2,6 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.exceptions
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.location
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -204,7 +205,7 @@ class RethrowCaughtExceptionSpec {
         val result = subject.compileAndLint(code)
         assertThat(result).hasSize(2)
         // ensure correct violation order
-        assertThat(result[0].startPosition.line == 4).isTrue
-        assertThat(result[1].startPosition.line == 7).isTrue
+        assertThat(result[0].location.source.line == 4).isTrue
+        assertThat(result[1].location.source.line == 7).isTrue
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLengthSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLengthSpec.kt
@@ -110,7 +110,7 @@ class MaxLineLengthSpec {
             val rule = MaxLineLength(Config.empty)
 
             val findings = rule.compileAndLint(code)
-            val locations = findings.map { it.signature.substringAfterLast('$') }
+            val locations = findings.map { it.entity.signature.substringAfterLast('$') }
             doAssert(locations).allSatisfy { doAssert(it).isNotBlank() }
         }
     }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/MandatoryBracesLoopsSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/MandatoryBracesLoopsSpec.kt
@@ -3,6 +3,7 @@ package io.gitlab.arturbosch.detekt.rules.style.optional
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.location
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test

--- a/detekt-test/api/detekt-test.api
+++ b/detekt-test/api/detekt-test.api
@@ -5,6 +5,10 @@ public final class io/gitlab/arturbosch/detekt/test/FindingAssert : org/assertj/
 	public final fun hasSourceLocation (II)Lio/gitlab/arturbosch/detekt/test/FindingAssert;
 }
 
+public final class io/gitlab/arturbosch/detekt/test/FindingExtensionsKt {
+	public static final fun getLocation (Lio/gitlab/arturbosch/detekt/api/Finding;)Lio/gitlab/arturbosch/detekt/api/Location;
+}
+
 public final class io/gitlab/arturbosch/detekt/test/FindingsAssert : org/assertj/core/api/AbstractListAssert {
 	public fun <init> (Ljava/util/List;)V
 	public final fun hasEndSourceLocation (II)Lio/gitlab/arturbosch/detekt/test/FindingsAssert;

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/FindingExtensions.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/FindingExtensions.kt
@@ -1,0 +1,7 @@
+package io.gitlab.arturbosch.detekt.test
+
+import io.gitlab.arturbosch.detekt.api.Finding
+import io.gitlab.arturbosch.detekt.api.Location
+
+val Finding.location: Location
+    get() = entity.location


### PR DESCRIPTION
Another PR in the line to reduce our public api surface. This time remove `HasEntity`.