### PR TITLE
Run same rule multiple times with different configuration

### DIFF
--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt
@@ -166,7 +166,7 @@ class CliArgs {
 
     @Parameter(
         names = ["--run-rule"],
-        description = "Specify a rule by [RuleSet:Rule] pattern and run it on input.",
+        description = "Specify a rule by [RuleSet:RuleId] pattern and run it on input.",
         hidden = true
     )
     var runRule: String? = null

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Spec.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Spec.kt
@@ -5,7 +5,6 @@ import io.github.detekt.tooling.api.spec.RulesSpec
 import io.github.detekt.tooling.api.spec.RulesSpec.RunPolicy.DisableDefaultRuleSets
 import io.github.detekt.tooling.api.spec.RulesSpec.RunPolicy.NoRestrictions
 import io.github.detekt.utils.PathFilters
-import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.RuleSet
 import java.nio.file.Path
 import kotlin.io.path.ExperimentalPathApi
@@ -103,5 +102,5 @@ private fun CliArgs.toRunPolicy(): RulesSpec.RunPolicy {
     val parts = runRule?.split(":")
         ?: return if (disableDefaultRuleSets) DisableDefaultRuleSets else NoRestrictions
     require(parts.size == 2) { "Pattern 'RuleSetId:RuleName' expected." }
-    return RulesSpec.RunPolicy.RestrictToSingleRule(RuleSet.Id(parts[0]), Rule.Name(parts[1]))
+    return RulesSpec.RunPolicy.RestrictToSingleRule(RuleSet.Id(parts[0]), parts[1])
 }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/validation/InvalidPropertiesConfigValidator.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/validation/InvalidPropertiesConfigValidator.kt
@@ -2,6 +2,7 @@ package io.gitlab.arturbosch.detekt.core.config.validation
 
 import io.gitlab.arturbosch.detekt.api.Notification
 import io.gitlab.arturbosch.detekt.core.config.YamlConfig
+import io.gitlab.arturbosch.detekt.core.extractRuleName
 import io.gitlab.arturbosch.detekt.core.util.SimpleNotification
 
 internal class InvalidPropertiesConfigValidator(
@@ -46,7 +47,7 @@ internal class InvalidPropertiesConfigValidator(
         return notifications
     }
 
-    @Suppress("UNCHECKED_CAST")
+    @Suppress("UNCHECKED_CAST", "ReturnCount")
     private fun checkProp(
         propertyName: String,
         propertyPath: String,
@@ -54,7 +55,10 @@ internal class InvalidPropertiesConfigValidator(
         baseline: Map<String, Any>
     ): List<Notification> {
         if (!baseline.contains(propertyName)) {
-            return listOf(propertyDoesNotExists(propertyPath))
+            val ruleName = extractRuleName(propertyName)
+            if (ruleName == null || !baseline.contains(ruleName.value)) {
+                return listOf(propertyDoesNotExists(propertyPath))
+            }
         }
         if (configToValidate[propertyName] is String && baseline[propertyName] is List<*>) {
             return listOf(propertyShouldBeAnArray(propertyPath))

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/rules/RuleSets.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/rules/RuleSets.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.api.RuleSetProvider
 import io.gitlab.arturbosch.detekt.api.internal.DefaultRuleSetProvider
 import io.gitlab.arturbosch.detekt.core.ProcessingSettings
 import io.gitlab.arturbosch.detekt.core.extensions.LIST_ITEM_SPACING
+import io.gitlab.arturbosch.detekt.core.extractRuleName
 import java.util.ServiceLoader
 
 fun ProcessingSettings.createRuleProviders(): List<RuleSetProvider> {
@@ -20,9 +21,12 @@ fun ProcessingSettings.createRuleProviders(): List<RuleSetProvider> {
 
         is RulesSpec.RunPolicy.RestrictToSingleRule -> {
             val ruleSetId = runPolicy.ruleSetId
-            val ruleName = runPolicy.ruleName
+            val ruleId = runPolicy.ruleId
             val realProvider = requireNotNull(ruleSetProviders.find { it.ruleSetId == ruleSetId }) {
                 "There was no rule set with id '$ruleSetId'."
+            }
+            val ruleName = requireNotNull(extractRuleName(ruleId)) {
+                "There was not rule '$ruleId' in rule set '$ruleSetId'."
             }
             listOf(SingleRuleProvider(ruleName, realProvider))
         }

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/AnalyzerSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/AnalyzerSpec.kt
@@ -136,6 +136,30 @@ class AnalyzerSpec(val env: KotlinCoreEnvironment) {
         }
 
         @Test
+        fun `with multiple instances of same rule`() {
+            val testFile = path.resolve("Test.kt")
+            val output = StringPrintStream()
+            val settings = createProcessingSettings(
+                testFile,
+                yamlConfigFromContent(
+                    """
+                        custom:
+                          MaxLineLength/foo:
+                            active: true
+                            maxLineLength: 30
+                          MaxLineLength/bar:
+                            active: true
+                            maxLineLength: 30
+                    """.trimIndent()
+                ),
+                outputChannel = output,
+            )
+            val analyzer = Analyzer(settings, listOf(CustomRuleSetProvider()), emptyList())
+
+            assertThat(settings.use { analyzer.run(listOf(compileForTest(testFile))) }).hasSize(2)
+        }
+
+        @Test
         fun `with findings and context binding`() {
             val testFile = path.resolve("Test.kt")
             val output = StringPrintStream()

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/validation/InvalidPropertiesConfigValidatorSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/validation/InvalidPropertiesConfigValidatorSpec.kt
@@ -40,6 +40,12 @@ internal class InvalidPropertiesConfigValidatorSpec {
     }
 
     @Test
+    fun `passes for rules defined with rule id`() {
+        val result = subject.validate(yamlConfig("config_validation/rule-id.yml"))
+        assertThat(result).isEmpty()
+    }
+
+    @Test
     fun `reports different rule set name`() {
         val result = subject.validate(yamlConfig("config_validation/other-ruleset-name.yml"))
         assertThat(result).contains(propertyDoesNotExists("code-smell"))

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/rules/RuleSetsSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/rules/RuleSetsSpec.kt
@@ -10,6 +10,8 @@ import io.gitlab.arturbosch.detekt.core.tooling.withSettings
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 
 class RuleSetsSpec {
 
@@ -45,10 +47,11 @@ class RuleSetsSpec {
             .containsExactlyInAnyOrder("sample-rule-set")
     }
 
-    @Test
-    fun `only loads the provider with the selected rule`() {
+    @ParameterizedTest
+    @ValueSource(strings = ["MagicNumber", "MagicNumber/id"])
+    fun `only loads the provider with the selected rule`(ruleId: String) {
         val providers = createNullLoggingSpec {
-            rules { runPolicy = RestrictToSingleRule(RuleSet.Id("style"), Rule.Name("MagicNumber")) }
+            rules { runPolicy = RestrictToSingleRule(RuleSet.Id("style"), ruleId) }
         }
             .withSettings { createRuleProviders() }
 
@@ -58,11 +61,12 @@ class RuleSetsSpec {
             .containsOnlyKeys(Rule.Name("MagicNumber"))
     }
 
-    @Test
-    fun `throws when rule set doesn't exist`() {
+    @ParameterizedTest
+    @ValueSource(strings = ["MagicNumber", "MagicNumber/id"])
+    fun `throws when rule set doesn't exist`(ruleId: String) {
         assertThatThrownBy {
             createNullLoggingSpec {
-                rules { runPolicy = RestrictToSingleRule(RuleSet.Id("foo"), Rule.Name("MagicNumber")) }
+                rules { runPolicy = RestrictToSingleRule(RuleSet.Id("foo"), ruleId) }
             }
                 .withSettings { createRuleProviders() }
         }

--- a/detekt-core/src/test/resources/config_validation/rule-id.yml
+++ b/detekt-core/src/test/resources/config_validation/rule-id.yml
@@ -1,0 +1,8 @@
+style:
+  active: true
+  WildcardImport:
+    active: true
+  WildcardImport/extra:
+    active: true
+  WildcardImport/extra2:
+    active: true

--- a/detekt-tooling/api/detekt-tooling.api
+++ b/detekt-tooling/api/detekt-tooling.api
@@ -213,8 +213,8 @@ public final class io/github/detekt/tooling/api/spec/RulesSpec$RunPolicy$NoRestr
 }
 
 public final class io/github/detekt/tooling/api/spec/RulesSpec$RunPolicy$RestrictToSingleRule : io/github/detekt/tooling/api/spec/RulesSpec$RunPolicy {
-	public fun <init> (Lio/gitlab/arturbosch/detekt/api/RuleSet$Id;Lio/gitlab/arturbosch/detekt/api/Rule$Name;)V
-	public final fun getRuleName ()Lio/gitlab/arturbosch/detekt/api/Rule$Name;
+	public fun <init> (Lio/gitlab/arturbosch/detekt/api/RuleSet$Id;Ljava/lang/String;)V
+	public final fun getRuleId ()Ljava/lang/String;
 	public final fun getRuleSetId ()Lio/gitlab/arturbosch/detekt/api/RuleSet$Id;
 }
 

--- a/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/api/spec/RulesSpec.kt
+++ b/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/api/spec/RulesSpec.kt
@@ -67,6 +67,6 @@ interface RulesSpec {
         /**
          * Run a single rule.
          */
-        class RestrictToSingleRule(val ruleSetId: RuleSet.Id, val ruleName: Rule.Name) : RunPolicy()
+        class RestrictToSingleRule(val ruleSetId: RuleSet.Id, val ruleId: String) : RunPolicy()
     }
 }


### PR DESCRIPTION
With this PR we finally are able to run the same run multiple times with different configurations.

The most important part to discuss, I think, is if we like how those new instances are configured.

Right now if you want to create a new instance of the same rule you should add on your `detekt.yml` something like this:

```yaml
styles:
  ForbiddenImport/compose:
    active: true
    ...
```

Close #6738