### PR TITLE
Rename `UnusedPrivateMember` to `UnusedPrivateFunction`

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -273,9 +273,6 @@ style:
     ignoreAnnotated: ['Nested']
   UnusedImport:
     active: false # formatting already have this rule enabled
-  UnusedPrivateMember:
-    active: true
-    allowedNames: '(_|ignored|expected)'
   UseAnyOrNoneInsteadOfFind:
     active: true
   UseCheckOrError:

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/MainSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/MainSpec.kt
@@ -27,7 +27,7 @@ class MainSpec {
     @Nested
     inner class `Build runner` {
 
-        @Suppress("UnusedPrivateMember")
+        @Suppress("UnusedPrivateFunction")
         private fun runnerConfigs(): List<Arguments> {
             return listOf(
                 arguments(arrayOf("--generate-config", "detekt-test.yml"), ConfigExporter::class),

--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -781,7 +781,7 @@ style:
   UnusedPrivateClass:
     active: true
     aliases: ['unused']
-  UnusedPrivateMember:
+  UnusedPrivateFunction:
     active: true
     aliases: ['unused']
     allowedNames: ''

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/StyleGuideProvider.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/StyleGuideProvider.kt
@@ -66,7 +66,7 @@ class StyleGuideProvider : DefaultRuleSetProvider {
             ::UnusedImport,
             ::UnusedParameter,
             ::UnusedPrivateClass,
-            ::UnusedPrivateMember,
+            ::UnusedPrivateFunction,
             ::UnusedPrivateProperty,
             ::UnusedVariable,
             ::ExpressionBodySyntax,

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateFunction.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateFunction.kt
@@ -47,11 +47,10 @@ private const val ARRAY_GET_METHOD_NAME = "get"
 @RequiresTypeResolution
 @ActiveByDefault(since = "1.16.0")
 @Alias("unused")
-class UnusedPrivateMember(config: Config) : Rule(
+class UnusedPrivateFunction(config: Config) : Rule(
     config,
     "Private function is unused and should be removed."
 ) {
-
     @Configuration("unused private function names matching this regex are ignored")
     private val allowedNames: Regex by config("", String::toRegex)
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenCommentSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenCommentSpec.kt
@@ -716,7 +716,7 @@ class ForbiddenCommentSpec {
     @Nested
     inner class `comment getContent` {
 
-        @Suppress("LongMethod", "UnusedPrivateMember")
+        @Suppress("LongMethod", "UnusedPrivateFunction")
         private fun getCommentsContentArguments() = listOf(
             Arguments.of("// comment", "comment"),
             Arguments.of("//  comment", " comment"),

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumberSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumberSpec.kt
@@ -874,7 +874,7 @@ class MagicNumberSpec {
     @Nested
     inner class `a number as part of a range` {
 
-        @Suppress("UnusedPrivateMember")
+        @Suppress("UnusedPrivateFunction")
         private fun cases() = listOf(
             "val range = 1..27",
             "val range = (1..27)",

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateFunctionSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateFunctionSpec.kt
@@ -12,8 +12,8 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
-class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
-    val subject = UnusedPrivateMember(Config.empty)
+class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
+    val subject = UnusedPrivateFunction(Config.empty)
 
     @Nested
     inner class `interface functions` {
@@ -300,7 +300,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
         @Test
         fun `does not report annotated private functions`() {
             val code = """
-                @Suppress("UnusedPrivateMember")
+                @Suppress("UnusedPrivateFunction")
                 private fun foo(): String = ""
             """.trimIndent()
 
@@ -322,7 +322,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
         @Test
         fun `does not report private functions in annotated class`() {
             val code = """
-                @Suppress("UnusedPrivateMember")
+                @Suppress("UnusedPrivateFunction")
                 class Test {
                     private fun foo(): String = ""
                 }
@@ -334,7 +334,7 @@ class UnusedPrivateMemberSpec(val env: KotlinCoreEnvironment) {
         @Test
         fun `does not report private functions in class with annotated outer class`() {
             val code = """
-                @Suppress("UnusedPrivateMember")
+                @Suppress("UnusedPrivateFunction")
                 class Test {
                     private fun foo(): String = ""
                     private fun bar(): String = ""

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivatePropertySpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivatePropertySpec.kt
@@ -95,7 +95,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
         fun `does fail when enabled with invalid regex`() {
             val config = TestConfig(ALLOWED_NAMES_PATTERN to "*foo")
             assertThatExceptionOfType(PatternSyntaxException::class.java)
-                .isThrownBy { UnusedPrivateMember(config).lint(regexTestingCode) }
+                .isThrownBy { UnusedPrivateProperty(config).lint(regexTestingCode) }
         }
     }
 

--- a/website/docs/introduction/suppressors.md
+++ b/website/docs/introduction/suppressors.md
@@ -10,7 +10,7 @@ The `Suppressor`s are a tool that you can use to customize the reports of detekt
 An example is the **annotation** suppressor. It works like this. First, you need to configure the tag `ignoreAnnotated` with a list of annotations, you want the suppressor to consider. Example:
 
 ```yaml
-UnusedPrivateMember:
+UnusedPrivateFunction:
   active: true
   ignoreAnnotated:
     - 'Preview'


### PR DESCRIPTION
We were calling `UnusedPrivateMember` to a rule that only checked functions. So I renamed it to make more clear what it does. Also, it was called like this because time ago this rule handled lots of cases so for that reason I also reduced the number of `aliases`.