### PR TITLE
Execute compiler plugin tests on language version 1.9 due to K2 incompatibility

### DIFF
--- a/detekt-compiler-plugin/build.gradle.kts
+++ b/detekt-compiler-plugin/build.gradle.kts
@@ -95,6 +95,8 @@ val testPluginKotlinc by tasks.registering(Task::class) {
 
         args = listOf(
             sourceFile.path,
+            "-language-version",
+            "1.9",
             "-Xplugin=${tasks.shadowJar.get().archiveFile.get().asFile.absolutePath}",
             "-P",
             "plugin:detekt-compiler-plugin:debug=true".toArg(),

--- a/detekt-compiler-plugin/src/test/kotlin/io/github/detekt/compiler/plugin/util/CompilerTestUtils.kt
+++ b/detekt-compiler-plugin/src/test/kotlin/io/github/detekt/compiler/plugin/util/CompilerTestUtils.kt
@@ -39,6 +39,7 @@ object CompilerTestUtils {
                     workingDir.absolutePath
                 )
             )
+            languageVersion = "1.9"
         }.compile()
     }
 }


### PR DESCRIPTION
The compiler plugin doesn't work with language version 2.0. Work needs to be done to implement this feature (issue #7303 opened to track this).

(Based on [this commit history](https://github.com/JetBrains/kotlin/commits/e84e83568cde569ee54980542e37c87507e914bc/) Kotlin 2.0.0 will be based on same commit as 2.0.0-RC3. I'm cherry-picking a couple of commits from the kotlin-2 branch to minimise the diff in https://github.com/detekt/detekt/pull/6640)