### PR TITLE
Don't duplicate constants

### DIFF
--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/Reporting.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/Reporting.kt
@@ -27,7 +27,6 @@ const val BUILD = "build"
 const val EXCLUDE_CORRECTABLE = "excludeCorrectable"
 
 const val DETEKT_OUTPUT_REPORT_PATHS_KEY = "detekt.output.report.paths.key"
-const val DETEKT_OUTPUT_REPORT_BASE_PATH_KEY = "detekt.output.report.base.path"
 
 private const val REPORT_MESSAGE_SIZE_LIMIT = 80
 private val messageReplacementRegex = Regex("\\s+")

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/tooling/ProcessingSpecSettingsBridge.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/tooling/ProcessingSpecSettingsBridge.kt
@@ -3,6 +3,7 @@ package io.gitlab.arturbosch.detekt.core.tooling
 import io.github.detekt.tooling.api.spec.ProcessingSpec
 import io.github.detekt.utils.openSafeStream
 import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.OutputReport.Companion.DETEKT_OUTPUT_REPORT_BASE_PATH_KEY
 import io.gitlab.arturbosch.detekt.core.ProcessingSettings
 import io.gitlab.arturbosch.detekt.core.baseline.DETEKT_BASELINE_CREATION_KEY
 import io.gitlab.arturbosch.detekt.core.baseline.DETEKT_BASELINE_PATH_KEY
@@ -12,7 +13,6 @@ import io.gitlab.arturbosch.detekt.core.config.DisabledAutoCorrectConfig
 import io.gitlab.arturbosch.detekt.core.config.YamlConfig
 import io.gitlab.arturbosch.detekt.core.config.validation.DeprecatedRule
 import io.gitlab.arturbosch.detekt.core.config.validation.loadDeprecations
-import io.gitlab.arturbosch.detekt.core.reporting.DETEKT_OUTPUT_REPORT_BASE_PATH_KEY
 import io.gitlab.arturbosch.detekt.core.reporting.DETEKT_OUTPUT_REPORT_PATHS_KEY
 import io.gitlab.arturbosch.detekt.core.util.MONITOR_PROPERTY_KEY
 import io.gitlab.arturbosch.detekt.core.util.PerformanceMonitor


### PR DESCRIPTION
We had `DETEKT_OUTPUT_REPORT_BASE_PATH_KEY` on `:detekt-api` and `detekt-core`. `core` can use the value in `api` to avoid disalignments.

#7241 will obsolete this PR but meanwhile it will help to find the usages too.