### PR TITLE
Increase max metaspace limit to 1G

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ kotlin.daemon.useFallbackStrategy=false
 org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.configuration-cache=true
-org.gradle.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8
 org.gradle.kotlin.dsl.allWarningsAsErrors=true
 org.gradle.kotlin.dsl.skipMetadataVersionCheck=false
 


### PR DESCRIPTION
Vercel deployments are failing due to hitting the current limit