### PR TITLE
Enable and encrypt Gradle configuration cache on CI

### DIFF
--- a/.github/workflows/codecoverage.yaml
+++ b/.github/workflows/codecoverage.yaml
@@ -29,6 +29,7 @@ jobs:
         uses: gradle/actions/setup-gradle@1168cd3d07c1876a65e1724114de42ccbdfa7b78 # v3
         with:
           gradle-home-cache-cleanup: true
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Generate Coverage Report
         run: ./gradlew jacocoMergedReport

--- a/.github/workflows/deploy-snapshot.yaml
+++ b/.github/workflows/deploy-snapshot.yaml
@@ -30,6 +30,7 @@ jobs:
         uses: gradle/actions/setup-gradle@1168cd3d07c1876a65e1724114de42ccbdfa7b78 # v3
         with:
           gradle-home-cache-cleanup: true
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Assemble and publish artifacts to Maven Local
         run: ./gradlew publishToMavenLocal

--- a/.github/workflows/detekt-with-type-resolution.yaml
+++ b/.github/workflows/detekt-with-type-resolution.yaml
@@ -32,6 +32,7 @@ jobs:
         uses: gradle/actions/setup-gradle@1168cd3d07c1876a65e1724114de42ccbdfa7b78 # v3
         with:
           gradle-home-cache-cleanup: true
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Run detekt-cli with argsfile
         run: ./gradlew :detekt-cli:runWithArgsFile
@@ -62,6 +63,7 @@ jobs:
         uses: gradle/actions/setup-gradle@1168cd3d07c1876a65e1724114de42ccbdfa7b78 # v3
         with:
           gradle-home-cache-cleanup: true
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Run analysis
         run: ./gradlew detektMain detektTest detektFunctionalTest detektTestFixtures detektFunctionalTestMinSupportedGradle detektReportMergeSarif --continue

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -41,6 +41,7 @@ jobs:
         uses: gradle/actions/setup-gradle@1168cd3d07c1876a65e1724114de42ccbdfa7b78 # v3
         with:
           gradle-home-cache-cleanup: true
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Assemble and publish artifacts to Maven Local
         run: ./gradlew publishToMavenLocal
@@ -70,6 +71,7 @@ jobs:
         uses: gradle/actions/setup-gradle@1168cd3d07c1876a65e1724114de42ccbdfa7b78 # v3
         with:
           gradle-home-cache-cleanup: true
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Verify Generated Detekt Config File
         run: ./gradlew verifyGeneratorOutput
@@ -90,6 +92,7 @@ jobs:
         uses: gradle/actions/setup-gradle@1168cd3d07c1876a65e1724114de42ccbdfa7b78 # v3
         with:
           gradle-home-cache-cleanup: true
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Build and compile test snippets
         run: ./gradlew test -Pcompile-test-snippets=true
@@ -110,6 +113,7 @@ jobs:
         uses: gradle/actions/setup-gradle@1168cd3d07c1876a65e1724114de42ccbdfa7b78 # v3
         with:
           gradle-home-cache-cleanup: true
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Run with allWarningsAsErrors
         run: ./gradlew compileKotlin compileTestKotlin compileTestFixturesKotlin -PwarningsAsErrors=true

--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -30,6 +30,7 @@ jobs:
         uses: gradle/actions/setup-gradle@1168cd3d07c1876a65e1724114de42ccbdfa7b78 # v3
         with:
           gradle-home-cache-cleanup: true
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Setup Node
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4


### PR DESCRIPTION
Closes #6934

This uses a repo-specific key, so a new key would need to be generated for other repos in the detekt org if this feature was enabled anywhere else.