### PR TITLE
Fix small corner-case in "SerialVersionUIDInSerializableClass" rule, …

### DIFF
--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/SerialVersionUIDInSerializableClass.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/SerialVersionUIDInSerializableClass.kt
@@ -96,7 +96,8 @@ class SerialVersionUIDInSerializableClass(config: Config) : Rule(
                     if (parentDeclaration is KtClass) "class" else "object"
                 )
             )
-        return if (property.isConstant() && isLongProperty(property) && property.isPrivate()) {
+        val isPropertyPrivate = declaration.isPrivate() || property.isPrivate()
+        return if (property.isConstant() && isLongProperty(property) && isPropertyPrivate) {
             null
         } else {
             SerialVersionUIDFindings(

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/SerialVersionUIDInSerializableClassSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/SerialVersionUIDInSerializableClassSpec.kt
@@ -240,6 +240,20 @@ class SerialVersionUIDInSerializableClassSpec {
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
+    @Test
+    fun `does not report constant in private companion object`() {
+        val code = """
+            import java.io.Serializable
+            
+            class C : Serializable {
+                private companion object {
+                    const val serialVersionUID: Long = 1
+                }
+            }
+        """.trimIndent()
+        assertThat(subject.compileAndLint(code)).isEmpty()
+    }
+
     companion object {
         private const val WRONG_SERIAL_VERSION_UID_MESSAGE =
             "The property `serialVersionUID` signature is not correct. `serialVersionUID` should be " +


### PR DESCRIPTION
…when property was declared inside private object.

Your `serialVersionUID` could be declared inside `private companion object`, and in this case `SerialVersionUIDInSerializableClass` rule should not raise any violations, as declared property is private.

```kotlin
class MyClass : Serializable {
     private companion object {
          const val serialVersionUID = 1L // should be OK for "SerialVersionUIDInSerializableClass" rule
     }
}
```
