### PR TITLE
Test autocorrect with rule that uses rawReplaceWithText

### DIFF
--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/RunnerSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/RunnerSpec.kt
@@ -221,7 +221,7 @@ class RunnerSpec {
 
         assertThat(errPrintStream.toString()).isEmpty()
         assertThat(outPrintStream.toString())
-            .contains("${inputPath.absolutePathString()}:1:30: File must end with a newline (\\n) [FinalNewline]")
+            .contains("${inputPath.absolutePathString()}:3:1: Needless blank line(s) [NoConsecutiveBlankLines]")
             .contains("File ${inputPath.absolutePathString()} was modified")
         assertThat(inputPath).content().endsWith("\n")
     }

--- a/detekt-cli/src/test/resources/autocorrect/Test.kt
+++ b/detekt-cli/src/test/resources/autocorrect/Test.kt
@@ -1,1 +1,9 @@
-class Test // no final newline
+class Test {
+
+
+
+
+
+
+
+}

--- a/detekt-cli/src/test/resources/configs/formatting-config.yml
+++ b/detekt-cli/src/test/resources/configs/formatting-config.yml
@@ -1,5 +1,5 @@
 formatting:
   autoCorrect: true
-  FinalNewline:
+  NoConsecutiveBlankLines:
     active: true
     autoCorrect: true


### PR DESCRIPTION
Previous test added in https://github.com/detekt/detekt/pull/7185 didn't throw "Cannot modify a read-only file" when auto correcting a KtFile that has property `virtualFile.isWritable == false` which makes it harder to pick up regressions when changing how KtFiles are created.

Turns out not all modifications trigger that error, but rules that use `rawReplaceWithText` do, so this switches the test to call a rule that uses `rawReplaceWithText`.