### PR TITLE
Improve cli error message

### DIFF
--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/ArgumentConverters.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/ArgumentConverters.kt
@@ -52,7 +52,7 @@ class PathSplitter : IParameterSplitter {
 class PathValidator : IValueValidator<List<Path>> {
     override fun validate(name: String, value: List<Path>) {
         value.forEach {
-            if (!it.exists()) throw ParameterException("Input path does not exist: $it")
+            if (!it.exists()) throw ParameterException("Input path does not exist: '$it'")
         }
     }
 }

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgsSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgsSpec.kt
@@ -65,7 +65,7 @@ internal class CliArgsSpec {
 
             assertThatExceptionOfType(HandledArgumentViolation::class.java)
                 .isThrownBy { parseArguments(params) }
-                .withMessage("Input path does not exist: nonExistent ")
+                .withMessage("Input path does not exist: 'nonExistent '")
         }
     }
 


### PR DESCRIPTION
This PR is related with this comment: https://github.com/detekt/detekt/pull/7092#issuecomment-2022252115

#7092 introduced a change that makes that the paths are not trimmed. That seems like a good change to me but the error message to spot it:

> Input path does not exist: nonExistent 

vs

> Input path does not exist: 'nonExistent '

check that the first one has a ` ` at the end. But it is really difficult to spot.