### PR TITLE
Add new id for the rules

### DIFF
--- a/detekt-api/api/detekt-api.api
+++ b/detekt-api/api/detekt-api.api
@@ -300,6 +300,7 @@ public final class io/gitlab/arturbosch/detekt/api/Rule$Name {
 
 public abstract interface class io/gitlab/arturbosch/detekt/api/RuleInstance {
 	public abstract fun getDescription ()Ljava/lang/String;
+	public abstract fun getId ()Ljava/lang/String;
 	public abstract fun getName ()Lio/gitlab/arturbosch/detekt/api/Rule$Name;
 	public abstract fun getRuleSetId ()Lio/gitlab/arturbosch/detekt/api/RuleSet$Id;
 }

--- a/detekt-api/api/detekt-api.api
+++ b/detekt-api/api/detekt-api.api
@@ -279,7 +279,7 @@ public class io/gitlab/arturbosch/detekt/api/Rule : io/gitlab/arturbosch/detekt/
 	public final fun getCompilerResources ()Lio/gitlab/arturbosch/detekt/api/CompilerResources;
 	public final fun getConfig ()Lio/gitlab/arturbosch/detekt/api/Config;
 	public final fun getDescription ()Ljava/lang/String;
-	public fun getRuleId ()Lio/gitlab/arturbosch/detekt/api/Rule$Id;
+	public fun getRuleName ()Lio/gitlab/arturbosch/detekt/api/Rule$Name;
 	protected fun postVisit (Lorg/jetbrains/kotlin/psi/KtFile;)V
 	protected fun preVisit (Lorg/jetbrains/kotlin/psi/KtFile;)V
 	public final fun report (Lio/gitlab/arturbosch/detekt/api/Finding;)V
@@ -290,7 +290,7 @@ public class io/gitlab/arturbosch/detekt/api/Rule : io/gitlab/arturbosch/detekt/
 	public static synthetic fun visitFile$default (Lio/gitlab/arturbosch/detekt/api/Rule;Lorg/jetbrains/kotlin/psi/KtFile;Lorg/jetbrains/kotlin/resolve/BindingContext;Lio/gitlab/arturbosch/detekt/api/CompilerResources;ILjava/lang/Object;)Ljava/util/List;
 }
 
-public final class io/gitlab/arturbosch/detekt/api/Rule$Id {
+public final class io/gitlab/arturbosch/detekt/api/Rule$Name {
 	public fun <init> (Ljava/lang/String;)V
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getValue ()Ljava/lang/String;
@@ -300,7 +300,7 @@ public final class io/gitlab/arturbosch/detekt/api/Rule$Id {
 
 public abstract interface class io/gitlab/arturbosch/detekt/api/RuleInstance {
 	public abstract fun getDescription ()Ljava/lang/String;
-	public abstract fun getId ()Lio/gitlab/arturbosch/detekt/api/Rule$Id;
+	public abstract fun getName ()Lio/gitlab/arturbosch/detekt/api/Rule$Name;
 	public abstract fun getRuleSetId ()Lio/gitlab/arturbosch/detekt/api/RuleSet$Id;
 }
 

--- a/detekt-api/api/detekt-api.api
+++ b/detekt-api/api/detekt-api.api
@@ -180,18 +180,12 @@ public abstract interface class io/gitlab/arturbosch/detekt/api/Issue {
 	public abstract fun getLocation ()Lio/gitlab/arturbosch/detekt/api/Location;
 	public abstract fun getMessage ()Ljava/lang/String;
 	public abstract fun getReferences ()Ljava/util/List;
-	public abstract fun getRuleInfo ()Lio/gitlab/arturbosch/detekt/api/Issue$RuleInfo;
+	public abstract fun getRuleInstance ()Lio/gitlab/arturbosch/detekt/api/RuleInstance;
 	public abstract fun getSeverity ()Lio/gitlab/arturbosch/detekt/api/Severity;
 }
 
 public final class io/gitlab/arturbosch/detekt/api/Issue$DefaultImpls {
 	public static fun getLocation (Lio/gitlab/arturbosch/detekt/api/Issue;)Lio/gitlab/arturbosch/detekt/api/Location;
-}
-
-public abstract interface class io/gitlab/arturbosch/detekt/api/Issue$RuleInfo {
-	public abstract fun getDescription ()Ljava/lang/String;
-	public abstract fun getId ()Lio/gitlab/arturbosch/detekt/api/Rule$Id;
-	public abstract fun getRuleSetId ()Lio/gitlab/arturbosch/detekt/api/RuleSet$Id;
 }
 
 public final class io/gitlab/arturbosch/detekt/api/Location : io/gitlab/arturbosch/detekt/api/Compactable {
@@ -302,6 +296,12 @@ public final class io/gitlab/arturbosch/detekt/api/Rule$Id {
 	public final fun getValue ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class io/gitlab/arturbosch/detekt/api/RuleInstance {
+	public abstract fun getDescription ()Ljava/lang/String;
+	public abstract fun getId ()Lio/gitlab/arturbosch/detekt/api/Rule$Id;
+	public abstract fun getRuleSetId ()Lio/gitlab/arturbosch/detekt/api/RuleSet$Id;
 }
 
 public final class io/gitlab/arturbosch/detekt/api/RuleSet {

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Issue.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Issue.kt
@@ -7,7 +7,7 @@ package io.gitlab.arturbosch.detekt.api
  * about the position. Entity references can also be considered for deeper characterization.
  */
 interface Issue {
-    val ruleInfo: RuleInfo
+    val ruleInstance: RuleInstance
     val entity: Entity
     val references: List<Entity>
     val message: String
@@ -16,10 +16,10 @@ interface Issue {
 
     val location: Location
         get() = entity.location
+}
 
-    interface RuleInfo {
-        val id: Rule.Id
-        val ruleSetId: RuleSet.Id
-        val description: String
-    }
+interface RuleInstance {
+    val id: Rule.Id
+    val ruleSetId: RuleSet.Id
+    val description: String
 }

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Issue.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Issue.kt
@@ -19,7 +19,7 @@ interface Issue {
 }
 
 interface RuleInstance {
-    val id: Rule.Id
+    val name: Rule.Name
     val ruleSetId: RuleSet.Id
     val description: String
 }

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Issue.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Issue.kt
@@ -19,6 +19,7 @@ interface Issue {
 }
 
 interface RuleInstance {
+    val id: String
     val name: Rule.Name
     val ruleSetId: RuleSet.Id
     val description: String

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Rule.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Rule.kt
@@ -24,7 +24,7 @@ open class Rule(
      *
      * By default, it is the name of the class name. Override to change it.
      */
-    open val ruleId: Id get() = Id(javaClass.simpleName)
+    open val ruleName: Name get() = Name(javaClass.simpleName)
 
     var bindingContext: BindingContext = BindingContext.EMPTY
     var compilerResources: CompilerResources? = null
@@ -89,7 +89,7 @@ open class Rule(
     }
 
     @Poko
-    class Id(val value: String) {
+    class Name(val value: String) {
         init {
             validateIdentifier(value)
         }

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/RuleSet.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/RuleSet.kt
@@ -6,10 +6,10 @@ import io.gitlab.arturbosch.detekt.api.internal.validateIdentifier
 /**
  * A rule set is a collection of rules and must be defined within a rule set provider implementation.
  */
-class RuleSet(val id: Id, val rules: Map<Rule.Id, (Config) -> Rule>) {
+class RuleSet(val id: Id, val rules: Map<Rule.Name, (Config) -> Rule>) {
     companion object {
         operator fun invoke(id: Id, rules: List<(Config) -> Rule>): RuleSet {
-            return RuleSet(id, rules.associateBy { it(Config.empty).ruleId })
+            return RuleSet(id, rules.associateBy { it(Config.empty).ruleName })
         }
     }
 

--- a/detekt-api/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/test/TestFactory.kt
+++ b/detekt-api/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/test/TestFactory.kt
@@ -4,6 +4,7 @@ import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Location
 import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.RuleInstance
 import io.gitlab.arturbosch.detekt.api.RuleSet
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.SourceLocation
@@ -19,7 +20,7 @@ fun createIssue(
     severity: Severity = Severity.Error,
     autoCorrectEnabled: Boolean = false,
 ): Issue = createIssue(
-    ruleInfo = createRuleInfo(ruleName),
+    ruleInstance = createRuleInstance(ruleName),
     entity = entity,
     message = message,
     severity = severity,
@@ -27,13 +28,13 @@ fun createIssue(
 )
 
 fun createIssue(
-    ruleInfo: Issue.RuleInfo,
+    ruleInstance: RuleInstance,
     entity: Entity = createEntity(),
     message: String = "TestMessage",
     severity: Severity = Severity.Error,
     autoCorrectEnabled: Boolean = false,
 ): Issue = IssueImpl(
-    ruleInfo = ruleInfo,
+    ruleInstance = ruleInstance,
     entity = entity,
     message = message,
     severity = severity,
@@ -41,36 +42,36 @@ fun createIssue(
 )
 
 fun createIssue(
-    ruleInfo: Issue.RuleInfo,
+    ruleInstance: RuleInstance,
     location: Location,
     message: String = "TestMessage",
     severity: Severity = Severity.Error,
     autoCorrectEnabled: Boolean = false,
 ): Issue = IssueImpl(
-    ruleInfo = ruleInfo,
+    ruleInstance = ruleInstance,
     entity = createEntity(location = location),
     message = message,
     severity = severity,
     autoCorrectEnabled = autoCorrectEnabled,
 )
 
-fun createRuleInfo(
+fun createRuleInstance(
     id: String = "TestSmell",
     ruleSetId: String = "RuleSet$id",
     description: String = "Description $id",
-): Issue.RuleInfo = IssueImpl.RuleInfo(
+): RuleInstance = RuleInstanceImpl(
     id = Rule.Id(id),
     ruleSetId = RuleSet.Id(ruleSetId),
     description = description
 )
 
 fun createIssueForRelativePath(
-    ruleInfo: Issue.RuleInfo,
+    ruleInstance: RuleInstance,
     basePath: String = "Users/tester/detekt/",
     relativePath: String = "TestFile.kt"
 ): Issue {
     return IssueImpl(
-        ruleInfo = ruleInfo,
+        ruleInstance = ruleInstance,
         entity = Entity(
             name = "TestEntity",
             signature = "TestEntitySignature",
@@ -114,16 +115,16 @@ fun createLocation(
 }
 
 private data class IssueImpl(
-    override val ruleInfo: Issue.RuleInfo,
+    override val ruleInstance: RuleInstance,
     override val entity: Entity,
     override val message: String,
     override val severity: Severity = Severity.Error,
     override val autoCorrectEnabled: Boolean = false,
     override val references: List<Entity> = emptyList(),
-) : Issue {
-    data class RuleInfo(
-        override val id: Rule.Id,
-        override val ruleSetId: RuleSet.Id,
-        override val description: String,
-    ) : Issue.RuleInfo
-}
+) : Issue
+
+private data class RuleInstanceImpl(
+    override val id: Rule.Id,
+    override val ruleSetId: RuleSet.Id,
+    override val description: String,
+) : RuleInstance

--- a/detekt-api/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/test/TestFactory.kt
+++ b/detekt-api/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/test/TestFactory.kt
@@ -58,8 +58,10 @@ fun createIssue(
 fun createRuleInstance(
     name: String = "TestSmell",
     ruleSetId: String = "RuleSet$name",
+    id: String = "$name/id",
     description: String = "Description $name",
 ): RuleInstance = RuleInstanceImpl(
+    id = id,
     name = Rule.Name(name),
     ruleSetId = RuleSet.Id(ruleSetId),
     description = description
@@ -124,6 +126,7 @@ private data class IssueImpl(
 ) : Issue
 
 private data class RuleInstanceImpl(
+    override val id: String,
     override val name: Rule.Name,
     override val ruleSetId: RuleSet.Id,
     override val description: String,

--- a/detekt-api/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/test/TestFactory.kt
+++ b/detekt-api/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/test/TestFactory.kt
@@ -56,11 +56,11 @@ fun createIssue(
 )
 
 fun createRuleInstance(
-    id: String = "TestSmell",
-    ruleSetId: String = "RuleSet$id",
-    description: String = "Description $id",
+    name: String = "TestSmell",
+    ruleSetId: String = "RuleSet$name",
+    description: String = "Description $name",
 ): RuleInstance = RuleInstanceImpl(
-    id = Rule.Id(id),
+    name = Rule.Name(name),
     ruleSetId = RuleSet.Id(ruleSetId),
     description = description
 )
@@ -124,7 +124,7 @@ private data class IssueImpl(
 ) : Issue
 
 private data class RuleInstanceImpl(
-    override val id: Rule.Id,
+    override val name: Rule.Name,
     override val ruleSetId: RuleSet.Id,
     override val description: String,
 ) : RuleInstance

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Spec.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Spec.kt
@@ -99,6 +99,6 @@ private fun asPatterns(rawValue: String): List<String> = rawValue.trim()
 
 private fun CliArgs.toRunPolicy(): RulesSpec.RunPolicy {
     val parts = runRule?.split(":") ?: return RulesSpec.RunPolicy.NoRestrictions
-    require(parts.size == 2) { "Pattern 'RuleSetId:RuleId' expected." }
-    return RulesSpec.RunPolicy.RestrictToSingleRule(RuleSet.Id(parts[0]), Rule.Id(parts[1]))
+    require(parts.size == 2) { "Pattern 'RuleSetId:RuleName' expected." }
+    return RulesSpec.RunPolicy.RestrictToSingleRule(RuleSet.Id(parts[0]), Rule.Name(parts[1]))
 }

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/RunnerSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/RunnerSpec.kt
@@ -195,7 +195,7 @@ class RunnerSpec {
         fun `should throw on non existing run-rule`() {
             assertThatThrownBy { executeDetekt("--run-rule", "") }
                 .isExactlyInstanceOf(IllegalArgumentException::class.java)
-                .hasMessage("Pattern 'RuleSetId:RuleId' expected.")
+                .hasMessage("Pattern 'RuleSetId:RuleName' expected.")
         }
     }
 

--- a/detekt-compiler-plugin/src/main/kotlin/io/github/detekt/compiler/plugin/internal/MessageCollectorExtensions.kt
+++ b/detekt-compiler-plugin/src/main/kotlin/io/github/detekt/compiler/plugin/internal/MessageCollectorExtensions.kt
@@ -39,5 +39,5 @@ fun Issue.renderAsCompilerWarningMessage(): Pair<String, CompilerMessageLocation
         )
     }
 
-    return "${ruleInfo.id}: $message" to sourceLocation
+    return "${ruleInstance.id}: $message" to sourceLocation
 }

--- a/detekt-compiler-plugin/src/main/kotlin/io/github/detekt/compiler/plugin/internal/MessageCollectorExtensions.kt
+++ b/detekt-compiler-plugin/src/main/kotlin/io/github/detekt/compiler/plugin/internal/MessageCollectorExtensions.kt
@@ -39,5 +39,5 @@ fun Issue.renderAsCompilerWarningMessage(): Pair<String, CompilerMessageLocation
         )
     }
 
-    return "${ruleInstance.id}: $message" to sourceLocation
+    return "${ruleInstance.name}: $message" to sourceLocation
 }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Analyzer.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Analyzer.kt
@@ -105,7 +105,7 @@ internal class Analyzer(
                     .filter { (_, config) -> config.shouldAnalyzeFile(file, settings.spec.projectSpec.basePath) }
                     .map { (ruleProvider, config) ->
                         val rule = ruleProvider(config)
-                        rule.toRuleInstance(ruleSet.id) to rule
+                        rule.toRuleInstance(rule.ruleName.value, ruleSet.id) to rule
                     }
             }
             .filterNot { (ruleInstance, rule) ->
@@ -175,8 +175,8 @@ private fun Finding.toIssue(rule: RuleInstance, severity: Severity): Issue {
     }
 }
 
-private fun Rule.toRuleInstance(ruleSetId: RuleSet.Id): RuleInstance {
-    return RuleInstanceImpl(ruleName, ruleSetId, description)
+private fun Rule.toRuleInstance(id: String, ruleSetId: RuleSet.Id): RuleInstance {
+    return RuleInstanceImpl(id, ruleName, ruleSetId, description)
 }
 
 private data class IssueImpl(
@@ -189,6 +189,7 @@ private data class IssueImpl(
 ) : Issue
 
 private data class RuleInstanceImpl(
+    override val id: String,
     override val name: Rule.Name,
     override val ruleSetId: RuleSet.Id,
     override val description: String,

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/DefaultBaseline.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/DefaultBaseline.kt
@@ -35,4 +35,4 @@ internal const val CURRENT_ISSUES = "CurrentIssues"
 internal const val ID = "ID"
 
 internal val Issue.baselineId: String
-    get() = "${ruleInstance.id}:${this.entity.signature}"
+    get() = "${ruleInstance.name}:${this.entity.signature}"

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/DefaultBaseline.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/DefaultBaseline.kt
@@ -35,4 +35,4 @@ internal const val CURRENT_ISSUES = "CurrentIssues"
 internal const val ID = "ID"
 
 internal val Issue.baselineId: String
-    get() = "${ruleInfo.id}:${this.entity.signature}"
+    get() = "${ruleInstance.id}:${this.entity.signature}"

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/AllRulesConfig.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/AllRulesConfig.kt
@@ -42,7 +42,7 @@ internal data class AllRulesConfig(
 
     private fun isDeprecated(): Boolean = deprecatedRules.any { parentPath == it.toPath() }
 
-    private fun DeprecatedRule.toPath() = "$ruleSetId > $ruleId"
+    private fun DeprecatedRule.toPath() = "$ruleSetId > $ruleName"
 
     @Suppress("MagicNumber")
     override fun toString() = """

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/validation/DeprecatedPropertiesConfigValidator.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/validation/DeprecatedPropertiesConfigValidator.kt
@@ -23,7 +23,7 @@ internal class DeprecatedPropertiesConfigValidator(
     @Suppress("UNCHECKED_CAST")
     private fun hasValue(configAsMap: Map<String, Any>, deprecatedProperty: DeprecatedProperty): Boolean {
         val ruleSetSubMap = configAsMap[deprecatedProperty.ruleSetId] as? Map<String, Any> ?: return false
-        val ruleSubMap = ruleSetSubMap[deprecatedProperty.ruleId] as? Map<String, Any> ?: return false
+        val ruleSubMap = ruleSetSubMap[deprecatedProperty.ruleName] as? Map<String, Any> ?: return false
         return ruleSubMap.containsKey(deprecatedProperty.propertyName)
     }
 
@@ -37,5 +37,5 @@ internal class DeprecatedPropertiesConfigValidator(
         )
     }
 
-    private fun DeprecatedProperty.asPath() = "$ruleSetId>$ruleId>$propertyName"
+    private fun DeprecatedProperty.asPath() = "$ruleSetId>$ruleName>$propertyName"
 }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/validation/Deprecations.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/validation/Deprecations.kt
@@ -6,13 +6,13 @@ import java.util.Properties
 internal sealed class Deprecation
 internal data class DeprecatedRule(
     val ruleSetId: String,
-    val ruleId: String,
+    val ruleName: String,
     val description: String
 ) : Deprecation()
 
 internal data class DeprecatedProperty(
     val ruleSetId: String,
-    val ruleId: String,
+    val ruleName: String,
     val propertyName: String,
     val description: String
 ) : Deprecation()
@@ -39,13 +39,13 @@ private fun deprecationFromPath(path: String, description: String): Deprecation 
     return when (pathElements.size) {
         RULE_PATH_SEGMENTS -> DeprecatedRule(
             ruleSetId = pathElements[0],
-            ruleId = pathElements[1],
+            ruleName = pathElements[1],
             description = description
         )
 
         PROPERTY_PATH_SEGMENTS -> DeprecatedProperty(
             ruleSetId = pathElements[0],
-            ruleId = pathElements[1],
+            ruleName = pathElements[1],
             propertyName = pathElements[2],
             description = description
         )

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/validation/InvalidPropertiesConfigValidator.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/validation/InvalidPropertiesConfigValidator.kt
@@ -11,7 +11,7 @@ internal class InvalidPropertiesConfigValidator(
 ) : AbstractYamlConfigValidator() {
 
     private val deprecatedPropertyPaths: Set<String> = deprecatedProperties
-        .map { "${it.ruleSetId}>${it.ruleId}>${it.propertyName}" }
+        .map { "${it.ruleSetId}>${it.ruleName}>${it.propertyName}" }
         .toSet()
 
     override val id: String = "InvalidPropertiesConfigValidator"

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/Reporting.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/Reporting.kt
@@ -55,4 +55,4 @@ private fun Issue.truncatedMessage(): String {
     }
 }
 
-private fun Issue.detailed(): String = "${ruleInstance.id} - [${truncatedMessage()}] at ${location.compact()}"
+private fun Issue.detailed(): String = "${ruleInstance.name} - [${truncatedMessage()}] at ${location.compact()}"

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/Reporting.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/Reporting.kt
@@ -55,4 +55,4 @@ private fun Issue.truncatedMessage(): String {
     }
 }
 
-private fun Issue.detailed(): String = "${ruleInfo.id} - [${truncatedMessage()}] at ${location.compact()}"
+private fun Issue.detailed(): String = "${ruleInstance.id} - [${truncatedMessage()}] at ${location.compact()}"

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/IssuesReport.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/IssuesReport.kt
@@ -12,6 +12,6 @@ class IssuesReport : AbstractIssuesReport() {
     override val id: String = "IssuesReport"
 
     override fun render(issues: List<Issue>): String {
-        return printIssues(issues.groupBy { it.ruleInfo.ruleSetId }.mapKeys { (key, _) -> key.value })
+        return printIssues(issues.groupBy { it.ruleInstance.ruleSetId }.mapKeys { (key, _) -> key.value })
     }
 }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/LiteIssuesReport.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/LiteIssuesReport.kt
@@ -13,7 +13,7 @@ class LiteIssuesReport : AbstractIssuesReport() {
     override fun render(issues: List<Issue>): String {
         return buildString {
             issues.forEach { issue ->
-                append("${issue.location.compact()}: ${issue.message} [${issue.ruleInfo.id}]")
+                append("${issue.location.compact()}: ${issue.message} [${issue.ruleInstance.id}]")
                 appendLine()
             }
         }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/LiteIssuesReport.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/LiteIssuesReport.kt
@@ -13,7 +13,7 @@ class LiteIssuesReport : AbstractIssuesReport() {
     override fun render(issues: List<Issue>): String {
         return buildString {
             issues.forEach { issue ->
-                append("${issue.location.compact()}: ${issue.message} [${issue.ruleInstance.id}]")
+                append("${issue.location.compact()}: ${issue.message} [${issue.ruleInstance.name}]")
                 appendLine()
             }
         }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/rules/RuleSets.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/rules/RuleSets.kt
@@ -8,10 +8,10 @@ fun ProcessingSettings.createRuleProviders(): List<RuleSetProvider> = when (val 
     RulesSpec.RunPolicy.NoRestrictions -> RuleSetLocator(this).load()
     is RulesSpec.RunPolicy.RestrictToSingleRule -> {
         val ruleSetId = runPolicy.ruleSetId
-        val ruleId = runPolicy.ruleId
+        val ruleName = runPolicy.ruleName
         val realProvider = requireNotNull(
             RuleSetLocator(this).load().find { it.ruleSetId == ruleSetId }
         ) { "There was no rule set with id '$ruleSetId'." }
-        listOf(SingleRuleProvider(ruleId, realProvider))
+        listOf(SingleRuleProvider(ruleName, realProvider))
     }
 }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/rules/SingleRuleProvider.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/rules/SingleRuleProvider.kt
@@ -6,7 +6,7 @@ import io.gitlab.arturbosch.detekt.api.RuleSet
 import io.gitlab.arturbosch.detekt.api.RuleSetProvider
 
 internal class SingleRuleProvider(
-    private val ruleId: Rule.Id,
+    private val ruleName: Rule.Name,
     private val wrapped: RuleSetProvider
 ) : RuleSetProvider {
 
@@ -23,6 +23,6 @@ internal class SingleRuleProvider(
 
     private fun createRuleInstance(): (Config) -> Rule =
         requireNotNull(
-            wrapped.instance().rules[ruleId]
-        ) { "There was no rule '$ruleId' in rule set '${wrapped.ruleSetId}'." }
+            wrapped.instance().rules[ruleName]
+        ) { "There was no rule '$ruleName' in rule set '${wrapped.ruleSetId}'." }
 }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/Suppressions.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/Suppressions.kt
@@ -12,10 +12,10 @@ import kotlin.text.RegexOption.IGNORE_CASE
  * Checks if this psi element is suppressed by @Suppress or @SuppressWarnings annotations.
  * If this element cannot have annotations, the first annotative parent is searched.
  */
-fun KtElement.isSuppressedBy(id: Rule.Id, aliases: Set<String>, ruleSetId: RuleSet.Id? = null): Boolean {
-    val acceptedSuppressionIds = mutableSetOf(id.value, "ALL", "all", "All")
+fun KtElement.isSuppressedBy(name: Rule.Name, aliases: Set<String>, ruleSetId: RuleSet.Id? = null): Boolean {
+    val acceptedSuppressionIds = mutableSetOf(name.value, "ALL", "all", "All")
     if (ruleSetId != null) {
-        acceptedSuppressionIds.addAll(listOf(ruleSetId.value, "$ruleSetId.$id", "$ruleSetId:$id"))
+        acceptedSuppressionIds.addAll(listOf(ruleSetId.value, "$ruleSetId.$name", "$ruleSetId:$name"))
     }
     acceptedSuppressionIds.addAll(aliases)
 

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/CorrectableRulesFirstSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/CorrectableRulesFirstSpec.kt
@@ -45,20 +45,20 @@ class CorrectableRulesFirstSpec {
 
         settings.use { detector.run(listOf(compileForTest(testFile))) }
 
-        assertThat(actualLastRuleId).isEqualTo("NonCorrectable")
+        assertThat(actualLastRuleName).isEqualTo("NonCorrectable")
     }
 }
 
-private var actualLastRuleId = ""
+private var actualLastRuleName = ""
 
 private class NonCorrectable(config: Config) : Rule(config, "") {
     override fun visitClass(klass: KtClass) {
-        actualLastRuleId = ruleId.value
+        actualLastRuleName = ruleName.value
     }
 }
 
 private class Correctable(config: Config) : Rule(config, "") {
     override fun visitClass(klass: KtClass) {
-        actualLastRuleId = ruleId.value
+        actualLastRuleName = ruleName.value
     }
 }

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineResultMappingSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineResultMappingSpec.kt
@@ -7,7 +7,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.SetupContext
 import io.gitlab.arturbosch.detekt.test.createEntity
 import io.gitlab.arturbosch.detekt.test.createIssue
-import io.gitlab.arturbosch.detekt.test.createRuleInfo
+import io.gitlab.arturbosch.detekt.test.createRuleInstance
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
@@ -24,7 +24,7 @@ class BaselineResultMappingSpec {
     private val existingBaselineFile = resourceAsPath("/baseline_feature/valid-baseline.xml")
     private val issues = listOf(
         createIssue(
-            ruleInfo = createRuleInfo("SomeIssueId", "RuleSet"),
+            ruleInstance = createRuleInstance("SomeIssueId", "RuleSet"),
             entity = createEntity(signature = "SomeSignature"),
         ),
         createIssue(

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/validation/DeprecatedPropertiesConfigValidatorSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/validation/DeprecatedPropertiesConfigValidatorSpec.kt
@@ -10,7 +10,7 @@ internal class DeprecatedPropertiesConfigValidatorSpec {
     private val deprecatedProperties = setOf(
         DeprecatedProperty(
             ruleSetId = "naming",
-            ruleId = "FunctionParameterNaming",
+            ruleName = "FunctionParameterNaming",
             propertyName = "ignoreOverriddenFunctions",
             description = "Use `ignoreOverridden` instead"
         )

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/validation/InvalidPropertiesConfigValidatorSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/validation/InvalidPropertiesConfigValidatorSpec.kt
@@ -18,7 +18,7 @@ internal class InvalidPropertiesConfigValidatorSpec {
     private val deprecatedProperties = setOf(
         DeprecatedProperty(
             ruleSetId = "complexity",
-            ruleId = "LongParameterList",
+            ruleName = "LongParameterList",
             propertyName = "threshold",
             description = "use xxx instead"
         )

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/OutputFacadeSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/OutputFacadeSpec.kt
@@ -13,7 +13,7 @@ import io.gitlab.arturbosch.detekt.core.tooling.withSettings
 import io.gitlab.arturbosch.detekt.test.createEntity
 import io.gitlab.arturbosch.detekt.test.createIssue
 import io.gitlab.arturbosch.detekt.test.createLocation
-import io.gitlab.arturbosch.detekt.test.createRuleInfo
+import io.gitlab.arturbosch.detekt.test.createRuleInstance
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.nio.file.Path
@@ -27,13 +27,8 @@ class OutputFacadeSpec {
         val defaultResult = DetektResult(
             listOf(
                 createIssue(
-                    createRuleInfo(ruleSetId = "Key"),
-                    createEntity(
-                        location = createLocation(
-                            "TestFile.kt",
-                            System.getProperty("user.dir")
-                        )
-                    )
+                    createRuleInstance(ruleSetId = "Key"),
+                    createEntity(location = createLocation("TestFile.kt", System.getProperty("user.dir")))
                 )
             )
         )

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/ComplexityReportSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/ComplexityReportSpec.kt
@@ -9,7 +9,7 @@ import io.github.detekt.metrics.processors.sourceLinesKey
 import io.gitlab.arturbosch.detekt.api.Detektion
 import io.gitlab.arturbosch.detekt.core.DetektResult
 import io.gitlab.arturbosch.detekt.test.createIssue
-import io.gitlab.arturbosch.detekt.test.createRuleInfo
+import io.gitlab.arturbosch.detekt.test.createRuleInstance
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -51,4 +51,4 @@ class ComplexityReportSpec {
     }
 }
 
-private fun createDetektion(): Detektion = DetektResult(listOf(createIssue(createRuleInfo(ruleSetId = "Key"))))
+private fun createDetektion(): Detektion = DetektResult(listOf(createIssue(createRuleInstance(ruleSetId = "Key"))))

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/FileBasedIssuesReportSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/FileBasedIssuesReportSpec.kt
@@ -6,7 +6,7 @@ import io.gitlab.arturbosch.detekt.core.reporting.decolorized
 import io.gitlab.arturbosch.detekt.test.TestDetektion
 import io.gitlab.arturbosch.detekt.test.createIssue
 import io.gitlab.arturbosch.detekt.test.createLocation
-import io.gitlab.arturbosch.detekt.test.createRuleInfo
+import io.gitlab.arturbosch.detekt.test.createRuleInstance
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -19,9 +19,9 @@ class FileBasedIssuesReportSpec {
         val location1 = createLocation("File1.kt")
         val location2 = createLocation("File2.kt")
         val detektion = TestDetektion(
-            createIssue(createRuleInfo(ruleSetId = "Ruleset1"), location1),
-            createIssue(createRuleInfo(ruleSetId = "Ruleset1"), location2),
-            createIssue(createRuleInfo(ruleSetId = "Ruleset2"), location1),
+            createIssue(createRuleInstance(ruleSetId = "Ruleset1"), location1),
+            createIssue(createRuleInstance(ruleSetId = "Ruleset1"), location2),
+            createIssue(createRuleInstance(ruleSetId = "Ruleset2"), location1),
         )
 
         val output = subject.render(detektion)?.decolorized()

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/IssuesReportSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/IssuesReportSpec.kt
@@ -6,7 +6,7 @@ import io.gitlab.arturbosch.detekt.core.reporting.decolorized
 import io.gitlab.arturbosch.detekt.test.TestDetektion
 import io.gitlab.arturbosch.detekt.test.createIssue
 import io.gitlab.arturbosch.detekt.test.createLocation
-import io.gitlab.arturbosch.detekt.test.createRuleInfo
+import io.gitlab.arturbosch.detekt.test.createRuleInstance
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -18,9 +18,9 @@ class IssuesReportSpec {
     fun `has the reference content`() {
         val location = createLocation()
         val detektion = TestDetektion(
-            createIssue(createRuleInfo(ruleSetId = "Ruleset1"), location),
-            createIssue(createRuleInfo(ruleSetId = "Ruleset1"), location),
-            createIssue(createRuleInfo(ruleSetId = "Ruleset2"), location),
+            createIssue(createRuleInstance(ruleSetId = "Ruleset1"), location),
+            createIssue(createRuleInstance(ruleSetId = "Ruleset1"), location),
+            createIssue(createRuleInstance(ruleSetId = "Ruleset2"), location),
         )
 
         val output = subject.render(detektion)?.decolorized()
@@ -53,11 +53,11 @@ class IssuesReportSpec {
     fun `truncates long message`() {
         val detektion = TestDetektion(
             createIssue(
-                createRuleInfo("LongRule", "Ruleset"),
+                createRuleInstance("LongRule", "Ruleset"),
                 message = "This is just a long message that should be truncated after a given threshold is reached.",
             ),
             createIssue(
-                createRuleInfo("MultilineRule", "Ruleset"),
+                createRuleInstance("MultilineRule", "Ruleset"),
                 message = "A multiline\n\r\tmessage.\t ",
             ),
         )

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/LiteIssuesReportSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/LiteIssuesReportSpec.kt
@@ -5,7 +5,7 @@ import io.gitlab.arturbosch.detekt.core.reporting.AutoCorrectableIssueAssert
 import io.gitlab.arturbosch.detekt.test.TestDetektion
 import io.gitlab.arturbosch.detekt.test.createIssue
 import io.gitlab.arturbosch.detekt.test.createLocation
-import io.gitlab.arturbosch.detekt.test.createRuleInfo
+import io.gitlab.arturbosch.detekt.test.createRuleInstance
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -17,8 +17,8 @@ class LiteIssuesReportSpec {
     fun `reports non-empty issues`() {
         val location = createLocation()
         val detektion = TestDetektion(
-            createIssue(createRuleInfo("SpacingAfterPackageDeclaration"), location),
-            createIssue(createRuleInfo("UnnecessarySafeCall"), location),
+            createIssue(createRuleInstance("SpacingAfterPackageDeclaration"), location),
+            createIssue(createRuleInstance("UnnecessarySafeCall"), location),
         )
         assertThat(subject.render(detektion)).isEqualTo(
             """

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/SuppressionsSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/SuppressionsSpec.kt
@@ -18,7 +18,7 @@ import org.junit.jupiter.params.provider.ValueSource
 class SuppressionsSpec {
 
     private fun KtElement.isSuppressedBy(): Boolean {
-        return isSuppressedBy(Rule.Id("RuleId"), setOf("alias1", "alias2"), RuleSet.Id("RuleSetId"))
+        return isSuppressedBy(Rule.Name("RuleName"), setOf("alias1", "alias2"), RuleSet.Id("RuleSetId"))
     }
 
     @Nested
@@ -27,7 +27,7 @@ class SuppressionsSpec {
         inner class AtFile {
             val file = compileContentForTest(
                 """
-                    @file:Suppress("RuleId")
+                    @file:Suppress("RuleName")
                     
                     class OneClass {
                         fun function(parameter: String) {
@@ -69,7 +69,7 @@ class SuppressionsSpec {
         inner class AtClass {
             val file = compileContentForTest(
                 """
-                    @Suppress("RuleId")
+                    @Suppress("RuleName")
                     class OneClass {
                         fun function(parameter: String) {
                             val a = 0
@@ -111,7 +111,7 @@ class SuppressionsSpec {
             val file = compileContentForTest(
                 """
                     class OneClass {
-                        @Suppress("RuleId")
+                        @Suppress("RuleName")
                         fun function(parameter: String) {
                             val a = 0
                         }
@@ -152,7 +152,7 @@ class SuppressionsSpec {
             val file = compileContentForTest(
                 """
                     class OneClass {
-                        fun function(@Suppress("RuleId") parameter: String) {
+                        fun function(@Suppress("RuleName") parameter: String) {
                             val a = 0
                         }
                     }
@@ -197,7 +197,7 @@ class SuppressionsSpec {
                         }
                     }
                     
-                    @Suppress("RuleId")
+                    @Suppress("RuleName")
                     fun topLevelFunction() = Unit
                 """.trimIndent()
             )
@@ -232,12 +232,12 @@ class SuppressionsSpec {
     @ParameterizedTest
     @ValueSource(strings = ["Suppress", "SuppressWarnings"])
     fun `works with both annotations`(annotation: String) {
-        assertThat(compileContentForTest("""@file:$annotation("RuleId")""").isSuppressedBy()).isTrue()
+        assertThat(compileContentForTest("""@file:$annotation("RuleName")""").isSuppressedBy()).isTrue()
     }
 
     @ParameterizedTest
     @ValueSource(
-        strings = ["all", "All", "ALL", "RuleId", "RuleSetId", "RuleSetId.RuleId", "RuleSetId:RuleId", "alias1", "alias2"]
+        strings = ["all", "All", "ALL", "RuleName", "RuleSetId", "RuleSetId.RuleName", "RuleSetId:RuleName", "alias1", "alias2"]
     )
     fun shouldSuppress(value: String) {
         assertThat(compileContentForTest("""@file:Suppress("$value")""").isSuppressedBy()).isTrue()
@@ -248,7 +248,7 @@ class SuppressionsSpec {
 
     @ParameterizedTest
     @ValueSource(
-        strings = ["aLL", "ruleid", "RuleId2", "RuleId.RuleSetId", "RuleSetId.alias1", "RuleSetId:alias2"]
+        strings = ["aLL", "Rulename", "RuleName2", "RuleName.RuleSetId", "RuleSetId.alias1", "RuleSetId:alias2"]
     )
     fun `should not suppress with @Suppress annotation with unexpected value`(value: String) {
         assertThat(compileContentForTest("""@file:Suppress("$value")""").isSuppressedBy()).isFalse()
@@ -262,7 +262,7 @@ class SuppressionsSpec {
         val file = compileContentForTest(
             """
                 @file:Suppress("Foo")
-                @file:SuppressWarnings("RuleId")
+                @file:SuppressWarnings("RuleName")
             """.trimIndent()
         )
         assertThat(file.isSuppressedBy()).isTrue()
@@ -272,7 +272,7 @@ class SuppressionsSpec {
     fun checkAllAnnotations2() {
         val file = compileContentForTest(
             """
-                @file:Suppress("RuleId")
+                @file:Suppress("RuleName")
                 @file:SuppressWarnings("Foo")
             """.trimIndent()
         )

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/AutoCorrectLevelSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/AutoCorrectLevelSpec.kt
@@ -80,7 +80,7 @@ private fun runRule(config: Config): Pair<KtFile, List<Finding>> {
 
     val ruleSet = loadRuleSet<FormattingProvider>()
     val rules = ruleSet.rules
-        .map { (ruleId, provider) -> provider(config.subConfig(ruleSet.id.value).subConfig(ruleId.value)) }
+        .map { (ruleName, provider) -> provider(config.subConfig(ruleSet.id.value).subConfig(ruleName.value)) }
         .filter { it.config.valueOrDefault("active", false) }
     return testFile to rules.flatMap { it.visitFile(testFile) }
 }

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/config/ConfigAssert.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/config/ConfigAssert.kt
@@ -52,9 +52,9 @@ class ConfigAssert(
 
     private fun verifyIssueIdMatchesName(rule: Rule) {
         val clazz = rule::class.java
-        assertThat(rule.ruleId)
-            .withFailMessage { "rule $clazz declares the rule id ${rule.ruleId} instead of ${clazz.simpleName}" }
-            .isEqualTo(Rule.Id(clazz.simpleName))
+        assertThat(rule.ruleName)
+            .withFailMessage { "rule $clazz declares the rule id ${rule.ruleName} instead of ${clazz.simpleName}" }
+            .isEqualTo(Rule.Name(clazz.simpleName))
     }
 
     private fun getYmlRuleConfig() = config.subConfig(name) as? YamlConfig

--- a/detekt-report-html/src/main/kotlin/io/github/detekt/report/html/HtmlOutputReport.kt
+++ b/detekt-report-html/src/main/kotlin/io/github/detekt/report/html/HtmlOutputReport.kt
@@ -6,6 +6,7 @@ import io.gitlab.arturbosch.detekt.api.Detektion
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.OutputReport
 import io.gitlab.arturbosch.detekt.api.ProjectMetric
+import io.gitlab.arturbosch.detekt.api.RuleInstance
 import io.gitlab.arturbosch.detekt.api.RuleSet
 import io.gitlab.arturbosch.detekt.api.SetupContext
 import io.gitlab.arturbosch.detekt.api.TextLocation
@@ -102,7 +103,7 @@ class HtmlOutputReport : BuiltInOutputReport, OutputReport() {
         text("Total: %,d".format(Locale.ROOT, total))
 
         issues
-            .groupBy { it.ruleInfo.ruleSetId }
+            .groupBy { it.ruleInstance.ruleSetId }
             .toList()
             .sortedBy { (group, _) -> group.value }
             .forEach { (group, groupIssues) ->
@@ -114,24 +115,24 @@ class HtmlOutputReport : BuiltInOutputReport, OutputReport() {
         h3 { text("$group: %,d".format(Locale.ROOT, issues.size)) }
 
         issues
-            .groupBy { it.ruleInfo }
+            .groupBy { it.ruleInstance }
             .toList()
-            .sortedBy { (ruleInfo, _) -> ruleInfo.id.value }
-            .forEach { (ruleInfo, ruleIssues) ->
-                renderRule(ruleInfo, ruleIssues)
+            .sortedBy { (ruleInstance, _) -> ruleInstance.id.value }
+            .forEach { (ruleInstance, ruleIssues) ->
+                renderRule(ruleInstance, ruleIssues)
             }
     }
 
-    private fun FlowContent.renderRule(ruleInfo: Issue.RuleInfo, issues: List<Issue>) {
-        val ruleId = ruleInfo.id.value
-        val ruleSetId = ruleInfo.ruleSetId.value
+    private fun FlowContent.renderRule(ruleInstance: RuleInstance, issues: List<Issue>) {
+        val ruleId = ruleInstance.id.value
+        val ruleSetId = ruleInstance.ruleSetId.value
         details {
             id = ruleId
             open = true
 
             summary("rule-container") {
                 span("rule") { text("$ruleId: %,d ".format(Locale.ROOT, issues.size)) }
-                span("description") { text(ruleInfo.description) }
+                span("description") { text(ruleInstance.description) }
             }
 
             a("$DETEKT_WEBSITE_BASE_URL/docs/rules/${ruleSetId.lowercase()}#${ruleId.lowercase()}") {
@@ -172,7 +173,7 @@ class HtmlOutputReport : BuiltInOutputReport, OutputReport() {
         val psiFile = issue.entity.ktElement?.containingFile
         if (psiFile != null) {
             val lineSequence = psiFile.text.splitToSequence('\n')
-            snippetCode(issue.ruleInfo.id, lineSequence, issue.location.source, issue.location.text.length())
+            snippetCode(issue.ruleInstance.id, lineSequence, issue.location.source, issue.location.text.length())
         }
     }
 

--- a/detekt-report-html/src/main/kotlin/io/github/detekt/report/html/HtmlOutputReport.kt
+++ b/detekt-report-html/src/main/kotlin/io/github/detekt/report/html/HtmlOutputReport.kt
@@ -117,25 +117,25 @@ class HtmlOutputReport : BuiltInOutputReport, OutputReport() {
         issues
             .groupBy { it.ruleInstance }
             .toList()
-            .sortedBy { (ruleInstance, _) -> ruleInstance.id.value }
+            .sortedBy { (ruleInstance, _) -> ruleInstance.name.value }
             .forEach { (ruleInstance, ruleIssues) ->
                 renderRule(ruleInstance, ruleIssues)
             }
     }
 
     private fun FlowContent.renderRule(ruleInstance: RuleInstance, issues: List<Issue>) {
-        val ruleId = ruleInstance.id.value
+        val ruleName = ruleInstance.name.value
         val ruleSetId = ruleInstance.ruleSetId.value
         details {
-            id = ruleId
+            id = ruleName
             open = true
 
             summary("rule-container") {
-                span("rule") { text("$ruleId: %,d ".format(Locale.ROOT, issues.size)) }
+                span("rule") { text("$ruleName: %,d ".format(Locale.ROOT, issues.size)) }
                 span("description") { text(ruleInstance.description) }
             }
 
-            a("$DETEKT_WEBSITE_BASE_URL/docs/rules/${ruleSetId.lowercase()}#${ruleId.lowercase()}") {
+            a("$DETEKT_WEBSITE_BASE_URL/docs/rules/${ruleSetId.lowercase()}#${ruleName.lowercase()}") {
                 +"Documentation"
             }
 
@@ -173,7 +173,7 @@ class HtmlOutputReport : BuiltInOutputReport, OutputReport() {
         val psiFile = issue.entity.ktElement?.containingFile
         if (psiFile != null) {
             val lineSequence = psiFile.text.splitToSequence('\n')
-            snippetCode(issue.ruleInstance.id, lineSequence, issue.location.source, issue.location.text.length())
+            snippetCode(issue.ruleInstance.name, lineSequence, issue.location.source, issue.location.text.length())
         }
     }
 

--- a/detekt-report-html/src/main/kotlin/io/github/detekt/report/html/HtmlUtils.kt
+++ b/detekt-report-html/src/main/kotlin/io/github/detekt/report/html/HtmlUtils.kt
@@ -19,7 +19,7 @@ import kotlin.math.max
 import kotlin.math.min
 
 internal fun FlowContent.snippetCode(
-    ruleName: Rule.Id,
+    ruleName: Rule.Name,
     lines: Sequence<String>,
     location: SourceLocation,
     length: Int,
@@ -67,7 +67,7 @@ private fun FlowContent.writeErrorLine(line: String, errorStarts: Int, length: I
     return errorEnds - errorStarts
 }
 
-private fun FlowContent.showError(ruleName: Rule.Id, throwable: Throwable) {
+private fun FlowContent.showError(ruleName: Rule.Name, throwable: Throwable) {
     div("exception") {
         h4 {
             text("Error showing the code snippet")
@@ -83,7 +83,7 @@ private fun FlowContent.showError(ruleName: Rule.Id, throwable: Throwable) {
     }
 }
 
-private fun createReportUrl(ruleName: Rule.Id, throwable: Throwable): String {
+private fun createReportUrl(ruleName: Rule.Name, throwable: Throwable): String {
     val title = URLEncoder.encode("HtmlReport error in rule: $ruleName", "UTF8")
     val stackTrace = throwable.printStackTraceString()
         .lineSequence()

--- a/detekt-report-html/src/test/kotlin/io/github/detekt/report/html/HtmlOutputReportSpec.kt
+++ b/detekt-report-html/src/test/kotlin/io/github/detekt/report/html/HtmlOutputReportSpec.kt
@@ -18,7 +18,7 @@ import io.gitlab.arturbosch.detekt.test.TestDetektion
 import io.gitlab.arturbosch.detekt.test.createEntity
 import io.gitlab.arturbosch.detekt.test.createIssue
 import io.gitlab.arturbosch.detekt.test.createLocation
-import io.gitlab.arturbosch.detekt.test.createRuleInfo
+import io.gitlab.arturbosch.detekt.test.createRuleInstance
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.psi.KtElement
 import org.junit.jupiter.api.Test
@@ -120,9 +120,9 @@ class HtmlOutputReportSpec {
     @Test
     fun `renders the right documentation links for the rules`() {
         val detektion = TestDetektion(
-            createIssue(createRuleInfo("ValCouldBeVar", "Style")),
-            createIssue(createRuleInfo("EmptyBody", "empty")),
-            createIssue(createRuleInfo("EmptyIf", "empty")),
+            createIssue(createRuleInstance("ValCouldBeVar", "Style")),
+            createIssue(createRuleInstance("EmptyBody", "empty")),
+            createIssue(createRuleInstance("EmptyIf", "empty")),
         )
 
         val result = htmlReport.render(detektion)
@@ -212,9 +212,9 @@ private fun createTestDetektionWithMultipleSmells(): Detektion {
     )
 
     return TestDetektion(
-        createIssue(createRuleInfo("rule_a", "RuleSet1"), entity1, "Issue message 1"),
-        createIssue(createRuleInfo("rule_a", "RuleSet1"), entity2, "Issue message 2"),
-        createIssue(createRuleInfo("rule_b", "RuleSet2"), entity3, "Issue message 3"),
+        createIssue(createRuleInstance("rule_a", "RuleSet1"), entity1, "Issue message 1"),
+        createIssue(createRuleInstance("rule_a", "RuleSet1"), entity2, "Issue message 2"),
+        createIssue(createRuleInstance("rule_b", "RuleSet2"), entity3, "Issue message 3"),
     )
 }
 
@@ -245,9 +245,9 @@ private fun createTestDetektionFromRelativePath(): Detektion {
     )
 
     return TestDetektion(
-        createIssue(createRuleInfo("rule_a", "RuleSet1"), entity1, "Issue message 1"),
-        createIssue(createRuleInfo("rule_a", "RuleSet1"), entity2, "Issue message 2"),
-        createIssue(createRuleInfo("rule_b", "RuleSet2"), entity3, "Issue message 3"),
+        createIssue(createRuleInstance("rule_a", "RuleSet1"), entity1, "Issue message 1"),
+        createIssue(createRuleInstance("rule_a", "RuleSet1"), entity2, "Issue message 2"),
+        createIssue(createRuleInstance("rule_b", "RuleSet2"), entity3, "Issue message 3"),
     )
 }
 
@@ -258,16 +258,16 @@ private fun issues(): Array<Issue> {
     val entity4 = createEntity(location = createLocation("src/main/com/sample/Sample2.kt", position = 1 to 1))
 
     return arrayOf(
-        createIssue(createRuleInfo("rule_a", "RuleSet1"), entity1),
-        createIssue(createRuleInfo("rule_a", "RuleSet1"), entity2),
-        createIssue(createRuleInfo("rule_a", "RuleSet1"), entity3),
-        createIssue(createRuleInfo("rule_a", "RuleSet1"), entity4),
-        createIssue(createRuleInfo("rule_b", "RuleSet1"), entity2),
-        createIssue(createRuleInfo("rule_b", "RuleSet1"), entity1),
-        createIssue(createRuleInfo("rule_b", "RuleSet1"), entity4),
-        createIssue(createRuleInfo("rule_b", "RuleSet2"), entity3),
-        createIssue(createRuleInfo("rule_c", "RuleSet2"), entity1),
-        createIssue(createRuleInfo("rule_c", "RuleSet2"), entity2),
+        createIssue(createRuleInstance("rule_a", "RuleSet1"), entity1),
+        createIssue(createRuleInstance("rule_a", "RuleSet1"), entity2),
+        createIssue(createRuleInstance("rule_a", "RuleSet1"), entity3),
+        createIssue(createRuleInstance("rule_a", "RuleSet1"), entity4),
+        createIssue(createRuleInstance("rule_b", "RuleSet1"), entity2),
+        createIssue(createRuleInstance("rule_b", "RuleSet1"), entity1),
+        createIssue(createRuleInstance("rule_b", "RuleSet1"), entity4),
+        createIssue(createRuleInstance("rule_b", "RuleSet2"), entity3),
+        createIssue(createRuleInstance("rule_c", "RuleSet2"), entity1),
+        createIssue(createRuleInstance("rule_c", "RuleSet2"), entity2),
     )
 }
 

--- a/detekt-report-html/src/test/kotlin/io/github/detekt/report/html/HtmlUtilsSpec.kt
+++ b/detekt-report-html/src/test/kotlin/io/github/detekt/report/html/HtmlUtilsSpec.kt
@@ -31,7 +31,7 @@ class HtmlUtilsSpec {
     @Test
     fun `all line`() {
         val snippet = createHTML().div {
-            snippetCode(Rule.Id("ruleName"), code, SourceLocation(7, 1), 34)
+            snippetCode(Rule.Name("ruleName"), code, SourceLocation(7, 1), 34)
         }
 
         assertThat(snippet).isEqualTo(
@@ -54,7 +54,7 @@ class HtmlUtilsSpec {
     @Test
     fun `part of line`() {
         val snippet = createHTML().div {
-            snippetCode(Rule.Id("ruleName"), code, SourceLocation(7, 7), 26)
+            snippetCode(Rule.Name("ruleName"), code, SourceLocation(7, 7), 26)
         }
 
         assertThat(snippet).isEqualTo(
@@ -77,7 +77,7 @@ class HtmlUtilsSpec {
     @Test
     fun `more than one line`() {
         val snippet = createHTML().div {
-            snippetCode(Rule.Id("ruleName"), code, SourceLocation(7, 7), 66)
+            snippetCode(Rule.Name("ruleName"), code, SourceLocation(7, 7), 66)
         }
 
         assertThat(snippet).isEqualTo(
@@ -100,7 +100,7 @@ class HtmlUtilsSpec {
     @Test
     fun `first line`() {
         val snippet = createHTML().div {
-            snippetCode(Rule.Id("ruleName"), code, SourceLocation(1, 1), 1)
+            snippetCode(Rule.Name("ruleName"), code, SourceLocation(1, 1), 1)
         }
 
         assertThat(snippet).contains((1..4).map { "  $it " })
@@ -109,7 +109,7 @@ class HtmlUtilsSpec {
     @Test
     fun `second line`() {
         val snippet = createHTML().div {
-            snippetCode(Rule.Id("ruleName"), code, SourceLocation(2, 1), 1)
+            snippetCode(Rule.Name("ruleName"), code, SourceLocation(2, 1), 1)
         }
 
         assertThat(snippet).contains((1..5).map { "  $it " })
@@ -118,7 +118,7 @@ class HtmlUtilsSpec {
     @Test
     fun `penultimate line`() {
         val snippet = createHTML().div {
-            snippetCode(Rule.Id("ruleName"), code, SourceLocation(15, 1), 1)
+            snippetCode(Rule.Name("ruleName"), code, SourceLocation(15, 1), 1)
         }
 
         assertThat(snippet).contains((12..16).map { "  $it " })
@@ -127,7 +127,7 @@ class HtmlUtilsSpec {
     @Test
     fun `last line`() {
         val snippet = createHTML().div {
-            snippetCode(Rule.Id("ruleName"), code, SourceLocation(16, 1), 1)
+            snippetCode(Rule.Name("ruleName"), code, SourceLocation(16, 1), 1)
         }
 
         assertThat(snippet).contains((13..16).map { "  $it " })
@@ -136,7 +136,7 @@ class HtmlUtilsSpec {
     @Test
     fun `when we provide an invalid source location the exception div is shown`() {
         val snippet = createHTML().div {
-            snippetCode(Rule.Id("ruleName"), code, SourceLocation(7, 100), 1)
+            snippetCode(Rule.Name("ruleName"), code, SourceLocation(7, 100), 1)
         }
 
         assertThat(snippet).contains("""<div class="exception">""")

--- a/detekt-report-md/src/main/kotlin/io/github/detekt/report/md/MdOutputReport.kt
+++ b/detekt-report-md/src/main/kotlin/io/github/detekt/report/md/MdOutputReport.kt
@@ -15,6 +15,7 @@ import io.gitlab.arturbosch.detekt.api.Detektion
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.OutputReport
 import io.gitlab.arturbosch.detekt.api.ProjectMetric
+import io.gitlab.arturbosch.detekt.api.RuleInstance
 import io.gitlab.arturbosch.detekt.api.SetupContext
 import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.api.getOrNull
@@ -94,19 +95,19 @@ private fun MarkdownContent.renderComplexity(complexityReport: List<String>) {
 
 private fun MarkdownContent.renderGroup(issues: List<Issue>, basePath: Path?) {
     issues
-        .groupBy { it.ruleInfo }
+        .groupBy { it.ruleInstance }
         .toList()
-        .sortedBy { (ruleInfo, _) -> ruleInfo.id.value }
-        .forEach { (ruleInfo, ruleIssues) ->
-            renderRule(ruleInfo, ruleIssues, basePath)
+        .sortedBy { (ruleInstance, _) -> ruleInstance.id.value }
+        .forEach { (ruleInstance, ruleIssues) ->
+            renderRule(ruleInstance, ruleIssues, basePath)
         }
 }
 
-private fun MarkdownContent.renderRule(ruleInfo: Issue.RuleInfo, issues: List<Issue>, basePath: Path?) {
-    val ruleId = ruleInfo.id.value
-    val ruleSetId = ruleInfo.ruleSetId.value
+private fun MarkdownContent.renderRule(ruleInstance: RuleInstance, issues: List<Issue>, basePath: Path?) {
+    val ruleId = ruleInstance.id.value
+    val ruleSetId = ruleInstance.ruleSetId.value
     h3 { "$ruleSetId, $ruleId (%,d)".format(Locale.ROOT, issues.size) }
-    paragraph { ruleInfo.description }
+    paragraph { ruleInstance.description }
 
     paragraph {
         link(
@@ -136,7 +137,7 @@ private fun MarkdownContent.renderIssues(issues: List<Issue>, basePath: Path?) {
     h2 { "Issues (%,d)".format(Locale.ROOT, total) }
 
     issues
-        .groupBy { it.ruleInfo.ruleSetId }
+        .groupBy { it.ruleInstance.ruleSetId }
         .toList()
         .sortedBy { (group, _) -> group.value }
         .forEach { (_, groupIssues) ->

--- a/detekt-report-md/src/main/kotlin/io/github/detekt/report/md/MdOutputReport.kt
+++ b/detekt-report-md/src/main/kotlin/io/github/detekt/report/md/MdOutputReport.kt
@@ -97,22 +97,22 @@ private fun MarkdownContent.renderGroup(issues: List<Issue>, basePath: Path?) {
     issues
         .groupBy { it.ruleInstance }
         .toList()
-        .sortedBy { (ruleInstance, _) -> ruleInstance.id.value }
+        .sortedBy { (ruleInstance, _) -> ruleInstance.name.value }
         .forEach { (ruleInstance, ruleIssues) ->
             renderRule(ruleInstance, ruleIssues, basePath)
         }
 }
 
 private fun MarkdownContent.renderRule(ruleInstance: RuleInstance, issues: List<Issue>, basePath: Path?) {
-    val ruleId = ruleInstance.id.value
+    val ruleName = ruleInstance.name.value
     val ruleSetId = ruleInstance.ruleSetId.value
-    h3 { "$ruleSetId, $ruleId (%,d)".format(Locale.ROOT, issues.size) }
+    h3 { "$ruleSetId, $ruleName (%,d)".format(Locale.ROOT, issues.size) }
     paragraph { ruleInstance.description }
 
     paragraph {
         link(
             "Documentation",
-            "$DETEKT_WEBSITE_BASE_URL/docs/rules/${ruleSetId.lowercase()}#${ruleId.lowercase()}"
+            "$DETEKT_WEBSITE_BASE_URL/docs/rules/${ruleSetId.lowercase()}#${ruleName.lowercase()}"
         )
     }
 

--- a/detekt-report-md/src/test/kotlin/io/github/detekt/report/md/MdOutputReportSpec.kt
+++ b/detekt-report-md/src/test/kotlin/io/github/detekt/report/md/MdOutputReportSpec.kt
@@ -16,7 +16,7 @@ import io.gitlab.arturbosch.detekt.test.TestDetektion
 import io.gitlab.arturbosch.detekt.test.createEntity
 import io.gitlab.arturbosch.detekt.test.createIssue
 import io.gitlab.arturbosch.detekt.test.createLocation
-import io.gitlab.arturbosch.detekt.test.createRuleInfo
+import io.gitlab.arturbosch.detekt.test.createRuleInstance
 import org.assertj.core.api.Assertions.assertThat
 import org.intellij.lang.annotations.Language
 import org.jetbrains.kotlin.psi.KtElement
@@ -81,9 +81,9 @@ class MdOutputReportSpec {
     @Test
     fun `renders the right documentation links for the rules`() {
         val detektion = TestDetektion(
-            createIssue(createRuleInfo("ValCouldBeVar", "Style")),
-            createIssue(createRuleInfo("EmptyBody", "empty")),
-            createIssue(createRuleInfo("EmptyIf", "empty")),
+            createIssue(createRuleInstance("ValCouldBeVar", "Style")),
+            createIssue(createRuleInstance("EmptyBody", "empty")),
+            createIssue(createRuleInstance("EmptyIf", "empty")),
         )
 
         val result = mdReport.render(detektion)
@@ -161,9 +161,9 @@ private fun createTestDetektionWithMultipleSmells(): Detektion {
     )
 
     return createMdDetektion(
-        createIssue(createRuleInfo("rule_a", "Section-1"), entity1, "Issue message 1"),
-        createIssue(createRuleInfo("rule_a", "Section-1"), entity2, "Issue message 2"),
-        createIssue(createRuleInfo("rule_b", "Section-2"), entity3, "Issue message 3"),
+        createIssue(createRuleInstance("rule_a", "Section-1"), entity1, "Issue message 1"),
+        createIssue(createRuleInstance("rule_a", "Section-1"), entity2, "Issue message 2"),
+        createIssue(createRuleInstance("rule_b", "Section-2"), entity3, "Issue message 3"),
     ).also {
         it.putUserData(complexityKey, 10)
         it.putUserData(CognitiveComplexity.KEY, 10)
@@ -188,15 +188,15 @@ private fun issues(): Array<Issue> {
     val entity4 = createEntity(location = createLocation("src/main/com/sample/Sample2.kt", position = 1 to 1))
 
     return arrayOf(
-        createIssue(createRuleInfo("rule_a", "RuleSet1"), entity1),
-        createIssue(createRuleInfo("rule_a", "RuleSet1"), entity2),
-        createIssue(createRuleInfo("rule_a", "RuleSet1"), entity3),
-        createIssue(createRuleInfo("rule_a", "RuleSet1"), entity4),
-        createIssue(createRuleInfo("rule_b", "RuleSet1"), entity2),
-        createIssue(createRuleInfo("rule_b", "RuleSet1"), entity1),
-        createIssue(createRuleInfo("rule_b", "RuleSet1"), entity4),
-        createIssue(createRuleInfo("rule_b", "RuleSet2"), entity3),
-        createIssue(createRuleInfo("rule_c", "RuleSet2"), entity1),
-        createIssue(createRuleInfo("rule_c", "RuleSet2"), entity2),
+        createIssue(createRuleInstance("rule_a", "RuleSet1"), entity1),
+        createIssue(createRuleInstance("rule_a", "RuleSet1"), entity2),
+        createIssue(createRuleInstance("rule_a", "RuleSet1"), entity3),
+        createIssue(createRuleInstance("rule_a", "RuleSet1"), entity4),
+        createIssue(createRuleInstance("rule_b", "RuleSet1"), entity2),
+        createIssue(createRuleInstance("rule_b", "RuleSet1"), entity1),
+        createIssue(createRuleInstance("rule_b", "RuleSet1"), entity4),
+        createIssue(createRuleInstance("rule_b", "RuleSet2"), entity3),
+        createIssue(createRuleInstance("rule_c", "RuleSet2"), entity1),
+        createIssue(createRuleInstance("rule_c", "RuleSet2"), entity2),
     )
 }

--- a/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/Results.kt
+++ b/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/Results.kt
@@ -24,7 +24,7 @@ internal fun Severity.toResultLevel() = when (this) {
 
 private fun Issue.toResult(basePath: String?): io.github.detekt.sarif4k.Result {
     return io.github.detekt.sarif4k.Result(
-        ruleID = "detekt.${ruleInstance.ruleSetId}.${ruleInstance.id}",
+        ruleID = "detekt.${ruleInstance.ruleSetId}.${ruleInstance.name}",
         level = severity.toResultLevel(),
         locations = (listOf(location) + references.map { it.location }).map { it.toLocation(basePath) }.distinct(),
         message = Message(text = message)

--- a/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/Results.kt
+++ b/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/Results.kt
@@ -24,7 +24,7 @@ internal fun Severity.toResultLevel() = when (this) {
 
 private fun Issue.toResult(basePath: String?): io.github.detekt.sarif4k.Result {
     return io.github.detekt.sarif4k.Result(
-        ruleID = "detekt.${ruleInfo.ruleSetId}.${ruleInfo.id}",
+        ruleID = "detekt.${ruleInstance.ruleSetId}.${ruleInstance.id}",
         level = severity.toResultLevel(),
         locations = (listOf(location) + references.map { it.location }).map { it.toLocation(basePath) }.distinct(),
         message = Message(text = message)

--- a/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/RuleDescriptors.kt
+++ b/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/RuleDescriptors.kt
@@ -27,13 +27,13 @@ internal fun toReportingDescriptors(config: Config): List<ReportingDescriptor> {
 
 private fun Rule.toDescriptor(ruleSetId: RuleSet.Id): ReportingDescriptor {
     val formattedRuleSetId = ruleSetId.value.lowercase()
-    val formattedRuleId = ruleId.value.lowercase()
+    val formattedRuleName = ruleName.value.lowercase()
 
     return ReportingDescriptor(
-        id = "detekt.$ruleSetId.$ruleId",
-        name = ruleId.value,
+        id = "detekt.$ruleSetId.$ruleName",
+        name = ruleName.value,
         shortDescription = MultiformatMessageString(text = description),
-        helpURI = "https://detekt.dev/$formattedRuleSetId.html#$formattedRuleId",
+        helpURI = "https://detekt.dev/$formattedRuleSetId.html#$formattedRuleName",
         defaultConfiguration = ReportingConfiguration(
             level = computeSeverity().toResultLevel()
         )

--- a/detekt-report-sarif/src/test/kotlin/io/github/detekt/report/sarif/SarifOutputReportSpec.kt
+++ b/detekt-report-sarif/src/test/kotlin/io/github/detekt/report/sarif/SarifOutputReportSpec.kt
@@ -16,7 +16,7 @@ import io.gitlab.arturbosch.detekt.test.createEntity
 import io.gitlab.arturbosch.detekt.test.createIssue
 import io.gitlab.arturbosch.detekt.test.createIssueForRelativePath
 import io.gitlab.arturbosch.detekt.test.createLocation
-import io.gitlab.arturbosch.detekt.test.createRuleInfo
+import io.gitlab.arturbosch.detekt.test.createRuleInstance
 import io.gitlab.arturbosch.detekt.test.yamlConfig
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.psi.KtClassOrObject
@@ -31,17 +31,17 @@ class SarifOutputReportSpec {
     fun `renders multiple issues`() {
         val result = TestDetektion(
             createIssue(
-                ruleInfo = createRuleInfo("TestSmellA", "RuleSet1"),
+                ruleInstance = createRuleInstance("TestSmellA", "RuleSet1"),
                 entity = createEntity(location = createLocation(position = 1 to 1, endPosition = 2 to 3)),
                 severity = Severity.Error
             ),
             createIssue(
-                ruleInfo = createRuleInfo("TestSmellB", "RuleSet2"),
+                ruleInstance = createRuleInstance("TestSmellB", "RuleSet2"),
                 entity = createEntity(location = createLocation(position = 3 to 5, endPosition = 3 to 5)),
                 severity = Severity.Warning
             ),
             createIssue(
-                ruleInfo = createRuleInfo("TestSmellC", "RuleSet2"),
+                ruleInstance = createRuleInstance("TestSmellC", "RuleSet2"),
                 entity = createEntity(location = createLocation(position = 2 to 1, endPosition = 3 to 1)),
                 severity = Severity.Info
             )
@@ -60,9 +60,9 @@ class SarifOutputReportSpec {
     @Test
     fun `renders multiple issues with rule set to warning by default`() {
         val result = TestDetektion(
-            createIssue(createRuleInfo("TestSmellA", "RuleSet1"), severity = Severity.Error),
-            createIssue(createRuleInfo("TestSmellB", "RuleSet2"), severity = Severity.Warning),
-            createIssue(createRuleInfo("TestSmellC", "RuleSet2"), severity = Severity.Info)
+            createIssue(createRuleInstance("TestSmellA", "RuleSet1"), severity = Severity.Error),
+            createIssue(createRuleInstance("TestSmellB", "RuleSet2"), severity = Severity.Warning),
+            createIssue(createRuleInstance("TestSmellC", "RuleSet2"), severity = Severity.Info)
         )
 
         val testConfig = yamlConfig("config_with_rule_set_to_warning.yml")
@@ -91,9 +91,9 @@ class SarifOutputReportSpec {
     @Test
     fun `renders multiple issues with relative path`() {
         val result = TestDetektion(
-            createIssueForRelativePath(createRuleInfo("TestSmellA", "RuleSet1")),
-            createIssueForRelativePath(createRuleInfo("TestSmellB", "RuleSet2")),
-            createIssueForRelativePath(createRuleInfo("TestSmellC", "RuleSet2")),
+            createIssueForRelativePath(createRuleInstance("TestSmellA", "RuleSet1")),
+            createIssueForRelativePath(createRuleInstance("TestSmellB", "RuleSet2")),
+            createIssueForRelativePath(createRuleInstance("TestSmellC", "RuleSet2")),
         )
 
         val basePath = Path("/").absolute().resolve("Users/tester/detekt/")

--- a/detekt-report-txt/src/main/kotlin/io/github/detekt/report/txt/TxtOutputReport.kt
+++ b/detekt-report-txt/src/main/kotlin/io/github/detekt/report/txt/TxtOutputReport.kt
@@ -22,4 +22,4 @@ class TxtOutputReport : BuiltInOutputReport, OutputReport() {
 }
 
 private fun Issue.compactWithSignature(): String =
-    "${ruleInfo.id} - ${entity.compact()} - Signature=${entity.signature}"
+    "${ruleInstance.id} - ${entity.compact()} - Signature=${entity.signature}"

--- a/detekt-report-txt/src/main/kotlin/io/github/detekt/report/txt/TxtOutputReport.kt
+++ b/detekt-report-txt/src/main/kotlin/io/github/detekt/report/txt/TxtOutputReport.kt
@@ -22,4 +22,4 @@ class TxtOutputReport : BuiltInOutputReport, OutputReport() {
 }
 
 private fun Issue.compactWithSignature(): String =
-    "${ruleInstance.id} - ${entity.compact()} - Signature=${entity.signature}"
+    "${ruleInstance.name} - ${entity.compact()} - Signature=${entity.signature}"

--- a/detekt-report-txt/src/test/kotlin/io/github/detekt/report/txt/TxtOutputReportSpec.kt
+++ b/detekt-report-txt/src/test/kotlin/io/github/detekt/report/txt/TxtOutputReportSpec.kt
@@ -3,7 +3,7 @@ package io.github.detekt.report.txt
 import io.gitlab.arturbosch.detekt.test.TestDetektion
 import io.gitlab.arturbosch.detekt.test.createIssue
 import io.gitlab.arturbosch.detekt.test.createLocation
-import io.gitlab.arturbosch.detekt.test.createRuleInfo
+import io.gitlab.arturbosch.detekt.test.createRuleInstance
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -19,7 +19,7 @@ class TxtOutputReportSpec {
     @Test
     fun `renders one`() {
         val location = createLocation()
-        val detektion = TestDetektion(createIssue(createRuleInfo(), location))
+        val detektion = TestDetektion(createIssue(createRuleInstance(), location))
         assertThat(TxtOutputReport().render(detektion))
             .isEqualTo("TestSmell - [TestEntity] at ${location.compact()} - Signature=TestEntitySignature\n")
     }
@@ -28,9 +28,9 @@ class TxtOutputReportSpec {
     fun `renders multiple`() {
         val location = createLocation()
         val detektion = TestDetektion(
-            createIssue(createRuleInfo("TestSmellA"), location),
-            createIssue(createRuleInfo("TestSmellB"), location),
-            createIssue(createRuleInfo("TestSmellC"), location),
+            createIssue(createRuleInstance("TestSmellA"), location),
+            createIssue(createRuleInstance("TestSmellB"), location),
+            createIssue(createRuleInstance("TestSmellC"), location),
         )
         assertThat(TxtOutputReport().render(detektion))
             .isEqualTo(

--- a/detekt-report-xml/src/main/kotlin/io/github/detekt/report/xml/XmlOutputReport.kt
+++ b/detekt-report-xml/src/main/kotlin/io/github/detekt/report/xml/XmlOutputReport.kt
@@ -45,7 +45,7 @@ class XmlOutputReport : BuiltInOutputReport, OutputReport() {
                         "column=\"${it.location.source.column.toXmlString()}\"",
                         "severity=\"${it.severityLabel.toXmlString()}\"",
                         "message=\"${it.message.toXmlString()}\"",
-                        "source=\"${"detekt.${it.ruleInfo.id.value.toXmlString()}"}\" />"
+                        "source=\"${"detekt.${it.ruleInstance.id.value.toXmlString()}"}\" />"
                     ).joinToString(separator = " ")
                 }
                 lines += "</file>"

--- a/detekt-report-xml/src/main/kotlin/io/github/detekt/report/xml/XmlOutputReport.kt
+++ b/detekt-report-xml/src/main/kotlin/io/github/detekt/report/xml/XmlOutputReport.kt
@@ -45,7 +45,7 @@ class XmlOutputReport : BuiltInOutputReport, OutputReport() {
                         "column=\"${it.location.source.column.toXmlString()}\"",
                         "severity=\"${it.severityLabel.toXmlString()}\"",
                         "message=\"${it.message.toXmlString()}\"",
-                        "source=\"${"detekt.${it.ruleInstance.id.value.toXmlString()}"}\" />"
+                        "source=\"${"detekt.${it.ruleInstance.name.value.toXmlString()}"}\" />"
                     ).joinToString(separator = " ")
                 }
                 lines += "</file>"

--- a/detekt-report-xml/src/test/kotlin/io/github/detekt/report/xml/XmlOutputReportSpec.kt
+++ b/detekt-report-xml/src/test/kotlin/io/github/detekt/report/xml/XmlOutputReportSpec.kt
@@ -196,7 +196,7 @@ class XmlOutputReportSpec {
                 <?xml version="1.0" encoding="UTF-8"?>
                 <checkstyle version="4.3">
                 <file name="${entity1.location.path.invariantSeparatorsPathString}">
-                $TAB<error line="${issue.location.source.line}" column="${issue.location.source.column}" severity="$xmlSeverity" message="${issue.message}" source="detekt.${issue.ruleInstance.id}" />
+                $TAB<error line="${issue.location.source.line}" column="${issue.location.source.column}" severity="$xmlSeverity" message="${issue.message}" source="detekt.${issue.ruleInstance.name}" />
                 </file>
                 </checkstyle>
             """.trimIndent()

--- a/detekt-report-xml/src/test/kotlin/io/github/detekt/report/xml/XmlOutputReportSpec.kt
+++ b/detekt-report-xml/src/test/kotlin/io/github/detekt/report/xml/XmlOutputReportSpec.kt
@@ -6,7 +6,7 @@ import io.gitlab.arturbosch.detekt.test.TestDetektion
 import io.gitlab.arturbosch.detekt.test.createIssue
 import io.gitlab.arturbosch.detekt.test.createIssueForRelativePath
 import io.gitlab.arturbosch.detekt.test.createLocation
-import io.gitlab.arturbosch.detekt.test.createRuleInfo
+import io.gitlab.arturbosch.detekt.test.createRuleInstance
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -115,12 +115,12 @@ class XmlOutputReportSpec {
     @Test
     fun `renders issues with relative path`() {
         val issueA = createIssueForRelativePath(
-            ruleInfo = createRuleInfo("rule_a"),
+            ruleInstance = createRuleInstance("rule_a"),
             basePath = "${System.getProperty("user.dir")}/Users/tester/detekt/",
             relativePath = "Sample1.kt"
         )
         val issueB = createIssueForRelativePath(
-            ruleInfo = createRuleInfo("rule_b"),
+            ruleInstance = createRuleInstance("rule_b"),
             basePath = "${System.getProperty("user.dir")}/Users/tester/detekt/",
             relativePath = "Sample2.kt"
         )
@@ -196,7 +196,7 @@ class XmlOutputReportSpec {
                 <?xml version="1.0" encoding="UTF-8"?>
                 <checkstyle version="4.3">
                 <file name="${entity1.location.path.invariantSeparatorsPathString}">
-                $TAB<error line="${issue.location.source.line}" column="${issue.location.source.column}" severity="$xmlSeverity" message="${issue.message}" source="detekt.${issue.ruleInfo.id}" />
+                $TAB<error line="${issue.location.source.line}" column="${issue.location.source.column}" severity="$xmlSeverity" message="${issue.message}" source="detekt.${issue.ruleInstance.id}" />
                 </file>
                 </checkstyle>
             """.trimIndent()

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/RuleExtensions.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/RuleExtensions.kt
@@ -67,7 +67,7 @@ fun Rule.lint(ktFile: KtFile): List<Finding> = visitFile(ktFile).filterSuppresse
 
 private fun List<Finding>.filterSuppressed(rule: Rule): List<Finding> {
     return filterNot {
-        it.entity.ktElement?.isSuppressedBy(rule.ruleId, rule.aliases, RuleSet.Id("NoARuleSetId")) == true
+        it.entity.ktElement?.isSuppressedBy(rule.ruleName, rule.aliases, RuleSet.Id("NoARuleSetId")) == true
     }
 }
 

--- a/detekt-tooling/api/detekt-tooling.api
+++ b/detekt-tooling/api/detekt-tooling.api
@@ -205,8 +205,8 @@ public final class io/github/detekt/tooling/api/spec/RulesSpec$RunPolicy$NoRestr
 }
 
 public final class io/github/detekt/tooling/api/spec/RulesSpec$RunPolicy$RestrictToSingleRule : io/github/detekt/tooling/api/spec/RulesSpec$RunPolicy {
-	public fun <init> (Lio/gitlab/arturbosch/detekt/api/RuleSet$Id;Lio/gitlab/arturbosch/detekt/api/Rule$Id;)V
-	public final fun getRuleId ()Lio/gitlab/arturbosch/detekt/api/Rule$Id;
+	public fun <init> (Lio/gitlab/arturbosch/detekt/api/RuleSet$Id;Lio/gitlab/arturbosch/detekt/api/Rule$Name;)V
+	public final fun getRuleName ()Lio/gitlab/arturbosch/detekt/api/Rule$Name;
 	public final fun getRuleSetId ()Lio/gitlab/arturbosch/detekt/api/RuleSet$Id;
 }
 

--- a/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/api/spec/RulesSpec.kt
+++ b/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/api/spec/RulesSpec.kt
@@ -62,6 +62,6 @@ interface RulesSpec {
         /**
          * Run a single rule.
          */
-        class RestrictToSingleRule(val ruleSetId: RuleSet.Id, val ruleId: Rule.Id) : RunPolicy()
+        class RestrictToSingleRule(val ruleSetId: RuleSet.Id, val ruleName: Rule.Name) : RunPolicy()
     }
 }


### PR DESCRIPTION
This PR changes some names. The first one is that `Rule` has a `Name` instead of an `Id`. A rule can no longer be identified by a static name.

The second one is to introduce a new `id` that can be different from `Rule.Name`.

And because now `RuleInfo` had a `name` and an `id` I renamed it to `RuleInstance`.

Naming is REALLY difficult so any help here is more than welcome.

This PR is part of #7263 but because that PR contains a lot of decissions I prefer to split it so we can talk about each one in different PRs but I recomment to read #7263 so you get the full context about why this change is needed.