### PR TITLE
Move report base path handling to OutputReport

### DIFF
--- a/detekt-api/api/detekt-api.api
+++ b/detekt-api/api/detekt-api.api
@@ -231,6 +231,8 @@ public final class io/gitlab/arturbosch/detekt/api/Notification$Level : java/lan
 }
 
 public abstract class io/gitlab/arturbosch/detekt/api/OutputReport : io/gitlab/arturbosch/detekt/api/Extension {
+	public static final field Companion Lio/gitlab/arturbosch/detekt/api/OutputReport$Companion;
+	public static final field DETEKT_OUTPUT_REPORT_BASE_PATH_KEY Ljava/lang/String;
 	public fun <init> ()V
 	public abstract fun getEnding ()Ljava/lang/String;
 	public fun getPriority ()I
@@ -238,6 +240,9 @@ public abstract class io/gitlab/arturbosch/detekt/api/OutputReport : io/gitlab/a
 	public fun init (Lio/gitlab/arturbosch/detekt/api/SetupContext;)V
 	public abstract fun render (Lio/gitlab/arturbosch/detekt/api/Detektion;)Ljava/lang/String;
 	public final fun write (Ljava/nio/file/Path;Lio/gitlab/arturbosch/detekt/api/Detektion;)V
+}
+
+public final class io/gitlab/arturbosch/detekt/api/OutputReport$Companion {
 }
 
 public class io/gitlab/arturbosch/detekt/api/ProjectMetric {

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/OutputReport.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/OutputReport.kt
@@ -34,4 +34,8 @@ abstract class OutputReport : Extension {
      * Defines the translation process of detekt's result into a string.
      */
     abstract fun render(detektion: Detektion): String?
+
+    companion object {
+        const val DETEKT_OUTPUT_REPORT_BASE_PATH_KEY = "detekt.output.report.base.path"
+    }
 }

--- a/detekt-api/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/test/TestFactory.kt
+++ b/detekt-api/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/test/TestFactory.kt
@@ -71,7 +71,6 @@ fun createIssueForRelativePath(
     basePath: String = "Users/tester/detekt/",
     relativePath: String = "TestFile.kt"
 ): Issue {
-    require(!basePath.startsWith("/")) { "The path shouldn't start with '/'" }
     return IssueImpl(
         ruleInfo = ruleInfo,
         entity = Entity(

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/OutputFacadeSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/OutputFacadeSpec.kt
@@ -10,7 +10,9 @@ import io.github.detekt.test.utils.resourceAsPath
 import io.gitlab.arturbosch.detekt.core.DetektResult
 import io.gitlab.arturbosch.detekt.core.createNullLoggingSpec
 import io.gitlab.arturbosch.detekt.core.tooling.withSettings
+import io.gitlab.arturbosch.detekt.test.createEntity
 import io.gitlab.arturbosch.detekt.test.createIssue
+import io.gitlab.arturbosch.detekt.test.createLocation
 import io.gitlab.arturbosch.detekt.test.createRuleInfo
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -22,7 +24,19 @@ class OutputFacadeSpec {
     fun `Running the output facade with multiple reports`() {
         val printStream = StringPrintStream()
         val inputPath: Path = resourceAsPath("/cases")
-        val defaultResult = DetektResult(listOf(createIssue(createRuleInfo(ruleSetId = "Key"))))
+        val defaultResult = DetektResult(
+            listOf(
+                createIssue(
+                    createRuleInfo(ruleSetId = "Key"),
+                    createEntity(
+                        location = createLocation(
+                            "TestFile.kt",
+                            System.getProperty("user.dir")
+                        )
+                    )
+                )
+            )
+        )
         val plainOutputPath = createTempFileForTest("detekt", ".txt")
         val htmlOutputPath = createTempFileForTest("detekt", ".html")
         val xmlOutputPath = createTempFileForTest("detekt", ".xml")

--- a/detekt-report-html/src/test/kotlin/io/github/detekt/report/html/HtmlOutputReportSpec.kt
+++ b/detekt-report-html/src/test/kotlin/io/github/detekt/report/html/HtmlOutputReportSpec.kt
@@ -82,6 +82,9 @@ class HtmlOutputReportSpec {
 
     @Test
     fun `renders the right file locations for relative paths`() {
+        val htmlReport = HtmlOutputReport()
+        htmlReport.basePath = Path("Users/tester/detekt/").absolute()
+
         val result = htmlReport.render(createTestDetektionFromRelativePath())
 
         assertThat(result).contains("<span class=\"location\">src/main/com/sample/Sample1.kt:11:1</span>")
@@ -208,10 +211,11 @@ private fun createTestDetektionWithMultipleSmells(): Detektion {
 }
 
 private fun createTestDetektionFromRelativePath(): Detektion {
+    val basePath = "${System.getProperty("user.dir")}/Users/tester/detekt/"
     val entity1 = createEntity(
         location = createLocation(
             path = "src/main/com/sample/Sample1.kt",
-            basePath = "Users/tester/detekt/",
+            basePath = basePath,
             position = 11 to 1,
             text = 10..14,
         ),
@@ -220,14 +224,14 @@ private fun createTestDetektionFromRelativePath(): Detektion {
     val entity2 = createEntity(
         location = createLocation(
             path = "src/main/com/sample/Sample2.kt",
-            basePath = "Users/tester/detekt/",
+            basePath = basePath,
             position = 22 to 2,
         )
     )
     val entity3 = createEntity(
         location = createLocation(
             path = "src/main/com/sample/Sample3.kt",
-            basePath = "Users/tester/detekt/",
+            basePath = basePath,
             position = 33 to 3,
         )
     )

--- a/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/SarifOutputReport.kt
+++ b/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/SarifOutputReport.kt
@@ -19,7 +19,6 @@ import kotlin.io.path.Path
 import kotlin.io.path.absolute
 import kotlin.io.path.invariantSeparatorsPathString
 
-const val DETEKT_OUTPUT_REPORT_BASE_PATH_KEY = "detekt.output.report.base.path"
 const val SRCROOT = "%SRCROOT%"
 
 class SarifOutputReport : BuiltInOutputReport, OutputReport() {

--- a/detekt-report-sarif/src/test/kotlin/io/github/detekt/report/sarif/SarifOutputReportSpec.kt
+++ b/detekt-report-sarif/src/test/kotlin/io/github/detekt/report/sarif/SarifOutputReportSpec.kt
@@ -4,6 +4,7 @@ import io.github.detekt.test.utils.readResourceContent
 import io.gitlab.arturbosch.detekt.api.CodeSmell
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.OutputReport.Companion.DETEKT_OUTPUT_REPORT_BASE_PATH_KEY
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.RuleSet
 import io.gitlab.arturbosch.detekt.api.RuleSetProvider

--- a/detekt-report-xml/src/main/kotlin/io/github/detekt/report/xml/XmlOutputReport.kt
+++ b/detekt-report-xml/src/main/kotlin/io/github/detekt/report/xml/XmlOutputReport.kt
@@ -3,9 +3,14 @@ package io.github.detekt.report.xml
 import io.gitlab.arturbosch.detekt.api.Detektion
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.OutputReport
+import io.gitlab.arturbosch.detekt.api.SetupContext
+import io.gitlab.arturbosch.detekt.api.getOrNull
 import io.gitlab.arturbosch.detekt.api.internal.BuiltInOutputReport
+import java.nio.file.Path
 import java.util.Locale
+import kotlin.io.path.absolute
 import kotlin.io.path.invariantSeparatorsPathString
+import kotlin.io.path.relativeTo
 
 /**
  * Contains rule violations in an XML format. The report follows the structure of a Checkstyle report.
@@ -19,13 +24,22 @@ class XmlOutputReport : BuiltInOutputReport, OutputReport() {
     private val Issue.severityLabel: String
         get() = severity.name.lowercase(Locale.US)
 
+    var basePath: Path? = null
+
+    override fun init(context: SetupContext) {
+        basePath = context.getOrNull<Path>(DETEKT_OUTPUT_REPORT_BASE_PATH_KEY)?.absolute()
+    }
+
     override fun render(detektion: Detektion): String {
         val lines = ArrayList<String>()
         lines += "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
         lines += "<checkstyle version=\"4.3\">"
 
         detektion.issues
-            .groupBy { it.location.filePath.relativePath ?: it.location.filePath.absolutePath }
+            .groupBy {
+                basePath?.let { path -> it.location.filePath.absolutePath.relativeTo(path) }
+                    ?: it.location.filePath.absolutePath
+            }
             .forEach { (filePath, issues) ->
                 lines += "<file name=\"${filePath.invariantSeparatorsPathString.toXmlString()}\">"
                 issues.forEach {

--- a/detekt-report-xml/src/test/kotlin/io/github/detekt/report/xml/XmlOutputFormatSpec.kt
+++ b/detekt-report-xml/src/test/kotlin/io/github/detekt/report/xml/XmlOutputFormatSpec.kt
@@ -13,6 +13,8 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import java.util.Locale
+import kotlin.io.path.Path
+import kotlin.io.path.absolute
 import kotlin.io.path.invariantSeparatorsPathString
 
 private const val TAB = "\t"
@@ -114,12 +116,17 @@ class XmlOutputFormatSpec {
     fun `renders issues with relative path`() {
         val issueA = createIssueForRelativePath(
             ruleInfo = createRuleInfo("id_a"),
+            basePath = "${System.getProperty("user.dir")}/Users/tester/detekt/",
             relativePath = "Sample1.kt"
         )
         val issueB = createIssueForRelativePath(
             ruleInfo = createRuleInfo("id_b"),
+            basePath = "${System.getProperty("user.dir")}/Users/tester/detekt/",
             relativePath = "Sample2.kt"
         )
+
+        val outputFormat = XmlOutputReport()
+        outputFormat.basePath = Path("Users/tester/detekt/").absolute()
 
         val result = outputFormat.render(TestDetektion(issueA, issueB))
 


### PR DESCRIPTION
Base path is only relevant for report output. This opens the next step of removing FilePath class and using absolute paths everywhere else.