### PR TITLE
Add autocorrect test in detekt-cli

### DIFF
--- a/detekt-cli/build.gradle.kts
+++ b/detekt-cli/build.gradle.kts
@@ -37,6 +37,7 @@ dependencies {
 
     testImplementation(projects.detektTestUtils)
     testImplementation(libs.assertj)
+    testRuntimeOnly(projects.detektFormatting)
 
     pluginsJar(projects.detektFormatting)
     pluginsJar(projects.detektRulesLibraries)

--- a/detekt-cli/src/test/resources/autocorrect/Test.kt
+++ b/detekt-cli/src/test/resources/autocorrect/Test.kt
@@ -1,0 +1,1 @@
+class Test // no final newline

--- a/detekt-cli/src/test/resources/configs/formatting-config.yml
+++ b/detekt-cli/src/test/resources/configs/formatting-config.yml
@@ -1,0 +1,5 @@
+formatting:
+  autoCorrect: true
+  FinalNewline:
+    active: true
+    autoCorrect: true


### PR DESCRIPTION
Add a functional test for the CLI to check autocorrect works.