### PR TITLE
Forbid imports of org.jetbrains.kotlin.backend.*

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -206,6 +206,8 @@ style:
         reason: "Use Kotlin's sequences instead."
       - value: 'org.jetbrains.kotlin.js.*'
         reason: "detekt does not support Kotlin/JS at this time"
+      - value: 'org.jetbrains.kotlin.backend.*'
+        reason: "detekt interacts with compiler frontend only"
   ForbiddenMethodCall:
     active: true
     methods:

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/NullCheckOnMutableProperty.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/NullCheckOnMutableProperty.kt
@@ -8,8 +8,6 @@ import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.rules.isNonNullCheck
 import io.gitlab.arturbosch.detekt.rules.isNullCheck
-import org.jetbrains.kotlin.backend.common.peek
-import org.jetbrains.kotlin.backend.common.pop
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.psi.KtBinaryExpression
 import org.jetbrains.kotlin.psi.KtConstantExpression
@@ -105,7 +103,7 @@ class NullCheckOnMutableProperty(config: Config) : Rule(
             // identified in this if-expression are being referenced.
             super.visitIfExpression(expression)
             // Remove the if-expression after having iterated out of its code block.
-            modifiedCandidateQueues.forEach { it.pop() }
+            modifiedCandidateQueues.forEach { it.removeLast() }
         }
 
         override fun visitReferenceExpression(expression: KtReferenceExpression) {
@@ -123,7 +121,7 @@ class NullCheckOnMutableProperty(config: Config) : Rule(
                     ) {
                         // If there's an if-expression attached to the candidate property, a null-checked
                         // mutable property is being referenced.
-                        candidateProperties[fqName]?.peek()?.let { ifExpression ->
+                        candidateProperties[fqName]?.lastOrNull()?.let { ifExpression ->
                             report(
                                 CodeSmell(
                                     Entity.from(ifExpression),

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryInnerClass.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryInnerClass.kt
@@ -5,8 +5,6 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
-import org.jetbrains.kotlin.backend.common.peek
-import org.jetbrains.kotlin.backend.common.pop
 import org.jetbrains.kotlin.descriptors.ClassifierDescriptor
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.psi.KtClass
@@ -64,7 +62,7 @@ class UnnecessaryInnerClass(config: Config) : Rule(
             )
             candidateClassToParentClasses.remove(klass)
         }
-        classChain.pop()
+        classChain.removeLast()
     }
 
     override fun visitReferenceExpression(expression: KtReferenceExpression) {
@@ -87,7 +85,7 @@ class UnnecessaryInnerClass(config: Config) : Rule(
     }
 
     private fun checkForOuterUsage(getTargetClassId: () -> ClassId?) {
-        val currentClass = classChain.peek() ?: return
+        val currentClass = classChain.lastOrNull() ?: return
         val parentClasses = candidateClassToParentClasses[currentClass] ?: return
 
         val targetClassId = getTargetClassId() ?: return

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateFunction.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateFunction.kt
@@ -11,7 +11,6 @@ import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.config
 import io.gitlab.arturbosch.detekt.rules.isOperator
-import org.jetbrains.kotlin.backend.jvm.ir.psiElement
 import org.jetbrains.kotlin.descriptors.CallableDescriptor
 import org.jetbrains.kotlin.descriptors.FunctionDescriptor
 import org.jetbrains.kotlin.descriptors.PropertyDescriptor
@@ -33,6 +32,7 @@ import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
 import org.jetbrains.kotlin.psi.psiUtil.isPrivate
 import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.calls.util.getResolvedCall
+import org.jetbrains.kotlin.resolve.source.getPsi
 import org.jetbrains.kotlin.types.expressions.OperatorConventions
 import org.jetbrains.kotlin.util.OperatorNameConventions
 
@@ -192,7 +192,7 @@ private class UnusedFunctionVisitor(
             is KtCallExpression -> {
                 val resolvedCall = expression.getResolvedCall(bindingContext) ?: return
                 val callableDescriptor = resolvedCall.resultingDescriptor
-                if ((callableDescriptor.psiElement as? KtNamedFunction)?.isOperator() == true) {
+                if ((callableDescriptor.source.getPsi() as? KtNamedFunction)?.isOperator() == true) {
                     invokeOperatorReferences.getOrPut(callableDescriptor) { mutableListOf() }.add(expression)
                 }
                 null


### PR DESCRIPTION
detekt interacts with compiler frontend only and should not call anything in compiler backend package.