### PR TITLE
Remove test failing on new compiler diagnostic error

### DIFF
--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/movelambdaout/UnnecessaryBracesAroundTrailingLambdaSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/movelambdaout/UnnecessaryBracesAroundTrailingLambdaSpec.kt
@@ -216,23 +216,6 @@ class UnnecessaryBracesAroundTrailingLambdaSpec(val env: KotlinCoreEnvironment) 
     }
 
     @Test
-    fun `does not report lambda has nested labels`() {
-        val code = """
-            fun test() {
-                foo(bar@ foo@{ bar(it) })
-            }
-
-            fun foo(f: (String) -> Int) {
-                f("")
-            }
-
-            fun bar(s: String) = s.length
-        """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
-        assertThat(findings).isEmpty()
-    }
-
-    @Test
     fun `does report generic param lambda has braces around it`() {
         val code = """
             fun <T> foo(t: T) {}


### PR DESCRIPTION
Multiple labels are forbidden on statements from 2.0.0-Beta4

https://youtrack.jetbrains.com/issue/KT-53629

(Based on [this commit history](https://github.com/JetBrains/kotlin/commits/e84e83568cde569ee54980542e37c87507e914bc/) Kotlin 2.0.0 will be based on same commit as 2.0.0-RC3. I'm cherry-picking a couple of commits from the kotlin-2 branch to minimise the diff in https://github.com/detekt/detekt/pull/6640)