### PR TITLE
Move helper functions to test fixtures

### DIFF
--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/CodeSmellSpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/CodeSmellSpec.kt
@@ -1,6 +1,6 @@
 package io.gitlab.arturbosch.detekt.api
 
-import io.github.detekt.psi.FilePath
+import io.gitlab.arturbosch.detekt.test.fromRelative
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.io.File
@@ -18,7 +18,7 @@ class CodeSmellSpec {
                     source = SourceLocation(1, 1),
                     endSource = SourceLocation(1, 1),
                     text = TextLocation(0, 0),
-                    filePath = FilePath.fromRelative(Path("/Users/tester/detekt/"), Path("TestFile.kt"))
+                    filePath = fromRelative(Path("/Users/tester/detekt/"), Path("TestFile.kt"))
                 ),
                 ktElement = null
             ),

--- a/detekt-api/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/test/TestFactory.kt
+++ b/detekt-api/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/test/TestFactory.kt
@@ -10,6 +10,7 @@ import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.api.TextLocation
 import org.jetbrains.kotlin.psi.KtElement
+import java.nio.file.Path
 import kotlin.io.path.Path
 
 fun createIssue(
@@ -63,7 +64,7 @@ fun createIssueForRelativePath(
             source = SourceLocation(1, 1),
             endSource = SourceLocation(1, 1),
             text = TextLocation(0, 0),
-            filePath = FilePath.fromRelative(Path(basePath), Path(relativePath))
+            filePath = fromRelative(Path(basePath), Path(relativePath))
         ),
         ktElement = null
     ),
@@ -91,8 +92,8 @@ fun createLocation(
     source = SourceLocation(position.first, position.second),
     endSource = SourceLocation(endPosition.first, endPosition.second),
     text = TextLocation(text.first, text.last),
-    filePath = basePath?.let { FilePath.fromRelative(Path(it), Path(path)) }
-        ?: FilePath.fromAbsolute(Path(path)),
+    filePath = basePath?.let { fromRelative(Path(it), Path(path)) }
+        ?: fromAbsolute(Path(path)),
 )
 
 private data class IssueImpl(
@@ -109,3 +110,10 @@ private data class IssueImpl(
         override val description: String,
     ) : Issue.RuleInfo
 }
+
+fun fromAbsolute(path: Path) = FilePath(absolutePath = path.normalize())
+fun fromRelative(basePath: Path, relativePath: Path) = FilePath(
+    absolutePath = basePath.resolve(relativePath).normalize(),
+    basePath = basePath.normalize(),
+    relativePath = relativePath
+)

--- a/detekt-psi-utils/api/detekt-psi-utils.api
+++ b/detekt-psi-utils/api/detekt-psi-utils.api
@@ -4,18 +4,12 @@ public final class io/github/detekt/psi/AnnotationExcluder {
 }
 
 public final class io/github/detekt/psi/FilePath {
-	public static final field Companion Lio/github/detekt/psi/FilePath$Companion;
 	public fun <init> (Ljava/nio/file/Path;Ljava/nio/file/Path;Ljava/nio/file/Path;)V
 	public synthetic fun <init> (Ljava/nio/file/Path;Ljava/nio/file/Path;Ljava/nio/file/Path;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getAbsolutePath ()Ljava/nio/file/Path;
 	public final fun getBasePath ()Ljava/nio/file/Path;
 	public final fun getRelativePath ()Ljava/nio/file/Path;
 	public fun toString ()Ljava/lang/String;
-}
-
-public final class io/github/detekt/psi/FilePath$Companion {
-	public final fun fromAbsolute (Ljava/nio/file/Path;)Lio/github/detekt/psi/FilePath;
-	public final fun fromRelative (Ljava/nio/file/Path;Ljava/nio/file/Path;)Lio/github/detekt/psi/FilePath;
 }
 
 public abstract class io/github/detekt/psi/FunctionMatcher {

--- a/detekt-psi-utils/src/main/kotlin/io/github/detekt/psi/KtFiles.kt
+++ b/detekt-psi-utils/src/main/kotlin/io/github/detekt/psi/KtFiles.kt
@@ -57,15 +57,6 @@ class FilePath(
 
     override fun toString(): String =
         "FilePath(absolutePath=$absolutePath, basePath=$basePath, relativePath=$relativePath)"
-
-    companion object {
-        fun fromAbsolute(path: Path) = FilePath(absolutePath = path.normalize())
-        fun fromRelative(basePath: Path, relativePath: Path) = FilePath(
-            absolutePath = basePath.resolve(relativePath).normalize(),
-            basePath = basePath.normalize(),
-            relativePath = relativePath
-        )
-    }
 }
 
 fun PsiFile.toFilePath(): FilePath {

--- a/detekt-psi-utils/src/test/kotlin/io/github/detekt/psi/KtFilesSpec.kt
+++ b/detekt-psi-utils/src/test/kotlin/io/github/detekt/psi/KtFilesSpec.kt
@@ -5,7 +5,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.com.intellij.psi.PsiFile
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import java.io.File
 
 class KtFilesSpec {
 
@@ -44,26 +43,4 @@ class KtFilesSpec {
     }
 
     private fun makeFile(filename: String): PsiFile = FakePsiFile(name = filename)
-
-    @Nested
-    inner class FilePathSpec {
-
-        // Path separator for the current platform, short name, because lots of usages.
-        private val ps = File.separator
-
-        @Test fun `toString of absolute path`() {
-            val filePath = FilePath.fromAbsolute(File("/a/b/c").toPath())
-
-            assertThat(filePath.toString())
-                .isEqualTo("FilePath(absolutePath=${ps}a${ps}b${ps}c, basePath=null, relativePath=null)")
-        }
-
-        @Test fun `toString of relative path`() {
-            val filePath = FilePath.fromRelative(File("/a/b").toPath(), File("c/d").toPath())
-
-            assertThat(filePath.toString()).isEqualTo(
-                "FilePath(absolutePath=${ps}a${ps}b${ps}c${ps}d, basePath=${ps}a${ps}b, relativePath=c${ps}d)"
-            )
-        }
-    }
 }


### PR DESCRIPTION
These were only called from test code so can be removed from the public API.

I'd hesitate to call this a breaking change though it technically is, if we don't use it in production code I can't see why third party code would need to either.