### PR TITLE
Remove KtExpression.isUnitExpression()

### DIFF
--- a/detekt-psi-utils/api/detekt-psi-utils.api
+++ b/detekt-psi-utils/api/detekt-psi-utils.api
@@ -53,10 +53,6 @@ public final class io/gitlab/arturbosch/detekt/rules/KtCallExpressionKt {
 	public static final fun isCallingWithNonNullCheckArgument (Lorg/jetbrains/kotlin/psi/KtCallExpression;Lorg/jetbrains/kotlin/name/FqName;Lorg/jetbrains/kotlin/resolve/BindingContext;)Z
 }
 
-public final class io/gitlab/arturbosch/detekt/rules/KtExpressionKt {
-	public static final fun isUnitExpression (Lorg/jetbrains/kotlin/psi/KtExpression;)Z
-}
-
 public final class io/gitlab/arturbosch/detekt/rules/KtLambdaExpressionKt {
 	public static final fun firstParameter (Lorg/jetbrains/kotlin/psi/KtLambdaExpression;Lorg/jetbrains/kotlin/resolve/BindingContext;)Lorg/jetbrains/kotlin/descriptors/ValueParameterDescriptor;
 	public static final fun hasImplicitParameterReference (Lorg/jetbrains/kotlin/psi/KtLambdaExpression;Lorg/jetbrains/kotlin/descriptors/ValueParameterDescriptor;Lorg/jetbrains/kotlin/resolve/BindingContext;)Z

--- a/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/KtExpression.kt
+++ b/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/KtExpression.kt
@@ -1,6 +1,0 @@
-package io.gitlab.arturbosch.detekt.rules
-
-import org.jetbrains.kotlin.builtins.StandardNames
-import org.jetbrains.kotlin.psi.KtExpression
-
-fun KtExpression.isUnitExpression() = text == StandardNames.FqNames.unit.shortName().asString()

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ImplicitUnitReturnType.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ImplicitUnitReturnType.kt
@@ -8,7 +8,6 @@ import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.config
 import io.gitlab.arturbosch.detekt.rules.hasImplicitUnitReturnType
-import io.gitlab.arturbosch.detekt.rules.isUnitExpression
 import org.jetbrains.kotlin.psi.KtNamedFunction
 
 /**
@@ -52,10 +51,7 @@ class ImplicitUnitReturnType(config: Config) : Rule(
             return
         }
 
-        val bodyExpression = function.bodyExpression
-        if (bodyExpression == null || bodyExpression.isUnitExpression()) {
-            return
-        }
+        if (function.bodyExpression?.text == "Unit") return
 
         if (function.hasImplicitUnitReturnType(bindingContext)) {
             val message = buildString {

--- a/detekt-rules-libraries/src/main/kotlin/io/gitlab/arturbosch/detekt/libraries/LibraryCodeMustSpecifyReturnType.kt
+++ b/detekt-rules-libraries/src/main/kotlin/io/gitlab/arturbosch/detekt/libraries/LibraryCodeMustSpecifyReturnType.kt
@@ -9,7 +9,6 @@ import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.config
 import io.gitlab.arturbosch.detekt.rules.hasImplicitUnitReturnType
-import io.gitlab.arturbosch.detekt.rules.isUnitExpression
 import org.jetbrains.kotlin.psi.KtCallableDeclaration
 import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.KtProperty
@@ -77,13 +76,8 @@ class LibraryCodeMustSpecifyReturnType(config: Config) : Rule(
         super.visitNamedFunction(function)
     }
 
-    private fun KtNamedFunction.isUnitOmissionAllowed(): Boolean {
-        val bodyExpression = this.bodyExpression
-        if (bodyExpression == null || bodyExpression.isUnitExpression()) {
-            return true
-        }
-        return allowOmitUnit && this.hasImplicitUnitReturnType(bindingContext)
-    }
+    private fun KtNamedFunction.isUnitOmissionAllowed(): Boolean =
+        bodyExpression?.text == "Unit" || (allowOmitUnit && this.hasImplicitUnitReturnType(bindingContext))
 
     private fun KtCallableDeclaration.explicitReturnTypeRequired(): Boolean =
         ExplicitApiDeclarationChecker.returnTypeCheckIsApplicable(this) &&


### PR DESCRIPTION
This function is a bit overengineered and it's simple to refactor to remove its usage.