### PR TITLE
Set compiler JDK home to java.home by default

### DIFF
--- a/detekt-parser/src/main/kotlin/io/github/detekt/parser/KotlinEnvironmentUtils.kt
+++ b/detekt-parser/src/main/kotlin/io/github/detekt/parser/KotlinEnvironmentUtils.kt
@@ -100,7 +100,12 @@ fun createCompilerConfiguration(
         addKotlinSourceRoots(kotlinFiles)
         addJvmClasspathRoots(classpathFiles)
 
-        jdkHome?.let { put(JVMConfigurationKeys.JDK_HOME, it.toFile()) }
+        if (jdkHome != null) {
+            put(JVMConfigurationKeys.JDK_HOME, jdkHome.toFile())
+        } else {
+            put(JVMConfigurationKeys.JDK_HOME, File(System.getProperty("java.home")))
+        }
+
         configureJdkClasspathRoots()
     }
 }

--- a/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/KtTestCompiler.kt
+++ b/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/KtTestCompiler.kt
@@ -34,10 +34,6 @@ internal object KtTestCompiler : KtCompiler() {
         configuration.put(CommonConfigurationKeys.MODULE_NAME, "test_module")
         configuration.put(CLIConfigurationKeys.MESSAGE_COLLECTOR_KEY, MessageCollector.NONE)
 
-        if (System.getenv("JAVA_HOME") != null) {
-            configuration.put(JVMConfigurationKeys.JDK_HOME, File(System.getenv("JAVA_HOME")))
-        }
-
         // Get the runtime locations of both the stdlib and kotlinx coroutines core jars and pass
         // to the compiler so it's available to generate the BindingContext for rules under test.
         configuration.apply {
@@ -45,6 +41,7 @@ internal object KtTestCompiler : KtCompiler() {
             addJvmClasspathRoot(kotlinxCoroutinesCorePath())
             addJvmClasspathRoots(additionalRootPaths)
             addJavaSourceRoots(additionalJavaSourceRootPaths)
+            put(JVMConfigurationKeys.JDK_HOME, File(System.getProperty("java.home")))
             configureJdkClasspathRoots()
         }
 


### PR DESCRIPTION
This ensures JDK home is always set to a value and aligns to compiler behaviour.