### PR TITLE
Update noncompliant code of `ForbiddenMethodCall`

### DIFF
--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCall.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCall.kt
@@ -33,7 +33,6 @@ import org.jetbrains.kotlin.resolve.descriptorUtil.overriddenTreeUniqueAsSequenc
  * of unstable, experimental or deprecated methods, especially for methods imported from external libraries.
  *
  * <noncompliant>
- * import java.lang.System
  * fun main() {
  *   println()
  *   val myPrintln : () -> Unit = ::println

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCall.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCall.kt
@@ -35,8 +35,9 @@ import org.jetbrains.kotlin.resolve.descriptorUtil.overriddenTreeUniqueAsSequenc
  * <noncompliant>
  * import java.lang.System
  * fun main() {
- *    System.gc()
- *    System::gc
+ *   println()
+ *   val myPrintln : () -> Unit = ::println
+ *   kotlin.io.print("Hello, World!")
  * }
  * </noncompliant>
  *

--- a/website/versioned_docs/version-1.21.0/rules/style.md
+++ b/website/versioned_docs/version-1.21.0/rules/style.md
@@ -506,7 +506,9 @@ Detekt will then report all method invocations that are forbidden.
 ```kotlin
 import java.lang.System
 fun main() {
-    System.gc()
+    println()
+    val myPrintln : () -> Unit = ::println
+    kotlin.io.print("Hello, World!")
 }
 ```
 

--- a/website/versioned_docs/version-1.21.0/rules/style.md
+++ b/website/versioned_docs/version-1.21.0/rules/style.md
@@ -504,7 +504,6 @@ Detekt will then report all method invocations that are forbidden.
 #### Noncompliant Code:
 
 ```kotlin
-import java.lang.System
 fun main() {
     println()
     val myPrintln : () -> Unit = ::println

--- a/website/versioned_docs/version-1.22.0/rules/style.md
+++ b/website/versioned_docs/version-1.22.0/rules/style.md
@@ -545,7 +545,6 @@ Detekt will then report all method or constructor invocations that are forbidden
 #### Noncompliant Code:
 
 ```kotlin
-import java.lang.System
 fun main() {
     println()
     val myPrintln : () -> Unit = ::println

--- a/website/versioned_docs/version-1.22.0/rules/style.md
+++ b/website/versioned_docs/version-1.22.0/rules/style.md
@@ -547,8 +547,9 @@ Detekt will then report all method or constructor invocations that are forbidden
 ```kotlin
 import java.lang.System
 fun main() {
-    System.gc()
-    System::gc
+    println()
+    val myPrintln : () -> Unit = ::println
+    kotlin.io.print("Hello, World!")
 }
 ```
 

--- a/website/versioned_docs/version-1.23.0/rules/style.md
+++ b/website/versioned_docs/version-1.23.0/rules/style.md
@@ -992,8 +992,9 @@ of unstable, experimental or deprecated methods, especially for methods imported
 ```kotlin
 import java.lang.System
 fun main() {
-    System.gc()
-    System::gc
+    println()
+    val myPrintln : () -> Unit = ::println
+    kotlin.io.print("Hello, World!")
 }
 ```
 

--- a/website/versioned_docs/version-1.23.0/rules/style.md
+++ b/website/versioned_docs/version-1.23.0/rules/style.md
@@ -990,7 +990,6 @@ of unstable, experimental or deprecated methods, especially for methods imported
 #### Noncompliant Code:
 
 ```kotlin
-import java.lang.System
 fun main() {
     println()
     val myPrintln : () -> Unit = ::println

--- a/website/versioned_docs/version-1.23.1/rules/style.md
+++ b/website/versioned_docs/version-1.23.1/rules/style.md
@@ -992,8 +992,9 @@ of unstable, experimental or deprecated methods, especially for methods imported
 ```kotlin
 import java.lang.System
 fun main() {
-    System.gc()
-    System::gc
+    println()
+    val myPrintln : () -> Unit = ::println
+    kotlin.io.print("Hello, World!")
 }
 ```
 

--- a/website/versioned_docs/version-1.23.1/rules/style.md
+++ b/website/versioned_docs/version-1.23.1/rules/style.md
@@ -990,7 +990,6 @@ of unstable, experimental or deprecated methods, especially for methods imported
 #### Noncompliant Code:
 
 ```kotlin
-import java.lang.System
 fun main() {
     println()
     val myPrintln : () -> Unit = ::println

--- a/website/versioned_docs/version-1.23.3/rules/style.md
+++ b/website/versioned_docs/version-1.23.3/rules/style.md
@@ -992,8 +992,9 @@ of unstable, experimental or deprecated methods, especially for methods imported
 ```kotlin
 import java.lang.System
 fun main() {
-    System.gc()
-    System::gc
+    println()
+    val myPrintln : () -> Unit = ::println
+    kotlin.io.print("Hello, World!")
 }
 ```
 

--- a/website/versioned_docs/version-1.23.3/rules/style.md
+++ b/website/versioned_docs/version-1.23.3/rules/style.md
@@ -990,7 +990,6 @@ of unstable, experimental or deprecated methods, especially for methods imported
 #### Noncompliant Code:
 
 ```kotlin
-import java.lang.System
 fun main() {
     println()
     val myPrintln : () -> Unit = ::println

--- a/website/versioned_docs/version-1.23.4/rules/style.md
+++ b/website/versioned_docs/version-1.23.4/rules/style.md
@@ -992,8 +992,9 @@ of unstable, experimental or deprecated methods, especially for methods imported
 ```kotlin
 import java.lang.System
 fun main() {
-    System.gc()
-    System::gc
+    println()
+    val myPrintln : () -> Unit = ::println
+    kotlin.io.print("Hello, World!")
 }
 ```
 

--- a/website/versioned_docs/version-1.23.4/rules/style.md
+++ b/website/versioned_docs/version-1.23.4/rules/style.md
@@ -990,7 +990,6 @@ of unstable, experimental or deprecated methods, especially for methods imported
 #### Noncompliant Code:
 
 ```kotlin
-import java.lang.System
 fun main() {
     println()
     val myPrintln : () -> Unit = ::println

--- a/website/versioned_docs/version-1.23.5/rules/style.md
+++ b/website/versioned_docs/version-1.23.5/rules/style.md
@@ -992,8 +992,9 @@ of unstable, experimental or deprecated methods, especially for methods imported
 ```kotlin
 import java.lang.System
 fun main() {
-    System.gc()
-    System::gc
+    println()
+    val myPrintln : () -> Unit = ::println
+    kotlin.io.print("Hello, World!")
 }
 ```
 

--- a/website/versioned_docs/version-1.23.5/rules/style.md
+++ b/website/versioned_docs/version-1.23.5/rules/style.md
@@ -990,7 +990,6 @@ of unstable, experimental or deprecated methods, especially for methods imported
 #### Noncompliant Code:
 
 ```kotlin
-import java.lang.System
 fun main() {
     println()
     val myPrintln : () -> Unit = ::println

--- a/website/versioned_docs/version-1.23.6/rules/style.md
+++ b/website/versioned_docs/version-1.23.6/rules/style.md
@@ -992,8 +992,9 @@ of unstable, experimental or deprecated methods, especially for methods imported
 ```kotlin
 import java.lang.System
 fun main() {
-    System.gc()
-    System::gc
+    println()
+    val myPrintln : () -> Unit = ::println
+    kotlin.io.print("Hello, World!")
 }
 ```
 

--- a/website/versioned_docs/version-1.23.6/rules/style.md
+++ b/website/versioned_docs/version-1.23.6/rules/style.md
@@ -990,7 +990,6 @@ of unstable, experimental or deprecated methods, especially for methods imported
 #### Noncompliant Code:
 
 ```kotlin
-import java.lang.System
 fun main() {
     println()
     val myPrintln : () -> Unit = ::println


### PR DESCRIPTION
https://github.com/detekt/detekt/pull/2753 did not update the document.
This PR is released on [v1.10.0-RC1](https://github.com/detekt/detekt/releases/tag/v1.10.0-RC1), so I updated documentation created later than this PR.