### PR TITLE
Add KotlinBuiltIns extensions

### DIFF
--- a/detekt-psi-utils/api/detekt-psi-utils.api
+++ b/detekt-psi-utils/api/detekt-psi-utils.api
@@ -101,5 +101,7 @@ public final class io/gitlab/arturbosch/detekt/rules/TypeUtilsKt {
 	public static final fun getDataFlowAwareTypes (Lorg/jetbrains/kotlin/psi/KtExpression;Lorg/jetbrains/kotlin/resolve/BindingContext;Lorg/jetbrains/kotlin/config/LanguageVersionSettings;Lorg/jetbrains/kotlin/resolve/calls/smartcasts/DataFlowValueFactory;Lorg/jetbrains/kotlin/types/KotlinType;)Ljava/util/Set;
 	public static synthetic fun getDataFlowAwareTypes$default (Lorg/jetbrains/kotlin/psi/KtExpression;Lorg/jetbrains/kotlin/resolve/BindingContext;Lorg/jetbrains/kotlin/config/LanguageVersionSettings;Lorg/jetbrains/kotlin/resolve/calls/smartcasts/DataFlowValueFactory;Lorg/jetbrains/kotlin/types/KotlinType;ILjava/lang/Object;)Ljava/util/Set;
 	public static final fun isNullable (Lorg/jetbrains/kotlin/psi/KtExpression;Lorg/jetbrains/kotlin/resolve/BindingContext;Lorg/jetbrains/kotlin/config/LanguageVersionSettings;Lorg/jetbrains/kotlin/resolve/calls/smartcasts/DataFlowValueFactory;Z)Z
+	public static final fun isPrimitiveType (Lorg/jetbrains/kotlin/types/KotlinType;)Z
+	public static final fun isString (Lorg/jetbrains/kotlin/types/KotlinType;)Z
 }
 

--- a/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/KtValueArgument.kt
+++ b/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/KtValueArgument.kt
@@ -1,6 +1,5 @@
 package io.gitlab.arturbosch.detekt.rules
 
-import org.jetbrains.kotlin.builtins.KotlinBuiltIns
 import org.jetbrains.kotlin.psi.KtStringTemplateExpression
 import org.jetbrains.kotlin.psi.KtValueArgument
 import org.jetbrains.kotlin.resolve.BindingContext
@@ -10,7 +9,7 @@ fun KtValueArgument.isString(bindingContext: BindingContext): Boolean {
     val argumentExpression = getArgumentExpression()
     return if (bindingContext != BindingContext.EMPTY) {
         val type = argumentExpression?.getResolvedCall(bindingContext)?.resultingDescriptor?.returnType
-        argumentExpression is KtStringTemplateExpression || type != null && KotlinBuiltIns.isString(type)
+        argumentExpression is KtStringTemplateExpression || type.isString()
     } else {
         argumentExpression is KtStringTemplateExpression
     }

--- a/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/TypeUtils.kt
+++ b/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/TypeUtils.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules
 
+import org.jetbrains.kotlin.builtins.KotlinBuiltIns
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.config.LanguageVersionSettings
 import org.jetbrains.kotlin.descriptors.CallableDescriptor
@@ -20,6 +21,10 @@ import org.jetbrains.kotlin.util.containingNonLocalDeclaration
 fun KotlinType.fqNameOrNull(): FqName? {
     return TypeUtils.getClassDescriptor(this)?.fqNameOrNull()
 }
+
+fun KotlinType?.isString(): Boolean = KotlinBuiltIns.isString(this)
+
+fun KotlinType.isPrimitiveType(): Boolean = KotlinBuiltIns.isPrimitiveType(this)
 
 /**
  * Returns types considering data flow.

--- a/detekt-rules-performance/build.gradle.kts
+++ b/detekt-rules-performance/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
 
 dependencies {
     compileOnly(projects.detektApi)
+    compileOnly(projects.detektPsiUtils)
     testImplementation(projects.detektTest)
     testImplementation(libs.assertj)
 }

--- a/detekt-rules-performance/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/ArrayPrimitive.kt
+++ b/detekt-rules-performance/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/ArrayPrimitive.kt
@@ -6,7 +6,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
-import org.jetbrains.kotlin.builtins.KotlinBuiltIns
+import io.gitlab.arturbosch.detekt.rules.isPrimitiveType
 import org.jetbrains.kotlin.builtins.PrimitiveType
 import org.jetbrains.kotlin.descriptors.CallableDescriptor
 import org.jetbrains.kotlin.name.FqName
@@ -69,7 +69,7 @@ class ArrayPrimitive(config: Config) : Rule(
 
     private fun isArrayPrimitive(descriptor: CallableDescriptor): Boolean {
         val type = descriptor.returnType?.arguments?.singleOrNull()?.type
-        return descriptor.fqNameOrNull() in factoryMethodFqNames && type != null && KotlinBuiltIns.isPrimitiveType(type)
+        return descriptor.fqNameOrNull() in factoryMethodFqNames && type?.isPrimitiveType() == true
     }
 
     private fun isArrayPrimitive(it: KtTypeReference): Boolean {

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/CanBeNonNullable.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/CanBeNonNullable.kt
@@ -57,8 +57,8 @@ import org.jetbrains.kotlin.resolve.calls.util.getResolvedCall
 import org.jetbrains.kotlin.resolve.calls.util.getType
 import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameOrNull
 import org.jetbrains.kotlin.types.KotlinType
-import org.jetbrains.kotlin.types.TypeUtils
 import org.jetbrains.kotlin.types.isNullable
+import org.jetbrains.kotlin.types.typeUtil.isTypeParameter
 
 /**
  * This rule inspects variables marked as nullable and reports which could be
@@ -520,7 +520,7 @@ class CanBeNonNullable(config: Config) : Rule(
          * But even if T is nullable, a property `val t: T` cannot be made into a non-nullable type.
          */
         private fun KotlinType.isNullableAndCanBeNonNullable(): Boolean {
-            return if (TypeUtils.isTypeParameter(this)) isMarkedNullable else isNullable()
+            return if (isTypeParameter()) isMarkedNullable else isNullable()
         }
 
         private fun KtProperty.isCandidate(): Boolean {

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantExplicitType.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantExplicitType.kt
@@ -5,8 +5,8 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.rules.isString
 import org.jetbrains.kotlin.KtNodeTypes
-import org.jetbrains.kotlin.builtins.KotlinBuiltIns
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtConstantExpression
 import org.jetbrains.kotlin.psi.KtNameReferenceExpression
@@ -57,7 +57,7 @@ class RedundantExplicitType(config: Config) : Rule(
 
         when (val initializer = property.initializer) {
             is KtConstantExpression -> if (!initializer.typeIsSameAs(type)) return
-            is KtStringTemplateExpression -> if (!KotlinBuiltIns.isString(type)) return
+            is KtStringTemplateExpression -> if (!type.isString()) return
             is KtNameReferenceExpression -> if (typeReference.text != initializer.getReferencedName()) return
             is KtCallExpression -> if (typeReference.text != initializer.calleeExpression?.text) return
             else -> return


### PR DESCRIPTION
These would ideally be provided by org.jetbrains.kotlin.types.typeUtil which has wrappers for most KotlinBuiltIns functions. Those that are missing that would be generally useful can be added to detekt's TypeUtils.