### PR TITLE
Faster `InvalidPackageDeclaration`

### DIFF
--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/InvalidPackageDeclaration.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/InvalidPackageDeclaration.kt
@@ -10,7 +10,7 @@ import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.config
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.psi.KtElement
-import org.jetbrains.kotlin.psi.KtPackageDirective
+import org.jetbrains.kotlin.psi.KtFile
 
 /**
  * Reports when the file location does not match the declared package.
@@ -29,8 +29,8 @@ class InvalidPackageDeclaration(config: Config) : Rule(
     @Configuration("requires the declaration to start with the specified rootPackage")
     private val requireRootInDeclaration: Boolean by config(false)
 
-    override fun visitPackageDirective(directive: KtPackageDirective) {
-        super.visitPackageDirective(directive)
+    override fun visit(root: KtFile) {
+        val directive = root.packageDirective ?: return
         val packageName = directive.fqName
         if (!packageName.isRoot) {
             val rootPackageName = FqName(rootPackage)


### PR DESCRIPTION
We know that visit a `KtFile` is not free at all. But we don't have any values to see if this is really faster or not.

My next project on detekt is going to be a tool to monitor the detekt performance. Once we have that we could take a look at the `Rule` implementation because I think that it pushes to overuse the `visit` pattern everywhere even in cases that is not needed (for example the one of this PR)

I left this PR as draft because I want to know how much faster is `InvalidPackageDeclaration` with this change.