### PR TITLE
No nullable line separator

### DIFF
--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/KtFileModifier.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/KtFileModifier.kt
@@ -6,7 +6,6 @@ import io.gitlab.arturbosch.detekt.api.Detektion
 import io.gitlab.arturbosch.detekt.api.FileProcessListener
 import io.gitlab.arturbosch.detekt.api.Notification
 import org.jetbrains.kotlin.com.intellij.openapi.util.text.StringUtilRt
-import org.jetbrains.kotlin.fileClasses.javaFileFacadeFqName
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.resolve.BindingContext
 import java.nio.file.Path
@@ -26,9 +25,6 @@ class KtFileModifier : FileProcessListener {
     }
 
     private fun KtFile.unnormalizeContent(): String {
-        val lineSeparator = requireNotNull(this.lineSeparator) {
-            "No line separator entry for ktFile ${javaFileFacadeFqName.asString()}"
-        }
         return StringUtilRt.convertLineSeparators(text, lineSeparator)
     }
 }

--- a/detekt-psi-utils/src/main/kotlin/io/github/detekt/psi/Keys.kt
+++ b/detekt-psi-utils/src/main/kotlin/io/github/detekt/psi/Keys.kt
@@ -2,9 +2,10 @@ package io.github.detekt.psi
 
 import org.jetbrains.kotlin.com.intellij.openapi.util.Key
 import org.jetbrains.kotlin.com.intellij.psi.PsiFile
+import org.jetbrains.kotlin.psi.NotNullableUserDataProperty
 import org.jetbrains.kotlin.psi.UserDataProperty
 import java.nio.file.Path
 
 var PsiFile.relativePath: Path? by UserDataProperty(Key("relativePath"))
 var PsiFile.basePath: Path? by UserDataProperty(Key("basePath"))
-var PsiFile.lineSeparator: String? by UserDataProperty(Key("lineSeparator"))
+var PsiFile.lineSeparator: String by NotNullableUserDataProperty(Key("lineSeparator"), System.lineSeparator())


### PR DESCRIPTION
We are always setting this value for all the `KtFile`s that we generate. And, also, we can define a sane default value and this avoid us to handle the `null` case.