### PR TITLE
Do not run vercel on gh-pages

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,10 @@
 {
   "github": {
     "silent": true
-   }
+  },
+  "git": {
+    "deploymentEnabled": {
+      "gh-pages": false
+    }
+  }
 }


### PR DESCRIPTION
Vercel is currently failing on `gh-pages` because the `website` folder is missing. This is expected as we don't want to run website preview there