### PR TITLE
Rename `getContextForPaths` to `createContextBinding`

### DIFF
--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/AnalyzerSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/AnalyzerSpec.kt
@@ -11,7 +11,7 @@ import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.RuleSet
 import io.gitlab.arturbosch.detekt.api.RuleSetProvider
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
-import io.gitlab.arturbosch.detekt.test.getContextForPaths
+import io.gitlab.arturbosch.detekt.test.createBindingContext
 import io.gitlab.arturbosch.detekt.test.yamlConfigFromContent
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -152,7 +152,7 @@ class AnalyzerSpec(val env: KotlinCoreEnvironment) {
             )
             val analyzer = Analyzer(settings, listOf(CustomRuleSetProvider()), emptyList())
             val ktFile = compileForTest(testFile)
-            val bindingContext = env.getContextForPaths(listOf(ktFile))
+            val bindingContext = env.createBindingContext(listOf(ktFile))
 
             assertThat(settings.use { analyzer.run(listOf(ktFile), bindingContext) }).hasSize(2)
             assertThat(output.toString()).isEmpty()

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/AnnotationSuppressorSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/AnnotationSuppressorSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.core.suppressors
 
 import io.github.detekt.test.utils.compileContentForTest
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
-import io.gitlab.arturbosch.detekt.test.getContextForPaths
+import io.gitlab.arturbosch.detekt.test.createBindingContext
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.jetbrains.kotlin.psi.KtClass
@@ -317,7 +317,7 @@ class AnnotationSuppressorSpec(private val env: KotlinCoreEnvironment) {
             )
 
             val bindings = listOf(
-                env.getContextForPaths(listOf(root, *composableFiles)),
+                env.createBindingContext(listOf(root, *composableFiles)),
                 BindingContext.EMPTY,
             )
 
@@ -414,7 +414,7 @@ class AnnotationSuppressorSpec(private val env: KotlinCoreEnvironment) {
 
             val suppressor = annotationSuppressorFactory(
                 buildRule("ignoreAnnotated" to listOf("androidx.compose.runtime.Composable")),
-                env.getContextForPaths(listOf(root, *composableFiles)),
+                env.createBindingContext(listOf(root, *composableFiles)),
             )!!
 
             val ktFunction = root.findChildByClass(KtFunction::class.java)!!
@@ -435,7 +435,7 @@ class AnnotationSuppressorSpec(private val env: KotlinCoreEnvironment) {
 
             val suppressor = annotationSuppressorFactory(
                 buildRule("ignoreAnnotated" to listOf("androidx.compose.runtime.Composable")),
-                env.getContextForPaths(listOf(root, *composableFiles)),
+                env.createBindingContext(listOf(root, *composableFiles)),
             )!!
 
             val ktFunction = root.findChildByClass(KtFunction::class.java)!!
@@ -458,7 +458,7 @@ class AnnotationSuppressorSpec(private val env: KotlinCoreEnvironment) {
 
             val suppressor = annotationSuppressorFactory(
                 buildRule("ignoreAnnotated" to listOf("androidx.compose.runtime.Composable")),
-                env.getContextForPaths(listOf(root, *composableFiles)),
+                env.createBindingContext(listOf(root, *composableFiles)),
             )!!
 
             val ktFunction = root.findChildByClass(KtFunction::class.java)!!
@@ -501,7 +501,7 @@ class AnnotationSuppressorSpec(private val env: KotlinCoreEnvironment) {
         fun `suppress if it has parameters with type solving`() {
             val suppressor = annotationSuppressorFactory(
                 buildRule("ignoreAnnotated" to listOf("Preview")),
-                env.getContextForPaths(listOf(root, *composableFiles)),
+                env.createBindingContext(listOf(root, *composableFiles)),
             )!!
 
             val ktFunction = root.findChildByClass(KtFunction::class.java)!!

--- a/detekt-psi-utils/src/test/kotlin/io/github/detekt/psi/AnnotationExcluderSpec.kt
+++ b/detekt-psi-utils/src/test/kotlin/io/github/detekt/psi/AnnotationExcluderSpec.kt
@@ -2,7 +2,7 @@ package io.github.detekt.psi
 
 import io.github.detekt.test.utils.compileContentForTest
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
-import io.gitlab.arturbosch.detekt.test.getContextForPaths
+import io.gitlab.arturbosch.detekt.test.createBindingContext
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.jetbrains.kotlin.psi.KtAnnotationEntry
@@ -44,7 +44,7 @@ class AnnotationExcluderSpec(private val env: KotlinCoreEnvironment) {
     @CsvFileSource(resources = ["/annotation_excluder.csv"])
     fun `all cases - Type Solving`(exclusion: String, annotation: String, shouldExclude: Boolean) {
         val (file, ktAnnotation) = createKtFile(annotation)
-        val binding = env.getContextForPaths(listOf(file, annotationsKtFile))
+        val binding = env.createBindingContext(listOf(file, annotationsKtFile))
         val excluder = AnnotationExcluder(file, listOf(exclusion.toRegex()), binding)
 
         assertThat(excluder.shouldExclude(listOf(ktAnnotation))).isEqualTo(shouldExclude)
@@ -94,7 +94,7 @@ class AnnotationExcluderSpec(private val env: KotlinCoreEnvironment) {
             @Test
             fun `correct without type solving`() {
                 val (file, ktAnnotation) = createKtFile("@Deprecated")
-                val binding = env.getContextForPaths(listOf(file, annotationsKtFile))
+                val binding = env.createBindingContext(listOf(file, annotationsKtFile))
                 val excluder = AnnotationExcluder(file, listOf("foo\\.Deprecated".toRegex()), binding)
 
                 assertThat(excluder.shouldExclude(listOf(ktAnnotation))).isFalse()
@@ -132,7 +132,7 @@ class AnnotationExcluderSpec(private val env: KotlinCoreEnvironment) {
             @Test
             @Disabled("This should be doable but it's not imlemented yet")
             fun `correct with type solving`() {
-                val binding = env.getContextForPaths(listOf(file, helloWorldAnnotationsKtFile))
+                val binding = env.createBindingContext(listOf(file, helloWorldAnnotationsKtFile))
                 val excluder = AnnotationExcluder(file, listOf("Hello\\.World".toRegex()), binding)
 
                 assertThat(excluder.shouldExclude(listOf(ktAnnotation))).isFalse()
@@ -173,7 +173,7 @@ class AnnotationExcluderSpec(private val env: KotlinCoreEnvironment) {
 
             @Test
             fun `correct with type solving`() {
-                val binding = env.getContextForPaths(listOf(file, helloWorldAnnotationsKtFile))
+                val binding = env.createBindingContext(listOf(file, helloWorldAnnotationsKtFile))
                 val excluder = AnnotationExcluder(file, listOf("foo\\.World".toRegex()), binding)
 
                 assertThat(excluder.shouldExclude(listOf(ktAnnotation))).isFalse()

--- a/detekt-psi-utils/src/test/kotlin/io/github/detekt/psi/FunctionMatcherSpec.kt
+++ b/detekt-psi-utils/src/test/kotlin/io/github/detekt/psi/FunctionMatcherSpec.kt
@@ -2,7 +2,7 @@ package io.github.detekt.psi
 
 import io.github.detekt.test.utils.compileContentForTest
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
-import io.gitlab.arturbosch.detekt.test.getContextForPaths
+import io.gitlab.arturbosch.detekt.test.createBindingContext
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.jetbrains.kotlin.psi.KtClass
@@ -328,7 +328,7 @@ class FunctionMatcherSpec(private val env: KotlinCoreEnvironment) {
                     }
                 """.trimIndent()
             )
-            val bindingContext = env.getContextForPaths(listOf(ktFile))
+            val bindingContext = env.createBindingContext(listOf(ktFile))
             val function = ktFile.findChildByClass(KtClass::class.java)!!
                 .findFunctionByName("bar") as KtNamedFunction
 
@@ -355,6 +355,6 @@ private fun buildKtFunction(
             $code
         """.trimIndent()
     )
-    val bindingContext = environment.getContextForPaths(listOf(ktFile))
+    val bindingContext = environment.createBindingContext(listOf(ktFile))
     return ktFile.findChildByClass(KtNamedFunction::class.java)!! to bindingContext
 }

--- a/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/CoroutineLaunchedInTestWithoutRunTestSpec.kt
+++ b/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/CoroutineLaunchedInTestWithoutRunTestSpec.kt
@@ -4,7 +4,7 @@ import io.github.detekt.test.utils.compileContentForTest
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
-import io.gitlab.arturbosch.detekt.test.getContextForPaths
+import io.gitlab.arturbosch.detekt.test.createBindingContext
 import io.gitlab.arturbosch.detekt.test.location
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
@@ -248,7 +248,7 @@ class CoroutineLaunchedInTestWithoutRunTestSpec(private val env: KotlinCoreEnvir
         """.trimIndent()
 
         val ktFile = compileContentForTest(code)
-        val bindingContext = env.getContextForPaths(listOf(ktFile))
+        val bindingContext = env.createBindingContext(listOf(ktFile))
 
         val namedFunctions = ktFile
             .collectDescendantsOfType<KtNamedFunction>()

--- a/detekt-test/api/detekt-test.api
+++ b/detekt-test/api/detekt-test.api
@@ -27,7 +27,7 @@ public final class io/gitlab/arturbosch/detekt/test/FindingsAssertionsKt {
 }
 
 public final class io/gitlab/arturbosch/detekt/test/KotlinCoreEnvironmentExtensionsKt {
-	public static final fun getContextForPaths (Lorg/jetbrains/kotlin/cli/jvm/compiler/KotlinCoreEnvironment;Ljava/util/List;)Lorg/jetbrains/kotlin/resolve/BindingContext;
+	public static final fun createBindingContext (Lorg/jetbrains/kotlin/cli/jvm/compiler/KotlinCoreEnvironment;Ljava/util/List;)Lorg/jetbrains/kotlin/resolve/BindingContext;
 }
 
 public final class io/gitlab/arturbosch/detekt/test/ResourcesKt {

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/KotlinCoreEnvironmentExtensions.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/KotlinCoreEnvironmentExtensions.kt
@@ -7,10 +7,10 @@ import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.lazy.declarations.FileBasedDeclarationProviderFactory
 
-fun KotlinCoreEnvironment.getContextForPaths(paths: List<KtFile>): BindingContext =
+fun KotlinCoreEnvironment.createBindingContext(files: List<KtFile>): BindingContext =
     TopDownAnalyzerFacadeForJVM.analyzeFilesWithJavaIntegration(
         this.project,
-        paths,
+        files,
         NoScopeRecordCliBindingTrace(),
         this.configuration,
         this::createPackagePartProvider,

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/RuleExtensions.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/RuleExtensions.kt
@@ -42,7 +42,7 @@ fun Rule.lintWithContext(
     val additionalKtFiles = additionalContents.mapIndexed { index, additionalContent ->
         compileContentForTest(additionalContent, "AdditionalTest$index.kt")
     }
-    val bindingContext = environment.getContextForPaths(listOf(ktFile) + additionalKtFiles)
+    val bindingContext = environment.createBindingContext(listOf(ktFile) + additionalKtFiles)
     val languageVersionSettings = environment.configuration.languageVersionSettings
 
     val dataFlowValueFactory = DataFlowValueFactoryImpl(languageVersionSettings)


### PR DESCRIPTION
`getContextForPaths` was a bad name for this function. It doesn't "get" it "creates" the `ContextBinding`. And also it doesn't receive any "Path". For that reason I renamed it to `createContextBinding` that explain more clearly what this function does.