### PR TITLE
Don't use `Entity.ktElement` on sarif report

### DIFF
--- a/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/Results.kt
+++ b/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/Results.kt
@@ -24,33 +24,22 @@ internal fun Severity.toResultLevel() = when (this) {
 }
 
 private fun Finding2.toResult(ruleSetId: RuleSet.Id): io.github.detekt.sarif4k.Result {
-    val code = entity.ktElement?.containingFile?.text
-
     return io.github.detekt.sarif4k.Result(
         ruleID = "detekt.$ruleSetId.${rule.id}",
         level = severity.toResultLevel(),
-        locations = (listOf(location) + references.map { it.location }).map { it.toLocation(code) }.distinct().toList(),
+        locations = (listOf(location) + references.map { it.location }).map { it.toLocation() }.distinct(),
         message = Message(text = message)
     )
 }
 
-private fun Location.toLocation(code: String?): io.github.detekt.sarif4k.Location {
-    var endLine: Long? = null
-    var endColumn: Long? = null
-
-    if (code != null) {
-        val snippet = code.take(text.end).split('\n')
-        endLine = snippet.size.toLong()
-        endColumn = snippet.last().length.toLong() + 1
-    }
-
+private fun Location.toLocation(): io.github.detekt.sarif4k.Location {
     return io.github.detekt.sarif4k.Location(
         physicalLocation = PhysicalLocation(
             region = Region(
                 startLine = source.line.toLong(),
                 startColumn = source.column.toLong(),
-                endLine = endLine,
-                endColumn = endColumn
+                endLine = endSource.line.toLong(),
+                endColumn = endSource.column.toLong(),
             ),
             artifactLocation = if (filePath.relativePath != null) {
                 ArtifactLocation(

--- a/detekt-report-sarif/src/test/kotlin/io/github/detekt/report/sarif/SarifOutputReportSpec.kt
+++ b/detekt-report-sarif/src/test/kotlin/io/github/detekt/report/sarif/SarifOutputReportSpec.kt
@@ -4,20 +4,18 @@ import io.github.detekt.test.utils.readResourceContent
 import io.gitlab.arturbosch.detekt.api.CodeSmell
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Entity
-import io.gitlab.arturbosch.detekt.api.Location
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.RuleSet
 import io.gitlab.arturbosch.detekt.api.RuleSetProvider
 import io.gitlab.arturbosch.detekt.api.SetupContext
 import io.gitlab.arturbosch.detekt.api.Severity
-import io.gitlab.arturbosch.detekt.api.SourceLocation
-import io.gitlab.arturbosch.detekt.api.TextLocation
 import io.gitlab.arturbosch.detekt.api.internal.whichOS
 import io.gitlab.arturbosch.detekt.test.EmptySetupContext
 import io.gitlab.arturbosch.detekt.test.TestDetektion
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.createEntity
 import io.gitlab.arturbosch.detekt.test.createFinding
 import io.gitlab.arturbosch.detekt.test.createFindingForRelativePath
+import io.gitlab.arturbosch.detekt.test.createLocation
 import io.gitlab.arturbosch.detekt.test.yamlConfig
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.psi.KtClassOrObject
@@ -31,9 +29,21 @@ class SarifOutputReportSpec {
     @Test
     fun `renders multiple issues`() {
         val result = TestDetektion(
-            createFinding(ruleName = "TestSmellA", severity = Severity.Error),
-            createFinding(ruleName = "TestSmellB", severity = Severity.Warning),
-            createFinding(ruleName = "TestSmellC", severity = Severity.Info)
+            createFinding(
+                ruleName = "TestSmellA",
+                entity = createEntity(location = createLocation(position = 1 to 1, endPosition = 2 to 3)),
+                severity = Severity.Error
+            ),
+            createFinding(
+                ruleName = "TestSmellB",
+                entity = createEntity(location = createLocation(position = 3 to 5, endPosition = 3 to 5)),
+                severity = Severity.Warning
+            ),
+            createFinding(
+                ruleName = "TestSmellC",
+                entity = createEntity(location = createLocation(position = 2 to 1, endPosition = 3 to 1)),
+                severity = Severity.Info
+            )
         )
 
         val report = SarifOutputReport()
@@ -109,104 +119,7 @@ class SarifOutputReportSpec {
 
         assertThat(report).isEqualToIgnoringWhitespace(systemAwareExpectedReport)
     }
-
-    @Test
-    fun `region should be bounded with word`() {
-        /**
-         * Region constraints in Snippet for word 'TestClass'
-         *  @sample Snippet.code
-         */
-        val startLine = 3
-        val startColumn = 7
-        val endLine = 3
-        val endColumn = 15
-
-        val refEntity = TestRule().compileAndLint(Snippet.code).first().entity
-        val location = Location(
-            source = SourceLocation(startLine, startColumn),
-            endSource = SourceLocation(startLine, startColumn),
-            text = TextLocation(
-                startLine + (startColumn - 1) * Snippet.LINE_LENGTH,
-                endColumn + (endLine - 1) * Snippet.LINE_LENGTH
-            ),
-            filePath = refEntity.location.filePath
-        )
-
-        val result = TestDetektion(
-            createFinding(
-                ruleName = "TestSmellB",
-                entity = Entity(refEntity.name, refEntity.signature, location, refEntity.ktElement),
-                severity = Severity.Warning
-            )
-        )
-
-        val report = SarifOutputReport()
-            .apply { init(EmptySetupContext()) }
-            .render(result)
-
-        assertThat(report)
-            .containsIgnoringWhitespaces(constrainRegion(startLine, startColumn, endLine, endColumn))
-    }
-
-    @Test
-    fun `region should be bounded with block`() {
-        /**
-         * Region constraints in Snippet for curly braces
-         *  @sample Snippet.code
-         */
-        val startLine = 3
-        val startColumn = 17
-        val endLine = 5
-        val endColumn = 1
-
-        val refEntity = TestRule().compileAndLint(Snippet.code).first().entity
-        val location = Location(
-            source = SourceLocation(startLine, startColumn),
-            endSource = SourceLocation(startLine, startColumn),
-            text = TextLocation(
-                startLine + (startColumn - 1) * Snippet.LINE_LENGTH,
-                endColumn + (endLine - 1) * Snippet.LINE_LENGTH
-            ),
-            filePath = refEntity.location.filePath
-        )
-
-        val result = TestDetektion(
-            createFinding(
-                ruleName = "TestSmellB",
-                entity = Entity(refEntity.name, refEntity.signature, location, refEntity.ktElement),
-                severity = Severity.Warning
-            )
-        )
-
-        val report = SarifOutputReport()
-            .apply { init(EmptySetupContext()) }
-            .render(result)
-
-        assertThat(report)
-            .containsIgnoringWhitespaces(constrainRegion(startLine, startColumn, endLine, endColumn))
-    }
 }
-
-private object Snippet {
-    // Each line of code is 50 chars long
-    const val LINE_LENGTH = 50
-    val code = """
-        // 4567890123456789012345678901234567890123456789
-        // 0000001111111111222222222233333333334444444444
-        class TestClass { ///////////////////////////////
-            val greeting: String = "Hello, World!"///////
-        }////////////////////////////////////////////////
-    """.trimIndent()
-}
-
-private fun constrainRegion(startLine: Int, startColumn: Int, endLine: Int, endColumn: Int) = """
-    "region": {
-      "endColumn": ${endColumn + 1},
-      "endLine": $endLine,
-      "startColumn": $startColumn,
-      "startLine": $startLine
-    }
-""".trimIndent()
 
 class TestProvider : RuleSetProvider {
     override val ruleSetId = RuleSet.Id("test")

--- a/detekt-report-sarif/src/test/resources/relative_path.sarif.json
+++ b/detekt-report-sarif/src/test/resources/relative_path.sarif.json
@@ -19,6 +19,8 @@
                   "uriBaseId": "%SRCROOT%"
                 },
                 "region": {
+                  "endColumn": 1,
+                  "endLine": 1,
                   "startColumn": 1,
                   "startLine": 1
                 }
@@ -40,6 +42,8 @@
                   "uriBaseId": "%SRCROOT%"
                 },
                 "region": {
+                  "endColumn": 1,
+                  "endLine": 1,
                   "startColumn": 1,
                   "startLine": 1
                 }
@@ -61,6 +65,8 @@
                   "uriBaseId": "%SRCROOT%"
                 },
                 "region": {
+                  "endColumn": 1,
+                  "endLine": 1,
                   "startColumn": 1,
                   "startLine": 1
                 }

--- a/detekt-report-sarif/src/test/resources/rule_warning.sarif.json
+++ b/detekt-report-sarif/src/test/resources/rule_warning.sarif.json
@@ -13,6 +13,8 @@
                   "uri": "<PREFIX>TestFile.kt"
                 },
                 "region": {
+                  "endColumn": 1,
+                  "endLine": 1,
                   "startColumn": 1,
                   "startLine": 1
                 }
@@ -33,6 +35,8 @@
                   "uri": "<PREFIX>TestFile.kt"
                 },
                 "region": {
+                  "endColumn": 1,
+                  "endLine": 1,
                   "startColumn": 1,
                   "startLine": 1
                 }
@@ -53,6 +57,8 @@
                   "uri": "<PREFIX>TestFile.kt"
                 },
                 "region": {
+                  "endColumn": 1,
+                  "endLine": 1,
                   "startColumn": 1,
                   "startLine": 1
                 }

--- a/detekt-report-sarif/src/test/resources/vanilla.sarif.json
+++ b/detekt-report-sarif/src/test/resources/vanilla.sarif.json
@@ -13,6 +13,8 @@
                   "uri": "<PREFIX>TestFile.kt"
                 },
                 "region": {
+                  "endColumn": 3,
+                  "endLine": 2,
                   "startColumn": 1,
                   "startLine": 1
                 }
@@ -33,8 +35,10 @@
                   "uri": "<PREFIX>TestFile.kt"
                 },
                 "region": {
-                  "startColumn": 1,
-                  "startLine": 1
+                  "endColumn": 5,
+                  "endLine": 3,
+                  "startColumn": 5,
+                  "startLine": 3
                 }
               }
             }
@@ -53,8 +57,10 @@
                   "uri": "<PREFIX>TestFile.kt"
                 },
                 "region": {
+                  "endColumn": 1,
+                  "endLine": 3,
                   "startColumn": 1,
-                  "startLine": 1
+                  "startLine": 2
                 }
               }
             }


### PR DESCRIPTION
We had that code because when we added sarif support we didn't support `endSource`. After that we added it but this code wasn't updated.

This PR relates with #7077 because it will force to any rule author to define the `endSource`. The sarif reporter will just report what the rule says.

Also this is a step forward in make the `results` of detekt serializables. Once this is merged only `report-html` and `report-md` will use `ktElement`.