### PR TITLE
Rename `RedundantVisibilityModifierRule` to `RedundantVisibilityModifier`

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -241,7 +241,7 @@ style:
     active: true
   RedundantHigherOrderMapUsage:
     active: true
-  RedundantVisibilityModifierRule:
+  RedundantVisibilityModifier:
     active: true
   ReturnCount:
     active: true

--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -705,7 +705,7 @@ style:
     active: false
   RedundantHigherOrderMapUsage:
     active: true
-  RedundantVisibilityModifierRule:
+  RedundantVisibilityModifier:
     active: false
   ReturnCount:
     active: true

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantVisibilityModifier.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantVisibilityModifier.kt
@@ -40,13 +40,10 @@ import org.jetbrains.kotlin.psi.psiUtil.isPrivate
  * }
  * </compliant>
  */
-class RedundantVisibilityModifierRule(config: Config) : Rule(
+class RedundantVisibilityModifier(config: Config) : Rule(
     config,
     "Redundant visibility modifiers detected, which can be safely removed."
 ) {
-
-    override val defaultRuleIdAliases: Set<String> = setOf("RedundantVisibilityModifier")
-
     private val classVisitor = ClassVisitor()
     private val childrenVisitor = ChildrenVisitor()
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/StyleGuideProvider.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/StyleGuideProvider.kt
@@ -70,7 +70,7 @@ class StyleGuideProvider : DefaultRuleSetProvider {
             ::UnusedPrivateProperty,
             ::ExpressionBodySyntax,
             ::NestedClassesVisibility,
-            ::RedundantVisibilityModifierRule,
+            ::RedundantVisibilityModifier,
             ::RangeUntilInsteadOfRangeTo,
             ::UnnecessaryApply,
             ::UnnecessaryAny,

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantVisibilityModifierSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantVisibilityModifierSpec.kt
@@ -16,8 +16,8 @@ import org.jetbrains.kotlin.resolve.calls.smartcasts.DataFlowValueFactoryImpl
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
-class RedundantVisibilityModifierRuleSpec {
-    val subject = RedundantVisibilityModifierRule(Config.empty)
+class RedundantVisibilityModifierSpec {
+    val subject = RedundantVisibilityModifier(Config.empty)
 
     @Test
     fun `does not report overridden function of abstract class with public modifier`() {
@@ -56,17 +56,6 @@ class RedundantVisibilityModifierRuleSpec {
             
             class Test : A {
                 override public fun f() {}
-            }
-        """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
-    }
-
-    @Test
-    fun `should ignore the issue by alias suppression`() {
-        val code = """
-            class Test {
-                @Suppress("RedundantVisibilityModifier")
-                public fun f() {}
             }
         """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
@@ -191,7 +180,7 @@ class RedundantVisibilityModifierRuleSpec {
             """.trimIndent()
         )
 
-        val rule = RedundantVisibilityModifierRule(Config.empty)
+        val rule = RedundantVisibilityModifier(Config.empty)
 
         private fun fakeCompilerResources(mode: ExplicitApiMode): CompilerResources {
             val languageVersionSettings = object : LanguageVersionSettings {


### PR DESCRIPTION
`RedundantVisibilityModifierRule` was the only rule on detekt that ended with `Rule`. And even the rule had an alias to be able to suppress it with `RedundantVisibilityModifier`. So for 2.0 we can rename it to `RedundantVisibilityModifier` and remove the alias.