### PR TITLE
Add missing tests on `SuppressionSpec.kt`

### DIFF
--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/SuppressionSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/SuppressionSpec.kt
@@ -257,6 +257,28 @@ class SuppressionSpec {
         assertThat(compileContentForTest("""@file:Suppress("detekt:$value")""").isSuppressedBy()).isFalse()
         assertThat(compileContentForTest("""@file:Suppress("Detekt.$value")""").isSuppressedBy()).isFalse()
     }
+
+    @Test
+    fun checkAllAnnotations1() {
+        val file = compileContentForTest(
+            """
+                @file:Suppress("Foo")
+                @file:SuppressWarnings("RuleId")
+            """.trimIndent()
+        )
+        assertThat(file.isSuppressedBy()).isTrue()
+    }
+
+    @Test
+    fun checkAllAnnotations2() {
+        val file = compileContentForTest(
+            """
+                @file:Suppress("RuleId")
+                @file:SuppressWarnings("Foo")
+            """.trimIndent()
+        )
+        assertThat(file.isSuppressedBy()).isTrue()
+    }
 }
 
 private fun KtFile.getClass(): KtElement {


### PR DESCRIPTION
This PR is related with #7107 and #7108. While working on #7107 I found an edge case that we didn't have covered and I covered it. And then on #7108 I rewrote all the tests.

So instead of adding the tests of that edge case on #7107 I'm waiting for those two PRs to be merged and then add the tests that you see here.