### PR TITLE
Remove IT_LITERAL & LET_LITERAL

### DIFF
--- a/detekt-psi-utils/api/detekt-psi-utils.api
+++ b/detekt-psi-utils/api/detekt-psi-utils.api
@@ -46,7 +46,6 @@ public final class io/gitlab/arturbosch/detekt/rules/JunkKt {
 
 public final class io/gitlab/arturbosch/detekt/rules/KeywordsKt {
 	public static final field IT_LITERAL Ljava/lang/String;
-	public static final field LET_LITERAL Ljava/lang/String;
 }
 
 public final class io/gitlab/arturbosch/detekt/rules/KtAnnotatedExtensionsKt {

--- a/detekt-psi-utils/api/detekt-psi-utils.api
+++ b/detekt-psi-utils/api/detekt-psi-utils.api
@@ -44,10 +44,6 @@ public final class io/gitlab/arturbosch/detekt/rules/JunkKt {
 	public static final fun receiverIsUsed (Lorg/jetbrains/kotlin/psi/KtCallExpression;Lorg/jetbrains/kotlin/resolve/BindingContext;)Z
 }
 
-public final class io/gitlab/arturbosch/detekt/rules/KeywordsKt {
-	public static final field IT_LITERAL Ljava/lang/String;
-}
-
 public final class io/gitlab/arturbosch/detekt/rules/KtAnnotatedExtensionsKt {
 	public static final fun hasAnnotation (Lorg/jetbrains/kotlin/psi/KtAnnotated;[Ljava/lang/String;)Z
 }

--- a/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/Keywords.kt
+++ b/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/Keywords.kt
@@ -1,7 +1,0 @@
-package io.gitlab.arturbosch.detekt.rules
-
-/**
- * This file contains common literals of keywords, library functions and other idioms of Kotlin language
- */
-
-const val IT_LITERAL = "it"

--- a/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/Keywords.kt
+++ b/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/Keywords.kt
@@ -5,4 +5,3 @@ package io.gitlab.arturbosch.detekt.rules
  */
 
 const val IT_LITERAL = "it"
-const val LET_LITERAL = "let"

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/AlsoCouldBeApply.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/AlsoCouldBeApply.kt
@@ -4,7 +4,6 @@ import io.gitlab.arturbosch.detekt.api.CodeSmell
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Rule
-import io.gitlab.arturbosch.detekt.rules.IT_LITERAL
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtLambdaExpression
 import org.jetbrains.kotlin.psi.KtQualifiedExpression
@@ -47,7 +46,7 @@ class AlsoCouldBeApply(config: Config) : Rule(
             ?: expression.valueArguments.singleOrNull()?.getArgumentExpression() as? KtLambdaExpression
             ?: return
         val statements = lambda.bodyExpression?.statements.orEmpty().ifEmpty { return }
-        if (statements.all { (it as? KtQualifiedExpression)?.receiverExpression?.text == IT_LITERAL }) {
+        if (statements.all { (it as? KtQualifiedExpression)?.receiverExpression?.text == "it" }) {
             report(CodeSmell(Entity.from(callee), description))
         }
     }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitItLambdaParameter.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitItLambdaParameter.kt
@@ -5,7 +5,7 @@ import io.gitlab.arturbosch.detekt.api.CodeSmell
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Rule
-import io.gitlab.arturbosch.detekt.rules.IT_LITERAL
+import org.jetbrains.kotlin.builtins.StandardNames.IMPLICIT_LAMBDA_PARAMETER_NAME
 import org.jetbrains.kotlin.psi.KtLambdaExpression
 
 /**
@@ -48,8 +48,8 @@ class ExplicitItLambdaParameter(config: Config) : Rule(
 
     override fun visitLambdaExpression(lambdaExpression: KtLambdaExpression) {
         super.visitLambdaExpression(lambdaExpression)
-        val parameterNames = lambdaExpression.valueParameters.map { it.name }
-        if (IT_LITERAL in parameterNames) {
+        val parameterNames = lambdaExpression.valueParameters.map { it.nameAsName }
+        if (IMPLICIT_LAMBDA_PARAMETER_NAME in parameterNames) {
             val message =
                 if (
                     parameterNames.size == 1 &&

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MultilineLambdaItParameter.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MultilineLambdaItParameter.kt
@@ -5,9 +5,9 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
-import io.gitlab.arturbosch.detekt.rules.IT_LITERAL
 import io.gitlab.arturbosch.detekt.rules.hasImplicitParameterReference
 import io.gitlab.arturbosch.detekt.rules.implicitParameter
+import org.jetbrains.kotlin.builtins.StandardNames.IMPLICIT_LAMBDA_PARAMETER_NAME
 import org.jetbrains.kotlin.psi.KtLambdaExpression
 
 /**
@@ -71,8 +71,8 @@ class MultilineLambdaItParameter(config: Config) : Rule(
 
         if (!lambdaExpression.isMultiline()) return
 
-        val parameterNames = lambdaExpression.valueParameters.map { it.name }
-        if (IT_LITERAL in parameterNames) {
+        val parameterNames = lambdaExpression.valueParameters.map { it.nameAsName }
+        if (IMPLICIT_LAMBDA_PARAMETER_NAME in parameterNames) {
             // Explicit `it`
             report(
                 CodeSmell(

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLet.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLet.kt
@@ -5,10 +5,10 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
-import io.gitlab.arturbosch.detekt.rules.IT_LITERAL
 import io.gitlab.arturbosch.detekt.rules.firstParameter
 import io.gitlab.arturbosch.detekt.rules.isCalling
 import io.gitlab.arturbosch.detekt.rules.receiverIsUsed
+import org.jetbrains.kotlin.builtins.StandardNames.IMPLICIT_LAMBDA_PARAMETER_NAME
 import org.jetbrains.kotlin.descriptors.impl.ValueParameterDescriptorImpl.WithDestructuringDeclaration
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.psi.KtCallExpression
@@ -98,14 +98,14 @@ private fun canBeReplacedWithCall(lambdaExpr: KtLambdaExpression?): Boolean {
 
     val lambdaParameter = lambdaExpr.valueParameters.singleOrNull()
     val lambdaParameterNames = if (lambdaParameter == null) {
-        listOf(IT_LITERAL)
+        listOf(IMPLICIT_LAMBDA_PARAMETER_NAME)
     } else {
         lambdaParameter.destructuringDeclaration?.entries.orEmpty()
             .plus(lambdaParameter)
             .filterIsInstance<KtNamedDeclaration>()
-            .map { it.nameAsSafeName.asString() }
+            .map { it.nameAsSafeName }
     }
-    return lambdaParameterNames.any { receiver.textMatches(it) }
+    return lambdaParameterNames.any { receiver.textMatches(it.asString()) }
 }
 
 private fun KtLambdaExpression.countLambdaParameterReference(context: BindingContext): Int {


### PR DESCRIPTION
LET_LITERAL was unused.

IT_LITERAL is provided by `StandardNames.IMPLICIT_LAMBDA_PARAMETER_NAME` which has resulted in more descriptive code IMHO. There was one usage which I've replaced with string `"it"` because the rule is literally checking for "\`it`-started expressions" so I think this is reasonable.