### PR TITLE
Fix parameter name of NamedArguments rule

### DIFF
--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NamedArguments.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NamedArguments.kt
@@ -36,16 +36,16 @@ class NamedArguments(config: Config) : Rule(
 ) {
 
     @Configuration("The allowed number of arguments for a function.")
-    private val allowedArguments: Int by config(defaultValue = 3)
+    private val threshold: Int by config(defaultValue = 3)
 
     @Configuration("ignores when argument values are the same as the parameter names")
     private val ignoreArgumentsMatchingNames: Boolean by config(defaultValue = false)
 
     override fun visitCallExpression(expression: KtCallExpression) {
         val valueArguments = expression.valueArguments.filterNot { it is KtLambdaArgument }
-        if (valueArguments.size > allowedArguments && expression.canNameArguments()) {
+        if (valueArguments.size > threshold && expression.canNameArguments()) {
             val message = "This function call has ${valueArguments.size} arguments. To call a function with more " +
-                "than $allowedArguments arguments you should set the name of each argument."
+                "than $threshold arguments you should set the name of each argument."
             report(CodeSmell(Entity.from(expression), message))
         } else {
             super.visitCallExpression(expression)


### PR DESCRIPTION
According to the document, we can take 2 config options for `NamedArguments` rule. `threshold` and `ignoreArgumentsMatchingNames`.
But according to actual implementation, config option names are `allowedArguments` and `ignoreArgumentsMatchingNames`.

I think `allowedArguments` should be `threshold`.

https://detekt.dev/docs/rules/complexity/#namedarguments

I will fix CI but can you check this is correct fix or not?.