### PR TITLE
Remove `extensions.disableDefaultRuleSets` in favor of `RulesSpec.RunPolicy.DisableDefaultRuleSets`

### DIFF
--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Spec.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Spec.kt
@@ -2,6 +2,8 @@ package io.gitlab.arturbosch.detekt.cli
 
 import io.github.detekt.tooling.api.spec.ProcessingSpec
 import io.github.detekt.tooling.api.spec.RulesSpec
+import io.github.detekt.tooling.api.spec.RulesSpec.RunPolicy.DisableDefaultRuleSets
+import io.github.detekt.tooling.api.spec.RulesSpec.RunPolicy.NoRestrictions
 import io.github.detekt.utils.PathFilters
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.RuleSet
@@ -96,7 +98,8 @@ private fun asPatterns(rawValue: String): List<String> = rawValue.trim()
     .toList()
 
 private fun CliArgs.toRunPolicy(): RulesSpec.RunPolicy {
-    val parts = runRule?.split(":") ?: return RulesSpec.RunPolicy.NoRestrictions
+    val parts = runRule?.split(":")
+        ?: return if (disableDefaultRuleSets) DisableDefaultRuleSets else NoRestrictions
     require(parts.size == 2) { "Pattern 'RuleSetId:RuleName' expected." }
     return RulesSpec.RunPolicy.RestrictToSingleRule(RuleSet.Id(parts[0]), Rule.Name(parts[1]))
 }

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/ConfigExporter.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/ConfigExporter.kt
@@ -14,7 +14,6 @@ class ConfigExporter(
         val configPath = arguments.generateConfig ?: error("Unexpected error generating config file")
         val spec = ProcessingSpec {
             extensions {
-                disableDefaultRuleSets = arguments.disableDefaultRuleSets
                 fromPaths { arguments.plugins }
             }
         }

--- a/detekt-compiler-plugin/src/main/kotlin/io/github/detekt/compiler/plugin/internal/CompilerConfigToProcessingSpec.kt
+++ b/detekt-compiler-plugin/src/main/kotlin/io/github/detekt/compiler/plugin/internal/CompilerConfigToProcessingSpec.kt
@@ -2,6 +2,7 @@ package io.github.detekt.compiler.plugin.internal
 
 import io.github.detekt.compiler.plugin.Keys
 import io.github.detekt.tooling.api.spec.ProcessingSpec
+import io.github.detekt.tooling.api.spec.RulesSpec
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import kotlin.io.path.Path
@@ -27,11 +28,13 @@ internal fun CompilerConfiguration.toSpec(log: MessageCollector) = ProcessingSpe
             report { it.key to it.value }
         }
     }
-    extensions {
-        disableDefaultRuleSets = get(Keys.DISABLE_DEFAULT_RULE_SETS, false)
-    }
     rules {
         activateAllRules = get(Keys.ALL_RULES, false)
+        runPolicy = if (get(Keys.DISABLE_DEFAULT_RULE_SETS, false)) {
+            RulesSpec.RunPolicy.DisableDefaultRuleSets
+        } else {
+            RulesSpec.RunPolicy.NoRestrictions
+        }
     }
     execution {
         parallelAnalysis = get(Keys.PARALLEL, false)

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/rules/RuleSets.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/rules/RuleSets.kt
@@ -9,6 +9,11 @@ import java.util.ServiceLoader
 
 fun ProcessingSettings.createRuleProviders(): List<RuleSetProvider> = when (val runPolicy = spec.rulesSpec.runPolicy) {
     RulesSpec.RunPolicy.NoRestrictions -> RuleSetLocator(this).load()
+
+    RulesSpec.RunPolicy.DisableDefaultRuleSets ->
+        RuleSetLocator(this).load()
+            .filterNot { it is DefaultRuleSetProvider }
+
     is RulesSpec.RunPolicy.RestrictToSingleRule -> {
         val ruleSetId = runPolicy.ruleSetId
         val ruleName = runPolicy.ruleName
@@ -20,16 +25,8 @@ fun ProcessingSettings.createRuleProviders(): List<RuleSetProvider> = when (val 
 }
 
 private class RuleSetLocator(private val settings: ProcessingSettings) {
-
-    private val excludeDefaultRuleSets: Boolean = settings.spec.extensionsSpec.disableDefaultRuleSets
-
     fun load(): List<RuleSetProvider> =
         ServiceLoader.load(RuleSetProvider::class.java, settings.pluginLoader)
             .filterNot { it.ruleSetId.value in settings.spec.extensionsSpec.disabledExtensions }
-            .filter(::shouldIncludeProvider)
             .also { settings.debug { "Registered rule sets: $LIST_ITEM_SPACING${it.joinToString(LIST_ITEM_SPACING)}" } }
-
-    private fun shouldIncludeProvider(provider: RuleSetProvider) =
-        !excludeDefaultRuleSets ||
-            (excludeDefaultRuleSets && provider !is DefaultRuleSetProvider)
 }

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/rules/RuleSetsSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/rules/RuleSetsSpec.kt
@@ -1,6 +1,7 @@
 package io.gitlab.arturbosch.detekt.core.rules
 
 import io.github.detekt.test.utils.resourceAsPath
+import io.github.detekt.tooling.api.spec.RulesSpec.RunPolicy.DisableDefaultRuleSets
 import io.github.detekt.tooling.api.spec.RulesSpec.RunPolicy.RestrictToSingleRule
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.RuleSet
@@ -37,7 +38,7 @@ class RuleSetsSpec {
 
     @Test
     fun `does not load any default rule set provider when opt out`() {
-        val providers = createNullLoggingSpec { extensions { disableDefaultRuleSets = true } }
+        val providers = createNullLoggingSpec { rules { runPolicy = DisableDefaultRuleSets } }
             .withSettings { createRuleProviders() }
 
         assertThat(providers.map { it.ruleSetId.value })

--- a/detekt-tooling/api/detekt-tooling.api
+++ b/detekt-tooling/api/detekt-tooling.api
@@ -118,7 +118,6 @@ public abstract interface class io/github/detekt/tooling/api/spec/ExecutionSpec 
 }
 
 public abstract interface class io/github/detekt/tooling/api/spec/ExtensionsSpec {
-	public abstract fun getDisableDefaultRuleSets ()Z
 	public abstract fun getDisabledExtensions ()Ljava/util/Set;
 	public abstract fun getPlugins ()Lio/github/detekt/tooling/api/spec/ExtensionsSpec$Plugins;
 }
@@ -197,6 +196,13 @@ public final class io/github/detekt/tooling/api/spec/RulesSpec$FailurePolicy$Nev
 public abstract class io/github/detekt/tooling/api/spec/RulesSpec$RunPolicy {
 }
 
+public final class io/github/detekt/tooling/api/spec/RulesSpec$RunPolicy$DisableDefaultRuleSets : io/github/detekt/tooling/api/spec/RulesSpec$RunPolicy {
+	public static final field INSTANCE Lio/github/detekt/tooling/api/spec/RulesSpec$RunPolicy$DisableDefaultRuleSets;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class io/github/detekt/tooling/api/spec/RulesSpec$RunPolicy$NoRestrictions : io/github/detekt/tooling/api/spec/RulesSpec$RunPolicy {
 	public static final field INSTANCE Lio/github/detekt/tooling/api/spec/RulesSpec$RunPolicy$NoRestrictions;
 	public fun equals (Ljava/lang/Object;)Z
@@ -271,9 +277,7 @@ public final class io/github/detekt/tooling/dsl/ExtensionsSpecBuilder : io/githu
 	public final fun disableExtension (Ljava/lang/String;)V
 	public final fun fromClassloader (Lkotlin/jvm/functions/Function0;)V
 	public final fun fromPaths (Lkotlin/jvm/functions/Function0;)V
-	public final fun getDisableDefaultRuleSets ()Z
 	public final fun getPlugins ()Lio/github/detekt/tooling/api/spec/ExtensionsSpec$Plugins;
-	public final fun setDisableDefaultRuleSets (Z)V
 	public final fun setPlugins (Lio/github/detekt/tooling/api/spec/ExtensionsSpec$Plugins;)V
 }
 

--- a/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/api/spec/ExtensionsSpec.kt
+++ b/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/api/spec/ExtensionsSpec.kt
@@ -5,14 +5,6 @@ import java.nio.file.Path
 interface ExtensionsSpec {
 
     /**
-     * Exclude all default rule sets from current analysis.
-     *
-     * Official shortcut instead of keeping track of the [io.gitlab.arturbosch.detekt.api.RuleSetProvider] id's
-     * and adding them to the [disabledExtensions].
-     */
-    val disableDefaultRuleSets: Boolean
-
-    /**
      * Where to look for [io.gitlab.arturbosch.detekt.api.Extension]s?
      *
      * Defaults to looking at the running classpath.

--- a/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/api/spec/RulesSpec.kt
+++ b/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/api/spec/RulesSpec.kt
@@ -60,6 +60,11 @@ interface RulesSpec {
         data object NoRestrictions : RunPolicy()
 
         /**
+         * Exclude all default rule sets provided by detekt.
+         */
+        data object DisableDefaultRuleSets : RunPolicy()
+
+        /**
          * Run a single rule.
          */
         class RestrictToSingleRule(val ruleSetId: RuleSet.Id, val ruleName: Rule.Name) : RunPolicy()

--- a/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/dsl/ExtensionsSpecBuilder.kt
+++ b/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/dsl/ExtensionsSpecBuilder.kt
@@ -8,13 +8,11 @@ import java.nio.file.Path
 @ProcessingModelDsl
 class ExtensionsSpecBuilder : Builder<ExtensionsSpec> {
 
-    var disableDefaultRuleSets: Boolean = false
     var plugins: ExtensionsSpec.Plugins? = null
 
     private val disabledExtensions: MutableSet<ExtensionId> = mutableSetOf()
 
     override fun build(): ExtensionsSpec = ExtensionsModel(
-        disableDefaultRuleSets,
         plugins,
         disabledExtensions
     )
@@ -35,7 +33,6 @@ class ExtensionsSpecBuilder : Builder<ExtensionsSpec> {
 }
 
 private data class ExtensionsModel(
-    override val disableDefaultRuleSets: Boolean,
     override val plugins: ExtensionsSpec.Plugins?,
     override val disabledExtensions: Set<ExtensionId>
 ) : ExtensionsSpec

--- a/detekt-tooling/src/test/kotlin/io/github/detekt/tooling/api/DefaultConfigurationProviderSpec.kt
+++ b/detekt-tooling/src/test/kotlin/io/github/detekt/tooling/api/DefaultConfigurationProviderSpec.kt
@@ -32,8 +32,6 @@ internal class TestConfigurationProvider : DefaultConfigurationProvider {
 }
 
 private object Spec : ExtensionsSpec {
-    override val disableDefaultRuleSets: Boolean
-        get() = error("No expected call")
     override val plugins: ExtensionsSpec.Plugins?
         get() = null
     override val disabledExtensions: Set<ExtensionId>


### PR DESCRIPTION
Introduce `RulesSpec.RunPolicy.DisableDefaultRuleSets` and remove the boolean `extensions.disableDefaultRuleSets`. This makes our public api a bit easier and the code that implements it too.