### PR TITLE
Bump min supported AGP version to 7.1.3

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,7 +24,7 @@ kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-t
 
 # This represents the oldest AGP version that is supported by detekt.
 # This should only be updated when updating the minimum version supported by detekt's Gradle plugin.
-android-gradle-minSupported = "com.android.tools.build:gradle-api:7.1.0"
+android-gradle-minSupported = "com.android.tools.build:gradle-api:7.1.3"
 
 # This version of AGP is used for testing and should be updated when new AGP versions are released to ensure detekt's
 # Gradle plugin remains compatible.


### PR DESCRIPTION
Kotlin 2.0.0-RC3 increased its min supported AGP version to 7.1.3. Bumping in detekt to match.

https://kotlinlang.org/docs/whatsnew-eap.html#bumped-minimum-supported-agp-version

(Based on [this commit history](https://github.com/JetBrains/kotlin/commits/e84e83568cde569ee54980542e37c87507e914bc/) Kotlin 2.0.0 will be based on same commit as 2.0.0-RC3. I'm cherry-picking a couple of commits from the kotlin-2 branch to minimise the diff in https://github.com/detekt/detekt/pull/6640)