### PR TITLE
Enable FunctionExpressionBody on detekt codebase

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -78,6 +78,8 @@ formatting:
     active: true
   Filename:
     active: false
+  FunctionExpressionBody:
+    active: true
   FunctionSignature:
     active: false
   Kdoc:

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/CodeSmell.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/CodeSmell.kt
@@ -16,11 +16,10 @@ open class CodeSmell(
         require(message.isNotBlank()) { "The message should not be empty" }
     }
 
-    override fun toString(): String {
-        return "CodeSmell(entity=$entity, " +
+    override fun toString(): String =
+        "CodeSmell(entity=$entity, " +
             "message=$message, " +
             "references=$references)"
-    }
 }
 
 /**
@@ -38,11 +37,10 @@ open class CorrectableCodeSmell(
     message,
     references
 ) {
-    override fun toString(): String {
-        return "CorrectableCodeSmell(" +
+    override fun toString(): String =
+        "CorrectableCodeSmell(" +
             "autoCorrectEnabled=$autoCorrectEnabled, " +
             "entity=$entity, " +
             "message=$message, " +
             "references=$references)"
-    }
 }

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Config.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Config.kt
@@ -69,9 +69,7 @@ interface Config {
 
             override fun <T : Any> valueOrNull(key: String): T? = null
 
-            override fun toString(): String {
-                return "Config.empty"
-            }
+            override fun toString(): String = "Config.empty"
         }
 
         const val ACTIVE_KEY: String = "active"

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/ConfigProperty.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/ConfigProperty.kt
@@ -121,15 +121,14 @@ private fun <T : Any> getValueOrDefault(config: Config, propertyName: String, de
     }
 }
 
-private fun Config.getListOrDefault(propertyName: String, defaultValue: List<*>): List<String> {
-    return if (defaultValue.all { it is String }) {
+private fun Config.getListOrDefault(propertyName: String, defaultValue: List<*>): List<String> =
+    if (defaultValue.all { it is String }) {
         @Suppress("UNCHECKED_CAST")
         val defaultValueAsListOfStrings = defaultValue as List<String>
         valueOrDefault(propertyName, defaultValueAsListOfStrings)
     } else {
         error("Only lists of strings are supported. '$propertyName' is invalid. ")
     }
-}
 
 private fun Config.getValuesWithReasonOrDefault(
     propertyName: String,
@@ -163,9 +162,8 @@ private fun Config.getValuesWithReasonOrDefault(
 private abstract class MemoizedConfigProperty<U : Any> : ReadOnlyProperty<Rule, U> {
     private var value: U? = null
 
-    override fun getValue(thisRef: Rule, property: KProperty<*>): U {
-        return value ?: doGetValue(thisRef, property).also { value = it }
-    }
+    override fun getValue(thisRef: Rule, property: KProperty<*>): U =
+        value ?: doGetValue(thisRef, property).also { value = it }
 
     abstract fun doGetValue(thisRef: Rule, property: KProperty<*>): U
 }
@@ -189,9 +187,8 @@ private class TransformedConfigProperty<T : Any, U : Any>(
     private val defaultValue: T,
     private val transform: (T) -> U
 ) : MemoizedConfigProperty<U>() {
-    override fun doGetValue(thisRef: Rule, property: KProperty<*>): U {
-        return transform(getValueOrDefault(thisRef.config, property.name, defaultValue))
-    }
+    override fun doGetValue(thisRef: Rule, property: KProperty<*>): U =
+        transform(getValueOrDefault(thisRef.config, property.name, defaultValue))
 }
 
 private class FallbackConfigProperty<T : Any, U : Any>(

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Rule.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Rule.kt
@@ -94,8 +94,6 @@ open class Rule(
             validateIdentifier(value)
         }
 
-        override fun toString(): String {
-            return value
-        }
+        override fun toString(): String = value
     }
 }

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/RuleSet.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/RuleSet.kt
@@ -8,9 +8,8 @@ import io.gitlab.arturbosch.detekt.api.internal.validateIdentifier
  */
 class RuleSet(val id: Id, val rules: Map<Rule.Name, (Config) -> Rule>) {
     companion object {
-        operator fun invoke(id: Id, rules: List<(Config) -> Rule>): RuleSet {
-            return RuleSet(id, rules.associateBy { it(Config.empty).ruleName })
-        }
+        operator fun invoke(id: Id, rules: List<(Config) -> Rule>): RuleSet =
+            RuleSet(id, rules.associateBy { it(Config.empty).ruleName })
     }
 
     @Poko
@@ -19,8 +18,6 @@ class RuleSet(val id: Id, val rules: Map<Rule.Name, (Config) -> Rule>) {
             validateIdentifier(value)
         }
 
-        override fun toString(): String {
-            return value
-        }
+        override fun toString(): String = value
     }
 }

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/SplitPattern.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/SplitPattern.kt
@@ -9,10 +9,9 @@ package io.gitlab.arturbosch.detekt.api
  * '*' matches any zero or more characters
  * '?' matches any one character
  */
-fun String.simplePatternToRegex(): Regex {
-    return this
+fun String.simplePatternToRegex(): Regex =
+    this
         .replace(".", "\\.")
         .replace("*", ".*")
         .replace("?", ".")
         .toRegex()
-}

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/ValuesWithReason.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/ValuesWithReason.kt
@@ -15,9 +15,8 @@ import dev.drewhamilton.poko.Poko
  *
  * Note that the [config] property delegate only supports the factory methods when defining [ValuesWithReason].
  */
-fun valuesWithReason(vararg values: Pair<String, String?>): ValuesWithReason {
-    return valuesWithReason(values.map { ValueWithReason(it.first, it.second) })
-}
+fun valuesWithReason(vararg values: Pair<String, String?>): ValuesWithReason =
+    valuesWithReason(values.map { ValueWithReason(it.first, it.second) })
 
 /**
  * This factory method can be used by rule authors to specify one or many configuration values along with an
@@ -25,9 +24,7 @@ fun valuesWithReason(vararg values: Pair<String, String?>): ValuesWithReason {
  *
  * Note that the [config] property delegate only supports the factory methods when defining [ValuesWithReason].
  */
-fun valuesWithReason(values: List<ValueWithReason>): ValuesWithReason {
-    return ValuesWithReason(values)
-}
+fun valuesWithReason(values: List<ValueWithReason>): ValuesWithReason = ValuesWithReason(values)
 
 /**
  * [ValuesWithReason] is essentially the same as [List] of [ValueWithReason]. Due to type erasure we cannot use the

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/Signatures.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/Signatures.kt
@@ -13,9 +13,7 @@ import org.jetbrains.kotlin.psi.psiUtil.startOffsetSkippingComments
 
 private val multipleWhitespaces = Regex("\\s{2,}")
 
-internal fun PsiElement.searchName(): String {
-    return this.namedUnwrappedElement?.name ?: "<UnknownName>"
-}
+internal fun PsiElement.searchName(): String = this.namedUnwrappedElement?.name ?: "<UnknownName>"
 
 /*
  * KtCompiler wrongly used Path.filename as the name for a KtFile instead of the whole path.
@@ -51,14 +49,13 @@ internal fun PsiElement.buildFullSignature(): String {
 private fun PsiElement.extractClassName() =
     this.getNonStrictParentOfType<KtClassOrObject>()?.nameAsSafeName?.asString().orEmpty()
 
-private fun PsiElement.searchSignature(): String {
-    return when (this) {
+private fun PsiElement.searchSignature(): String =
+    when (this) {
         is KtNamedFunction -> buildFunctionSignature(this)
         is KtClassOrObject -> buildClassSignature(this)
         is KtFile -> fileSignature()
         else -> this.text
     }.replace('\n', ' ').replace(multipleWhitespaces, " ")
-}
 
 private fun KtFile.fileSignature() = "${this.packageFqName.asString()}.${this.name}"
 

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/ConfigPropertySpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/ConfigPropertySpec.kt
@@ -436,9 +436,7 @@ class ConfigPropertySpec {
                     it.toString()
                 }
 
-                fun useProperty(): String {
-                    return "something with $prop"
-                }
+                fun useProperty(): String = "something with $prop"
             }
 
             @Test

--- a/detekt-api/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/test/TestFactory.kt
+++ b/detekt-api/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/test/TestFactory.kt
@@ -73,8 +73,8 @@ fun createIssueForRelativePath(
     ruleInstance: RuleInstance,
     basePath: String = "Users/tester/detekt/",
     relativePath: String = "TestFile.kt"
-): Issue {
-    return IssueImpl(
+): Issue =
+    IssueImpl(
         ruleInstance = ruleInstance,
         entity = createEntity(
             location = Location(
@@ -86,7 +86,6 @@ fun createIssueForRelativePath(
         ),
         message = "TestMessage"
     )
-}
 
 fun createEntity(
     signature: String = "TestEntitySignature",

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/ArgumentConverters.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/ArgumentConverters.kt
@@ -12,21 +12,19 @@ import kotlin.io.path.exists
 import kotlin.io.path.isDirectory
 
 class LanguageVersionConverter : IStringConverter<LanguageVersion> {
-    override fun convert(value: String): LanguageVersion {
-        return requireNotNull(LanguageVersion.fromFullVersionString(value)) {
+    override fun convert(value: String): LanguageVersion =
+        requireNotNull(LanguageVersion.fromFullVersionString(value)) {
             val validValues = LanguageVersion.entries.joinToString { it.toString() }
             "\"$value\" passed to --language-version, expected one of [$validValues]"
         }
-    }
 }
 
 class JvmTargetConverter : IStringConverter<JvmTarget> {
-    override fun convert(value: String): JvmTarget {
-        return checkNotNull(JvmTarget.fromString(value)) {
+    override fun convert(value: String): JvmTarget =
+        checkNotNull(JvmTarget.fromString(value)) {
             val validValues = JvmTarget.entries.joinToString { it.toString() }
             "Invalid value passed to --jvm-target, expected one of [$validValues]"
         }
-    }
 }
 
 class ClasspathResourceConverter : IStringConverter<URL> {

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/FailureSeverity.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/FailureSeverity.kt
@@ -8,14 +8,13 @@ enum class FailureSeverity {
     Info,
     Never;
 
-    internal fun toSeverity(): Severity {
-        return when (this) {
+    internal fun toSeverity(): Severity =
+        when (this) {
             Error -> Severity.Error
             Warning -> Severity.Warning
             Info -> Severity.Info
             Never -> error("'$this' does not have a corresponding severity.")
         }
-    }
 
     internal companion object {
         fun fromString(value: String): FailureSeverity {

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Spec.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Spec.kt
@@ -83,9 +83,7 @@ internal fun CliArgs.createSpec(output: Appendable, error: Appendable): Processi
 }
 
 @OptIn(ExperimentalPathApi::class)
-private fun Iterable<Path>.walk(): Sequence<Path> {
-    return asSequence().flatMap { it.walk() }
-}
+private fun Iterable<Path>.walk(): Sequence<Path> = asSequence().flatMap { it.walk() }
 
 private fun Path.isKotlinFile() = extension in KT_ENDINGS
 

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/MainSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/MainSpec.kt
@@ -28,14 +28,13 @@ class MainSpec {
     inner class `Build runner` {
 
         @Suppress("UnusedPrivateFunction")
-        private fun runnerConfigs(): List<Arguments> {
-            return listOf(
+        private fun runnerConfigs(): List<Arguments> =
+            listOf(
                 arguments(arrayOf("--generate-config", "detekt-test.yml"), ConfigExporter::class),
                 arguments(arrayOf("--run-rule", "RuleSet:Rule"), Runner::class),
                 arguments(arrayOf("--version"), VersionPrinter::class),
                 arguments(emptyArray<String>(), Runner::class),
             )
-        }
 
         @ParameterizedTest
         @MethodSource("runnerConfigs")

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Analyzer.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Analyzer.kt
@@ -165,19 +165,17 @@ private fun throwIllegalStateException(file: KtFile, error: Throwable): Nothing 
     throw IllegalStateException(message, error)
 }
 
-private fun Finding.toIssue(rule: RuleInstance, severity: Severity): Issue {
-    return when (this) {
+private fun Finding.toIssue(rule: RuleInstance, severity: Severity): Issue =
+    when (this) {
         is CorrectableCodeSmell -> IssueImpl(rule, entity, message, references, severity, autoCorrectEnabled)
 
         is CodeSmell -> IssueImpl(rule, entity, message, references, severity)
 
         else -> error("wtf?")
     }
-}
 
-private fun Rule.toRuleInstance(id: String, ruleSetId: RuleSet.Id): RuleInstance {
-    return RuleInstanceImpl(id, ruleName, ruleSetId, description)
-}
+private fun Rule.toRuleInstance(id: String, ruleSetId: RuleSet.Id): RuleInstance =
+    RuleInstanceImpl(id, ruleName, ruleSetId, description)
 
 private data class IssueImpl(
     override val ruleInstance: RuleInstance,

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineResultMapping.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineResultMapping.kt
@@ -40,14 +40,13 @@ class BaselineResultMapping : ReportingExtension {
         return filterByBaseline(baselinePath, this)
     }
 
-    fun filterByBaseline(baselineFile: Path, issues: List<Issue>): List<Issue> {
-        return if (baselineExists(baselineFile)) {
+    fun filterByBaseline(baselineFile: Path, issues: List<Issue>): List<Issue> =
+        if (baselineExists(baselineFile)) {
             val baseline = DefaultBaseline.load(baselineFile)
             issues.filterNot { baseline.contains(it.baselineId) }
         } else {
             issues
         }
-    }
 
     fun createOrUpdate(baselineFile: Path, issues: List<Issue>) {
         val ids = issues.map { it.baselineId }.toSortedSet()

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/AllRulesConfig.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/AllRulesConfig.kt
@@ -19,23 +19,19 @@ internal data class AllRulesConfig(
     override fun subConfig(key: String) =
         AllRulesConfig(wrapped.subConfig(key), deprecatedRules, this)
 
-    override fun subConfigKeys(): Set<String> {
-        return wrapped.subConfigKeys()
-    }
+    override fun subConfigKeys(): Set<String> = wrapped.subConfigKeys()
 
-    override fun <T : Any> valueOrDefault(key: String, default: T): T {
-        return when (key) {
+    override fun <T : Any> valueOrDefault(key: String, default: T): T =
+        when (key) {
             Config.ACTIVE_KEY -> if (isDeprecated()) false as T else wrapped.valueOrDefault(key, true) as T
             else -> wrapped.valueOrDefault(key, default)
         }
-    }
 
-    override fun <T : Any> valueOrNull(key: String): T? {
-        return when (key) {
+    override fun <T : Any> valueOrNull(key: String): T? =
+        when (key) {
             Config.ACTIVE_KEY -> if (isDeprecated()) false as T else wrapped.valueOrNull(key) ?: true as? T
             else -> wrapped.valueOrNull(key)
         }
-    }
 
     override fun validate(baseline: Config, excludePatterns: Set<Regex>) =
         validateConfig(wrapped, baseline, excludePatterns)

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/BaseConfig.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/BaseConfig.kt
@@ -14,8 +14,8 @@ fun Config.valueOrDefaultInternal(
     result: Any?,
     default: Any,
     parser: (result: String, default: Any) -> Any = ::tryParseBasedOnDefault
-): Any {
-    return try {
+): Any =
+    try {
         if (result != null) {
             when {
                 result is String -> parser(result, default)
@@ -49,7 +49,6 @@ fun Config.valueOrDefaultInternal(
                 " required type ${default::class.simpleName}."
         )
     }
-}
 
 fun tryParseBasedOnDefault(result: String, defaultResult: Any): Any = when (defaultResult) {
     is Int -> result.toInt()

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/CompositeConfig.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/CompositeConfig.kt
@@ -21,9 +21,7 @@ class CompositeConfig(
     override fun subConfig(key: String): Config =
         CompositeConfig(lookFirst.subConfig(key), lookSecond.subConfig(key), this)
 
-    override fun subConfigKeys(): Set<String> {
-        return lookFirst.subConfigKeys() + lookSecond.subConfigKeys()
-    }
+    override fun subConfigKeys(): Set<String> = lookFirst.subConfigKeys() + lookSecond.subConfigKeys()
 
     override fun <T : Any> valueOrDefault(key: String, default: T): T {
         if (lookFirst.valueOrNull<T>(key) != null) {

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/DisabledAutoCorrectConfig.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/DisabledAutoCorrectConfig.kt
@@ -17,9 +17,7 @@ class DisabledAutoCorrectConfig(
 
     override fun subConfig(key: String): Config = DisabledAutoCorrectConfig(wrapped.subConfig(key), this)
 
-    override fun subConfigKeys(): Set<String> {
-        return wrapped.subConfigKeys()
-    }
+    override fun subConfigKeys(): Set<String> = wrapped.subConfigKeys()
 
     override fun <T : Any> valueOrDefault(key: String, default: T): T = when (key) {
         Config.AUTO_CORRECT_KEY -> false as T

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/YamlConfig.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/YamlConfig.kt
@@ -35,9 +35,7 @@ class YamlConfig internal constructor(
         )
     }
 
-    override fun subConfigKeys(): Set<String> {
-        return properties.keys
-    }
+    override fun subConfigKeys(): Set<String> = properties.keys
 
     override fun <T : Any> valueOrDefault(key: String, default: T): T {
         val result = properties[key]
@@ -103,8 +101,8 @@ class YamlConfig internal constructor(
 }
 
 @Suppress("MagicNumber")
-private fun Map<*, *>.toPrettyString(recursive: Int): String {
-    return if (isEmpty()) {
+private fun Map<*, *>.toPrettyString(recursive: Int): String =
+    if (isEmpty()) {
         "{}"
     } else {
         toList()
@@ -116,4 +114,3 @@ private fun Map<*, *>.toPrettyString(recursive: Int): String {
                 }
             }
     }
-}

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/validation/Deprecations.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/validation/Deprecations.kt
@@ -17,8 +17,8 @@ internal data class DeprecatedProperty(
     val description: String
 ) : Deprecation()
 
-internal fun loadDeprecations(): Set<Deprecation> {
-    return ValidationSettings::class.java.classLoader
+internal fun loadDeprecations(): Set<Deprecation> =
+    ValidationSettings::class.java.classLoader
         .getResource("deprecation.properties")!!
         .openSafeStream()
         .use { inputStream ->
@@ -26,13 +26,11 @@ internal fun loadDeprecations(): Set<Deprecation> {
                 .apply { load(inputStream) }
                 .toDeprecations()
         }
-}
 
-private fun Properties.toDeprecations(): Set<Deprecation> {
-    return entries
+private fun Properties.toDeprecations(): Set<Deprecation> =
+    entries
         .map { deprecationFromPath(it.key as String, it.value as String) }
         .toSet()
-}
 
 private fun deprecationFromPath(path: String, description: String): Deprecation {
     val pathElements = path.split(">")

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/validation/InvalidPropertiesConfigValidator.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/validation/InvalidPropertiesConfigValidator.kt
@@ -19,9 +19,7 @@ internal class InvalidPropertiesConfigValidator(
     override fun validate(
         configToValidate: YamlConfig,
         settings: ValidationSettings
-    ): Collection<Notification> {
-        return testKeys(configToValidate.properties, baseline.properties)
-    }
+    ): Collection<Notification> = testKeys(configToValidate.properties, baseline.properties)
 
     private fun testKeys(
         configToValidate: Map<String, Any>,

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/validation/MissingRulesConfigValidator.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/validation/MissingRulesConfigValidator.kt
@@ -71,12 +71,11 @@ internal class MissingRulesConfigValidator(
     companion object {
 
         private val ruleSetNames: List<RuleSet.Id> by lazy(Companion::loadRuleSets)
-        private fun loadRuleSets(): List<RuleSet.Id> {
-            return ServiceLoader.load(
+        private fun loadRuleSets(): List<RuleSet.Id> =
+            ServiceLoader.load(
                 RuleSetProvider::class.java,
                 MissingRulesConfigValidator::class.java.classLoader
             )
                 .map { it.ruleSetId }
-        }
     }
 }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/Reporting.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/Reporting.kt
@@ -9,8 +9,8 @@ import io.gitlab.arturbosch.detekt.api.internal.BuiltInOutputReport
 internal fun defaultReportMapping(report: OutputReport) =
     if (report is BuiltInOutputReport) report.ending else report.id
 
-internal fun printIssues(issues: Map<String, List<Issue>>): String {
-    return buildString {
+internal fun printIssues(issues: Map<String, List<Issue>>): String =
+    buildString {
         issues.forEach { (key, issues) ->
             append(key)
             append("\n")
@@ -21,7 +21,6 @@ internal fun printIssues(issues: Map<String, List<Issue>>): String {
             }
         }
     }
-}
 
 const val BUILD = "build"
 const val EXCLUDE_CORRECTABLE = "excludeCorrectable"
@@ -33,10 +32,7 @@ private val messageReplacementRegex = Regex("\\s+")
 
 fun Config.excludeCorrectable(): Boolean = subConfig(BUILD).valueOrDefault(EXCLUDE_CORRECTABLE, false)
 
-fun Detektion.filterEmptyIssues(config: Config): List<Issue> {
-    return this
-        .filterAutoCorrectedIssues(config)
-}
+fun Detektion.filterEmptyIssues(config: Config): List<Issue> = this.filterAutoCorrectedIssues(config)
 
 fun Detektion.filterAutoCorrectedIssues(config: Config): List<Issue> {
     if (!config.excludeCorrectable()) {

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/IssuesReport.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/IssuesReport.kt
@@ -11,7 +11,6 @@ class IssuesReport : AbstractIssuesReport() {
 
     override val id: String = "IssuesReport"
 
-    override fun render(issues: List<Issue>): String {
-        return printIssues(issues.groupBy { it.ruleInstance.ruleSetId }.mapKeys { (key, _) -> key.value })
-    }
+    override fun render(issues: List<Issue>): String =
+        printIssues(issues.groupBy { it.ruleInstance.ruleSetId }.mapKeys { (key, _) -> key.value })
 }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/LiteIssuesReport.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/LiteIssuesReport.kt
@@ -10,12 +10,11 @@ class LiteIssuesReport : AbstractIssuesReport() {
 
     override val id: String = "LiteIssuesReport"
 
-    override fun render(issues: List<Issue>): String {
-        return buildString {
+    override fun render(issues: List<Issue>): String =
+        buildString {
             issues.forEach { issue ->
                 append("${issue.location.compact()}: ${issue.message} [${issue.ruleInstance.id}]")
                 appendLine()
             }
         }
-    }
 }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/settings/EnvironmentAware.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/settings/EnvironmentAware.kt
@@ -63,12 +63,11 @@ internal fun CompilerSpec.parseLanguageVersion(): LanguageVersion? {
     return languageVersion?.let(::parse)
 }
 
-internal fun CompilerSpec.parseJvmTarget(): JvmTarget {
-    return checkNotNull(JvmTarget.fromString(jvmTarget)) {
+internal fun CompilerSpec.parseJvmTarget(): JvmTarget =
+    checkNotNull(JvmTarget.fromString(jvmTarget)) {
         "Invalid value ($jvmTarget) passed to --jvm-target," +
             " must be one of ${JvmTarget.entries.map(JvmTarget::description)}"
     }
-}
 
 private object NullPrintStream : PrintStream(
     object : OutputStream() {

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/AnnotationSuppressor.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/AnnotationSuppressor.kt
@@ -29,20 +29,18 @@ internal fun annotationSuppressorFactory(rule: Rule, bindingContext: BindingCont
     }
 }
 
-private fun KtElement.isAnnotatedWith(excluder: AnnotationExcluder): Boolean {
-    return if (this is KtAnnotated && excluder.shouldExclude(annotationEntries)) {
+private fun KtElement.isAnnotatedWith(excluder: AnnotationExcluder): Boolean =
+    if (this is KtAnnotated && excluder.shouldExclude(annotationEntries)) {
         true
     } else {
         getStrictParentOfType<KtAnnotated>()?.isAnnotatedWith(excluder) ?: false
     }
-}
 
-private fun String.qualifiedNameGlobToRegex(): Regex {
-    return this
+private fun String.qualifiedNameGlobToRegex(): Regex =
+    this
         .replace(".", """\.""")
         .replace("**", "//")
         .replace("*", "[^.]*")
         .replace("//", ".*")
         .replace("?", ".")
         .toRegex()
-}

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/FunctionSuppressor.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/FunctionSuppressor.kt
@@ -37,17 +37,14 @@ private fun functionSuppressor(
     element: KtElement,
     bindingContext: BindingContext,
     functionMatchers: List<FunctionMatcher>,
-): Boolean {
-    return element.isInFunctionNamed(bindingContext, functionMatchers)
-}
+): Boolean = element.isInFunctionNamed(bindingContext, functionMatchers)
 
 private fun KtElement.isInFunctionNamed(
     bindingContext: BindingContext,
     functionMatchers: List<FunctionMatcher>,
-): Boolean {
-    return if (this is KtNamedFunction && functionMatchers.any { it.match(this, bindingContext) }) {
+): Boolean =
+    if (this is KtNamedFunction && functionMatchers.any { it.match(this, bindingContext) }) {
         true
     } else {
         getStrictParentOfType<KtNamedFunction>()?.isInFunctionNamed(bindingContext, functionMatchers) ?: false
     }
-}

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/Suppressor.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/Suppressor.kt
@@ -11,9 +11,8 @@ fun interface Suppressor {
     fun shouldSuppress(finding: Finding): Boolean
 }
 
-internal fun buildSuppressors(rule: Rule, bindingContext: BindingContext): List<Suppressor> {
-    return listOfNotNull(
+internal fun buildSuppressors(rule: Rule, bindingContext: BindingContext): List<Suppressor> =
+    listOfNotNull(
         annotationSuppressorFactory(rule, bindingContext),
         functionSuppressorFactory(rule, bindingContext),
     )
-}

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/tooling/DefaultConfigProvider.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/tooling/DefaultConfigProvider.kt
@@ -45,16 +45,11 @@ private fun configInputStream(extensionsSpec: ExtensionsSpec): InputStream {
     return ByteArrayInputStream(outputStream.toByteArray())
 }
 
-private fun ClassLoader.getSafeResourcesAsStreams(name: String): Sequence<InputStream> {
-    return getResources(name)
+private fun ClassLoader.getSafeResourcesAsStreams(name: String): Sequence<InputStream> =
+    getResources(name)
         .asSequence()
         .map { it.openSafeStream() }
-}
 
-private fun ExtensionsSpec.getDefaultConfiguration(): Config {
-    return YamlConfig.load(configInputStream(this).reader())
-}
+private fun ExtensionsSpec.getDefaultConfiguration(): Config = YamlConfig.load(configInputStream(this).reader())
 
-fun ProcessingSpec.getDefaultConfiguration(): Config {
-    return extensionsSpec.getDefaultConfiguration()
-}
+fun ProcessingSpec.getDefaultConfiguration(): Config = extensionsSpec.getDefaultConfiguration()

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/tooling/DefaultDetektProvider.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/tooling/DefaultDetektProvider.kt
@@ -6,7 +6,5 @@ import io.github.detekt.tooling.api.spec.ProcessingSpec
 
 class DefaultDetektProvider : DetektProvider {
 
-    override fun get(processingSpec: ProcessingSpec): Detekt {
-        return AnalysisFacade(processingSpec)
-    }
+    override fun get(processingSpec: ProcessingSpec): Detekt = AnalysisFacade(processingSpec)
 }

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/AnalyzerSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/AnalyzerSpec.kt
@@ -447,30 +447,27 @@ private open class MaxLineLength(config: Config) : Rule(config, "TestDescription
         }
     }
 
-    private fun KtFile.findFirstMeaningfulKtElementInParents(range: IntRange): PsiElement {
-        return elementsInRange(TextRange.create(range.first, range.last))
+    private fun KtFile.findFirstMeaningfulKtElementInParents(range: IntRange): PsiElement =
+        elementsInRange(TextRange.create(range.first, range.last))
             .asSequence()
             .plus(findElementAt(range.last))
             .mapNotNull { it?.getNonStrictParentOfType() }
             .first { it.text.isNotBlank() }
-    }
 }
 
 @RequiresTypeResolution
 private class RequiresTypeResolutionMaxLineLength(config: Config) : MaxLineLength(config)
 
 private class FaultyRule(config: Config) : Rule(config, "") {
-    override fun visitKtFile(file: KtFile) {
+    override fun visitKtFile(file: KtFile): Unit =
         throw object : IllegalStateException("Deliberately triggered error.") {}
-    }
 }
 
 private class FaultyRuleNoStackTrace(config: Config) : Rule(config, "") {
-    override fun visitKtFile(file: KtFile) {
+    override fun visitKtFile(file: KtFile): Unit =
         throw object : IllegalStateException("Deliberately triggered error without stack trace.") {
             init {
                 stackTrace = emptyArray()
             }
         }
-    }
 }

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/OutputReportsSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/OutputReportsSpec.kt
@@ -128,7 +128,5 @@ class TestOutputReport : OutputReport() {
     override val id: String = "TestOutputReport"
     override val ending: String = "yml"
 
-    override fun render(detektion: Detektion): String? {
-        throw UnsupportedOperationException("not implemented")
-    }
+    override fun render(detektion: Detektion): String? = throw UnsupportedOperationException("not implemented")
 }

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/FunctionSuppressorSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/FunctionSuppressorSpec.kt
@@ -212,6 +212,5 @@ class FunctionSuppressorSpec {
     }
 }
 
-private fun buildFunctionSuppressor(ignoreFunction: List<String>, bindingContext: BindingContext): Suppressor {
-    return functionSuppressorFactory(buildRule("ignoreFunction" to ignoreFunction), bindingContext)!!
-}
+private fun buildFunctionSuppressor(ignoreFunction: List<String>, bindingContext: BindingContext): Suppressor =
+    functionSuppressorFactory(buildRule("ignoreFunction" to ignoreFunction), bindingContext)!!

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/SuppressionsSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/SuppressionsSpec.kt
@@ -16,9 +16,8 @@ import org.junit.jupiter.params.provider.ValueSource
 
 class SuppressionsSpec {
 
-    private fun KtElement.isSuppressedBy(): Boolean {
-        return isSuppressedBy("RuleName", setOf("alias1", "alias2"), RuleSet.Id("RuleSetId"))
-    }
+    private fun KtElement.isSuppressedBy(): Boolean =
+        isSuppressedBy("RuleName", setOf("alias1", "alias2"), RuleSet.Id("RuleSetId"))
 
     @Nested
     inner class DifferentSuppressLocation {
@@ -279,27 +278,21 @@ class SuppressionsSpec {
     }
 }
 
-private fun KtFile.getClass(): KtElement {
-    return findChildByClass(KtClass::class.java)!!
-}
+private fun KtFile.getClass(): KtElement = findChildByClass(KtClass::class.java)!!
 
-private fun KtFile.getMethod(): KtElement {
-    return findChildByClass(KtClass::class.java)!!
+private fun KtFile.getMethod(): KtElement =
+    findChildByClass(KtClass::class.java)!!
         .body!!
         .children
         .single { it is KtFunction }
         .let { it as KtFunction }
         .bodyBlockExpression!!
-}
 
-private fun KtFile.getMethodParameter(): KtElement {
-    return findChildByClass(KtClass::class.java)!!
+private fun KtFile.getMethodParameter(): KtElement =
+    findChildByClass(KtClass::class.java)!!
         .body!!
         .children
         .single { it is KtFunction }
         .findDescendantOfType<KtParameter>()!!
-}
 
-private fun KtFile.getFunction(): KtElement {
-    return findChildByClass(KtFunction::class.java)!!
-}
+private fun KtFile.getFunction(): KtElement = findChildByClass(KtFunction::class.java)!!

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/KtLintLineColCalculator.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/KtLintLineColCalculator.kt
@@ -9,16 +9,14 @@ package io.gitlab.arturbosch.detekt.formatting
 object KtLintLineColCalculator {
     private const val UTF8_BOM = "\uFEFF"
 
-    fun calculateLineColByOffset(text: String): (offset: Int) -> Pair<Int, Int> {
-        return buildPositionInTextLocator(normalizeText(text))
-    }
+    fun calculateLineColByOffset(text: String): (offset: Int) -> Pair<Int, Int> =
+        buildPositionInTextLocator(normalizeText(text))
 
-    private fun normalizeText(text: String): String {
-        return text
+    private fun normalizeText(text: String): String =
+        text
             .replace("\r\n", "\n")
             .replace("\r", "\n")
             .replaceFirst(UTF8_BOM, "")
-    }
 
     private fun buildPositionInTextLocator(
         text: String

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/AutoCorrectLevelSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/AutoCorrectLevelSpec.kt
@@ -49,17 +49,16 @@ enum class AutoCorrectConfig {
     False,
     Undefined;
 
-    override fun toString(): String {
-        return when (this) {
+    override fun toString(): String =
+        when (this) {
             True -> "true"
             False -> "false"
             Undefined -> "Undefined"
         }
-    }
 }
 
-private fun createConfig(ruleSet: AutoCorrectConfig, rule: AutoCorrectConfig): String {
-    return buildString {
+private fun createConfig(ruleSet: AutoCorrectConfig, rule: AutoCorrectConfig): String =
+    buildString {
         appendLine("formatting:")
         appendLine("  active: true")
         if (ruleSet != AutoCorrectConfig.Undefined) {
@@ -71,7 +70,6 @@ private fun createConfig(ruleSet: AutoCorrectConfig, rule: AutoCorrectConfig): S
             appendLine("    autoCorrect: $rule")
         }
     }
-}
 
 private fun runRule(config: Config): Pair<KtFile, List<Finding>> {
     val testFile = loadFile("configTests/fixed.kt")

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/WrapperSmokeTestSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/WrapperSmokeTestSpec.kt
@@ -23,11 +23,10 @@ class WrapperSmokeTestSpec {
         assertThat(result).isEmpty()
     }
 
-    fun formattingRules(): List<FormattingRule> {
-        return ClassGraph()
+    fun formattingRules(): List<FormattingRule> =
+        ClassGraph()
             .acceptPackages("io.gitlab.arturbosch.detekt.formatting.wrappers")
             .scan()
             .use { scanResult -> scanResult.getSubclasses(FormattingRule::class.java).loadClasses() }
             .map { it.getDeclaredConstructor(Config::class.java).newInstance(Config.empty) as FormattingRule }
-    }
 }

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/DetektPrinter.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/DetektPrinter.kt
@@ -64,8 +64,8 @@ class DetektPrinter(
         }
     }
 
-    private fun markdownHeader(ruleSetName: String): String {
-        return """
+    private fun markdownHeader(ruleSetName: String): String =
+        """
             ---
             title: ${ruleSetName[0].uppercaseChar()}${ruleSetName.substring(1)} Rule Set
             sidebar: home_sidebar
@@ -75,5 +75,4 @@ class DetektPrinter(
             folder: documentation
             ---
         """.trimIndent()
-    }
 }

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/ConfigurationCollector.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/ConfigurationCollector.kt
@@ -37,9 +37,7 @@ class ConfigurationCollector {
     private val constantsByName = mutableMapOf<String, DefaultValue>()
     private val properties = mutableListOf<KtProperty>()
 
-    fun getConfigurations(): List<Configuration> {
-        return properties.mapNotNull { it.parseConfigurationAnnotation() }
-    }
+    fun getConfigurations(): List<Configuration> = properties.mapNotNull { it.parseConfigurationAnnotation() }
 
     fun addProperty(prop: KtProperty) {
         properties.add(prop)
@@ -136,13 +134,12 @@ class ConfigurationCollector {
             return defaultValueArgument?.getArgumentExpression()?.toDefaultValue(constantsByName)
         }
 
-        fun KtExpression.toDefaultValue(constantsByName: Map<String, DefaultValue>): DefaultValue {
-            return getValuesWithReasonDefaultOrNull()
+        fun KtExpression.toDefaultValue(constantsByName: Map<String, DefaultValue>): DefaultValue =
+            getValuesWithReasonDefaultOrNull()
                 ?: getListDefaultOrNull(constantsByName)
                 ?: toDefaultValueIfLiteral()
                 ?: constantsByName[text.withoutQuotes()]
                 ?: error("$text is neither a literal nor a constant")
-        }
 
         fun KtExpression.toDefaultValueIfLiteral(): DefaultValue? = createDefaultValueIfLiteral(text)
     }
@@ -187,19 +184,17 @@ class ConfigurationCollector {
     private object ValuesWithReasonSupport {
         private const val VALUES_WITH_REASON_FACTORY_METHOD = "valuesWithReason"
 
-        fun KtElement.getValuesWithReasonDefaultOrNull(): DefaultValue? {
-            return getValuesWithReasonDeclarationOrNull()
+        fun KtElement.getValuesWithReasonDefaultOrNull(): DefaultValue? =
+            getValuesWithReasonDeclarationOrNull()
                 ?.valueArguments
                 ?.map(::toValueWithReason)
                 ?.let { DefaultValue.of(valuesWithReason(it)) }
-        }
 
         fun KtElement.getValuesWithReasonDeclarationOrNull(): KtCallExpression? =
             findDescendantOfType { it.isValuesWithReasonDeclaration() }
 
-        fun KtCallExpression.isValuesWithReasonDeclaration(): Boolean {
-            return referenceExpression()?.text == VALUES_WITH_REASON_FACTORY_METHOD
-        }
+        fun KtCallExpression.isValuesWithReasonDeclaration(): Boolean =
+            referenceExpression()?.text == VALUES_WITH_REASON_FACTORY_METHOD
 
         fun KtProperty.hasValuesWithReasonDeclaration(): Boolean =
             anyDescendantOfType<KtCallExpression> { it.isValuesWithReasonDeclaration() }
@@ -222,11 +217,10 @@ class ConfigurationCollector {
         private const val EMPTY_LIST = "emptyList"
         private val LIST_CREATORS = setOf(LIST_OF, EMPTY_LIST)
 
-        fun KtElement.getListDefaultOrNull(constantsByName: Map<String, DefaultValue>): DefaultValue? {
-            return getListDeclarationOrNull()?.valueArguments?.map {
+        fun KtElement.getListDefaultOrNull(constantsByName: Map<String, DefaultValue>): DefaultValue? =
+            getListDeclarationOrNull()?.valueArguments?.map {
                 (constantsByName[it.text]?.getPlainValue() ?: it.text.withoutQuotes())
             }?.let { DefaultValue.of(it) }
-        }
 
         fun KtElement.getListDeclarationOrNull(): KtCallExpression? =
             findDescendantOfType { it.isListDeclaration() }
@@ -250,9 +244,8 @@ class ConfigurationCollector {
         private fun KtProperty.isInitializedWithConfigDelegate(): Boolean =
             delegate?.expression?.referenceExpression()?.text in DELEGATE_NAMES
 
-        private fun KtElement.invalidDocumentation(message: () -> String): Nothing {
+        private fun KtElement.invalidDocumentation(message: () -> String): Nothing =
             throw InvalidDocumentationException("[${containingFile.name}] ${message.invoke()}")
-        }
 
         private fun KtProperty.getValueArgument(
             name: String,

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/DefaultValue.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/DefaultValue.kt
@@ -73,7 +73,5 @@ private data class ValuesWithReasonDefault(private val defaultValue: ValuesWithR
         yaml.listOfMaps(name, asMap)
     }
 
-    override fun printAsMarkdownCode(): String {
-        return defaultValue.map { "'${it.value}'" }.toString()
-    }
+    override fun printAsMarkdownCode(): String = defaultValue.map { "'${it.value}'" }.toString()
 }

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/DefaultValues.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/DefaultValues.kt
@@ -5,14 +5,13 @@ import org.jetbrains.kotlin.lexer.KtTokens.TRUE_KEYWORD
 
 fun createDefaultValueIfLiteral(maybeLiteral: String): DefaultValue? = maybeLiteral.toDefaultValueIfLiteral()
 
-private fun String.toDefaultValueIfLiteral(): DefaultValue? {
-    return when {
+private fun String.toDefaultValueIfLiteral(): DefaultValue? =
+    when {
         isStringLiteral() -> DefaultValue.of(withoutQuotes())
         isBooleanLiteral() -> DefaultValue.of(toBoolean())
         isIntegerLiteral() -> DefaultValue.of(withoutUnderscores().toInt())
         else -> null
     }
-}
 
 private fun String.withoutUnderscores() = replace("_", "")
 private fun String.isStringLiteral() = length > 1 && startsWith(QUOTES) && endsWith(QUOTES)

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/DetektCollector.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/DetektCollector.kt
@@ -28,11 +28,10 @@ class DetektCollector(textReplacements: Map<String, String>) : Collector<RuleSet
         }
     }
 
-    private fun List<Rule>.findRuleByName(ruleName: String): Rule {
-        return find { it.name == ruleName } ?: throw InvalidDocumentationException(
+    private fun List<Rule>.findRuleByName(ruleName: String): Rule =
+        find { it.name == ruleName } ?: throw InvalidDocumentationException(
             "Rule '$ruleName' was specified in a provider but it was not defined."
         )
-    }
 
     override fun visit(file: KtFile) {
         collectors.forEach {

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/DeprecatedPrinter.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/DeprecatedPrinter.kt
@@ -6,8 +6,8 @@ import io.gitlab.arturbosch.detekt.generator.collection.RuleSetPage
 
 object DeprecatedPrinter : DocumentationPrinter<List<RuleSetPage>> {
     @Suppress("NestedBlockDepth")
-    override fun print(item: List<RuleSetPage>): String {
-        return item.flatMap { ruleSet ->
+    override fun print(item: List<RuleSetPage>): String =
+        item.flatMap { ruleSet ->
             ruleSet.rules.flatMap { rule ->
                 buildList {
                     if (rule.isDeprecated()) {
@@ -24,7 +24,6 @@ object DeprecatedPrinter : DocumentationPrinter<List<RuleSetPage>> {
             .plus(migratedRules())
             .sorted()
             .joinToString("\n", postfix = "\n")
-    }
 }
 
 private fun writeRule(ruleSet: RuleSetPage, rule: Rule): String {

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/RulePrinter.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/RulePrinter.kt
@@ -13,8 +13,8 @@ import io.gitlab.arturbosch.detekt.generator.collection.Rule
 
 internal object RulePrinter : DocumentationPrinter<Rule> {
 
-    override fun print(item: Rule): String {
-        return markdown {
+    override fun print(item: Rule): String =
+        markdown {
             if (item.isDeprecated()) {
                 h3 { crossOut { item.name } }
                 paragraph { item.deprecationMessage.orEmpty() }
@@ -49,7 +49,6 @@ internal object RulePrinter : DocumentationPrinter<Rule> {
 
             printRuleCodeExamples(item)
         }
-    }
 
     private fun MarkdownContent.printRuleCodeExamples(rule: Rule) {
         if (rule.nonCompliantCodeExample.isNotEmpty()) {

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/RuleSetPagePrinter.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/RuleSetPagePrinter.kt
@@ -6,8 +6,8 @@ import io.gitlab.arturbosch.detekt.generator.collection.RuleSetPage
 
 object RuleSetPagePrinter : DocumentationPrinter<RuleSetPage> {
 
-    override fun print(item: RuleSetPage): String {
-        return markdown {
+    override fun print(item: RuleSetPage): String =
+        markdown {
             if (item.ruleSet.description.isNotEmpty()) {
                 paragraph { item.ruleSet.description }
             } else {
@@ -17,5 +17,4 @@ object RuleSetPagePrinter : DocumentationPrinter<RuleSetPage> {
                 markdown { RulePrinter.print(it) }
             }
         }
-    }
 }

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/defaultconfig/ConfigPrinter.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/defaultconfig/ConfigPrinter.kt
@@ -6,8 +6,8 @@ import io.gitlab.arturbosch.detekt.generator.printer.DocumentationPrinter
 
 object ConfigPrinter : DocumentationPrinter<List<RuleSetPage>> {
 
-    override fun print(item: List<RuleSetPage>): String {
-        return yaml {
+    override fun print(item: List<RuleSetPage>): String =
+        yaml {
             yaml { defaultBuildConfiguration() }
             emptyLine()
             yaml { defaultConfigConfiguration() }
@@ -22,14 +22,12 @@ object ConfigPrinter : DocumentationPrinter<List<RuleSetPage>> {
             item.sortedBy { it.ruleSet.name }
                 .forEach { printRuleSetPage(it) }
         }
-    }
 
-    fun printCustomRuleConfig(item: List<RuleSetPage>): String {
-        return yaml {
+    fun printCustomRuleConfig(item: List<RuleSetPage>): String =
+        yaml {
             item.sortedBy { it.ruleSet.name }
                 .forEach { printRuleSetPage(it) }
         }
-    }
 
     private fun defaultBuildConfiguration(): String = """
         build:

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/config/ConfigAssert.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/config/ConfigAssert.kt
@@ -60,13 +60,12 @@ class ConfigAssert(
     private fun getYmlRuleConfig() = config.subConfig(name) as? YamlConfig
         ?: error("yaml config expected but got ${config.javaClass}")
 
-    private fun getRulesDefinedByRuleSet(): List<Rule> {
-        return getRuleSetProviderInPackageOrNull()
+    private fun getRulesDefinedByRuleSet(): List<Rule> =
+        getRuleSetProviderInPackageOrNull()
             ?.instance()
             ?.rules
             ?.map { (_, provider) -> provider(Config.empty) }
             .orEmpty()
-    }
 
     private fun getRuleSetProviderInPackageOrNull(): RuleSetProvider? =
         ClassGraph()

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektMultiplatformSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektMultiplatformSpec.kt
@@ -352,8 +352,8 @@ class DetektMultiplatformSpec {
     }
 }
 
-private fun setupProject(projectLayoutAction: ProjectLayout.() -> Unit): DslGradleRunner {
-    return DslGradleRunner(
+private fun setupProject(projectLayoutAction: ProjectLayout.() -> Unit): DslGradleRunner =
+    DslGradleRunner(
         projectLayout = ProjectLayout(numberOfSourceFilesInRootPerSourceDir = 0).apply { projectLayoutAction() },
         buildFileName = "build.gradle.kts",
         mainBuildFileContent = """
@@ -369,7 +369,6 @@ private fun setupProject(projectLayoutAction: ProjectLayout.() -> Unit): DslGrad
     ).also {
         it.setupProject()
     }
-}
 
 private fun setupAndroidProject(projectLayoutAction: ProjectLayout.() -> Unit): DslGradleRunner {
     val gradleRunner = setupProject { projectLayoutAction() }
@@ -412,8 +411,8 @@ private val DETEKT_BLOCK = """
     }
 """.trimIndent()
 
-fun isXCodeInstalled(): Boolean {
-    return try {
+fun isXCodeInstalled(): Boolean =
+    try {
         val process = ProcessBuilder()
             .command("xcode-select", "--print-path")
             .start()
@@ -422,4 +421,3 @@ fun isXCodeInstalled(): Boolean {
     } catch (ignored: Throwable) {
         false
     }
-}

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
@@ -165,17 +165,15 @@ class DetektPlugin : Plugin<Project> {
 
 internal const val CONFIGURATION_DETEKT = "detekt"
 
-internal fun ProviderFactory.isWorkerApiEnabled(): Boolean {
-    return gradleProperty("detekt.use.worker.api").getOrElse("false") == "true"
-}
+internal fun ProviderFactory.isWorkerApiEnabled(): Boolean =
+    gradleProperty("detekt.use.worker.api").getOrElse("false") == "true"
 
 @Incubating
-fun getSupportedKotlinVersion(): String {
-    return DetektPlugin::class.java.classLoader.getResources("META-INF/MANIFEST.MF")
+fun getSupportedKotlinVersion(): String =
+    DetektPlugin::class.java.classLoader.getResources("META-INF/MANIFEST.MF")
         .asSequence()
         .mapNotNull { runCatching { readVersion(it) }.getOrNull() }
         .first()
-}
 
 private fun readVersion(resource: URL): String? = resource.openConnection()
     .apply { useCaches = false }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/CustomDetektReport.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/CustomDetektReport.kt
@@ -12,7 +12,5 @@ abstract class CustomDetektReport {
     @get:OutputFile
     abstract val outputLocation: RegularFileProperty
 
-    override fun toString(): String {
-        return "CustomDetektReport(reportId=$reportId, outputLocation=$outputLocation)"
-    }
+    override fun toString(): String = "CustomDetektReport(reportId=$reportId, outputLocation=$outputLocation)"
 }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektExtension.kt
@@ -80,8 +80,8 @@ internal fun loadDetektVersion(classLoader: ClassLoader): String {
 
 // Copy-paste from io.github.detekt.utils.openSafeStream in Resources.kt.
 // Can't use that function, because gradle-plugin is minimising dependencies: see #4748.
-private fun URL.openSafeStream(): InputStream {
-    return openConnection()
+private fun URL.openSafeStream(): InputStream =
+    openConnection()
         /*
          * Due to https://bugs.openjdk.java.net/browse/JDK-6947916 and https://bugs.openjdk.java.net/browse/JDK-8155607,
          * it is necessary to disallow caches to maintain stability on JDK 8 and 11 (and possibly more).
@@ -91,4 +91,3 @@ private fun URL.openSafeStream(): InputStream {
          */
         .apply { useCaches = false }
         .getInputStream()
-}

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektReport.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektReport.kt
@@ -14,7 +14,5 @@ abstract class DetektReport @Inject constructor(@get:Internal val type: DetektRe
     @get:OutputFile
     abstract val outputLocation: RegularFileProperty
 
-    override fun toString(): String {
-        return "DetektReport(type='$type', required=$required, outputLocation=$outputLocation)"
-    }
+    override fun toString(): String = "DetektReport(type='$type', required=$required, outputLocation=$outputLocation)"
 }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/CliArgument.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/CliArgument.kt
@@ -71,13 +71,12 @@ internal data class BaselineArgument(val baseline: RegularFile?) : CliArgument()
 }
 
 internal data class DefaultReportArgument(val report: DetektReport) : CliArgument() {
-    override fun toArgument(): List<String> {
-        return if (report.required.get()) {
+    override fun toArgument(): List<String> =
+        if (report.required.get()) {
             listOf(REPORT_PARAMETER, "${report.type.reportId}:${report.outputLocation.get().asFile.absoluteFile}")
         } else {
             emptyList()
         }
-    }
 }
 
 internal data class CustomReportArgument(val reportId: String, val file: RegularFile) : CliArgument() {

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/Main.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/Main.kt
@@ -11,7 +11,5 @@ fun buildRunner(
     outputPrinter: PrintStream,
     errorPrinter: PrintStream
 ) = object {
-    fun execute() {
-        throw ClassCastException("testing reflection wrapper...")
-    }
+    fun execute(): Unit = throw ClassCastException("testing reflection wrapper...")
 }

--- a/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/ComplexityReportGenerator.kt
+++ b/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/ComplexityReportGenerator.kt
@@ -26,8 +26,8 @@ class ComplexityReportGenerator(private val complexityMetric: ComplexityMetric) 
         )
     }
 
-    private fun cannotGenerate(): Boolean {
-        return when {
+    private fun cannotGenerate(): Boolean =
+        when {
             null in setOf(
                 complexityMetric.mcc,
                 complexityMetric.cloc,
@@ -43,7 +43,6 @@ class ComplexityReportGenerator(private val complexityMetric: ComplexityMetric) 
                 false
             }
         }
-    }
 
     companion object Factory {
         fun create(detektion: Detektion): ComplexityReportGenerator =

--- a/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/processors/ProjectSLOCProcessor.kt
+++ b/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/processors/ProjectSLOCProcessor.kt
@@ -23,11 +23,10 @@ class SLOCVisitor : DetektVisitor() {
 
         private val comments = arrayOf("//", "/*", "*/", "*")
 
-        fun count(lines: List<String>): Int {
-            return lines
+        fun count(lines: List<String>): Int =
+            lines
                 .map { it.trim() }
                 .count { trim -> trim.isNotEmpty() && !comments.any { trim.startsWith(it) } }
-        }
     }
 }
 

--- a/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/processors/util/LLOC.kt
+++ b/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/processors/util/LLOC.kt
@@ -77,9 +77,7 @@ object LLOC {
             }
         }
 
-        private fun isEscaped(trimmed: String, rules: Array<String>): Boolean {
-            return rules.any { trimmed.startsWith(it) }
-        }
+        private fun isEscaped(trimmed: String, rules: Array<String>): Boolean = rules.any { trimmed.startsWith(it) }
 
         private fun frequency(source: String, part: String): Int {
             if (source.isEmpty() || part.isEmpty()) {

--- a/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/processors/ClassCountVisitorSpec.kt
+++ b/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/processors/ClassCountVisitorSpec.kt
@@ -34,13 +34,10 @@ class ClassCountVisitorSpec {
     }
 }
 
-private fun getClassCount(files: Array<KtFile>): Int {
-    return files.sumOf { getData(it) }
-}
+private fun getClassCount(files: Array<KtFile>): Int = files.sumOf { getData(it) }
 
-private fun getData(file: KtFile): Int {
-    return with(file) {
+private fun getData(file: KtFile): Int =
+    with(file) {
         accept(ClassCountVisitor())
         checkNotNull(getUserData(numberOfClassesKey))
     }
-}

--- a/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/processors/KtFileCountVisitorSpec.kt
+++ b/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/processors/KtFileCountVisitorSpec.kt
@@ -18,9 +18,8 @@ class KtFileCountVisitorSpec {
     }
 }
 
-private fun getData(file: KtFile): Int {
-    return with(file) {
+private fun getData(file: KtFile): Int =
+    with(file) {
         accept(KtFileCountVisitor())
         checkNotNull(getUserData(numberOfFilesKey))
     }
-}

--- a/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/processors/MethodCountVisitorSpec.kt
+++ b/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/processors/MethodCountVisitorSpec.kt
@@ -15,9 +15,8 @@ class MethodCountVisitorSpec {
     }
 }
 
-private fun getMethodCount(file: KtFile): Int {
-    return with(file) {
+private fun getMethodCount(file: KtFile): Int =
+    with(file) {
         accept(FunctionCountVisitor())
         checkNotNull(getUserData(numberOfFunctionsKey))
     }
-}

--- a/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/processors/MetricProcessorTester.kt
+++ b/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/processors/MetricProcessorTester.kt
@@ -31,9 +31,7 @@ private class MetricResults : Detektion, UserDataHolderBase() {
         get() = throw UnsupportedOperationException()
     override val metrics: MutableList<ProjectMetric> = mutableListOf()
 
-    override fun add(notification: Notification) {
-        throw UnsupportedOperationException()
-    }
+    override fun add(notification: Notification): Unit = throw UnsupportedOperationException()
 
     override fun add(projectMetric: ProjectMetric) {
         metrics.add(projectMetric)

--- a/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/processors/PackageCountVisitorSpec.kt
+++ b/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/processors/PackageCountVisitorSpec.kt
@@ -20,9 +20,8 @@ class PackageCountVisitorSpec {
     }
 }
 
-private fun getData(file: KtFile): String {
-    return with(file) {
+private fun getData(file: KtFile): String =
+    with(file) {
         accept(PackageCountVisitor())
         checkNotNull(getUserData(numberOfPackagesKey))
     }
-}

--- a/detekt-psi-utils/src/main/kotlin/io/github/detekt/psi/AnnotationExcluder.kt
+++ b/detekt-psi-utils/src/main/kotlin/io/github/detekt/psi/AnnotationExcluder.kt
@@ -25,9 +25,8 @@ class AnnotationExcluder(
      * Is true if any given annotation name is declared in the SplitPattern
      * which basically describes entries to exclude.
      */
-    fun shouldExclude(annotations: List<KtAnnotationEntry>): Boolean {
-        return annotations.any { annotation -> annotation.typeReference?.let { isExcluded(it, context) } ?: false }
-    }
+    fun shouldExclude(annotations: List<KtAnnotationEntry>): Boolean =
+        annotations.any { annotation -> annotation.typeReference?.let { isExcluded(it, context) } ?: false }
 
     private fun isExcluded(annotation: KtTypeReference, context: BindingContext): Boolean {
         val fqName = if (context == BindingContext.EMPTY) null else annotation.fqNameOrNull(context)
@@ -71,9 +70,8 @@ private fun String.getPackage(): String {
         .joinToString(".")
 }
 
-private fun KtTypeReference.fqNameOrNull(bindingContext: BindingContext): FqName? {
-    return bindingContext[BindingContext.TYPE, this]?.fqNameOrNull()
-}
+private fun KtTypeReference.fqNameOrNull(bindingContext: BindingContext): FqName? =
+    bindingContext[BindingContext.TYPE, this]?.fqNameOrNull()
 
 private operator fun Iterable<Regex>.contains(a: String?): Boolean {
     if (a == null) return false

--- a/detekt-psi-utils/src/main/kotlin/io/github/detekt/psi/FunctionMatcher.kt
+++ b/detekt-psi-utils/src/main/kotlin/io/github/detekt/psi/FunctionMatcher.kt
@@ -17,18 +17,14 @@ sealed class FunctionMatcher {
     internal data class NameOnly(
         private val fullyQualifiedName: String
     ) : FunctionMatcher() {
-        override fun match(callableDescriptor: CallableDescriptor): Boolean {
-            return callableDescriptor.fqNameSafe.asString() == fullyQualifiedName
-        }
+        override fun match(callableDescriptor: CallableDescriptor): Boolean =
+            callableDescriptor.fqNameSafe.asString() == fullyQualifiedName
 
-        override fun match(function: KtNamedFunction, bindingContext: BindingContext): Boolean {
-            return function.name == fullyQualifiedName ||
+        override fun match(function: KtNamedFunction, bindingContext: BindingContext): Boolean =
+            function.name == fullyQualifiedName ||
                 function.fqName?.asString() == fullyQualifiedName
-        }
 
-        override fun toString(): String {
-            return fullyQualifiedName
-        }
+        override fun toString(): String = fullyQualifiedName
     }
 
     internal data class WithParameters(
@@ -57,9 +53,7 @@ sealed class FunctionMatcher {
             return encounteredParameters == parameters
         }
 
-        override fun toString(): String {
-            return "$fullyQualifiedName(${parameters.joinToString()})"
-        }
+        override fun toString(): String = "$fullyQualifiedName(${parameters.joinToString()})"
     }
 
     companion object {
@@ -84,13 +78,12 @@ sealed class FunctionMatcher {
     }
 }
 
-private fun KotlinType.getSignatureParameter(): String? {
-    return if (isTypeParameter()) {
+private fun KotlinType.getSignatureParameter(): String? =
+    if (isTypeParameter()) {
         toString()
     } else {
         fqNameOrNull()?.toString()
     }
-}
 
 // Extracted from: https://stackoverflow.com/a/16108347/842697
 private fun String.splitParams(): List<String> {

--- a/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/KtBinaryExpression.kt
+++ b/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/KtBinaryExpression.kt
@@ -3,12 +3,10 @@ package io.gitlab.arturbosch.detekt.rules
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtBinaryExpression
 
-fun KtBinaryExpression.isNonNullCheck(): Boolean {
-    return operationToken == KtTokens.EXCLEQ && (left?.text == NULL_TEXT || right?.text == NULL_TEXT)
-}
+fun KtBinaryExpression.isNonNullCheck(): Boolean =
+    operationToken == KtTokens.EXCLEQ && (left?.text == NULL_TEXT || right?.text == NULL_TEXT)
 
-fun KtBinaryExpression.isNullCheck(): Boolean {
-    return operationToken == KtTokens.EQEQ && (left?.text == NULL_TEXT || right?.text == NULL_TEXT)
-}
+fun KtBinaryExpression.isNullCheck(): Boolean =
+    operationToken == KtTokens.EQEQ && (left?.text == NULL_TEXT || right?.text == NULL_TEXT)
 
 private const val NULL_TEXT = "null"

--- a/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/KtLambdaExpression.kt
+++ b/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/KtLambdaExpression.kt
@@ -21,18 +21,16 @@ fun KtLambdaExpression.implicitParameter(bindingContext: BindingContext): ValueP
 fun KtLambdaExpression.hasImplicitParameterReference(
     implicitParameter: ValueParameterDescriptor,
     bindingContext: BindingContext
-): Boolean {
-    return anyDescendantOfType<KtNameReferenceExpression> {
+): Boolean =
+    anyDescendantOfType<KtNameReferenceExpression> {
         it.isImplicitParameterReference(this, implicitParameter, bindingContext)
     }
-}
 
 private fun KtNameReferenceExpression.isImplicitParameterReference(
     lambda: KtLambdaExpression,
     implicitParameter: ValueParameterDescriptor,
     bindingContext: BindingContext
-): Boolean {
-    return text == "it" &&
+): Boolean =
+    text == "it" &&
         getStrictParentOfType<KtLambdaExpression>() == lambda &&
         getResolvedCall(bindingContext)?.resultingDescriptor == implicitParameter
-}

--- a/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/ThrowExtensions.kt
+++ b/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/ThrowExtensions.kt
@@ -13,17 +13,15 @@ fun KtThrowExpression.isIllegalStateException() =
 fun KtThrowExpression.isIllegalArgumentException() =
     isExceptionOfType<IllegalArgumentException>()
 
-inline fun <reified T : Exception> KtThrowExpression.isExceptionOfType(): Boolean {
-    return findDescendantOfType<KtCallExpression>()?.firstChild?.text == T::class.java.simpleName
-}
+inline fun <reified T : Exception> KtThrowExpression.isExceptionOfType(): Boolean =
+    findDescendantOfType<KtCallExpression>()?.firstChild?.text == T::class.java.simpleName
 
 val KtThrowExpression.arguments: List<KtValueArgument>
     get() = findDescendantOfType<KtCallExpression>()?.valueArguments.orEmpty()
 
-fun KtThrowExpression.isEnclosedByConditionalStatement(): Boolean {
-    return when (parent) {
+fun KtThrowExpression.isEnclosedByConditionalStatement(): Boolean =
+    when (parent) {
         is KtContainerNodeForControlStructureBody -> true
         is KtBlockExpression -> parent.parent is KtContainerNodeForControlStructureBody
         else -> false
     }
-}

--- a/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/TypeUtils.kt
+++ b/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/TypeUtils.kt
@@ -17,9 +17,7 @@ import org.jetbrains.kotlin.types.isFlexible
 import org.jetbrains.kotlin.types.isNullable
 import org.jetbrains.kotlin.util.containingNonLocalDeclaration
 
-fun KotlinType.fqNameOrNull(): FqName? {
-    return TypeUtils.getClassDescriptor(this)?.fqNameOrNull()
-}
+fun KotlinType.fqNameOrNull(): FqName? = TypeUtils.getClassDescriptor(this)?.fqNameOrNull()
 
 /**
  * Returns types considering data flow.

--- a/detekt-report-html/src/main/kotlin/io/github/detekt/report/html/HtmlOutputReport.kt
+++ b/detekt-report-html/src/main/kotlin/io/github/detekt/report/html/HtmlOutputReport.kt
@@ -178,9 +178,8 @@ class HtmlOutputReport : BuiltInOutputReport, OutputReport() {
         }
     }
 
-    private fun getComplexityMetrics(detektion: Detektion): List<String> {
-        return ComplexityReportGenerator.create(detektion).generate().orEmpty()
-    }
+    private fun getComplexityMetrics(detektion: Detektion): List<String> =
+        ComplexityReportGenerator.create(detektion).generate().orEmpty()
 }
 
 @HtmlTagMarker

--- a/detekt-report-md/src/main/kotlin/io/github/detekt/report/md/MdOutputReport.kt
+++ b/detekt-report-md/src/main/kotlin/io/github/detekt/report/md/MdOutputReport.kt
@@ -76,9 +76,8 @@ class MdOutputReport : BuiltInOutputReport, OutputReport() {
         return "${OffsetDateTime.now(ZoneOffset.UTC).format(formatter)} UTC"
     }
 
-    private fun getComplexityMetrics(detektion: Detektion): List<String> {
-        return ComplexityReportGenerator.create(detektion).generate().orEmpty()
-    }
+    private fun getComplexityMetrics(detektion: Detektion): List<String> =
+        ComplexityReportGenerator.create(detektion).generate().orEmpty()
 }
 
 private fun MarkdownContent.renderMetrics(metrics: Collection<ProjectMetric>) {

--- a/detekt-report-md/src/test/kotlin/io/github/detekt/report/md/MdOutputReportSpec.kt
+++ b/detekt-report-md/src/test/kotlin/io/github/detekt/report/md/MdOutputReportSpec.kt
@@ -174,12 +174,11 @@ private fun createTestDetektionWithMultipleSmells(): Detektion {
     }
 }
 
-private fun createMdDetektion(vararg issues: Issue): Detektion {
-    return TestDetektion(
+private fun createMdDetektion(vararg issues: Issue): Detektion =
+    TestDetektion(
         *issues,
         metrics = listOf(ProjectMetric("M1", 10_000), ProjectMetric("M2", 2))
     )
-}
 
 private fun issues(): Array<Issue> {
     val entity1 = createEntity(location = createLocation("src/main/com/sample/Sample1.kt", position = 11 to 5))

--- a/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/Results.kt
+++ b/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/Results.kt
@@ -22,17 +22,16 @@ internal fun Severity.toResultLevel() = when (this) {
     Severity.Info -> Level.Note
 }
 
-private fun Issue.toResult(basePath: String?): io.github.detekt.sarif4k.Result {
-    return io.github.detekt.sarif4k.Result(
+private fun Issue.toResult(basePath: String?): io.github.detekt.sarif4k.Result =
+    io.github.detekt.sarif4k.Result(
         ruleID = "detekt.${ruleInstance.ruleSetId}.${ruleInstance.id}",
         level = severity.toResultLevel(),
         locations = (listOf(location) + references.map { it.location }).map { it.toLocation(basePath) }.distinct(),
         message = Message(text = message)
     )
-}
 
-private fun Location.toLocation(basePath: String?): io.github.detekt.sarif4k.Location {
-    return io.github.detekt.sarif4k.Location(
+private fun Location.toLocation(basePath: String?): io.github.detekt.sarif4k.Location =
+    io.github.detekt.sarif4k.Location(
         physicalLocation = PhysicalLocation(
             region = Region(
                 startLine = source.line.toLong(),
@@ -50,4 +49,3 @@ private fun Location.toLocation(basePath: String?): io.github.detekt.sarif4k.Loc
             }
         )
     )
-}

--- a/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/RuleDescriptors.kt
+++ b/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/RuleDescriptors.kt
@@ -13,8 +13,8 @@ import java.util.ServiceLoader
 /**
  * Given the existing config, return a list of [ReportingDescriptor] for the rules.
  */
-internal fun toReportingDescriptors(config: Config): List<ReportingDescriptor> {
-    return ServiceLoader.load(RuleSetProvider::class.java, SarifOutputReport::class.java.classLoader)
+internal fun toReportingDescriptors(config: Config): List<ReportingDescriptor> =
+    ServiceLoader.load(RuleSetProvider::class.java, SarifOutputReport::class.java.classLoader)
         .map { it.instance() }
         .flatMap { ruleSet ->
             val ruleSetConfig = config.subConfig(ruleSet.id.value)
@@ -23,7 +23,6 @@ internal fun toReportingDescriptors(config: Config): List<ReportingDescriptor> {
                 rule.toDescriptor(ruleSet.id)
             }
         }
-}
 
 private fun Rule.toDescriptor(ruleSetId: RuleSet.Id): ReportingDescriptor {
     val formattedRuleSetId = ruleSetId.value.lowercase()

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LabeledExpression.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LabeledExpression.kt
@@ -87,10 +87,9 @@ class LabeledExpression(config: Config) : Rule(
         return !containingClasses.any { it.name == expression.getLabelName() }
     }
 
-    private fun isAllowedToReferenceContainingClass(klass: KtClass, expression: KtExpressionWithLabel): Boolean {
-        return !klass.isInner() ||
+    private fun isAllowedToReferenceContainingClass(klass: KtClass, expression: KtExpressionWithLabel): Boolean =
+        !klass.isInner() ||
             expression.getStrictParentOfType<KtNamedFunction>()?.isExtensionDeclaration() == true
-    }
 
     private fun getClassHierarchy(element: KtElement, classes: MutableList<KtClass>) {
         val containingClass = element.containingClass() ?: return

--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterList.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterList.kt
@@ -76,9 +76,7 @@ class LongParameterList(config: Config) : Rule(
         validateConstructor(constructor)
     }
 
-    private fun KtAnnotated.isIgnored(): Boolean {
-        return annotationExcluder.shouldExclude(annotationEntries)
-    }
+    private fun KtAnnotated.isIgnored(): Boolean = annotationExcluder.shouldExclude(annotationEntries)
 
     private fun validateConstructor(constructor: KtConstructor<*>) {
         val owner = constructor.getContainingClassOrObject()

--- a/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/RedundantSuspendModifier.kt
+++ b/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/RedundantSuspendModifier.kt
@@ -72,8 +72,8 @@ class RedundantSuspendModifier(config: Config) : Rule(
         }
     }
 
-    private fun KtExpression.isValidCandidateExpression(): Boolean {
-        return when (this) {
+    private fun KtExpression.isValidCandidateExpression(): Boolean =
+        when (this) {
             is KtOperationReferenceExpression, is KtForExpression, is KtProperty, is KtNameReferenceExpression -> true
             else -> {
                 val parent = parent
@@ -84,7 +84,6 @@ class RedundantSuspendModifier(config: Config) : Rule(
                 }
             }
         }
-    }
 
     private fun KtExpression.hasSuspendCalls(): Boolean {
         if (!isValidCandidateExpression()) return false

--- a/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SleepInsteadOfDelay.kt
+++ b/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SleepInsteadOfDelay.kt
@@ -67,14 +67,13 @@ class SleepInsteadOfDelay(config: Config) : Rule(
     }
 
     private fun KtExpression.isThreadSleepFunction(): Boolean {
-        fun KtCallableReferenceExpression.isSleepCallableRef(): Boolean {
-            return if (this.parent is KtValueArgument) {
+        fun KtCallableReferenceExpression.isSleepCallableRef(): Boolean =
+            if (this.parent is KtValueArgument) {
                 // Only checking if this is used as for invocation
                 this.callableReference.isThreadSleepFunction()
             } else {
                 false
             }
-        }
         return if (this is KtCallableReferenceExpression) {
             this.isSleepCallableRef()
         } else {
@@ -124,8 +123,8 @@ class SleepInsteadOfDelay(config: Config) : Rule(
         }
     }
 
-    private fun PsiElement.isSuspendAllowed(): Boolean {
-        return when (this) {
+    private fun PsiElement.isSuspendAllowed(): Boolean =
+        when (this) {
             is KtValueArgument -> {
                 this.isSuspendAllowed()
             }
@@ -142,7 +141,6 @@ class SleepInsteadOfDelay(config: Config) : Rule(
                 false
             }
         }
-    }
 
     private fun KtValueArgument.isSuspendAllowed(): Boolean {
         val parent = this.getParentOfTypes(true, KtCallExpression::class.java) ?: return false

--- a/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunWithFlowReturnType.kt
+++ b/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunWithFlowReturnType.kt
@@ -79,12 +79,11 @@ class SuspendFunWithFlowReturnType(config: Config) : Rule(
             }
     }
 
-    private fun KotlinType.isCoroutinesFlow(): Boolean {
-        return sequence {
+    private fun KotlinType.isCoroutinesFlow(): Boolean =
+        sequence {
             yield(this@isCoroutinesFlow)
             yieldAll(this@isCoroutinesFlow.supertypes())
         }
             .mapNotNull { it.fqNameOrNull()?.asString() }
             .contains("kotlinx.coroutines.flow.Flow")
-    }
 }

--- a/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/OutdatedDocumentation.kt
+++ b/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/OutdatedDocumentation.kt
@@ -129,16 +129,14 @@ class OutdatedDocumentation(config: Config) : Rule(
         return typeParams + valueParams
     }
 
-    private fun getPrimaryConstructorDeclarations(constructor: KtPrimaryConstructor): List<Declaration> {
-        return getDeclarationsForValueParameters(constructor.valueParameters)
-    }
+    private fun getPrimaryConstructorDeclarations(constructor: KtPrimaryConstructor): List<Declaration> =
+        getDeclarationsForValueParameters(constructor.valueParameters)
 
-    private fun getSecondaryConstructorDeclarations(constructor: KtSecondaryConstructor): List<Declaration> {
-        return getDeclarationsForValueParameters(constructor.valueParameters)
-    }
+    private fun getSecondaryConstructorDeclarations(constructor: KtSecondaryConstructor): List<Declaration> =
+        getDeclarationsForValueParameters(constructor.valueParameters)
 
-    private fun getDeclarationsForValueParameters(valueParameters: List<KtParameter>): List<Declaration> {
-        return valueParameters.mapNotNull {
+    private fun getDeclarationsForValueParameters(valueParameters: List<KtParameter>): List<Declaration> =
+        valueParameters.mapNotNull {
             it.name?.let { name ->
                 val type = if (it.isPropertyParameter() && it.isPrivate().not()) {
                     if (allowParamOnConstructorProperties) {
@@ -152,14 +150,11 @@ class OutdatedDocumentation(config: Config) : Rule(
                 Declaration(name, type)
             }
         }
-    }
 
-    private fun getDocDeclarations(doc: KDoc): List<Declaration> {
-        return processDocChildren(doc.allChildren)
-    }
+    private fun getDocDeclarations(doc: KDoc): List<Declaration> = processDocChildren(doc.allChildren)
 
-    private fun processDocChildren(children: PsiChildRange): List<Declaration> {
-        return children
+    private fun processDocChildren(children: PsiChildRange): List<Declaration> =
+        children
             .map {
                 when (it) {
                     is KDocSection -> processDocChildren(it.allChildren)
@@ -168,7 +163,6 @@ class OutdatedDocumentation(config: Config) : Rule(
                 }
             }
             .fold(emptyList()) { acc, declarations -> acc + declarations }
-    }
 
     @Suppress("ElseCaseInsteadOfExhaustiveWhen")
     private fun processDocTag(docTag: KDocTag): List<Declaration> {
@@ -217,9 +211,8 @@ class OutdatedDocumentation(config: Config) : Rule(
         return zippedElements.all { (doc, element) -> declarationMatches(doc, element) }
     }
 
-    private fun declarationMatches(doc: Declaration, element: Declaration): Boolean {
-        return element.name == doc.name && (element.type == DeclarationType.ANY || element.type == doc.type)
-    }
+    private fun declarationMatches(doc: Declaration, element: Declaration): Boolean =
+        element.name == doc.name && (element.type == DeclarationType.ANY || element.type == doc.type)
 
     private fun reportCodeSmell(element: KtNamedDeclaration) {
         report(
@@ -230,9 +223,7 @@ class OutdatedDocumentation(config: Config) : Rule(
         )
     }
 
-    private fun String?.toParamOrNull(): Declaration? {
-        return this?.let { Declaration(it, DeclarationType.PARAM) }
-    }
+    private fun String?.toParamOrNull(): Declaration? = this?.let { Declaration(it, DeclarationType.PARAM) }
 
     data class Declaration(
         val name: String,

--- a/detekt-rules-empty/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyDefaultConstructor.kt
+++ b/detekt-rules-empty/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyDefaultConstructor.kt
@@ -43,13 +43,11 @@ class EmptyDefaultConstructor(config: Config) : EmptyRule(config = config) {
             constructor.annotationEntries.isEmpty() &&
             constructor.valueParameters.isEmpty()
 
-    private fun hasPublicVisibility(visibility: KtModifierKeywordToken?): Boolean {
-        return visibility == null || visibility == KtTokens.PUBLIC_KEYWORD
-    }
+    private fun hasPublicVisibility(visibility: KtModifierKeywordToken?): Boolean =
+        visibility == null || visibility == KtTokens.PUBLIC_KEYWORD
 
-    private fun isNotCalled(constructor: KtPrimaryConstructor): Boolean {
-        return constructor.getContainingClassOrObject().secondaryConstructors.none {
+    private fun isNotCalled(constructor: KtPrimaryConstructor): Boolean =
+        constructor.getContainingClassOrObject().secondaryConstructors.none {
             it.getDelegationCall().isCallToThis && it.getDelegationCall().valueArguments.isEmpty()
         }
-    }
 }

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IteratorHasNextCallsNextMethod.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IteratorHasNextCallsNextMethod.kt
@@ -50,7 +50,6 @@ class IteratorHasNextCallsNextMethod(config: Config) : Rule(
         super.visitClassOrObject(classOrObject)
     }
 
-    private fun callsNextMethod(method: KtNamedDeclaration): Boolean {
-        return method.anyDescendantOfType<KtCallExpression> { it.calleeExpression?.text == "next" }
-    }
+    private fun callsNextMethod(method: KtNamedDeclaration): Boolean =
+        method.anyDescendantOfType<KtCallExpression> { it.calleeExpression?.text == "next" }
 }

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MapGetWithNotNullAssertionOperator.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MapGetWithNotNullAssertionOperator.kt
@@ -56,11 +56,10 @@ class MapGetWithNotNullAssertionOperator(config: Config) : Rule(
         super.visitPostfixExpression(expression)
     }
 
-    private fun KtPostfixExpression.isMapGet(): Boolean {
-        return this
+    private fun KtPostfixExpression.isMapGet(): Boolean =
+        this
             .baseExpression
             .getResolvedCall(bindingContext)
             ?.resultingDescriptor
             ?.fqNameSafe == FqName("kotlin.collections.Map.get")
-    }
 }

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingSuperCall.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingSuperCall.kt
@@ -71,14 +71,12 @@ class MissingSuperCall(config: Config) : Rule(
         report(CodeSmell(Entity.from(function), "Overriding method is missing a call to overridden super method."))
     }
 
-    private fun CallableDescriptor.superFunctionWithAnnotation(): CallableDescriptor? {
-        return overriddenDescriptors.firstOrNull { d -> d.annotations.any { it.fqName in mustInvokeSuperAnnotations } }
+    private fun CallableDescriptor.superFunctionWithAnnotation(): CallableDescriptor? =
+        overriddenDescriptors.firstOrNull { d -> d.annotations.any { it.fqName in mustInvokeSuperAnnotations } }
             ?: overriddenDescriptors.firstNotNullOfOrNull { it.superFunctionWithAnnotation() }
-    }
 
-    private fun KtNamedFunction.hasSuperCall(superFunctionDescriptor: CallableDescriptor): Boolean {
-        return anyDescendantOfType<KtQualifiedExpression> {
+    private fun KtNamedFunction.hasSuperCall(superFunctionDescriptor: CallableDescriptor): Boolean =
+        anyDescendantOfType<KtQualifiedExpression> {
             it.getResolvedCall(bindingContext)?.resultingDescriptor == superFunctionDescriptor
         }
-    }
 }

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/NullCheckOnMutableProperty.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/NullCheckOnMutableProperty.kt
@@ -133,8 +133,8 @@ class NullCheckOnMutableProperty(config: Config) : Rule(
                 }
         }
 
-        private fun KtBinaryExpression.collectNonNullChecks(): List<KtBinaryExpression> {
-            return if (isNonNullCheck()) {
+        private fun KtBinaryExpression.collectNonNullChecks(): List<KtBinaryExpression> =
+            if (isNonNullCheck()) {
                 listOf(this)
             } else {
                 val nonNullChecks = mutableListOf<KtBinaryExpression>()
@@ -142,6 +142,5 @@ class NullCheckOnMutableProperty(config: Config) : Rule(
                 (right as? KtBinaryExpression)?.let { nonNullChecks.addAll(it.collectNonNullChecks()) }
                 nonNullChecks
             }
-        }
     }
 }

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnusedUnaryOperator.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnusedUnaryOperator.kt
@@ -67,7 +67,6 @@ class UnusedUnaryOperator(config: Config) : Rule(
         report(CodeSmell(Entity.from(expression), message))
     }
 
-    private fun KtExpression.parentBinaryExpressionOrThis(): KtExpression {
-        return parents.takeWhile { it is KtBinaryExpression }.lastOrNull() as? KtBinaryExpression ?: this
-    }
+    private fun KtExpression.parentBinaryExpressionOrThis(): KtExpression =
+        parents.takeWhile { it is KtBinaryExpression }.lastOrNull() as? KtBinaryExpression ?: this
 }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingUseCallSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingUseCallSpec.kt
@@ -796,12 +796,11 @@ class MissingUseCallSpec(private val env: KotlinCoreEnvironment) {
     }
 }
 
-private fun myClosable(clazz: String = "java.io.Closeable", isOpen: Boolean = false): String {
-    return """
+private fun myClosable(clazz: String = "java.io.Closeable", isOpen: Boolean = false): String =
+    """
         ${if (isOpen) "open " else ""} class MyCloseable(private val i: Int) : $clazz {
             override fun close() { /* no-op */ }
 
             fun doStuff() { /* no-op */ }
         }
     """.trimIndent().replaceIndent("    ".repeat(3)).trim()
-}

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnamedParameterUseSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnamedParameterUseSpec.kt
@@ -456,14 +456,13 @@ class UnnamedParameterUseSpec(private val env: KotlinCoreEnvironment) {
     private fun getSubject(
         ignoreSingleParamUse: Boolean = true,
         allowAdjacentDifferentTypeParams: Boolean = true,
-    ): UnnamedParameterUse {
-        return UnnamedParameterUse(
+    ): UnnamedParameterUse =
+        UnnamedParameterUse(
             TestConfig(
                 ALLOW_SINGLE_PARAM_USE to ignoreSingleParamUse,
                 ALLOW_NON_ADJACENT_PARAM to allowAdjacentDifferentTypeParams,
             )
         )
-    }
 
     companion object {
         private const val ALLOW_SINGLE_PARAM_USE = "allowSingleParamUse"

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ObjectExtendsThrowable.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ObjectExtendsThrowable.kt
@@ -58,11 +58,10 @@ class ObjectExtendsThrowable(config: Config) : Rule(
         }
     }
 
-    private fun KtObjectDeclaration.isSubtypeOfThrowable(): Boolean {
-        return bindingContext[BindingContext.CLASS, this]
+    private fun KtObjectDeclaration.isSubtypeOfThrowable(): Boolean =
+        bindingContext[BindingContext.CLASS, this]
             ?.defaultType
             ?.supertypes()
             .orEmpty()
             .any { it.isNotNullThrowable() }
-    }
 }

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingNewInstanceOfSameException.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingNewInstanceOfSameException.kt
@@ -55,11 +55,9 @@ class ThrowingNewInstanceOfSameException(config: Config) : Rule(
         }
     }
 
-    private fun createsSameExceptionType(thrownExpression: KtCallExpression, typeReference: String?): Boolean {
-        return thrownExpression.calleeExpression?.text == typeReference
-    }
+    private fun createsSameExceptionType(thrownExpression: KtCallExpression, typeReference: String?): Boolean =
+        thrownExpression.calleeExpression?.text == typeReference
 
-    private fun hasSameExceptionParameter(valueArguments: List<KtValueArgument>, parameterName: String?): Boolean {
-        return valueArguments.size == 1 && valueArguments.first().text == parameterName
-    }
+    private fun hasSameExceptionParameter(valueArguments: List<KtValueArgument>, parameterName: String?): Boolean =
+        valueArguments.size == 1 && valueArguments.first().text == parameterName
 }

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionCaught.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionCaught.kt
@@ -56,9 +56,7 @@ class TooGenericExceptionCaught(config: Config) : Rule(
         super.visitCatchSection(catchClause)
     }
 
-    private fun isTooGenericException(typeReference: KtTypeReference?): Boolean {
-        return typeReference?.text in exceptionNames
-    }
+    private fun isTooGenericException(typeReference: KtTypeReference?): Boolean = typeReference?.text in exceptionNames
 
     companion object {
         val caughtExceptionDefaults = listOf(

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/BooleanPropertyNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/BooleanPropertyNaming.kt
@@ -77,12 +77,11 @@ class BooleanPropertyNaming(config: Config) : Rule(
         )
     }
 
-    private fun getTypeName(parameter: KtCallableDeclaration): String {
-        return parameter.createTypeBindingForReturnType(bindingContext)
+    private fun getTypeName(parameter: KtCallableDeclaration): String =
+        parameter.createTypeBindingForReturnType(bindingContext)
             ?.type
             ?.fqNameOrNull()
             .toString()
-    }
 
     companion object {
         const val KOTLIN_BOOLEAN_TYPE_NAME = "kotlin.Boolean"

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ConstructorParameterNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ConstructorParameterNaming.kt
@@ -71,7 +71,5 @@ class ConstructorParameterNaming(config: Config) : Rule(
         }
     }
 
-    private fun KtParameter.isConstructor(): Boolean {
-        return this.ownerFunction is KtConstructor<*>
-    }
+    private fun KtParameter.isConstructor(): Boolean = this.ownerFunction is KtConstructor<*>
 }

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionParameterNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionParameterNaming.kt
@@ -57,10 +57,9 @@ class FunctionParameterNaming(config: Config) : Rule(
         }
     }
 
-    private fun KtParameter.isParameterInFunction(): Boolean {
-        return this.nameAsSafeName.isSpecial ||
+    private fun KtParameter.isParameterInFunction(): Boolean =
+        this.nameAsSafeName.isSpecial ||
             (this.nameIdentifier?.parent?.javaClass == null) ||
             (this.ownerFunction !is KtNamedFunction) ||
             this.isContainingExcludedClass(excludeClassPattern)
-    }
 }

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/LambdaParameterNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/LambdaParameterNaming.kt
@@ -39,7 +39,6 @@ class LambdaParameterNaming(config: Config) : Rule(
             }
     }
 
-    private fun KtParameter.getNamedDeclarations(): List<KtNamedDeclaration> {
-        return this.destructuringDeclaration?.entries ?: listOf(this)
-    }
+    private fun KtParameter.getNamedDeclarations(): List<KtNamedDeclaration> =
+        this.destructuringDeclaration?.entries ?: listOf(this)
 }

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MemberNameEqualsClassName.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MemberNameEqualsClassName.kt
@@ -92,12 +92,11 @@ class MemberNameEqualsClassName(config: Config) : Rule(
             .filter { it.name?.equals(name, ignoreCase = true) == true }
     }
 
-    private fun getMisnamedCompanionObjectMembers(klass: KtClass): Sequence<KtNamedDeclaration> {
-        return klass.companionObjects
+    private fun getMisnamedCompanionObjectMembers(klass: KtClass): Sequence<KtNamedDeclaration> =
+        klass.companionObjects
             .asSequence()
             .flatMap { getMisnamedMembers(it, klass.name) }
             .filterNot { it is KtNamedFunction && isFactoryMethod(it, klass) }
-    }
 
     private fun isFactoryMethod(function: KtNamedFunction, klass: KtClass): Boolean {
         val typeReference = function.typeReference

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableNaming.kt
@@ -62,12 +62,11 @@ class VariableNaming(config: Config) : Rule(
         }
     }
 
-    private fun KtProperty.isPropertyTopLevelOrInCompanion(): Boolean {
-        return this.nameAsSafeName.isSpecial ||
+    private fun KtProperty.isPropertyTopLevelOrInCompanion(): Boolean =
+        this.nameAsSafeName.isSpecial ||
             this.getNonStrictParentOfType<KtObjectDeclaration>() != null ||
             this.isTopLevel ||
             this.nameIdentifier?.parent?.javaClass == null
-    }
 
     private fun report(property: KtProperty, message: String) {
         report(

--- a/detekt-rules-ruleauthors/src/main/kotlin/io/gitlab/arturbosch/detekt/authors/ViolatesTypeResolutionRequirements.kt
+++ b/detekt-rules-ruleauthors/src/main/kotlin/io/gitlab/arturbosch/detekt/authors/ViolatesTypeResolutionRequirements.kt
@@ -70,18 +70,16 @@ class ViolatesTypeResolutionRequirements(config: Config) : Rule(
 }
 
 context(Rule)
-private inline fun <reified T : Any> KtClass.extendsFrom(kClass: KClass<T>): Boolean {
-    return bindingContext[BindingContext.CLASS, this]
+private inline fun <reified T : Any> KtClass.extendsFrom(kClass: KClass<T>): Boolean =
+    bindingContext[BindingContext.CLASS, this]
         ?.getAllSuperclassesWithoutAny()
         .orEmpty()
         .any { it.fqNameOrNull()?.toString() == checkNotNull(kClass.qualifiedName) }
-}
 
 context(Rule)
-private inline fun <reified T : Any> KtClass.isAnnotatedWith(kClass: KClass<T>): Boolean {
-    return annotationEntries
+private inline fun <reified T : Any> KtClass.isAnnotatedWith(kClass: KClass<T>): Boolean =
+    annotationEntries
         .asSequence()
         .mapNotNull { it.typeReference }
         .mapNotNull { bindingContext[BindingContext.TYPE, it] }
         .any { it.fqNameOrNull()?.toString() == checkNotNull(kClass.qualifiedName) }
-}

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/AbstractClassCanBeConcreteClass.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/AbstractClassCanBeConcreteClass.kt
@@ -103,8 +103,8 @@ class AbstractClassCanBeConcreteClass(config: Config) : Rule(
 
     private fun KtClass.hasConstructorParameter() = primaryConstructor?.valueParameters?.isNotEmpty() == true
 
-    private fun KtClass.hasInheritedMember(isAbstract: Boolean): Boolean {
-        return when {
+    private fun KtClass.hasInheritedMember(isAbstract: Boolean): Boolean =
+        when {
             superTypeListEntries.isEmpty() -> false
             bindingContext == BindingContext.EMPTY -> true
             else -> {
@@ -114,7 +114,6 @@ class AbstractClassCanBeConcreteClass(config: Config) : Rule(
                 }
             }
         }
-    }
 
     private fun KtClass.isAnyParentAbstract() =
         (bindingContext[BindingContext.CLASS, this]?.unsubstitutedMemberScope as? LazyClassMemberScope)

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/AbstractClassCanBeInterface.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/AbstractClassCanBeInterface.kt
@@ -90,8 +90,8 @@ class AbstractClassCanBeInterface(config: Config) : Rule(
 
     private fun KtClass.hasConstructorParameter() = primaryConstructor?.valueParameters?.isNotEmpty() == true
 
-    private fun KtClass.hasInheritedMember(isAbstract: Boolean): Boolean {
-        return when {
+    private fun KtClass.hasInheritedMember(isAbstract: Boolean): Boolean =
+        when {
             superTypeListEntries.isEmpty() -> false
             bindingContext == BindingContext.EMPTY -> true
             else -> {
@@ -101,7 +101,6 @@ class AbstractClassCanBeInterface(config: Config) : Rule(
                 }
             }
         }
-    }
 
     private fun KtClass.isAnyParentAbstract() =
         (bindingContext[BindingContext.CLASS, this]?.unsubstitutedMemberScope as? LazyClassMemberScope)

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/CanBeNonNullable.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/CanBeNonNullable.kt
@@ -309,8 +309,8 @@ class CanBeNonNullable(config: Config) : Rule(
             return receiverExpression
         }
 
-        private fun KtExpression?.determineSingleExpression(candidateDescriptors: Set<DeclarationDescriptor>): Boolean {
-            return when (this) {
+        private fun KtExpression?.determineSingleExpression(candidateDescriptors: Set<DeclarationDescriptor>): Boolean =
+            when (this) {
                 is KtReturnExpression -> INELIGIBLE_SINGLE_EXPRESSION
                 is KtIfExpression -> ELIGIBLE_SINGLE_EXPRESSION
                 is KtDotQualifiedExpression -> {
@@ -322,15 +322,13 @@ class CanBeNonNullable(config: Config) : Rule(
                 is KtCallExpression -> INELIGIBLE_SINGLE_EXPRESSION
                 else -> ELIGIBLE_SINGLE_EXPRESSION
             }
-        }
 
-        private fun KtElement?.getNonNullChecks(parentOperatorToken: IElementType?): List<CallableDescriptor>? {
-            return when (this) {
+        private fun KtElement?.getNonNullChecks(parentOperatorToken: IElementType?): List<CallableDescriptor>? =
+            when (this) {
                 is KtBinaryExpression -> evaluateBinaryExpression(parentOperatorToken)
                 is KtIsExpression -> evaluateIsExpression()
                 else -> null
             }
-        }
 
         private fun KtExpression?.evaluateCheckStatement(elseExpression: KtExpression?) {
             this.getNonNullChecks(null)?.let { nonNullChecks ->
@@ -370,14 +368,13 @@ class CanBeNonNullable(config: Config) : Rule(
             return nonNullChecks
         }
 
-        private fun getDescriptor(leftExpression: KtElement?, rightExpression: KtElement?): CallableDescriptor? {
-            return when {
+        private fun getDescriptor(leftExpression: KtElement?, rightExpression: KtElement?): CallableDescriptor? =
+            when {
                 leftExpression is KtNameReferenceExpression -> leftExpression
                 rightExpression is KtNameReferenceExpression -> rightExpression
                 else -> null
             }?.getResolvedCall(bindingContext)
                 ?.resultingDescriptor
-        }
 
         private fun KtIsExpression.evaluateIsExpression(): List<CallableDescriptor> {
             val descriptor = this.leftHandSide.getResolvedCall(bindingContext)?.resultingDescriptor
@@ -432,13 +429,11 @@ class CanBeNonNullable(config: Config) : Rule(
             return (isNullable && !isNegated) || (!isNullable && isNegated)
         }
 
-        private fun KtExpression?.isValidElseExpression(): Boolean {
-            return this != null && this !is KtIfExpression && this !is KtWhenExpression
-        }
+        private fun KtExpression?.isValidElseExpression(): Boolean =
+            this != null && this !is KtIfExpression && this !is KtWhenExpression
 
-        private fun KtTypeReference?.isNullable(bindingContext: BindingContext): Boolean {
-            return this?.let { bindingContext[BindingContext.TYPE, it] }?.isMarkedNullable == true
-        }
+        private fun KtTypeReference?.isNullable(bindingContext: BindingContext): Boolean =
+            this?.let { bindingContext[BindingContext.TYPE, it] }?.isMarkedNullable == true
 
         private fun updateNullableParam(expression: KtExpression, updateCallback: (NullableParam) -> Unit) {
             expression.getResolvedCall(bindingContext)
@@ -519,9 +514,8 @@ class CanBeNonNullable(config: Config) : Rule(
          * - non-nullable: <T : Any>
          * But even if T is nullable, a property `val t: T` cannot be made into a non-nullable type.
          */
-        private fun KotlinType.isNullableAndCanBeNonNullable(): Boolean {
-            return if (TypeUtils.isTypeParameter(this)) isMarkedNullable else isNullable()
-        }
+        private fun KotlinType.isNullableAndCanBeNonNullable(): Boolean =
+            if (TypeUtils.isTypeParameter(this)) isMarkedNullable else isNullable()
 
         private fun KtProperty.isCandidate(): Boolean {
             if (isOpen() || isAbstract() || containingClass()?.isInterface() == true) return false
@@ -548,8 +542,8 @@ class CanBeNonNullable(config: Config) : Rule(
             } ?: false
         }
 
-        private fun KtExpression?.isNullableType(): Boolean {
-            return when (this) {
+        private fun KtExpression?.isNullableType(): Boolean =
+            when (this) {
                 is KtConstantExpression -> {
                     this.text == "null"
                 }
@@ -572,7 +566,6 @@ class CanBeNonNullable(config: Config) : Rule(
                     this?.getType(bindingContext)?.isNullableAndCanBeNonNullable() == true
                 }
             }
-        }
     }
 
     private companion object {

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/DoubleNegativeExpression.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/DoubleNegativeExpression.kt
@@ -81,10 +81,8 @@ class DoubleNegativeExpression(config: Config) : Rule(
         return count == 2
     }
 
-    private fun KtExpression?.isBooleanNotCall(): Boolean {
-        return this is KtCallExpression &&
-            getResolvedCall(bindingContext)?.resultingDescriptor?.fqNameSafe == booleanNotFqName
-    }
+    private fun KtExpression?.isBooleanNotCall(): Boolean =
+        this is KtCallExpression && getResolvedCall(bindingContext)?.resultingDescriptor?.fqNameSafe == booleanNotFqName
 
     companion object {
         private val booleanNotFqName = FqName("kotlin.Boolean.not")

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/DoubleNegativeLambda.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/DoubleNegativeLambda.kt
@@ -83,8 +83,8 @@ class DoubleNegativeLambda(config: Config) : Rule(
         }
     }
 
-    private fun KtExpression.isForbiddenNegation(): Boolean {
-        return when (this) {
+    private fun KtExpression.isForbiddenNegation(): Boolean =
+        when (this) {
             is KtOperationReferenceExpression -> operationSignTokenType in negationTokens
             is KtCallExpression -> {
                 text == "not()" ||
@@ -92,7 +92,6 @@ class DoubleNegativeLambda(config: Config) : Rule(
             }
             else -> false
         }
-    }
 
     private fun formatMessage(
         forbiddenChildren: List<KtExpression>,

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenComment.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenComment.kt
@@ -171,8 +171,8 @@ class ForbiddenComment(config: Config) : Rule(
     }
 }
 
-internal fun String.getCommentContent(): String {
-    return if (this.startsWith("//")) {
+internal fun String.getCommentContent(): String =
+    if (this.startsWith("//")) {
         this.removePrefix("//").removePrefix(" ")
     } else {
         this
@@ -205,7 +205,6 @@ internal fun String.getCommentContent(): String {
             // Reconstruct the comment contents.
             .joinToString("\n")
     }
-}
 
 private fun String.trimIndentIgnoringFirstLine(): String =
     if ('\n' !in this) {

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenImport.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenImport.kt
@@ -56,9 +56,8 @@ class ForbiddenImport(config: Config) : Rule(
         }
     }
 
-    private fun defaultReason(forbiddenImport: String): String {
-        return "The import `$forbiddenImport` has been forbidden in the detekt config."
-    }
+    private fun defaultReason(forbiddenImport: String): String =
+        "The import `$forbiddenImport` has been forbidden in the detekt config."
 
     private fun containsForbiddenPattern(import: String): Boolean =
         forbiddenPatterns.pattern.isNotEmpty() && forbiddenPatterns.containsMatchIn(import)

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/FunctionOnlyReturningConstant.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/FunctionOnlyReturningConstant.kt
@@ -101,6 +101,4 @@ class FunctionOnlyReturningConstant(config: Config) : Rule(
     }
 }
 
-private operator fun Iterable<Regex>.contains(input: String?): Boolean {
-    return input != null && any { it.matches(input) }
-}
+private operator fun Iterable<Regex>.contains(input: String?): Boolean = input != null && any { it.matches(input) }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/Junk.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/Junk.kt
@@ -20,12 +20,11 @@ import org.jetbrains.kotlin.psi.psiUtil.lastBlockStatementOrThis
  * Util function to search for the [KtElement]s in the parents of
  * the given [line] from a given offset in a [KtFile].
  */
-internal fun findKtElementInParents(file: KtFile, offset: Int, line: String): Sequence<PsiElement> {
-    return file.elementsInRange(TextRange.create(offset, offset + line.length))
+internal fun findKtElementInParents(file: KtFile, offset: Int, line: String): Sequence<PsiElement> =
+    file.elementsInRange(TextRange.create(offset, offset + line.length))
         .asSequence()
         .plus(file.findElementAt(offset))
         .mapNotNull { it?.getNonStrictParentOfType() }
-}
 
 inline fun <reified T : KtExpression> KtNamedFunction.yieldStatementsSkippingGuardClauses(): Sequence<KtExpression> =
     sequence {
@@ -40,9 +39,7 @@ inline fun <reified T : KtExpression> KtNamedFunction.yieldStatementsSkippingGua
         }
     }
 
-fun KtExpression.isSuperCall(): Boolean {
-    return (this as? KtDotQualifiedExpression)?.receiverExpression is KtSuperExpression
-}
+fun KtExpression.isSuperCall(): Boolean = (this as? KtDotQualifiedExpression)?.receiverExpression is KtSuperExpression
 
 inline fun <reified T : KtExpression> KtExpression.isGuardClause(): Boolean {
     val descendantExpr = this.findDescendantOfType<T>() ?: return false

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumber.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumber.kt
@@ -169,14 +169,13 @@ class MagicNumber(config: Config) : Rule(
         }
     }
 
-    private fun normalizeForParsingAsDouble(text: String): String {
-        return text.trim()
+    private fun normalizeForParsingAsDouble(text: String): String =
+        text.trim()
             .lowercase(Locale.US)
             .replace("_", "")
             .removeSuffix("l")
             .removeSuffix("d")
             .removeSuffix("f")
-    }
 
     private fun KtConstantExpression.isNamedArgument(): Boolean {
         val valueArgument = this.getNonStrictParentOfType<KtValueArgument>()
@@ -186,13 +185,12 @@ class MagicNumber(config: Config) : Rule(
     private fun KtConstantExpression.isPartOfFunctionReturnConstant() =
         parent is KtNamedFunction || parent is KtReturnExpression && parent.parent.children.size == 1
 
-    private fun KtConstantExpression.isPartOfConstructorOrFunctionConstant(): Boolean {
-        return parent is KtParameter &&
+    private fun KtConstantExpression.isPartOfConstructorOrFunctionConstant(): Boolean =
+        parent is KtParameter &&
             when (parent.parent.parent) {
                 is KtNamedFunction, is KtPrimaryConstructor, is KtSecondaryConstructor -> true
                 else -> false
             }
-    }
 
     private fun KtConstantExpression.isPartOfRange(): Boolean {
         val theParent = parent
@@ -205,9 +203,7 @@ class MagicNumber(config: Config) : Rule(
         }
     }
 
-    private fun KtConstantExpression.isSubjectOfExtensionFunction(): Boolean {
-        return parent is KtDotQualifiedExpression
-    }
+    private fun KtConstantExpression.isSubjectOfExtensionFunction(): Boolean = parent is KtDotQualifiedExpression
 
     private fun KtConstantExpression.isPartOfHashCode(): Boolean {
         val containingFunction = getNonStrictParentOfType<KtNamedFunction>()

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxChainedCallsOnSameLine.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxChainedCallsOnSameLine.kt
@@ -64,8 +64,8 @@ class MaxChainedCallsOnSameLine(config: Config) : Rule(
         }
     }
 
-    private fun KtExpression.countChainedCalls(): Int {
-        return when (this) {
+    private fun KtExpression.countChainedCalls(): Int =
+        when (this) {
             is KtQualifiedExpression -> when {
                 receiverExpression.isReferenceToPackageOrClass() || callOnNewLine() -> 0
                 else -> receiverExpression.countChainedCalls() + 1
@@ -73,7 +73,6 @@ class MaxChainedCallsOnSameLine(config: Config) : Rule(
             is KtUnaryExpression -> baseExpression?.countChainedCalls() ?: 0
             else -> 0
         }
-    }
 
     private fun KtExpression.isReferenceToPackageOrClass(): Boolean {
         val selectorOrThis = (this as? KtQualifiedExpression)?.selectorExpression ?: this

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLength.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLength.kt
@@ -81,12 +81,11 @@ class MaxLineLength(config: Config) : Rule(
         return line.length <= maxLineLength || isIgnoredStatement(file, offset, line) || isUrl || isMarkdownOrRefUrl
     }
 
-    private fun isIgnoredStatement(file: KtFile, offset: Int, line: String): Boolean {
-        return containsIgnoredPackageStatement(line) ||
+    private fun isIgnoredStatement(file: KtFile, offset: Int, line: String): Boolean =
+        containsIgnoredPackageStatement(line) ||
             containsIgnoredImportStatement(line) ||
             containsIgnoredCommentStatement(line) ||
             containsIgnoredRawString(file, offset, line)
-    }
 
     private fun containsIgnoredRawString(file: KtFile, offset: Int, line: String): Boolean {
         if (!excludeRawStrings) return false
@@ -118,13 +117,10 @@ class MaxLineLength(config: Config) : Rule(
         private const val DEFAULT_IDEA_LINE_LENGTH = 120
         private val BLANK_OR_QUOTES = """[\s"]*""".toRegex()
 
-        private fun findFirstMeaningfulKtElementInParents(file: KtFile, offset: Int, line: String): PsiElement? {
-            return findKtElementInParents(file, offset, line)
-                .firstOrNull { !BLANK_OR_QUOTES.matches(it.text) }
-        }
+        private fun findFirstMeaningfulKtElementInParents(file: KtFile, offset: Int, line: String): PsiElement? =
+            findKtElementInParents(file, offset, line).firstOrNull { !BLANK_OR_QUOTES.matches(it.text) }
     }
 }
 
-private fun PsiElement.isInsideRawString(): Boolean {
-    return this is KtStringTemplateExpression || getNonStrictParentOfType<KtStringTemplateExpression>() != null
-}
+private fun PsiElement.isInsideRawString(): Boolean =
+    this is KtStringTemplateExpression || getNonStrictParentOfType<KtStringTemplateExpression>() != null

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MayBeConstant.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MayBeConstant.kt
@@ -99,20 +99,19 @@ class MayBeConstant(config: Config) : Rule(
         return annotationEntries.isNotEmpty() && !isJvmField
     }
 
-    private fun KtProperty.cannotBeConstant(): Boolean {
-        return isLocal ||
+    private fun KtProperty.cannotBeConstant(): Boolean =
+        isLocal ||
             isVar ||
             isActual ||
             getter != null ||
             isConstant() ||
             isOverride()
-    }
 
     private fun KtProperty.isInObject() =
         !isTopLevel && containingClassOrObject !is KtObjectDeclaration
 
-    private fun KtExpression.isConstantExpression(): Boolean {
-        return this is KtStringTemplateExpression &&
+    private fun KtExpression.isConstantExpression(): Boolean =
+        this is KtStringTemplateExpression &&
             !hasInterpolation() ||
             node.elementType == KtNodeTypes.BOOLEAN_CONSTANT ||
             node.elementType == KtNodeTypes.INTEGER_CONSTANT ||
@@ -122,16 +121,14 @@ class MayBeConstant(config: Config) : Rule(
             companionObjectConstants.contains(text) ||
             isBinaryExpression(this) ||
             isParenthesizedExpression(this)
-    }
 
     private fun isParenthesizedExpression(expression: KtExpression) =
         (expression as? KtParenthesizedExpression)?.expression?.isConstantExpression() == true
 
-    private fun isBinaryExpression(expression: KtExpression): Boolean {
-        return expression is KtBinaryExpression &&
+    private fun isBinaryExpression(expression: KtExpression): Boolean =
+        expression is KtBinaryExpression &&
             expression.node.elementType == KtNodeTypes.BINARY_EXPRESSION &&
             binaryTokens.contains(expression.operationToken) &&
             expression.left?.isConstantExpression() == true &&
             expression.right?.isConstantExpression() == true
-    }
 }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MultilineRawStringIndentation.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MultilineRawStringIndentation.kt
@@ -161,9 +161,8 @@ private fun Rule.report(element: KtElement, location: Location, message: String)
     report(CodeSmell(Entity.from(element, location), message))
 }
 
-private fun message(desiredIntent: Int, currentIndent: Int): String {
-    return "The indentation should be $desiredIntent but it is $currentIndent."
-}
+private fun message(desiredIntent: Int, currentIndent: Int): String =
+    "The indentation should be $desiredIntent but it is $currentIndent."
 
 private fun KtStringTemplateExpression.isSurroundedByLineBreaks(): Boolean {
     val entries = this.entries
@@ -180,9 +179,7 @@ private fun Char.isTabChar() = this == ' ' || this == '\t'
 
 private fun String.countIndent() = this.takeWhile { it.isTabChar() }.count()
 
-private fun PsiFile.getLine(line: Int): String {
-    return text.lineSequence().drop(line - 1).first()
-}
+private fun PsiFile.getLine(line: Int): String = text.lineSequence().drop(line - 1).first()
 
 private fun PsiFile.getLocation(start: SourceLocation, end: SourceLocation): Location {
     val lines = this.text.lines()

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/NoTabs.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/NoTabs.kt
@@ -28,9 +28,7 @@ class NoTabs(config: Config) : Rule(
         }
     }
 
-    private fun PsiWhiteSpace.isTab(): Boolean {
-        return (!isPartOfString() || isStringInterpolated()) && text.contains('\t')
-    }
+    private fun PsiWhiteSpace.isTab(): Boolean = (!isPartOfString() || isStringInterpolated()) && text.contains('\t')
 
     private fun PsiWhiteSpace.isStringInterpolated(): Boolean =
         this.isPartOf<KtStringTemplateEntryWithExpression>()

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCount.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCount.kt
@@ -106,6 +106,4 @@ class ReturnCount(config: Config) : Rule(
     }
 }
 
-private operator fun Iterable<Regex>.contains(input: String?): Boolean {
-    return input != null && any { it.matches(input) }
-}
+private operator fun Iterable<Regex>.contains(input: String?): Boolean = input != null && any { it.matches(input) }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/StringShouldBeRawString.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/StringShouldBeRawString.kt
@@ -142,8 +142,8 @@ class StringShouldBeRawString(config: Config) : Rule(
         }
     }
 
-    private fun KtElement.getRootExpression(): KtElement? {
-        return this.getParentOfTypesAndPredicate(
+    private fun KtElement.getRootExpression(): KtElement? =
+        this.getParentOfTypesAndPredicate(
             false,
             KtBinaryExpression::class.java,
             KtParenthesizedExpression::class.java,
@@ -152,7 +152,6 @@ class StringShouldBeRawString(config: Config) : Rule(
             val parent = (it as KtExpression).parent
             parent !is KtBinaryExpression && parent !is KtParenthesizedExpression
         }?.deparenthesize()
-    }
 
     companion object {
         private val REGEX_FOR_ESCAPE_CHARS = """\\[t"\\n]""".toRegex()

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/TrailingWhitespace.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/TrailingWhitespace.kt
@@ -57,14 +57,12 @@ class TrailingWhitespace(config: Config) : Rule(
         }
     }
 
-    private fun countTrailingWhitespace(line: String): Int {
-        return line.length - line.indexOfLast { it != ' ' && it != '\t' } - 1
-    }
+    private fun countTrailingWhitespace(line: String): Int =
+        line.length - line.indexOfLast { it != ' ' && it != '\t' } - 1
 
     private fun createMessage(line: Int) = "Line ${line + 1} ends with a whitespace."
 
-    private fun findFirstKtElementInParentsOrNull(file: KtFile, offset: Int, line: String): PsiElement? {
-        return findKtElementInParents(file, offset, line)
+    private fun findFirstKtElementInParentsOrNull(file: KtFile, offset: Int, line: String): PsiElement? =
+        findKtElementInParents(file, offset, line)
             .firstOrNull()
-    }
 }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiterals.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiterals.kt
@@ -73,11 +73,10 @@ class UnderscoresInNumericLiterals(config: Config) : Rule(
         }
     }
 
-    private fun isNotDecimalNumber(rawText: String): Boolean {
-        return rawText.replace("_", "").toDoubleOrNull() == null ||
+    private fun isNotDecimalNumber(rawText: String): Boolean =
+        rawText.replace("_", "").toDoubleOrNull() == null ||
             rawText.startsWith(HEX_PREFIX) ||
             rawText.startsWith(BIN_PREFIX)
-    }
 
     private fun KtConstantExpression.isSerialUidProperty(): Boolean {
         val propertyElement = if (parent is KtPrefixExpression) parent?.parent else parent
@@ -95,13 +94,12 @@ class UnderscoresInNumericLiterals(config: Config) : Rule(
             ?.any { it.text == SERIALIZABLE } == true
     }
 
-    private fun normalizeForMatching(text: String): String {
-        return text.trim()
+    private fun normalizeForMatching(text: String): String =
+        text.trim()
             .lowercase(Locale.ROOT)
             .removeSuffix("l")
             .removeSuffix("d")
             .removeSuffix("f")
-    }
 
     private fun doReport(expression: KtConstantExpression, message: String) {
         report(CodeSmell(Entity.from(expression), message))

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAny.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAny.kt
@@ -117,8 +117,8 @@ class UnnecessaryAny(config: Config) : Rule(
         return statement.shouldStatementBeReported(descriptor)
     }
 
-    private fun KtExpression.shouldStatementBeReported(descriptor: VariableDescriptor): String? {
-        return when {
+    private fun KtExpression.shouldStatementBeReported(descriptor: VariableDescriptor): String? =
+        when {
             this is KtBinaryExpression && operationToken == KtTokens.EQEQ -> {
                 isUsageOfValueAndItEligible(descriptor, left, right)
             }
@@ -136,7 +136,6 @@ class UnnecessaryAny(config: Config) : Rule(
                 if (this.getItUsageCount(descriptor) <= 0) ANY_CAN_BE_OMITTED_MSG else null
             }
         }
-    }
 
     @Suppress("ReturnCount")
     private fun isUsageOfValueAndItEligible(

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryFilter.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryFilter.kt
@@ -112,11 +112,10 @@ class UnnecessaryFilter(config: Config) : Rule(
     private fun getReferrers(
         property: KtProperty,
         propertyDescriptor: DeclarationDescriptor
-    ): Sequence<KtNameReferenceExpression> {
-        return property.siblings(forward = true, withItself = false).flatMap { sibling ->
+    ): Sequence<KtNameReferenceExpression> =
+        property.siblings(forward = true, withItself = false).flatMap { sibling ->
             sibling.collectDescendantsOfType<KtNameReferenceExpression> { it.descriptor() == propertyDescriptor }
         }
-    }
 
     private fun KtProperty.descriptor(): DeclarationDescriptor? =
         bindingContext[BindingContext.DECLARATION_TO_DESCRIPTOR, this]

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryInnerClass.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryInnerClass.kt
@@ -104,12 +104,11 @@ class UnnecessaryInnerClass(config: Config) : Rule(
         (bindingContext[BindingContext.REFERENCE_TARGET, expression]?.containingDeclaration as? ClassifierDescriptor)
             ?.classId
 
-    private fun KtThisExpression.referenceClassId(): ClassId? {
-        return getResolvedCall(bindingContext)
+    private fun KtThisExpression.referenceClassId(): ClassId? =
+        getResolvedCall(bindingContext)
             ?.resultingDescriptor
             ?.returnType
             ?.constructor
             ?.declarationDescriptor
             ?.classId
-    }
 }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryParentheses.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryParentheses.kt
@@ -122,24 +122,22 @@ class UnnecessaryParentheses(config: Config) : Rule(
          * Retrieves the [IElementType] of the binary operation from this element if it is a non-assignment binary
          * expression, or null otherwise.
          */
-        private fun PsiElement.binaryOp(): IElementType? {
-            return when (this) {
+        private fun PsiElement.binaryOp(): IElementType? =
+            when (this) {
                 is KtBinaryExpression ->
                     operationReference.takeUnless { operationToken in KtTokens.ALL_ASSIGNMENTS }
                 is KtBinaryExpressionWithTypeRHS -> operationReference
                 is KtIsExpression -> operationReference
                 else -> null
             }?.getReferencedNameElementType()
-        }
 
         /**
          * Returns either the parent of this [KtExpression] or its first parent expression which is not a
          * [KtParenthesizedExpression].
          */
-        private fun KtExpression.firstNonParenParent(): PsiElement? {
-            return generateSequence(parent) { (it as? KtParenthesizedExpression)?.parent }
+        private fun KtExpression.firstNonParenParent(): PsiElement? =
+            generateSequence(parent) { (it as? KtParenthesizedExpression)?.parent }
                 .firstOrNull { it !is KtParenthesizedExpression }
-        }
 
         /**
          * Determines whether this is a binary expression whose operation precedence is unclear with the parent binary

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedParameter.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedParameter.kt
@@ -64,11 +64,10 @@ private class UnusedParameterVisitor(private val allowedNames: Regex) : DetektVi
 
     private val unusedParameters: MutableSet<KtParameter> = mutableSetOf()
 
-    fun getUnusedReports(): List<CodeSmell> {
-        return unusedParameters.map {
+    fun getUnusedReports(): List<CodeSmell> =
+        unusedParameters.map {
             CodeSmell(Entity.atName(it), "Function parameter `${it.nameAsSafeName.identifier}` is unused.")
         }
-    }
 
     override fun visitClassOrObject(klassOrObject: KtClassOrObject) {
         if (klassOrObject.isExpect()) return

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateClass.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateClass.kt
@@ -62,9 +62,7 @@ class UnusedPrivateClass(config: Config) : Rule(
         private val namedClasses = mutableSetOf<String>()
         private val importedFqNames = mutableSetOf<FqName>()
 
-        fun getUnusedClasses(): List<KtNamedDeclaration> {
-            return privateClasses.filter { !it.isUsed() }
-        }
+        fun getUnusedClasses(): List<KtNamedDeclaration> = privateClasses.filter { !it.isUsed() }
 
         private fun KtNamedDeclaration.isUsed(): Boolean {
             if (nameAsSafeName.identifier in namedClasses) return true

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseDataClass.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseDataClass.kt
@@ -149,8 +149,8 @@ class UseDataClass(config: Config) : Rule(
     private fun KtNamedFunction.isDefaultFunction(
         classType: KotlinType?,
         primaryConstructorParameterTypes: List<KotlinType>
-    ): Boolean {
-        return when (name) {
+    ): Boolean =
+        when (name) {
             !in DEFAULT_FUNCTION_NAMES -> false
             "copy" -> {
                 if (classType != null) {
@@ -166,7 +166,6 @@ class UseDataClass(config: Config) : Rule(
             }
             else -> true
         }
-    }
 
     companion object {
         private val DEFAULT_FUNCTION_NAMES = hashSetOf("hashCode", "equals", "toString", "copy")

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIsNullOrEmpty.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIsNullOrEmpty.kt
@@ -77,13 +77,12 @@ class UseIsNullOrEmpty(config: Config) : Rule(
         }?.takeIf { it.getType(bindingContext)?.isNullable() == true }
     }
 
-    private fun KtExpression.sizeCheckedExpression(): KtExpression? {
-        return when (this) {
+    private fun KtExpression.sizeCheckedExpression(): KtExpression? =
+        when (this) {
             is KtDotQualifiedExpression -> sizeCheckedExpression()
             is KtBinaryExpression -> sizeCheckedExpression()
             else -> null
         }
-    }
 
     private fun KtDotQualifiedExpression.sizeCheckedExpression(): KtExpression? {
         if (!selectorExpression.isCalling(emptyCheckFunctions)) return null

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UtilityClassWithPublicConstructor.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UtilityClassWithPublicConstructor.kt
@@ -87,12 +87,11 @@ class UtilityClassWithPublicConstructor(config: Config) : Rule(
         super.visitClass(klass)
     }
 
-    private fun canBeCheckedForUtilityClass(klass: KtClass): Boolean {
-        return !klass.isInterface() &&
+    private fun canBeCheckedForUtilityClass(klass: KtClass): Boolean =
+        !klass.isInterface() &&
             !klass.superTypeListEntries.any() &&
             !klass.isAnnotation() &&
             !klass.isSealed()
-    }
 
     private fun hasOnlyUtilityClassMembers(declarations: List<KtDeclaration>?): Boolean {
         if (declarations.isNullOrEmpty()) {

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/VarCouldBeVal.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/VarCouldBeVal.kt
@@ -87,9 +87,8 @@ class VarCouldBeVal(config: Config) : Rule(
         private val assignments = mutableMapOf<String, MutableSet<KtExpression>>()
         private val escapeCandidates = mutableMapOf<DeclarationDescriptor, List<KtProperty>>()
 
-        fun getNonReAssignedDeclarations(): List<KtNamedDeclaration> {
-            return declarationCandidates.filterNot { it.hasAssignments() }
-        }
+        fun getNonReAssignedDeclarations(): List<KtNamedDeclaration> =
+            declarationCandidates.filterNot { it.hasAssignments() }
 
         private fun KtNamedDeclaration.hasAssignments(): Boolean {
             val declarationName = nameAsSafeName.toString()
@@ -199,8 +198,8 @@ class VarCouldBeVal(config: Config) : Rule(
             }
         }
 
-        private fun KtProperty.isDeclarationCandidate(): Boolean {
-            return when {
+        private fun KtProperty.isDeclarationCandidate(): Boolean =
+            when {
                 !isVar || isOverride() || (ignoreLateinitVar && isLateinit()) -> false
                 isLocal || isPrivate() -> true
                 else -> {
@@ -211,12 +210,9 @@ class VarCouldBeVal(config: Config) : Rule(
                         ?.containingNonLocalDeclaration() != null
                 }
             }
-        }
 
-        private fun KtProperty.isEscapeCandidate(): Boolean {
-            return !isPrivate() &&
-                (containingClassOrObject as? KtObjectDeclaration)?.isObjectLiteral() == true
-        }
+        private fun KtProperty.isEscapeCandidate(): Boolean =
+            !isPrivate() && (containingClassOrObject as? KtObjectDeclaration)?.isObjectLiteral() == true
 
         private fun visitAssignment(assignedExpression: KtExpression) {
             val name = if (assignedExpression is KtQualifiedExpression) {

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/movelambdaout/MoveLambdaOutsideParenthesesInspection.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/movelambdaout/MoveLambdaOutsideParenthesesInspection.kt
@@ -55,13 +55,12 @@ private fun KtCallExpression.canMoveLambdaOutsideParentheses(bindingContext: Bin
     return true
 }
 
-private fun KtCallExpression.isEligible(): Boolean {
-    return when {
+private fun KtCallExpression.isEligible(): Boolean =
+    when {
         valueArguments.lastOrNull()?.isNamed() == true -> false
         valueArguments.count { it.getArgumentExpression()?.unpackFunctionLiteral() != null } > 1 -> false
         else -> true
     }
-}
 
 internal fun shouldReportUnnecessaryBracesAroundTrailingLambda(
     bindingContext: BindingContext,
@@ -74,6 +73,5 @@ private fun KtCallExpression.getLastLambdaExpression(): KtLambdaExpression? {
     return valueArguments.lastOrNull()?.getArgumentExpression()?.unpackFunctionLiteral()
 }
 
-private fun KtExpression.parentLabeledExpression(): KtLabeledExpression? {
-    return getStrictParentOfType<KtLabeledExpression>()?.takeIf { it.baseExpression == this }
-}
+private fun KtExpression.parentLabeledExpression(): KtLabeledExpression? =
+    getStrictParentOfType<KtLabeledExpression>()?.takeIf { it.baseExpression == this }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/movelambdaout/UnnecessaryBracesAroundTrailingLambda.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/movelambdaout/UnnecessaryBracesAroundTrailingLambda.kt
@@ -48,7 +48,6 @@ class UnnecessaryBracesAroundTrailingLambda(config: Config) : Rule(
         }
     }
 
-    private fun getIssueElement(expression: KtCallExpression): PsiElement {
-        return (expression.calleeExpression as? KtNameReferenceExpression) ?: expression
-    }
+    private fun getIssueElement(expression: KtCallExpression): PsiElement =
+        (expression.calleeExpression as? KtNameReferenceExpression) ?: expression
 }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/OptionalUnit.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/OptionalUnit.kt
@@ -89,8 +89,8 @@ class OptionalUnit(config: Config) : Rule(
         super.visitBlockExpression(expression)
     }
 
-    private fun KtExpression.canBeUsedAsValue(): Boolean {
-        return when (this) {
+    private fun KtExpression.canBeUsedAsValue(): Boolean =
+        when (this) {
             is KtIfExpression -> {
                 val elseExpression = `else`
                 if (elseExpression is KtIfExpression) elseExpression.canBeUsedAsValue() else elseExpression != null
@@ -102,7 +102,6 @@ class OptionalUnit(config: Config) : Rule(
             else ->
                 true
         }
-    }
 
     private fun checkFunctionWithExplicitReturnType(function: KtNamedFunction, typeReference: KtTypeReference) {
         val typeElementText = typeReference.typeElement?.text

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxChainedCallsOnSameLineSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxChainedCallsOnSameLineSpec.kt
@@ -563,8 +563,7 @@ class MaxChainedCallsOnSameLineSpec(private val env: KotlinCoreEnvironment) {
         }
     }
 
-    private fun getTestMessage(chainedCalls: Int, maxChainedCalls: Int): String {
-        return "$chainedCalls chained calls on a single line; more than $maxChainedCalls calls should " +
+    private fun getTestMessage(chainedCalls: Int, maxChainedCalls: Int): String =
+        "$chainedCalls chained calls on a single line; more than $maxChainedCalls calls should " +
             "be wrapped to a new line."
-    }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/NullableBooleanCheckSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/NullableBooleanCheckSpec.kt
@@ -17,9 +17,7 @@ class NullableBooleanCheckSpec(val env: KotlinCoreEnvironment) {
     /**
      * The recommended replacement string for `?: [fallback]`.
      */
-    private fun replacementForElvis(fallback: Boolean): String {
-        return if (fallback) "!= false" else "== true"
-    }
+    private fun replacementForElvis(fallback: Boolean): String = if (fallback) "!= false" else "== true"
 
     @ParameterizedTest
     @ValueSource(booleans = [true, false])

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryParenthesesSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryParenthesesSpec.kt
@@ -578,8 +578,8 @@ class UnnecessaryParenthesesSpec {
         }
 
         @JvmStatic
-        fun cases(): List<Arguments> {
-            return listOf(
+        fun cases(): List<Arguments> =
+            listOf(
                 Arguments.of(
                     Named.of("Without allow for unclear precedence", RuleTestCase(allowForUnclearPrecedence = false))
                 ),
@@ -587,6 +587,5 @@ class UnnecessaryParenthesesSpec {
                     Named.of("With allow for unclear precedence", RuleTestCase(allowForUnclearPrecedence = true))
                 ),
             )
-        }
     }
 }

--- a/detekt-sample-extensions/src/main/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/reports/QualifiedNamesConsoleReport.kt
+++ b/detekt-sample-extensions/src/main/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/reports/QualifiedNamesConsoleReport.kt
@@ -7,7 +7,5 @@ class QualifiedNamesConsoleReport : ConsoleReport() {
 
     override val id: String = "QualifiedNamesConsoleReport"
 
-    override fun render(detektion: Detektion): String? {
-        return qualifiedNamesReport(detektion)
-    }
+    override fun render(detektion: Detektion): String? = qualifiedNamesReport(detektion)
 }

--- a/detekt-sample-extensions/src/main/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/reports/QualifiedNamesOutputReport.kt
+++ b/detekt-sample-extensions/src/main/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/reports/QualifiedNamesOutputReport.kt
@@ -8,7 +8,5 @@ class QualifiedNamesOutputReport : OutputReport() {
     override val id: String = "QualifiedNamesOutputReport"
     override val ending: String = "txt"
 
-    override fun render(detektion: Detektion): String? {
-        return qualifiedNamesReport(detektion)
-    }
+    override fun render(detektion: Detektion): String? = qualifiedNamesReport(detektion)
 }

--- a/detekt-sample-extensions/src/test/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/processors/QualifiedNameProcessorSpec.kt
+++ b/detekt-sample-extensions/src/test/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/processors/QualifiedNameProcessorSpec.kt
@@ -33,13 +33,9 @@ private val result = object : Detektion, UserDataHolderBase() {
     override val notifications: Collection<Notification> = emptyList()
     override val metrics: Collection<ProjectMetric> = emptyList()
 
-    override fun add(notification: Notification) {
-        throw UnsupportedOperationException("not implemented")
-    }
+    override fun add(notification: Notification): Unit = throw UnsupportedOperationException("not implemented")
 
-    override fun add(projectMetric: ProjectMetric) {
-        throw UnsupportedOperationException("not implemented")
-    }
+    override fun add(projectMetric: ProjectMetric): Unit = throw UnsupportedOperationException("not implemented")
 }
 
 private val code = """

--- a/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/CompileExtensions.kt
+++ b/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/CompileExtensions.kt
@@ -25,9 +25,7 @@ fun compileContentForTest(
 fun compileContentForTest(
     @Language("kotlin") content: String,
     path: Path = Path("/").absolute().resolve("Test.kt"),
-): KtFile {
-    return KtTestCompiler.createKtFile(content, path)
-}
+): KtFile = KtTestCompiler.createKtFile(content, path)
 
 /**
  * Use this method if you test a kt file/class in the test resources.

--- a/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/KtTestCompiler.kt
+++ b/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/KtTestCompiler.kt
@@ -65,11 +65,8 @@ internal object KtTestCompiler : KtCompiler() {
     fun createKtFile(@Language("kotlin") content: String, path: Path): KtFile =
         psiFileFactory.createPhysicalFile(path.name, StringUtilRt.convertLineSeparators(content))
 
-    private fun kotlinStdLibPath(): File {
-        return File(CharRange::class.java.protectionDomain.codeSource.location.path)
-    }
+    private fun kotlinStdLibPath(): File = File(CharRange::class.java.protectionDomain.codeSource.location.path)
 
-    private fun kotlinxCoroutinesCorePath(): File {
-        return File(CoroutineScope::class.java.protectionDomain.codeSource.location.path)
-    }
+    private fun kotlinxCoroutinesCorePath(): File =
+        File(CoroutineScope::class.java.protectionDomain.codeSource.location.path)
 }

--- a/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/Resources.kt
+++ b/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/Resources.kt
@@ -16,6 +16,4 @@ fun resource(name: String): URI = resourceUrl(name).toURI()
 
 fun resourceAsPath(name: String): Path = resource(name).toPath()
 
-fun readResourceContent(name: String): String {
-    return resourceUrl(name).readText()
-}
+fun readResourceContent(name: String): String = resourceUrl(name).readText()

--- a/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/StringPrintStream.kt
+++ b/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/StringPrintStream.kt
@@ -9,7 +9,5 @@ class StringPrintStream private constructor(
 
     constructor() : this(ByteArrayOutputStream())
 
-    override fun toString(): String {
-        return stream.toString()
-    }
+    override fun toString(): String = stream.toString()
 }

--- a/detekt-test-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/KotlinEnvironmentTestSetup.kt
+++ b/detekt-test-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/KotlinEnvironmentTestSetup.kt
@@ -23,9 +23,8 @@ internal class KotlinEnvironmentResolver : ParameterResolver {
         get() = getStore(NAMESPACE)[WRAPPER_KEY, CloseableWrapper::class.java]
         set(value) = getStore(NAMESPACE).put(WRAPPER_KEY, value)
 
-    override fun supportsParameter(parameterContext: ParameterContext, extensionContext: ExtensionContext): Boolean {
-        return parameterContext.parameter.type == KotlinCoreEnvironment::class.java
-    }
+    override fun supportsParameter(parameterContext: ParameterContext, extensionContext: ExtensionContext): Boolean =
+        parameterContext.parameter.type == KotlinCoreEnvironment::class.java
 
     override fun resolveParameter(parameterContext: ParameterContext, extensionContext: ExtensionContext): Any {
         val closeableWrapper = extensionContext.wrapper

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/FindingsAssertions.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/FindingsAssertions.kt
@@ -17,9 +17,8 @@ fun assertThat(finding: Finding) = FindingAssert(finding)
 class FindingsAssert(actual: List<Finding>) :
     AbstractListAssert<FindingsAssert, List<Finding>, Finding, FindingAssert>(actual, FindingsAssert::class.java) {
 
-    override fun newAbstractIterableAssert(iterable: MutableIterable<Finding>): FindingsAssert {
+    override fun newAbstractIterableAssert(iterable: MutableIterable<Finding>): FindingsAssert =
         throw UnsupportedOperationException("not implemented")
-    }
 
     override fun toAssert(value: Finding?, description: String?): FindingAssert =
         FindingAssert(value).`as`(description)

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/RuleExtensions.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/RuleExtensions.kt
@@ -65,10 +65,9 @@ fun Rule.compileAndLintWithContext(
 
 fun Rule.lint(ktFile: KtFile): List<Finding> = visitFile(ktFile).filterSuppressed(this)
 
-private fun List<Finding>.filterSuppressed(rule: Rule): List<Finding> {
-    return filterNot {
+private fun List<Finding>.filterSuppressed(rule: Rule): List<Finding> =
+    filterNot {
         it.entity.ktElement?.isSuppressedBy(rule.ruleName.value, rule.aliases, RuleSet.Id("NoARuleSetId")) == true
     }
-}
 
 private val Rule.aliases: Set<String> get() = config.valueOrDefault(Config.ALIASES_KEY, emptyList<String>()).toSet()

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/TestConfig.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/TestConfig.kt
@@ -15,9 +15,7 @@ class TestConfig(override val parent: Config?, vararg pairs: Pair<String, Any>) 
 
     override fun subConfig(key: String) = TestConfig(this, *values.map { (key, value) -> key to value }.toTypedArray())
 
-    override fun subConfigKeys(): Set<String> {
-        return values.keys
-    }
+    override fun subConfigKeys(): Set<String> = values.keys
 
     override fun <T : Any> valueOrDefault(key: String, default: T) =
         if (key == Config.ACTIVE_KEY) {
@@ -61,6 +59,4 @@ class TestConfig(override val parent: Config?, vararg pairs: Pair<String, Any>) 
     }
 }
 
-fun ValueWithReason.toConfig(): Map<String, String?> {
-    return mapOf("value" to value, "reason" to reason)
-}
+fun ValueWithReason.toConfig(): Map<String, String?> = mapOf("value" to value, "reason" to reason)

--- a/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/api/DefaultConfigurationProvider.kt
+++ b/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/api/DefaultConfigurationProvider.kt
@@ -18,10 +18,9 @@ interface DefaultConfigurationProvider {
         fun load(
             extensionsSpec: ExtensionsSpec,
             classLoader: ClassLoader = DefaultConfigurationProvider::class.java.classLoader,
-        ): DefaultConfigurationProvider {
-            return ServiceLoader.load(DefaultConfigurationProvider::class.java, classLoader)
+        ): DefaultConfigurationProvider =
+            ServiceLoader.load(DefaultConfigurationProvider::class.java, classLoader)
                 .first()
                 .apply { init(extensionsSpec) }
-        }
     }
 }

--- a/detekt-utils/src/main/kotlin/io/github/detekt/utils/Markdown.kt
+++ b/detekt-utils/src/main/kotlin/io/github/detekt/utils/Markdown.kt
@@ -16,12 +16,11 @@ sealed class Markdown(open var content: String = "") {
 data class MarkdownContent(override var content: String = "") : Markdown()
 data class MarkdownList(override var content: String = "") : Markdown()
 
-inline fun markdown(content: MarkdownContent.() -> Unit): String {
-    return MarkdownContent().let { markdown ->
+inline fun markdown(content: MarkdownContent.() -> Unit): String =
+    MarkdownContent().let { markdown ->
         content(markdown)
         markdown.content
     }
-}
 
 inline fun MarkdownContent.markdown(markdown: () -> String): Unit = append(markdown())
 inline fun MarkdownContent.paragraph(content: () -> String): Unit = append("${content()}\n")
@@ -47,14 +46,13 @@ inline fun MarkdownContent.codeBlock(syntax: String = "kotlin", code: () -> Stri
 
 fun MarkdownContent.emptyLine(): Unit = append("")
 
-inline fun MarkdownContent.list(listContent: MarkdownList.() -> Unit) {
-    return MarkdownList().let { list ->
+inline fun MarkdownContent.list(listContent: MarkdownList.() -> Unit): Unit =
+    MarkdownList().let { list ->
         listContent(list)
         if (list.content.isNotEmpty()) {
             append(list.content)
         }
     }
-}
 
 inline fun MarkdownList.item(item: () -> String): Unit = append("* ${item()}\n")
 inline fun MarkdownList.description(description: () -> String): Unit = append("  ${description()}\n")

--- a/detekt-utils/src/main/kotlin/io/github/detekt/utils/Resources.kt
+++ b/detekt-utils/src/main/kotlin/io/github/detekt/utils/Resources.kt
@@ -3,8 +3,8 @@ package io.github.detekt.utils
 import java.io.InputStream
 import java.net.URL
 
-fun URL.openSafeStream(): InputStream {
-    return openConnection()
+fun URL.openSafeStream(): InputStream =
+    openConnection()
         /*
          * Due to https://bugs.openjdk.java.net/browse/JDK-6947916 and https://bugs.openjdk.java.net/browse/JDK-8155607,
          * it is necessary to disallow caches to maintain stability on JDK 8 and 11 (and possibly more).
@@ -14,12 +14,7 @@ fun URL.openSafeStream(): InputStream {
          */
         .apply { useCaches = false }
         .getInputStream()
-}
 
-fun <T> Class<T>.getSafeResourceAsStream(name: String): InputStream? {
-    return getResource(name)?.openSafeStream()
-}
+fun <T> Class<T>.getSafeResourceAsStream(name: String): InputStream? = getResource(name)?.openSafeStream()
 
-fun ClassLoader.getSafeResourceAsStream(name: String): InputStream? {
-    return getResource(name)?.openSafeStream()
-}
+fun ClassLoader.getSafeResourceAsStream(name: String): InputStream? = getResource(name)?.openSafeStream()

--- a/detekt-utils/src/main/kotlin/io/github/detekt/utils/Yaml.kt
+++ b/detekt-utils/src/main/kotlin/io/github/detekt/utils/Yaml.kt
@@ -18,12 +18,11 @@ sealed class YML(open val indent: Int = 0, open var content: String = "") {
 
 data class YamlNode(override val indent: Int = 0, override var content: String = "") : YML()
 
-inline fun yaml(content: YamlNode.() -> Unit): String {
-    return YamlNode().let { yaml ->
+inline fun yaml(content: YamlNode.() -> Unit): String =
+    YamlNode().let { yaml ->
         content(yaml)
         yaml.content
     }
-}
 
 fun YamlNode.node(name: String, node: YamlNode.() -> Unit) {
     val yamlNode = YamlNode(indent = indent + 1, content = "$name:")
@@ -78,8 +77,8 @@ private fun YamlNode.map(map: Map<String, String?>) {
 
 inline fun YamlNode.yaml(yaml: () -> String): Unit = append(yaml())
 
-private fun String.ensureQuoted(): String {
-    return when {
+private fun String.ensureQuoted(): String =
+    when {
         isBlank() -> quoted()
         startsWith(SINGLE_QUOTE) &&
             endsWith(SINGLE_QUOTE) ||
@@ -87,7 +86,6 @@ private fun String.ensureQuoted(): String {
             endsWith(DOUBLE_QUOTE) -> this
         else -> quoted()
     }
-}
 
 private fun String.quoted() = "'$this'"
 


### PR DESCRIPTION
I tried the autocorrect but it seemed to make several errors. It did fix most violations but in some cases I had to manually replace the autocorrect suggestions from ktlint. I didn't dig in any further to troubleshoot the ktlint side of things.

This rule is enabled by default in ktlint 1.3.0 and it's one I wanted to see enforced in detekt for a while. I've explicitly enabled it here but I have another PR to enable rules that migrated to ktlint's standard rule set by default in detekt. This PR is big enough that it needs to be done separately.