### PR TITLE
Refactor `Suppressions.kt`

### DIFF
--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/Suppressions.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/Suppressions.kt
@@ -3,58 +3,42 @@ package io.gitlab.arturbosch.detekt.api.internal
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.RuleSet
 import org.jetbrains.kotlin.psi.KtAnnotated
+import org.jetbrains.kotlin.psi.KtAnnotationEntry
 import org.jetbrains.kotlin.psi.KtElement
-import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
+import kotlin.text.RegexOption.IGNORE_CASE
 
 /**
  * Checks if this psi element is suppressed by @Suppress or @SuppressWarnings annotations.
  * If this element cannot have annotations, the first annotative parent is searched.
  */
-fun KtElement.isSuppressedBy(id: Rule.Id, aliases: Set<String>, ruleSetId: RuleSet.Id? = null): Boolean =
-    this is KtAnnotated &&
-        this.isSuppressedBy(id, aliases, ruleSetId) ||
-        findAnnotatedSuppressedParent(id, aliases, ruleSetId)
-
-private fun KtElement.findAnnotatedSuppressedParent(
-    id: Rule.Id,
-    aliases: Set<String>,
-    ruleSetId: RuleSet.Id? = null
-): Boolean {
-    val parent = getStrictParentOfType<KtAnnotated>()
-
-    var suppressed = false
-    if (parent != null && parent !is KtFile) {
-        suppressed = if (parent.isSuppressedBy(id, aliases, ruleSetId)) {
-            true
-        } else {
-            parent.findAnnotatedSuppressedParent(id, aliases, ruleSetId)
-        }
-    }
-
-    return suppressed
-}
-
-private val detektSuppressionPrefixRegex = Regex("(?i)detekt([.:])")
-private const val QUOTES = "\""
-private val suppressionAnnotations = setOf("Suppress", "SuppressWarnings")
-
-/**
- * Checks if this kt element is suppressed by @Suppress or @SuppressWarnings annotations.
- */
-fun KtAnnotated.isSuppressedBy(id: Rule.Id, aliases: Set<String>, ruleSetId: RuleSet.Id? = null): Boolean {
+fun KtElement.isSuppressedBy(id: Rule.Id, aliases: Set<String>, ruleSetId: RuleSet.Id? = null): Boolean {
     val acceptedSuppressionIds = mutableSetOf(id.value, "ALL", "all", "All")
     if (ruleSetId != null) {
         acceptedSuppressionIds.addAll(listOf(ruleSetId.value, "$ruleSetId.$id", "$ruleSetId:$id"))
     }
     acceptedSuppressionIds.addAll(aliases)
-    return annotationEntries
-        .find { it.typeReference?.text in suppressionAnnotations }
-        ?.run {
-            valueArguments
-                .map { it.getArgumentExpression()?.text }
-                .map { it?.replace(detektSuppressionPrefixRegex, "") }
-                .map { it?.replace(QUOTES, "") }
-                .find { it in acceptedSuppressionIds }
-        } != null
+
+    return allAnnotationEntries()
+        .filter { it.typeReference?.text in suppressionAnnotations }
+        .flatMap { it.valueArguments }
+        .mapNotNull { it.getArgumentExpression()?.text }
+        .map { it.replace(detektSuppressionPrefixRegex, "") }
+        .map { it.replace(QUOTES, "") }
+        .any { it in acceptedSuppressionIds }
 }
+
+private fun KtElement.allAnnotationEntries(): Sequence<KtAnnotationEntry> {
+    val element = this
+    return sequence {
+        if (element is KtAnnotated) {
+            yieldAll(element.annotationEntries)
+        }
+
+        element.getStrictParentOfType<KtAnnotated>()?.let { yieldAll(it.allAnnotationEntries()) }
+    }
+}
+
+private val detektSuppressionPrefixRegex = "detekt[.:]".toRegex(IGNORE_CASE)
+private const val QUOTES = "\""
+private val suppressionAnnotations = setOf("Suppress", "SuppressWarnings")


### PR DESCRIPTION
The idea of suppression is to look if the reported element (or any of it's parents) has a `@Suppression` annotation with a matching name (what is a matching name can be discussed later, I didn't touch that part at all).

The new implementation creates a `Sequence` with all the annotations that the element and all it's parents have. And then check if any of them matches. And, because `Sequence` is lazy, as soon as we find one we don't need to continue to traverse the parents so this shouldn't create any performance issue.

With that idea I think that `Suppresson.kt` is easier to read now. I know that it's not really easy now wither but PSI doesn't help.