### PR TITLE
Improve core tests

### DIFF
--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/AnalyzerSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/AnalyzerSpec.kt
@@ -405,7 +405,7 @@ private class NoEmptyFile(config: Config) : Rule(config, "TestDescription") {
     }
 }
 
-private class MaxLineLength(config: Config) : Rule(config, "TestDescription") {
+private open class MaxLineLength(config: Config) : Rule(config, "TestDescription") {
     private val lengthThreshold: Int = config.valueOrDefault("maxLineLength", 10)
     override fun visitKtFile(file: KtFile) {
         super.visitKtFile(file)
@@ -418,17 +418,7 @@ private class MaxLineLength(config: Config) : Rule(config, "TestDescription") {
 }
 
 @RequiresTypeResolution
-private class RequiresTypeResolutionMaxLineLength(config: Config) : Rule(config, "TestDescription") {
-    private val lengthThreshold: Int = config.valueOrDefault("maxLineLength", 10)
-    override fun visitKtFile(file: KtFile) {
-        super.visitKtFile(file)
-        for (line in file.text.lineSequence()) {
-            if (line.length > lengthThreshold) {
-                report(CodeSmell(Entity.atPackageOrFirstDecl(file), description))
-            }
-        }
-    }
-}
+private class RequiresTypeResolutionMaxLineLength(config: Config) : MaxLineLength(config)
 
 private class FaultyRule(config: Config) : Rule(config, "") {
     override fun visitKtFile(file: KtFile) {


### PR DESCRIPTION
This PR include the 2 first commits of #7101. The idea is that this will simplify the review of that other PR.

In this PR I make that the custom rules that we have for tests on `core` report the correct location of the issue. This is done because later I want to test the suppression and it only works if the location if correct.
