### PR TITLE
Remove PsiFile.absolutePath

### DIFF
--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/AnalyzerSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/AnalyzerSpec.kt
@@ -3,6 +3,7 @@ package io.gitlab.arturbosch.detekt.core
 import io.github.detekt.test.utils.StringPrintStream
 import io.github.detekt.test.utils.compileContentForTest
 import io.github.detekt.test.utils.compileForTest
+import io.github.detekt.test.utils.resourceAsPath
 import io.gitlab.arturbosch.detekt.api.CodeSmell
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Entity
@@ -25,8 +26,6 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
-import kotlin.io.path.Path
-import kotlin.io.path.absolute
 
 @KotlinCoreEnvironmentTest
 class AnalyzerSpec(val env: KotlinCoreEnvironment) {
@@ -349,12 +348,13 @@ class AnalyzerSpec(val env: KotlinCoreEnvironment) {
             path: String,
             config: Config,
         ): Boolean {
-            val root = Path("").absolute()
+            val root = resourceAsPath("include_exclude")
+            val pathToCheck = resourceAsPath("include_exclude").resolve(path)
 
             return createProcessingSettings(config = config) { project { basePath = root } }
                 .use { settings ->
                     Analyzer(settings, listOf(CustomRuleSetProvider()), emptyList())
-                        .run(listOf(compileContentForTest("", Path(path))))
+                        .run(listOf(compileForTest(pathToCheck)))
                         .isNotEmpty()
                 }
         }

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/util/ConfigExtensionsSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/util/ConfigExtensionsSpec.kt
@@ -1,6 +1,7 @@
 package io.gitlab.arturbosch.detekt.core.util
 
-import io.github.detekt.test.utils.compileContentForTest
+import io.github.detekt.test.utils.compileForTest
+import io.github.detekt.test.utils.resourceAsPath
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.yamlConfigFromContent
@@ -8,8 +9,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import kotlin.io.path.Path
-import kotlin.io.path.absolute
 
 class IsActiveOrDefaultSpec {
 
@@ -35,8 +34,8 @@ class IsActiveOrDefaultSpec {
 @Nested
 class ShouldAnalyzeFileSpec {
 
-    private val basePath = Path("/cases").absolute()
-    private val file = compileContentForTest("", path = Path("/cases/Default.kt"))
+    private val basePath = resourceAsPath("cases")
+    private val file = compileForTest(basePath.resolve("Default.kt"))
 
     @Test
     fun `analyzes file with an empty config`() {

--- a/detekt-parser/build.gradle.kts
+++ b/detekt-parser/build.gradle.kts
@@ -6,7 +6,6 @@ plugins {
 
 dependencies {
     api(libs.kotlin.compilerEmbeddable)
-    implementation(projects.detektPsiUtils)
     testImplementation(projects.detektTestUtils)
     testImplementation(libs.assertj)
 }

--- a/detekt-parser/src/main/kotlin/io/github/detekt/parser/KtCompiler.kt
+++ b/detekt-parser/src/main/kotlin/io/github/detekt/parser/KtCompiler.kt
@@ -1,6 +1,5 @@
 package io.github.detekt.parser
 
-import io.github.detekt.psi.absolutePath
 import org.intellij.lang.annotations.Language
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.jetbrains.kotlin.com.intellij.openapi.util.text.StringUtilRt
@@ -8,7 +7,6 @@ import org.jetbrains.kotlin.com.intellij.psi.util.PsiUtilCore
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtPsiFactory
 import java.nio.file.Path
-import kotlin.io.path.absolute
 import kotlin.io.path.isRegularFile
 import kotlin.io.path.name
 
@@ -28,7 +26,5 @@ open class KtCompiler(
     }
 
     fun createKtFile(@Language("kotlin") content: String, path: Path): KtFile =
-        psiFileFactory.createPhysicalFile(path.name, StringUtilRt.convertLineSeparators(content)).apply {
-            absolutePath = path.absolute().normalize()
-        }
+        psiFileFactory.createPhysicalFile(path.name, StringUtilRt.convertLineSeparators(content))
 }

--- a/detekt-psi-utils/api/detekt-psi-utils.api
+++ b/detekt-psi-utils/api/detekt-psi-utils.api
@@ -15,11 +15,10 @@ public final class io/github/detekt/psi/FunctionMatcher$Companion {
 
 public final class io/github/detekt/psi/KtFilesKt {
 	public static final fun absolutePath (Lorg/jetbrains/kotlin/com/intellij/psi/PsiFile;)Ljava/nio/file/Path;
+	public static final fun absolutePath (Lorg/jetbrains/kotlin/psi/KtFile;)Ljava/nio/file/Path;
 	public static final fun fileNameWithoutSuffix (Lorg/jetbrains/kotlin/com/intellij/psi/PsiFile;Ljava/util/List;)Ljava/lang/String;
 	public static synthetic fun fileNameWithoutSuffix$default (Lorg/jetbrains/kotlin/com/intellij/psi/PsiFile;Ljava/util/List;ILjava/lang/Object;)Ljava/lang/String;
-	public static final fun getAbsolutePath (Lorg/jetbrains/kotlin/com/intellij/psi/PsiFile;)Ljava/nio/file/Path;
 	public static final fun getLineAndColumnInPsiFile (Lorg/jetbrains/kotlin/com/intellij/psi/PsiFile;Lorg/jetbrains/kotlin/com/intellij/openapi/util/TextRange;)Lorg/jetbrains/kotlin/diagnostics/PsiDiagnosticUtils$LineAndColumn;
-	public static final fun setAbsolutePath (Lorg/jetbrains/kotlin/com/intellij/psi/PsiFile;Ljava/nio/file/Path;)V
 }
 
 public final class io/gitlab/arturbosch/detekt/rules/AllowedExceptionNamePatternKt {

--- a/detekt-psi-utils/src/main/kotlin/io/github/detekt/psi/KtFiles.kt
+++ b/detekt-psi-utils/src/main/kotlin/io/github/detekt/psi/KtFiles.kt
@@ -4,6 +4,7 @@ import org.jetbrains.kotlin.com.intellij.openapi.util.TextRange
 import org.jetbrains.kotlin.com.intellij.psi.PsiFile
 import org.jetbrains.kotlin.diagnostics.DiagnosticUtils
 import org.jetbrains.kotlin.diagnostics.PsiDiagnosticUtils
+import org.jetbrains.kotlin.psi.KtFile
 import java.nio.file.Path
 import kotlin.io.path.Path
 
@@ -25,6 +26,9 @@ fun PsiFile.fileNameWithoutSuffix(multiplatformTargetSuffixes: List<String> = em
 }
 
 fun PsiFile.absolutePath(): Path = Path(virtualFile.path)
+
+// KtFile.virtualFilePath is cached so should be a tiny bit more performant when called repeatedly for the same file.
+fun KtFile.absolutePath(): Path = Path(virtualFilePath)
 
 // #3317 If any rule mutates the PsiElement, searching the original PsiElement may throw an exception.
 fun getLineAndColumnInPsiFile(file: PsiFile, range: TextRange): PsiDiagnosticUtils.LineAndColumn? {

--- a/detekt-psi-utils/src/main/kotlin/io/github/detekt/psi/KtFiles.kt
+++ b/detekt-psi-utils/src/main/kotlin/io/github/detekt/psi/KtFiles.kt
@@ -1,11 +1,9 @@
 package io.github.detekt.psi
 
-import org.jetbrains.kotlin.com.intellij.openapi.util.Key
 import org.jetbrains.kotlin.com.intellij.openapi.util.TextRange
 import org.jetbrains.kotlin.com.intellij.psi.PsiFile
 import org.jetbrains.kotlin.diagnostics.DiagnosticUtils
 import org.jetbrains.kotlin.diagnostics.PsiDiagnosticUtils
-import org.jetbrains.kotlin.psi.UserDataProperty
 import java.nio.file.Path
 import kotlin.io.path.Path
 
@@ -26,13 +24,7 @@ fun PsiFile.fileNameWithoutSuffix(multiplatformTargetSuffixes: List<String> = em
     return fileName
 }
 
-var PsiFile.absolutePath: Path? by UserDataProperty(Key("absolutePath"))
-
-/*
-absolutePath will be null when the Kotlin compiler plugin is used. The file's path can be obtained from the virtual file
-instead.
-*/
-fun PsiFile.absolutePath(): Path = absolutePath ?: Path(virtualFile.path)
+fun PsiFile.absolutePath(): Path = Path(virtualFile.path)
 
 // #3317 If any rule mutates the PsiElement, searching the original PsiElement may throw an exception.
 fun getLineAndColumnInPsiFile(file: PsiFile, range: TextRange): PsiDiagnosticUtils.LineAndColumn? {


### PR DESCRIPTION
This is now fully handled by the IntelliJ components in the embeddable compiler.