### PR TITLE
Remove isUsedForNesting function

### DIFF
--- a/detekt-psi-utils/api/detekt-psi-utils.api
+++ b/detekt-psi-utils/api/detekt-psi-utils.api
@@ -45,7 +45,6 @@ public final class io/gitlab/arturbosch/detekt/rules/JunkKt {
 	public static final fun getIntValueForPsiElement (Lorg/jetbrains/kotlin/com/intellij/psi/PsiElement;)Ljava/lang/Integer;
 	public static final fun hasCommentInside (Lorg/jetbrains/kotlin/com/intellij/psi/PsiElement;)Z
 	public static final fun hasCommentInside (Lorg/jetbrains/kotlin/psi/KtClassOrObject;)Z
-	public static final fun isUsedForNesting (Lorg/jetbrains/kotlin/psi/KtCallExpression;)Z
 	public static final fun receiverIsUsed (Lorg/jetbrains/kotlin/psi/KtCallExpression;Lorg/jetbrains/kotlin/resolve/BindingContext;)Z
 }
 

--- a/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/Junk.kt
+++ b/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/Junk.kt
@@ -10,14 +10,8 @@ import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.KtConstantExpression
 import org.jetbrains.kotlin.psi.KtQualifiedExpression
 import org.jetbrains.kotlin.psi.KtTreeVisitorVoid
-import org.jetbrains.kotlin.psi.psiUtil.getCallNameExpression
 import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.bindingContextUtil.isUsedAsExpression
-
-fun KtCallExpression.isUsedForNesting(): Boolean = when (getCallNameExpression()?.text) {
-    "run", "let", "apply", "with", "use", "forEach" -> true
-    else -> false
-}
 
 fun KtClassOrObject.hasCommentInside() = this.body?.hasCommentInside() ?: false
 

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedBlockDepth.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedBlockDepth.kt
@@ -7,7 +7,6 @@ import io.gitlab.arturbosch.detekt.api.DetektVisitor
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.config
-import io.gitlab.arturbosch.detekt.rules.isUsedForNesting
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtContainerNodeForControlStructureBody
 import org.jetbrains.kotlin.psi.KtIfExpression
@@ -16,6 +15,7 @@ import org.jetbrains.kotlin.psi.KtLoopExpression
 import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.KtTryExpression
 import org.jetbrains.kotlin.psi.KtWhenExpression
+import org.jetbrains.kotlin.psi.psiUtil.getCallNameExpression
 
 /**
  * This rule reports excessive nesting depth in functions. Excessively nested code becomes harder to read and increases
@@ -110,5 +110,8 @@ class NestedBlockDepth(config: Config) : Rule(
                 }
             }
         }
+
+        private fun KtCallExpression.isUsedForNesting(): Boolean =
+            getCallNameExpression()?.text in setOf("run", "let", "apply", "with", "use", "forEach")
     }
 }


### PR DESCRIPTION
This function is not general purpose (used in a single rule) so can be removed from the API.

Technically breaking change but this is very unlikely to be used in 3rd party rules.