### PR TITLE
`IgnoredReturnValue` honors `ignoreReturnValueAnnotations` on parent

### DIFF
--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValue.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValue.kt
@@ -116,16 +116,15 @@ class IgnoredReturnValue(config: Config) : Rule(
 
         if (ignoreFunctionCall.any { it.match(resultingDescriptor) }) return
 
-        val annotations = resultingDescriptor.annotations + resultingDescriptor.findPackage().annotations
-        if (resultingDescriptor.annotations.any { it in ignoreReturnValueAnnotations } ||
-            resultingDescriptor.findPackage().annotations.any { it in ignoreReturnValueAnnotations }
-        ) {
-            return
+        val annotations = buildList {
+            addAll(resultingDescriptor.annotations)
+            addAll(resultingDescriptor.findPackage().annotations)
+            addAll(resultingDescriptor.containingDeclaration.annotations)
         }
+        if (annotations.any { it in ignoreReturnValueAnnotations }) return
         if (restrictToConfig &&
             resultingDescriptor.returnType !in returnValueTypes &&
-            annotations.none { it in returnValueAnnotations } &&
-            resultingDescriptor.containingDeclaration.annotations.none { it in returnValueAnnotations }
+            annotations.none { it in returnValueAnnotations }
         ) {
             return
         }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValueSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValueSpec.kt
@@ -976,6 +976,33 @@ class IgnoredReturnValueSpec {
         }
 
         @Test
+        fun `does not report when a function has a custom annotation on parent`() {
+            val code = """
+                package foo
+                
+                annotation class CustomIgnoreReturn
+                
+                @CustomIgnoreReturn
+                object Foo {
+                    fun listOfChecked(value: String) = listOf(value)
+                }
+                
+                fun foo() : Int {
+                    Foo.listOfChecked("hello")
+                    return 42
+                }
+            """.trimIndent()
+            val rule = IgnoredReturnValue(
+                TestConfig(
+                    "ignoreReturnValueAnnotations" to listOf("*.CustomIgnoreReturn"),
+                    "restrictToConfig" to false,
+                )
+            )
+            val findings = rule.compileAndLintWithContext(env, code)
+            assertThat(findings).isEmpty()
+        }
+
+        @Test
         fun `does not report when a function is in ignoreFunctionCall`() {
             val code = """
                 package foo


### PR DESCRIPTION
I was looking at #6499 with no success but I found this little bug.

Also, I think, that now the code is a bit easier to read.