### PR TITLE
Use constrained syntax to declare plugins

### DIFF
--- a/build-logic/src/main/kotlin/module.gradle.kts
+++ b/build-logic/src/main/kotlin/module.gradle.kts
@@ -5,8 +5,8 @@ import org.jetbrains.kotlin.gradle.tasks.UsesKotlinJavaToolchain
 plugins {
     id("packaging")
     kotlin("jvm")
-    `maven-publish`
-    jacoco
+    id("maven-publish")
+    id("jacoco")
 }
 
 // Add attributes to JAR manifest, to be used at runtime

--- a/build-logic/src/main/kotlin/packaging.gradle.kts
+++ b/build-logic/src/main/kotlin/packaging.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
-    `java-library`
-    `maven-publish`
-    signing
+    id("java-library")
+    id("maven-publish")
+    id("signing")
 }
 
 publishing {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ import org.jetbrains.dokka.gradle.DokkaMultiModuleTask
 plugins {
     id("releasing")
     id("io.gitlab.arturbosch.detekt")
-    alias(libs.plugins.dokka)
+    id("org.jetbrains.dokka") version "1.9.20"
 }
 
 tasks.withType<DokkaMultiModuleTask>().configureEach {

--- a/detekt-api/build.gradle.kts
+++ b/detekt-api/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("module")
     id("public-api")
-    `java-test-fixtures`
+    id("java-test-fixtures")
     alias(libs.plugins.poko)
 }
 

--- a/detekt-api/build.gradle.kts
+++ b/detekt-api/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     id("module")
     id("public-api")
     id("java-test-fixtures")
-    alias(libs.plugins.poko)
+    id("dev.drewhamilton.poko") version "0.15.2"
 }
 
 dependencies {

--- a/detekt-cli/build.gradle.kts
+++ b/detekt-cli/build.gradle.kts
@@ -4,7 +4,7 @@ import java.io.ByteArrayOutputStream
 plugins {
     alias(libs.plugins.shadow)
     id("module")
-    application
+    id("application")
 }
 
 application {

--- a/detekt-cli/build.gradle.kts
+++ b/detekt-cli/build.gradle.kts
@@ -2,7 +2,7 @@ import org.apache.tools.ant.filters.ReplaceTokens
 import java.io.ByteArrayOutputStream
 
 plugins {
-    alias(libs.plugins.shadow)
+    id("com.github.johnrengelman.shadow") version "8.1.1"
     id("module")
     id("application")
 }

--- a/detekt-compiler-plugin/build.gradle.kts
+++ b/detekt-compiler-plugin/build.gradle.kts
@@ -13,8 +13,8 @@ val detektPublication = "DetektPublication"
 
 plugins {
     id("module")
-    alias(libs.plugins.shadow)
-    alias(libs.plugins.download)
+    id("com.github.johnrengelman.shadow") version "8.1.1"
+    id("de.undercouch.download") version "5.6.0"
 }
 
 kotlin {

--- a/detekt-generator/build.gradle.kts
+++ b/detekt-generator/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     alias(libs.plugins.shadow)
     id("module")
-    application
+    id("application")
 }
 
 application {

--- a/detekt-generator/build.gradle.kts
+++ b/detekt-generator/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    alias(libs.plugins.shadow)
+    id("com.github.johnrengelman.shadow") version "8.1.1"
     id("module")
     id("application")
 }

--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -9,9 +9,9 @@ import java.net.URI
 
 plugins {
     id("module")
-    `java-gradle-plugin`
-    `java-test-fixtures`
-    idea
+    id("java-gradle-plugin")
+    id("java-test-fixtures")
+    id("idea")
     alias(libs.plugins.pluginPublishing)
     // We use this published version of the detekt plugin to self analyse this project.
     id("io.gitlab.arturbosch.detekt") version "1.23.6"

--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -12,11 +12,11 @@ plugins {
     id("java-gradle-plugin")
     id("java-test-fixtures")
     id("idea")
-    alias(libs.plugins.pluginPublishing)
+    id("com.gradle.plugin-publish") version "1.2.1"
     // We use this published version of the detekt plugin to self analyse this project.
     id("io.gitlab.arturbosch.detekt") version "1.23.6"
-    alias(libs.plugins.binaryCompatibilityValidator)
-    alias(libs.plugins.dokka)
+    id("org.jetbrains.kotlinx.binary-compatibility-validator") version "0.14.0"
+    id("org.jetbrains.dokka") version "1.9.20"
 }
 
 repositories {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -51,9 +51,5 @@ jetbrains-annotations = "org.jetbrains:annotations:24.1.0"
 kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 binaryCompatibilityValidator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version = "0.14.0" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
-download = { id = "de.undercouch.download", version = "5.6.0" }
-pluginPublishing = { id = "com.gradle.plugin-publish", version = "1.2.1" }
-poko = { id = "dev.drewhamilton.poko", version.ref = "poko" }
 nexusPublish = { id = "io.github.gradle-nexus.publish-plugin", version = "1.3.0" }
-shadow = { id = "com.github.johnrengelman.shadow", version = "8.1.1" }
 githubRelease = { id = "com.github.breadmoirai.github-release", version = "2.5.2" }


### PR DESCRIPTION
Gradle 8.0 introduced [faster Kotlin DSL build script compilation](https://docs.gradle.org/8.0/release-notes.html#new-features,-performance-and-usability-improvements). Gradle uses its own interpreter to interpret the plugins block, avoiding the need to use the Kotlin compiler, but it supports constrained syntax only. This is defined here: https://docs.gradle.org/8.7/userguide/plugins.html#sec:constrained_syntax

It also says:

> Note that using version catalog aliases for plugins (e.g. alias(libs.plugins.acme)) or type-safe plugin accessors (e.g. `acme-plugin`) will not see a performance improvement. Support for these formats will be added later.

However that support is not currently on the Gradle roadmap for 2024.

The performance improvement of 20% faster script compilation should be worth the loss of type safe accessors (issues are identified at runtime) or version catalog aliases (Renovate will take care of updates).