### PR TITLE
Add class name exclusions to UndocumentedPublicClass rule

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -75,6 +75,7 @@ comments:
     searchInInnerObject: true
     searchInInnerInterface: true
     searchInProtectedClass: false
+    excludeClassNames: []
   UndocumentedPublicFunction:
     active: false
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']

--- a/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicClass.kt
+++ b/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicClass.kt
@@ -42,7 +42,7 @@ class UndocumentedPublicClass(config: Config) : Rule(
     private val searchInProtectedClass: Boolean by config(false)
 
     @Configuration("a list of class names to exclude from this rule")
-    private val excludeClassNames: List<String> by config(listOf())
+    private val excludeClassNames: List<String> by config(emptyList())
 
     override fun visitClass(klass: KtClass) {
         if (requiresDocumentation(klass)) {

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicClassSpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicClassSpec.kt
@@ -11,6 +11,7 @@ private const val SEARCH_IN_INNER_CLASS = "searchInInnerClass"
 private const val SEARCH_IN_INNER_OBJECT = "searchInInnerObject"
 private const val SEARCH_IN_INNER_INTERFACE = "searchInInnerInterface"
 private const val SEARCH_IN_PROTECTED_CLASS = "searchInProtectedClass"
+private const val EXCLUDE_CLASS_NAMES = "excludeClassNames"
 
 class UndocumentedPublicClassSpec {
     val subject = UndocumentedPublicClass(Config.empty)
@@ -301,5 +302,33 @@ class UndocumentedPublicClassSpec {
             }
         """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(2)
+    }
+
+    @Test
+    fun `should not report excluded class names`() {
+        val code = """
+            /**
+             * Sample KDoc for parent class.
+             */
+            class Test {
+                class Factory
+            }
+        """.trimIndent()
+        val subject = UndocumentedPublicClass(TestConfig(EXCLUDE_CLASS_NAMES to listOf("Factory")))
+        assertThat(subject.compileAndLint(code)).isEmpty()
+    }
+
+    @Test
+    fun `should not report excluded object names`() {
+        val code = """
+            /**
+             * Sample KDoc for parent class.
+             */
+            class Test {
+                object Factory
+            }
+        """.trimIndent()
+        val subject = UndocumentedPublicClass(TestConfig(EXCLUDE_CLASS_NAMES to listOf("Factory")))
+        assertThat(subject.compileAndLint(code)).isEmpty()
     }
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Link to relevant issues if possible. -->

<!-- For more information, see the [CONTRIBUTING guide](https://github.com/detekt/detekt/blob/main/.github/CONTRIBUTING.md). -->

This PR adds a parameter to the `UndocumentedPublicClass` rule to exclude exact class or object names. The rationale for this rule is situations like the following:
```kotlin
class Foo private constructor (val s: String) {
  class Factory {
    fun create(s: String): Foo = Foo(s)
  }
}
```

The outer class `Foo` should be documented to explain what it does and why. But the inner class `Foo.Factory` is very much self-documenting: it is a factory that creates new Foos. The same idea can apply to a `Builder` class.

Currently the only way to exclude these kinds of classes is to manually `@Suppress` them or disable the rule for all nested classes with the `searchInNestedClass` config. But doing so would disable it for lots of cases where the nested class should be documented because it's more complex than a factory class with a single create function.
***
I made this change with the nested Factory class example above in mind, but I implemented it to look at all classes. I think it would primarily apply to nested classes where the outer class provides all the needed documentation, but I wasn't sure if it made sense to limit the usage in case there was a use case for non-nested classes that I couldn't think of. I'm open to changing this to only apply to nested classes if people think that makes more sense.