### PR TITLE
Set task defaults using withType convention

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektPlain.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektPlain.kt
@@ -1,5 +1,7 @@
 package io.gitlab.arturbosch.detekt.internal
 
+import io.gitlab.arturbosch.detekt.Detekt
+import io.gitlab.arturbosch.detekt.DetektCreateBaselineTask
 import io.gitlab.arturbosch.detekt.DetektPlugin
 import io.gitlab.arturbosch.detekt.extensions.DetektExtension
 import org.gradle.api.Project
@@ -15,11 +17,11 @@ internal class DetektPlain(private val project: Project) {
     }
 
     private fun Project.registerDetektTask(extension: DetektExtension) {
-        val detektTaskProvider = registerDetektTask(DetektPlugin.DETEKT_TASK_NAME, extension) {
-            baseline.convention(extension.baseline)
-            setSource(existingInputDirectoriesProvider(project, extension))
-            setIncludes(DetektPlugin.defaultIncludes)
-            setExcludes(DetektPlugin.defaultExcludes)
+        val detektTaskProvider = tasks.register(DetektPlugin.DETEKT_TASK_NAME, Detekt::class.java) { detektTask ->
+            detektTask.baseline.convention(extension.baseline)
+            detektTask.setSource(existingInputDirectoriesProvider(project, extension))
+            detektTask.setIncludes(DetektPlugin.defaultIncludes)
+            detektTask.setExcludes(DetektPlugin.defaultExcludes)
         }
 
         tasks.matching { it.name == LifecycleBasePlugin.CHECK_TASK_NAME }.configureEach {
@@ -28,9 +30,9 @@ internal class DetektPlain(private val project: Project) {
     }
 
     private fun Project.registerCreateBaselineTask(extension: DetektExtension) {
-        registerCreateBaselineTask(DetektPlugin.BASELINE_TASK_NAME, extension) {
-            baseline.convention(extension.baseline)
-            setSource(existingInputDirectoriesProvider(project, extension))
+        tasks.register(DetektPlugin.BASELINE_TASK_NAME, DetektCreateBaselineTask::class.java) {
+            it.baseline.convention(extension.baseline)
+            it.setSource(existingInputDirectoriesProvider(project, extension))
         }
     }
 

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/SharedTasks.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/SharedTasks.kt
@@ -7,16 +7,11 @@ import org.gradle.api.JavaVersion
 import org.gradle.api.Project
 import org.gradle.api.plugins.JavaBasePlugin
 import org.gradle.api.plugins.JavaPluginExtension
-import org.gradle.api.tasks.TaskProvider
 import org.gradle.jvm.toolchain.JavaToolchainService
 import org.gradle.util.GradleVersion
 
-internal fun Project.registerDetektTask(
-    name: String,
-    extension: DetektExtension,
-    configuration: Detekt.() -> Unit
-): TaskProvider<Detekt> =
-    tasks.register(name, Detekt::class.java) {
+internal fun Project.setDetektTaskDefaults(extension: DetektExtension) {
+    tasks.withType(Detekt::class.java) {
         project.plugins.withType(JavaBasePlugin::class.java) { _ ->
             val toolchain = project.extensions.getByType(JavaPluginExtension::class.java).toolchain
 
@@ -45,15 +40,11 @@ internal fun Project.registerDetektTask(
         }
         it.basePath.convention(extension.basePath.map { basePath -> basePath.asFile.absolutePath })
         it.allRules.convention(extension.allRules)
-        configuration(it)
     }
+}
 
-internal fun Project.registerCreateBaselineTask(
-    name: String,
-    extension: DetektExtension,
-    configuration: DetektCreateBaselineTask.() -> Unit
-): TaskProvider<DetektCreateBaselineTask> =
-    tasks.register(name, DetektCreateBaselineTask::class.java) {
+internal fun Project.setCreateBaselineTaskDefaults(extension: DetektExtension) {
+    tasks.withType(DetektCreateBaselineTask::class.java) {
         project.plugins.withType(JavaBasePlugin::class.java) { _ ->
             val toolchain = project.extensions.getByType(JavaPluginExtension::class.java).toolchain
 
@@ -81,5 +72,5 @@ internal fun Project.registerCreateBaselineTask(
         it.ignoreFailures.convention(extension.ignoreFailures)
         it.basePath.convention(extension.basePath.map { basePath -> basePath.asFile.absolutePath })
         it.allRules.convention(extension.allRules)
-        configuration(it)
     }
+}


### PR DESCRIPTION
Refactor to set task defaults using `withType`. This make future refactoring simpler.

One behaviour change is that anyone creating their own Detekt or DetektCreateBaselineTask will have the task inherit the plugin defaults. This aligns to the core Gradle plugins so I don't see this as a downside at all.

Stacks on #7397