### PR TITLE
Use `RuleInstance.id` instead of `RuleInstance.name`

### DIFF
--- a/detekt-api/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/test/TestFactory.kt
+++ b/detekt-api/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/test/TestFactory.kt
@@ -14,13 +14,13 @@ import kotlin.io.path.Path
 import kotlin.io.path.absolute
 
 fun createIssue(
-    ruleName: String = "TestSmell",
+    ruleId: String = "TestSmell/id",
     entity: Entity = createEntity(),
     message: String = "TestMessage",
     severity: Severity = Severity.Error,
     autoCorrectEnabled: Boolean = false,
 ): Issue = createIssue(
-    ruleInstance = createRuleInstance(ruleName),
+    ruleInstance = createRuleInstance(ruleId),
     entity = entity,
     message = message,
     severity = severity,
@@ -56,16 +56,18 @@ fun createIssue(
 )
 
 fun createRuleInstance(
-    name: String = "TestSmell",
-    ruleSetId: String = "RuleSet$name",
-    id: String = "$name/id",
-    description: String = "Description $name",
-): RuleInstance = RuleInstanceImpl(
-    id = id,
-    name = Rule.Name(name),
-    ruleSetId = RuleSet.Id(ruleSetId),
-    description = description
-)
+    id: String = "TestSmell/id",
+    ruleSetId: String = "RuleSet${id.split("/", limit = 2).first()}",
+    description: String = "Description ${id.split("/", limit = 2).first()}",
+): RuleInstance {
+    val split = id.split("/", limit = 2)
+    return RuleInstanceImpl(
+        id = id,
+        name = Rule.Name(split.first()),
+        ruleSetId = RuleSet.Id(ruleSetId),
+        description = description
+    )
+}
 
 fun createIssueForRelativePath(
     ruleInstance: RuleInstance,

--- a/detekt-compiler-plugin/src/main/kotlin/io/github/detekt/compiler/plugin/internal/MessageCollectorExtensions.kt
+++ b/detekt-compiler-plugin/src/main/kotlin/io/github/detekt/compiler/plugin/internal/MessageCollectorExtensions.kt
@@ -39,5 +39,5 @@ fun Issue.renderAsCompilerWarningMessage(): Pair<String, CompilerMessageLocation
         )
     }
 
-    return "${ruleInstance.name}: $message" to sourceLocation
+    return "${ruleInstance.id}: $message" to sourceLocation
 }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Analyzer.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Analyzer.kt
@@ -109,7 +109,7 @@ internal class Analyzer(
                     }
             }
             .filterNot { (ruleInstance, rule) ->
-                file.isSuppressedBy(ruleInstance.name, rule.aliases, ruleInstance.ruleSetId)
+                file.isSuppressedBy(ruleInstance.id, rule.aliases, ruleInstance.ruleSetId)
             }
             .filter { (_, rule) ->
                 bindingContext != BindingContext.EMPTY || !rule::class.hasAnnotation<RequiresTypeResolution>()
@@ -119,7 +119,7 @@ internal class Analyzer(
         return (correctableRules + otherRules).flatMap { (ruleInstance, rule) ->
             rule.visitFile(file, bindingContext, compilerResources)
                 .filterNot {
-                    it.entity.ktElement?.isSuppressedBy(ruleInstance.name, rule.aliases, ruleInstance.ruleSetId) == true
+                    it.entity.ktElement?.isSuppressedBy(ruleInstance.id, rule.aliases, ruleInstance.ruleSetId) == true
                 }
                 .filterSuppressedFindings(rule, bindingContext)
                 .map { it.toIssue(ruleInstance, rule.computeSeverity()) }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/DefaultBaseline.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/DefaultBaseline.kt
@@ -35,4 +35,4 @@ internal const val CURRENT_ISSUES = "CurrentIssues"
 internal const val ID = "ID"
 
 internal val Issue.baselineId: String
-    get() = "${ruleInstance.name}:${this.entity.signature}"
+    get() = "${ruleInstance.id}:${this.entity.signature}"

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/Reporting.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/Reporting.kt
@@ -55,4 +55,4 @@ private fun Issue.truncatedMessage(): String {
     }
 }
 
-private fun Issue.detailed(): String = "${ruleInstance.name} - [${truncatedMessage()}] at ${location.compact()}"
+private fun Issue.detailed(): String = "${ruleInstance.id} - [${truncatedMessage()}] at ${location.compact()}"

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/LiteIssuesReport.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/LiteIssuesReport.kt
@@ -13,7 +13,7 @@ class LiteIssuesReport : AbstractIssuesReport() {
     override fun render(issues: List<Issue>): String {
         return buildString {
             issues.forEach { issue ->
-                append("${issue.location.compact()}: ${issue.message} [${issue.ruleInstance.name}]")
+                append("${issue.location.compact()}: ${issue.message} [${issue.ruleInstance.id}]")
                 appendLine()
             }
         }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/Suppressions.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/Suppressions.kt
@@ -1,6 +1,5 @@
 package io.gitlab.arturbosch.detekt.core.suppressors
 
-import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.RuleSet
 import org.jetbrains.kotlin.psi.KtAnnotated
 import org.jetbrains.kotlin.psi.KtAnnotationEntry
@@ -12,10 +11,10 @@ import kotlin.text.RegexOption.IGNORE_CASE
  * Checks if this psi element is suppressed by @Suppress or @SuppressWarnings annotations.
  * If this element cannot have annotations, the first annotative parent is searched.
  */
-fun KtElement.isSuppressedBy(name: Rule.Name, aliases: Set<String>, ruleSetId: RuleSet.Id? = null): Boolean {
-    val acceptedSuppressionIds = mutableSetOf(name.value, "ALL", "all", "All")
+fun KtElement.isSuppressedBy(id: String, aliases: Set<String>, ruleSetId: RuleSet.Id? = null): Boolean {
+    val acceptedSuppressionIds = mutableSetOf(id, "ALL", "all", "All")
     if (ruleSetId != null) {
-        acceptedSuppressionIds.addAll(listOf(ruleSetId.value, "$ruleSetId.$name", "$ruleSetId:$name"))
+        acceptedSuppressionIds.addAll(listOf(ruleSetId.value, "$ruleSetId.$id", "$ruleSetId:$id"))
     }
     acceptedSuppressionIds.addAll(aliases)
 

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineResultMappingSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineResultMappingSpec.kt
@@ -24,19 +24,19 @@ class BaselineResultMappingSpec {
     private val existingBaselineFile = resourceAsPath("/baseline_feature/valid-baseline.xml")
     private val issues = listOf(
         createIssue(
-            ruleInstance = createRuleInstance("SomeIssueId", "RuleSet"),
+            ruleInstance = createRuleInstance("SomeIssue", "RuleSet"),
             entity = createEntity(signature = "SomeSignature"),
         ),
         createIssue(
-            ruleName = "LongParameterList",
+            ruleId = "LongParameterList",
             entity = createEntity(signature = "Signature")
         ),
         createIssue(
-            ruleName = "LongMethod",
+            ruleId = "LongMethod",
             entity = createEntity(signature = "Signature")
         ),
         createIssue(
-            ruleName = "FeatureEnvy",
+            ruleId = "FeatureEnvy",
             entity = createEntity(signature = "Signature")
         ),
     )
@@ -206,7 +206,7 @@ class BaselineResultMappingSpec {
                     <ID>LongMethod:Signature</ID>
                   </ManuallySuppressedIssues>
                   <CurrentIssues>
-                    <ID>TestSmell:TestEntitySignature</ID>
+                    <ID>TestSmell/id:TestEntitySignature</ID>
                   </CurrentIssues>
                 </SmellBaseline>
             """.trimIndent()

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/DefaultBaselineKtTest.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/DefaultBaselineKtTest.kt
@@ -7,6 +7,6 @@ import org.junit.jupiter.api.Test
 class DefaultBaselineKtTest {
     @Test
     fun `baselineId Extension`() {
-        assertThat(createIssue().baselineId).isEqualTo("TestSmell:TestEntitySignature")
+        assertThat(createIssue().baselineId).isEqualTo("TestSmell/id:TestEntitySignature")
     }
 }

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/FileBasedIssuesReportSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/FileBasedIssuesReportSpec.kt
@@ -29,10 +29,10 @@ class FileBasedIssuesReportSpec {
         assertThat(output).isEqualTo(
             """
                 ${location1.path}
-                	TestSmell - [TestMessage] at ${location1.compact()}
-                	TestSmell - [TestMessage] at ${location1.compact()}
+                	TestSmell/id - [TestMessage] at ${location1.compact()}
+                	TestSmell/id - [TestMessage] at ${location1.compact()}
                 ${location2.path}
-                	TestSmell - [TestMessage] at ${location2.compact()}
+                	TestSmell/id - [TestMessage] at ${location2.compact()}
                 
             """.trimIndent()
         )

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/IssuesReportSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/IssuesReportSpec.kt
@@ -28,10 +28,10 @@ class IssuesReportSpec {
         assertThat(output).isEqualTo(
             """
                 Ruleset1
-                	TestSmell - [TestMessage] at ${location.compact()}
-                	TestSmell - [TestMessage] at ${location.compact()}
+                	TestSmell/id - [TestMessage] at ${location.compact()}
+                	TestSmell/id - [TestMessage] at ${location.compact()}
                 Ruleset2
-                	TestSmell - [TestMessage] at ${location.compact()}
+                	TestSmell/id - [TestMessage] at ${location.compact()}
                 
             """.trimIndent()
         )

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/LiteIssuesReportSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/LiteIssuesReportSpec.kt
@@ -17,12 +17,12 @@ class LiteIssuesReportSpec {
     fun `reports non-empty issues`() {
         val location = createLocation()
         val detektion = TestDetektion(
-            createIssue(createRuleInstance("SpacingAfterPackageDeclaration"), location),
+            createIssue(createRuleInstance("SpacingAfterPackageDeclaration/id"), location),
             createIssue(createRuleInstance("UnnecessarySafeCall"), location),
         )
         assertThat(subject.render(detektion)).isEqualTo(
             """
-                ${location.compact()}: TestMessage [SpacingAfterPackageDeclaration]
+                ${location.compact()}: TestMessage [SpacingAfterPackageDeclaration/id]
                 ${location.compact()}: TestMessage [UnnecessarySafeCall]
 
             """.trimIndent()

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/SuppressionsSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/SuppressionsSpec.kt
@@ -1,7 +1,6 @@
 package io.gitlab.arturbosch.detekt.core.suppressors
 
 import io.github.detekt.test.utils.compileContentForTest
-import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.RuleSet
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.psi.KtClass
@@ -18,7 +17,7 @@ import org.junit.jupiter.params.provider.ValueSource
 class SuppressionsSpec {
 
     private fun KtElement.isSuppressedBy(): Boolean {
-        return isSuppressedBy(Rule.Name("RuleName"), setOf("alias1", "alias2"), RuleSet.Id("RuleSetId"))
+        return isSuppressedBy("RuleName", setOf("alias1", "alias2"), RuleSet.Id("RuleSetId"))
     }
 
     @Nested

--- a/detekt-core/src/test/resources/baseline_feature/valid-baseline.xml
+++ b/detekt-core/src/test/resources/baseline_feature/valid-baseline.xml
@@ -5,6 +5,6 @@
         <ID>LongMethod:Signature</ID>
     </ManuallySuppressedIssues>
     <CurrentIssues>
-        <ID>FeatureEnvy:Signature</ID>
+        <ID>FeatureEnvy/id:Signature</ID>
     </CurrentIssues>
 </SmellBaseline>

--- a/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/ComplexityReportGeneratorSpec.kt
+++ b/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/ComplexityReportGeneratorSpec.kt
@@ -19,7 +19,7 @@ internal class ComplexityReportGeneratorSpec {
 
     @BeforeEach
     fun setupMocks() {
-        detektion = TestDetektion(createIssue(ruleName = "test")).withTestData()
+        detektion = TestDetektion(createIssue("test")).withTestData()
     }
 
     @Nested

--- a/detekt-report-html/src/main/kotlin/io/github/detekt/report/html/HtmlOutputReport.kt
+++ b/detekt-report-html/src/main/kotlin/io/github/detekt/report/html/HtmlOutputReport.kt
@@ -117,21 +117,22 @@ class HtmlOutputReport : BuiltInOutputReport, OutputReport() {
         issues
             .groupBy { it.ruleInstance }
             .toList()
-            .sortedBy { (ruleInstance, _) -> ruleInstance.name.value }
+            .sortedBy { (ruleInstance, _) -> ruleInstance.id }
             .forEach { (ruleInstance, ruleIssues) ->
                 renderRule(ruleInstance, ruleIssues)
             }
     }
 
     private fun FlowContent.renderRule(ruleInstance: RuleInstance, issues: List<Issue>) {
+        val ruleId = ruleInstance.id
         val ruleName = ruleInstance.name.value
         val ruleSetId = ruleInstance.ruleSetId.value
         details {
-            id = ruleName
+            id = ruleId
             open = true
 
             summary("rule-container") {
-                span("rule") { text("$ruleName: %,d ".format(Locale.ROOT, issues.size)) }
+                span("rule") { text("$ruleId: %,d ".format(Locale.ROOT, issues.size)) }
                 span("description") { text(ruleInstance.description) }
             }
 

--- a/detekt-report-html/src/test/kotlin/io/github/detekt/report/html/HtmlOutputReportSpec.kt
+++ b/detekt-report-html/src/test/kotlin/io/github/detekt/report/html/HtmlOutputReportSpec.kt
@@ -96,7 +96,7 @@ class HtmlOutputReportSpec {
     fun `renders the right number of issues per rule`() {
         val result = htmlReport.render(createTestDetektionWithMultipleSmells())
 
-        assertThat(result).contains("<span class=\"rule\">rule_a: 2 </span>")
+        assertThat(result).contains("<span class=\"rule\">rule_a/id: 2 </span>")
         assertThat(result).contains("<span class=\"rule\">rule_b: 1 </span>")
     }
 
@@ -212,8 +212,8 @@ private fun createTestDetektionWithMultipleSmells(): Detektion {
     )
 
     return TestDetektion(
-        createIssue(createRuleInstance("rule_a", "RuleSet1"), entity1, "Issue message 1"),
-        createIssue(createRuleInstance("rule_a", "RuleSet1"), entity2, "Issue message 2"),
+        createIssue(createRuleInstance("rule_a/id", "RuleSet1"), entity1, "Issue message 1"),
+        createIssue(createRuleInstance("rule_a/id", "RuleSet1"), entity2, "Issue message 2"),
         createIssue(createRuleInstance("rule_b", "RuleSet2"), entity3, "Issue message 3"),
     )
 }

--- a/detekt-report-html/src/test/resources/HtmlOutputFormatTest.html
+++ b/detekt-report-html/src/test/resources/HtmlOutputFormatTest.html
@@ -170,8 +170,8 @@
 <h2>Issues</h2>
 <div>Total: 3
   <h3>RuleSet1: 2</h3>
-  <details id="rule_a" open="open">
-    <summary class="rule-container"><span class="rule">rule_a: 2 </span><span class="description">Description rule_a</span></summary>
+  <details id="rule_a/id" open="open">
+    <summary class="rule-container"><span class="rule">rule_a/id: 2 </span><span class="description">Description rule_a</span></summary>
 <a href="https://detekt.dev/docs/rules/ruleset1#rule_a">Documentation</a>
     <ul>
       <li><span class="location"><PREFIX>/src/main/com/sample/Sample1.kt:11:1</span><span class="message">Issue message 1</span>

--- a/detekt-report-md/src/main/kotlin/io/github/detekt/report/md/MdOutputReport.kt
+++ b/detekt-report-md/src/main/kotlin/io/github/detekt/report/md/MdOutputReport.kt
@@ -97,16 +97,17 @@ private fun MarkdownContent.renderGroup(issues: List<Issue>, basePath: Path?) {
     issues
         .groupBy { it.ruleInstance }
         .toList()
-        .sortedBy { (ruleInstance, _) -> ruleInstance.name.value }
+        .sortedBy { (ruleInstance, _) -> ruleInstance.id }
         .forEach { (ruleInstance, ruleIssues) ->
             renderRule(ruleInstance, ruleIssues, basePath)
         }
 }
 
 private fun MarkdownContent.renderRule(ruleInstance: RuleInstance, issues: List<Issue>, basePath: Path?) {
+    val ruleId = ruleInstance.id
     val ruleName = ruleInstance.name.value
     val ruleSetId = ruleInstance.ruleSetId.value
-    h3 { "$ruleSetId, $ruleName (%,d)".format(Locale.ROOT, issues.size) }
+    h3 { "$ruleSetId, $ruleId (%,d)".format(Locale.ROOT, issues.size) }
     paragraph { ruleInstance.description }
 
     paragraph {

--- a/detekt-report-md/src/test/kotlin/io/github/detekt/report/md/MdOutputReportSpec.kt
+++ b/detekt-report-md/src/test/kotlin/io/github/detekt/report/md/MdOutputReportSpec.kt
@@ -62,7 +62,7 @@ class MdOutputReportSpec {
 
     @Test
     fun `renders the right number of issues per rule`() {
-        assertThat(result).contains("rule_a (2)")
+        assertThat(result).contains("rule_a/id (2)")
         assertThat(result).contains("rule_b (1)")
     }
 
@@ -161,8 +161,8 @@ private fun createTestDetektionWithMultipleSmells(): Detektion {
     )
 
     return createMdDetektion(
-        createIssue(createRuleInstance("rule_a", "Section-1"), entity1, "Issue message 1"),
-        createIssue(createRuleInstance("rule_a", "Section-1"), entity2, "Issue message 2"),
+        createIssue(createRuleInstance("rule_a/id", "Section-1"), entity1, "Issue message 1"),
+        createIssue(createRuleInstance("rule_a/id", "Section-1"), entity2, "Issue message 2"),
         createIssue(createRuleInstance("rule_b", "Section-2"), entity3, "Issue message 3"),
     ).also {
         it.putUserData(complexityKey, 10)

--- a/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/Results.kt
+++ b/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/Results.kt
@@ -24,7 +24,7 @@ internal fun Severity.toResultLevel() = when (this) {
 
 private fun Issue.toResult(basePath: String?): io.github.detekt.sarif4k.Result {
     return io.github.detekt.sarif4k.Result(
-        ruleID = "detekt.${ruleInstance.ruleSetId}.${ruleInstance.name}",
+        ruleID = "detekt.${ruleInstance.ruleSetId}.${ruleInstance.id}",
         level = severity.toResultLevel(),
         locations = (listOf(location) + references.map { it.location }).map { it.toLocation(basePath) }.distinct(),
         message = Message(text = message)

--- a/detekt-report-sarif/src/test/kotlin/io/github/detekt/report/sarif/SarifOutputReportSpec.kt
+++ b/detekt-report-sarif/src/test/kotlin/io/github/detekt/report/sarif/SarifOutputReportSpec.kt
@@ -31,17 +31,17 @@ class SarifOutputReportSpec {
     fun `renders multiple issues`() {
         val result = TestDetektion(
             createIssue(
-                ruleInstance = createRuleInstance("TestSmellA", "RuleSet1"),
+                ruleInstance = createRuleInstance("TestSmellA/id", "RuleSet1"),
                 entity = createEntity(location = createLocation(position = 1 to 1, endPosition = 2 to 3)),
                 severity = Severity.Error
             ),
             createIssue(
-                ruleInstance = createRuleInstance("TestSmellB", "RuleSet2"),
+                ruleInstance = createRuleInstance("TestSmellB/id", "RuleSet2"),
                 entity = createEntity(location = createLocation(position = 3 to 5, endPosition = 3 to 5)),
                 severity = Severity.Warning
             ),
             createIssue(
-                ruleInstance = createRuleInstance("TestSmellC", "RuleSet2"),
+                ruleInstance = createRuleInstance("TestSmellC/id", "RuleSet2"),
                 entity = createEntity(location = createLocation(position = 2 to 1, endPosition = 3 to 1)),
                 severity = Severity.Info
             )
@@ -60,9 +60,9 @@ class SarifOutputReportSpec {
     @Test
     fun `renders multiple issues with rule set to warning by default`() {
         val result = TestDetektion(
-            createIssue(createRuleInstance("TestSmellA", "RuleSet1"), severity = Severity.Error),
-            createIssue(createRuleInstance("TestSmellB", "RuleSet2"), severity = Severity.Warning),
-            createIssue(createRuleInstance("TestSmellC", "RuleSet2"), severity = Severity.Info)
+            createIssue(createRuleInstance("TestSmellA/id", "RuleSet1"), severity = Severity.Error),
+            createIssue(createRuleInstance("TestSmellB/id", "RuleSet2"), severity = Severity.Warning),
+            createIssue(createRuleInstance("TestSmellC/id", "RuleSet2"), severity = Severity.Info)
         )
 
         val testConfig = yamlConfig("config_with_rule_set_to_warning.yml")
@@ -91,9 +91,9 @@ class SarifOutputReportSpec {
     @Test
     fun `renders multiple issues with relative path`() {
         val result = TestDetektion(
-            createIssueForRelativePath(createRuleInstance("TestSmellA", "RuleSet1")),
-            createIssueForRelativePath(createRuleInstance("TestSmellB", "RuleSet2")),
-            createIssueForRelativePath(createRuleInstance("TestSmellC", "RuleSet2")),
+            createIssueForRelativePath(createRuleInstance("TestSmellA/id", "RuleSet1")),
+            createIssueForRelativePath(createRuleInstance("TestSmellB/id", "RuleSet2")),
+            createIssueForRelativePath(createRuleInstance("TestSmellC/id", "RuleSet2")),
         )
 
         val basePath = Path("/").absolute().resolve("Users/tester/detekt/")

--- a/detekt-report-sarif/src/test/resources/relative_path.sarif.json
+++ b/detekt-report-sarif/src/test/resources/relative_path.sarif.json
@@ -30,7 +30,7 @@
           "message": {
             "text": "TestMessage"
           },
-          "ruleId": "detekt.RuleSet1.TestSmellA"
+          "ruleId": "detekt.RuleSet1.TestSmellA/id"
         },
         {
           "level": "error",
@@ -53,7 +53,7 @@
           "message": {
             "text": "TestMessage"
           },
-          "ruleId": "detekt.RuleSet2.TestSmellB"
+          "ruleId": "detekt.RuleSet2.TestSmellB/id"
         },
         {
           "level": "error",
@@ -76,7 +76,7 @@
           "message": {
             "text": "TestMessage"
           },
-          "ruleId": "detekt.RuleSet2.TestSmellC"
+          "ruleId": "detekt.RuleSet2.TestSmellC/id"
         }
       ],
       "tool": {

--- a/detekt-report-sarif/src/test/resources/rule_warning.sarif.json
+++ b/detekt-report-sarif/src/test/resources/rule_warning.sarif.json
@@ -24,7 +24,7 @@
           "message": {
             "text": "TestMessage"
           },
-          "ruleId": "detekt.RuleSet1.TestSmellA"
+          "ruleId": "detekt.RuleSet1.TestSmellA/id"
         },
         {
           "level": "warning",
@@ -46,7 +46,7 @@
           "message": {
             "text": "TestMessage"
           },
-          "ruleId": "detekt.RuleSet2.TestSmellB"
+          "ruleId": "detekt.RuleSet2.TestSmellB/id"
         },
         {
           "level": "note",
@@ -68,7 +68,7 @@
           "message": {
             "text": "TestMessage"
           },
-          "ruleId": "detekt.RuleSet2.TestSmellC"
+          "ruleId": "detekt.RuleSet2.TestSmellC/id"
         }
       ],
       "tool": {

--- a/detekt-report-sarif/src/test/resources/vanilla.sarif.json
+++ b/detekt-report-sarif/src/test/resources/vanilla.sarif.json
@@ -24,7 +24,7 @@
           "message": {
             "text": "TestMessage"
           },
-          "ruleId": "detekt.RuleSet1.TestSmellA"
+          "ruleId": "detekt.RuleSet1.TestSmellA/id"
         },
         {
           "level": "warning",
@@ -46,7 +46,7 @@
           "message": {
             "text": "TestMessage"
           },
-          "ruleId": "detekt.RuleSet2.TestSmellB"
+          "ruleId": "detekt.RuleSet2.TestSmellB/id"
         },
         {
           "level": "note",
@@ -68,7 +68,7 @@
           "message": {
             "text": "TestMessage"
           },
-          "ruleId": "detekt.RuleSet2.TestSmellC"
+          "ruleId": "detekt.RuleSet2.TestSmellC/id"
         }
       ],
       "tool": {

--- a/detekt-report-txt/src/main/kotlin/io/github/detekt/report/txt/TxtOutputReport.kt
+++ b/detekt-report-txt/src/main/kotlin/io/github/detekt/report/txt/TxtOutputReport.kt
@@ -22,4 +22,4 @@ class TxtOutputReport : BuiltInOutputReport, OutputReport() {
 }
 
 private fun Issue.compactWithSignature(): String =
-    "${ruleInstance.name} - ${entity.compact()} - Signature=${entity.signature}"
+    "${ruleInstance.id} - ${entity.compact()} - Signature=${entity.signature}"

--- a/detekt-report-txt/src/test/kotlin/io/github/detekt/report/txt/TxtOutputReportSpec.kt
+++ b/detekt-report-txt/src/test/kotlin/io/github/detekt/report/txt/TxtOutputReportSpec.kt
@@ -21,22 +21,22 @@ class TxtOutputReportSpec {
         val location = createLocation()
         val detektion = TestDetektion(createIssue(createRuleInstance(), location))
         assertThat(TxtOutputReport().render(detektion))
-            .isEqualTo("TestSmell - [TestEntity] at ${location.compact()} - Signature=TestEntitySignature\n")
+            .isEqualTo("TestSmell/id - [TestEntity] at ${location.compact()} - Signature=TestEntitySignature\n")
     }
 
     @Test
     fun `renders multiple`() {
         val location = createLocation()
         val detektion = TestDetektion(
-            createIssue(createRuleInstance("TestSmellA"), location),
-            createIssue(createRuleInstance("TestSmellB"), location),
+            createIssue(createRuleInstance("TestSmellA/id"), location),
+            createIssue(createRuleInstance("TestSmellB/id"), location),
             createIssue(createRuleInstance("TestSmellC"), location),
         )
         assertThat(TxtOutputReport().render(detektion))
             .isEqualTo(
                 """
-                    TestSmellA - [TestEntity] at ${location.compact()} - Signature=TestEntitySignature
-                    TestSmellB - [TestEntity] at ${location.compact()} - Signature=TestEntitySignature
+                    TestSmellA/id - [TestEntity] at ${location.compact()} - Signature=TestEntitySignature
+                    TestSmellB/id - [TestEntity] at ${location.compact()} - Signature=TestEntitySignature
                     TestSmellC - [TestEntity] at ${location.compact()} - Signature=TestEntitySignature
 
                 """.trimIndent()

--- a/detekt-report-xml/src/main/kotlin/io/github/detekt/report/xml/XmlOutputReport.kt
+++ b/detekt-report-xml/src/main/kotlin/io/github/detekt/report/xml/XmlOutputReport.kt
@@ -45,7 +45,7 @@ class XmlOutputReport : BuiltInOutputReport, OutputReport() {
                         "column=\"${it.location.source.column.toXmlString()}\"",
                         "severity=\"${it.severityLabel.toXmlString()}\"",
                         "message=\"${it.message.toXmlString()}\"",
-                        "source=\"${"detekt.${it.ruleInstance.name.value.toXmlString()}"}\" />"
+                        "source=\"${"detekt.${it.ruleInstance.id.toXmlString()}"}\" />"
                     ).joinToString(separator = " ")
                 }
                 lines += "</file>"

--- a/detekt-report-xml/src/test/kotlin/io/github/detekt/report/xml/XmlOutputReportSpec.kt
+++ b/detekt-report-xml/src/test/kotlin/io/github/detekt/report/xml/XmlOutputReportSpec.kt
@@ -54,7 +54,7 @@ class XmlOutputReportSpec {
 
     @Test
     fun `renders one reported issue in single file`() {
-        val smell = createIssue("rule_a", entity1, "TestMessage")
+        val smell = createIssue("rule_a/id", entity1, "TestMessage")
 
         val result = outputReport.render(TestDetektion(smell))
 
@@ -63,7 +63,7 @@ class XmlOutputReportSpec {
                 <?xml version="1.0" encoding="UTF-8"?>
                 <checkstyle version="4.3">
                 <file name="${entity1.location.path.invariantSeparatorsPathString}">
-                $TAB<error line="11" column="1" severity="error" message="TestMessage" source="detekt.rule_a" />
+                $TAB<error line="11" column="1" severity="error" message="TestMessage" source="detekt.rule_a/id" />
                 </file>
                 </checkstyle>
             """.trimIndent()
@@ -72,7 +72,7 @@ class XmlOutputReportSpec {
 
     @Test
     fun `renders two reported issues in single file`() {
-        val smell1 = createIssue("rule_a", entity1, "TestMessage")
+        val smell1 = createIssue("rule_a/id", entity1, "TestMessage")
         val smell2 = createIssue("rule_b", entity1, "TestMessage")
 
         val result = outputReport.render(TestDetektion(smell1, smell2))
@@ -82,7 +82,7 @@ class XmlOutputReportSpec {
                 <?xml version="1.0" encoding="UTF-8"?>
                 <checkstyle version="4.3">
                 <file name="${entity1.location.path.invariantSeparatorsPathString}">
-                $TAB<error line="11" column="1" severity="error" message="TestMessage" source="detekt.rule_a" />
+                $TAB<error line="11" column="1" severity="error" message="TestMessage" source="detekt.rule_a/id" />
                 $TAB<error line="11" column="1" severity="error" message="TestMessage" source="detekt.rule_b" />
                 </file>
                 </checkstyle>
@@ -92,8 +92,8 @@ class XmlOutputReportSpec {
 
     @Test
     fun `renders one reported issue across multiple files`() {
-        val smell1 = createIssue("rule_a", entity1, "TestMessage")
-        val smell2 = createIssue("rule_a", entity2, "TestMessage")
+        val smell1 = createIssue("rule_a/id", entity1, "TestMessage")
+        val smell2 = createIssue("rule_a/id", entity2, "TestMessage")
 
         val result = outputReport.render(TestDetektion(smell1, smell2))
 
@@ -102,10 +102,10 @@ class XmlOutputReportSpec {
                 <?xml version="1.0" encoding="UTF-8"?>
                 <checkstyle version="4.3">
                 <file name="${entity1.location.path.invariantSeparatorsPathString}">
-                $TAB<error line="11" column="1" severity="error" message="TestMessage" source="detekt.rule_a" />
+                $TAB<error line="11" column="1" severity="error" message="TestMessage" source="detekt.rule_a/id" />
                 </file>
                 <file name="${entity2.location.path.invariantSeparatorsPathString}">
-                $TAB<error line="22" column="2" severity="error" message="TestMessage" source="detekt.rule_a" />
+                $TAB<error line="22" column="2" severity="error" message="TestMessage" source="detekt.rule_a/id" />
                 </file>
                 </checkstyle>
             """.trimIndent()
@@ -115,7 +115,7 @@ class XmlOutputReportSpec {
     @Test
     fun `renders issues with relative path`() {
         val issueA = createIssueForRelativePath(
-            ruleInstance = createRuleInstance("rule_a"),
+            ruleInstance = createRuleInstance("rule_a/id"),
             basePath = "${System.getProperty("user.dir")}/Users/tester/detekt/",
             relativePath = "Sample1.kt"
         )
@@ -135,7 +135,7 @@ class XmlOutputReportSpec {
                 <?xml version="1.0" encoding="UTF-8"?>
                 <checkstyle version="4.3">
                 <file name="Sample1.kt">
-                $TAB<error line="1" column="1" severity="error" message="TestMessage" source="detekt.rule_a" />
+                $TAB<error line="1" column="1" severity="error" message="TestMessage" source="detekt.rule_a/id" />
                 </file>
                 <file name="Sample2.kt">
                 $TAB<error line="1" column="1" severity="error" message="TestMessage" source="detekt.rule_b" />
@@ -147,9 +147,9 @@ class XmlOutputReportSpec {
 
     @Test
     fun `renders two reported issues across multiple files`() {
-        val smell1 = createIssue("rule_a", entity1, "TestMessage")
+        val smell1 = createIssue("rule_a/id", entity1, "TestMessage")
         val smell2 = createIssue("rule_b", entity1, "TestMessage")
-        val smell3 = createIssue("rule_a", entity2, "TestMessage")
+        val smell3 = createIssue("rule_a/id", entity2, "TestMessage")
         val smell4 = createIssue("rule_b", entity2, "TestMessage")
 
         val result = outputReport.render(
@@ -166,11 +166,11 @@ class XmlOutputReportSpec {
                 <?xml version="1.0" encoding="UTF-8"?>
                 <checkstyle version="4.3">
                 <file name="${entity1.location.path.invariantSeparatorsPathString}">
-                $TAB<error line="11" column="1" severity="error" message="TestMessage" source="detekt.rule_a" />
+                $TAB<error line="11" column="1" severity="error" message="TestMessage" source="detekt.rule_a/id" />
                 $TAB<error line="11" column="1" severity="error" message="TestMessage" source="detekt.rule_b" />
                 </file>
                 <file name="${entity2.location.path.invariantSeparatorsPathString}">
-                $TAB<error line="22" column="2" severity="error" message="TestMessage" source="detekt.rule_a" />
+                $TAB<error line="22" column="2" severity="error" message="TestMessage" source="detekt.rule_a/id" />
                 $TAB<error line="22" column="2" severity="error" message="TestMessage" source="detekt.rule_b" />
                 </file>
                 </checkstyle>
@@ -186,7 +186,7 @@ class XmlOutputReportSpec {
         fun `renders detektion with severity as XML with severity`(severity: Severity) {
             val xmlSeverity = severity.name.lowercase(Locale.US)
             val issue = createIssue(
-                ruleName = "issue_id",
+                ruleId = "issue/id",
                 entity = entity1,
                 message = "message",
                 severity = severity,
@@ -196,7 +196,7 @@ class XmlOutputReportSpec {
                 <?xml version="1.0" encoding="UTF-8"?>
                 <checkstyle version="4.3">
                 <file name="${entity1.location.path.invariantSeparatorsPathString}">
-                $TAB<error line="${issue.location.source.line}" column="${issue.location.source.column}" severity="$xmlSeverity" message="${issue.message}" source="detekt.${issue.ruleInstance.name}" />
+                $TAB<error line="${issue.location.source.line}" column="${issue.location.source.column}" severity="$xmlSeverity" message="${issue.message}" source="detekt.${issue.ruleInstance.id}" />
                 </file>
                 </checkstyle>
             """.trimIndent()

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/RuleExtensions.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/RuleExtensions.kt
@@ -67,7 +67,7 @@ fun Rule.lint(ktFile: KtFile): List<Finding> = visitFile(ktFile).filterSuppresse
 
 private fun List<Finding>.filterSuppressed(rule: Rule): List<Finding> {
     return filterNot {
-        it.entity.ktElement?.isSuppressedBy(rule.ruleName, rule.aliases, RuleSet.Id("NoARuleSetId")) == true
+        it.entity.ktElement?.isSuppressedBy(rule.ruleName.value, rule.aliases, RuleSet.Id("NoARuleSetId")) == true
     }
 }
 


### PR DESCRIPTION
Now that we have `RuleInstance.id` we should use it in the correct places instead of `RuleInstance.name`. Basically we should use `RuleInstance.id` nearly always.