### PR TITLE
Stricter paths

### DIFF
--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/CodeSmellSpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/CodeSmellSpec.kt
@@ -1,9 +1,9 @@
 package io.gitlab.arturbosch.detekt.api
 
 import io.gitlab.arturbosch.detekt.test.fromRelative
+import io.gitlab.arturbosch.detekt.test.location
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import java.io.File
 import kotlin.io.path.Path
 
 class CodeSmellSpec {
@@ -24,13 +24,11 @@ class CodeSmellSpec {
             ),
             message = "TestMessage"
         )
-        val basePath = "${File.separator}Users${File.separator}tester${File.separator}detekt"
 
         assertThat(codeSmell.toString()).isEqualTo(
             "CodeSmell(entity=Entity(name=TestEntity, signature=TestEntitySignature, " +
                 "location=Location(source=1:1, endSource=1:1, text=0:0, " +
-                "filePath=FilePath(absolutePath=$basePath${File.separator}TestFile.kt, " +
-                "basePath=$basePath, relativePath=TestFile.kt)), ktElement=null), message=TestMessage, " +
+                "filePath=${codeSmell.location.filePath}), ktElement=null), message=TestMessage, " +
                 "references=[])"
         )
     }

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/CodeSmellSpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/CodeSmellSpec.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.test.location
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import kotlin.io.path.Path
+import kotlin.io.path.absolute
 
 class CodeSmellSpec {
 
@@ -18,7 +19,10 @@ class CodeSmellSpec {
                     source = SourceLocation(1, 1),
                     endSource = SourceLocation(1, 1),
                     text = TextLocation(0, 0),
-                    filePath = fromRelative(Path("/Users/tester/detekt/"), Path("TestFile.kt"))
+                    filePath = fromRelative(
+                        Path("/").absolute().resolve("Users/tester/detekt/"),
+                        Path("TestFile.kt"),
+                    ),
                 ),
                 ktElement = null
             ),

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/CorrectableCodeSmellSpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/CorrectableCodeSmellSpec.kt
@@ -1,7 +1,7 @@
 package io.gitlab.arturbosch.detekt.api
 
 import io.gitlab.arturbosch.detekt.test.createEntity
-import io.gitlab.arturbosch.detekt.test.createLocation
+import io.gitlab.arturbosch.detekt.test.location
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -10,7 +10,7 @@ class CorrectableCodeSmellSpec {
     @Test
     fun `toString contains all information`() {
         val codeSmell: CorrectableCodeSmell = object : CorrectableCodeSmell(
-            entity = createEntity(location = createLocation("TestFile.kt")),
+            entity = createEntity(),
             message = "TestMessage",
             autoCorrectEnabled = true
         ) {}
@@ -18,8 +18,7 @@ class CorrectableCodeSmellSpec {
         assertThat(codeSmell.toString()).isEqualTo(
             "CorrectableCodeSmell(autoCorrectEnabled=true, " +
                 "entity=Entity(name=TestEntity, signature=TestEntitySignature, " +
-                "location=Location(source=1:1, endSource=1:1, text=0:0, " +
-                "filePath=FilePath(absolutePath=TestFile.kt, basePath=null, relativePath=null)), " +
+                "location=Location(source=1:1, endSource=1:1, text=0:0, filePath=${codeSmell.location.filePath}), " +
                 "ktElement=null), message=TestMessage, references=[])"
         )
     }

--- a/detekt-api/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/test/TestFactory.kt
+++ b/detekt-api/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/test/TestFactory.kt
@@ -12,6 +12,7 @@ import io.gitlab.arturbosch.detekt.api.TextLocation
 import org.jetbrains.kotlin.psi.KtElement
 import java.nio.file.Path
 import kotlin.io.path.Path
+import kotlin.io.path.absolute
 
 fun createIssue(
     ruleName: String = "TestSmell",
@@ -67,23 +68,26 @@ fun createRuleInfo(
 
 fun createIssueForRelativePath(
     ruleInfo: Issue.RuleInfo,
-    basePath: String = "/Users/tester/detekt/",
+    basePath: String = "Users/tester/detekt/",
     relativePath: String = "TestFile.kt"
-): Issue = IssueImpl(
-    ruleInfo = ruleInfo,
-    entity = Entity(
-        name = "TestEntity",
-        signature = "TestEntitySignature",
-        location = Location(
-            source = SourceLocation(1, 1),
-            endSource = SourceLocation(1, 1),
-            text = TextLocation(0, 0),
-            filePath = fromRelative(Path(basePath), Path(relativePath))
+): Issue {
+    require(!basePath.startsWith("/")) { "The path shouldn't start with '/'" }
+    return IssueImpl(
+        ruleInfo = ruleInfo,
+        entity = Entity(
+            name = "TestEntity",
+            signature = "TestEntitySignature",
+            location = Location(
+                source = SourceLocation(1, 1),
+                endSource = SourceLocation(1, 1),
+                text = TextLocation(0, 0),
+                filePath = fromRelative(Path("/").absolute().resolve(basePath), Path(relativePath))
+            ),
+            ktElement = null
         ),
-        ktElement = null
-    ),
-    message = "TestMessage"
-)
+        message = "TestMessage"
+    )
+}
 
 fun createEntity(
     signature: String = "TestEntitySignature",
@@ -102,13 +106,16 @@ fun createLocation(
     position: Pair<Int, Int> = 1 to 1,
     endPosition: Pair<Int, Int> = 1 to 1,
     text: IntRange = 0..0,
-) = Location(
-    source = SourceLocation(position.first, position.second),
-    endSource = SourceLocation(endPosition.first, endPosition.second),
-    text = TextLocation(text.first, text.last),
-    filePath = basePath?.let { fromRelative(Path(it), Path(path)) }
-        ?: fromAbsolute(Path(path)),
-)
+): Location {
+    require(!path.startsWith("/")) { "The path shouldn't start with '/'" }
+    return Location(
+        source = SourceLocation(position.first, position.second),
+        endSource = SourceLocation(endPosition.first, endPosition.second),
+        text = TextLocation(text.first, text.last),
+        filePath = basePath?.let { fromRelative(Path("/").absolute().resolve(it), Path(path)) }
+            ?: fromAbsolute(Path("/").absolute().resolve(path)),
+    )
+}
 
 private data class IssueImpl(
     override val ruleInfo: Issue.RuleInfo,

--- a/detekt-api/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/test/TestFactory.kt
+++ b/detekt-api/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/test/TestFactory.kt
@@ -41,6 +41,20 @@ fun createIssue(
     autoCorrectEnabled = autoCorrectEnabled,
 )
 
+fun createIssue(
+    ruleInfo: Issue.RuleInfo,
+    location: Location,
+    message: String = "TestMessage",
+    severity: Severity = Severity.Error,
+    autoCorrectEnabled: Boolean = false,
+): Issue = IssueImpl(
+    ruleInfo = ruleInfo,
+    entity = createEntity(location = location),
+    message = message,
+    severity = severity,
+    autoCorrectEnabled = autoCorrectEnabled,
+)
+
 fun createRuleInfo(
     id: String = "TestSmell",
     ruleSetId: String = "RuleSet$id",

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/FileBasedIssuesReportSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/FileBasedIssuesReportSpec.kt
@@ -1,11 +1,9 @@
 package io.gitlab.arturbosch.detekt.core.reporting.console
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.core.reporting.AutoCorrectableIssueAssert
 import io.gitlab.arturbosch.detekt.core.reporting.decolorized
 import io.gitlab.arturbosch.detekt.test.TestDetektion
-import io.gitlab.arturbosch.detekt.test.createEntity
 import io.gitlab.arturbosch.detekt.test.createIssue
 import io.gitlab.arturbosch.detekt.test.createLocation
 import io.gitlab.arturbosch.detekt.test.createRuleInfo
@@ -18,21 +16,23 @@ class FileBasedIssuesReportSpec {
 
     @Test
     fun `has the reference content`() {
+        val location1 = createLocation("File1.kt")
+        val location2 = createLocation("File2.kt")
         val detektion = TestDetektion(
-            createIssue(ruleSetId = "Ruleset1", fileName = "File1.kt"),
-            createIssue(ruleSetId = "Ruleset1", fileName = "File2.kt"),
-            createIssue(ruleSetId = "Ruleset2", fileName = "File1.kt"),
+            createIssue(createRuleInfo(ruleSetId = "Ruleset1"), location1),
+            createIssue(createRuleInfo(ruleSetId = "Ruleset1"), location2),
+            createIssue(createRuleInfo(ruleSetId = "Ruleset2"), location1),
         )
 
         val output = subject.render(detektion)?.decolorized()
 
         assertThat(output).isEqualTo(
             """
-                File1.kt
-                	TestSmell - [TestMessage] at File1.kt:1:1
-                	TestSmell - [TestMessage] at File1.kt:1:1
-                File2.kt
-                	TestSmell - [TestMessage] at File2.kt:1:1
+                ${location1.filePath.absolutePath}
+                	TestSmell - [TestMessage] at ${location1.compact()}
+                	TestSmell - [TestMessage] at ${location1.compact()}
+                ${location2.filePath.absolutePath}
+                	TestSmell - [TestMessage] at ${location2.compact()}
                 
             """.trimIndent()
         )
@@ -56,8 +56,3 @@ private fun createFileBasedIssuesReport(): FileBasedIssuesReport {
     report.init(Config.empty)
     return report
 }
-
-private fun createIssue(ruleSetId: String, fileName: String): Issue = createIssue(
-    ruleInfo = createRuleInfo(ruleSetId = ruleSetId),
-    entity = createEntity(location = createLocation(fileName)),
-)

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/IssuesReportSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/IssuesReportSpec.kt
@@ -49,20 +49,23 @@ class IssuesReportSpec {
 
     @Test
     fun `truncates long message`() {
-        val expectedContent = """
-            Ruleset
-            	LongRule - [This is just a long message that should be truncated after a given threshold is (...)] at TestFile.kt:1:1
-            	MultilineRule - [A multiline message.] at TestFile.kt:1:1
-            
-        """.trimIndent()
-        val longMessage = "This is just a long message that should be truncated after a given " +
-            "threshold is reached."
-        val multilineMessage = "A multiline\n\r\tmessage.\t "
         val detektion = TestDetektion(
-            createIssue(createRuleInfo("LongRule", "Ruleset"), message = longMessage),
-            createIssue(createRuleInfo("MultilineRule", "Ruleset"), message = multilineMessage),
+            createIssue(
+                createRuleInfo("LongRule", "Ruleset"),
+                message = "This is just a long message that should be truncated after a given threshold is reached.",
+            ),
+            createIssue(
+                createRuleInfo("MultilineRule", "Ruleset"),
+                message = "A multiline\n\r\tmessage.\t ",
+            ),
         )
-        assertThat(subject.render(detektion)?.decolorized()).isEqualTo(expectedContent)
+        val output = subject.render(detektion)?.decolorized()
+        assertThat(output)
+            .contains(
+                "LongRule - [This is just a long message that should be truncated after a given threshold is (...)]"
+            )
+        assertThat(output)
+            .contains("MultilineRule - [A multiline message.]")
     }
 }
 

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/IssuesReportSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/IssuesReportSpec.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.core.reporting.AutoCorrectableIssueAssert
 import io.gitlab.arturbosch.detekt.core.reporting.decolorized
 import io.gitlab.arturbosch.detekt.test.TestDetektion
 import io.gitlab.arturbosch.detekt.test.createIssue
+import io.gitlab.arturbosch.detekt.test.createLocation
 import io.gitlab.arturbosch.detekt.test.createRuleInfo
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -15,10 +16,11 @@ class IssuesReportSpec {
 
     @Test
     fun `has the reference content`() {
+        val location = createLocation()
         val detektion = TestDetektion(
-            createIssue(createRuleInfo(ruleSetId = "Ruleset1")),
-            createIssue(createRuleInfo(ruleSetId = "Ruleset1")),
-            createIssue(createRuleInfo(ruleSetId = "Ruleset2")),
+            createIssue(createRuleInfo(ruleSetId = "Ruleset1"), location),
+            createIssue(createRuleInfo(ruleSetId = "Ruleset1"), location),
+            createIssue(createRuleInfo(ruleSetId = "Ruleset2"), location),
         )
 
         val output = subject.render(detektion)?.decolorized()
@@ -26,10 +28,10 @@ class IssuesReportSpec {
         assertThat(output).isEqualTo(
             """
                 Ruleset1
-                	TestSmell - [TestMessage] at TestFile.kt:1:1
-                	TestSmell - [TestMessage] at TestFile.kt:1:1
+                	TestSmell - [TestMessage] at ${location.compact()}
+                	TestSmell - [TestMessage] at ${location.compact()}
                 Ruleset2
-                	TestSmell - [TestMessage] at TestFile.kt:1:1
+                	TestSmell - [TestMessage] at ${location.compact()}
                 
             """.trimIndent()
         )

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/LiteIssuesReportSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/LiteIssuesReportSpec.kt
@@ -4,6 +4,8 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.core.reporting.AutoCorrectableIssueAssert
 import io.gitlab.arturbosch.detekt.test.TestDetektion
 import io.gitlab.arturbosch.detekt.test.createIssue
+import io.gitlab.arturbosch.detekt.test.createLocation
+import io.gitlab.arturbosch.detekt.test.createRuleInfo
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -13,14 +15,15 @@ class LiteIssuesReportSpec {
 
     @Test
     fun `reports non-empty issues`() {
+        val location = createLocation()
         val detektion = TestDetektion(
-            createIssue("SpacingAfterPackageDeclaration"),
-            createIssue("UnnecessarySafeCall")
+            createIssue(createRuleInfo("SpacingAfterPackageDeclaration"), location),
+            createIssue(createRuleInfo("UnnecessarySafeCall"), location),
         )
         assertThat(subject.render(detektion)).isEqualTo(
             """
-                TestFile.kt:1:1: TestMessage [SpacingAfterPackageDeclaration]
-                TestFile.kt:1:1: TestMessage [UnnecessarySafeCall]
+                ${location.compact()}: TestMessage [SpacingAfterPackageDeclaration]
+                ${location.compact()}: TestMessage [UnnecessarySafeCall]
 
             """.trimIndent()
         )

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/Builders.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/Builders.kt
@@ -16,7 +16,7 @@ internal fun buildFinding(element: KtElement?): Finding = CodeSmell(
 private fun buildEmptyEntity(): Entity = Entity(
     name = "",
     signature = "",
-    location = createLocation(path = "/"),
+    location = createLocation(""),
     ktElement = null,
 )
 

--- a/detekt-psi-utils/src/main/kotlin/io/github/detekt/psi/KtFiles.kt
+++ b/detekt-psi-utils/src/main/kotlin/io/github/detekt/psi/KtFiles.kt
@@ -53,6 +53,9 @@ class FilePath(
         ) {
             "Absolute path = $absolutePath much match base path = $basePath and relative path = $relativePath"
         }
+        require(absolutePath.isAbsolute) { "absolutePath should be absolute" }
+        require(basePath?.isAbsolute != false) { "basePath should be absolute" }
+        require(relativePath?.isAbsolute != true) { "relativePath should not be absolute" }
     }
 
     override fun toString(): String =

--- a/detekt-psi-utils/src/test/kotlin/io/github/detekt/psi/KtFilesSpec.kt
+++ b/detekt-psi-utils/src/test/kotlin/io/github/detekt/psi/KtFilesSpec.kt
@@ -5,6 +5,8 @@ import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.com.intellij.psi.PsiFile
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import kotlin.io.path.Path
+import kotlin.io.path.absolute
 
 class KtFilesSpec {
 
@@ -43,4 +45,15 @@ class KtFilesSpec {
     }
 
     private fun makeFile(filename: String): PsiFile = FakePsiFile(name = filename)
+
+    @Test
+    fun `FilePath toString`() {
+        val basePath = Path("/").absolute().resolve("a/b")
+        val relativePath = Path("c/d")
+        val absolutePath = Path("/").absolute().resolve("a/b/c/d")
+        val filePath = FilePath(absolutePath, basePath, relativePath)
+
+        assertThat(filePath.toString())
+            .isEqualTo("FilePath(absolutePath=$absolutePath, basePath=$basePath, relativePath=$relativePath)")
+    }
 }

--- a/detekt-report-html/src/test/kotlin/io/github/detekt/report/html/HtmlOutputReportSpec.kt
+++ b/detekt-report-html/src/test/kotlin/io/github/detekt/report/html/HtmlOutputReportSpec.kt
@@ -158,11 +158,10 @@ class HtmlOutputReportSpec {
     @Test
     fun `asserts that the generated HTML is the same as expected`() {
         val expected = resourceAsPath("HtmlOutputFormatTest.html")
-        var result = htmlReport.render(createTestDetektionWithMultipleSmells())
-        result = generatedRegex.replace(result, REPLACEMENT)
+        val result = htmlReport.render(createTestDetektionWithMultipleSmells())
+            .replace(generatedRegex, REPLACEMENT)
 
-        val actual = createTempFileForTest("actual-report", ".html")
-        actual.writeText(result)
+        val actual = createTempFileForTest("actual-report", ".html").apply { writeText(result) }
 
         assertThat(actual).hasSameTextualContentAs(expected)
     }

--- a/detekt-report-html/src/test/resources/HtmlOutputFormatTest.html
+++ b/detekt-report-html/src/test/resources/HtmlOutputFormatTest.html
@@ -174,7 +174,7 @@
     <summary class="rule-container"><span class="rule">id_a: 2 </span><span class="description">Description id_a</span></summary>
 <a href="https://detekt.dev/docs/rules/ruleset1#id_a">Documentation</a>
     <ul>
-      <li><span class="location">src/main/com/sample/Sample1.kt:11:1</span><span class="message">Issue message 1</span>
+      <li><span class="location"><PREFIX>src/main/com/sample/Sample1.kt:11:1</span><span class="message">Issue message 1</span>
         <pre><code><span class="lineno">   8 </span>
 <span class="lineno">   9 </span>
 <span class="lineno">  10 </span>
@@ -183,7 +183,7 @@
 <span class="lineno">  13 </span>
 </code></pre>
       </li>
-      <li><span class="location">src/main/com/sample/Sample2.kt:22:2</span><span class="message">Issue message 2</span></li>
+      <li><span class="location"><PREFIX>src/main/com/sample/Sample2.kt:22:2</span><span class="message">Issue message 2</span></li>
     </ul>
   </details>
   <h3>RuleSet2: 1</h3>
@@ -191,7 +191,7 @@
     <summary class="rule-container"><span class="rule">id_b: 1 </span><span class="description">Description id_b</span></summary>
 <a href="https://detekt.dev/docs/rules/ruleset2#id_b">Documentation</a>
     <ul>
-      <li><span class="location">src/main/com/sample/Sample3.kt:33:3</span><span class="message">Issue message 3</span></li>
+      <li><span class="location"><PREFIX>src/main/com/sample/Sample3.kt:33:3</span><span class="message">Issue message 3</span></li>
     </ul>
   </details>
 </div>

--- a/detekt-report-md/src/test/kotlin/io/github/detekt/report/md/MdOutputReportSpec.kt
+++ b/detekt-report-md/src/test/kotlin/io/github/detekt/report/md/MdOutputReportSpec.kt
@@ -137,7 +137,7 @@ private fun createTestDetektionWithMultipleSmells(): Detektion {
     val entity1 = createEntity(
         location = createLocation(
             path = "src/main/com/sample/Sample1.kt",
-            basePath = "/Users/tester/detekt/",
+            basePath = "Users/tester/detekt/",
             position = 9 to 17,
             text = 17..20,
         ),
@@ -146,7 +146,7 @@ private fun createTestDetektionWithMultipleSmells(): Detektion {
     val entity2 = createEntity(
         location = createLocation(
             path = "src/main/com/sample/Sample2.kt",
-            basePath = "/Users/tester/detekt/",
+            basePath = "Users/tester/detekt/",
             position = 13 to 17,
         ),
         ktElement = fakeKtElement(),
@@ -154,7 +154,7 @@ private fun createTestDetektionWithMultipleSmells(): Detektion {
     val entity3 = createEntity(
         location = createLocation(
             path = "src/main/com/sample/Sample3.kt",
-            basePath = "/Users/tester/detekt/",
+            basePath = "Users/tester/detekt/",
             position = 14 to 16,
         ),
         ktElement = fakeKtElement(),

--- a/detekt-report-md/src/test/kotlin/io/github/detekt/report/md/MdOutputReportSpec.kt
+++ b/detekt-report-md/src/test/kotlin/io/github/detekt/report/md/MdOutputReportSpec.kt
@@ -93,7 +93,7 @@ class MdOutputReportSpec {
     }
 
     @Test
-    fun `asserts that the generated HTML is the same even if we change the order of the issues`() {
+    fun `asserts that the generated md is the same even if we change the order of the issues`() {
         val issues = issues()
         val reversedIssues = issues.reversedArray()
 

--- a/detekt-report-sarif/src/test/resources/relative_path.sarif.json
+++ b/detekt-report-sarif/src/test/resources/relative_path.sarif.json
@@ -5,7 +5,7 @@
     {
       "originalUriBaseIds": {
         "%SRCROOT%": {
-          "uri": "file:///Users/tester/detekt"
+          "uri": "<BASE_URI>"
         }
       },
       "results": [

--- a/detekt-report-txt/src/test/kotlin/io/github/detekt/report/txt/TxtOutputReportSpec.kt
+++ b/detekt-report-txt/src/test/kotlin/io/github/detekt/report/txt/TxtOutputReportSpec.kt
@@ -2,6 +2,8 @@ package io.github.detekt.report.txt
 
 import io.gitlab.arturbosch.detekt.test.TestDetektion
 import io.gitlab.arturbosch.detekt.test.createIssue
+import io.gitlab.arturbosch.detekt.test.createLocation
+import io.gitlab.arturbosch.detekt.test.createRuleInfo
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -16,24 +18,26 @@ class TxtOutputReportSpec {
 
     @Test
     fun `renders one`() {
-        val detektion = TestDetektion(createIssue())
+        val location = createLocation()
+        val detektion = TestDetektion(createIssue(createRuleInfo(), location))
         assertThat(TxtOutputReport().render(detektion))
-            .isEqualTo("TestSmell - [TestEntity] at TestFile.kt:1:1 - Signature=TestEntitySignature\n")
+            .isEqualTo("TestSmell - [TestEntity] at ${location.compact()} - Signature=TestEntitySignature\n")
     }
 
     @Test
     fun `renders multiple`() {
+        val location = createLocation()
         val detektion = TestDetektion(
-            createIssue(ruleName = "TestSmellA"),
-            createIssue(ruleName = "TestSmellB"),
-            createIssue(ruleName = "TestSmellC"),
+            createIssue(createRuleInfo("TestSmellA"), location),
+            createIssue(createRuleInfo("TestSmellB"), location),
+            createIssue(createRuleInfo("TestSmellC"), location),
         )
         assertThat(TxtOutputReport().render(detektion))
             .isEqualTo(
                 """
-                    TestSmellA - [TestEntity] at TestFile.kt:1:1 - Signature=TestEntitySignature
-                    TestSmellB - [TestEntity] at TestFile.kt:1:1 - Signature=TestEntitySignature
-                    TestSmellC - [TestEntity] at TestFile.kt:1:1 - Signature=TestEntitySignature
+                    TestSmellA - [TestEntity] at ${location.compact()} - Signature=TestEntitySignature
+                    TestSmellB - [TestEntity] at ${location.compact()} - Signature=TestEntitySignature
+                    TestSmellC - [TestEntity] at ${location.compact()} - Signature=TestEntitySignature
 
                 """.trimIndent()
             )

--- a/detekt-report-txt/src/test/kotlin/io/github/detekt/report/txt/TxtOutputReportSpec.kt
+++ b/detekt-report-txt/src/test/kotlin/io/github/detekt/report/txt/TxtOutputReportSpec.kt
@@ -9,34 +9,33 @@ class TxtOutputReportSpec {
 
     @Test
     fun `renders none`() {
-        val report = TxtOutputReport()
         val detektion = TestDetektion()
-        val renderedText = ""
-        assertThat(report.render(detektion)).isEqualTo(renderedText)
+        assertThat(TxtOutputReport().render(detektion))
+            .isEqualTo("")
     }
 
     @Test
     fun `renders one`() {
-        val report = TxtOutputReport()
         val detektion = TestDetektion(createIssue())
-        val renderedText = "TestSmell - [TestEntity] at TestFile.kt:1:1 - Signature=TestEntitySignature\n"
-        assertThat(report.render(detektion)).isEqualTo(renderedText)
+        assertThat(TxtOutputReport().render(detektion))
+            .isEqualTo("TestSmell - [TestEntity] at TestFile.kt:1:1 - Signature=TestEntitySignature\n")
     }
 
     @Test
     fun `renders multiple`() {
-        val report = TxtOutputReport()
         val detektion = TestDetektion(
             createIssue(ruleName = "TestSmellA"),
             createIssue(ruleName = "TestSmellB"),
-            createIssue(ruleName = "TestSmellC")
+            createIssue(ruleName = "TestSmellC"),
         )
-        val renderedText = """
-            TestSmellA - [TestEntity] at TestFile.kt:1:1 - Signature=TestEntitySignature
-            TestSmellB - [TestEntity] at TestFile.kt:1:1 - Signature=TestEntitySignature
-            TestSmellC - [TestEntity] at TestFile.kt:1:1 - Signature=TestEntitySignature
+        assertThat(TxtOutputReport().render(detektion))
+            .isEqualTo(
+                """
+                    TestSmellA - [TestEntity] at TestFile.kt:1:1 - Signature=TestEntitySignature
+                    TestSmellB - [TestEntity] at TestFile.kt:1:1 - Signature=TestEntitySignature
+                    TestSmellC - [TestEntity] at TestFile.kt:1:1 - Signature=TestEntitySignature
 
-        """.trimIndent()
-        assertThat(report.render(detektion)).isEqualTo(renderedText)
+                """.trimIndent()
+            )
     }
 }

--- a/detekt-report-xml/src/test/kotlin/io/github/detekt/report/xml/XmlOutputFormatSpec.kt
+++ b/detekt-report-xml/src/test/kotlin/io/github/detekt/report/xml/XmlOutputFormatSpec.kt
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import java.util.Locale
+import kotlin.io.path.invariantSeparatorsPathString
 
 private const val TAB = "\t"
 
@@ -59,7 +60,7 @@ class XmlOutputFormatSpec {
             """
                 <?xml version="1.0" encoding="UTF-8"?>
                 <checkstyle version="4.3">
-                <file name="src/main/com/sample/Sample1.kt">
+                <file name="${entity1.location.filePath.absolutePath.invariantSeparatorsPathString}">
                 $TAB<error line="11" column="1" severity="error" message="TestMessage" source="detekt.id_a" />
                 </file>
                 </checkstyle>
@@ -78,7 +79,7 @@ class XmlOutputFormatSpec {
             """
                 <?xml version="1.0" encoding="UTF-8"?>
                 <checkstyle version="4.3">
-                <file name="src/main/com/sample/Sample1.kt">
+                <file name="${entity1.location.filePath.absolutePath.invariantSeparatorsPathString}">
                 $TAB<error line="11" column="1" severity="error" message="TestMessage" source="detekt.id_a" />
                 $TAB<error line="11" column="1" severity="error" message="TestMessage" source="detekt.id_b" />
                 </file>
@@ -98,10 +99,10 @@ class XmlOutputFormatSpec {
             """
                 <?xml version="1.0" encoding="UTF-8"?>
                 <checkstyle version="4.3">
-                <file name="src/main/com/sample/Sample1.kt">
+                <file name="${entity1.location.filePath.absolutePath.invariantSeparatorsPathString}">
                 $TAB<error line="11" column="1" severity="error" message="TestMessage" source="detekt.id_a" />
                 </file>
-                <file name="src/main/com/sample/Sample2.kt">
+                <file name="${entity2.location.filePath.absolutePath.invariantSeparatorsPathString}">
                 $TAB<error line="22" column="2" severity="error" message="TestMessage" source="detekt.id_a" />
                 </file>
                 </checkstyle>
@@ -113,12 +114,10 @@ class XmlOutputFormatSpec {
     fun `renders issues with relative path`() {
         val issueA = createIssueForRelativePath(
             ruleInfo = createRuleInfo("id_a"),
-            basePath = "/Users/tester/detekt/",
             relativePath = "Sample1.kt"
         )
         val issueB = createIssueForRelativePath(
             ruleInfo = createRuleInfo("id_b"),
-            basePath = "/Users/tester/detekt/",
             relativePath = "Sample2.kt"
         )
 
@@ -159,11 +158,11 @@ class XmlOutputFormatSpec {
             """
                 <?xml version="1.0" encoding="UTF-8"?>
                 <checkstyle version="4.3">
-                <file name="src/main/com/sample/Sample1.kt">
+                <file name="${entity1.location.filePath.absolutePath.invariantSeparatorsPathString}">
                 $TAB<error line="11" column="1" severity="error" message="TestMessage" source="detekt.id_a" />
                 $TAB<error line="11" column="1" severity="error" message="TestMessage" source="detekt.id_b" />
                 </file>
-                <file name="src/main/com/sample/Sample2.kt">
+                <file name="${entity2.location.filePath.absolutePath.invariantSeparatorsPathString}">
                 $TAB<error line="22" column="2" severity="error" message="TestMessage" source="detekt.id_a" />
                 $TAB<error line="22" column="2" severity="error" message="TestMessage" source="detekt.id_b" />
                 </file>
@@ -189,7 +188,7 @@ class XmlOutputFormatSpec {
             val expected = """
                 <?xml version="1.0" encoding="UTF-8"?>
                 <checkstyle version="4.3">
-                <file name="src/main/com/sample/Sample1.kt">
+                <file name="${entity1.location.filePath.absolutePath.invariantSeparatorsPathString}">
                 $TAB<error line="${issue.location.source.line}" column="${issue.location.source.column}" severity="$xmlSeverity" message="${issue.message}" source="detekt.${issue.ruleInfo.id}" />
                 </file>
                 </checkstyle>

--- a/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/CompileExtensions.kt
+++ b/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/CompileExtensions.kt
@@ -4,6 +4,7 @@ import org.intellij.lang.annotations.Language
 import org.jetbrains.kotlin.psi.KtFile
 import java.nio.file.Path
 import kotlin.io.path.Path
+import kotlin.io.path.absolute
 
 /**
  * Use this method if you define a kt file/class as a plain string in your test.
@@ -23,8 +24,8 @@ fun compileContentForTest(
  */
 fun compileContentForTest(
     @Language("kotlin") content: String,
-    basePath: Path = Path("/"),
-    path: Path = Path("/Test.kt"),
+    basePath: Path = Path("/").absolute(),
+    path: Path = basePath.resolve("Test.kt"),
 ): KtFile {
     return KtTestCompiler.createKtFile(content, basePath, path)
 }

--- a/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/Resources.kt
+++ b/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/Resources.kt
@@ -3,7 +3,6 @@ package io.github.detekt.test.utils
 import java.net.URI
 import java.net.URL
 import java.nio.file.Path
-import kotlin.io.path.readLines
 import kotlin.io.path.toPath
 
 internal object Resources
@@ -18,6 +17,5 @@ fun resource(name: String): URI = resourceUrl(name).toURI()
 fun resourceAsPath(name: String): Path = resource(name).toPath()
 
 fun readResourceContent(name: String): String {
-    val path = resourceAsPath(name)
-    return path.readLines().joinToString("\n") + "\n"
+    return resourceUrl(name).readText()
 }


### PR DESCRIPTION
Part of #7140

This PR makes our core more strict to how the paths should look like. I know that `KtFiles` will be removed. but that's the reason I'm doing this now. Our tests were a bit "loose" on the paths. With this change our tests are a better representation of what happen in the real life and can spot real bugs once we start to refactor this part of the code to remove `KtFiles`.