### PR TITLE
Make `Entity.ktElement` no nullable

### DIFF
--- a/detekt-api/build.gradle.kts
+++ b/detekt-api/build.gradle.kts
@@ -11,6 +11,7 @@ dependencies {
 
     testImplementation(projects.detektTest)
     testImplementation(libs.assertj)
+    testFixturesImplementation(projects.detektTestUtils)
 }
 
 detekt {

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Entity.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Entity.kt
@@ -15,7 +15,7 @@ class Entity(
     val name: String,
     val signature: String,
     val location: Location,
-    val ktElement: KtElement?
+    val ktElement: KtElement
 ) : Compactable {
 
     override fun compact(): String = "[$name] at ${location.compact()}"

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/CodeSmellSpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/CodeSmellSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.api
 
+import io.github.detekt.test.utils.internal.FakeKtElement
 import io.gitlab.arturbosch.detekt.test.location
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -20,16 +21,15 @@ class CodeSmellSpec {
                     text = TextLocation(0, 0),
                     path = Path("/").absolute().resolve("Users/tester/detekt/TestFile.kt"),
                 ),
-                ktElement = null
+                ktElement = FakeKtElement()
             ),
             message = "TestMessage"
         )
 
         assertThat(codeSmell.toString()).isEqualTo(
             "CodeSmell(entity=Entity(name=TestEntity, signature=TestEntitySignature, " +
-                "location=Location(source=1:1, endSource=1:1, text=0:0, " +
-                "path=${codeSmell.location.path}), ktElement=null), message=TestMessage, " +
-                "references=[])"
+                "location=Location(source=1:1, endSource=1:1, text=0:0, path=${codeSmell.location.path}), " +
+                "ktElement=FakeKtElement), message=TestMessage, references=[])"
         )
     }
 }

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/CorrectableCodeSmellSpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/CorrectableCodeSmellSpec.kt
@@ -19,7 +19,7 @@ class CorrectableCodeSmellSpec {
             "CorrectableCodeSmell(autoCorrectEnabled=true, " +
                 "entity=Entity(name=TestEntity, signature=TestEntitySignature, " +
                 "location=Location(source=1:1, endSource=1:1, text=0:0, " +
-                "path=${codeSmell.location.path}), ktElement=null), " +
+                "path=${codeSmell.location.path}), ktElement=FakeKtElement), " +
                 "message=TestMessage, references=[])"
         )
     }

--- a/detekt-api/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/test/TestFactory.kt
+++ b/detekt-api/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/test/TestFactory.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.test
 
+import io.github.detekt.test.utils.internal.FakeKtElement
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Location
@@ -90,7 +91,7 @@ fun createIssueForRelativePath(
 fun createEntity(
     signature: String = "TestEntitySignature",
     location: Location = createLocation(),
-    ktElement: KtElement? = null,
+    ktElement: KtElement = FakeKtElement(),
 ) = Entity(
     name = "TestEntity",
     signature = signature,

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Analyzer.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Analyzer.kt
@@ -119,7 +119,7 @@ internal class Analyzer(
         return (correctableRules + otherRules).flatMap { (ruleInstance, rule) ->
             rule.visitFile(file, bindingContext, compilerResources)
                 .filterNot {
-                    it.entity.ktElement?.isSuppressedBy(ruleInstance.id, rule.aliases, ruleInstance.ruleSetId) == true
+                    it.entity.ktElement.isSuppressedBy(ruleInstance.id, rule.aliases, ruleInstance.ruleSetId)
                 }
                 .filterSuppressedFindings(rule, bindingContext)
                 .map { it.toIssue(ruleInstance, rule.computeSeverity()) }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/AnnotationSuppressor.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/AnnotationSuppressor.kt
@@ -21,8 +21,7 @@ internal fun annotationSuppressorFactory(rule: Rule, bindingContext: BindingCont
     return if (annotations.isNotEmpty()) {
         Suppressor { finding ->
             val element = finding.entity.ktElement
-            element != null &&
-                element.isAnnotatedWith(AnnotationExcluder(element.containingKtFile, annotations, bindingContext))
+            element.isAnnotatedWith(AnnotationExcluder(element.containingKtFile, annotations, bindingContext))
         }
     } else {
         null

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/FunctionSuppressor.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/FunctionSuppressor.kt
@@ -25,8 +25,7 @@ internal fun functionSuppressorFactory(rule: Rule, bindingContext: BindingContex
         .map(FunctionMatcher::fromFunctionSignature)
     return if (functionMatchers.isNotEmpty()) {
         Suppressor { finding ->
-            val element = finding.entity.ktElement
-            element != null && functionSuppressor(element, bindingContext, functionMatchers)
+            functionSuppressor(finding.entity.ktElement, bindingContext, functionMatchers)
         }
     } else {
         null

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/Builders.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/Builders.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.core.suppressors
 
+import io.github.detekt.test.utils.compileContentForTest
 import io.gitlab.arturbosch.detekt.api.CodeSmell
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Finding
@@ -17,7 +18,7 @@ private fun buildEmptyEntity(): Entity = Entity(
     name = "",
     signature = "",
     location = createLocation(""),
-    ktElement = null,
+    ktElement = compileContentForTest(""),
 )
 
 internal fun buildRule(

--- a/detekt-report-html/src/main/kotlin/io/github/detekt/report/html/HtmlOutputReport.kt
+++ b/detekt-report-html/src/main/kotlin/io/github/detekt/report/html/HtmlOutputReport.kt
@@ -171,7 +171,7 @@ class HtmlOutputReport : BuiltInOutputReport, OutputReport() {
             span("message") { text(issue.message) }
         }
 
-        val psiFile = issue.entity.ktElement?.containingFile
+        val psiFile = issue.entity.ktElement.containingFile
         if (psiFile != null) {
             val lineSequence = psiFile.text.splitToSequence('\n')
             snippetCode(issue.ruleInstance.name, lineSequence, issue.location.source, issue.location.text.length())

--- a/detekt-report-html/src/test/kotlin/io/github/detekt/report/html/HtmlOutputReportSpec.kt
+++ b/detekt-report-html/src/test/kotlin/io/github/detekt/report/html/HtmlOutputReportSpec.kt
@@ -209,10 +209,12 @@ private fun createTestDetektionWithMultipleSmells(): Detektion {
         ktElement = fakeKtElement()
     )
     val entity2 = createEntity(
-        location = createLocation("src/main/com/sample/Sample2.kt", basePath, position = 22 to 2)
+        location = createLocation("src/main/com/sample/Sample2.kt", basePath, position = 22 to 2, text = 10..14),
+        ktElement = fakeKtElement()
     )
     val entity3 = createEntity(
-        location = createLocation("src/main/com/sample/Sample3.kt", basePath, position = 33 to 3)
+        location = createLocation("src/main/com/sample/Sample3.kt", basePath, position = 33 to 3, text = 10..14),
+        ktElement = fakeKtElement()
     )
 
     return TestDetektion(

--- a/detekt-report-html/src/test/resources/HtmlOutputFormatTest.html
+++ b/detekt-report-html/src/test/resources/HtmlOutputFormatTest.html
@@ -184,7 +184,16 @@
 <span class="lineno">  14 </span>val val14 = 14
 </code></pre>
       </li>
-      <li><span class="location"><PREFIX>/src/main/com/sample/Sample2.kt:22:2</span><span class="message">Issue message 2</span></li>
+      <li><span class="location"><PREFIX>/src/main/com/sample/Sample2.kt:22:2</span><span class="message">Issue message 2</span>
+        <pre><code><span class="lineno">  19 </span>val val19 = 19
+<span class="lineno">  20 </span>val val20 = 20
+<span class="lineno">  21 </span>val val21 = 21
+<span class="lineno">  22 </span>v<span class="error">al v</span>al22 = 22
+<span class="lineno">  23 </span>val val23 = 23
+<span class="lineno">  24 </span>val val24 = 24
+<span class="lineno">  25 </span>val val25 = 25
+</code></pre>
+      </li>
     </ul>
   </details>
   <h3>RuleSet2: 1</h3>
@@ -192,7 +201,14 @@
     <summary class="rule-container"><span class="rule">rule_b: 1 </span><span class="description">Description rule_b</span></summary>
 <a href="https://detekt.dev/docs/rules/ruleset2#rule_b">Documentation</a>
     <ul>
-      <li><span class="location"><PREFIX>/src/main/com/sample/Sample3.kt:33:3</span><span class="message">Issue message 3</span></li>
+      <li><span class="location"><PREFIX>/src/main/com/sample/Sample3.kt:33:3</span><span class="message">Issue message 3</span>
+        <pre><code><span class="lineno">  30 </span>val val30 = 30
+<span class="lineno">  31 </span>val val31 = 31
+<span class="lineno">  32 </span>val val32 = 32
+<span class="lineno">  33 </span>va<span class="error">l va</span>l33 = 33
+<span class="lineno">  34 </span>
+</code></pre>
+      </li>
     </ul>
   </details>
 </div>

--- a/detekt-report-md/src/main/kotlin/io/github/detekt/report/md/MdOutputReport.kt
+++ b/detekt-report-md/src/main/kotlin/io/github/detekt/report/md/MdOutputReport.kt
@@ -156,13 +156,9 @@ private fun MarkdownContent.renderIssue(issue: Issue, basePath: Path?): String {
         ""
     }
 
-    val psiFile = issue.entity.ktElement?.containingFile
-    val snippet = if (psiFile != null) {
-        val lineSequence = psiFile.text.splitToSequence('\n')
-        snippetCode(lineSequence, issue.location.source)
-    } else {
-        ""
-    }
+    val psiFile = issue.entity.ktElement.containingFile
+    val lineSequence = psiFile.text.splitToSequence('\n')
+    val snippet = snippetCode(lineSequence, issue.location.source)
 
     return "$location\n$message\n$snippet"
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/VarCouldBeValSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/VarCouldBeValSpec.kt
@@ -261,7 +261,7 @@ class VarCouldBeValSpec(val env: KotlinCoreEnvironment) {
 
             assertThat(lint).hasSize(1)
             with(lint[0].entity) {
-                assertThat(ktElement?.text).isEqualTo("var shadowed = 1")
+                assertThat(ktElement.text).isEqualTo("var shadowed = 1")
             }
         }
     }
@@ -307,7 +307,7 @@ class VarCouldBeValSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
             with(subject.compileAndLintWithContext(env, code)[0]) {
-                assertThat(entity.ktElement?.text).isEqualTo("var myVar = value")
+                assertThat(entity.ktElement.text).isEqualTo("var myVar = value")
             }
         }
     }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/MandatoryBracesLoopsSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/MandatoryBracesLoopsSpec.kt
@@ -61,7 +61,7 @@ class MandatoryBracesLoopsSpec {
             val findings = subject.compileAndLint(code)
 
             assertThat(findings).hasSize(1)
-            assertThat(findings[0].entity.ktElement?.text).isEqualTo("println(i)")
+            assertThat(findings[0].entity.ktElement.text).isEqualTo("println(i)")
         }
 
         @Test
@@ -234,7 +234,7 @@ class MandatoryBracesLoopsSpec {
             val findings = subject.compileAndLint(code)
 
             assertThat(findings).hasSize(1)
-            assertThat(findings[0].entity.ktElement?.text).isEqualTo("println()")
+            assertThat(findings[0].entity.ktElement.text).isEqualTo("println()")
         }
 
         @Test
@@ -307,7 +307,7 @@ class MandatoryBracesLoopsSpec {
             val findings = subject.compileAndLint(code)
 
             assertThat(findings).hasSize(1)
-            assertThat(findings[0].entity.ktElement?.text).isEqualTo("println()")
+            assertThat(findings[0].entity.ktElement.text).isEqualTo("println()")
         }
 
         @Test

--- a/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/internal/FakeKtElement.kt
+++ b/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/internal/FakeKtElement.kt
@@ -243,4 +243,6 @@ class FakeKtElement(private val psiFile: PsiFile = FakePsiFile("")) : KtElement 
     override fun textMatches(p0: PsiElement): Boolean = false
 
     override fun textToCharArray(): CharArray = "".toCharArray()
+
+    override fun toString() = "FakeKtElement"
 }

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/FindingsAssertions.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/FindingsAssertions.kt
@@ -84,11 +84,12 @@ class FindingsAssert(actual: List<Finding>) :
                 return this
             } else {
                 failWithMessage("Expected ${expected.size} findings but was 0")
+                // This should never execute. `failWithMessage` always throws an exception but the kotlin compiled
+                // doesn't know that. So this line below helps it.
+                error("This should never execute, if you find this please open an issue with a reproducer")
             }
         }
-        val code = requireNotNull(finding?.entity?.ktElement?.run { containingKtFile.text }) {
-            "Finding expected to provide a KtElement."
-        }
+        val code = finding.entity.ktElement.containingKtFile.text
 
         val textLocations = expected.map { snippet ->
             val index = code.indexOf(snippet)

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/RuleExtensions.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/RuleExtensions.kt
@@ -67,7 +67,7 @@ fun Rule.lint(ktFile: KtFile): List<Finding> = visitFile(ktFile).filterSuppresse
 
 private fun List<Finding>.filterSuppressed(rule: Rule): List<Finding> =
     filterNot {
-        it.entity.ktElement?.isSuppressedBy(rule.ruleName.value, rule.aliases, RuleSet.Id("NoARuleSetId")) == true
+        it.entity.ktElement.isSuppressedBy(rule.ruleName.value, rule.aliases, RuleSet.Id("NoARuleSetId"))
     }
 
 private val Rule.aliases: Set<String> get() = config.valueOrDefault(Config.ALIASES_KEY, emptyList<String>()).toSet()


### PR DESCRIPTION
There is not a good reason to keep `Entity.ktElement` nullable. It just make the API messier and provide no value.