### PR TITLE
Remove hasCommentInside functions

### DIFF
--- a/detekt-psi-utils/api/detekt-psi-utils.api
+++ b/detekt-psi-utils/api/detekt-psi-utils.api
@@ -42,8 +42,6 @@ public final class io/gitlab/arturbosch/detekt/rules/IsPartOfUtilsKt {
 
 public final class io/gitlab/arturbosch/detekt/rules/JunkKt {
 	public static final fun companionObject (Lorg/jetbrains/kotlin/psi/KtClass;)Lorg/jetbrains/kotlin/psi/KtObjectDeclaration;
-	public static final fun hasCommentInside (Lorg/jetbrains/kotlin/com/intellij/psi/PsiElement;)Z
-	public static final fun hasCommentInside (Lorg/jetbrains/kotlin/psi/KtClassOrObject;)Z
 	public static final fun receiverIsUsed (Lorg/jetbrains/kotlin/psi/KtCallExpression;Lorg/jetbrains/kotlin/resolve/BindingContext;)Z
 }
 

--- a/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/Junk.kt
+++ b/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/Junk.kt
@@ -1,28 +1,11 @@
 package io.gitlab.arturbosch.detekt.rules
 
-import org.jetbrains.kotlin.com.intellij.openapi.util.Key
-import org.jetbrains.kotlin.com.intellij.psi.PsiComment
-import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.psi.KtBlockExpression
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtClass
-import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.KtQualifiedExpression
-import org.jetbrains.kotlin.psi.KtTreeVisitorVoid
 import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.bindingContextUtil.isUsedAsExpression
-
-fun KtClassOrObject.hasCommentInside() = this.body?.hasCommentInside() ?: false
-
-fun PsiElement.hasCommentInside(): Boolean {
-    val commentKey = Key<Boolean>("comment")
-    this.acceptChildren(object : KtTreeVisitorVoid() {
-        override fun visitComment(comment: PsiComment) {
-            putUserData(commentKey, true)
-        }
-    })
-    return getUserData(commentKey) == true
-}
 
 fun KtClass.companionObject() = this.companionObjects.singleOrNull { it.isCompanion() }
 

--- a/detekt-rules-empty/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyClassBlock.kt
+++ b/detekt-rules-empty/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyClassBlock.kt
@@ -4,7 +4,7 @@ import io.gitlab.arturbosch.detekt.api.ActiveByDefault
 import io.gitlab.arturbosch.detekt.api.CodeSmell
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Entity
-import io.gitlab.arturbosch.detekt.rules.hasCommentInside
+import io.gitlab.arturbosch.detekt.rules.empty.internal.hasCommentInside
 import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.psiUtil.isObjectLiteral
 

--- a/detekt-rules-empty/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyRule.kt
+++ b/detekt-rules-empty/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyRule.kt
@@ -4,7 +4,7 @@ import io.gitlab.arturbosch.detekt.api.CodeSmell
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Rule
-import io.gitlab.arturbosch.detekt.rules.hasCommentInside
+import io.gitlab.arturbosch.detekt.rules.empty.internal.hasCommentInside
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
 import org.jetbrains.kotlin.lexer.KtSingleValueToken
 import org.jetbrains.kotlin.psi.KtBlockExpression

--- a/detekt-rules-empty/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/internal/ContainsComments.kt
+++ b/detekt-rules-empty/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/internal/ContainsComments.kt
@@ -1,0 +1,19 @@
+package io.gitlab.arturbosch.detekt.rules.empty.internal
+
+import org.jetbrains.kotlin.com.intellij.openapi.util.Key
+import org.jetbrains.kotlin.com.intellij.psi.PsiComment
+import org.jetbrains.kotlin.com.intellij.psi.PsiElement
+import org.jetbrains.kotlin.psi.KtClassOrObject
+import org.jetbrains.kotlin.psi.KtTreeVisitorVoid
+
+fun KtClassOrObject.hasCommentInside() = this.body?.hasCommentInside() ?: false
+
+fun PsiElement.hasCommentInside(): Boolean {
+    val commentKey = Key<Boolean>("comment")
+    this.acceptChildren(object : KtTreeVisitorVoid() {
+        override fun visitComment(comment: PsiComment) {
+            putUserData(commentKey, true)
+        }
+    })
+    return getUserData(commentKey) == true
+}

--- a/detekt-rules-empty/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/internal/ContainsComments.kt
+++ b/detekt-rules-empty/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/internal/ContainsComments.kt
@@ -1,19 +1,10 @@
 package io.gitlab.arturbosch.detekt.rules.empty.internal
 
-import org.jetbrains.kotlin.com.intellij.openapi.util.Key
 import org.jetbrains.kotlin.com.intellij.psi.PsiComment
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.psi.KtClassOrObject
-import org.jetbrains.kotlin.psi.KtTreeVisitorVoid
+import org.jetbrains.kotlin.psi.psiUtil.getChildrenOfType
 
 fun KtClassOrObject.hasCommentInside() = this.body?.hasCommentInside() ?: false
 
-fun PsiElement.hasCommentInside(): Boolean {
-    val commentKey = Key<Boolean>("comment")
-    this.acceptChildren(object : KtTreeVisitorVoid() {
-        override fun visitComment(comment: PsiComment) {
-            putUserData(commentKey, true)
-        }
-    })
-    return getUserData(commentKey) == true
-}
+fun PsiElement.hasCommentInside(): Boolean = getChildrenOfType<PsiComment>().isNotEmpty()


### PR DESCRIPTION
These functions are not general purpose (only used in a couple of rules that check for empty blocks) so can be removed from the API.

Technically breaking change but this is very unlikely to be used in 3rd party rules.