### PR TITLE
Fix some Gradle Isolated Projects violations caused by detekt Gradle plugin

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/DetektBasePlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/DetektBasePlugin.kt
@@ -12,6 +12,7 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.plugins.ReportingBasePlugin
 import org.gradle.api.reporting.ReportingExtension
+import org.gradle.util.GradleVersion
 import org.jetbrains.kotlin.gradle.plugin.KotlinBasePlugin
 import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSetContainer
 
@@ -42,11 +43,19 @@ class DetektBasePlugin : Plugin<Project> {
             reportsDir.convention(
                 project.extensions.getByType(ReportingExtension::class.java).baseDirectory.dir("detekt")
             )
-            basePath.convention(project.rootProject.layout.projectDirectory)
+            if (GradleVersion.current() >= GradleVersion.version("8.8")) {
+                basePath.convention(project.isolated.rootProject.projectDirectory)
+            } else {
+                basePath.convention(project.rootProject.layout.projectDirectory)
+            }
         }
 
         val defaultConfigFile =
-            project.file("${project.rootProject.layout.projectDirectory.dir(CONFIG_DIR_NAME)}/$CONFIG_FILE")
+            if (GradleVersion.current() >= GradleVersion.version("8.8")) {
+                project.file("${project.isolated.rootProject.projectDirectory.dir(CONFIG_DIR_NAME)}/$CONFIG_FILE")
+            } else {
+                project.file("${project.rootProject.layout.projectDirectory.dir(CONFIG_DIR_NAME)}/$CONFIG_FILE")
+            }
         if (defaultConfigFile.exists()) {
             extension.config.setFrom(project.files(defaultConfigFile))
         }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
@@ -29,10 +29,24 @@ class DetektPlugin : Plugin<Project> {
 
         project.registerDetektPlainTask(extension)
         project.registerDetektJvmTasks(extension)
-        if (!project.providers.gradleProperty(DETEKT_ANDROID_DISABLED_PROPERTY).getOrElse("false").toBoolean()) {
+        @Suppress("DEPRECATION")
+        val enableAndroidTasks =
+            !project.providers
+                .gradleProperty(DETEKT_ANDROID_DISABLED_PROPERTY)
+                .forUseAtConfigurationTime()
+                .getOrElse("false")
+                .toBoolean()
+        if (enableAndroidTasks) {
             project.registerDetektAndroidTasks(extension)
         }
-        if (!project.providers.gradleProperty(DETEKT_MULTIPLATFORM_DISABLED_PROPERTY).getOrElse("false").toBoolean()) {
+        @Suppress("DEPRECATION")
+        val enableMppTasks =
+            !project.providers
+                .gradleProperty(DETEKT_MULTIPLATFORM_DISABLED_PROPERTY)
+                .forUseAtConfigurationTime()
+                .getOrElse("false")
+                .toBoolean()
+        if (enableMppTasks) {
             project.registerDetektMultiplatformTasks(extension)
         }
         project.registerGenerateConfigTask(extension)

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
@@ -29,10 +29,10 @@ class DetektPlugin : Plugin<Project> {
 
         project.registerDetektPlainTask(extension)
         project.registerDetektJvmTasks(extension)
-        if (project.findProperty(DETEKT_ANDROID_DISABLED_PROPERTY) != "true") {
+        if (!project.providers.gradleProperty(DETEKT_ANDROID_DISABLED_PROPERTY).getOrElse("false").toBoolean()) {
             project.registerDetektAndroidTasks(extension)
         }
-        if (project.findProperty(DETEKT_MULTIPLATFORM_DISABLED_PROPERTY) != "true") {
+        if (!project.providers.gradleProperty(DETEKT_MULTIPLATFORM_DISABLED_PROPERTY).getOrElse("false").toBoolean()) {
             project.registerDetektMultiplatformTasks(extension)
         }
         project.registerGenerateConfigTask(extension)


### PR DESCRIPTION
About this feature: https://docs.gradle.org/current/userguide/isolated_projects.html

This PR should resolve all current IP violations for anyone using detekt on Gradle 8.8 and 8.9, except when using:
* Kotlin Mutiplatform ([KT-57279](https://youtrack.jetbrains.com/issue/KT-57279/Support-Gradle-Project-Isolation-Feature-for-Kotlin-Multiplatform))
* detekt report merging. We need a solution that properly shares & aggregates reports without referring to subprojects. I'm sure IP won't allow aggregating subproject task output into another project at any point, so we need to start doing things the "proper" way - https://docs.gradle.org/current/userguide/cross_project_publications.html
* DetektTaskMultiModuleSpec. These test whether setting things in allprojects/subprojects blocks are correctly applied to the relevant projects. Most of this behaviour is currently forbidden in IP. Gradle is making changes, so this situation should improve in future, possibly with changes required to build scripts: https://github.com/gradle/gradle/issues/25179

Our build also cannot use IP yet, there are violations in nexus publishing (https://github.com/gradle-nexus/publish-plugin/issues/343), dokka (https://github.com/Kotlin/dokka/issues/3656) and shadow (https://github.com/johnrengelman/shadow/issues/907) plugins (and a few in our build scripts, but no point fixing those until the dependencies are fixed).