### PR TITLE
Simplify baseline validation

### DIFF
--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/JCommander.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/JCommander.kt
@@ -33,22 +33,22 @@ private fun JCommander.usageAsString(): String {
 }
 
 private fun CliArgs.validate(jCommander: JCommander) {
-    val violations = StringBuilder()
+    var violation: String? = null
     val baseline = baseline
 
     if (createBaseline && baseline == null) {
-        violations.appendLine("Creating a baseline.xml requires the --baseline parameter to specify a path.")
+        violation = "Creating a baseline.xml requires the --baseline parameter to specify a path."
     }
 
     if (!createBaseline && baseline != null) {
         if (baseline.notExists()) {
-            violations.appendLine("The file specified by --baseline should exist '$baseline'.")
+            violation = "The file specified by --baseline should exist '$baseline'."
         } else if (!baseline.isRegularFile()) {
-            violations.appendLine("The path specified by --baseline should be a file '$baseline'.")
+            violation = "The path specified by --baseline should be a file '$baseline'."
         }
     }
 
-    if (violations.isNotEmpty()) {
-        throw HandledArgumentViolation(violations.toString(), jCommander.usageAsString())
+    if (violation != null) {
+        throw HandledArgumentViolation(violation, jCommander.usageAsString())
     }
 }

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgsSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgsSpec.kt
@@ -79,7 +79,7 @@ internal class CliArgsSpec {
             fun `reports an error when using --create-baseline without a --baseline file`() {
                 assertThatCode { parseArguments(arrayOf("--create-baseline")) }
                     .isInstanceOf(HandledArgumentViolation::class.java)
-                    .hasMessageContaining("Creating a baseline.xml requires the --baseline parameter to specify a path")
+                    .hasMessage("Creating a baseline.xml requires the --baseline parameter to specify a path.")
             }
 
             @Test
@@ -87,7 +87,7 @@ internal class CliArgsSpec {
                 val nonExistingDirectory = projectPath.resolve("nonExistent").toString()
                 assertThatCode { parseArguments(arrayOf("--baseline", nonExistingDirectory)) }
                     .isInstanceOf(HandledArgumentViolation::class.java)
-                    .hasMessageContaining("The file specified by --baseline should exist '$nonExistingDirectory'.")
+                    .hasMessage("The file specified by --baseline should exist '$nonExistingDirectory'.")
             }
 
             @Test
@@ -95,7 +95,7 @@ internal class CliArgsSpec {
                 val directory = resourceAsPath("/cases").toString()
                 assertThatCode { parseArguments(arrayOf("--baseline", directory)) }
                     .isInstanceOf(HandledArgumentViolation::class.java)
-                    .hasMessageContaining("The path specified by --baseline should be a file '$directory'.")
+                    .hasMessage("The path specified by --baseline should be a file '$directory'.")
             }
         }
 


### PR DESCRIPTION
We were adding a "free" `\n` at the end of these error messages and these messages can never happen at the same time.
