### PR TITLE
Simplify implementation of InvalidRange rule

### DIFF
--- a/detekt-psi-utils/api/detekt-psi-utils.api
+++ b/detekt-psi-utils/api/detekt-psi-utils.api
@@ -42,7 +42,6 @@ public final class io/gitlab/arturbosch/detekt/rules/IsPartOfUtilsKt {
 
 public final class io/gitlab/arturbosch/detekt/rules/JunkKt {
 	public static final fun companionObject (Lorg/jetbrains/kotlin/psi/KtClass;)Lorg/jetbrains/kotlin/psi/KtObjectDeclaration;
-	public static final fun getIntValueForPsiElement (Lorg/jetbrains/kotlin/com/intellij/psi/PsiElement;)Ljava/lang/Integer;
 	public static final fun hasCommentInside (Lorg/jetbrains/kotlin/com/intellij/psi/PsiElement;)Z
 	public static final fun hasCommentInside (Lorg/jetbrains/kotlin/psi/KtClassOrObject;)Z
 	public static final fun isUsedForNesting (Lorg/jetbrains/kotlin/psi/KtCallExpression;)Z

--- a/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/Junk.kt
+++ b/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/Junk.kt
@@ -7,7 +7,6 @@ import org.jetbrains.kotlin.psi.KtBlockExpression
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtClassOrObject
-import org.jetbrains.kotlin.psi.KtConstantExpression
 import org.jetbrains.kotlin.psi.KtQualifiedExpression
 import org.jetbrains.kotlin.psi.KtTreeVisitorVoid
 import org.jetbrains.kotlin.psi.psiUtil.getCallNameExpression
@@ -29,10 +28,6 @@ fun PsiElement.hasCommentInside(): Boolean {
         }
     })
     return getUserData(commentKey) == true
-}
-
-fun getIntValueForPsiElement(element: PsiElement): Int? {
-    return (element as? KtConstantExpression)?.text?.toIntOrNull()
 }
 
 fun KtClass.companionObject() = this.companionObjects.singleOrNull { it.isCompanion() }


### PR DESCRIPTION
Also allows removal of `getIntValueForPsiElement` function - technically a breaking change however this function is so specific I'd be surprised if it's used anywhere else.