### PR TITLE
Refactor CLI args processing

### DIFF
--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/ArgumentConverters.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/ArgumentConverters.kt
@@ -20,10 +20,6 @@ class ExistingPathConverter : IStringConverter<Path> {
     }
 }
 
-class PathConverter : IStringConverter<Path> {
-    override fun convert(value: String) = Path(value)
-}
-
 interface DetektInputPathConverter<T> : IStringConverter<List<T>> {
     val converter: IStringConverter<T>
     override fun convert(value: String): List<T> =

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/ArgumentConverters.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/ArgumentConverters.kt
@@ -38,21 +38,15 @@ class ClasspathResourceConverter : IStringConverter<URL> {
 }
 
 class FailureSeverityConverter : IStringConverter<FailureSeverity> {
-    override fun convert(value: String): FailureSeverity {
-        return FailureSeverity.fromString(value)
-    }
+    override fun convert(value: String): FailureSeverity = FailureSeverity.fromString(value)
 }
 
 class ReportPathConverter : IStringConverter<ReportPath> {
-    override fun convert(value: String): ReportPath {
-        return ReportPath.from(value)
-    }
+    override fun convert(value: String): ReportPath = ReportPath.from(value)
 }
 
 class PathSplitter : IParameterSplitter {
-    override fun split(value: String): List<String> {
-        return value.split(',', ';')
-    }
+    override fun split(value: String): List<String> = value.split(',', ';')
 }
 
 class PathValidator : IValueValidator<List<Path>> {

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/ArgumentConverters.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/ArgumentConverters.kt
@@ -9,6 +9,7 @@ import org.jetbrains.kotlin.config.LanguageVersion
 import java.net.URL
 import java.nio.file.Path
 import kotlin.io.path.exists
+import kotlin.io.path.isDirectory
 
 class LanguageVersionConverter : IStringConverter<LanguageVersion> {
     override fun convert(value: String): LanguageVersion {
@@ -59,5 +60,11 @@ class PathValidator : IValueValidator<List<Path>> {
         value.forEach {
             if (!it.exists()) throw ParameterException("Input path does not exist: $it")
         }
+    }
+}
+
+class DirectoryValidator : IValueValidator<Path> {
+    override fun validate(name: String, value: Path) {
+        if (!value.isDirectory()) throw ParameterException("Value passed to $name must be a directory.")
     }
 }

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/ArgumentConverters.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/ArgumentConverters.kt
@@ -42,6 +42,12 @@ class FailureSeverityConverter : IStringConverter<FailureSeverity> {
     }
 }
 
+class ReportPathConverter : IStringConverter<ReportPath> {
+    override fun convert(value: String): ReportPath {
+        return ReportPath.from(value)
+    }
+}
+
 class PathSplitter : IParameterSplitter {
     override fun split(value: String): List<String> {
         return value.split(',', ';')

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/ArgumentConverters.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/ArgumentConverters.kt
@@ -1,43 +1,14 @@
 package io.gitlab.arturbosch.detekt.cli
 
 import com.beust.jcommander.IStringConverter
+import com.beust.jcommander.IValueValidator
 import com.beust.jcommander.ParameterException
+import com.beust.jcommander.converters.IParameterSplitter
 import org.jetbrains.kotlin.config.JvmTarget
 import org.jetbrains.kotlin.config.LanguageVersion
 import java.net.URL
 import java.nio.file.Path
-import kotlin.io.path.Path
-import kotlin.io.path.notExists
-
-class ExistingPathConverter : IStringConverter<Path> {
-    override fun convert(value: String): Path {
-        require(value.isNotBlank()) { "Provided path '$value' is empty." }
-        val config = Path(value)
-        if (config.notExists()) {
-            throw ParameterException("Provided path '$value' does not exist!")
-        }
-        return config
-    }
-}
-
-interface DetektInputPathConverter<T> : IStringConverter<List<T>> {
-    val converter: IStringConverter<T>
-    override fun convert(value: String): List<T> =
-        value.splitToSequence(SEPARATOR_COMMA, SEPARATOR_SEMICOLON)
-            .map { it.trim() }
-            .map { converter.convert(it) }
-            .toList()
-            .takeIf { it.isNotEmpty() }
-            ?: error("Given input '$value' was impossible to parse!")
-}
-
-class MultipleClasspathResourceConverter : DetektInputPathConverter<URL> {
-    override val converter = ClasspathResourceConverter()
-}
-
-class MultipleExistingPathConverter : DetektInputPathConverter<Path> {
-    override val converter = ExistingPathConverter()
-}
+import kotlin.io.path.exists
 
 class LanguageVersionConverter : IStringConverter<LanguageVersion> {
     override fun convert(value: String): LanguageVersion {
@@ -68,5 +39,19 @@ class ClasspathResourceConverter : IStringConverter<URL> {
 class FailureSeverityConverter : IStringConverter<FailureSeverity> {
     override fun convert(value: String): FailureSeverity {
         return FailureSeverity.fromString(value)
+    }
+}
+
+class PathSplitter : IParameterSplitter {
+    override fun split(value: String): List<String> {
+        return value.split(',', ';')
+    }
+}
+
+class PathValidator : IValueValidator<List<Path>> {
+    override fun validate(name: String, value: List<Path>) {
+        value.forEach {
+            if (!it.exists()) throw ParameterException("Input path does not exist: $it")
+        }
     }
 }

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt
@@ -1,6 +1,7 @@
 package io.gitlab.arturbosch.detekt.cli
 
 import com.beust.jcommander.Parameter
+import com.beust.jcommander.converters.PathConverter
 import io.github.detekt.tooling.api.spec.RulesSpec
 import io.github.detekt.tooling.api.spec.RulesSpec.FailurePolicy.FailOnSeverity
 import io.github.detekt.tooling.api.spec.RulesSpec.FailurePolicy.NeverFail

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt
@@ -88,7 +88,7 @@ class CliArgs {
             "These can also be used in combination with each other " +
             "e.g. '-r txt:reports/detekt.txt -r xml:reports/detekt.xml'"
     )
-    private var reports: List<String>? = null
+    private var reports: List<String> = emptyList()
 
     @Parameter(
         names = ["--fail-on-severity"],
@@ -202,7 +202,7 @@ class CliArgs {
     }
 
     val reportPaths: List<ReportPath> by lazy {
-        reports?.map { ReportPath.from(it) }.orEmpty()
+        reports.map { ReportPath.from(it) }
     }
 
     val failurePolicy: RulesSpec.FailurePolicy

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt
@@ -7,6 +7,7 @@ import io.github.detekt.tooling.api.spec.RulesSpec.FailurePolicy.FailOnSeverity
 import io.github.detekt.tooling.api.spec.RulesSpec.FailurePolicy.NeverFail
 import org.jetbrains.kotlin.config.JvmTarget
 import org.jetbrains.kotlin.config.LanguageVersion
+import java.net.URL
 import java.nio.file.Path
 import kotlin.io.path.Path
 
@@ -14,10 +15,13 @@ class CliArgs {
 
     @Parameter(
         names = ["--input", "-i"],
+        converter = PathConverter::class,
+        splitter = PathSplitter::class,
+        validateValueWith = [PathValidator::class],
         description = "Input paths to analyze. Multiple paths are separated by comma. If not specified the " +
             "current working directory is used."
     )
-    var input: String? = null
+    var inputPaths: List<Path> = listOf(Path(System.getProperty("user.dir")))
 
     @Parameter(
         names = ["--includes", "-in"],
@@ -34,16 +38,21 @@ class CliArgs {
 
     @Parameter(
         names = ["--config", "-c"],
+        converter = PathConverter::class,
+        splitter = PathSplitter::class,
+        validateValueWith = [PathValidator::class],
         description = "Path to the config file (path/to/config.yml). " +
             "Multiple configuration files can be specified with ',' or ';' as separator."
     )
-    var config: String? = null
+    var config: List<Path> = emptyList()
 
     @Parameter(
         names = ["--config-resource", "-cr"],
+        converter = ClasspathResourceConverter::class,
+        splitter = PathSplitter::class,
         description = "Path to the config resource on detekt's classpath (path/to/config.yml)."
     )
-    var configResource: String? = null
+    var configResource: List<URL> = emptyList()
 
     @Parameter(
         names = ["--generate-config", "-gc"],
@@ -54,9 +63,12 @@ class CliArgs {
 
     @Parameter(
         names = ["--plugins", "-p"],
+        converter = PathConverter::class,
+        splitter = PathSplitter::class,
+        validateValueWith = [PathValidator::class],
         description = "Extra paths to plugin jars separated by ',' or ';'."
     )
-    var plugins: String? = null
+    var plugins: List<Path> = emptyList()
 
     @Parameter(
         names = ["--parallel"],
@@ -196,10 +208,6 @@ class CliArgs {
         description = "Prints the detekt CLI version."
     )
     var showVersion: Boolean = false
-
-    val inputPaths: List<Path> by lazy {
-        MultipleExistingPathConverter().convert(input ?: System.getProperty("user.dir"))
-    }
 
     val reportPaths: List<ReportPath> by lazy {
         reports.map { ReportPath.from(it) }

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt
@@ -117,6 +117,7 @@ class CliArgs {
         description = "Specifies a directory as the base path." +
             "Currently it impacts all file paths in the formatted reports. " +
             "File paths in console output and txt report are not affected and remain as absolute paths.",
+        validateValueWith = [DirectoryValidator::class],
         converter = PathConverter::class
     )
     var basePath: Path = Path(System.getProperty("user.dir"))
@@ -200,6 +201,7 @@ class CliArgs {
     @Parameter(
         names = ["--jdk-home"],
         description = "EXPERIMENTAL: Use a custom JDK home directory to include into the classpath",
+        validateValueWith = [DirectoryValidator::class],
         converter = PathConverter::class
     )
     var jdkHome: Path? = null

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt
@@ -94,13 +94,14 @@ class CliArgs {
 
     @Parameter(
         names = ["--report", "-r"],
+        converter = ReportPathConverter::class,
         description = "Generates a report for given 'report-id' and stores it on given 'path'. " +
             "Entry should consist of: [report-id:path]. " +
             "Available 'report-id' values: 'txt', 'xml', 'html', 'md', 'sarif'. " +
             "These can also be used in combination with each other " +
             "e.g. '-r txt:reports/detekt.txt -r xml:reports/detekt.xml'"
     )
-    private var reports: List<String> = emptyList()
+    var reportPaths: List<ReportPath> = emptyList()
 
     @Parameter(
         names = ["--fail-on-severity"],
@@ -208,10 +209,6 @@ class CliArgs {
         description = "Prints the detekt CLI version."
     )
     var showVersion: Boolean = false
-
-    val reportPaths: List<ReportPath> by lazy {
-        reports.map { ReportPath.from(it) }
-    }
 
     val failurePolicy: RulesSpec.FailurePolicy
         get() {

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Spec.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Spec.kt
@@ -37,8 +37,8 @@ internal fun CliArgs.createSpec(output: Appendable, error: Appendable): Processi
         config {
             useDefaultConfig = args.buildUponDefaultConfig
             shouldValidateBeforeAnalysis = null
-            configPaths = config?.let { MultipleExistingPathConverter().convert(it) }.orEmpty()
-            resources = configResource?.let { MultipleClasspathResourceConverter().convert(it) }.orEmpty()
+            configPaths = args.config
+            resources = args.configResource
         }
 
         execution {
@@ -48,7 +48,7 @@ internal fun CliArgs.createSpec(output: Appendable, error: Appendable): Processi
 
         extensions {
             disableDefaultRuleSets = args.disableDefaultRuleSets
-            fromPaths { args.plugins?.let { MultipleExistingPathConverter().convert(it) }.orEmpty() }
+            fromPaths { args.plugins }
         }
 
         reports {

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/ConfigExporter.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/ConfigExporter.kt
@@ -3,7 +3,6 @@ package io.gitlab.arturbosch.detekt.cli.runners
 import io.github.detekt.tooling.api.DefaultConfigurationProvider
 import io.github.detekt.tooling.api.spec.ProcessingSpec
 import io.gitlab.arturbosch.detekt.cli.CliArgs
-import io.gitlab.arturbosch.detekt.cli.MultipleExistingPathConverter
 import kotlin.io.path.absolute
 
 class ConfigExporter(
@@ -16,7 +15,7 @@ class ConfigExporter(
         val spec = ProcessingSpec {
             extensions {
                 disableDefaultRuleSets = arguments.disableDefaultRuleSets
-                fromPaths { arguments.plugins?.let { MultipleExistingPathConverter().convert(it) }.orEmpty() }
+                fromPaths { arguments.plugins }
             }
         }
         DefaultConfigurationProvider.load(spec.extensionsSpec).copy(configPath)

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgsSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgsSpec.kt
@@ -1,6 +1,5 @@
 package io.gitlab.arturbosch.detekt.cli
 
-import com.beust.jcommander.ParameterException
 import io.github.detekt.test.utils.resourceAsPath
 import io.github.detekt.tooling.api.spec.RulesSpec.FailurePolicy.FailOnSeverity
 import io.github.detekt.tooling.api.spec.RulesSpec.FailurePolicy.NeverFail
@@ -8,7 +7,6 @@ import io.gitlab.arturbosch.detekt.api.Severity
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatCode
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
-import org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgsSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgsSpec.kt
@@ -53,7 +53,7 @@ internal class CliArgsSpec {
             val pathToNonExistentDirectory = projectPath.resolve("nonExistent")
             val params = arrayOf("--input", "$pathToNonExistentDirectory")
 
-            assertThatExceptionOfType(ParameterException::class.java)
+            assertThatExceptionOfType(HandledArgumentViolation::class.java)
                 .isThrownBy { parseArguments(params).inputPaths }
                 .withMessageContaining("does not exist")
         }
@@ -64,11 +64,9 @@ internal class CliArgsSpec {
 
         @Test
         fun `should fail on invalid config value`() {
-            assertThatIllegalArgumentException()
-                .isThrownBy { parseArguments(arrayOf("--config", ",")).toSpec() }
-            assertThatExceptionOfType(ParameterException::class.java)
+            assertThatExceptionOfType(HandledArgumentViolation::class.java)
                 .isThrownBy { parseArguments(arrayOf("--config", "sfsjfsdkfsd")).toSpec() }
-            assertThatExceptionOfType(ParameterException::class.java)
+            assertThatExceptionOfType(HandledArgumentViolation::class.java)
                 .isThrownBy { parseArguments(arrayOf("--config", "./i.do.not.exist.yml")).toSpec() }
         }
     }

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/GeneratorArgs.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/GeneratorArgs.kt
@@ -9,6 +9,7 @@ import com.beust.jcommander.converters.PathConverter
 import java.nio.file.Path
 import kotlin.io.path.Path
 import kotlin.io.path.exists
+import kotlin.io.path.isDirectory
 
 class GeneratorArgs {
 
@@ -26,6 +27,7 @@ class GeneratorArgs {
         names = ["--documentation", "-d"],
         required = true,
         converter = PathConverter::class,
+        validateValueWith = [DirectoryValidator::class],
         description = "Output path for generated documentation."
     )
     var documentationPath: Path = Path("")
@@ -34,6 +36,7 @@ class GeneratorArgs {
         names = ["--config", "-c"],
         required = true,
         converter = PathConverter::class,
+        validateValueWith = [DirectoryValidator::class],
         description = "Output path for generated detekt config."
     )
     var configPath: Path = Path("")
@@ -71,6 +74,12 @@ class GeneratorArgs {
             value.forEach {
                 if (!it.exists()) throw ParameterException("Input path does not exist: $it")
             }
+        }
+    }
+
+    class DirectoryValidator : IValueValidator<Path> {
+        override fun validate(name: String, value: Path) {
+            if (!value.isDirectory()) throw ParameterException("Value passed to $name must be a directory.")
         }
     }
 }

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/GeneratorArgs.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/GeneratorArgs.kt
@@ -1,7 +1,10 @@
 package io.gitlab.arturbosch.detekt.generator
 
 import com.beust.jcommander.DynamicParameter
+import com.beust.jcommander.IValueValidator
 import com.beust.jcommander.Parameter
+import com.beust.jcommander.ParameterException
+import com.beust.jcommander.converters.IParameterSplitter
 import com.beust.jcommander.converters.PathConverter
 import java.nio.file.Path
 import kotlin.io.path.Path
@@ -12,9 +15,12 @@ class GeneratorArgs {
     @Parameter(
         names = ["--input", "-i"],
         required = true,
+        converter = PathConverter::class,
+        splitter = PathSplitter::class,
+        validateValueWith = [PathValidator::class],
         description = "Input paths to analyze."
     )
-    private var input: String = ""
+    var inputPath: List<Path> = emptyList()
 
     @Parameter(
         names = ["--documentation", "-d"],
@@ -54,13 +60,17 @@ class GeneratorArgs {
     )
     var textReplacements: Map<String, String> = mutableMapOf()
 
-    val inputPath: List<Path> by lazy {
-        input
-            .splitToSequence(",", ";")
-            .map(String::trim)
-            .filter { it.isNotEmpty() }
-            .map { first -> Path(first) }
-            .onEach { require(it.exists()) { "Input path must exist!" } }
-            .toList()
+    class PathSplitter : IParameterSplitter {
+        override fun split(value: String): List<String> {
+            return value.split(',', ';')
+        }
+    }
+
+    class PathValidator : IValueValidator<List<Path>> {
+        override fun validate(name: String, value: List<Path>) {
+            value.forEach {
+                if (!it.exists()) throw ParameterException("Input path does not exist: $it")
+            }
+        }
     }
 }

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/GeneratorArgs.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/GeneratorArgs.kt
@@ -17,17 +17,17 @@ class GeneratorArgs {
 
     @Parameter(
         names = ["--documentation", "-d"],
-        required = false,
+        required = true,
         description = "Output path for generated documentation."
     )
-    private var documentation: String? = null
+    private var documentation: String = ""
 
     @Parameter(
         names = ["--config", "-c"],
-        required = false,
+        required = true,
         description = "Output path for generated detekt config."
     )
-    private var config: String? = null
+    private var config: String = ""
 
     @Parameter(
         names = ["--help", "-h"],
@@ -63,12 +63,8 @@ class GeneratorArgs {
             .toList()
     }
     val documentationPath: Path
-        get() = Path(
-            checkNotNull(documentation) {
-                "Documentation output path was not initialized by jcommander!"
-            }
-        )
+        get() = Path(documentation)
 
     val configPath: Path
-        get() = Path(checkNotNull(config) { "Configuration output path was not initialized by jcommander!" })
+        get() = Path(config)
 }

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/GeneratorArgs.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/GeneratorArgs.kt
@@ -14,7 +14,7 @@ class GeneratorArgs {
         required = true,
         description = "Input paths to analyze."
     )
-    private var input: String? = null
+    private var input: String = ""
 
     @Parameter(
         names = ["--documentation", "-d"],
@@ -55,7 +55,7 @@ class GeneratorArgs {
     var textReplacements: Map<String, String> = mutableMapOf()
 
     val inputPath: List<Path> by lazy {
-        checkNotNull(input) { "Input parameter was not initialized by jcommander!" }
+        input
             .splitToSequence(",", ";")
             .map(String::trim)
             .filter { it.isNotEmpty() }

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/GeneratorArgs.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/GeneratorArgs.kt
@@ -64,9 +64,7 @@ class GeneratorArgs {
     var textReplacements: Map<String, String> = mutableMapOf()
 
     class PathSplitter : IParameterSplitter {
-        override fun split(value: String): List<String> {
-            return value.split(',', ';')
-        }
+        override fun split(value: String): List<String> = value.split(',', ';')
     }
 
     class PathValidator : IValueValidator<List<Path>> {

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/GeneratorArgs.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/GeneratorArgs.kt
@@ -2,6 +2,7 @@ package io.gitlab.arturbosch.detekt.generator
 
 import com.beust.jcommander.DynamicParameter
 import com.beust.jcommander.Parameter
+import com.beust.jcommander.converters.PathConverter
 import java.nio.file.Path
 import kotlin.io.path.Path
 import kotlin.io.path.exists
@@ -18,16 +19,18 @@ class GeneratorArgs {
     @Parameter(
         names = ["--documentation", "-d"],
         required = true,
+        converter = PathConverter::class,
         description = "Output path for generated documentation."
     )
-    private var documentation: String = ""
+    var documentationPath: Path = Path("")
 
     @Parameter(
         names = ["--config", "-c"],
         required = true,
+        converter = PathConverter::class,
         description = "Output path for generated detekt config."
     )
-    private var config: String = ""
+    var configPath: Path = Path("")
 
     @Parameter(
         names = ["--help", "-h"],
@@ -60,9 +63,4 @@ class GeneratorArgs {
             .onEach { require(it.exists()) { "Input path must exist!" } }
             .toList()
     }
-    val documentationPath: Path
-        get() = Path(documentation)
-
-    val configPath: Path
-        get() = Path(config)
 }

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/GeneratorArgs.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/GeneratorArgs.kt
@@ -38,7 +38,6 @@ class GeneratorArgs {
 
     @Parameter(
         names = ["--generate-custom-rule-config", "-gcrc"],
-        required = false,
         description = "Generate config for user-defined rules. " +
             "Path to user rules can be specified with --input option"
     )
@@ -46,7 +45,6 @@ class GeneratorArgs {
 
     @DynamicParameter(
         names = ["--replace", "-r"],
-        required = false,
         description = "Any number of key and value pairs that are used to replace placeholders " +
             "during data collection and output generation. Key and value are separated by '='. " +
             "The property may be used multiple times."

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/Main.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/Main.kt
@@ -3,7 +3,6 @@
 package io.gitlab.arturbosch.detekt.generator
 
 import com.beust.jcommander.JCommander
-import kotlin.io.path.isDirectory
 import kotlin.system.exitProcess
 
 @Suppress("detekt.SpreadOperator")
@@ -16,9 +15,6 @@ fun main(args: Array<String>) {
         parser.usage()
         exitProcess(0)
     }
-
-    require(options.documentationPath.isDirectory()) { "Documentation path must be a directory." }
-    require(options.configPath.isDirectory()) { "Config path must be a directory." }
 
     val generator = Generator(
         inputPaths = options.inputPath,

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/GeneratorArgsSpec.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/GeneratorArgsSpec.kt
@@ -12,7 +12,7 @@ class GeneratorArgsSpec {
         private fun parse(vararg args: String): GeneratorArgs {
             val options = GeneratorArgs()
             val parser = JCommander(options)
-            parser.parse("-i", ".", *args)
+            parser.parse("-i", ".", "-d", ".", "-c", ".", *args)
             return options
         }
 

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/printer/GeneratorSpec.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/printer/GeneratorSpec.kt
@@ -21,7 +21,7 @@ class GeneratorSpec {
         val args = arrayOf(
             "--generate-custom-rule-config",
             "--input",
-            "$rulePath1, $rulePath2",
+            "$rulePath1,$rulePath2",
             "--documentation",
             documentationOutput.toString(),
             "--config",


### PR DESCRIPTION
The only functional change is that directories passed to detekt CLI are validated as directories. Other than that, this just makes the code a bit more consistent by using more of JCommander's features, and using stronger typing when args are processed.