### PR TITLE
Better values for the tests

### DIFF
--- a/detekt-report-html/src/test/kotlin/io/github/detekt/report/html/HtmlOutputReportSpec.kt
+++ b/detekt-report-html/src/test/kotlin/io/github/detekt/report/html/HtmlOutputReportSpec.kt
@@ -96,8 +96,8 @@ class HtmlOutputReportSpec {
     fun `renders the right number of issues per rule`() {
         val result = htmlReport.render(createTestDetektionWithMultipleSmells())
 
-        assertThat(result).contains("<span class=\"rule\">id_a: 2 </span>")
-        assertThat(result).contains("<span class=\"rule\">id_b: 1 </span>")
+        assertThat(result).contains("<span class=\"rule\">rule_a: 2 </span>")
+        assertThat(result).contains("<span class=\"rule\">rule_b: 1 </span>")
     }
 
     @Test
@@ -113,8 +113,8 @@ class HtmlOutputReportSpec {
     fun `renders the right violation description for the rules`() {
         val result = htmlReport.render(createTestDetektionWithMultipleSmells())
 
-        assertThat(result).contains("<span class=\"description\">Description id_a</span>")
-        assertThat(result).contains("<span class=\"description\">Description id_b</span>")
+        assertThat(result).contains("<span class=\"description\">Description rule_a</span>")
+        assertThat(result).contains("<span class=\"description\">Description rule_b</span>")
     }
 
     @Test
@@ -212,9 +212,9 @@ private fun createTestDetektionWithMultipleSmells(): Detektion {
     )
 
     return TestDetektion(
-        createIssue(createRuleInfo("id_a", "RuleSet1"), entity1, "Issue message 1"),
-        createIssue(createRuleInfo("id_a", "RuleSet1"), entity2, "Issue message 2"),
-        createIssue(createRuleInfo("id_b", "RuleSet2"), entity3, "Issue message 3"),
+        createIssue(createRuleInfo("rule_a", "RuleSet1"), entity1, "Issue message 1"),
+        createIssue(createRuleInfo("rule_a", "RuleSet1"), entity2, "Issue message 2"),
+        createIssue(createRuleInfo("rule_b", "RuleSet2"), entity3, "Issue message 3"),
     )
 }
 
@@ -245,9 +245,9 @@ private fun createTestDetektionFromRelativePath(): Detektion {
     )
 
     return TestDetektion(
-        createIssue(createRuleInfo("id_a", "RuleSet1"), entity1, "Issue message 1"),
-        createIssue(createRuleInfo("id_a", "RuleSet1"), entity2, "Issue message 2"),
-        createIssue(createRuleInfo("id_b", "RuleSet2"), entity3, "Issue message 3"),
+        createIssue(createRuleInfo("rule_a", "RuleSet1"), entity1, "Issue message 1"),
+        createIssue(createRuleInfo("rule_a", "RuleSet1"), entity2, "Issue message 2"),
+        createIssue(createRuleInfo("rule_b", "RuleSet2"), entity3, "Issue message 3"),
     )
 }
 
@@ -258,16 +258,16 @@ private fun issues(): Array<Issue> {
     val entity4 = createEntity(location = createLocation("src/main/com/sample/Sample2.kt", position = 1 to 1))
 
     return arrayOf(
-        createIssue(createRuleInfo("id_a", "RuleSet1"), entity1),
-        createIssue(createRuleInfo("id_a", "RuleSet1"), entity2),
-        createIssue(createRuleInfo("id_a", "RuleSet1"), entity3),
-        createIssue(createRuleInfo("id_a", "RuleSet1"), entity4),
-        createIssue(createRuleInfo("id_b", "RuleSet1"), entity2),
-        createIssue(createRuleInfo("id_b", "RuleSet1"), entity1),
-        createIssue(createRuleInfo("id_b", "RuleSet1"), entity4),
-        createIssue(createRuleInfo("id_b", "RuleSet2"), entity3),
-        createIssue(createRuleInfo("id_c", "RuleSet2"), entity1),
-        createIssue(createRuleInfo("id_c", "RuleSet2"), entity2),
+        createIssue(createRuleInfo("rule_a", "RuleSet1"), entity1),
+        createIssue(createRuleInfo("rule_a", "RuleSet1"), entity2),
+        createIssue(createRuleInfo("rule_a", "RuleSet1"), entity3),
+        createIssue(createRuleInfo("rule_a", "RuleSet1"), entity4),
+        createIssue(createRuleInfo("rule_b", "RuleSet1"), entity2),
+        createIssue(createRuleInfo("rule_b", "RuleSet1"), entity1),
+        createIssue(createRuleInfo("rule_b", "RuleSet1"), entity4),
+        createIssue(createRuleInfo("rule_b", "RuleSet2"), entity3),
+        createIssue(createRuleInfo("rule_c", "RuleSet2"), entity1),
+        createIssue(createRuleInfo("rule_c", "RuleSet2"), entity2),
     )
 }
 

--- a/detekt-report-html/src/test/resources/HtmlOutputFormatTest.html
+++ b/detekt-report-html/src/test/resources/HtmlOutputFormatTest.html
@@ -170,9 +170,9 @@
 <h2>Issues</h2>
 <div>Total: 3
   <h3>RuleSet1: 2</h3>
-  <details id="id_a" open="open">
-    <summary class="rule-container"><span class="rule">id_a: 2 </span><span class="description">Description id_a</span></summary>
-<a href="https://detekt.dev/docs/rules/ruleset1#id_a">Documentation</a>
+  <details id="rule_a" open="open">
+    <summary class="rule-container"><span class="rule">rule_a: 2 </span><span class="description">Description rule_a</span></summary>
+<a href="https://detekt.dev/docs/rules/ruleset1#rule_a">Documentation</a>
     <ul>
       <li><span class="location"><PREFIX>/src/main/com/sample/Sample1.kt:11:1</span><span class="message">Issue message 1</span>
         <pre><code><span class="lineno">   8 </span>
@@ -187,9 +187,9 @@
     </ul>
   </details>
   <h3>RuleSet2: 1</h3>
-  <details id="id_b" open="open">
-    <summary class="rule-container"><span class="rule">id_b: 1 </span><span class="description">Description id_b</span></summary>
-<a href="https://detekt.dev/docs/rules/ruleset2#id_b">Documentation</a>
+  <details id="rule_b" open="open">
+    <summary class="rule-container"><span class="rule">rule_b: 1 </span><span class="description">Description rule_b</span></summary>
+<a href="https://detekt.dev/docs/rules/ruleset2#rule_b">Documentation</a>
     <ul>
       <li><span class="location"><PREFIX>/src/main/com/sample/Sample3.kt:33:3</span><span class="message">Issue message 3</span></li>
     </ul>

--- a/detekt-report-md/src/test/kotlin/io/github/detekt/report/md/MdOutputReportSpec.kt
+++ b/detekt-report-md/src/test/kotlin/io/github/detekt/report/md/MdOutputReportSpec.kt
@@ -62,8 +62,8 @@ class MdOutputReportSpec {
 
     @Test
     fun `renders the right number of issues per rule`() {
-        assertThat(result).contains("id_a (2)")
-        assertThat(result).contains("id_b (1)")
+        assertThat(result).contains("rule_a (2)")
+        assertThat(result).contains("rule_b (1)")
     }
 
     @Test
@@ -74,8 +74,8 @@ class MdOutputReportSpec {
 
     @Test
     fun `renders the right violation description for the rules`() {
-        assertThat(result).contains("Description id_a")
-        assertThat(result).contains("Description id_b")
+        assertThat(result).contains("Description rule_a")
+        assertThat(result).contains("Description rule_b")
     }
 
     @Test
@@ -161,9 +161,9 @@ private fun createTestDetektionWithMultipleSmells(): Detektion {
     )
 
     return createMdDetektion(
-        createIssue(createRuleInfo("id_a", "Section-1"), entity1, "Issue message 1"),
-        createIssue(createRuleInfo("id_a", "Section-1"), entity2, "Issue message 2"),
-        createIssue(createRuleInfo("id_b", "Section-2"), entity3, "Issue message 3"),
+        createIssue(createRuleInfo("rule_a", "Section-1"), entity1, "Issue message 1"),
+        createIssue(createRuleInfo("rule_a", "Section-1"), entity2, "Issue message 2"),
+        createIssue(createRuleInfo("rule_b", "Section-2"), entity3, "Issue message 3"),
     ).also {
         it.putUserData(complexityKey, 10)
         it.putUserData(CognitiveComplexity.KEY, 10)
@@ -188,15 +188,15 @@ private fun issues(): Array<Issue> {
     val entity4 = createEntity(location = createLocation("src/main/com/sample/Sample2.kt", position = 1 to 1))
 
     return arrayOf(
-        createIssue(createRuleInfo("id_a", "RuleSet1"), entity1),
-        createIssue(createRuleInfo("id_a", "RuleSet1"), entity2),
-        createIssue(createRuleInfo("id_a", "RuleSet1"), entity3),
-        createIssue(createRuleInfo("id_a", "RuleSet1"), entity4),
-        createIssue(createRuleInfo("id_b", "RuleSet1"), entity2),
-        createIssue(createRuleInfo("id_b", "RuleSet1"), entity1),
-        createIssue(createRuleInfo("id_b", "RuleSet1"), entity4),
-        createIssue(createRuleInfo("id_b", "RuleSet2"), entity3),
-        createIssue(createRuleInfo("id_c", "RuleSet2"), entity1),
-        createIssue(createRuleInfo("id_c", "RuleSet2"), entity2),
+        createIssue(createRuleInfo("rule_a", "RuleSet1"), entity1),
+        createIssue(createRuleInfo("rule_a", "RuleSet1"), entity2),
+        createIssue(createRuleInfo("rule_a", "RuleSet1"), entity3),
+        createIssue(createRuleInfo("rule_a", "RuleSet1"), entity4),
+        createIssue(createRuleInfo("rule_b", "RuleSet1"), entity2),
+        createIssue(createRuleInfo("rule_b", "RuleSet1"), entity1),
+        createIssue(createRuleInfo("rule_b", "RuleSet1"), entity4),
+        createIssue(createRuleInfo("rule_b", "RuleSet2"), entity3),
+        createIssue(createRuleInfo("rule_c", "RuleSet2"), entity1),
+        createIssue(createRuleInfo("rule_c", "RuleSet2"), entity2),
     )
 }

--- a/detekt-report-xml/src/test/kotlin/io/github/detekt/report/xml/XmlOutputReportSpec.kt
+++ b/detekt-report-xml/src/test/kotlin/io/github/detekt/report/xml/XmlOutputReportSpec.kt
@@ -54,7 +54,7 @@ class XmlOutputReportSpec {
 
     @Test
     fun `renders one reported issue in single file`() {
-        val smell = createIssue("id_a", entity1, "TestMessage")
+        val smell = createIssue("rule_a", entity1, "TestMessage")
 
         val result = outputReport.render(TestDetektion(smell))
 
@@ -63,7 +63,7 @@ class XmlOutputReportSpec {
                 <?xml version="1.0" encoding="UTF-8"?>
                 <checkstyle version="4.3">
                 <file name="${entity1.location.path.invariantSeparatorsPathString}">
-                $TAB<error line="11" column="1" severity="error" message="TestMessage" source="detekt.id_a" />
+                $TAB<error line="11" column="1" severity="error" message="TestMessage" source="detekt.rule_a" />
                 </file>
                 </checkstyle>
             """.trimIndent()
@@ -72,8 +72,8 @@ class XmlOutputReportSpec {
 
     @Test
     fun `renders two reported issues in single file`() {
-        val smell1 = createIssue("id_a", entity1, "TestMessage")
-        val smell2 = createIssue("id_b", entity1, "TestMessage")
+        val smell1 = createIssue("rule_a", entity1, "TestMessage")
+        val smell2 = createIssue("rule_b", entity1, "TestMessage")
 
         val result = outputReport.render(TestDetektion(smell1, smell2))
 
@@ -82,8 +82,8 @@ class XmlOutputReportSpec {
                 <?xml version="1.0" encoding="UTF-8"?>
                 <checkstyle version="4.3">
                 <file name="${entity1.location.path.invariantSeparatorsPathString}">
-                $TAB<error line="11" column="1" severity="error" message="TestMessage" source="detekt.id_a" />
-                $TAB<error line="11" column="1" severity="error" message="TestMessage" source="detekt.id_b" />
+                $TAB<error line="11" column="1" severity="error" message="TestMessage" source="detekt.rule_a" />
+                $TAB<error line="11" column="1" severity="error" message="TestMessage" source="detekt.rule_b" />
                 </file>
                 </checkstyle>
             """.trimIndent()
@@ -92,8 +92,8 @@ class XmlOutputReportSpec {
 
     @Test
     fun `renders one reported issue across multiple files`() {
-        val smell1 = createIssue("id_a", entity1, "TestMessage")
-        val smell2 = createIssue("id_a", entity2, "TestMessage")
+        val smell1 = createIssue("rule_a", entity1, "TestMessage")
+        val smell2 = createIssue("rule_a", entity2, "TestMessage")
 
         val result = outputReport.render(TestDetektion(smell1, smell2))
 
@@ -102,10 +102,10 @@ class XmlOutputReportSpec {
                 <?xml version="1.0" encoding="UTF-8"?>
                 <checkstyle version="4.3">
                 <file name="${entity1.location.path.invariantSeparatorsPathString}">
-                $TAB<error line="11" column="1" severity="error" message="TestMessage" source="detekt.id_a" />
+                $TAB<error line="11" column="1" severity="error" message="TestMessage" source="detekt.rule_a" />
                 </file>
                 <file name="${entity2.location.path.invariantSeparatorsPathString}">
-                $TAB<error line="22" column="2" severity="error" message="TestMessage" source="detekt.id_a" />
+                $TAB<error line="22" column="2" severity="error" message="TestMessage" source="detekt.rule_a" />
                 </file>
                 </checkstyle>
             """.trimIndent()
@@ -115,12 +115,12 @@ class XmlOutputReportSpec {
     @Test
     fun `renders issues with relative path`() {
         val issueA = createIssueForRelativePath(
-            ruleInfo = createRuleInfo("id_a"),
+            ruleInfo = createRuleInfo("rule_a"),
             basePath = "${System.getProperty("user.dir")}/Users/tester/detekt/",
             relativePath = "Sample1.kt"
         )
         val issueB = createIssueForRelativePath(
-            ruleInfo = createRuleInfo("id_b"),
+            ruleInfo = createRuleInfo("rule_b"),
             basePath = "${System.getProperty("user.dir")}/Users/tester/detekt/",
             relativePath = "Sample2.kt"
         )
@@ -135,10 +135,10 @@ class XmlOutputReportSpec {
                 <?xml version="1.0" encoding="UTF-8"?>
                 <checkstyle version="4.3">
                 <file name="Sample1.kt">
-                $TAB<error line="1" column="1" severity="error" message="TestMessage" source="detekt.id_a" />
+                $TAB<error line="1" column="1" severity="error" message="TestMessage" source="detekt.rule_a" />
                 </file>
                 <file name="Sample2.kt">
-                $TAB<error line="1" column="1" severity="error" message="TestMessage" source="detekt.id_b" />
+                $TAB<error line="1" column="1" severity="error" message="TestMessage" source="detekt.rule_b" />
                 </file>
                 </checkstyle>
             """.trimIndent()
@@ -147,10 +147,10 @@ class XmlOutputReportSpec {
 
     @Test
     fun `renders two reported issues across multiple files`() {
-        val smell1 = createIssue("id_a", entity1, "TestMessage")
-        val smell2 = createIssue("id_b", entity1, "TestMessage")
-        val smell3 = createIssue("id_a", entity2, "TestMessage")
-        val smell4 = createIssue("id_b", entity2, "TestMessage")
+        val smell1 = createIssue("rule_a", entity1, "TestMessage")
+        val smell2 = createIssue("rule_b", entity1, "TestMessage")
+        val smell3 = createIssue("rule_a", entity2, "TestMessage")
+        val smell4 = createIssue("rule_b", entity2, "TestMessage")
 
         val result = outputReport.render(
             TestDetektion(
@@ -166,12 +166,12 @@ class XmlOutputReportSpec {
                 <?xml version="1.0" encoding="UTF-8"?>
                 <checkstyle version="4.3">
                 <file name="${entity1.location.path.invariantSeparatorsPathString}">
-                $TAB<error line="11" column="1" severity="error" message="TestMessage" source="detekt.id_a" />
-                $TAB<error line="11" column="1" severity="error" message="TestMessage" source="detekt.id_b" />
+                $TAB<error line="11" column="1" severity="error" message="TestMessage" source="detekt.rule_a" />
+                $TAB<error line="11" column="1" severity="error" message="TestMessage" source="detekt.rule_b" />
                 </file>
                 <file name="${entity2.location.path.invariantSeparatorsPathString}">
-                $TAB<error line="22" column="2" severity="error" message="TestMessage" source="detekt.id_a" />
-                $TAB<error line="22" column="2" severity="error" message="TestMessage" source="detekt.id_b" />
+                $TAB<error line="22" column="2" severity="error" message="TestMessage" source="detekt.rule_a" />
+                $TAB<error line="22" column="2" severity="error" message="TestMessage" source="detekt.rule_b" />
                 </file>
                 </checkstyle>
             """.trimIndent()


### PR DESCRIPTION
`Rule.Id` will stop being an id (for more context read #7313).

This PR only makes the tests a bit easier to read because it doesn't set the value `"id_a"` to something that is not an id.