### PR TITLE
Remove invalid test

### DIFF
--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/CastNullableToNonNullableTypeSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/CastNullableToNonNullableTypeSpec.kt
@@ -135,17 +135,6 @@ class CastNullableToNonNullableTypeSpec(private val env: KotlinCoreEnvironment) 
     }
 
     @Test
-    fun `does not report casting of Nullable type to NonNullable smart casted variable to NonNullable type`() {
-        val code = """
-            fun foo(bar: Any?) {
-                val x = bar?.let { bar as String }
-            }
-        """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
-        assertThat(findings).isEmpty()
-    }
-
-    @Test
     fun `does not report casting of NonNullable type to NonNullable type`() {
         val code = """
             fun foo(bar: Any?) {


### PR DESCRIPTION
This test is invalid - the compiler does not smart cast `bar` to a non-nullable type, so the rule shouldn't ignore this. The correct code would be `bar?.let { it as String }`, and also does not rely on smart casts.