### PR TITLE
generator: Make --documentation and --config optional

### DIFF
--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/Generator.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/Generator.kt
@@ -13,8 +13,8 @@ import kotlin.system.measureTimeMillis
 class Generator(
     private val inputPaths: List<Path>,
     private val textReplacements: Map<String, String>,
-    documentationPath: Path,
-    configPath: Path,
+    documentationPath: Path?,
+    configPath: Path?,
     private val outPrinter: PrintStream = System.out
 ) {
     private val collector = DetektCollector(textReplacements)

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/GeneratorArgs.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/GeneratorArgs.kt
@@ -7,7 +7,6 @@ import com.beust.jcommander.ParameterException
 import com.beust.jcommander.converters.IParameterSplitter
 import com.beust.jcommander.converters.PathConverter
 import java.nio.file.Path
-import kotlin.io.path.Path
 import kotlin.io.path.exists
 import kotlin.io.path.isDirectory
 
@@ -25,21 +24,19 @@ class GeneratorArgs {
 
     @Parameter(
         names = ["--documentation", "-d"],
-        required = true,
         converter = PathConverter::class,
         validateValueWith = [DirectoryValidator::class],
         description = "Output path for generated documentation."
     )
-    var documentationPath: Path = Path("")
+    var documentationPath: Path? = null
 
     @Parameter(
         names = ["--config", "-c"],
-        required = true,
         converter = PathConverter::class,
         validateValueWith = [DirectoryValidator::class],
         description = "Output path for generated detekt config."
     )
-    var configPath: Path = Path("")
+    var configPath: Path? = null
 
     @Parameter(
         names = ["--help", "-h"],

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/GeneratorArgsSpec.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/GeneratorArgsSpec.kt
@@ -12,7 +12,7 @@ class GeneratorArgsSpec {
         private fun parse(vararg args: String): GeneratorArgs {
             val options = GeneratorArgs()
             val parser = JCommander(options)
-            parser.parse("-i", ".", "-d", ".", "-c", ".", *args)
+            parser.parse("-i", ".", *args)
             return options
         }
 

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/printer/GeneratorSpec.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/printer/GeneratorSpec.kt
@@ -6,15 +6,12 @@ import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import kotlin.io.path.Path
-import kotlin.io.path.createTempDirectory
 import kotlin.io.path.readText
 
 class GeneratorSpec {
     private val configPath = "src/main/resources/config/config.yml"
     private val rulePath1 = "src/test/resources/ruleset1"
     private val rulePath2 = "src/test/resources/ruleset2"
-    private val documentationOutput = createTempDirectory()
-    private val configurationOutput = createTempDirectory()
 
     @BeforeAll
     fun init() {
@@ -22,10 +19,6 @@ class GeneratorSpec {
             "--generate-custom-rule-config",
             "--input",
             "$rulePath1,$rulePath2",
-            "--documentation",
-            documentationOutput.toString(),
-            "--config",
-            configurationOutput.toString(),
         )
         main(args)
     }
@@ -51,7 +44,5 @@ class GeneratorSpec {
     fun tearDown() {
         Path(rulePath1, configPath).toFile().delete()
         Path(rulePath2, configPath).toFile().delete()
-        documentationOutput.toFile().deleteRecursively()
-        configurationOutput.toFile().deleteRecursively()
     }
 }


### PR DESCRIPTION
These are currently only useful for the detekt project. Maintainers of third party rule sets should be able to use the -gcrc option without generating the documentation and config files, and should not have to pass these as CLI options.