### PR TITLE
Tell Renovate to ignore AGP API for updates

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -1,5 +1,6 @@
 {
   "labels": ["dependencies"],
+  "ignoreDeps": ["com.android.tools.build:gradle-api"],
   "extends": [
     "config:base",
     "helpers:pinGitHubActionDigests"


### PR DESCRIPTION
This version is static until we raise the minimum supported AGP version, so we don't need Renovate to update it for us.