### PR TITLE
Remove dead code on our core tests

### DIFF
--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/KT.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/KT.kt
@@ -1,35 +1,6 @@
 package io.gitlab.arturbosch.detekt.core
 
 import io.github.detekt.test.utils.resourceAsPath
-import io.gitlab.arturbosch.detekt.api.CodeSmell
-import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.Entity
-import io.gitlab.arturbosch.detekt.api.Rule
-import io.gitlab.arturbosch.detekt.api.RuleSet
-import io.gitlab.arturbosch.detekt.api.RuleSetProvider
-import org.jetbrains.kotlin.psi.KtClassOrObject
 import java.nio.file.Path
 
 val path: Path = resourceAsPath("/cases")
-
-class TestProvider : RuleSetProvider {
-    override val ruleSetId: RuleSet.Id = RuleSet.Id("Test")
-
-    override fun instance(): RuleSet {
-        return RuleSet(ruleSetId, listOf(::FindName))
-    }
-}
-
-class TestProvider2 : RuleSetProvider {
-    override val ruleSetId: RuleSet.Id = RuleSet.Id("Test2")
-
-    override fun instance(): RuleSet {
-        return RuleSet(ruleSetId, emptyList())
-    }
-}
-
-class FindName(config: Config) : Rule(config, "") {
-    override fun visitClassOrObject(classOrObject: KtClassOrObject) {
-        report(CodeSmell(Entity.atName(classOrObject), message = "TestMessage"))
-    }
-}

--- a/detekt-core/src/test/resources/META-INF/services/io.gitlab.arturbosch.detekt.api.RuleSetProvider
+++ b/detekt-core/src/test/resources/META-INF/services/io.gitlab.arturbosch.detekt.api.RuleSetProvider
@@ -1,3 +1,1 @@
-io.gitlab.arturbosch.detekt.core.TestProvider
-io.gitlab.arturbosch.detekt.core.TestProvider2
 io.gitlab.arturbosch.detekt.core.config.validation.SampleRuleProvider


### PR DESCRIPTION
No idea when we stop to use this but it seems that now it's safe to remove it