### PR TITLE
Remove the default value of `Entity.ktElement`

### DIFF
--- a/detekt-api/api/detekt-api.api
+++ b/detekt-api/api/detekt-api.api
@@ -121,7 +121,6 @@ public abstract interface class io/gitlab/arturbosch/detekt/api/Detektion : org/
 public final class io/gitlab/arturbosch/detekt/api/Entity : io/gitlab/arturbosch/detekt/api/Compactable {
 	public static final field Companion Lio/gitlab/arturbosch/detekt/api/Entity$Companion;
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lio/gitlab/arturbosch/detekt/api/Location;Lorg/jetbrains/kotlin/psi/KtElement;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lio/gitlab/arturbosch/detekt/api/Location;Lorg/jetbrains/kotlin/psi/KtElement;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun compact ()Ljava/lang/String;
 	public final fun getKtElement ()Lorg/jetbrains/kotlin/psi/KtElement;
 	public final fun getLocation ()Lio/gitlab/arturbosch/detekt/api/Location;

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Entity.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Entity.kt
@@ -15,7 +15,7 @@ class Entity(
     val name: String,
     val signature: String,
     val location: Location,
-    val ktElement: KtElement? = null
+    val ktElement: KtElement?
 ) : Compactable {
 
     override fun compact(): String = "[$name] at ${location.compact()}"

--- a/detekt-report-xml/build.gradle.kts
+++ b/detekt-report-xml/build.gradle.kts
@@ -6,4 +6,5 @@ dependencies {
     compileOnly(projects.detektApi)
     testImplementation(testFixtures(projects.detektApi))
     testImplementation(libs.assertj)
+    testImplementation(projects.detektTestUtils)
 }

--- a/detekt-report-xml/src/test/kotlin/io/github/detekt/report/xml/XmlOutputReportSpec.kt
+++ b/detekt-report-xml/src/test/kotlin/io/github/detekt/report/xml/XmlOutputReportSpec.kt
@@ -1,5 +1,6 @@
 package io.github.detekt.report.xml
 
+import io.github.detekt.test.utils.internal.FakeKtElement
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.test.TestDetektion
@@ -27,7 +28,8 @@ class XmlOutputReportSpec {
         createLocation(
             path = "src/main/com/sample/Sample1.kt",
             position = 11 to 1,
-        )
+        ),
+        FakeKtElement()
     )
     private val entity2 = Entity(
         "Sample2",
@@ -35,7 +37,8 @@ class XmlOutputReportSpec {
         createLocation(
             path = "src/main/com/sample/Sample2.kt",
             position = 22 to 2,
-        )
+        ),
+        FakeKtElement()
     )
     private val outputReport = XmlOutputReport()
 

--- a/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/internal/FakeKtElement.kt
+++ b/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/internal/FakeKtElement.kt
@@ -20,7 +20,7 @@ import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtVisitor
 import javax.swing.Icon
 
-class FakeKtElement(val psiFile: PsiFile) : KtElement {
+class FakeKtElement(private val psiFile: PsiFile = FakePsiFile("")) : KtElement {
 
     override fun <R, D> accept(visitor: KtVisitor<R, D>, data: D): R {
         error("Fake not implemented yet")


### PR DESCRIPTION
This commits were proposed at #7259 but because it is taking too long to merge I'm moving these to their own PR.

We only use the default value for tests. That's not a good reason to have a default value, for that reason I'm removing it.