### PR TITLE
Remove default value for `Location.endSource`

### DIFF
--- a/detekt-api/api/detekt-api.api
+++ b/detekt-api/api/detekt-api.api
@@ -227,7 +227,6 @@ public final class io/gitlab/arturbosch/detekt/api/HasEntity$DefaultImpls {
 public final class io/gitlab/arturbosch/detekt/api/Location : io/gitlab/arturbosch/detekt/api/Compactable {
 	public static final field Companion Lio/gitlab/arturbosch/detekt/api/Location$Companion;
 	public fun <init> (Lio/gitlab/arturbosch/detekt/api/SourceLocation;Lio/gitlab/arturbosch/detekt/api/SourceLocation;Lio/gitlab/arturbosch/detekt/api/TextLocation;Lio/github/detekt/psi/FilePath;)V
-	public synthetic fun <init> (Lio/gitlab/arturbosch/detekt/api/SourceLocation;Lio/gitlab/arturbosch/detekt/api/SourceLocation;Lio/gitlab/arturbosch/detekt/api/TextLocation;Lio/github/detekt/psi/FilePath;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun compact ()Ljava/lang/String;
 	public fun compactWithSignature ()Ljava/lang/String;
 	public final fun getEndSource ()Lio/gitlab/arturbosch/detekt/api/SourceLocation;

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Location.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Location.kt
@@ -16,9 +16,9 @@ import org.jetbrains.kotlin.psi.psiUtil.startOffset
  */
 class Location(
     val source: SourceLocation,
-    val endSource: SourceLocation = source,
+    val endSource: SourceLocation,
     val text: TextLocation,
-    val filePath: FilePath
+    val filePath: FilePath,
 ) : Compactable {
 
     override fun compact(): String = "${filePath.absolutePath}:$source"

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/CodeSmellSpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/CodeSmellSpec.kt
@@ -16,6 +16,7 @@ class CodeSmellSpec {
                 signature = "TestEntitySignature",
                 location = Location(
                     source = SourceLocation(1, 1),
+                    endSource = SourceLocation(1, 1),
                     text = TextLocation(0, 0),
                     filePath = FilePath.fromRelative(Path("/Users/tester/detekt/"), Path("TestFile.kt"))
                 ),

--- a/detekt-api/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/test/TestFactory.kt
+++ b/detekt-api/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/test/TestFactory.kt
@@ -37,6 +37,7 @@ fun createFindingForRelativePath(
         signature = "TestEntitySignature",
         location = Location(
             source = SourceLocation(1, 1),
+            endSource = SourceLocation(1, 1),
             text = TextLocation(0, 0),
             filePath = FilePath.fromRelative(Path(basePath), Path(relativePath))
         ),
@@ -60,9 +61,11 @@ fun createLocation(
     path: String = "TestFile.kt",
     basePath: String? = null,
     position: Pair<Int, Int> = 1 to 1,
+    endPosition: Pair<Int, Int> = 1 to 1,
     text: IntRange = 0..0,
 ) = Location(
     source = SourceLocation(position.first, position.second),
+    endSource = SourceLocation(endPosition.first, endPosition.second),
     text = TextLocation(text.first, text.last),
     filePath = basePath?.let { FilePath.fromRelative(Path(it), Path(path)) }
         ?: FilePath.fromAbsolute(Path(path)),

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/Builders.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/Builders.kt
@@ -1,16 +1,12 @@
 package io.gitlab.arturbosch.detekt.core.suppressors
 
-import io.github.detekt.psi.FilePath
 import io.gitlab.arturbosch.detekt.api.CodeSmell
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Finding
-import io.gitlab.arturbosch.detekt.api.Location
 import io.gitlab.arturbosch.detekt.api.Rule
-import io.gitlab.arturbosch.detekt.api.SourceLocation
-import io.gitlab.arturbosch.detekt.api.TextLocation
 import io.gitlab.arturbosch.detekt.test.TestConfig
+import io.gitlab.arturbosch.detekt.test.createLocation
 import org.jetbrains.kotlin.psi.KtElement
-import kotlin.io.path.Path
 
 internal fun buildFinding(element: KtElement?): Finding = CodeSmell(
     entity = element?.let { Entity.from(element) } ?: buildEmptyEntity(),
@@ -20,11 +16,7 @@ internal fun buildFinding(element: KtElement?): Finding = CodeSmell(
 private fun buildEmptyEntity(): Entity = Entity(
     name = "",
     signature = "",
-    location = Location(
-        source = SourceLocation(1, 1),
-        text = TextLocation(0, 0),
-        filePath = FilePath.fromAbsolute(Path("/"))
-    ),
+    location = createLocation(path = "/"),
     ktElement = null,
 )
 

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingRule.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingRule.kt
@@ -38,8 +38,7 @@ abstract class FormattingRule(config: Config, description: String) : Rule(config
 
     override fun visit(root: KtFile) {
         this.root = root
-        positionByOffset = KtLintLineColCalculator
-            .calculateLineColByOffset(KtLintLineColCalculator.normalizeText(root.text))
+        positionByOffset = KtLintLineColCalculator.calculateLineColByOffset(root.text)
 
         wrapping.beforeFirstNode(computeEditorConfigProperties())
         root.node.visitASTNodes()
@@ -82,6 +81,7 @@ abstract class FormattingRule(config: Config, description: String) : Rule(config
         val (line, column) = positionByOffset(offset)
         val location = Location(
             source = SourceLocation(line, column),
+            endSource = SourceLocation(line, column),
             // Use offset + 1 since ktlint always reports a single location.
             text = TextLocation(offset, offset + 1),
             filePath = root.toFilePath()

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/KtLintLineColCalculator.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/KtLintLineColCalculator.kt
@@ -9,17 +9,15 @@ package io.gitlab.arturbosch.detekt.formatting
 object KtLintLineColCalculator {
     private const val UTF8_BOM = "\uFEFF"
 
-    fun normalizeText(text: String): String {
+    fun calculateLineColByOffset(text: String): (offset: Int) -> Pair<Int, Int> {
+        return buildPositionInTextLocator(normalizeText(text))
+    }
+
+    private fun normalizeText(text: String): String {
         return text
             .replace("\r\n", "\n")
             .replace("\r", "\n")
             .replaceFirst(UTF8_BOM, "")
-    }
-
-    fun calculateLineColByOffset(
-        text: String
-    ): (offset: Int) -> Pair<Int, Int> {
-        return buildPositionInTextLocator(text)
     }
 
     private fun buildPositionInTextLocator(

--- a/detekt-report-sarif/src/test/kotlin/io/github/detekt/report/sarif/SarifOutputReportSpec.kt
+++ b/detekt-report-sarif/src/test/kotlin/io/github/detekt/report/sarif/SarifOutputReportSpec.kt
@@ -124,6 +124,7 @@ class SarifOutputReportSpec {
         val refEntity = TestRule().compileAndLint(Snippet.code).first().entity
         val location = Location(
             source = SourceLocation(startLine, startColumn),
+            endSource = SourceLocation(startLine, startColumn),
             text = TextLocation(
                 startLine + (startColumn - 1) * Snippet.LINE_LENGTH,
                 endColumn + (endLine - 1) * Snippet.LINE_LENGTH
@@ -161,6 +162,7 @@ class SarifOutputReportSpec {
         val refEntity = TestRule().compileAndLint(Snippet.code).first().entity
         val location = Location(
             source = SourceLocation(startLine, startColumn),
+            endSource = SourceLocation(startLine, startColumn),
             text = TextLocation(
                 startLine + (startColumn - 1) * Snippet.LINE_LENGTH,
                 endColumn + (endLine - 1) * Snippet.LINE_LENGTH

--- a/detekt-report-xml/src/test/kotlin/io/github/detekt/report/xml/XmlOutputFormatSpec.kt
+++ b/detekt-report-xml/src/test/kotlin/io/github/detekt/report/xml/XmlOutputFormatSpec.kt
@@ -1,21 +1,17 @@
 package io.github.detekt.report.xml
 
-import io.github.detekt.psi.FilePath
 import io.gitlab.arturbosch.detekt.api.Entity
-import io.gitlab.arturbosch.detekt.api.Location
 import io.gitlab.arturbosch.detekt.api.Severity
-import io.gitlab.arturbosch.detekt.api.SourceLocation
-import io.gitlab.arturbosch.detekt.api.TextLocation
 import io.gitlab.arturbosch.detekt.test.TestDetektion
 import io.gitlab.arturbosch.detekt.test.createFinding
 import io.gitlab.arturbosch.detekt.test.createFindingForRelativePath
+import io.gitlab.arturbosch.detekt.test.createLocation
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import java.util.Locale
-import kotlin.io.path.Path
 
 private const val TAB = "\t"
 
@@ -24,19 +20,17 @@ class XmlOutputFormatSpec {
     private val entity1 = Entity(
         "Sample1",
         "",
-        Location(
-            source = SourceLocation(11, 1),
-            text = TextLocation(0, 10),
-            filePath = FilePath.fromAbsolute(Path("src/main/com/sample/Sample1.kt"))
+        createLocation(
+            path = "src/main/com/sample/Sample1.kt",
+            position = 11 to 1,
         )
     )
     private val entity2 = Entity(
         "Sample2",
         "",
-        Location(
-            source = SourceLocation(22, 2),
-            text = TextLocation(0, 20),
-            filePath = FilePath.fromAbsolute(Path("src/main/com/sample/Sample2.kt"))
+        createLocation(
+            path = "src/main/com/sample/Sample2.kt",
+            position = 22 to 2,
         )
     )
     private val outputFormat = XmlOutputReport()

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/NewLineAtEndOfFile.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/NewLineAtEndOfFile.kt
@@ -34,6 +34,7 @@ class NewLineAtEndOfFile(config: Config) : Rule(
             val textLocation = TextLocation(file.endOffset, file.endOffset)
             val location = Location(
                 source = sourceLocation,
+                endSource = sourceLocation,
                 text = textLocation,
                 filePath = file.containingFile.toFilePath()
             )


### PR DESCRIPTION
Another PR in the line of simplify our public API. This default value was added for compatibility purposes. Now with 2.0 we don't need to keep it and we can force everyone to implement it.