### PR TITLE
Add `ObjectPropertyName` as alias for `ObjectPropertyNaming`

### DIFF
--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNaming.kt
@@ -24,6 +24,8 @@ class ObjectPropertyNaming(config: Config) : Rule(
     "Property names inside objects should follow the naming convention set in the projects configuration."
 ) {
 
+    override val defaultRuleIdAliases: Set<String> = setOf("ObjectPropertyName")
+
     @Configuration("naming pattern")
     private val constantPattern: Regex by config("[A-Za-z][_A-Za-z0-9]*") { it.toRegex() }
 


### PR DESCRIPTION
Fixes https://github.com/detekt/detekt/issues/7265
