### PR TITLE
Move generateBindingContext to detekt-parser

### DIFF
--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/tooling/Lifecycle.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/tooling/Lifecycle.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.core.tooling
 
+import io.github.detekt.parser.generateBindingContext
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Detektion
 import io.gitlab.arturbosch.detekt.api.FileProcessListener
@@ -10,7 +11,6 @@ import io.gitlab.arturbosch.detekt.core.FileProcessorLocator
 import io.gitlab.arturbosch.detekt.core.ProcessingSettings
 import io.gitlab.arturbosch.detekt.core.config.validation.checkConfiguration
 import io.gitlab.arturbosch.detekt.core.extensions.handleReportingExtensions
-import io.gitlab.arturbosch.detekt.core.generateBindingContext
 import io.gitlab.arturbosch.detekt.core.reporting.OutputFacade
 import io.gitlab.arturbosch.detekt.core.rules.createRuleProviders
 import io.gitlab.arturbosch.detekt.core.util.PerformanceMonitor.Phase

--- a/detekt-parser/src/main/kotlin/io/github/detekt/parser/BindingContextUtils.kt
+++ b/detekt-parser/src/main/kotlin/io/github/detekt/parser/BindingContextUtils.kt
@@ -1,4 +1,4 @@
-package io.gitlab.arturbosch.detekt.core
+package io.github.detekt.parser
 
 import org.jetbrains.kotlin.cli.common.messages.AnalyzerWithCompilerReport
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
@@ -13,7 +13,7 @@ import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.lazy.declarations.FileBasedDeclarationProviderFactory
 
-internal fun generateBindingContext(
+fun generateBindingContext(
     environment: KotlinCoreEnvironment,
     classpath: List<String>,
     files: List<KtFile>,

--- a/detekt-parser/src/test/kotlin/io/github/detekt/parser/DetektMessageCollectorSpec.kt
+++ b/detekt-parser/src/test/kotlin/io/github/detekt/parser/DetektMessageCollectorSpec.kt
@@ -1,4 +1,4 @@
-package io.gitlab.arturbosch.detekt.core
+package io.github.detekt.parser
 
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity


### PR DESCRIPTION
To me it makes more sense to have functions in detekt-parser that either create KtFiles from paths or directly from a source snippet, or generate the BindingContext for full analysis - or to look at it another way, anywhere we're delegating to the Kotlin compiler to do something for us.

Once we have either a list of KtFiles (for basic analysis) and optionally BindingContext (for full analysis) detekt-core can take of things from then on.