### PR TITLE
Use detekt's Location path for compiler plugin output

### DIFF
--- a/detekt-compiler-plugin/src/main/kotlin/io/github/detekt/compiler/plugin/internal/MessageCollectorExtensions.kt
+++ b/detekt-compiler-plugin/src/main/kotlin/io/github/detekt/compiler/plugin/internal/MessageCollectorExtensions.kt
@@ -32,7 +32,7 @@ fun Issue.renderAsCompilerWarningMessage(): Pair<String, CompilerMessageLocation
 
     val sourceLocation = location?.let {
         CompilerMessageLocation.create(
-            location.path,
+            entity.location.path.toString(),
             entity.location.source.line,
             entity.location.source.column,
             location.lineContent


### PR DESCRIPTION
https://github.com/detekt/detekt/pull/7206 created an issue. Path output in the CLI messages is based on a ktElement's containing file path. detekt-formatting now operates on a copy of a KtFile with a pseudo-file path which should not be displayed in CLI output. This updates so it's based on the issue location which carries the correct path.
