### PR TITLE
Stop verifying downloaded Kotlin compiler's checksum

### DIFF
--- a/detekt-compiler-plugin/build.gradle.kts
+++ b/detekt-compiler-plugin/build.gradle.kts
@@ -1,10 +1,7 @@
 import de.undercouch.gradle.tasks.download.Download
-import de.undercouch.gradle.tasks.download.Verify
 
 val kotlinVersion: String = libs.versions.kotlin.get()
 val detektVersion: String = Versions.DETEKT
-
-val kotlinCompilerChecksum: String by project
 
 group = "io.github.detekt"
 version = "$kotlinVersion-$detektVersion"
@@ -55,18 +52,10 @@ tasks.shadowJar {
     }
 }
 
-val verifyKotlinCompilerDownload by tasks.registering(Verify::class) {
-    src(file("$rootDir/build/kotlinc/kotlin-compiler-$kotlinVersion.zip"))
-    algorithm("SHA-256")
-    checksum(kotlinCompilerChecksum)
-    outputs.upToDateWhen { true }
-}
-
 val downloadKotlinCompiler by tasks.registering(Download::class) {
     src("https://github.com/JetBrains/kotlin/releases/download/v$kotlinVersion/kotlin-compiler-$kotlinVersion.zip")
     dest(file("$rootDir/build/kotlinc/kotlin-compiler-$kotlinVersion.zip"))
     overwrite(false)
-    finalizedBy(verifyKotlinCompilerDownload)
 }
 
 val unzipKotlinCompiler by tasks.registering(Copy::class) {

--- a/detekt-compiler-plugin/gradle.properties
+++ b/detekt-compiler-plugin/gradle.properties
@@ -1,6 +1,0 @@
-kotlinCompilerChecksum=ef578730976154fd2c5968d75af8c2703b3de84a78dffe913f670326e149da3b
-
-kotlin.code.style=official
-systemProp.sonar.host.url=http://localhost:9000
-systemProp.detektVersion=detektVersion
-systemProp.file.encoding=UTF-8


### PR DESCRIPTION
Two reasons:
1. The checksum is only published to the same place as the download itself e.g. https://github.com/JetBrains/kotlin/releases/tag/v2.0.0, so anyone who has access to publish or re-publish the kotlin-compiler ZIP can update the checksum as well. This means there's really no security benefit to using this. It's not published to another location that could be checked & verified e.g. Kotlin public website.
2. Having to update it in our build for every new Kotlin release is annoying especially if there's no benefit to doing so.

Corrupted downloads are the only other possible use case but these will be identified by zip CRC-32 checks.