### PR TITLE
Remove getLineAndColumnInPsiFile function

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -212,7 +212,6 @@ style:
       - 'java.net.URL.openStream'
       - 'java.lang.Class.getResourceAsStream'
       - 'java.lang.ClassLoader.getResourceAsStream'
-      - 'org.jetbrains.kotlin.diagnostics.DiagnosticUtils.getLineAndColumnInPsiFile'
   ForbiddenVoid:
     active: true
     ignoreOverridden: true

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Location.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Location.kt
@@ -2,9 +2,9 @@ package io.gitlab.arturbosch.detekt.api
 
 import dev.drewhamilton.poko.Poko
 import io.github.detekt.psi.absolutePath
-import io.github.detekt.psi.getLineAndColumnInPsiFile
 import org.jetbrains.kotlin.com.intellij.openapi.util.TextRange
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
+import org.jetbrains.kotlin.diagnostics.DiagnosticUtils.getLineAndColumnInPsiFile
 import org.jetbrains.kotlin.diagnostics.PsiDiagnosticUtils
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.psiUtil.endOffset
@@ -58,10 +58,12 @@ class Location(
                 TextRange(element.textRange.endOffset + offset, element.textRange.endOffset + offset)
             )
 
-        private fun lineAndColumn(element: PsiElement, range: TextRange): PsiDiagnosticUtils.LineAndColumn {
-            return getLineAndColumnInPsiFile(element.containingFile, range)
-                ?: PsiDiagnosticUtils.LineAndColumn(1, 1, null)
-        }
+        private fun lineAndColumn(element: PsiElement, range: TextRange): PsiDiagnosticUtils.LineAndColumn =
+            if (element.containingFile.text.isNotEmpty()) {
+                getLineAndColumnInPsiFile(element.containingFile, range)
+            } else {
+                PsiDiagnosticUtils.LineAndColumn(1, 1, null)
+            }
     }
 }
 

--- a/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/LinesOfCode.kt
+++ b/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/LinesOfCode.kt
@@ -1,6 +1,5 @@
 package io.github.detekt.metrics
 
-import io.github.detekt.psi.getLineAndColumnInPsiFile
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.psi.PsiComment
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
@@ -8,6 +7,7 @@ import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafElement
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.PsiCommentImpl
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.PsiWhiteSpaceImpl
+import org.jetbrains.kotlin.diagnostics.DiagnosticUtils
 import org.jetbrains.kotlin.kdoc.psi.api.KDoc
 import org.jetbrains.kotlin.kdoc.psi.api.KDocElement
 import org.jetbrains.kotlin.kdoc.psi.impl.KDocElementImpl
@@ -41,7 +41,7 @@ fun KtElement.linesOfCode(inFile: KtFile = this.containingKtFile): Int =
         .distinct()
         .count()
 
-fun ASTNode.line(inFile: KtFile): Int = getLineAndColumnInPsiFile(inFile, this.textRange)?.line ?: -1
+fun ASTNode.line(inFile: KtFile): Int = DiagnosticUtils.getLineAndColumnInPsiFile(inFile, this.textRange).line
 
 private val comments: Set<Class<out PsiElement>> = setOf(
     PsiWhiteSpace::class.java,

--- a/detekt-psi-utils/api/detekt-psi-utils.api
+++ b/detekt-psi-utils/api/detekt-psi-utils.api
@@ -18,7 +18,6 @@ public final class io/github/detekt/psi/KtFilesKt {
 	public static final fun absolutePath (Lorg/jetbrains/kotlin/psi/KtFile;)Ljava/nio/file/Path;
 	public static final fun fileNameWithoutSuffix (Lorg/jetbrains/kotlin/com/intellij/psi/PsiFile;Ljava/util/List;)Ljava/lang/String;
 	public static synthetic fun fileNameWithoutSuffix$default (Lorg/jetbrains/kotlin/com/intellij/psi/PsiFile;Ljava/util/List;ILjava/lang/Object;)Ljava/lang/String;
-	public static final fun getLineAndColumnInPsiFile (Lorg/jetbrains/kotlin/com/intellij/psi/PsiFile;Lorg/jetbrains/kotlin/com/intellij/openapi/util/TextRange;)Lorg/jetbrains/kotlin/diagnostics/PsiDiagnosticUtils$LineAndColumn;
 }
 
 public final class io/gitlab/arturbosch/detekt/rules/AllowedExceptionNamePatternKt {

--- a/detekt-psi-utils/src/main/kotlin/io/github/detekt/psi/KtFiles.kt
+++ b/detekt-psi-utils/src/main/kotlin/io/github/detekt/psi/KtFiles.kt
@@ -1,9 +1,6 @@
 package io.github.detekt.psi
 
-import org.jetbrains.kotlin.com.intellij.openapi.util.TextRange
 import org.jetbrains.kotlin.com.intellij.psi.PsiFile
-import org.jetbrains.kotlin.diagnostics.DiagnosticUtils
-import org.jetbrains.kotlin.diagnostics.PsiDiagnosticUtils
 import org.jetbrains.kotlin.psi.KtFile
 import java.nio.file.Path
 import kotlin.io.path.Path
@@ -29,18 +26,6 @@ fun PsiFile.absolutePath(): Path = Path(virtualFile.path)
 
 // KtFile.virtualFilePath is cached so should be a tiny bit more performant when called repeatedly for the same file.
 fun KtFile.absolutePath(): Path = Path(virtualFilePath)
-
-// #3317 If any rule mutates the PsiElement, searching the original PsiElement may throw an exception.
-fun getLineAndColumnInPsiFile(file: PsiFile, range: TextRange): PsiDiagnosticUtils.LineAndColumn? {
-    return if (file.textLength == 0) {
-        null
-    } else {
-        runCatching {
-            @Suppress("ForbiddenMethodCall")
-            DiagnosticUtils.getLineAndColumnInPsiFile(file, range)
-        }.getOrNull()
-    }
-}
 
 private fun buildPlatformSpecificSuffixes(platforms: List<String>): List<String> =
     platforms.map { platform -> ".$platform.kt" }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MultilineRawStringIndentation.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MultilineRawStringIndentation.kt
@@ -1,7 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
 import io.github.detekt.psi.absolutePath
-import io.github.detekt.psi.getLineAndColumnInPsiFile
 import io.gitlab.arturbosch.detekt.api.CodeSmell
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Configuration
@@ -12,6 +11,7 @@ import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.api.TextLocation
 import io.gitlab.arturbosch.detekt.api.config
 import org.jetbrains.kotlin.com.intellij.psi.PsiFile
+import org.jetbrains.kotlin.diagnostics.DiagnosticUtils
 import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.psi.KtLiteralStringTemplateEntry
 import org.jetbrains.kotlin.psi.KtStringTemplateEntry
@@ -75,7 +75,7 @@ class MultilineRawStringIndentation(config: Config) : Rule(
             return
         }
 
-        val lineAndColumn = getLineAndColumnInPsiFile(expression.containingFile, expression.textRange) ?: return
+        val lineAndColumn = DiagnosticUtils.getLineAndColumnInPsiFile(expression.containingFile, expression.textRange)
         val lineCount = expression.text.lines().count()
 
         expression.checkIndentation(

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/NewLineAtEndOfFile.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/NewLineAtEndOfFile.kt
@@ -1,7 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
 import io.github.detekt.psi.absolutePath
-import io.github.detekt.psi.getLineAndColumnInPsiFile
 import io.gitlab.arturbosch.detekt.api.ActiveByDefault
 import io.gitlab.arturbosch.detekt.api.CodeSmell
 import io.gitlab.arturbosch.detekt.api.Config
@@ -11,6 +10,7 @@ import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.api.TextLocation
 import org.jetbrains.kotlin.com.intellij.openapi.util.TextRange
+import org.jetbrains.kotlin.diagnostics.DiagnosticUtils
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.psiUtil.endOffset
 
@@ -26,11 +26,11 @@ class NewLineAtEndOfFile(config: Config) : Rule(
     override fun visitKtFile(file: KtFile) {
         val text = file.text
         if (text.isNotEmpty() && !text.endsWith('\n')) {
-            val coords = getLineAndColumnInPsiFile(
+            val coords = DiagnosticUtils.getLineAndColumnInPsiFile(
                 file,
                 TextRange(file.endOffset, file.endOffset)
             )
-            val sourceLocation = SourceLocation(coords?.line ?: 0, coords?.column ?: 0)
+            val sourceLocation = SourceLocation(coords.line, coords.column)
             val textLocation = TextLocation(file.endOffset, file.endOffset)
             val location = Location(
                 source = sourceLocation,


### PR DESCRIPTION
This was introduced to work around issues with mutated PSI. This is no longer an issue since #7206. Because the formatting rule set operates on a copy of the PsiFile and not the original PsiFile the original PsiFile will never be modified, so the protection offered by this function is not needed.

This also masks some issues with rule implementations due to use of `runCatching` - MaxLineLength was previously raising `IndexOutOfBoundException` when `DiagnosticUtils.getLineAndColumnInPsiFile` was called, but it was caught by `runCatching` and the exception was hidden. Avoiding that behaviour will avoid masking those issues in future.