### PR TITLE
Remove BindingContext from FileProcessListener

### DIFF
--- a/detekt-api/api/detekt-api.api
+++ b/detekt-api/api/detekt-api.api
@@ -147,20 +147,20 @@ public final class io/gitlab/arturbosch/detekt/api/Extension$DefaultImpls {
 }
 
 public abstract interface class io/gitlab/arturbosch/detekt/api/FileProcessListener : io/gitlab/arturbosch/detekt/api/Extension {
-	public abstract fun onFinish (Ljava/util/List;Lio/gitlab/arturbosch/detekt/api/Detektion;Lorg/jetbrains/kotlin/resolve/BindingContext;)V
-	public abstract fun onProcess (Lorg/jetbrains/kotlin/psi/KtFile;Lorg/jetbrains/kotlin/resolve/BindingContext;)V
-	public abstract fun onProcessComplete (Lorg/jetbrains/kotlin/psi/KtFile;Ljava/util/List;Lorg/jetbrains/kotlin/resolve/BindingContext;)V
-	public abstract fun onStart (Ljava/util/List;Lorg/jetbrains/kotlin/resolve/BindingContext;)V
+	public abstract fun onFinish (Ljava/util/List;Lio/gitlab/arturbosch/detekt/api/Detektion;)V
+	public abstract fun onProcess (Lorg/jetbrains/kotlin/psi/KtFile;)V
+	public abstract fun onProcessComplete (Lorg/jetbrains/kotlin/psi/KtFile;Ljava/util/List;)V
+	public abstract fun onStart (Ljava/util/List;)V
 }
 
 public final class io/gitlab/arturbosch/detekt/api/FileProcessListener$DefaultImpls {
 	public static fun getPriority (Lio/gitlab/arturbosch/detekt/api/FileProcessListener;)I
 	public static fun init (Lio/gitlab/arturbosch/detekt/api/FileProcessListener;Lio/gitlab/arturbosch/detekt/api/Config;)V
 	public static fun init (Lio/gitlab/arturbosch/detekt/api/FileProcessListener;Lio/gitlab/arturbosch/detekt/api/SetupContext;)V
-	public static fun onFinish (Lio/gitlab/arturbosch/detekt/api/FileProcessListener;Ljava/util/List;Lio/gitlab/arturbosch/detekt/api/Detektion;Lorg/jetbrains/kotlin/resolve/BindingContext;)V
-	public static fun onProcess (Lio/gitlab/arturbosch/detekt/api/FileProcessListener;Lorg/jetbrains/kotlin/psi/KtFile;Lorg/jetbrains/kotlin/resolve/BindingContext;)V
-	public static fun onProcessComplete (Lio/gitlab/arturbosch/detekt/api/FileProcessListener;Lorg/jetbrains/kotlin/psi/KtFile;Ljava/util/List;Lorg/jetbrains/kotlin/resolve/BindingContext;)V
-	public static fun onStart (Lio/gitlab/arturbosch/detekt/api/FileProcessListener;Ljava/util/List;Lorg/jetbrains/kotlin/resolve/BindingContext;)V
+	public static fun onFinish (Lio/gitlab/arturbosch/detekt/api/FileProcessListener;Ljava/util/List;Lio/gitlab/arturbosch/detekt/api/Detektion;)V
+	public static fun onProcess (Lio/gitlab/arturbosch/detekt/api/FileProcessListener;Lorg/jetbrains/kotlin/psi/KtFile;)V
+	public static fun onProcessComplete (Lio/gitlab/arturbosch/detekt/api/FileProcessListener;Lorg/jetbrains/kotlin/psi/KtFile;Ljava/util/List;)V
+	public static fun onStart (Lio/gitlab/arturbosch/detekt/api/FileProcessListener;Ljava/util/List;)V
 }
 
 public abstract interface class io/gitlab/arturbosch/detekt/api/Finding {

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/FileProcessListener.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/FileProcessListener.kt
@@ -1,7 +1,6 @@
 package io.gitlab.arturbosch.detekt.api
 
 import org.jetbrains.kotlin.psi.KtFile
-import org.jetbrains.kotlin.resolve.BindingContext
 
 /**
  * Gather additional metrics about the analyzed kotlin file.
@@ -16,19 +15,19 @@ interface FileProcessListener : Extension {
      * Use this to gather some additional information for the real onProcess function.
      * This calculation should be lightweight as this method is called from the main thread.
      */
-    fun onStart(files: List<KtFile>, bindingContext: BindingContext) {}
+    fun onStart(files: List<KtFile>) {}
 
     /**
      * Called when processing of a file begins.
      * This method is called from a thread pool thread. Heavy computations allowed.
      */
-    fun onProcess(file: KtFile, bindingContext: BindingContext) {}
+    fun onProcess(file: KtFile) {}
 
     /**
      * Called when processing of a file completes.
      * This method is called from a thread pool thread. Heavy computations allowed.
      */
-    fun onProcessComplete(file: KtFile, issues: List<Issue>, bindingContext: BindingContext) {}
+    fun onProcessComplete(file: KtFile, issues: List<Issue>) {}
 
     /**
      * Mainly use this method to save computed metrics from KtFile's to the {@link Detektion} container.
@@ -36,5 +35,5 @@ interface FileProcessListener : Extension {
      *
      * This method is called before any [ReportingExtension].
      */
-    fun onFinish(files: List<KtFile>, result: Detektion, bindingContext: BindingContext) {}
+    fun onFinish(files: List<KtFile>, result: Detektion) {}
 }

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/DetektProgressListener.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/DetektProgressListener.kt
@@ -4,7 +4,6 @@ import io.gitlab.arturbosch.detekt.api.Detektion
 import io.gitlab.arturbosch.detekt.api.FileProcessListener
 import io.gitlab.arturbosch.detekt.api.SetupContext
 import org.jetbrains.kotlin.psi.KtFile
-import org.jetbrains.kotlin.resolve.BindingContext
 
 class DetektProgressListener : FileProcessListener {
 
@@ -16,11 +15,11 @@ class DetektProgressListener : FileProcessListener {
         this.outPrinter = context.outputChannel
     }
 
-    override fun onProcess(file: KtFile, bindingContext: BindingContext) {
+    override fun onProcess(file: KtFile) {
         outPrinter.append('.')
     }
 
-    override fun onFinish(files: List<KtFile>, result: Detektion, bindingContext: BindingContext) {
+    override fun onFinish(files: List<KtFile>, result: Detektion) {
         val middlePart = if (files.size == 1) "file was" else "files were"
         outPrinter.appendLine("\n\n${files.size} kotlin $middlePart analyzed.")
     }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Analyzer.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Analyzer.kt
@@ -56,11 +56,11 @@ internal class Analyzer(
         compilerResources: CompilerResources
     ): List<Issue> =
         ktFiles.flatMap { file ->
-            processors.forEach { it.onProcess(file, bindingContext) }
+            processors.forEach { it.onProcess(file) }
             val issues = runCatching { analyze(file, bindingContext, compilerResources) }
                 .onFailure { throwIllegalStateException(file, it) }
                 .getOrDefault(emptyList())
-            processors.forEach { it.onProcessComplete(file, issues, bindingContext) }
+            processors.forEach { it.onProcessComplete(file, issues) }
             issues
         }
 
@@ -72,9 +72,9 @@ internal class Analyzer(
         val service = settings.taskPool
         val tasks: TaskList<List<Issue>?> = ktFiles.map { file ->
             service.task {
-                processors.forEach { it.onProcess(file, bindingContext) }
+                processors.forEach { it.onProcess(file) }
                 val issues = analyze(file, bindingContext, compilerResources)
-                processors.forEach { it.onProcessComplete(file, issues, bindingContext) }
+                processors.forEach { it.onProcessComplete(file, issues) }
                 issues
             }.recover { throwIllegalStateException(file, it) }
         }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/KtFileModifier.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/KtFileModifier.kt
@@ -7,7 +7,6 @@ import io.gitlab.arturbosch.detekt.api.FileProcessListener
 import io.gitlab.arturbosch.detekt.api.Notification
 import org.jetbrains.kotlin.com.intellij.openapi.util.text.StringUtilRt
 import org.jetbrains.kotlin.psi.KtFile
-import org.jetbrains.kotlin.resolve.BindingContext
 import java.nio.file.Path
 import kotlin.io.path.writeText
 
@@ -15,7 +14,7 @@ class KtFileModifier : FileProcessListener {
 
     override val id: String = "KtFileModifier"
 
-    override fun onFinish(files: List<KtFile>, result: Detektion, bindingContext: BindingContext) {
+    override fun onFinish(files: List<KtFile>, result: Detektion) {
         files.filter { it.modificationStamp > 0 }
             .map { it.absolutePath() to it.unnormalizeContent() }
             .forEach { (path, content) ->

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/tooling/Lifecycle.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/tooling/Lifecycle.kt
@@ -39,10 +39,10 @@ internal interface Lifecycle {
 
         val result = measure(Phase.Analyzer) {
             val analyzer = Analyzer(settings, ruleSets, processors)
-            processors.forEach { it.onStart(filesToAnalyze, bindingContext) }
+            processors.forEach { it.onStart(filesToAnalyze) }
             val issues = analyzer.run(filesToAnalyze, bindingContext)
             val result: Detektion = DetektResult(issues)
-            processors.forEach { it.onFinish(filesToAnalyze, result, bindingContext) }
+            processors.forEach { it.onFinish(filesToAnalyze, result) }
             result
         }
 

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/TopLevelAutoCorrectSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/TopLevelAutoCorrectSpec.kt
@@ -17,7 +17,6 @@ import io.gitlab.arturbosch.detekt.core.tooling.inputPathsToKtFiles
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.psi.KtAnnotation
 import org.jetbrains.kotlin.psi.KtFile
-import org.jetbrains.kotlin.resolve.BindingContext
 import org.junit.jupiter.api.Test
 
 class TopLevelAutoCorrectSpec {
@@ -45,7 +44,7 @@ class TopLevelAutoCorrectSpec {
         val contentChangedListener = object : FileProcessListener {
             override val id: String = "ContentChangedListener"
 
-            override fun onFinish(files: List<KtFile>, result: Detektion, bindingContext: BindingContext) {
+            override fun onFinish(files: List<KtFile>, result: Detektion) {
                 assertThat(files).hasSize(1)
                 assertThat(files[0].text).isNotEqualToIgnoringWhitespace(fileContentBeforeAutoCorrect)
             }

--- a/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/processors/AbstractProcessor.kt
+++ b/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/processors/AbstractProcessor.kt
@@ -5,18 +5,17 @@ import io.gitlab.arturbosch.detekt.api.Detektion
 import io.gitlab.arturbosch.detekt.api.FileProcessListener
 import org.jetbrains.kotlin.com.intellij.openapi.util.Key
 import org.jetbrains.kotlin.psi.KtFile
-import org.jetbrains.kotlin.resolve.BindingContext
 
 abstract class AbstractProcessor : FileProcessListener {
 
     protected abstract val visitor: DetektVisitor
     protected abstract val key: Key<Int>
 
-    override fun onProcess(file: KtFile, bindingContext: BindingContext) {
+    override fun onProcess(file: KtFile) {
         file.accept(visitor)
     }
 
-    override fun onFinish(files: List<KtFile>, result: Detektion, bindingContext: BindingContext) {
+    override fun onFinish(files: List<KtFile>, result: Detektion) {
         val count = files
             .mapNotNull { it.getUserData(key) }
             .sum()

--- a/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/processors/AbstractProjectMetricProcessor.kt
+++ b/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/processors/AbstractProjectMetricProcessor.kt
@@ -3,13 +3,12 @@ package io.github.detekt.metrics.processors
 import io.gitlab.arturbosch.detekt.api.Detektion
 import io.gitlab.arturbosch.detekt.api.ProjectMetric
 import org.jetbrains.kotlin.psi.KtFile
-import org.jetbrains.kotlin.resolve.BindingContext
 
 abstract class AbstractProjectMetricProcessor : AbstractProcessor() {
 
     val type: String get() = key.toString()
 
-    override fun onFinish(files: List<KtFile>, result: Detektion, bindingContext: BindingContext) {
+    override fun onFinish(files: List<KtFile>, result: Detektion) {
         val count = files
             .mapNotNull { it.getUserData(key) }
             .sum()

--- a/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/processors/PackageCountProcessor.kt
+++ b/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/processors/PackageCountProcessor.kt
@@ -6,7 +6,6 @@ import io.gitlab.arturbosch.detekt.api.FileProcessListener
 import io.gitlab.arturbosch.detekt.api.ProjectMetric
 import org.jetbrains.kotlin.com.intellij.openapi.util.Key
 import org.jetbrains.kotlin.psi.KtFile
-import org.jetbrains.kotlin.resolve.BindingContext
 
 class PackageCountProcessor : FileProcessListener {
 
@@ -15,11 +14,11 @@ class PackageCountProcessor : FileProcessListener {
 
     override val id: String = "PackageCountProcessor"
 
-    override fun onProcess(file: KtFile, bindingContext: BindingContext) {
+    override fun onProcess(file: KtFile) {
         file.accept(visitor)
     }
 
-    override fun onFinish(files: List<KtFile>, result: Detektion, bindingContext: BindingContext) {
+    override fun onFinish(files: List<KtFile>, result: Detektion) {
         val count = files
             .mapNotNull { it.getUserData(key) }
             .distinct()

--- a/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/processors/MetricProcessorTester.kt
+++ b/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/processors/MetricProcessorTester.kt
@@ -7,7 +7,6 @@ import io.gitlab.arturbosch.detekt.api.ProjectMetric
 import org.jetbrains.kotlin.com.intellij.openapi.util.Key
 import org.jetbrains.kotlin.com.intellij.openapi.util.UserDataHolderBase
 import org.jetbrains.kotlin.psi.KtFile
-import org.jetbrains.kotlin.resolve.BindingContext
 
 class MetricProcessorTester(
     private val file: KtFile,
@@ -16,10 +15,10 @@ class MetricProcessorTester(
 
     fun <T : Any> test(processor: AbstractProcessor, key: Key<T>): T {
         with(processor) {
-            onStart(listOf(file), BindingContext.EMPTY)
-            onProcess(file, BindingContext.EMPTY)
-            onProcessComplete(file, emptyList(), BindingContext.EMPTY)
-            onFinish(listOf(file), result, BindingContext.EMPTY)
+            onStart(listOf(file))
+            onProcess(file)
+            onProcessComplete(file, emptyList())
+            onFinish(listOf(file), result)
         }
         return checkNotNull(result.getUserData(key))
     }

--- a/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/LicenceHeaderLoaderExtension.kt
+++ b/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/LicenceHeaderLoaderExtension.kt
@@ -11,7 +11,6 @@ import io.gitlab.arturbosch.detekt.rules.documentation.AbsentOrWrongFileLicense.
 import org.jetbrains.kotlin.com.intellij.openapi.util.Key
 import org.jetbrains.kotlin.com.intellij.openapi.util.text.StringUtilRt
 import org.jetbrains.kotlin.psi.KtFile
-import org.jetbrains.kotlin.resolve.BindingContext
 import java.nio.file.Path
 import kotlin.io.path.absolute
 import kotlin.io.path.exists
@@ -30,7 +29,7 @@ class LicenceHeaderLoaderExtension : FileProcessListener {
         this.configPath = context.configUris.lastOrNull()?.toPath()
     }
 
-    override fun onStart(files: List<KtFile>, bindingContext: BindingContext) {
+    override fun onStart(files: List<KtFile>) {
         fun Config.isActive() = this.valueOrDefault(Config.ACTIVE_KEY, false)
 
         fun shouldRuleRun(): Boolean {

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/AbsentOrWrongFileLicenseSpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/AbsentOrWrongFileLicenseSpec.kt
@@ -10,7 +10,6 @@ import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lint
 import io.gitlab.arturbosch.detekt.test.yamlConfig
 import org.intellij.lang.annotations.Language
-import org.jetbrains.kotlin.resolve.BindingContext
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import java.io.PrintStream
@@ -198,7 +197,7 @@ private fun checkLicence(@Language("kotlin") content: String, isRegexLicense: Bo
                 properties[key] = value
             }
         })
-        onStart(listOf(file), BindingContext.EMPTY)
+        onStart(listOf(file))
     }
 
     return AbsentOrWrongFileLicense(Config.empty).lint(file)

--- a/detekt-sample-extensions/src/main/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/processors/NumberOfLoopsProcessor.kt
+++ b/detekt-sample-extensions/src/main/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/processors/NumberOfLoopsProcessor.kt
@@ -5,12 +5,11 @@ import io.gitlab.arturbosch.detekt.api.FileProcessListener
 import org.jetbrains.kotlin.com.intellij.openapi.util.Key
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtLoopExpression
-import org.jetbrains.kotlin.resolve.BindingContext
 
 class NumberOfLoopsProcessor : FileProcessListener {
 
     override val id: String = "NumberOfLoopsProcessor"
-    override fun onProcess(file: KtFile, bindingContext: BindingContext) {
+    override fun onProcess(file: KtFile) {
         val visitor = LoopVisitor()
         file.accept(visitor)
         file.putUserData(numberOfLoopsKey, visitor.numberOfLoops)

--- a/detekt-sample-extensions/src/main/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/processors/QualifiedNameProcessor.kt
+++ b/detekt-sample-extensions/src/main/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/processors/QualifiedNameProcessor.kt
@@ -6,13 +6,12 @@ import io.gitlab.arturbosch.detekt.api.FileProcessListener
 import org.jetbrains.kotlin.com.intellij.openapi.util.Key
 import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.KtFile
-import org.jetbrains.kotlin.resolve.BindingContext
 
 class QualifiedNameProcessor : FileProcessListener {
 
     override val id: String = "QualifiedNameProcessor"
 
-    override fun onProcess(file: KtFile, bindingContext: BindingContext) {
+    override fun onProcess(file: KtFile) {
         val packageName = file.packageFqName.asString()
         val nameVisitor = ClassNameVisitor()
         file.accept(nameVisitor)
@@ -21,7 +20,7 @@ class QualifiedNameProcessor : FileProcessListener {
         file.putUserData(fqNamesKey, fqNames)
     }
 
-    override fun onFinish(files: List<KtFile>, result: Detektion, bindingContext: BindingContext) {
+    override fun onFinish(files: List<KtFile>, result: Detektion) {
         val fqNames = files
             .mapNotNull { it.getUserData(fqNamesKey) }
             .flatMapTo(HashSet()) { it }

--- a/detekt-sample-extensions/src/test/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/processors/NumberOfLoopsProcessorSpec.kt
+++ b/detekt-sample-extensions/src/test/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/processors/NumberOfLoopsProcessorSpec.kt
@@ -3,7 +3,6 @@ package io.gitlab.arturbosch.detekt.sample.extensions.processors
 import io.github.detekt.test.utils.compileContentForTest
 import io.gitlab.arturbosch.detekt.api.DetektVisitor
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.kotlin.resolve.BindingContext
 import org.junit.jupiter.api.Test
 
 class NumberOfLoopsProcessorSpec {
@@ -22,7 +21,7 @@ class NumberOfLoopsProcessorSpec {
 
         val ktFile = compileContentForTest(code)
         ktFile.accept(DetektVisitor())
-        NumberOfLoopsProcessor().onProcess(ktFile, BindingContext.EMPTY)
+        NumberOfLoopsProcessor().onProcess(ktFile)
 
         assertThat(ktFile.getUserData(NumberOfLoopsProcessor.numberOfLoopsKey)).isEqualTo(2)
     }

--- a/detekt-sample-extensions/src/test/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/processors/QualifiedNameProcessorSpec.kt
+++ b/detekt-sample-extensions/src/test/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/processors/QualifiedNameProcessorSpec.kt
@@ -7,7 +7,6 @@ import io.gitlab.arturbosch.detekt.api.Notification
 import io.gitlab.arturbosch.detekt.api.ProjectMetric
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.com.intellij.openapi.util.UserDataHolderBase
-import org.jetbrains.kotlin.resolve.BindingContext
 import org.junit.jupiter.api.Test
 
 class QualifiedNameProcessorSpec {
@@ -16,8 +15,8 @@ class QualifiedNameProcessorSpec {
     fun fqNamesOfTestFiles() {
         val ktFile = compileContentForTest(code)
         val processor = QualifiedNameProcessor()
-        processor.onProcess(ktFile, BindingContext.EMPTY)
-        processor.onFinish(listOf(ktFile), result, BindingContext.EMPTY)
+        processor.onProcess(ktFile)
+        processor.onFinish(listOf(ktFile), result)
 
         val data = result.getUserData(fqNamesKey)
         assertThat(data).contains(


### PR DESCRIPTION
This is unused in detekt itself and there wouldn't be any use cases where it makes sense to make this available in this API.

<!-- A similar PR may already be submitted! -->
<!-- Please search among the [Pull requests](https://github.com/detekt/detekt/pulls) before creating one. -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Link to relevant issues if possible. -->

<!-- For more information, see the [CONTRIBUTING guide](https://github.com/detekt/detekt/blob/main/.github/CONTRIBUTING.md). -->
