### PR TITLE
Remove ability to create AnalysisResult by passing source code and filename

### DIFF
--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/tooling/AnalysisFacade.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/tooling/AnalysisFacade.kt
@@ -14,7 +14,6 @@ import io.gitlab.arturbosch.detekt.core.ProcessingSettings
 import io.gitlab.arturbosch.detekt.core.config.check
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.resolve.BindingContext
-import kotlin.io.path.Path
 
 class AnalysisFacade(
     private val spec: ProcessingSpec
@@ -23,11 +22,6 @@ class AnalysisFacade(
     override fun run(): AnalysisResult = runAnalysis {
         DefaultLifecycle(spec.getDefaultConfiguration(), it, inputPathsToKtFiles)
     }
-
-    override fun run(sourceCode: String, filename: String): AnalysisResult =
-        runAnalysis {
-            DefaultLifecycle(spec.getDefaultConfiguration(), it, contentToKtFile(sourceCode, Path(filename)))
-        }
 
     override fun run(files: Collection<KtFile>, bindingContext: BindingContext): AnalysisResult =
         runAnalysis {

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/tooling/ParsingStrategy.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/tooling/ParsingStrategy.kt
@@ -3,17 +3,8 @@ package io.gitlab.arturbosch.detekt.core.tooling
 import io.github.detekt.parser.KtCompiler
 import io.gitlab.arturbosch.detekt.core.ProcessingSettings
 import org.jetbrains.kotlin.psi.KtFile
-import java.nio.file.Path
-import kotlin.io.path.isRegularFile
 
 typealias ParsingStrategy = (settings: ProcessingSettings) -> List<KtFile>
-
-fun contentToKtFile(content: String, path: Path): ParsingStrategy = { settings ->
-    require(path.isRegularFile()) { "Given sub path ($path) should be a regular file!" }
-    listOf(
-        KtCompiler(settings.environment).createKtFile(content, path)
-    )
-}
 
 val inputPathsToKtFiles: ParsingStrategy = { settings ->
     val compiler = KtCompiler(settings.environment)

--- a/detekt-parser/src/main/kotlin/io/github/detekt/parser/KtCompiler.kt
+++ b/detekt-parser/src/main/kotlin/io/github/detekt/parser/KtCompiler.kt
@@ -1,20 +1,14 @@
 package io.github.detekt.parser
 
-import org.intellij.lang.annotations.Language
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
-import org.jetbrains.kotlin.com.intellij.openapi.util.text.StringUtilRt
 import org.jetbrains.kotlin.com.intellij.psi.util.PsiUtilCore
 import org.jetbrains.kotlin.psi.KtFile
-import org.jetbrains.kotlin.psi.KtPsiFactory
 import java.nio.file.Path
 import kotlin.io.path.isRegularFile
-import kotlin.io.path.name
 
 open class KtCompiler(
     protected val environment: KotlinCoreEnvironment = createKotlinCoreEnvironment(printStream = System.err)
 ) {
-
-    protected val psiFileFactory = KtPsiFactory(environment.project, markGenerated = false)
 
     fun compile(path: Path): KtFile {
         require(path.isRegularFile()) { "Given path '$path' should be a regular file!" }
@@ -24,7 +18,4 @@ open class KtCompiler(
             "$path is not a Kotlin file"
         }
     }
-
-    fun createKtFile(@Language("kotlin") content: String, path: Path): KtFile =
-        psiFileFactory.createPhysicalFile(path.name, StringUtilRt.convertLineSeparators(content))
 }

--- a/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/KtTestCompiler.kt
+++ b/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/KtTestCompiler.kt
@@ -11,7 +11,6 @@ import org.jetbrains.kotlin.cli.jvm.config.addJavaSourceRoots
 import org.jetbrains.kotlin.cli.jvm.config.addJvmClasspathRoot
 import org.jetbrains.kotlin.cli.jvm.config.addJvmClasspathRoots
 import org.jetbrains.kotlin.cli.jvm.config.configureJdkClasspathRoots
-import org.jetbrains.kotlin.com.intellij.openapi.project.Project
 import org.jetbrains.kotlin.com.intellij.openapi.util.Disposer
 import org.jetbrains.kotlin.com.intellij.openapi.util.text.StringUtilRt
 import org.jetbrains.kotlin.config.CommonConfigurationKeys
@@ -62,8 +61,6 @@ internal object KtTestCompiler : KtCompiler() {
             )
         return KotlinCoreEnvironmentWrapper(kotlinCoreEnvironment, parentDisposable)
     }
-
-    fun project(): Project = environment.project
 
     fun createKtFile(@Language("kotlin") content: String, path: Path): KtFile =
         psiFileFactory.createPhysicalFile(path.name, StringUtilRt.convertLineSeparators(content))

--- a/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/KtTestCompiler.kt
+++ b/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/KtTestCompiler.kt
@@ -2,6 +2,7 @@ package io.github.detekt.test.utils
 
 import io.github.detekt.parser.KtCompiler
 import kotlinx.coroutines.CoroutineScope
+import org.intellij.lang.annotations.Language
 import org.jetbrains.kotlin.cli.common.CLIConfigurationKeys
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.cli.jvm.compiler.EnvironmentConfigFiles
@@ -12,15 +13,22 @@ import org.jetbrains.kotlin.cli.jvm.config.addJvmClasspathRoots
 import org.jetbrains.kotlin.cli.jvm.config.configureJdkClasspathRoots
 import org.jetbrains.kotlin.com.intellij.openapi.project.Project
 import org.jetbrains.kotlin.com.intellij.openapi.util.Disposer
+import org.jetbrains.kotlin.com.intellij.openapi.util.text.StringUtilRt
 import org.jetbrains.kotlin.config.CommonConfigurationKeys
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.config.JVMConfigurationKeys
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtPsiFactory
 import java.io.File
+import java.nio.file.Path
+import kotlin.io.path.name
 
 /**
  * Test compiler extends kt compiler and adds ability to compile from text content.
  */
 internal object KtTestCompiler : KtCompiler() {
+
+    private val psiFileFactory = KtPsiFactory(environment.project, markGenerated = false)
 
     /**
      * Not sure why but this function only works from this context.
@@ -56,6 +64,9 @@ internal object KtTestCompiler : KtCompiler() {
     }
 
     fun project(): Project = environment.project
+
+    fun createKtFile(@Language("kotlin") content: String, path: Path): KtFile =
+        psiFileFactory.createPhysicalFile(path.name, StringUtilRt.convertLineSeparators(content))
 
     private fun kotlinStdLibPath(): File {
         return File(CharRange::class.java.protectionDomain.codeSource.location.path)

--- a/detekt-tooling/api/detekt-tooling.api
+++ b/detekt-tooling/api/detekt-tooling.api
@@ -35,7 +35,6 @@ public final class io/github/detekt/tooling/api/DefaultConfigurationProvider$Com
 
 public abstract interface class io/github/detekt/tooling/api/Detekt {
 	public abstract fun run ()Lio/github/detekt/tooling/api/AnalysisResult;
-	public abstract fun run (Ljava/lang/String;Ljava/lang/String;)Lio/github/detekt/tooling/api/AnalysisResult;
 	public abstract fun run (Ljava/util/Collection;Lorg/jetbrains/kotlin/resolve/BindingContext;)Lio/github/detekt/tooling/api/AnalysisResult;
 }
 

--- a/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/api/Detekt.kt
+++ b/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/api/Detekt.kt
@@ -13,9 +13,6 @@ interface Detekt {
     // Used by detekt-cli
     fun run(): AnalysisResult
 
-    // Used by detekt-intellij-plugin
-    fun run(sourceCode: String, filename: String): AnalysisResult
-
     // Used by detekt-compiler-plugin
     fun run(files: Collection<KtFile>, bindingContext: BindingContext): AnalysisResult
 }


### PR DESCRIPTION
Calling detekt from production code should only ever pass a `KtFile` or a `Path` (from which a KtFile can be created).

Creating `KtFile` from text directly is only required from tests.

This is a breaking change for detekt-intellij-plugin, but a quick look at the source in that project suggests it will be a simple update.

Waiting on merge of:
* #7235
* #7237 
* #7238
* #7240
* #7250 
* #7251 
* #7254 