### PR TITLE
Align build cache config across builds

### DIFF
--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -1,6 +1,7 @@
 rootProject.name = "build-logic"
 
 plugins {
+    id("com.gradle.develocity") version "3.17"
     id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
 }
 
@@ -18,13 +19,10 @@ buildCache {
     local {
         isEnabled = !isCiBuild
     }
-    remote<HttpBuildCache> {
-        isPush = isCiBuild
+    remote(develocity.buildCache) {
+        server = "https://ge.detekt.dev"
         isEnabled = true
-        url = uri("https://ge.detekt.dev/cache/")
-        credentials {
-            username = providers.environmentVariable("GRADLE_CACHE_USERNAME").orNull
-            password = providers.environmentVariable("GRADLE_CACHE_PASSWORD").orNull
-        }
+        val accessKey = System.getenv("DEVELOCITY_ACCESS_KEY")
+        isPush = isCiBuild && !accessKey.isNullOrEmpty()
     }
 }

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -15,6 +15,7 @@ dependencyResolutionManagement {
 
 val isCiBuild = providers.environmentVariable("CI").isPresent
 
+// Ensure buildCache config is kept in sync with all builds (root, build-logic & detekt-gradle-plugin)
 buildCache {
     local {
         isEnabled = !isCiBuild

--- a/detekt-gradle-plugin/settings.gradle.kts
+++ b/detekt-gradle-plugin/settings.gradle.kts
@@ -23,13 +23,10 @@ buildCache {
     local {
         isEnabled = !isCiBuild
     }
-    remote<HttpBuildCache> {
-        isPush = isCiBuild
+    remote(develocity.buildCache) {
+        server = "https://ge.detekt.dev"
         isEnabled = true
-        url = uri("https://ge.detekt.dev/cache/")
-        credentials {
-            username = providers.environmentVariable("GRADLE_CACHE_USERNAME").orNull
-            password = providers.environmentVariable("GRADLE_CACHE_PASSWORD").orNull
-        }
+        val accessKey = System.getenv("DEVELOCITY_ACCESS_KEY")
+        isPush = isCiBuild && !accessKey.isNullOrEmpty()
     }
 }

--- a/detekt-gradle-plugin/settings.gradle.kts
+++ b/detekt-gradle-plugin/settings.gradle.kts
@@ -19,6 +19,7 @@ plugins {
 
 val isCiBuild = providers.environmentVariable("CI").isPresent
 
+// Ensure buildCache config is kept in sync with all builds (root, build-logic & detekt-gradle-plugin)
 buildCache {
     local {
         isEnabled = !isCiBuild

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -61,6 +61,7 @@ develocity {
     }
 }
 
+// Ensure buildCache config is kept in sync with all builds (root, build-logic & detekt-gradle-plugin)
 buildCache {
     local {
         isEnabled = !isCiBuild

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -66,6 +66,7 @@ buildCache {
         isEnabled = !isCiBuild
     }
     remote(develocity.buildCache) {
+        server = "https://ge.detekt.dev"
         isEnabled = true
         val accessKey = System.getenv("DEVELOCITY_ACCESS_KEY")
         isPush = isCiBuild && !accessKey.isNullOrEmpty()


### PR DESCRIPTION
Somehow things got out of sync between the builds. Fixes so they're aligned and added a reminder so this doesn't happen again.

After merging the GRADLE_CACHE_PASSWORD and GRADLE_CACHE_USERNAME secrets can be safely deleted. They're actually not used in any actions right now but better safe than sorry :)