### PR TITLE
Remove Kotlin file extension constants from API

### DIFF
--- a/detekt-psi-utils/api/detekt-psi-utils.api
+++ b/detekt-psi-utils/api/detekt-psi-utils.api
@@ -32,8 +32,6 @@ public final class io/github/detekt/psi/KeysKt {
 }
 
 public final class io/github/detekt/psi/KtFilesKt {
-	public static final field KOTLIN_SCRIPT_SUFFIX Ljava/lang/String;
-	public static final field KOTLIN_SUFFIX Ljava/lang/String;
 	public static final fun absolutePath (Lorg/jetbrains/kotlin/com/intellij/psi/PsiFile;)Ljava/nio/file/Path;
 	public static final fun fileNameWithoutSuffix (Lorg/jetbrains/kotlin/com/intellij/psi/PsiFile;Ljava/util/List;)Ljava/lang/String;
 	public static synthetic fun fileNameWithoutSuffix$default (Lorg/jetbrains/kotlin/com/intellij/psi/PsiFile;Ljava/util/List;ILjava/lang/Object;)Ljava/lang/String;

--- a/detekt-psi-utils/src/main/kotlin/io/github/detekt/psi/KtFiles.kt
+++ b/detekt-psi-utils/src/main/kotlin/io/github/detekt/psi/KtFiles.kt
@@ -9,9 +9,7 @@ import org.jetbrains.kotlin.psi.UserDataProperty
 import java.nio.file.Path
 import kotlin.io.path.Path
 
-const val KOTLIN_SUFFIX = ".kt"
-const val KOTLIN_SCRIPT_SUFFIX = ".kts"
-private val KOTLIN_GENERIC_SUFFIXES = listOf(KOTLIN_SUFFIX, KOTLIN_SCRIPT_SUFFIX)
+private val KOTLIN_GENERIC_SUFFIXES = listOf(".kt", ".kts")
 
 /**
  * Removes kotlin specific file name suffixes, e.g. .kt.


### PR DESCRIPTION
I don't think these need to be part of the public API.