### PR TITLE
Simplify MaxLineLength and TrailingWhitespace

### DIFF
--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/KtFileContent.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/KtFileContent.kt
@@ -1,7 +1,0 @@
-package io.gitlab.arturbosch.detekt.rules.style
-
-import org.jetbrains.kotlin.psi.KtFile
-
-internal data class KtFileContent(val file: KtFile, val content: Sequence<String>)
-
-internal fun KtFile.toFileContent() = KtFileContent(this, text.splitToSequence("\n"))

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLength.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLength.kt
@@ -48,13 +48,8 @@ class MaxLineLength(config: Config) : Rule(
 
     override fun visitKtFile(file: KtFile) {
         super.visitKtFile(file)
-        visit(file.toFileContent())
-    }
-
-    private fun visit(element: KtFileContent) {
         var offset = 0
-        val lines = element.content
-        val file = element.file
+        val lines = file.text.lines()
 
         for (line in lines) {
             offset += line.length

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/TrailingWhitespace.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/TrailingWhitespace.kt
@@ -26,16 +26,11 @@ class TrailingWhitespace(config: Config) : Rule(
 
     override fun visitKtFile(file: KtFile) {
         super.visitKtFile(file)
-        visit(file.toFileContent())
-    }
-
-    private fun visit(fileContent: KtFileContent) {
         var offset = 0
-        fileContent.content.forEachIndexed { index, line ->
+        file.text.lineSequence().forEachIndexed { index, line ->
             offset += line.length
             val trailingWhitespaces = countTrailingWhitespace(line)
             if (trailingWhitespaces > 0) {
-                val file = fileContent.file
                 val ktElement = findFirstKtElementInParentsOrNull(file, offset, line)
                 if (ktElement == null || !ktElement.isPartOfString()) {
                     val entity = Entity.from(file, offset - trailingWhitespaces).let { entity ->


### PR DESCRIPTION
We don't need the data class `KtFileContent` for this. It's simpler to use `lineSequence()`.