### PR TITLE
Publish detekt-compiler-plugin-all to Maven and GH Releases

### DIFF
--- a/build-logic/src/main/kotlin/releasing.gradle.kts
+++ b/build-logic/src/main/kotlin/releasing.gradle.kts
@@ -54,6 +54,9 @@ dependencies {
     releaseArtifacts(project(":detekt-generator")) {
         targetConfiguration = "shadow" // com.github.jengelman.gradle.plugins.shadow.ShadowBasePlugin.CONFIGURATION_NAME
     }
+    releaseArtifacts(project(":detekt-compiler-plugin")) {
+        targetConfiguration = "shadow" // com.github.jengelman.gradle.plugins.shadow.ShadowBasePlugin.CONFIGURATION_NAME
+    }
     releaseArtifacts(project(":detekt-formatting")) {
         targetConfiguration = Dependency.DEFAULT_CONFIGURATION
         isTransitive = false

--- a/detekt-compiler-plugin/build.gradle.kts
+++ b/detekt-compiler-plugin/build.gradle.kts
@@ -40,6 +40,12 @@ javaComponent.withVariantsFromConfiguration(configurations["shadowRuntimeElement
     skip()
 }
 
+publishing {
+    publications.named<MavenPublication>(DETEKT_PUBLICATION) {
+        artifact(tasks.shadowJar)
+    }
+}
+
 tasks.shadowJar {
     relocate("org.jetbrains.kotlin.com.intellij", "com.intellij")
     relocate("org.snakeyaml.engine", "dev.detekt.shaded.snakeyaml")


### PR DESCRIPTION
Fixes https://github.com/detekt/detekt/issues/7176

I've used `.\gradlew publishToMavenLocal` to check publishing results.

Now, `detekt-compiler-plugin-1.23.6-all.jar` is published along all other previously published files in the `detekt-compiler-plugin` artifact.