### PR TITLE
Don't pass FileBasedDeclarationProviderFactory explicitly

### DIFF
--- a/detekt-parser/src/main/kotlin/io/github/detekt/parser/BindingContextUtils.kt
+++ b/detekt-parser/src/main/kotlin/io/github/detekt/parser/BindingContextUtils.kt
@@ -11,7 +11,6 @@ import org.jetbrains.kotlin.cli.jvm.compiler.TopDownAnalyzerFacadeForJVM
 import org.jetbrains.kotlin.config.languageVersionSettings
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.resolve.BindingContext
-import org.jetbrains.kotlin.resolve.lazy.declarations.FileBasedDeclarationProviderFactory
 
 fun generateBindingContext(
     environment: KotlinCoreEnvironment,
@@ -39,8 +38,7 @@ fun generateBindingContext(
             files,
             NoScopeRecordCliBindingTrace(),
             environment.configuration,
-            environment::createPackagePartProvider,
-            ::FileBasedDeclarationProviderFactory
+            environment::createPackagePartProvider
         )
     }
 

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/KotlinCoreEnvironmentExtensions.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/KotlinCoreEnvironmentExtensions.kt
@@ -5,7 +5,6 @@ import org.jetbrains.kotlin.cli.jvm.compiler.NoScopeRecordCliBindingTrace
 import org.jetbrains.kotlin.cli.jvm.compiler.TopDownAnalyzerFacadeForJVM
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.resolve.BindingContext
-import org.jetbrains.kotlin.resolve.lazy.declarations.FileBasedDeclarationProviderFactory
 
 fun KotlinCoreEnvironment.createBindingContext(files: List<KtFile>): BindingContext =
     TopDownAnalyzerFacadeForJVM.analyzeFilesWithJavaIntegration(
@@ -13,6 +12,5 @@ fun KotlinCoreEnvironment.createBindingContext(files: List<KtFile>): BindingCont
         files,
         NoScopeRecordCliBindingTrace(),
         this.configuration,
-        this::createPackagePartProvider,
-        ::FileBasedDeclarationProviderFactory
+        this::createPackagePartProvider
     ).bindingContext


### PR DESCRIPTION
This is the default value for the parameter so there's no need to pass it through.