### PR TITLE
Use DEVELOCITY_ACCESS_KEY env var on CLI

### DIFF
--- a/.github/workflows/codecoverage.yaml
+++ b/.github/workflows/codecoverage.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Generate Coverage Report
         run: ./gradlew jacocoMergedReport
         env:
-          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
 
       - name: Publish Coverage
         if: success()

--- a/.github/workflows/deploy-snapshot.yaml
+++ b/.github/workflows/deploy-snapshot.yaml
@@ -6,7 +6,7 @@ on:
       - main
 
 env:
-  GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+  DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
   ORG_GRADLE_PROJECT_enablePTS: false
 
 permissions:

--- a/.github/workflows/detekt-with-type-resolution.yaml
+++ b/.github/workflows/detekt-with-type-resolution.yaml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 env:
-  GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+  DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
 
 permissions:
   contents: read

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 env:
-  GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+  DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
   ORG_GRADLE_PROJECT_enablePTS: ${{ github.ref_name != 'main' }}
 
 permissions:

--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 env:
-  GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+  DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
 
 permissions:
   contents: write  # for JamesIves/github-pages-deploy-action to push changes in repo

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -67,7 +67,7 @@ buildCache {
     }
     remote(develocity.buildCache) {
         isEnabled = true
-        val accessKey = System.getenv("GRADLE_ENTERPRISE_ACCESS_KEY")
+        val accessKey = System.getenv("DEVELOCITY_ACCESS_KEY")
         isPush = isCiBuild && !accessKey.isNullOrEmpty()
     }
 }


### PR DESCRIPTION
Fixes a deprecation warning:

```
WARNING: The following functionality has been deprecated and will be removed in the next major release of the Develocity Gradle plugin:
- The deprecated "GRADLE_ENTERPRISE_ACCESS_KEY" environment variable has been replaced by "DEVELOCITY_ACCESS_KEY"
```