### PR TITLE
Remove line separator detection logic

### DIFF
--- a/detekt-parser/src/main/kotlin/io/github/detekt/parser/KtCompiler.kt
+++ b/detekt-parser/src/main/kotlin/io/github/detekt/parser/KtCompiler.kt
@@ -27,21 +27,8 @@ open class KtCompiler(
         }
     }
 
-    fun createKtFile(@Language("kotlin") content: String, path: Path): KtFile {
-        val psiFile = psiFileFactory.createPhysicalFile(path.name, StringUtilRt.convertLineSeparators(content))
-
-        return psiFile.apply {
-            val normalizedAbsolutePath = path.absolute().normalize()
-            this.absolutePath = normalizedAbsolutePath
-            virtualFile.detectedLineSeparator = content.determineLineSeparator()
+    fun createKtFile(@Language("kotlin") content: String, path: Path): KtFile =
+        psiFileFactory.createPhysicalFile(path.name, StringUtilRt.convertLineSeparators(content)).apply {
+            absolutePath = path.absolute().normalize()
         }
-    }
-}
-
-internal fun String.determineLineSeparator(): String {
-    val i = this.lastIndexOf('\n')
-    if (i == -1) {
-        return if (this.lastIndexOf('\r') == -1) System.lineSeparator() else "\r"
-    }
-    return if (i != 0 && this[i - 1] == '\r') "\r\n" else "\n"
 }

--- a/detekt-parser/src/test/kotlin/io/github/detekt/parser/KtCompilerSpec.kt
+++ b/detekt-parser/src/test/kotlin/io/github/detekt/parser/KtCompilerSpec.kt
@@ -58,22 +58,4 @@ class KtCompilerSpec {
                 .withMessage("$cssPath is not a Kotlin file")
         }
     }
-
-    @Nested
-    inner class `line ending detection` {
-        @Test
-        fun `detects CRLF line endings`() {
-            assertThat("1\r\n2".determineLineSeparator()).isEqualTo("\r\n")
-        }
-
-        @Test
-        fun `detects LF line endings`() {
-            assertThat("1\n2".determineLineSeparator()).isEqualTo("\n")
-        }
-
-        @Test
-        fun `detects CR line endings`() {
-            assertThat("1\r2".determineLineSeparator()).isEqualTo("\r")
-        }
-    }
 }


### PR DESCRIPTION
This is now fully handled by the IntelliJ components in the embeddable compiler.