### PR TITLE
Remove platform core hack to use nio2

### DIFF
--- a/detekt-parser/src/main/kotlin/io/github/detekt/parser/KotlinEnvironmentUtils.kt
+++ b/detekt-parser/src/main/kotlin/io/github/detekt/parser/KotlinEnvironmentUtils.kt
@@ -2,7 +2,6 @@ package io.github.detekt.parser
 
 import org.jetbrains.kotlin.cli.common.CLIConfigurationKeys
 import org.jetbrains.kotlin.cli.common.config.addKotlinSourceRoots
-import org.jetbrains.kotlin.cli.common.environment.setIdeaIoUseFallback
 import org.jetbrains.kotlin.cli.common.messages.MessageRenderer
 import org.jetbrains.kotlin.cli.common.messages.PrintingMessageCollector
 import org.jetbrains.kotlin.cli.jvm.compiler.EnvironmentConfigFiles
@@ -36,8 +35,6 @@ fun createKotlinCoreEnvironment(
     disposable: Disposable = Disposer.newDisposable(),
     printStream: PrintStream,
 ): KotlinCoreEnvironment {
-    // https://github.com/JetBrains/kotlin/commit/2568804eaa2c8f6b10b735777218c81af62919c1
-    setIdeaIoUseFallback()
     configuration.put(
         CLIConfigurationKeys.MESSAGE_COLLECTOR_KEY,
         PrintingMessageCollector(printStream, MessageRenderer.PLAIN_FULL_PATHS, false)


### PR DESCRIPTION
All instances of KotlinCoreEnvironment call this since Kotlin 1.8.20 so calling it here is redundant.

https://github.com/JetBrains/kotlin/commit/a29c418b638a728c1cbf9509c8f3e486a5b95b72