### PR TITLE
Handle non-existent baseline file handling at task execution

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -6,7 +6,7 @@ import io.gitlab.arturbosch.detekt.extensions.FailOnSeverity
 import io.gitlab.arturbosch.detekt.invoke.AllRulesArgument
 import io.gitlab.arturbosch.detekt.invoke.AutoCorrectArgument
 import io.gitlab.arturbosch.detekt.invoke.BasePathArgument
-import io.gitlab.arturbosch.detekt.invoke.BaselineArgument
+import io.gitlab.arturbosch.detekt.invoke.BaselineArgumentOrEmpty
 import io.gitlab.arturbosch.detekt.invoke.BuildUponDefaultConfigArgument
 import io.gitlab.arturbosch.detekt.invoke.ClasspathArgument
 import io.gitlab.arturbosch.detekt.invoke.CliArgument
@@ -36,7 +36,6 @@ import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.Console
 import org.gradle.api.tasks.IgnoreEmptyDirectories
 import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Nested
@@ -64,7 +63,7 @@ abstract class Detekt @Inject constructor(
     @get:Classpath
     abstract val pluginClasspath: ConfigurableFileCollection
 
-    @get:InputFile
+    @get:InputFiles // Why not InputFile? See https://github.com/gradle/gradle/issues/2016
     @get:Optional
     @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val baseline: RegularFileProperty
@@ -144,7 +143,7 @@ abstract class Detekt @Inject constructor(
             JvmTargetArgument(jvmTarget.orNull),
             JdkHomeArgument(jdkHome),
             ConfigArgument(config),
-            BaselineArgument(baseline.orNull),
+            BaselineArgumentOrEmpty(baseline.orNull),
             DefaultReportArgument(reports.xml),
             DefaultReportArgument(reports.html),
             DefaultReportArgument(reports.txt),

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektPlain.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektPlain.kt
@@ -16,9 +16,7 @@ internal class DetektPlain(private val project: Project) {
 
     private fun Project.registerDetektTask(extension: DetektExtension) {
         val detektTaskProvider = registerDetektTask(DetektPlugin.DETEKT_TASK_NAME, extension) {
-            extension.baseline.asFile.orNull?.takeIf { it.exists() }?.let { baselineFile ->
-                baseline.convention(project.layout.file(project.provider { baselineFile }))
-            }
+            baseline.convention(extension.baseline)
             setSource(existingInputDirectoriesProvider(project, extension))
             setIncludes(DetektPlugin.defaultIncludes)
             setExcludes(DetektPlugin.defaultExcludes)

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/CliArgument.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/CliArgument.kt
@@ -70,6 +70,15 @@ internal data class BaselineArgument(val baseline: RegularFile?) : CliArgument()
     override fun toArgument() = baseline?.let { listOf(BASELINE_PARAMETER, it.asFile.absolutePath) }.orEmpty()
 }
 
+internal data class BaselineArgumentOrEmpty(val baseline: RegularFile?) : CliArgument() {
+    override fun toArgument(): List<String> =
+        if (baseline?.asFile?.exists() == true) {
+            listOf(BASELINE_PARAMETER, baseline.asFile.absolutePath)
+        } else {
+            emptyList()
+        }
+}
+
 internal data class DefaultReportArgument(val report: DetektReport) : CliArgument() {
     override fun toArgument(): List<String> =
         if (report.required.get()) {


### PR DESCRIPTION
This allows use of lazy configuration for the baseline property instead of checking if the file exists at configuration time. It also fixes some config ordering issues that were exposed by #7398.

Doing this is a little awkward due to https://github.com/gradle/gradle/issues/12388. This situation should improve with Gradle 9 when https://github.com/gradle/gradle/issues/24767 is addressed (it's dependent on Kotlin 2.0.0 for Gradle).