### PR TITLE
Set forceMultilineWhenChainOperatorCountGreaterOrEqualThan default to 4

### DIFF
--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/ChainMethodContinuation.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/ChainMethodContinuation.kt
@@ -31,7 +31,7 @@ class ChainMethodContinuation(config: Config) : FormattingRule(
     private val maxLineLength by configWithAndroidVariants(120, 100)
 
     @Configuration("chain operator count means multiline threshold")
-    private val forceMultilineWhenChainOperatorCountGreaterOrEqualThan by config(2_147_483_647)
+    private val forceMultilineWhenChainOperatorCountGreaterOrEqualThan by config(4)
 
     override fun overrideEditorConfigProperties(): Map<EditorConfigProperty<*>, String> =
         mapOf(

--- a/detekt-formatting/src/main/resources/config/config.yml
+++ b/detekt-formatting/src/main/resources/config/config.yml
@@ -37,7 +37,7 @@ formatting:
     autoCorrect: true
     indentSize: 4
     maxLineLength: 120
-    forceMultilineWhenChainOperatorCountGreaterOrEqualThan: 2147483647
+    forceMultilineWhenChainOperatorCountGreaterOrEqualThan: 4
   ChainWrapping:
     active: true
     autoCorrect: true


### PR DESCRIPTION
This matches the default ktlint value.

https://github.com/pinterest/ktlint/blob/1.3.0/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ChainMethodContinuationRule.kt#L499